### PR TITLE
Add release pipeline: launchd runtime, deploy scripts, release workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 HOST=0.0.0.0
-PORT=8787
-DATABASE_URL=postgres://hostess:hostess@127.0.0.1:5432/hostess
+DISPATCH_PORT=8787
+DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=change-me
-MEDIA_ROOT=/tmp/hostess-media
-DISPATCH_BIN_DIR=/Users/bharris/dev/apps/hostess/bin
-HOSTESS_BIN_DIR=/Users/bharris/dev/apps/hostess/bin
+MEDIA_ROOT=/tmp/dispatch-media
+DISPATCH_BIN_DIR=/path/to/dispatch/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "25.8.0"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install web dependencies
+        run: npm --prefix web ci
+
+      - name: Type check
+        run: npm run check
+
+      - name: Lint
+        run: npm run lint:web
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and tag
+        id: version
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.version }} --no-git-tag-version)
+          # Also bump web package to keep versions in sync
+          npm --prefix web version ${{ inputs.version }} --no-git-tag-version
+          git add package.json package-lock.json web/package.json web/package-lock.json
+          git commit -m "Release ${NEW_VERSION}"
+          git tag "${NEW_VERSION}"
+          git push origin main --follow-tags
+          echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        run: |
+          gh release create ${{ steps.version.outputs.tag }} \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes "Release ${{ steps.version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}

--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -1,7 +1,203 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SERVER_DIR="${DISPATCH_SERVER_DIR:-$HOME/.dispatch/server}"
+DEFAULT_PORT="8787"
+PLIST="$HOME/Library/LaunchAgents/com.dispatch.server.plist"
+LOG_FILE="$HOME/.dispatch/logs/dispatch.log"
+FAILURE_LOG="$HOME/.dispatch/logs/last-release-failure.log"
 
