### PR TITLE
Disable tmux status bar on agent session creation

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -312,6 +312,9 @@ export class AgentManager {
     await mkdir(mediaDir, { recursive: true });
     const agentCommand = this.buildAgentCommand(type, codexArgs, mediaDir, sessionName);
     await runCommand("tmux", ["new-session", "-d", "-s", sessionName, "-c", cwd, agentCommand]);
+    await runCommand("tmux", ["set-option", "-t", sessionName, "status", "off"], {
+      allowedExitCodes: [0, 1]
+    });
 
     // Detect fast-fail launches (for example, missing codex executable) so status
     // is not left as "running" with no backing tmux session.


### PR DESCRIPTION
## Summary
- Adds `tmux set-option status off` after creating each agent tmux session to hide the status bar footer in terminal views

## Test plan
- [ ] Launch an agent and verify the tmux footer/status bar is not visible in the terminal view

🤖 Generated with [Claude Code](https://claude.com/claude-code)