### PR TITLE
Animate header logo on sidebar toggle

### DIFF
--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -36,26 +36,32 @@ export function AppHeader({
 }: AppHeaderProps): JSX.Element {
   return (
     <header className={cn("relative flex h-14 items-center border-b-2 border-b-border bg-[#11120f] px-3 pt-[env(safe-area-inset-top)]")}>
-      <div className="flex shrink-0 items-center gap-2">
-        {(!leftOpen || isMobile) ? (
-          <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
-            <PanelRightOpen className="h-4 w-4" />
-          </Button>
-        ) : null}
-        {!isMobile ? (
+      <div className="flex shrink-0 items-center gap-1">
+        {isMobile ? (
+          !leftOpen ? (
+            <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
+              <PanelRightOpen className="h-4 w-4" />
+            </Button>
+          ) : null
+        ) : (
           <div
             className={cn(
-              "overflow-hidden transition-[width,opacity] duration-300 ease-out",
-              leftOpen ? "w-0 opacity-0" : "w-7 opacity-100"
+              "flex items-center gap-1 transition-[opacity,transform] duration-300 ease-out",
+              leftOpen
+                ? "pointer-events-none -translate-x-3 opacity-0"
+                : "translate-x-0 opacity-100 delay-150"
             )}
           >
+            <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
+              <PanelRightOpen className="h-4 w-4" />
+            </Button>
             <img
               src="/brand-icon.svg"
               alt="Dispatch logo"
               className="h-6 w-auto object-contain"
             />
           </div>
-        ) : null}
+        )}
       </div>
 
       {showHeaderStatus ? (

--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -42,7 +42,20 @@ export function AppHeader({
             <PanelRightOpen className="h-4 w-4" />
           </Button>
         ) : null}
-        {!isMobile ? <img src="/brand-icon.svg" alt="Dispatch logo" className="h-6 w-auto object-contain" /> : null}
+        {!isMobile ? (
+          <div
+            className={cn(
+              "overflow-hidden transition-[width,opacity] duration-300 ease-out",
+              leftOpen ? "w-0 opacity-0" : "w-7 opacity-100"
+            )}
+          >
+            <img
+              src="/brand-icon.svg"
+              alt="Dispatch logo"
+              className="h-6 w-auto object-contain"
+            />
+          </div>
+        ) : null}
       </div>
 
       {showHeaderStatus ? (


### PR DESCRIPTION
## Summary
- Hide the Dispatch logo in the header when the agent sidebar is open (since the sidebar already shows it)
- Slide/fade the logo into the header with a 300ms ease-out transition when the sidebar collapses, matching existing sidebar animation timing
- Uses CSS `width` + `opacity` transition on a wrapper div for a clean slide-fade effect

## Test plan
- [ ] Open the app with the sidebar open — header should have no logo
- [ ] Close the sidebar — logo should smoothly slide and fade into the header
- [ ] Re-open the sidebar — logo should smoothly slide and fade out of the header
- [ ] Verify on mobile — logo should not appear in the header (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)