-echo "bin/dispatch-deploy now delegates to tmux release flow."
-exec "$ROOT_DIR/bin/dispatch-server" update
+usage() {
+  cat <<USAGE
+Usage: bin/dispatch-deploy <tag>
+       bin/dispatch-deploy --latest
+
+Checks out a verified release tag in the server directory, builds, reloads
+the launchd service, and verifies Dispatch comes back up healthy.
+
+On failure, attempts automatic rollback to the previously deployed tag.
+
+Examples:
+  bin/dispatch-deploy v0.2.0    # deploy a specific tag
+  bin/dispatch-deploy --latest  # deploy the latest tag
+  bin/dispatch-deploy v0.1.0    # rollback to a previous tag
+USAGE
+}
+
+load_nvm() {
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck disable=SC1090
+    . "$NVM_DIR/nvm.sh"
+  else
+    echo "error: nvm not found at $NVM_DIR/nvm.sh" >&2
+    exit 1
+  fi
+}
+
+health_check() {
+  local port="${DISPATCH_PORT:-$DEFAULT_PORT}"
+  curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
+}
+
+wait_for_health() {
+  local attempts=20
+  local delay=2
+  local i
+  echo "==> waiting for health check..."
+  for ((i = 1; i <= attempts; i++)); do
+    if health_check >/tmp/dispatch-health.json 2>/dev/null; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+  return 1
+}
+
+current_tag() {
+  git -C "$SERVER_DIR" describe --tags --exact-match HEAD 2>/dev/null \
+    || git -C "$SERVER_DIR" rev-parse --short HEAD 2>/dev/null \
+    || echo "unknown"
+}
+
+resolve_tag() {
+  local tag="$1"
+  if [[ "$tag" == "--latest" ]]; then
+    git -C "$SERVER_DIR" fetch --tags --quiet
+    tag=$(git -C "$SERVER_DIR" tag --sort=-version:refname | grep '^v' | head -1)
+    if [[ -z "$tag" ]]; then
+      echo "error: no release tags found" >&2
+      exit 1
+    fi
+    echo "resolved latest tag: $tag" >&2
+  fi
+  echo "$tag"
+}
+
+build_tag() {
+  local tag="$1"
+  git -C "$SERVER_DIR" checkout "$tag"
+  load_nvm
+  cd "$SERVER_DIR"
+  nvm use >/dev/null
+  npm ci --silent
+  npm --prefix web ci --silent
+  npm run build
+}
+
+write_failure_log() {
+  local step="$1"
+  local tag="$2"
+  local rollback_tag="${3:-}"
+  local rollback_status="${4:-}"
+  local extra="${5:-}"
+
+  mkdir -p "$(dirname "$FAILURE_LOG")"
+  {
+    echo "=== Dispatch Release Failure ==="
+    echo "Time:        $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Deploying:   $tag"
+    echo "Failed at:   $step"
+    if [[ -n "$rollback_tag" ]]; then
+      echo "Rollback:    attempted $rollback_tag → $rollback_status"
+    fi
+    if [[ -n "$extra" ]]; then
+      echo ""
+      echo "$extra"
+    fi
+    echo ""
+    echo "--- Last 50 lines of server log ---"
+    tail -50 "$LOG_FILE" 2>/dev/null || echo "(log not available)"
+    echo ""
+    echo "--- Recovery ---"
+    if [[ "$rollback_status" == "succeeded" ]]; then
+      echo "Server is running $rollback_tag (rollback succeeded)"
+    else
+      echo "Server may be down. Manual intervention required."
+    fi
+    echo "To retry:          bin/dispatch-deploy $tag"
+    echo "To deploy another: bin/dispatch-deploy <tag>"
+    echo "Available tags:    git -C $SERVER_DIR tag --sort=-version:refname"
+  } > "$FAILURE_LOG"
+
+  echo "failure details written to $FAILURE_LOG" >&2
+}
+
+main() {
+  local tag="${1:-}"
+  if [[ -z "$tag" ]]; then
+    usage
+    exit 1
+  fi
+
+  if [[ ! -d "$SERVER_DIR/.git" ]]; then
+    echo "error: server directory not found at $SERVER_DIR" >&2
+    echo "       run bin/install-launchd to set up the service first" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$PLIST" ]]; then
+    echo "error: launchd plist not found at $PLIST" >&2
+    echo "       run bin/install-launchd to set up the service first" >&2
+    exit 1
+  fi
+
+  echo "==> fetching tags"
+  git -C "$SERVER_DIR" fetch --tags --quiet
+
+  tag=$(resolve_tag "$tag")
+
+  if ! git -C "$SERVER_DIR" rev-parse "$tag" >/dev/null 2>&1; then
+    echo "error: tag '$tag' not found" >&2
+    exit 1
+  fi
+
+  # Record what's currently deployed so we can roll back if needed
+  local previous_tag
+  previous_tag=$(current_tag)
+  echo "==> deploying $tag (replacing $previous_tag)"
+
+  echo "==> building $tag"
+  if ! build_tag "$tag"; then
+    write_failure_log "build" "$tag" "$previous_tag" "" "Build failed for $tag."
+    echo "error: build failed" >&2
+    exit 1
+  fi
+
+  echo "==> reloading launchd service"
+  launchctl unload "$PLIST"
+  launchctl load "$PLIST"
+
+  if wait_for_health; then
+    echo "==> deployed $tag successfully"
+    cat /tmp/dispatch-health.json
+    echo
+    return 0
+  fi
+
+  # Health check failed — attempt rollback
+  echo "error: health check failed after deploying $tag" >&2
+
+  if [[ "$previous_tag" == "$tag" || "$previous_tag" == "unknown" ]]; then
+    write_failure_log "health check" "$tag" "" "" ""
+    echo "error: cannot roll back (no previous tag available)" >&2
+    exit 1
+  fi
+
+  echo "==> rolling back to $previous_tag"
+  if build_tag "$previous_tag" && \
+     { launchctl unload "$PLIST"; launchctl load "$PLIST"; } && \
+     wait_for_health; then
+    write_failure_log "health check" "$tag" "$previous_tag" "succeeded"
+    echo "error: deploy of $tag failed — rolled back to $previous_tag" >&2
+    exit 1
+  fi
+
+  write_failure_log "health check" "$tag" "$previous_tag" "failed" \
+    "Rollback to $previous_tag also failed. Server may be down."
+  echo "error: deploy failed and rollback failed — server may be down" >&2
+  echo "       check logs: tail -f $LOG_FILE" >&2
+  exit 1
+}
+
+main "$@"

