### PR TITLE
fix(web): catch agent-status API failure during terminal reconnect

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -381,10 +381,26 @@ export function App(): JSX.Element {
         ? (agents.find((item) => item.id === resolvedAgentId) ?? null)
         : null;
       if (!agent || agent.status !== "running") {
-        const payload = await api<{ agent: Agent }>(
-          `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
-        );
-        agent = payload.agent;
+        try {
+          const payload = await api<{ agent: Agent }>(
+            `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
+          );
+          agent = payload.agent;
+        } catch {
+          // Server is temporarily unreachable (e.g. mid-deploy). Schedule a
+          // retry so reconnection continues once the server is back up.
+          if (!shouldKeepAttachedRef.current) return;
+          clearReconnectTimer();
+          reconnectAttemptsRef.current += 1;
+          const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
+          setConnState("reconnecting");
+          setStatusMessage("Session disconnected, reconnecting...");
+          reconnectTimerRef.current = window.setTimeout(() => {
+            reconnectTimerRef.current = null;
+            void ensureTerminalConnected(false, false, resolvedAgentId);
+          }, delay);
+          return;
+        }
       }
 
       if (agent.status !== "running") {


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in `0724d4d` where the terminal gets stuck at \"Session disconnected, reconnecting...\" after a deploy and never auto-recovers
- **Root cause:** `0724d4d` changed timer-driven reconnects to always call the agent status API — but that `await api(...)` call was outside the try-catch block. A network error (server still booting mid-deploy) threw an uncaught exception, silently exiting `ensureTerminalConnected` without rescheduling a retry
- **Fix:** wrap the agent status fetch in its own try-catch; on failure, schedule a backoff retry (same `1200ms × attempt` logic as `scheduleReconnect`) so the loop continues until the server is back up

## Test plan

- [x] Playwright test: attached terminal to running agent, intercepted agent status API to fail 2× then succeed, force-closed the WebSocket — verified 2× ERR_FAILED retries then clean reconnect to \"Connected\"
- [x] `npm run finalize:web` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)