### PR TITLE
Change default port from 8787 to 6767

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 HOST=0.0.0.0
-DISPATCH_PORT=8787
+DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=change-me
 MEDIA_ROOT=/tmp/dispatch-media

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,6 @@
 - If multiple local Dispatch instances are running, always use the exact URL printed by the active Vite process for Playwright/manual checks.
 
 ## Backend Testing Safety
-- Treat `127.0.0.1:8787` as production by default; do not stop or kill the existing production server for ad-hoc testing.
+- Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, run a separate backend instance on a different port (for example `DISPATCH_PORT=8788 npm run dev`) and point validation tooling to that port.
-- Only operate on production (`:8787`) when explicitly requested by the user.
+- Only operate on production (`:6767`) when explicitly requested by the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,6 @@
 - If multiple local Dispatch instances are running, always use the exact URL printed by the active Vite process for Playwright/manual checks.
 
 ## Backend Testing Safety
-- Treat `127.0.0.1:8787` as production by default; do not stop or kill the existing production server for ad-hoc testing.
+- Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, run a separate backend instance on a different port (for example `DISPATCH_PORT=8788 npm run dev`) and point validation tooling to that port.
-- Only operate on production (`:8787`) when explicitly requested by the user.
+- Only operate on production (`:6767`) when explicitly requested by the user.

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ Dispatch is a local-first control plane for running and managing multiple Codex 
    - `npm install`
    - `npm run dev`
 4. Verify:
-   - UI: `http://127.0.0.1:8787`
-   - Health: `http://127.0.0.1:8787/api/v1/health`
+   - UI: `http://127.0.0.1:6767`
+   - Health: `http://127.0.0.1:6767/api/v1/health`
 
 ## Operations Quick Commands
 
 - Default release flow (no launchd, build + restart tmux + health): `bin/dispatch-server update`
 - Compatibility alias for release: `bin/dispatch-deploy` (delegates to tmux release flow)
 - Optional interactive debug mode in tmux: `bin/dispatch-server start|stop|status|logs|attach`
-- Git context worker diagnostics: `curl -s http://127.0.0.1:8787/api/v1/diagnostics/git-context | jq`
+- Git context worker diagnostics: `curl -s http://127.0.0.1:6767/api/v1/diagnostics/git-context | jq`
 
 ## Media Sharing
 

--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SERVER_DIR="${DISPATCH_SERVER_DIR:-$HOME/.dispatch/server}"
-DEFAULT_PORT="8787"
+DEFAULT_PORT="6767"
 PLIST="$HOME/Library/LaunchAgents/com.dispatch.server.plist"
 LOG_FILE="$HOME/.dispatch/logs/dispatch.log"
 FAILURE_LOG="$HOME/.dispatch/logs/last-release-failure.log"

--- a/bin/dispatch-event
+++ b/bin/dispatch-event
@@ -41,7 +41,7 @@ if [ -z "$AGENT_ID" ]; then
   exit 1
 fi
 
-PORT="${DISPATCH_PORT:-8787}"
+PORT="${DISPATCH_PORT:-6767}"
 API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${PORT}}"
 
 if [ -n "$METADATA_RAW" ]; then

--- a/bin/dispatch-release
+++ b/bin/dispatch-release
@@ -64,7 +64,7 @@ is needed, you can run: bin/dispatch-deploy --latest
 
 Report your findings via dispatch-event."
 
-  local port="${DISPATCH_PORT:-8787}"
+  local port="${DISPATCH_PORT:-6767}"
 
   echo "==> spawning diagnosis agent..."
   curl -fsS -X POST "http://127.0.0.1:${port}/api/v1/agents" \

--- a/bin/dispatch-server
+++ b/bin/dispatch-server
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SESSION_NAME="dispatch-server"
-DEFAULT_PORT="8787"
+DEFAULT_PORT="6767"
 
 usage() {
   cat <<USAGE

--- a/bin/install-launchd
+++ b/bin/install-launchd
@@ -17,7 +17,7 @@ Installs Dispatch as a launchd service. Clones the repo to $SERVER_DIR,
 does an initial build, and loads the service.
 
 Options:
-  --port <port>   Port to listen on (default: 8787)
+  --port <port>   Port to listen on (default: 6767)
 
 Examples:
   bin/install-launchd
@@ -121,7 +121,7 @@ launchctl load "$PLIST"
 echo ""
 echo "installed and started Dispatch as a launchd service"
 echo "server directory: $SERVER_DIR"
-echo "port:             ${PORT:-8787}"
+echo "port:             ${PORT:-6767}"
 echo "logs:             tail -f $LOG_FILE"
 echo ""
 echo "useful commands:"

--- a/docs/08-current-state-handoff.md
+++ b/docs/08-current-state-handoff.md
@@ -132,7 +132,7 @@ From `/Users/bharris/dev/apps/hostess`:
 3. `npm install`
 4. `npm run build`
 5. `npm run start`
-6. Open `http://127.0.0.1:8787`
+6. Open `http://127.0.0.1:6767`
 
 For development:
 - `npm run dev` (backend watch mode)

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -119,7 +119,7 @@ PRs must pass CI before merge.
 To install Dispatch as a launchd service on a new machine:
 
 ```bash
-# Install on default port (8787)
+# Install on default port (6767)
 bin/install-launchd
 
 # Install on a custom port
@@ -149,7 +149,7 @@ Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 
 | Variable | Default | Description |
 |---|---|---|
-| `DISPATCH_PORT` | `8787` | HTTP port the server listens on |
+| `DISPATCH_PORT` | `6767` | HTTP port the server listens on |
 | `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
 | `MEDIA_ROOT` | `/tmp/dispatch-media` | File upload storage path |
 | `ANTHROPIC_API_KEY` | — | Required for Claude agents |

--- a/docs/11-backend-compatibility-checklist.md
+++ b/docs/11-backend-compatibility-checklist.md
@@ -31,7 +31,7 @@ Use this checklist for backend changes when running a single always-on tmux back
 2. Confirm tmux restart path works:
    - `bin/dispatch-server update`
 3. Confirm health endpoint remains stable:
-   - `curl -sS http://127.0.0.1:8787/api/v1/health`
+   - `curl -sS http://127.0.0.1:6767/api/v1/health`
 
 ## Review Gate (Before Merge)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export type AppConfig = {
 export function loadConfig(): AppConfig {
   return {
     host: process.env.HOST ?? "0.0.0.0",
-    port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 8787),
+    port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 6767),
     databaseUrl:
       process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
     authToken: process.env.AUTH_TOKEN ?? "dev-token",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     host: "127.0.0.1",
     proxy: {
       "/api": {
-        target: `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 8787}`,
+        target: `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 6767}`,
         changeOrigin: true,
         ws: true
       }


### PR DESCRIPTION
## Summary
- Updates all default port references from 8787 to 6767 across scripts, config, docs, and examples
- The production server runs on 6767 (via `.env`), but scripts like `dispatch-deploy` and `dispatch-event` defaulted to 8787, causing the deploy health check to fail

## Test plan
- [x] `v0.1.2` deployed successfully with `DISPATCH_PORT=6767` after the health check fix
- [x] Verified no remaining `8787` references in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)