--- a/bin/dispatch-release
+++ b/bin/dispatch-release
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="selfcontained/dispatch"
+
+usage() {
+  cat <<USAGE
+Usage: bin/dispatch-release <patch|minor|major>
+
+Triggers the GitHub Actions release workflow to create a verified,
+tagged release, then deploys that tag locally.
+
+On workflow failure, spawns a Dispatch agent with the failure context for diagnosis.
+On deploy failure, dispatch-deploy handles rollback and writes a failure log.
+
+Examples:
+  bin/dispatch-release patch
+  bin/dispatch-release minor
+  bin/dispatch-release major
+USAGE
+}
+
+require_gh() {
+  if ! command -v gh &>/dev/null; then
+    echo "error: GitHub CLI (gh) is required" >&2
+    echo "       https://cli.github.com" >&2
+    exit 1
+  fi
+}
+
+require_clean_main() {
+  local branch
+  branch=$(git -C "$ROOT_DIR" branch --show-current)
+  if [[ "$branch" != "main" ]]; then
+    echo "error: must be on main branch (currently on '$branch')" >&2
+    exit 1
+  fi
+  if ! git -C "$ROOT_DIR" diff --quiet || ! git -C "$ROOT_DIR" diff --cached --quiet; then
+    echo "error: working directory has uncommitted changes" >&2
+    exit 1
+  fi
+  git -C "$ROOT_DIR" fetch origin --quiet
+  if ! git -C "$ROOT_DIR" diff --quiet main origin/main; then
+    echo "error: local main is not up to date with origin/main" >&2
+    exit 1
+  fi
+}
+
+spawn_diagnosis_agent() {
+  local step="$1"
+  local context="$2"
+  local run_url="${3:-}"
+
+  local prompt="The Dispatch release failed at step: $step
+
+Context:
+$context
+${run_url:+
+GitHub Actions run: $run_url}
+
+Please diagnose the failure. If it's fixable, describe the fix. If a rollback
+is needed, you can run: bin/dispatch-deploy --latest
+
+Report your findings via dispatch-event."
+
+  local port="${DISPATCH_PORT:-8787}"
+
+  echo "==> spawning diagnosis agent..."
+  curl -fsS -X POST "http://127.0.0.1:${port}/api/v1/agents" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n \
+      --arg name "release-diagnosis" \
+      --arg cwd "$ROOT_DIR" \
+      --arg prompt "$prompt" \
+      '{name: $name, type: "claude", cwd: $cwd, codexArgs: [$prompt]}')" \
+    >/dev/null 2>&1 || echo "warning: could not spawn diagnosis agent" >&2
+}
+
+main() {
+  local version="${1:-}"
+  if [[ -z "$version" ]]; then
+    usage
+    exit 1
+  fi
+
+  case "$version" in
+    patch|minor|major) ;;
+    *) echo "error: version must be patch, minor, or major" >&2; exit 1 ;;
+  esac
+
+  require_gh
+  require_clean_main
+
+  echo "==> triggering release workflow (version: $version)"
+  gh workflow run release.yml \
+    --repo "$REPO" \
+    --field "version=$version"
+
+  # Give GitHub a moment to register the run
+  sleep 3
+
+  # Get the run ID that was just triggered
+  local run_id
+  run_id=$(gh run list \
+    --repo "$REPO" \
+    --workflow release.yml \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId')
+
+  local run_url="https://github.com/$REPO/actions/runs/$run_id"
+  echo "==> watching run $run_id ($run_url)"
+
+  if ! gh run watch "$run_id" --repo "$REPO"; then
+    local logs
+    logs=$(gh run view "$run_id" --repo "$REPO" --log-failed 2>&1 | tail -50)
+    spawn_diagnosis_agent "GitHub Actions release workflow" "$logs" "$run_url"
+    echo "error: release workflow failed — diagnosis agent spawned" >&2
+    echo "       $run_url" >&2
+    exit 1
+  fi
+
+  # Read the tag produced by the workflow
+  local tag
+  tag=$(gh run view "$run_id" \
+    --repo "$REPO" \
+    --json jobs \
+    --jq '.jobs[0].steps[] | select(.name == "Bump version and tag") | .conclusion' 2>/dev/null || true)
+
+  # Fall back to reading the tag from the latest git tag on origin
+  git -C "$ROOT_DIR" fetch --tags --quiet
+  tag=$(git -C "$ROOT_DIR" tag --sort=-version:refname | grep '^v' | head -1)
+
+  if [[ -z "$tag" ]]; then
+    spawn_diagnosis_agent "reading release tag" "Could not determine the tag produced by the release workflow." "$run_url"
+    echo "error: could not determine release tag — diagnosis agent spawned" >&2
+    exit 1
+  fi
+
+  echo "==> release workflow produced tag: $tag"
+
+  # dispatch-deploy handles rollback and failure logging internally.
+  # We don't spawn a diagnosis agent here since Dispatch may be down.
+  if ! "$ROOT_DIR/bin/dispatch-deploy" "$tag"; then
+    echo "error: deploy failed — see $HOME/.dispatch/logs/last-release-failure.log" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/bin/install-launchd
+++ b/bin/install-launchd
@@ -1,8 +1,132 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "launchd support has been removed from Dispatch." >&2
-echo "Use tmux runtime commands instead:" >&2
-echo "  - start: bin/dispatch-server start" >&2
-echo "  - release: bin/dispatch-server update" >&2
-exit 1
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SERVER_DIR="${DISPATCH_SERVER_DIR:-$HOME/.dispatch/server}"
+PLIST="$HOME/Library/LaunchAgents/com.dispatch.server.plist"
+LOG_DIR="$HOME/.dispatch/logs"
+LOG_FILE="$LOG_DIR/dispatch.log"
+WRAPPER="$SERVER_DIR/bin/dispatch-launchd-wrapper"
+PORT=""
+
+usage() {
+  cat <<USAGE
+Usage: bin/install-launchd [--port <port>]
+
+Installs Dispatch as a launchd service. Clones the repo to $SERVER_DIR,
+does an initial build, and loads the service.
+
+Options:
+  --port <port>   Port to listen on (default: 8787)
+
+Examples:
+  bin/install-launchd
+  bin/install-launchd --port 6767
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -f "$PLIST" ]]; then
+  echo "launchd service already installed at $PLIST"
+  echo "run bin/uninstall-launchd first to reinstall"
+  exit 1
+fi
+
+# Clone repo to server directory if not already present
+if [[ ! -d "$SERVER_DIR/.git" ]]; then
+  REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin)
+  echo "==> cloning $REMOTE_URL to $SERVER_DIR"
+  git clone "$REMOTE_URL" "$SERVER_DIR"
+else
+  echo "==> server directory already exists at $SERVER_DIR"
+fi
+
+# Set up .env for the server directory
+SERVER_ENV="$SERVER_DIR/.env"
+if [[ ! -f "$SERVER_ENV" ]]; then
+  if [[ -f "$ROOT_DIR/.env" ]]; then
+    echo "==> copying .env from main repo"
+    cp "$ROOT_DIR/.env" "$SERVER_ENV"
+  elif [[ -f "$ROOT_DIR/.env.example" ]]; then
+    echo "==> copying .env.example as starting point — edit $SERVER_ENV before using"
+    cp "$ROOT_DIR/.env.example" "$SERVER_ENV"
+  else
+    echo "==> creating minimal .env"
+    touch "$SERVER_ENV"
+  fi
+fi
+
+# Set DISPATCH_PORT in server .env if specified
+if [[ -n "$PORT" ]]; then
+  if grep -q '^DISPATCH_PORT=' "$SERVER_ENV"; then
+    sed -i '' "s/^DISPATCH_PORT=.*/DISPATCH_PORT=$PORT/" "$SERVER_ENV"
+  else
+    echo "DISPATCH_PORT=$PORT" >> "$SERVER_ENV"
+  fi
+  echo "==> set DISPATCH_PORT=$PORT in $SERVER_ENV"
+fi
+
+# Initial build
+echo "==> installing dependencies"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1090
+[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"
+cd "$SERVER_DIR"
+nvm use >/dev/null
+npm ci --silent
+npm --prefix web ci --silent
+
+echo "==> building"
+npm run build
+
+mkdir -p "$LOG_DIR"
+
+cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dispatch.server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${WRAPPER}</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>${LOG_FILE}</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOG_FILE}</string>
+</dict>
+</plist>
+PLIST
+
+launchctl load "$PLIST"
+
+echo ""
+echo "installed and started Dispatch as a launchd service"
+echo "server directory: $SERVER_DIR"
+echo "port:             ${PORT:-8787}"
+echo "logs:             tail -f $LOG_FILE"
+echo ""
+echo "useful commands:"
+echo "  deploy:     bin/dispatch-deploy <tag>"
+echo "  status:     launchctl list com.dispatch.server"
+echo "  stop:       launchctl unload $PLIST"
+echo "  start:      launchctl load $PLIST"
+echo "  uninstall:  bin/uninstall-launchd"

