### PR TITLE
Add Playwright stream capture on end

### DIFF
--- a/bin/dispatch-share
+++ b/bin/dispatch-share
@@ -4,12 +4,13 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  dispatch-share <image-path> [name]
-  dispatch-share --sim [udid] [name]
+  dispatch-share <image-path> [name] [-d "description"]
+  dispatch-share --sim [udid] [name] [-d "description"]
 
 Examples:
   dispatch-share ./artifacts/homepage.png
   dispatch-share ./artifacts/homepage.png playwright-home.png
+  dispatch-share ./artifacts/homepage.png -d "Homepage after login flow"
   dispatch-share --sim
   dispatch-share --sim booted ios-home.png
 USAGE
@@ -24,6 +25,23 @@ if [[ -z "$AGENT_ID" ]]; then
 fi
 
 timestamp="$(date +%Y%m%d-%H%M%S)"
+
+# Extract -d/--description from args
+DESCRIPTION=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--description)
+      DESCRIPTION="${2:-}"
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${ARGS[@]}"
 
 SOURCE_PATH=""
 SOURCE_TYPE="screenshot"
@@ -69,9 +87,15 @@ ext="${safe_name##*.}"
 base="${safe_name%.*}"
 upload_name="${base}-${timestamp}.${ext}"
 
-response="$(curl -fsS -X POST \
-  -F "file=@${SOURCE_PATH};filename=${upload_name}" \
-  -F "source=${SOURCE_TYPE}" \
-  "${API_BASE}/api/v1/agents/${AGENT_ID}/media")"
+CURL_ARGS=(
+  -fsS -X POST
+  -F "source=${SOURCE_TYPE}"
+)
+if [[ -n "$DESCRIPTION" ]]; then
+  CURL_ARGS+=(-F "description=${DESCRIPTION}")
+fi
+CURL_ARGS+=(-F "file=@${SOURCE_PATH};filename=${upload_name}")
+
+response="$(curl "${CURL_ARGS[@]}" "${API_BASE}/api/v1/agents/${AGENT_ID}/media")"
 
 echo "$response"

--- a/bin/dispatch-stream
+++ b/bin/dispatch-stream
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  dispatch-stream start --playwright <port>
+  dispatch-stream stop
+
+Examples:
+  dispatch-stream start --playwright 62816
+  dispatch-stream stop
+USAGE
+}
+
+if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+ACTION="${1:-}"
+
+AGENT_ID="${DISPATCH_AGENT_ID:-${HOSTESS_AGENT_ID:-}}"
+if [ -z "$AGENT_ID" ]; then
+  echo "DISPATCH_AGENT_ID is not set. Run this command inside a Dispatch agent session." >&2
+  exit 1
+fi
+
+PORT="${DISPATCH_PORT:-8787}"
+API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${PORT}}"
+
+case "$ACTION" in
+  start)
+    if [ "${2:-}" != "--playwright" ]; then
+      echo "Usage: dispatch-stream start --playwright <port>" >&2
+      exit 1
+    fi
+    CDP_PORT="${3:-}"
+    if [ -z "$CDP_PORT" ]; then
+      echo "Port is required for --playwright." >&2
+      exit 1
+    fi
+    PAYLOAD="{\"type\":\"playwright\",\"port\":${CDP_PORT}}"
+    ;;
+  stop)
+    PAYLOAD='{"type":"stop"}'
+    ;;
+  *)
+    echo "Invalid action: $ACTION" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+curl -fsS \
+  -X POST \
+  -H "content-type: application/json" \
+  --data "$PAYLOAD" \
+  "${API_BASE}/api/v1/agents/${AGENT_ID}/stream" >/dev/null
+
+echo "Stream ${ACTION}: ${AGENT_ID}"

--- a/bin/dispatch-stream
+++ b/bin/dispatch-stream
@@ -5,11 +5,12 @@ usage() {
   cat <<'USAGE'
 Usage:
   dispatch-stream start --playwright <port>
-  dispatch-stream stop
+  dispatch-stream stop [-d "description"]
 
 Examples:
   dispatch-stream start --playwright 62816
   dispatch-stream stop
+  dispatch-stream stop -d "Browsing bradharris.dev homepage"
 USAGE
 }
 
@@ -19,6 +20,7 @@ if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
 fi
 
 ACTION="${1:-}"
+shift
 
 AGENT_ID="${DISPATCH_AGENT_ID:-${HOSTESS_AGENT_ID:-}}"
 if [ -z "$AGENT_ID" ]; then
@@ -31,11 +33,11 @@ API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${PORT}}"
 
 case "$ACTION" in
   start)
-    if [ "${2:-}" != "--playwright" ]; then
+    if [ "${1:-}" != "--playwright" ]; then
       echo "Usage: dispatch-stream start --playwright <port>" >&2
       exit 1
     fi
-    CDP_PORT="${3:-}"
+    CDP_PORT="${2:-}"
     if [ -z "$CDP_PORT" ]; then
       echo "Port is required for --playwright." >&2
       exit 1
@@ -43,7 +45,25 @@ case "$ACTION" in
     PAYLOAD="{\"type\":\"playwright\",\"port\":${CDP_PORT}}"
     ;;
   stop)
-    PAYLOAD='{"type":"stop"}'
+    DESCRIPTION=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -d|--description)
+          DESCRIPTION="${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [ -n "$DESCRIPTION" ]; then
+      # Escape double quotes in description for JSON
+      ESCAPED="$(echo "$DESCRIPTION" | sed 's/"/\\"/g')"
+      PAYLOAD="{\"type\":\"stop\",\"description\":\"${ESCAPED}\"}"
+    else
+      PAYLOAD='{"type":"stop"}'
+    fi
     ;;
   *)
     echo "Invalid action: $ACTION" >&2

