### PR TITLE
Reload app after successful release

### DIFF
--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -142,6 +142,8 @@ export function ReleaseManager(): JSX.Element {
             setPostRestartPolling(false);
             setStatus(data);
             setJob((prev) => prev ? { ...prev, phase: "done", tag: data.tag } : prev);
+            // App is confirmed running on new version — reload to pick up new UI
+            setTimeout(() => window.location.reload(), 1500);
           }
         }
       } catch { /* server still down */ }


### PR DESCRIPTION
## Summary
- Auto-reload the page after a release completes so the UI picks up the new frontend bundle
- Reload only fires after the health poll confirms the new version is live, ensuring the app is running before refreshing
- 1.5s delay lets the "Complete" state briefly display before the reload

## Test plan
- [ ] Trigger a release and verify the page auto-reloads after the "Complete" state appears
- [ ] Verify the reloaded page shows the new version in the release manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)