### PR TITLE
Add CI workflow and launchd runtime wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "25.8.0"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install web dependencies
+        run: npm --prefix web ci
+
+      - name: Type check
+        run: npm run check
+
+      - name: Lint
+        run: npm run lint:web
+
+      - name: Build
+        run: npm run build

--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -1,0 +1,14 @@
+#!/bin/zsh
+#
+# Wrapper script for launchd. Sources the user's shell config to ensure
+# the full environment (NVM, Homebrew, PATH, API keys, etc.) is available
+# to Dispatch and any agents it spawns.
+#
+# launchd runs with a minimal environment by default - this fixes that.
+
+[[ -f ~/.zprofile ]] && source ~/.zprofile
+[[ -f ~/.zshrc ]] && source ~/.zshrc
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec node "$ROOT_DIR/dist/server.js"


### PR DESCRIPTION
## Summary

- Adds GitHub Actions CI workflow that runs on every PR to `main`: type-check (backend + frontend), lint, and full build
- Adds `bin/dispatch-launchd-wrapper` — a `zsh -il` wrapper script for running Dispatch via launchd, ensuring the full user shell environment (NVM, Homebrew, API keys from `.zshrc`) is available to Dispatch and all agents it spawns

## Context

This is the first PR in the release pipeline work. The launchd wrapper addresses the previous regression where agents lost tool access when Dispatch ran as a launchd service (minimal environment, no NVM/Homebrew in PATH).

## Test plan

- [ ] CI workflow triggers and passes on this PR
- [ ] Verify type-check, lint, and build steps all complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)