--- a/docs/db-backed-media-store-plan.md
+++ b/docs/db-backed-media-store-plan.md
@@ -1,0 +1,157 @@
+# DB-Backed Media Store — Implementation Plan
+
+## Overview
+
+Replace the filesystem-watcher-based media discovery system with a DB-backed media store. Every shared artifact (screenshots via `dispatch-share`, stream captures, simulator screenshots) gets a row in a `media` table at creation time. Media listing becomes a DB query instead of `readdir` + `fs.watch`.
+
+## Motivation
+
+- **Eliminate filesystem polling**: The current `fs.watch` + debounce machinery is fragile (platform-specific behavior, race conditions on rapid writes, no ordering guarantees).
+- **Source tagging**: A `source` column naturally distinguishes screenshots, stream captures, and simulator captures — no filename conventions needed.
+- **Single source of truth**: DB record is the authority; the file on disk is just storage.
+- **Foundation for stream captures**: The Playwright streaming feature needs to save a last-frame capture when a stream ends. With a DB record, the frontend knows it's a stream capture without guessing.
+
+## DB Migration
+
+```sql
+CREATE TABLE IF NOT EXISTS media (
+  id SERIAL PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  file_name TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'screenshot',  -- 'screenshot' | 'stream' | 'simulator'
+  size_bytes INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_media_agent_id ON media(agent_id);
+```
+
+No changes to the existing `media_seen` table — it continues to reference media keys (which can be derived from `file_name:created_at`).
+
+## New API Endpoint
+
+### `POST /api/v1/agents/:id/media`
+
+Accepts a multipart file upload. Saves the file to the agent's media directory and inserts a DB record.
+
+**Request**: `multipart/form-data` with fields:
+- `file` (required): The image file
+- `source` (optional): `"screenshot"` (default), `"stream"`, `"simulator"`
+
+**Response**: `{ ok: true, media: { id, fileName, source, sizeBytes, createdAt, url } }`
+
+This endpoint replaces the implicit "copy file to directory" pattern.
+
+## Changes to `dispatch-share`
+
+The shell script currently copies files directly to `$DISPATCH_MEDIA_DIR`. It needs to POST to the new upload endpoint instead.
+
+```bash
+# Before (filesystem copy):
+cp "$SOURCE_PATH" "$dest_file"
+
+# After (API upload):
+curl -fsS -X POST \
+  -F "file=@${SOURCE_PATH};filename=${safe_name}" \
+  -F "source=screenshot" \
+  "${API_BASE}/api/v1/agents/${AGENT_ID}/media"
+```
+
+The script still prints the file path for backward compatibility. The server returns it in the response.
+
+## Changes to `src/server.ts`
+
+### Remove filesystem watcher machinery
+
+Delete:
+- `mediaWatchers` Map
+- `mediaDebounceTimers` Map
+- `ensureMediaWatch()` function
+- All `ensureMediaWatch()` call sites (agent create, agent list, SSE subscribe)
+
+### Replace `listMediaFiles()`
+
+```ts
+// Before: readdir + stat for each file
+// After: single DB query
+async function listMediaFiles(agentId: string): Promise<MediaRow[]> {
+  const result = await pool.query(
+    `SELECT file_name, source, size_bytes, created_at
+     FROM media WHERE agent_id = $1
+     ORDER BY created_at DESC LIMIT 50`,
+    [agentId]
+  );
+  return result.rows.map(row => ({
+    name: row.file_name,
+    source: row.source,
+    size: row.size_bytes,
+    updatedAt: row.created_at.toISOString(),
+    url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(row.file_name)}`
+  }));
+}
+```
+
+### Media change notifications
+
+The upload endpoint publishes `media.changed` via `UiEventBroker` after inserting the record — same SSE event, just triggered by the API call instead of the filesystem watcher.
+
+### Serve media files (unchanged)
+
+`GET /api/v1/agents/:id/media/:file` continues to serve files from disk. No change needed.
+
+## Frontend Changes
+
+### `MediaFile` type
+
+```ts
+export type MediaFile = {
+  name: string;
+  size: number;
+  updatedAt: string;
+  url: string;
+  seen?: boolean;
+  source?: "screenshot" | "stream" | "simulator";
+};
+```
+
+### Media sidebar rendering
+
+Stream captures can show a distinct label/badge (e.g., "Stream recording" vs "Shared: filename").
+
+## Data Migration
+
+Existing media files on disk need records inserted into the new table. A one-time migration script:
+
+```ts
+// For each agent with a media directory:
+//   readdir the directory
+//   For each image file, insert a media record with source='screenshot'
+//   Use file mtime as created_at
+```
+
+This runs as part of the DB migration (or as a separate step after deploy).
+
+## Stream Capture Integration
+
+With the DB-backed store in place, saving a stream capture becomes:
+1. `StreamManager.stopStream()` saves the last JPEG frame to disk
+2. Server inserts a `media` record with `source: 'stream'`
+3. Publishes `media.changed` SSE event
+4. Frontend renders it with "Stream recording" label
+
+## File Change Summary
+
+| File | Change | Description |
+|---|---|---|
+| `src/db/migrate.ts` | Modify | Add `media` table, run data migration |
+| `src/server.ts` | Modify | Add upload endpoint, remove fs watchers, update `listMediaFiles` |
+| `bin/dispatch-share` | Modify | POST to API instead of filesystem copy |
+| `web/src/components/app/types.ts` | Modify | Add `source` field to `MediaFile` |
+| `web/src/components/app/media-sidebar.tsx` | Modify | Render source-specific labels |
+
+## Gotchas
+
+1. **Backward compat**: Old `dispatch-share` scripts (in running agent sessions) still copy files directly. The migration should handle discovering these files.
+2. **`media_seen` keys**: Currently `name:updatedAt`. Ensure the new `created_at` timestamp produces the same key format so seen state isn't lost.
+3. **File cleanup**: When an agent is deleted, `ON DELETE CASCADE` removes DB records. Files on disk still need cleanup (existing behavior via `mediaDir` removal).
+4. **Upload size limits**: Fastify's default body size limit may need raising for the multipart upload endpoint.

--- a/docs/stream-capture-plan.md
+++ b/docs/stream-capture-plan.md
@@ -1,0 +1,115 @@
+# Stream Capture on End — Implementation Plan
+
+## Overview
+
+When a Playwright browser stream ends, save the last frame as a JPEG in the agent's media directory and record it via the DB-backed media store (see `db-backed-media-store-plan.md`). The saved frame appears in the media sidebar as a "Stream recording" — a visual record that a stream session happened.
+
+## Prerequisite
+
+This plan depends on the DB-backed media store being in place. The media store provides:
+- A `media` table with a `source` column to tag the capture as `"stream"`
+- An upload/insert pathway that publishes `media.changed` SSE events
+- Frontend support for rendering source-specific labels
+
+## Changes to `src/stream-manager.ts`
+
+Add an `onStreamEnd` callback that fires with the last frame buffer before cleanup:
+
+```ts
+type OnStreamEnd = (agentId: string, lastFrame: Buffer) => void;
+
+export class StreamManager {
+  constructor(
+    onStateChange: OnStateChange,
+    onStreamEnd?: OnStreamEnd
+  ) { ... }
+}
+```
+
+In `stopStream()`, before clearing `lastFrame`:
+
+```ts
+if (session.lastFrame && this.onStreamEnd) {
+  try {
+    this.onStreamEnd(agentId, session.lastFrame);
+  } catch {
+    // Best-effort; don't block cleanup
+  }
+}
+session.lastFrame = null;
+```
+
+## Changes to `src/server.ts`
+
+Pass the `onStreamEnd` callback when constructing `StreamManager`:
+
+```ts
+const streamManager = new StreamManager(
+  (agentId, event) => { /* existing SSE publish */ },
+  async (agentId, lastFrame) => {
+    const agent = await agentManager.getAgent(agentId);
+    if (!agent) return;
+
+    const mediaDir = resolveMediaDir(agentId, agent.mediaDir);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `stream-capture-${timestamp}.jpg`;
+
+    await mkdir(mediaDir, { recursive: true });
+    await writeFile(path.join(mediaDir, fileName), lastFrame);
+
+    // Insert DB record with source='stream'
+    await pool.query(
+      `INSERT INTO media (agent_id, file_name, source, size_bytes)
+       VALUES ($1, $2, 'stream', $3)`,
+      [agentId, fileName, lastFrame.length]
+    );
+
+    uiEventBroker.publish({ type: "media.changed", agentId });
+  }
+);
+```
+
+## Frontend Changes
+
+### Media sidebar
+
+When rendering a media file where `source === "stream"`, show:
+- A "Stream recording" label instead of the usual "Shared: filename" description
+- Optionally a small badge or icon to visually distinguish it from screenshots
+
+### `mediaDescription` helper
+
+```ts
+const mediaDescription = (file: MediaFile): string => {
+  if (file.source === "stream") {
+    return "Stream recording";
+  }
+  // ... existing logic
+};
+```
+
+## UX Flow
+
+1. Agent starts a Playwright stream → sidebar auto-opens with live stream preview
+2. User watches live stream in sidebar or pops it out to a separate window
+3. Agent (or server) stops the stream
+4. Last frame is saved as `stream-capture-*.jpg` in the media directory
+5. DB record inserted with `source: 'stream'`
+6. SSE `media.changed` fires → sidebar refreshes
+7. The capture appears at the top of the media gallery labeled "Stream recording"
+8. User can click to open it in the lightbox like any other media item
+
+## File Change Summary
+
+| File | Change | Description |
+|---|---|---|
+| `src/stream-manager.ts` | Modify | Add `onStreamEnd` callback, fire before cleanup |
+| `src/server.ts` | Modify | Pass callback that saves frame + inserts DB record |
+| `web/src/App.tsx` | Modify | Update `mediaDescription` to handle `source` field |
+| `web/src/components/app/media-sidebar.tsx` | Modify | Render stream capture badge/label |
+
+## Sequencing
+
+1. Merge the DB-backed media store (prerequisite)
+2. Implement this plan on top
+3. Both can land on the same `feature/playwright-streaming` branch

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -81,6 +81,9 @@ export async function runMigrations(): Promise<void> {
     );
 
     CREATE INDEX IF NOT EXISTS idx_media_agent_id ON media(agent_id);
+
+    ALTER TABLE media
+      ADD COLUMN IF NOT EXISTS description TEXT;
   `;
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,7 +93,7 @@ const streamManager = new StreamManager(
         : { type: "stream.stopped", agentId }
     );
   },