--- a/bin/uninstall-launchd
+++ b/bin/uninstall-launchd
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "launchd support has been removed from Dispatch." >&2
-echo "Nothing to uninstall. Use tmux runtime commands:" >&2
-echo "  - status: bin/dispatch-server status" >&2
-echo "  - stop: bin/dispatch-server stop" >&2
-exit 1
+PLIST="$HOME/Library/LaunchAgents/com.dispatch.server.plist"
+
+if [[ ! -f "$PLIST" ]]; then
+  echo "launchd service is not installed"
+  exit 0
+fi
+
+launchctl unload "$PLIST" 2>/dev/null || true
+rm "$PLIST"
+
+echo "uninstalled Dispatch launchd service"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 services:
   postgres:
     image: postgres:17-alpine
-    container_name: hostess-postgres
+    container_name: dispatch-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: hostess
-      POSTGRES_PASSWORD: hostess
-      POSTGRES_DB: hostess
+      POSTGRES_USER: dispatch
+      POSTGRES_PASSWORD: dispatch
+      POSTGRES_DB: dispatch
     ports:
       - "5432:5432"
     volumes:
-      - hostess_pgdata:/var/lib/postgresql/data
+      - dispatch_pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hostess -d hostess"]
+      test: ["CMD-SHELL", "pg_isready -U dispatch -d dispatch"]
       interval: 5s
       timeout: 3s
       retries: 10
 
 volumes:
