### PR TITLE
Fix UI-triggered release failing to update release record

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -144,6 +144,7 @@ type ReleaseJob = {
 type ReleaseStreamEvent =
   | { type: "snapshot"; job: ReleaseJob | null }
   | { type: "log"; line: string }
+  | { type: "log.replace"; line: string }
   | { type: "phase"; phase: ReleasePhase; error?: string }
   | { type: "runUrl"; url: string }
   | { type: "tag"; tag: string };
@@ -169,6 +170,15 @@ function appendReleaseLog(job: ReleaseJob, line: string): void {
   broadcastReleaseEvent({ type: "log", line });
 }
 
+function replaceReleaseLog(job: ReleaseJob, line: string): void {
+  if (job.log.length > 0) {
+    job.log[job.log.length - 1] = line;
+  } else {
+    job.log.push(line);
+  }
+  broadcastReleaseEvent({ type: "log.replace", line });
+}
+
 function setReleasePhase(job: ReleaseJob, phase: ReleasePhase, error?: string): void {
   job.phase = phase;
   broadcastReleaseEvent({ type: "phase", phase, error });
@@ -188,13 +198,34 @@ function streamProcess(
     });
 
     let buffer = "";
+    let lastWasCR = false;
     const processChunk = (chunk: Buffer): void => {
       buffer += chunk.toString();
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";
       for (const line of lines) {
-        appendReleaseLog(job, line);
-        onLine?.(line);
+        // A line may contain \r-separated segments (in-place terminal updates).
+        // Only the final segment matters; earlier ones were meant to be overwritten.
+        const crParts = line.split("\r").filter(Boolean);
+        if (crParts.length > 1 || lastWasCR) {
+          // Replace the previous log entry with the last \r segment
+          const final = crParts[crParts.length - 1] ?? "";
+          replaceReleaseLog(job, final);
+          onLine?.(final);
+        } else {
+          appendReleaseLog(job, crParts[0] ?? line);
+          onLine?.(crParts[0] ?? line);
+        }
+        lastWasCR = false;
+      }
+      // If the remaining buffer contains \r, the next output will overwrite
+      if (buffer.includes("\r")) {
+        const crParts = buffer.split("\r").filter(Boolean);
+        const final = crParts[crParts.length - 1] ?? "";
+        replaceReleaseLog(job, final);
+        onLine?.(final);
+        buffer = "";
+        lastWasCR = true;
       }
     };
 
@@ -299,23 +330,38 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
     broadcastReleaseEvent({ type: "tag", tag });
     appendReleaseLog(job, `==> release workflow produced tag: ${tag}`);
 
-    // Deploy
+    // Deploy — build inline instead of shelling out to dispatch-deploy,
+    // because dispatch-deploy would be killed as part of the server's
+    // process group when launchd restarts the service.
     setReleasePhase(job, "deploying");
-    const deployBin = path.join(serverDir, "bin", "dispatch-deploy");
 
-    // Watch for the DISPATCH_RESTARTING marker to send the restarting phase
-    // before launchctl kills this server process.
-    await streamProcess(deployBin, [tag], { cwd: serverDir }, job, (line) => {
-      if (line.trim() === "DISPATCH_RESTARTING") {
-        setReleasePhase(job, "restarting");
-      }
-    });
+    appendReleaseLog(job, `==> checking out ${tag}`);
+    await runCommand("git", ["-C", serverDir, "checkout", tag]);
 
-    // If we reach here the deploy succeeded without restarting (unusual),
-    // mark done and write the store ourselves.
-    job.phase = "done";
+    appendReleaseLog(job, "==> installing dependencies");
+    await streamProcess("npm", ["ci", "--silent"], { cwd: serverDir }, job);
+    await streamProcess("npm", ["--prefix", "web", "ci", "--silent"], { cwd: serverDir }, job);
+
+    appendReleaseLog(job, "==> building");
+    await streamProcess("npm", ["run", "build"], { cwd: serverDir }, job);
+
+    // Write release record BEFORE the restart — after the restart our
+    // process is dead and can't write anything.
     await writeReleaseStore({ tag, deployedAt: new Date().toISOString() });
-    broadcastReleaseEvent({ type: "phase", phase: "done" });
+    appendReleaseLog(job, `==> wrote release record for ${tag}`);
+
+    // Tell SSE clients we're about to restart
+    setReleasePhase(job, "restarting");
+    appendReleaseLog(job, "==> restarting service");
+
+    // Trigger the restart. launchctl kill sends SIGKILL to this process
+    // (and its process group). KeepAlive ensures launchd restarts it
+    // with the newly built code. The UI health-poll takes over from here.
+    const uid = process.getuid?.() ?? 501;
+    spawn("launchctl", ["kill", "SIGKILL", `gui/${uid}/com.dispatch.server`], {
+      detached: true,
+      stdio: "ignore"
+    }).unref();
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     if (activeReleaseJob) {

--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -31,6 +31,7 @@ type ReleaseJob = {
 type ReleaseStreamEvent =
   | { type: "snapshot"; job: ReleaseJob | null }
   | { type: "log"; line: string }
+  | { type: "log.replace"; line: string }
   | { type: "phase"; phase: ReleasePhase; error?: string }
   | { type: "runUrl"; url: string }
   | { type: "tag"; tag: string };
@@ -135,7 +136,7 @@ export function ReleaseManager(): JSX.Element {
         const res = await fetch("/api/v1/release/status");
         if (res.ok) {
           const data = (await res.json()) as ReleaseStatus;
-          if (data.tag && data.tag !== expectedTag) {
+          if (data.tag && data.tag === expectedTag) {
             clearInterval(healthPollRef.current!);
             healthPollRef.current = null;
             setPostRestartPolling(false);
@@ -161,6 +162,15 @@ export function ReleaseManager(): JSX.Element {
       setJob((prev) => {
         if (!prev) return prev;
         if (event.type === "log") return { ...prev, log: [...prev.log, event.line] };
+        if (event.type === "log.replace") {
+          const updated = [...prev.log];
+          if (updated.length > 0) {
+            updated[updated.length - 1] = event.line;
+          } else {
+            updated.push(event.line);
+          }
+          return { ...prev, log: updated };
+        }
         if (event.type === "phase") return { ...prev, phase: event.phase, error: event.error ?? prev.error };
         if (event.type === "runUrl") return { ...prev, runUrl: event.url };
         if (event.type === "tag") return { ...prev, tag: event.tag };


### PR DESCRIPTION
## Summary
- **Root cause:** `dispatch-deploy` runs as a child of the server. When launchd restarts the service, it kills the entire process group — `dispatch-deploy` dies before writing `release.json`. The server runs the new code but reports the old version.
- **Server fix:** Inline the build steps (git checkout, npm ci, npm run build) directly in `runReleaseJob` and write `release.json` *before* triggering the restart. No more reliance on a subprocess surviving the kill.
- **UI fix:** Health poll condition was `tag !== expected` (resolved immediately with the old tag). Changed to `tag === expected` so it waits for the new tag to appear after restart.

## Test plan
- [ ] Merge, then trigger a patch release from the UI
- [ ] Verify the release progress shows all phases through "Restarting"
- [ ] After restart, confirm the UI resolves to "Done" with the correct new tag
- [ ] Verify `~/.dispatch/release.json` has the new tag
- [ ] Verify `/api/v1/release/status` reports the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)