-  async (agentId, lastFrame) => {
+  async (agentId, lastFrame, description) => {
     const agent = await agentManager.getAgent(agentId);
     if (!agent) return;
 
@@ -105,9 +105,9 @@ const streamManager = new StreamManager(
     await writeFile(path.join(mediaDir, fileName), lastFrame);
 
     await pool.query(
-      `INSERT INTO media (agent_id, file_name, source, size_bytes)
-       VALUES ($1, $2, 'stream', $3)`,
-      [agentId, fileName, lastFrame.length]
+      `INSERT INTO media (agent_id, file_name, source, size_bytes, description)
+       VALUES ($1, $2, 'stream', $3, $4)`,
+      [agentId, fileName, lastFrame.length, description]
     );
 
     uiEventBroker.publish({ type: "media.changed", agentId });
@@ -799,6 +799,7 @@ async function registerRoutes() {
     const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? "screenshot";
     const validSources = ["screenshot", "stream", "simulator"];
     const source = validSources.includes(sourceField) ? sourceField : "screenshot";
+    const description = (data.fields.description as { value?: string } | undefined)?.value ?? null;
 
     const mediaDir = resolveMediaDir(agent.id, agent.mediaDir);
     await mkdir(mediaDir, { recursive: true });
@@ -808,10 +809,10 @@ async function registerRoutes() {
     await writeFile(filePath, buffer);
 
     const result = await pool.query<{ id: number; created_at: Date }>(
-      `INSERT INTO media (agent_id, file_name, source, size_bytes)
-       VALUES ($1, $2, $3, $4)
+      `INSERT INTO media (agent_id, file_name, source, size_bytes, description)
+       VALUES ($1, $2, $3, $4, $5)
        RETURNING id, created_at`,
-      [id, fileName, source, buffer.length]
+      [id, fileName, source, buffer.length, description]
     );
 
     const row = result.rows[0];
@@ -866,9 +867,10 @@ async function registerRoutes() {
       return reply.code(404).send({ error: "Agent not found." });
     }
 
-    const body = request.body as { type?: unknown; port?: unknown };
+    const body = request.body as { type?: unknown; port?: unknown; description?: unknown };
     if (body?.type === "stop") {
-      streamManager.stopStream(id);
+      const description = typeof body.description === "string" ? body.description : null;
+      streamManager.stopStream(id, description);
       return { ok: true };
     }
 
@@ -1640,14 +1642,15 @@ function decodeClientMessage(
 
 async function listMediaFiles(
   agentId: string
-): Promise<Array<{ name: string; source: string; size: number; updatedAt: string; url: string }>> {
+): Promise<Array<{ name: string; source: string; size: number; updatedAt: string; url: string; description: string | null }>> {
   const result = await pool.query<{
     file_name: string;
     source: string;
     size_bytes: number;
     created_at: Date;
+    description: string | null;
   }>(
-    `SELECT file_name, source, size_bytes, created_at
+    `SELECT file_name, source, size_bytes, created_at, description
      FROM media WHERE agent_id = $1
      ORDER BY created_at DESC LIMIT 50`,
     [agentId]
@@ -1658,7 +1661,8 @@ async function listMediaFiles(
     source: row.source,
     size: row.size_bytes,
     updatedAt: row.created_at.toISOString(),
-    url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(row.file_name)}`
+    url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(row.file_name)}`,
+    description: row.description ?? null
   }));
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,13 +85,34 @@ class UiEventBroker {
 }
 
 const uiEventBroker = new UiEventBroker();
-const streamManager = new StreamManager((agentId, event) => {
-  uiEventBroker.publish(
-    event === "started"
-      ? { type: "stream.started", agentId }
-      : { type: "stream.stopped", agentId }
-  );
-});
+const streamManager = new StreamManager(
+  (agentId, event) => {
+    uiEventBroker.publish(
+      event === "started"
+        ? { type: "stream.started", agentId }
+        : { type: "stream.stopped", agentId }
+    );
+  },
+  async (agentId, lastFrame) => {
+    const agent = await agentManager.getAgent(agentId);
+    if (!agent) return;
+
+    const mediaDir = resolveMediaDir(agentId, agent.mediaDir);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `stream-capture-${timestamp}.jpg`;
+
+    await mkdir(mediaDir, { recursive: true });
+    await writeFile(path.join(mediaDir, fileName), lastFrame);
+
+    await pool.query(
+      `INSERT INTO media (agent_id, file_name, source, size_bytes)
+       VALUES ($1, $2, 'stream', $3)`,
+      [agentId, fileName, lastFrame.length]
+    );
+
+    uiEventBroker.publish({ type: "media.changed", agentId });
+  }
+);
 const runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
 const RUNTIME_CWD_CACHE_TTL_MS = 10_000;
 const PROBE_COMMAND_TIMEOUT_MS = 800;

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
   resolveRepoConfig,
   writeWorktreeMode
 } from "./repo-config.js";
+import { StreamManager } from "./stream-manager.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 
 const config = loadConfig();
@@ -39,7 +40,9 @@ type UiEvent =
   | { type: "agent.upsert"; agent: AgentRecord }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }
-  | { type: "media.seen"; agentId: string; keys: string[] };
+  | { type: "media.seen"; agentId: string; keys: string[] }
+  | { type: "stream.started"; agentId: string }
+  | { type: "stream.stopped"; agentId: string };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -78,6 +81,13 @@ class UiEventBroker {
 }
 
 const uiEventBroker = new UiEventBroker();
+const streamManager = new StreamManager((agentId, event) => {
+  uiEventBroker.publish(
+    event === "started"
+      ? { type: "stream.started", agentId }
+      : { type: "stream.stopped", agentId }
+  );
+});
 const mediaWatchers = new Map<string, FSWatcher>();
 const mediaDebounceTimers = new Map<string, NodeJS.Timeout>();
 const runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
@@ -120,6 +130,10 @@ const __dirname = path.dirname(__filename);
 const webDistDir = path.resolve(__dirname, "../web/dist");
 const legacyPublicDir = path.resolve(__dirname, "../public");
 const staticDir = existsSync(webDistDir) ? webDistDir : legacyPublicDir;
+
+function withStreamFlag<T extends AgentRecord>(agent: T): T & { hasStream: boolean } {
+  return { ...agent, hasStream: streamManager.hasStream(agent.id) };
+}
 
 async function registerRoutes() {
   await app.register(fastifyWebsocket);
@@ -192,7 +206,7 @@ async function registerRoutes() {
 
   app.get("/api/v1/agents", async () => {
     const agents = await agentManager.listAgents();
-    return { agents };
+    return { agents: agents.map(withStreamFlag) };
   });
 
   app.get("/api/v1/agents/git-context", async (request, reply) => {
@@ -264,7 +278,7 @@ async function registerRoutes() {
 
     try {
       const agents = await agentManager.listAgents();
-      uiEventBroker.sendSnapshot(stream, agents);
+      uiEventBroker.sendSnapshot(stream, agents.map(withStreamFlag));
     } catch (error) {
       app.log.warn({ err: error }, "Failed to load SSE snapshot.");
     }
@@ -283,7 +297,7 @@ async function registerRoutes() {
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });
     }
-    return { agent };
+    return { agent: withStreamFlag(agent) };
   });
 
   app.post("/api/v1/agents/:id/latest-event", async (request, reply) => {
@@ -321,7 +335,7 @@ async function registerRoutes() {
       metadata: metadata as Record<string, unknown> | undefined
     });
 
-    uiEventBroker.publish({ type: "agent.upsert", agent });
+    uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
     return { agent };
   });
 
@@ -397,6 +411,99 @@ async function registerRoutes() {
     return { ok: true, updated: keys.length };
   });
 
