### PR TITLE
Fix Postgres 15+ schema permissions in setup docs

### DIFF
--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -36,7 +36,7 @@ Set up Dispatch on this machine. The repo is at https://github.com/selfcontained
 2. Clone the repo to ~/dev/apps/dispatch.
 3. Run bin/preflight and fix any failures it reports.
 4. Start Postgres: brew services start postgresql@17
-5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch;"
+5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
 6. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
 7. Run: nvm use && npm ci && npm --prefix web ci && npm run build
 8. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
@@ -91,7 +91,7 @@ brew services start postgresql@17
 
 # Create database and role
 createdb dispatch
-psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch;"
+psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
 
 # Verify
 pg_isready


### PR DESCRIPTION
## Summary

- Add `GRANT ALL ON SCHEMA public TO dispatch` to the database setup SQL
- PostgreSQL 15+ revoked default CREATE privileges on the public schema, so without this the dispatch role can't create tables during migrations

Found during first real setup on a new machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)