### PR TITLE
fix(deploy): read port from .env instead of inherited DISPATCH_PORT

### DIFF
--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -35,8 +35,26 @@ load_nvm() {
   fi
 }
 
+resolve_port() {
+  # Read the port from the server's .env file (authoritative source),
+  # falling back to DEFAULT_PORT. We intentionally ignore the inherited
+  # DISPATCH_PORT env var because it may come from an agent shell that
+  # was spawned with a stale port value.
+  local env_file="$SERVER_DIR/.env"
+  if [[ -f "$env_file" ]]; then
+    local env_port
+    env_port=$(grep -E '^DISPATCH_PORT=' "$env_file" | tail -1 | cut -d= -f2)
+    if [[ -n "$env_port" ]]; then
+      echo "$env_port"
+      return
+    fi
+  fi
+  echo "$DEFAULT_PORT"
+}
+
 health_check() {
-  local port="${DISPATCH_PORT:-$DEFAULT_PORT}"
+  local port
+  port=$(resolve_port)
   curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
 }
 

--- a/bin/dispatch-release
+++ b/bin/dispatch-release
@@ -64,7 +64,13 @@ is needed, you can run: bin/dispatch-deploy --latest
 
 Report your findings via dispatch-event."
 
-  local port="${DISPATCH_PORT:-6767}"
+  local port="6767"
+  local env_file="$ROOT_DIR/.env"
+  if [[ -f "$env_file" ]]; then
+    local env_port
+    env_port=$(grep -E '^DISPATCH_PORT=' "$env_file" | tail -1 | cut -d= -f2)
+    [[ -n "$env_port" ]] && port="$env_port"
+  fi
 
   echo "==> spawning diagnosis agent..."
   curl -fsS -X POST "http://127.0.0.1:${port}/api/v1/agents" \

--- a/bin/dispatch-server
+++ b/bin/dispatch-server
@@ -42,8 +42,22 @@ is_running() {
   tmux has-session -t "$SESSION_NAME" 2>/dev/null
 }
 
+resolve_port() {
+  local env_file="$ROOT_DIR/.env"
+  if [[ -f "$env_file" ]]; then
+    local env_port
+    env_port=$(grep -E '^DISPATCH_PORT=' "$env_file" | tail -1 | cut -d= -f2)
+    if [[ -n "$env_port" ]]; then
+      echo "$env_port"
+      return
+    fi
+  fi
+  echo "$DEFAULT_PORT"
+}
+
 health_check() {
-  local port="${DISPATCH_PORT:-$DEFAULT_PORT}"
+  local port
+  port=$(resolve_port)
   curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
 }
 


### PR DESCRIPTION
## Summary
- Deploy health checks were failing because agent shells inherit `DISPATCH_PORT` from spawn time, which can be stale after a port default change
- All three scripts (`dispatch-deploy`, `dispatch-server`, `dispatch-release`) now read the port from the server's `.env` file as the authoritative source
- Falls back to `DEFAULT_PORT` only if `.env` is missing

## Test plan
- [x] Verified `resolve_port` returns 6767 from `.env` even when `DISPATCH_PORT=8787` is in the environment
- [x] Health check passes against running server with the fix
- [x] Full `launchctl unload/load` restart cycle: server came back healthy on attempt 3 (~5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)