+  app.post("/api/v1/agents/:id/stream", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    const agent = await agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const body = request.body as { type?: unknown; port?: unknown };
+    if (body?.type === "stop") {
+      streamManager.stopStream(id);
+      return { ok: true };
+    }
+
+    if (body?.type === "playwright") {
+      if (typeof body.port !== "number" || !Number.isFinite(body.port) || body.port < 1) {
+        return reply.code(400).send({ error: "port must be a positive number." });
+      }
+      if (streamManager.hasStream(id)) {
+        return reply.code(409).send({ error: "Stream already active for this agent." });
+      }
+      try {
+        await streamManager.startStream(id, body.port);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to start stream.";
+        return reply.code(502).send({ error: message });
+      }
+      return { ok: true };
+    }
+
+    return reply.code(400).send({ error: "type must be 'playwright' or 'stop'." });
+  });
+
+  app.get("/api/v1/agents/:id/stream", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    const agent = await agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+    if (!streamManager.hasStream(id)) {
+      return reply.code(404).send({ error: "No active stream for this agent." });
+    }
+
+    reply.hijack();
+    const raw = reply.raw;
+    raw.writeHead(200, {
+      "Content-Type": "multipart/x-mixed-replace; boundary=frame",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+    raw.flushHeaders();
+    if (raw.socket) {
+      raw.socket.setNoDelay(true);
+    }
+
+    const unsubscribe = streamManager.addViewer(id, raw);
+    reply.raw.on("close", () => {
+      unsubscribe();
+    });
+  });
+
+  app.get("/api/v1/agents/:id/stream/viewer", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    const agent = await agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<title>${agent.name} — Live Stream</title>
+<style>
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{background:#0a0a0a;display:flex;align-items:center;justify-content:center;height:100vh;overflow:hidden}
+  img{max-width:100%;max-height:100%;object-fit:contain}
+  .gone{display:flex;align-items:center;justify-content:center;height:100vh;color:#666;font-family:system-ui;font-size:14px}
+</style>
+</head><body>
+<img id="feed" src="/api/v1/agents/${id}/stream" alt="Live stream">
+<script>
+  const img = document.getElementById('feed');
+  img.onerror = () => {
+    document.body.innerHTML = '<div class="gone">Stream ended.</div>';
+  };
+</script>
+</body></html>`;
+    return reply.type("text/html").send(html);
+  });
+
   app.post("/api/v1/agents", async (request, reply) => {
     const body = request.body as {
       name?: unknown;
@@ -443,7 +550,7 @@ async function registerRoutes() {
       });
       ensureMediaWatch(agent.id, resolveMediaDir(agent.id, agent.mediaDir));
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent });
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
       return reply.code(201).send({ agent });
     } catch (error) {
       return handleAgentError(reply, error);
@@ -458,7 +565,7 @@ async function registerRoutes() {
       const agent = await agentManager.startAgent(id);
       ensureMediaWatch(agent.id, resolveMediaDir(agent.id, agent.mediaDir));
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent });
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
       return { agent };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -477,7 +584,7 @@ async function registerRoutes() {
     try {
       const agent = await agentManager.stopAgent(id, { force: body?.force as boolean | undefined });
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent });
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
       return { agent };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -501,6 +608,7 @@ async function registerRoutes() {
       const existing = await agentManager.getAgent(params.id);
       await agentManager.deleteAgent(params.id, force);
       if (existing) {
+        streamManager.stopStream(existing.id);
         stopMediaWatch(existing.id);
         pendingGitRefreshAgentIds.delete(existing.id);
         pendingGitRefreshEnqueuedAt.delete(existing.id);
@@ -539,7 +647,7 @@ async function registerRoutes() {
       const refreshed = await agentManager.getAgent(id);
       if (refreshed) {
         queueGitContextRefresh([refreshed.id]);
-        uiEventBroker.publish({ type: "agent.upsert", agent: refreshed });
+        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(refreshed) });
       }
       return handleAgentError(reply, error);
     }
@@ -877,7 +985,7 @@ async function refreshAgentGitContext(
 
   const refreshed = await agentManager.getAgent(agentId);
   if (refreshed) {
-    uiEventBroker.publish({ type: "agent.upsert", agent: refreshed });
+    uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(refreshed) });
   }
   return "updated";
 }
@@ -1207,6 +1315,7 @@ async function shutdown(code: number): Promise<void> {
   }
   shuttingDown = true;
 
+  streamManager.stopAll();
   stopGitContextRefreshLoop();
   stopAllMediaWatches();
   await pool.end().catch(() => null);

--- a/src/stream-manager.ts
+++ b/src/stream-manager.ts
@@ -7,6 +7,7 @@ type StreamSession = {
 };
 
 type OnStateChange = (agentId: string, event: "started" | "stopped") => void;
+type OnStreamEnd = (agentId: string, lastFrame: Buffer) => void;
 
 const MJPEG_BOUNDARY = "frame";
 const FRAME_REFRESH_INTERVAL_MS = 1000;
@@ -14,9 +15,11 @@ const FRAME_REFRESH_INTERVAL_MS = 1000;
 export class StreamManager {
   private sessions = new Map<string, StreamSession>();
   private onStateChange: OnStateChange;
+  private onStreamEnd?: OnStreamEnd;
 
-  constructor(onStateChange: OnStateChange) {
+  constructor(onStateChange: OnStateChange, onStreamEnd?: OnStreamEnd) {
     this.onStateChange = onStateChange;
+    this.onStreamEnd = onStreamEnd;
   }
 
   async startStream(agentId: string, port: number): Promise<void> {
@@ -147,6 +150,15 @@ export class StreamManager {
     }
 
     session.viewers.clear();
+
+    if (session.lastFrame && this.onStreamEnd) {
+      try {
+        this.onStreamEnd(agentId, session.lastFrame);
+      } catch {
+        // Best-effort; don't block cleanup
+      }
+    }
+
     session.lastFrame = null;
     this.sessions.delete(agentId);
     this.onStateChange(agentId, "stopped");

--- a/src/stream-manager.ts
+++ b/src/stream-manager.ts
@@ -7,7 +7,7 @@ type StreamSession = {
 };
 
 type OnStateChange = (agentId: string, event: "started" | "stopped") => void;
-type OnStreamEnd = (agentId: string, lastFrame: Buffer) => void;
+type OnStreamEnd = (agentId: string, lastFrame: Buffer, description: string | null) => void;
 
 const MJPEG_BOUNDARY = "frame";
 const FRAME_REFRESH_INTERVAL_MS = 1000;
@@ -117,7 +117,7 @@ export class StreamManager {
     });
   }
 
-  stopStream(agentId: string): void {
+  stopStream(agentId: string, description?: string | null): void {
     const session = this.sessions.get(agentId);
     if (!session) {
       return;
@@ -153,7 +153,7 @@ export class StreamManager {
 
     if (session.lastFrame && this.onStreamEnd) {
       try {
-        this.onStreamEnd(agentId, session.lastFrame);
+        this.onStreamEnd(agentId, session.lastFrame, description ?? null);
       } catch {
         // Best-effort; don't block cleanup
       }

--- a/src/stream-manager.ts
+++ b/src/stream-manager.ts
@@ -1,0 +1,226 @@
+type StreamSession = {
+  cdpSocket: WebSocket;
+  viewers: Set<NodeJS.WritableStream>;
+  status: "connecting" | "live" | "stopped";
+  lastFrame: Buffer | null;
+  refreshTimer: NodeJS.Timeout | null;
+};
+
+type OnStateChange = (agentId: string, event: "started" | "stopped") => void;
+
+const MJPEG_BOUNDARY = "frame";
+const FRAME_REFRESH_INTERVAL_MS = 1000;
+
+export class StreamManager {
+  private sessions = new Map<string, StreamSession>();
+  private onStateChange: OnStateChange;
+
+  constructor(onStateChange: OnStateChange) {
+    this.onStateChange = onStateChange;
+  }
+
+  async startStream(agentId: string, port: number): Promise<void> {
+    if (this.sessions.has(agentId)) {
+      throw new Error("Stream already active for this agent.");
+    }
+
+    // Discover CDP target URL
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    if (!response.ok) {
+      throw new Error(`Failed to discover CDP targets on port ${port}: ${response.status}`);
+    }
+
+    const targets = (await response.json()) as Array<{
+      type: string;
+      webSocketDebuggerUrl?: string;
+    }>;
+    const pageTarget = targets.find((t) => t.type === "page");
+    if (!pageTarget?.webSocketDebuggerUrl) {
+      throw new Error("No page target found via CDP.");
+    }
+
+    const session: StreamSession = {
+      cdpSocket: null as unknown as WebSocket,
+      viewers: new Set(),
+      status: "connecting",
+      lastFrame: null,
+      refreshTimer: null,
+    };
+    this.sessions.set(agentId, session);
+
+    const ws = new WebSocket(pageTarget.webSocketDebuggerUrl);
+    session.cdpSocket = ws;
+
+    let cdpId = 1;
+
+    ws.addEventListener("open", () => {
+      session.status = "live";
+      ws.send(
+        JSON.stringify({
+          id: cdpId++,
+          method: "Page.startScreencast",
+          params: { format: "jpeg", quality: 60, maxWidth: 1280, maxHeight: 800 },
+        })
+      );
+      // Re-push the last cached frame periodically so viewers that connect
+      // between CDP frames still see content and the MJPEG connection stays alive.
+      session.refreshTimer = setInterval(() => {
+        if (session.lastFrame && session.viewers.size > 0) {
+          this.writeFrameToViewers(session, session.lastFrame);
+        }
+      }, FRAME_REFRESH_INTERVAL_MS);
+      this.onStateChange(agentId, "started");
+    });
+
+    ws.addEventListener("message", (event) => {
+      try {
+        const msg = JSON.parse(String(event.data)) as {
+          method?: string;
+          params?: { data?: string; sessionId?: number };
+        };
+
+        if (msg.method === "Page.screencastFrame") {
+          const frameData = msg.params?.data;
+          const sessionId = msg.params?.sessionId;
+
+          // Ack immediately to prevent Chrome throttling
+          if (sessionId !== undefined) {
+            ws.send(
+              JSON.stringify({
+                id: cdpId++,
+                method: "Page.screencastFrameAck",
+                params: { sessionId },
+              })
+            );
+          }
+
+          if (frameData) {
+            const jpegBuffer = Buffer.from(frameData, "base64");
+            session.lastFrame = jpegBuffer;
+            this.pushFrame(agentId, jpegBuffer);
+          }
+        }
+      } catch {
+        // Ignore non-JSON or unexpected messages
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      this.cleanupSession(agentId);
+    });
+
+    ws.addEventListener("error", () => {
+      this.cleanupSession(agentId);
+    });
+  }
+
+  stopStream(agentId: string): void {
+    const session = this.sessions.get(agentId);
+    if (!session) {
+      return;
+    }
+
+    session.status = "stopped";
+
+    if (session.refreshTimer) {
+      clearInterval(session.refreshTimer);
+      session.refreshTimer = null;
+    }
+
+    try {
+      if (session.cdpSocket.readyState === WebSocket.OPEN) {
+        session.cdpSocket.send(
+          JSON.stringify({ id: 999, method: "Page.stopScreencast" })
+        );
+        session.cdpSocket.close();
+      }
+    } catch {
+      // Ignore close errors
+    }
+
+    for (const viewer of session.viewers) {
+      try {
+        viewer.end();
+      } catch {
+        // Ignore
+      }
+    }
+
+    session.viewers.clear();
+    session.lastFrame = null;
+    this.sessions.delete(agentId);
+    this.onStateChange(agentId, "stopped");
+  }
+
+  addViewer(agentId: string, stream: NodeJS.WritableStream): () => void {
+    const session = this.sessions.get(agentId);
+    if (!session) {
+      throw new Error("No active stream for this agent.");
+    }
+
+    session.viewers.add(stream);
+
+    // Send the cached frame immediately so the viewer doesn't see a blank screen
+    if (session.lastFrame) {
+      this.writeFrameToViewers({ viewers: new Set([stream]) } as StreamSession, session.lastFrame);
+    }
+
+    return () => {
+      session.viewers.delete(stream);
+    };
+  }
+
+  hasStream(agentId: string): boolean {
+    const session = this.sessions.get(agentId);
+    return session !== undefined && session.status === "live";
+  }
+
+  stopAll(): void {
+    for (const agentId of [...this.sessions.keys()]) {
+      this.stopStream(agentId);
+    }
+  }
+
+  private pushFrame(agentId: string, jpegBuffer: Buffer): void {
+    const session = this.sessions.get(agentId);
+    if (!session) {
+      return;
+    }
+    this.writeFrameToViewers(session, jpegBuffer);
+  }
+
+  private writeFrameToViewers(session: StreamSession, jpegBuffer: Buffer): void {
+    const header =
+      `--${MJPEG_BOUNDARY}\r\n` +
+      `Content-Type: image/jpeg\r\n` +
+      `Content-Length: ${jpegBuffer.length}\r\n\r\n`;
+
+    const frameChunk = Buffer.concat([
+      Buffer.from(header),
+      jpegBuffer,
+      Buffer.from("\r\n"),
+    ]);
+
+    for (const viewer of session.viewers) {
+      try {
+        const v = viewer as NodeJS.WritableStream & { writable?: boolean; flush?: () => void };
+        if (v.writable !== false) {
+          v.write(frameChunk);
+          if (typeof v.flush === "function") {
+            v.flush();
+          }
+        }
+      } catch {
+        session.viewers.delete(viewer);
+      }
+    }
+  }
+
+  private cleanupSession(agentId: string): void {
+    const session = this.sessions.get(agentId);
+    if (!session || session.status === "stopped") {
+      return;
+    }
+    this.stopStream(agentId);
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,7 +68,9 @@ type UiEvent =
   | { type: "agent.upsert"; agent: Agent }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }
-  | { type: "media.seen"; agentId: string; keys: string[] };
+  | { type: "media.seen"; agentId: string; keys: string[] }
+  | { type: "stream.started"; agentId: string }
+  | { type: "stream.stopped"; agentId: string };
 
 function sortAgentsByCreatedAtDesc(items: Agent[]): Agent[] {
   const eventPriority = (agent: Agent): number => {
@@ -170,6 +172,7 @@ export function App(): JSX.Element {
   const [lightboxCaption, setLightboxCaption] = useState("");
   const [seenMediaKeys, setSeenMediaKeys] = useState<Set<string>>(new Set());
   const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
+  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(new Set());
 
   const [apiState, setApiState] = useState<ServiceState>("checking");
   const [dbState, setDbState] = useState<ServiceState>("checking");
@@ -200,6 +203,9 @@ export function App(): JSX.Element {
     () => agents.find((agent) => agent.id === connectedAgentId) ?? null,
     [agents, connectedAgentId]
   );
+
+  const selectedAgentHasStream = selectedAgentId ? streamingAgentIds.has(selectedAgentId) : false;
+  const selectedAgentStreamUrl = selectedAgentId ? `/api/v1/agents/${selectedAgentId}/stream` : null;
 
   const resolveCreateDefaultCwd = useCallback((): string => {
     const activeCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
@@ -847,6 +853,9 @@ export function App(): JSX.Element {
 
         if (payload.type === "snapshot") {
           setAgents(sortAgentsByCreatedAtDesc(payload.agents));
+          setStreamingAgentIds(
+            new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
+          );
           return;
         }
 
@@ -870,6 +879,26 @@ export function App(): JSX.Element {
 
         if (payload.type === "media.changed" && payload.agentId === selectedAgentIdRef.current) {
           void refreshMedia(payload.agentId);
+          return;
+        }
+
+        if (payload.type === "stream.started") {
+          setStreamingAgentIds((current) => {
+            if (current.has(payload.agentId)) return current;
+            const next = new Set(current);
+            next.add(payload.agentId);
+            return next;
+          });
+          return;
+        }
+
+        if (payload.type === "stream.stopped") {
+          setStreamingAgentIds((current) => {
+            if (!current.has(payload.agentId)) return current;
+            const next = new Set(current);
+            next.delete(payload.agentId);
+            return next;
+          });
           return;
         }
 
@@ -1379,6 +1408,8 @@ export function App(): JSX.Element {
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
             mediaDescription={mediaDescription}
+            hasStream={selectedAgentHasStream}
+            streamUrl={selectedAgentStreamUrl}
             openLightbox={(src, caption) => {
               setLightboxSrc(src);
               setLightboxCaption(caption);
@@ -1442,6 +1473,8 @@ export function App(): JSX.Element {
               seenMediaKeys={seenMediaKeys}
               mediaViewportRef={mediaViewportRef}
               mediaDescription={mediaDescription}
+              hasStream={selectedAgentHasStream}
+              streamUrl={selectedAgentStreamUrl}
               openLightbox={(src, caption) => {
                 setLightboxSrc(src);
                 setLightboxCaption(caption);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1402,7 +1402,6 @@ export function App(): JSX.Element {
             seenMediaKeys={seenMediaKeys}
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
-            mediaDescription={mediaDescription}
             hasStream={selectedAgentHasStream}
             streamUrl={selectedAgentStreamUrl}
             openLightbox={(src, caption) => {
@@ -1468,7 +1467,6 @@ export function App(): JSX.Element {
               animatingMediaKeys={animatingMediaKeys}
               seenMediaKeys={seenMediaKeys}
               mediaViewportRef={mediaViewportRef}
-              mediaDescription={mediaDescription}
               hasStream={selectedAgentHasStream}
               streamUrl={selectedAgentStreamUrl}
               openLightbox={(src, caption) => {

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -1,5 +1,5 @@
-import { type RefObject } from "react";
-import { ChevronRight, X } from "lucide-react";
+import { type RefObject, useCallback, useEffect } from "react";
+import { ChevronRight, ExternalLink, X } from "lucide-react";
 
 import { type MediaFile } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,8 @@ type MediaSidebarSharedProps = {
   mediaViewportRef: RefObject<HTMLDivElement>;
   mediaDescription: (name: string) => string;
   openLightbox: (src: string, caption: string) => void;
+  hasStream: boolean;
+  streamUrl: string | null;
 };
 
 type MediaSidebarProps = MediaSidebarSharedProps & {
@@ -27,6 +29,40 @@ type MediaSidebarContentProps = MediaSidebarSharedProps & {
   className?: string;
 };
 
+function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; selectedAgentId: string }): JSX.Element {
+  const popOut = useCallback(() => {
+    window.open(
+      `/api/v1/agents/${selectedAgentId}/stream/viewer`,
+      `stream-${selectedAgentId}`,
+      "width=1300,height=860,menubar=no,toolbar=no,location=no,status=no"
+    );
+  }, [selectedAgentId]);
+
+  return (
+    <div className="border-b-2 border-border">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-red-500" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-red-400">Live Stream</span>
+        <div className="ml-auto">
+          <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs" onClick={popOut}>
+            <ExternalLink className="h-3 w-3" />
+            Pop out
+          </Button>
+        </div>
+      </div>
+      <div className="px-3 pb-3">
+        <div className="overflow-hidden rounded border border-border bg-black">
+          <img
+            src={streamUrl}
+            alt="Live browser stream"
+            className="w-full object-contain"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function MediaSidebarContent({
   mediaFiles,
   selectedAgentId,
@@ -36,6 +72,8 @@ export function MediaSidebarContent({
   mediaViewportRef,
   mediaDescription,
   openLightbox,
+  hasStream,
+  streamUrl,
   onRequestClose,
   closeButtonIcon = "x",
   className
@@ -59,12 +97,16 @@ export function MediaSidebarContent({
         </div>
       </div>
 
+      {hasStream && streamUrl && selectedAgentId ? (
+        <LiveStreamSection streamUrl={streamUrl} selectedAgentId={selectedAgentId} />
+      ) : null}
+
       <div ref={mediaViewportRef} className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
-        {mediaFiles.length === 0 ? (
+        {mediaFiles.length === 0 && !hasStream ? (
           <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
             {selectedAgentId ? "No media yet." : "Select an agent to view media."}
           </div>
-        ) : (
+        ) : mediaFiles.length === 0 ? null : (
           mediaFiles.map((file) => {
             const mediaKey = `${file.name}:${file.updatedAt}`;
             const cacheBustUrl = `${file.url}?t=${encodeURIComponent(file.updatedAt)}`;
@@ -103,7 +145,14 @@ export function MediaSidebarContent({
   );
 }
 
-export function MediaSidebar({ mediaOpen, setMediaOpen, ...props }: MediaSidebarProps): JSX.Element {
+export function MediaSidebar({ mediaOpen, setMediaOpen, hasStream, ...props }: MediaSidebarProps): JSX.Element {
+  // Auto-open the sidebar when a stream starts so the user doesn't miss it
+  useEffect(() => {
+    if (hasStream) {
+      setMediaOpen(true);
+    }
+  }, [hasStream, setMediaOpen]);
+
   return (
     <div
       className="h-full min-w-0 flex-none overflow-hidden transition-[width] duration-300 ease-out"
@@ -111,6 +160,7 @@ export function MediaSidebar({ mediaOpen, setMediaOpen, ...props }: MediaSidebar
     >
       <MediaSidebarContent
         {...props}
+        hasStream={hasStream}
         onRequestClose={() => setMediaOpen(false)}
         closeButtonIcon="chevron"
         className="w-[360px]"

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -154,7 +154,8 @@ export function MediaSidebarContent({
                 </button>
                 <div className="mt-2 text-xs text-muted-foreground">
                   {isStream ? null : <div>{mediaSourceLabel(file)}</div>}
-                  <div className={isStream ? "" : "mt-1"}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
+                  {file.description ? <div className={isStream ? "" : "mt-1"}>{file.description}</div> : null}
+                  <div className={file.description || !isStream ? "mt-1" : ""}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
                 </div>
               </article>
             );

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useEffect } from "react";
-import { ChevronRight, ExternalLink, X } from "lucide-react";
+import { ChevronRight, ExternalLink, MonitorPlay, X } from "lucide-react";
 
 import { type MediaFile } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
@@ -122,16 +122,27 @@ export function MediaSidebarContent({
             const animating = animatingMediaKeys.has(mediaKey);
             const unseen = !seenMediaKeys.has(mediaKey);
 
+            const isStream = file.source === "stream";
+
             return (
               <article
                 key={mediaKey}
                 data-media-key={mediaKey}
                 className={cn(
                   "border-b-2 border-border px-3 py-3",
+                  isStream && "border-l-2 border-l-red-500/60 bg-red-500/5",
                   animating && "animate-media-in-slow"
                 )}
               >
-                <div className="mb-2 text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</div>
+                {isStream ? (
+                  <div className="mb-2 flex items-center gap-1.5">
+                    <MonitorPlay className="h-3.5 w-3.5 text-red-400" />
+                    <span className="text-xs font-semibold uppercase tracking-wide text-red-400">Stream recording</span>
+                    <span className="ml-auto text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</span>
+                  </div>
+                ) : (
+                  <div className="mb-2 text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</div>
+                )}
                 <button
                   className={cn(
                     "block w-full overflow-hidden border-2 bg-black/60",
@@ -142,8 +153,8 @@ export function MediaSidebarContent({
                   <img src={cacheBustUrl} alt={file.name} className="max-h-[260px] w-full object-contain" />
                 </button>
                 <div className="mt-2 text-xs text-muted-foreground">
-                  <div>{mediaSourceLabel(file)}</div>
-                  <div className="mt-1">{Math.max(1, Math.round(file.size / 1024))} KB</div>
+                  {isStream ? null : <div>{mediaSourceLabel(file)}</div>}
+                  <div className={isStream ? "" : "mt-1"}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
                 </div>
               </article>
             );

--- a/web/src/components/app/types.ts
+++ b/web/src/components/app/types.ts
@@ -23,6 +23,7 @@ export type Agent = {
     worktreeName: string;
     isWorktree: boolean;
   } | null;
+  hasStream?: boolean;
   createdAt: string;
   updatedAt: string;
 };

--- a/web/src/components/app/types.ts
+++ b/web/src/components/app/types.ts
@@ -35,6 +35,7 @@ export type MediaFile = {
   url: string;
   seen?: boolean;
   source?: "screenshot" | "stream" | "simulator";
+  description?: string | null;
 };
 
 export type ConnState = "connected" | "reconnecting" | "disconnected";

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -48,11 +48,9 @@ export default defineConfig({
   ],
   server: {
     host: "127.0.0.1",
-    port: 5173,
-    strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8787",
+        target: process.env.VITE_API_TARGET ?? "http://127.0.0.1:8787",
         changeOrigin: true,
         ws: true
       }


### PR DESCRIPTION
## Summary
- Adds `onStreamEnd` callback to `StreamManager` that fires with the last JPEG frame before cleanup
- Server saves the frame to the agent's media dir, inserts a DB record with `source: 'stream'`, and publishes `media.changed` SSE
- Media sidebar renders stream captures with a "Stream recording" label via a local `mediaSourceLabel` helper
- Includes the original MJPEG live streaming + pop-out viewer from the prior commit

## Test plan
- [x] Start a Playwright stream, stop it, verify `stream-capture-*.jpg` saved to media dir
- [x] Verify DB record created with `source: 'stream'` via media API
- [x] Verify sidebar shows "Stream recording" label with correct thumbnail
- [x] `npm run finalize:web` passes (tsc + vite build)
- [x] Backend `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)