### PR TITLE
Switch primary color from orange to logo dark green

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -404,7 +404,7 @@ export function AgentSidebarContent({
                               className={cn(
                                 "inline-flex w-fit items-center gap-1.5 px-1.5 py-0.5 text-foreground",
                                 fullAccessEnabled &&
-                                  "border border-orange-400/45 bg-orange-500/15 text-orange-200"
+                                  "border border-emerald-400/45 bg-emerald-500/15 text-emerald-200"
                               )}
                             >
                               {fullAccessEnabled ? <AlertTriangle className="h-3.5 w-3.5" /> : null}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -9,8 +9,8 @@
   --card-foreground: 60 30% 96%;
   --popover: 50 8% 9%;
   --popover-foreground: 60 30% 96%;
-  --primary: 32 98% 56%;
-  --primary-foreground: 30 20% 8%;
+  --primary: 158 82% 28%;
+  --primary-foreground: 160 10% 95%;
   --muted: 42 8% 13%;
   --muted-foreground: 36 10% 66%;
   --accent: 42 8% 13%;
@@ -61,10 +61,10 @@ body {
 }
 
 .media-thumb-unseen {
-  border-color: rgba(251, 146, 60, 0.45);
+  border-color: rgba(13, 131, 88, 0.45);
   box-shadow:
-    inset 0 0 0 1px rgba(251, 146, 60, 0.28),
-    0 0 14px rgba(251, 146, 60, 0.2);
+    inset 0 0 0 1px rgba(13, 131, 88, 0.28),
+    0 0 14px rgba(13, 131, 88, 0.2);
   transition:
     border-color 1600ms ease-out,
     box-shadow 1600ms ease-out;
@@ -73,8 +73,8 @@ body {
 .media-thumb-seen {
   border-color: hsl(var(--border));
   box-shadow:
-    inset 0 0 0 1px rgba(251, 146, 60, 0),
-    0 0 0 rgba(251, 146, 60, 0);
+    inset 0 0 0 1px rgba(13, 131, 88, 0),
+    0 0 0 rgba(13, 131, 88, 0);
   transition:
     border-color 1600ms ease-out,
     box-shadow 1600ms ease-out;


### PR DESCRIPTION
## Summary
- Replace orange primary color (`32 98% 56%`) with the darker green from the Dispatch logo (`158 82% 28%`)
- Update media thumbnail glow effects to use matching green
- Switch full-access badge in agent sidebar from orange to emerald

## Test plan
- [x] Verified build passes (`npm run finalize:web`)
- [x] Validated "Create" button color in Playwright screenshot
- [x] Confirmed no remaining orange button references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)