### PR TITLE
Restore amber color for full-access warning badge

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -404,7 +404,7 @@ export function AgentSidebarContent({
                               className={cn(
                                 "inline-flex w-fit items-center gap-1.5 px-1.5 py-0.5 text-foreground",
                                 fullAccessEnabled &&
-                                  "border border-emerald-400/45 bg-emerald-500/15 text-emerald-200"
+                                  "border border-amber-400/45 bg-amber-500/15 text-amber-200"
                               )}
                             >
                               {fullAccessEnabled ? <AlertTriangle className="h-3.5 w-3.5" /> : null}


### PR DESCRIPTION
## Summary
- The green primary color migration (#19) inadvertently changed the full-access "Enabled" badge from orange/amber to emerald green
- Reverts the badge to amber (`amber-400/45`, `amber-500/15`, `amber-200`) so it retains its warning semantics alongside the ⚠️ AlertTriangle icon
- The CI active-step bullet was already using an explicit `bg-amber-500` and was not affected

## Test plan
- [x] Verified full-access badge renders in amber in Playwright
- [x] `npm run finalize:web` passes (typecheck + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)