### PR TITLE
Fix lightbox ESC key event propagation

### DIFF
--- a/web/src/components/app/media-lightbox.tsx
+++ b/web/src/components/app/media-lightbox.tsx
@@ -20,6 +20,8 @@ export function MediaLightbox({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         setLightboxSrc(null);
       }
     };


### PR DESCRIPTION
## Summary
- Adds `preventDefault()` and `stopPropagation()` to the Escape keydown handler in `MediaLightbox`, preventing the event from bubbling to other key listeners when closing the lightbox.

## Test plan
- [ ] Open a media item to full screen
- [ ] Press ESC to close — verify it closes without triggering other ESC-bound actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)