### PR TITLE
Add Playwright browser to setup and preflight

### DIFF
--- a/bin/preflight
+++ b/bin/preflight
@@ -95,6 +95,14 @@ else
   warn "codex — needed to spawn Codex agents: npm install -g codex"
 fi
 
+# Playwright browsers
+PW_CHROMIUM_DIR="$HOME/Library/Caches/ms-playwright"
+if [[ -d "$PW_CHROMIUM_DIR" ]] && ls "$PW_CHROMIUM_DIR"/chromium-* &>/dev/null 2>&1; then
+  ok "playwright chromium"
+else
+  warn "playwright chromium — needed for UI validation: npx playwright install chromium"
+fi
+
 # Xcode (full, for simulators)
 if xcode-select -p &>/dev/null; then
   if xcrun simctl list devices &>/dev/null 2>&1; then

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -17,6 +17,7 @@ The new machine needs:
 | **GitHub CLI** | Release automation | `brew install gh` |
 | **Claude CLI** | Agent runtime (Claude agents) | `npm install -g @anthropic-ai/claude-code` |
 | **Codex CLI** | Agent runtime (Codex agents) | `npm install -g codex` |
+| **Playwright browsers** | Headless Chrome for agent UI validation | `npx playwright install chromium` |
 
 ### Optional
 
@@ -32,7 +33,7 @@ Copy and paste this prompt to a Claude agent on the new machine to kick off setu
 ```
 Set up Dispatch on this machine. The repo is at https://github.com/selfcontained/dispatch.git
 
-1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Claude CLI, Codex CLI.
+1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Claude CLI, Codex CLI, Playwright browsers.
 2. Clone the repo to ~/dev/apps/dispatch.
 3. Run bin/preflight and fix any failures it reports.
 4. Start Postgres: brew services start postgresql@17
@@ -188,6 +189,14 @@ codex --version
 ```
 
 The config defaults to `claude` and `codex` on PATH. To override, set `DISPATCH_CLAUDE_BIN` or `DISPATCH_CODEX_BIN` in `.env`.
+
+### 9. Playwright browsers
+
+Agents use Playwright for headless UI validation. Install the browser once — it's shared across all agents:
+
+```bash
+npx playwright install chromium
+```
 
 ## Post-Setup Verification Checklist
 


### PR DESCRIPTION
## Summary

- Add `npx playwright install chromium` to prerequisites, setup steps (step 9), and agent prompt
- Add Playwright browser detection to `bin/preflight` (checks `~/Library/Caches/ms-playwright/chromium-*`)
- Found during first real agent run on new machine — Playwright failed because no browser was installed

## Test plan

- [x] `bin/preflight` detects installed Playwright Chromium
- [x] `bin/preflight` warns when Chromium is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)