-  hostess_pgdata:
+  dispatch_pgdata:

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,11 +15,11 @@ export type AppConfig = {
 export function loadConfig(): AppConfig {
   return {
     host: process.env.HOST ?? "0.0.0.0",
-    port: Number(process.env.PORT ?? 8787),
+    port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 8787),
     databaseUrl:
-      process.env.DATABASE_URL ?? "postgres://hostess:hostess@127.0.0.1:5432/hostess",
+      process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
     authToken: process.env.AUTH_TOKEN ?? "dev-token",
-    mediaRoot: process.env.MEDIA_ROOT ?? "/tmp/hostess-media",
+    mediaRoot: process.env.MEDIA_ROOT ?? "/tmp/dispatch-media",
     dispatchBinDir:
       process.env.DISPATCH_BIN_DIR ??
       process.env.HOSTESS_BIN_DIR ??


### PR DESCRIPTION
## Summary

- **`bin/install-launchd`** — clones repo to `~/.dispatch/server/`, builds, installs launchd service; `--port` flag for running on a custom port (e.g. `--port 6767`)
- **`bin/uninstall-launchd`** — unloads and removes plist
- **`bin/dispatch-deploy <tag|--latest>`** — deploys a verified tag to the server directory, reloads launchd, health checks; auto-rollback to previous tag on failure with detailed failure log at `~/.dispatch/logs/last-release-failure.log`
- **`bin/dispatch-release <patch|minor|major>`** — triggers GitHub Actions release workflow, waits, reads produced tag, calls `dispatch-deploy`; spawns diagnosis agent on workflow failure (not deploy failure, since Dispatch may be down then)
- **`.github/workflows/release.yml`** — manual `workflow_dispatch` with version input; runs full CI, bumps both `package.json` files, commits, tags, pushes, creates GitHub Release
- **`DISPATCH_PORT`** replaces `PORT` as primary env var (`PORT` kept as fallback)
- **`docker-compose.yml`** — rename `hostess-postgres` → `dispatch-postgres` (applied during migration, not automatically)
- **`src/config.ts`** — reads `DISPATCH_PORT` first, updated hostess defaults to dispatch

## Migration plan (after merge)

1. `bin/install-launchd --port 6767` — starts new launchd instance alongside existing tmux instance
2. Verify on port 6767
3. `pg_dump` from hostess-postgres
4. Start dispatch-postgres on 5433, restore dump
5. Update `~/.dispatch/server/.env` DATABASE_URL to dispatch on 5433, reload launchd
6. Stop hostess-postgres, move dispatch to 5432, reload
7. Stop tmux instance whenever ready

## Test plan

- [ ] CI passes on this PR
- [ ] `bin/install-launchd --port 6767` starts successfully
- [ ] Health check passes on 6767
- [ ] Agent spawned from 6767 instance has full tool access

🤖 Generated with [Claude Code](https://claude.com/claude-code)