### PR TITLE
Add Release Manager UI in Settings pane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           npm --prefix web version ${{ inputs.version }} --no-git-tag-version
           git add package.json package-lock.json web/package.json web/package-lock.json
           git commit -m "Release ${NEW_VERSION}"
-          git tag "${NEW_VERSION}"
+          git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
           git push origin main --follow-tags
           echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -85,6 +85,16 @@ build_tag() {
   npm run build
 }
 
+write_release_record() {
+  local tag="$1"
+  local record_path="$HOME/.dispatch/release.json"
+  mkdir -p "$(dirname "$record_path")"
+  printf '{\n  "tag": "%s",\n  "deployedAt": "%s"\n}\n' \
+    "$tag" \
+    "$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')" \
+    > "$record_path"
+}
+
 write_failure_log() {
   local step="$1"
   local tag="$2"
@@ -165,10 +175,13 @@ main() {
   fi
 
   echo "==> reloading launchd service"
+  echo "DISPATCH_RESTARTING"
+  sleep 1
   launchctl unload "$PLIST"
   launchctl load "$PLIST"
 
   if wait_for_health; then
+    write_release_record "$tag"
     echo "==> deployed $tag successfully"
     cat /tmp/dispatch-health.json
     echo

--- a/src/release-store.ts
+++ b/src/release-store.ts
@@ -1,0 +1,35 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+const RELEASE_STORE_PATH = path.join(os.homedir(), ".dispatch", "release.json");
+
+export type ReleaseRecord = {
+  tag: string;
+  deployedAt: string;
+};
+
+export async function readReleaseStore(): Promise<ReleaseRecord | null> {
+  try {
+    const raw = await readFile(RELEASE_STORE_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "tag" in parsed &&
+      "deployedAt" in parsed &&
+      typeof (parsed as Record<string, unknown>).tag === "string" &&
+      typeof (parsed as Record<string, unknown>).deployedAt === "string"
+    ) {
+      return parsed as ReleaseRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeReleaseStore(record: ReleaseRecord): Promise<void> {
+  await mkdir(path.dirname(RELEASE_STORE_PATH), { recursive: true });
+  await writeFile(RELEASE_STORE_PATH, JSON.stringify(record, null, 2) + "\n", "utf-8");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
 import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { existsSync, watch, type FSWatcher } from "node:fs";
@@ -22,6 +24,7 @@ import {
   resolveRepoConfig,
   writeWorktreeMode
 } from "./repo-config.js";
+import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 
 const config = loadConfig();
@@ -121,6 +124,208 @@ const webDistDir = path.resolve(__dirname, "../web/dist");
 const legacyPublicDir = path.resolve(__dirname, "../public");
 const staticDir = existsSync(webDistDir) ? webDistDir : legacyPublicDir;
 
+// ---------------------------------------------------------------------------
+// Release manager
+// ---------------------------------------------------------------------------
+
+const RELEASE_VERSION_TYPES = ["patch", "minor", "major"] as const;
+type ReleaseVersionType = (typeof RELEASE_VERSION_TYPES)[number];
+type ReleasePhase = "preflight" | "triggering" | "watching" | "deploying" | "restarting" | "done" | "failed";
+
+type ReleaseJob = {
+  versionType: ReleaseVersionType;
+  phase: ReleasePhase;
+  startedAt: string;
+  log: string[];
+  runUrl: string | null;
+  tag: string | null;
+  error: string | null;
+};
+
+type ReleaseStreamEvent =
+  | { type: "snapshot"; job: ReleaseJob | null }
+  | { type: "log"; line: string }
+  | { type: "phase"; phase: ReleasePhase; error?: string }
+  | { type: "runUrl"; url: string }
+  | { type: "tag"; tag: string };
+
+let activeReleaseJob: ReleaseJob | null = null;
+const releaseStreamClients = new Set<NodeJS.WritableStream>();
+
+const serverDir = process.env.DISPATCH_SERVER_DIR ?? path.join(os.homedir(), ".dispatch", "server");
+
+function broadcastReleaseEvent(event: ReleaseStreamEvent): void {
+  const payload = `data: ${JSON.stringify(event)}\n\n`;
+  for (const client of releaseStreamClients) {
+    try {
+      client.write(payload);
+    } catch {
+      releaseStreamClients.delete(client);
+    }
+  }
+}
+
+function appendReleaseLog(job: ReleaseJob, line: string): void {
+  job.log.push(line);
+  broadcastReleaseEvent({ type: "log", line });
+}
+
+function setReleasePhase(job: ReleaseJob, phase: ReleasePhase, error?: string): void {
+  job.phase = phase;
+  broadcastReleaseEvent({ type: "phase", phase, error });
+}
+
+function streamProcess(
+  command: string,
+  args: string[],
+  options: { cwd?: string },
+  job: ReleaseJob,
+  onLine?: (line: string) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let buffer = "";
+    const processChunk = (chunk: Buffer): void => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        appendReleaseLog(job, line);
+        onLine?.(line);
+      }
+    };
+
+    child.stdout.on("data", processChunk);
+    child.stderr.on("data", processChunk);
+
+    child.on("error", (err) => reject(err));
+    child.on("close", (code) => {
+      if (buffer) {
+        appendReleaseLog(job, buffer);
+        onLine?.(buffer);
+      }
+      if (code !== 0) {
+        reject(new Error(`Process exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function getGitHubRepo(): Promise<string> {
+  try {
+    const result = await runCommand("git", ["-C", serverDir, "remote", "get-url", "origin"]);
+    const url = result.stdout;
+    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?$/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  } catch {
+    // fall through
+  }
+  return "selfcontained/dispatch";
+}
+
+async function runReleaseJob(job: ReleaseJob): Promise<void> {
+  try {
+    // Preflight: check gh CLI is available
+    setReleasePhase(job, "preflight");
+    try {
+      await runCommand("gh", ["--version"]);
+    } catch {
+      throw new Error("GitHub CLI (gh) is not available. Install it from https://cli.github.com");
+    }
+
+    const repo = await getGitHubRepo();
+
+    // Trigger workflow
+    setReleasePhase(job, "triggering");
+    appendReleaseLog(job, `==> triggering release workflow (version: ${job.versionType})`);
+
+    try {
+      await runCommand("gh", [
+        "workflow", "run", "release.yml",
+        "--repo", repo,
+        "--field", `version=${job.versionType}`
+      ]);
+    } catch (err) {
+      throw new Error(`Failed to trigger workflow: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    // Give GitHub a moment to register the run
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Get the run ID
+    const runIdResult = await runCommand("gh", [
+      "run", "list",
+      "--repo", repo,
+      "--workflow", "release.yml",
+      "--limit", "1",
+      "--json", "databaseId",
+      "--jq", ".[0].databaseId"
+    ]);
+    const runId = runIdResult.stdout.trim();
+    if (!runId) {
+      throw new Error("Could not determine GitHub Actions run ID");
+    }
+
+    const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+    job.runUrl = runUrl;
+    broadcastReleaseEvent({ type: "runUrl", url: runUrl });
+    appendReleaseLog(job, `==> watching run ${runId}`);
+    appendReleaseLog(job, `    ${runUrl}`);
+
+    // Watch the workflow
+    setReleasePhase(job, "watching");
+    try {
+      await streamProcess("gh", ["run", "watch", runId, "--repo", repo], {}, job);
+    } catch {
+      throw new Error(`GitHub Actions workflow failed. See ${runUrl}`);
+    }
+
+    // Fetch tags and find the latest
+    await runCommand("git", ["-C", serverDir, "fetch", "--tags", "--quiet"]);
+    const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
+    const tag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? "";
+    if (!tag) {
+      throw new Error("Could not determine release tag after workflow completed");
+    }
+
+    job.tag = tag;
+    broadcastReleaseEvent({ type: "tag", tag });
+    appendReleaseLog(job, `==> release workflow produced tag: ${tag}`);
+
+    // Deploy
+    setReleasePhase(job, "deploying");
+    const deployBin = path.join(serverDir, "bin", "dispatch-deploy");
+
+    // Watch for the DISPATCH_RESTARTING marker to send the restarting phase
+    // before launchctl kills this server process.
+    await streamProcess(deployBin, [tag], { cwd: serverDir }, job, (line) => {
+      if (line.trim() === "DISPATCH_RESTARTING") {
+        setReleasePhase(job, "restarting");
+      }
+    });
+
+    // If we reach here the deploy succeeded without restarting (unusual),
+    // mark done and write the store ourselves.
+    job.phase = "done";
+    await writeReleaseStore({ tag, deployedAt: new Date().toISOString() });
+    broadcastReleaseEvent({ type: "phase", phase: "done" });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    if (activeReleaseJob) {
+      activeReleaseJob.error = error;
+    }
+    setReleasePhase(job, "failed", error);
+  }
+}
+
 async function registerRoutes() {
   await app.register(fastifyWebsocket);
 
@@ -128,6 +333,133 @@ async function registerRoutes() {
     root: staticDir,
     prefix: "/"
   });
+
+  // --- Release routes ---
+
+  app.get("/api/v1/release/status", async () => {
+    const record = await readReleaseStore();
+    return { tag: record?.tag ?? null, deployedAt: record?.deployedAt ?? null };
+  });
+
+  app.get("/api/v1/release/info", async (_, reply) => {
+    try {
+      await runCommand("git", ["-C", serverDir, "fetch", "origin", "--quiet"]);
+
+      // Current deployed tag from store (fast)
+      const record = await readReleaseStore();
+      const currentTag = record?.tag ?? null;
+
+      if (!currentTag) {
+        return { currentTag: null, unreleasedCount: 0, commits: [] };
+      }
+
+      // Verify the ref exists locally (tags may not be present in dev checkouts)
+      const refCheck = await runCommand(
+        "git", ["-C", serverDir, "rev-parse", "--verify", currentTag],
+        { allowedExitCodes: [0, 128] }
+      );
+      if (refCheck.exitCode !== 0) {
+        return { currentTag, unreleasedCount: 0, commits: [], refMissing: true };
+      }
+
+      // Count and list commits between current tag and origin/main
+      const countResult = await runCommand("git", [
+        "-C", serverDir,
+        "rev-list", `${currentTag}..origin/main`, "--count"
+      ]);
+      const unreleasedCount = Number(countResult.stdout) || 0;
+
+      let commits: Array<{ sha: string; subject: string }> = [];
+      if (unreleasedCount > 0) {
+        const logResult = await runCommand("git", [
+          "-C", serverDir,
+          "log", `${currentTag}..origin/main`,
+          "--no-merges",
+          "--format=%H\t%s",
+          "--max-count=20"
+        ]);
+        commits = logResult.stdout
+          .split("\n")
+          .filter((l) => l.trim())
+          .map((line) => {
+            const tab = line.indexOf("\t");
+            return {
+              sha: line.slice(0, tab).slice(0, 7),
+              subject: line.slice(tab + 1)
+            };
+          });
+      }
+
+      return { currentTag, unreleasedCount, commits };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  app.post("/api/v1/release", async (request, reply) => {
+    const body = request.body as { versionType?: unknown } | undefined;
+
+    if (!body?.versionType || !RELEASE_VERSION_TYPES.includes(body.versionType as ReleaseVersionType)) {
+      return reply.code(400).send({ error: `versionType must be one of: ${RELEASE_VERSION_TYPES.join(", ")}` });
+    }
+
+    const versionType = body.versionType as ReleaseVersionType;
+
+    // Only one release at a time
+    if (activeReleaseJob && activeReleaseJob.phase !== "done" && activeReleaseJob.phase !== "failed") {
+      return reply.code(409).send({ error: "A release is already in progress." });
+    }
+
+    // Quick pre-flight: check gh CLI before spawning the job
+    try {
+      await runCommand("gh", ["--version"]);
+    } catch {
+      return reply.code(422).send({ error: "GitHub CLI (gh) is not available. Install it from https://cli.github.com" });
+    }
+
+    const job: ReleaseJob = {
+      versionType,
+      phase: "preflight",
+      startedAt: new Date().toISOString(),
+      log: [],
+      runUrl: null,
+      tag: null,
+      error: null
+    };
+    activeReleaseJob = job;
+
+    // Run async — do not await
+    void runReleaseJob(job);
+
+    return reply.code(202).send({ ok: true });
+  });
+
+  app.get("/api/v1/release/stream", async (_request, reply) => {
+    reply.raw.setHeader("Content-Type", "text/event-stream");
+    reply.raw.setHeader("Cache-Control", "no-cache, no-transform");
+    reply.raw.setHeader("Connection", "keep-alive");
+    reply.raw.setHeader("X-Accel-Buffering", "no");
+    reply.hijack();
+
+    const stream = reply.raw;
+    releaseStreamClients.add(stream);
+
+    const heartbeat = setInterval(() => {
+      stream.write(": keepalive\n\n");
+    }, 20_000);
+
+    // Send current job snapshot
+    const snapshot: ReleaseStreamEvent = { type: "snapshot", job: activeReleaseJob };
+    stream.write(`data: ${JSON.stringify(snapshot)}\n\n`);
+
+    stream.on("close", () => {
+      clearInterval(heartbeat);
+      releaseStreamClients.delete(stream);
+    });
+  });
+
+  // --- Health / existing routes ---
 
   app.get("/api/v1/health", async () => {
     const result = await pool.query("SELECT NOW() AS now");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
+import { SettingsPane } from "@/components/app/settings-pane";
 import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
 import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
 import { EditWorktreeModeDialog } from "@/components/app/edit-worktree-mode-dialog";
@@ -112,6 +113,7 @@ export function App(): JSX.Element {
   const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState("Starting...");
 
+  const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createCwd, setCreateCwd] = useState(() => readLastUsedCwd());
@@ -1314,6 +1316,7 @@ export function App(): JSX.Element {
             setLeftOpen={setLeftOpen}
             onOpenCreateDialog={openCreateDialog}
             onOpenEditWorktreeDialog={openEditWorktreeDialog}
+            onOpenSettings={() => setSettingsPaneOpen(true)}
             setOverflowAgentId={setOverflowAgentId}
             setDeleteTarget={setDeleteTarget}
             setDeleteConfirmOpen={setDeleteConfirmOpen}
@@ -1405,6 +1408,7 @@ export function App(): JSX.Element {
             overflowAgentId={overflowAgentId}
             onOpenCreateDialog={openCreateDialog}
             onOpenEditWorktreeDialog={openEditWorktreeDialog}
+            onOpenSettings={() => setSettingsPaneOpen(true)}
             setOverflowAgentId={setOverflowAgentId}
             setDeleteTarget={setDeleteTarget}
             setDeleteConfirmOpen={setDeleteConfirmOpen}
@@ -1492,6 +1496,8 @@ export function App(): JSX.Element {
         setMode={setEditWorktreeMode}
         onSave={saveEditWorktreeMode}
       />
+
+      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} />
 
       <MediaLightbox
         lightboxSrc={lightboxSrc}

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   MonitorOff,
   Play,
   Plus,
+  Settings,
   Square,
   X
 } from "lucide-react";
@@ -26,6 +27,7 @@ type AgentSidebarSharedProps = {
   overflowAgentId: string | null;
   onOpenCreateDialog: () => void;
   onOpenEditWorktreeDialog: (agent: Agent) => void;
+  onOpenSettings: () => void;
   setOverflowAgentId: (value: string | null | ((current: string | null) => string | null)) => void;
   setDeleteTarget: (agent: Agent | null) => void;
   setDeleteConfirmOpen: (open: boolean) => void;
@@ -57,6 +59,7 @@ export function AgentSidebarContent({
   overflowAgentId,
   onOpenCreateDialog,
   onOpenEditWorktreeDialog,
+  onOpenSettings,
   setOverflowAgentId,
   setDeleteTarget,
   setDeleteConfirmOpen,
@@ -142,7 +145,7 @@ export function AgentSidebarContent({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         <TooltipProvider delayDuration={120}>
           {agents.length === 0 ? (
             <div className="p-4 text-sm text-muted-foreground">No agents yet.</div>
@@ -418,6 +421,15 @@ export function AgentSidebarContent({
             })
           )}
         </TooltipProvider>
+      </div>
+      <div className="border-t border-border px-3 pb-[env(safe-area-inset-bottom)]">
+        <button
+          onClick={onOpenSettings}
+          className="flex w-full items-center gap-2 py-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Settings className="h-3.5 w-3.5" />
+          Settings
+        </button>
       </div>
     </aside>
   );

--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -1,0 +1,441 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap, XCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ReleaseVersionType = "patch" | "minor" | "major";
+type ReleasePhase = "preflight" | "triggering" | "watching" | "deploying" | "restarting" | "done" | "failed";
+
+type ReleaseStatus = {
+  tag: string | null;
+  deployedAt: string | null;
+};
+
+type ReleaseInfo = {
+  currentTag: string | null;
+  unreleasedCount: number;
+  commits: Array<{ sha: string; subject: string }>;
+  refMissing?: boolean;
+};
+
+type ReleaseJob = {
+  versionType: ReleaseVersionType;
+  phase: ReleasePhase;
+  startedAt: string;
+  log: string[];
+  runUrl: string | null;
+  tag: string | null;
+  error: string | null;
+};
+
+type ReleaseStreamEvent =
+  | { type: "snapshot"; job: ReleaseJob | null }
+  | { type: "log"; line: string }
+  | { type: "phase"; phase: ReleasePhase; error?: string }
+  | { type: "runUrl"; url: string }
+  | { type: "tag"; tag: string };
+
+const VERSION_CONFIG: Record<ReleaseVersionType, {
+  icon: typeof ShieldCheck;
+  color: string;
+  border: string;
+  bg: string;
+  hover: string;
+}> = {
+  patch: {
+    icon: ShieldCheck,
+    color: "text-emerald-400",
+    border: "border-emerald-500/30",
+    bg: "bg-emerald-500/10",
+    hover: "hover:border-emerald-500/60 hover:bg-emerald-500/20"
+  },
+  minor: {
+    icon: Sparkles,
+    color: "text-blue-400",
+    border: "border-blue-500/30",
+    bg: "bg-blue-500/10",
+    hover: "hover:border-blue-500/60 hover:bg-blue-500/20"
+  },
+  major: {
+    icon: Zap,
+    color: "text-violet-400",
+    border: "border-violet-500/30",
+    bg: "bg-violet-500/10",
+    hover: "hover:border-violet-500/60 hover:bg-violet-500/20"
+  }
+};
+
+const PHASE_LABELS: Record<ReleasePhase, string> = {
+  preflight: "Pre-flight",
+  triggering: "Trigger workflow",
+  watching: "CI running",
+  deploying: "Deploying",
+  restarting: "Restarting",
+  done: "Complete",
+  failed: "Failed"
+};
+
+const PHASES_ORDER: ReleasePhase[] = ["preflight", "triggering", "watching", "deploying", "restarting", "done"];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function cleanError(raw: string): string {
+  // Strip "Command failed (...), exitCode=N, stderr=" wrapper from internal errors
+  const stderrMatch = raw.match(/stderr=(.+)$/s);
+  if (stderrMatch) {
+    const stderr = stderrMatch[1].trim();
+    // Strip "fatal: " prefix git adds
+    return stderr.replace(/^fatal:\s*/i, "");
+  }
+  return raw;
+}
+
+export function ReleaseManager(): JSX.Element {
+  const [status, setStatus] = useState<ReleaseStatus | null>(null);
+  const [info, setInfo] = useState<ReleaseInfo | null>(null);
+  const [infoLoading, setInfoLoading] = useState(false);
+  const [infoError, setInfoError] = useState<string | null>(null);
+  const [job, setJob] = useState<ReleaseJob | null>(null);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+  const [postRestartPolling, setPostRestartPolling] = useState(false);
+
+  const logRef = useRef<HTMLDivElement>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const healthPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/release/status");
+      if (res.ok) setStatus((await res.json()) as ReleaseStatus);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { void fetchStatus(); }, [fetchStatus]);
+
+  // Auto-scroll log
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [job?.log]);
+
+  const startHealthPoll = useCallback((expectedTag: string | null) => {
+    setPostRestartPolling(true);
+    if (healthPollRef.current) clearInterval(healthPollRef.current);
+
+    healthPollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch("/api/v1/release/status");
+        if (res.ok) {
+          const data = (await res.json()) as ReleaseStatus;
+          if (data.tag && data.tag !== expectedTag) {
+            clearInterval(healthPollRef.current!);
+            healthPollRef.current = null;
+            setPostRestartPolling(false);
+            setStatus(data);
+            setJob((prev) => prev ? { ...prev, phase: "done", tag: data.tag } : prev);
+          }
+        }
+      } catch { /* server still down */ }
+    }, 2000);
+  }, []);
+
+  const connectStream = useCallback(() => {
+    eventSourceRef.current?.close();
+    const es = new EventSource("/api/v1/release/stream");
+    eventSourceRef.current = es;
+
+    es.onmessage = (e) => {
+      const event = JSON.parse(e.data as string) as ReleaseStreamEvent;
+      if (event.type === "snapshot") {
+        setJob(event.job);
+        return;
+      }
+      setJob((prev) => {
+        if (!prev) return prev;
+        if (event.type === "log") return { ...prev, log: [...prev.log, event.line] };
+        if (event.type === "phase") return { ...prev, phase: event.phase, error: event.error ?? prev.error };
+        if (event.type === "runUrl") return { ...prev, runUrl: event.url };
+        if (event.type === "tag") return { ...prev, tag: event.tag };
+        return prev;
+      });
+    };
+
+    es.onerror = () => {
+      setJob((prev) => {
+        if (prev?.phase === "restarting" || prev?.phase === "deploying") {
+          startHealthPoll(prev.tag);
+          return { ...prev, phase: "restarting" };
+        }
+        return prev;
+      });
+      es.close();
+      eventSourceRef.current = null;
+    };
+  }, [startHealthPoll]);
+
+  // On mount, connect to SSE so we pick up any in-progress or recently finished job
+  useEffect(() => {
+    connectStream();
+    return () => {
+      eventSourceRef.current?.close();
+      if (healthPollRef.current) clearInterval(healthPollRef.current);
+    };
+  }, [connectStream]);
+
+  const handleCheckForUpdates = async () => {
+    setInfoLoading(true);
+    setInfoError(null);
+    setInfo(null);
+    try {
+      const res = await fetch("/api/v1/release/info");
+      if (!res.ok) {
+        const err = (await res.json()) as { error?: string };
+        setInfoError(cleanError(err.error ?? "Failed to check for updates"));
+        return;
+      }
+      setInfo((await res.json()) as ReleaseInfo);
+    } catch (err) {
+      setInfoError(err instanceof Error ? cleanError(err.message) : "Failed to check for updates");
+    } finally {
+      setInfoLoading(false);
+    }
+  };
+
+  const handleRelease = async (versionType: ReleaseVersionType) => {
+    setReleaseError(null);
+    const res = await fetch("/api/v1/release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ versionType })
+    });
+    if (!res.ok) {
+      const err = (await res.json()) as { error?: string };
+      setReleaseError(cleanError(err.error ?? "Failed to start release"));
+      return;
+    }
+    setJob({ versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
+    connectStream();
+  };
+
+  const isReleasing = job !== null && !["done", "failed"].includes(job.phase) && !postRestartPolling;
+  const isDone = job?.phase === "done" || (!postRestartPolling && job?.phase === "restarting" && status?.tag === job?.tag);
+  const isFailed = job?.phase === "failed";
+  const isRestarting = job?.phase === "restarting" || postRestartPolling;
+  const showLog = job !== null;
+  const phaseIndex = job ? PHASES_ORDER.indexOf(job.phase) : -1;
+
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Left column — controls */}
+      <div className="flex w-[360px] shrink-0 flex-col gap-6 overflow-y-auto border-r border-border p-6">
+
+        {/* Current version */}
+        <div>
+          <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Deployed version</div>
+          {status ? (
+            <div className="flex items-baseline gap-2">
+              <span className="font-mono text-xl font-bold text-foreground">{status.tag ?? "unknown"}</span>
+              {status.deployedAt ? (
+                <span className="text-xs text-muted-foreground">{formatDate(status.deployedAt)}</span>
+              ) : null}
+            </div>
+          ) : (
+            <span className="text-sm text-muted-foreground">Loading…</span>
+          )}
+        </div>
+
+        {/* Check for updates / info — hidden while a release is active */}
+        {!isReleasing && !isDone && (
+          <div className="flex flex-col gap-4">
+            {!info && !infoLoading && (
+              <button
+                onClick={() => void handleCheckForUpdates()}
+                className="self-start rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+              >
+                Check for updates
+              </button>
+            )}
+
+            {infoLoading && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Fetching…
+              </div>
+            )}
+
+            {infoError && (
+              <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {infoError}
+              </div>
+            )}
+
+            {info && (
+              <>
+                {info.refMissing ? (
+                  <div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
+                    Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
+                  </div>
+                ) : info.unreleasedCount === 0 ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    Up to date
+                  </div>
+                ) : (
+                  <div>
+                    <div className="mb-2 text-xs text-muted-foreground">
+                      {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
+                      <span className="font-mono">main</span>
+                    </div>
+                    <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
+                      {info.commits.map((c) => (
+                        <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
+                          <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
+                          <span className="text-foreground">{c.subject}</span>
+                        </div>
+                      ))}
+                      {info.unreleasedCount > info.commits.length && (
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          +{info.unreleasedCount - info.commits.length} more
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {(info.refMissing || info.unreleasedCount > 0) && (
+                  <>
+                    {releaseError && (
+                      <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        {releaseError}
+                      </div>
+                    )}
+
+                    <div className="flex flex-col gap-2">
+                      <div className="mb-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release type</div>
+                      {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
+                        const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
+                        return (
+                          <button
+                            key={type}
+                            onClick={() => void handleRelease(type)}
+                            className={cn(
+                              "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
+                              border, bg, hover
+                            )}
+                          >
+                            <Icon className={cn("h-5 w-5", color)} />
+                            <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Phase progress — shown when a release is running or finished */}
+        {job && (
+          <div className="flex flex-col gap-4">
+            <div>
+              <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Progress</div>
+              <div className="flex flex-col gap-2">
+                {PHASES_ORDER.filter((p) => p !== "done").map((phase, i) => {
+                  const current = phaseIndex === i;
+                  const done = phaseIndex > i || job.phase === "done";
+                  return (
+                    <div key={phase} className="flex items-center gap-3">
+                      <div className={cn(
+                        "h-2 w-2 rounded-full shrink-0",
+                        done && "bg-green-500",
+                        current && !isFailed && "animate-pulse bg-primary",
+                        current && isFailed && "bg-destructive",
+                        !done && !current && "bg-muted"
+                      )} />
+                      <span className={cn(
+                        "text-sm",
+                        done && "text-muted-foreground",
+                        current && !isFailed && "text-foreground font-medium",
+                        current && isFailed && "text-destructive font-medium",
+                        !done && !current && "text-muted-foreground/50"
+                      )}>
+                        {PHASE_LABELS[phase]}
+                      </span>
+                      {current && isRestarting && phase === "restarting" && (
+                        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {job.runUrl && (
+              <a
+                href={job.runUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
+              >
+                <ExternalLink className="h-3 w-3" />
+                View GitHub Actions run
+              </a>
+            )}
+
+            {isDone && (
+              <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
+                <CheckCircle2 className="h-4 w-4 shrink-0" />
+                <span>
+                  Deployed <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
+                </span>
+              </div>
+            )}
+
+            {isFailed && (
+              <div className="flex items-start gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{job.error ? cleanError(job.error) : "Release failed"}</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Right column — log */}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {showLog ? (
+          <div
+            ref={logRef}
+            className="min-h-0 flex-1 overflow-y-auto bg-black/60 p-4 font-mono text-[12px] leading-relaxed text-green-300"
+          >
+            {job!.log
+              .filter((line) => line.trim() !== "DISPATCH_RESTARTING")
+              .map((line, i) => (
+                <div key={i}>{line || "\u00A0"}</div>
+              ))}
+            {isRestarting && !job?.log.length && (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Waiting for Dispatch to restart…
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground/40">
+            Log output will appear here during a release
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,0 +1,67 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Rocket, X } from "lucide-react";
+
+import { ReleaseManager } from "@/components/app/release-manager";
+import { cn } from "@/lib/utils";
+
+type SettingsSection = "release";
+
+const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof Rocket }> = [
+  { id: "release", label: "Release", icon: Rocket }
+];
+
+type SettingsPaneProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function SettingsPane({ open, onClose }: SettingsPaneProps): JSX.Element {
+  const activeSection: SettingsSection = "release";
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content className="fixed inset-4 z-50 flex flex-col overflow-hidden rounded-sm border border-border bg-card text-foreground shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <DialogPrimitive.Title className="sr-only">Settings</DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">Dispatch settings and release manager</DialogPrimitive.Description>
+
+          {/* Header */}
+          <div className="flex h-12 shrink-0 items-center border-b border-border px-5">
+            <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Settings</span>
+            <DialogPrimitive.Close className="ml-auto rounded-sm p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </div>
+
+          {/* Body */}
+          <div className="flex min-h-0 flex-1">
+            {/* Nav */}
+            <nav className="flex w-40 shrink-0 flex-col border-r border-border py-2">
+              {SECTIONS.map(({ id, label, icon: Icon }) => (
+                <div
+                  key={id}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2.5 px-4 py-2.5 text-sm transition-colors",
+                    activeSection === id
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5 shrink-0" />
+                  {label}
+                </div>
+              ))}
+            </nav>
+
+            {/* Content */}
+            <div className="min-h-0 min-w-0 flex-1">
+              {activeSection === "release" && <ReleaseManager />}
+            </div>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -48,11 +48,9 @@ export default defineConfig({
   ],
   server: {
     host: "127.0.0.1",
-    port: 5173,
-    strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8787",
+        target: `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 8787}`,
         changeOrigin: true,
         ws: true
       }


### PR DESCRIPTION
## Summary
- Adds a full-area Settings dialog (accessible from agent sidebar) with a Release Manager section
- Shows deployed version from `~/.dispatch/release.json`, lazily checks for unreleased commits on `origin/main`
- Color-coded release type buttons (patch/minor/major) that trigger the GitHub Actions workflow + local deploy pipeline
- Live SSE streaming of release log with phase progress indicators (preflight → triggering → watching → deploying → restarting → done/failed)
- Graceful server restart handling: detects `DISPATCH_RESTARTING` sentinel, health-polls until new version appears
- Fixes release workflow CI bug: annotated tag so `--follow-tags` actually pushes it

## Test plan
- [x] "Up to date" state when no unreleased commits
- [x] Unreleased commits list with release buttons
- [x] refMissing warning with release buttons still available
- [x] CI watching phase with live log streaming
- [x] Restarting phase with spinner
- [x] Done state with success banner
- [x] Failed state with error message
- [x] Duplicate job guard (409)
- [x] SSE snapshot restore on page reload
- [x] GitHub Actions link (blue, tight click target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)