### PR TITLE
Add optional TLS support for secure LAN access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=change-me
 MEDIA_ROOT=~/.dispatch/media
+# TLS_CERT=~/.dispatch/tls/cert.pem
+# TLS_KEY=~/.dispatch/tls/key.pem

--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -65,10 +65,25 @@ reload_service() {
   sleep 3
 }
 
+resolve_scheme() {
+  local env_file="$SERVER_DIR/.env"
+  if [[ -f "$env_file" ]]; then
+    local tls_cert tls_key
+    tls_cert=$(grep -E '^TLS_CERT=' "$env_file" | tail -1 | cut -d= -f2)
+    tls_key=$(grep -E '^TLS_KEY=' "$env_file" | tail -1 | cut -d= -f2)
+    if [[ -n "$tls_cert" && -n "$tls_key" ]]; then
+      echo "https"
+      return
+    fi
+  fi
+  echo "http"
+}
+
 health_check() {
-  local port
+  local port scheme
   port=$(resolve_port)
-  curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
+  scheme=$(resolve_scheme)
+  curl -fsS -k -m 3 "${scheme}://127.0.0.1:${port}/api/v1/health"
 }
 
 wait_for_health() {
@@ -234,6 +249,7 @@ If you can fix the issue, do so and redeploy with: bin/dispatch-deploy $tag"
     "DISPATCH_AGENT_ID='${agent_id}' \
      DISPATCH_MEDIA_DIR='${media_dir}' \
      DISPATCH_PORT='${port}' \
+     DISPATCH_SCHEME='$(resolve_scheme)' \
      PATH='${path_prefix}':\"\$PATH\" \
      claude --append-system-prompt 'You are a Dispatch deploy diagnosis agent. Call dispatch-event at start (working), when blocked (blocked), and before final response (done/idle).' \
      -p '${prompt//\'/\'\\\'\'}'" \

--- a/bin/dispatch-event
+++ b/bin/dispatch-event
@@ -42,7 +42,7 @@ if [ -z "$AGENT_ID" ]; then
 fi
 
 PORT="${DISPATCH_PORT:-6767}"
-API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${PORT}}"
+API_BASE="${DISPATCH_API_BASE:-${DISPATCH_SCHEME:-http}://127.0.0.1:${PORT}}"
 
 if [ -n "$METADATA_RAW" ]; then
   node -e 'JSON.parse(process.argv[1])' "$METADATA_RAW" >/dev/null
@@ -57,7 +57,7 @@ PAYLOAD="$(node -e '
   process.stdout.write(JSON.stringify(payload));
 ' "$EVENT_TYPE" "$MESSAGE" "$METADATA_RAW")"
 
-curl -fsS \
+curl -fsS -k \
   -X POST \
   -H "content-type: application/json" \
   --data "$PAYLOAD" \

--- a/bin/dispatch-release
+++ b/bin/dispatch-release
@@ -72,8 +72,16 @@ Report your findings via dispatch-event."
     [[ -n "$env_port" ]] && port="$env_port"
   fi
 
+  local scheme="http"
+  if [[ -f "$env_file" ]]; then
+    local tls_cert tls_key
+    tls_cert=$(grep -E '^TLS_CERT=' "$env_file" | tail -1 | cut -d= -f2)
+    tls_key=$(grep -E '^TLS_KEY=' "$env_file" | tail -1 | cut -d= -f2)
+    [[ -n "$tls_cert" && -n "$tls_key" ]] && scheme="https"
+  fi
+
   echo "==> spawning diagnosis agent..."
-  curl -fsS -X POST "http://127.0.0.1:${port}/api/v1/agents" \
+  curl -fsS -k -X POST "${scheme}://127.0.0.1:${port}/api/v1/agents" \
     -H "Content-Type: application/json" \
     -d "$(jq -n \
       --arg name "release-diagnosis" \

--- a/bin/dispatch-server
+++ b/bin/dispatch-server
@@ -58,7 +58,9 @@ resolve_port() {
 health_check() {
   local port
   port=$(resolve_port)
-  curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
+  # Try HTTPS first (TLS-enabled), fall back to HTTP
+  curl -fsS -k -m 3 "https://127.0.0.1:${port}/api/v1/health" 2>/dev/null \
+    || curl -fsS -m 3 "http://127.0.0.1:${port}/api/v1/health"
 }
 
 wait_for_health() {

--- a/bin/dispatch-share
+++ b/bin/dispatch-share
@@ -16,7 +16,7 @@ Examples:
 USAGE
 }
 
-API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${DISPATCH_PORT:-8787}}"
+API_BASE="${DISPATCH_API_BASE:-${DISPATCH_SCHEME:-http}://127.0.0.1:${DISPATCH_PORT:-8787}}"
 AGENT_ID="${DISPATCH_AGENT_ID:-}"
 
 if [[ -z "$AGENT_ID" ]]; then
@@ -88,7 +88,7 @@ base="${safe_name%.*}"
 upload_name="${base}-${timestamp}.${ext}"
 
 CURL_ARGS=(
-  -fsS -X POST
+  -fsS -k -X POST
   -F "source=${SOURCE_TYPE}"
 )
 if [[ -n "$DESCRIPTION" ]]; then

--- a/bin/dispatch-stream
+++ b/bin/dispatch-stream
@@ -29,7 +29,7 @@ if [ -z "$AGENT_ID" ]; then
 fi
 
 PORT="${DISPATCH_PORT:-8787}"
-API_BASE="${DISPATCH_API_BASE:-http://127.0.0.1:${PORT}}"
+API_BASE="${DISPATCH_API_BASE:-${DISPATCH_SCHEME:-http}://127.0.0.1:${PORT}}"
 
 case "$ACTION" in
   start)
@@ -72,7 +72,7 @@ case "$ACTION" in
     ;;
 esac
 
-curl -fsS \
+curl -fsS -k \
   -X POST \
   -H "content-type: application/json" \
   --data "$PAYLOAD" \

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -360,6 +360,7 @@ export class AgentManager {
       `HOSTESS_AGENT_ID=${this.shellEscape(agentId)}`,
       `HOSTESS_MEDIA_DIR=${this.shellEscape(mediaDir)}`,
       `DISPATCH_PORT=${this.shellEscape(String(this.config.port))}`,
+      `DISPATCH_SCHEME=${this.config.tls ? "https" : "http"}`,
       `HOSTESS_PORT=${this.shellEscape(String(this.config.port))}`,
       // Compatibility alias for common typo to keep screenshot sharing reliable.
       `HOSTESS_MDEIA_DIR=${this.shellEscape(mediaDir)}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,14 @@
 import "dotenv/config";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export type TlsConfig = {
+  cert: Buffer;
+  key: Buffer;
+};
 
 export type AppConfig = {
   host: string;
@@ -13,7 +19,21 @@ export type AppConfig = {
   dispatchBinDir: string;
   codexBin: string;
   claudeBin: string;
+  tls: TlsConfig | null;
 };
+
+function loadTls(): TlsConfig | null {
+  const certPath = process.env.TLS_CERT;
+  const keyPath = process.env.TLS_KEY;
+  if (!certPath && !keyPath) return null;
+  if (!certPath || !keyPath) {
+    throw new Error("Both TLS_CERT and TLS_KEY must be set to enable TLS");
+  }
+  return {
+    cert: readFileSync(certPath),
+    key: readFileSync(keyPath),
+  };
+}
 
 export function loadConfig(): AppConfig {
   return {
@@ -33,6 +53,7 @@ export function loadConfig(): AppConfig {
       process.env.DISPATCH_CLAUDE_BIN ??
       process.env.HOSTESS_CLAUDE_BIN ??
       process.env.CLAUDE_BIN ??
-      "claude"
+      "claude",
+    tls: loadTls(),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,10 @@ import { StreamManager } from "./stream-manager.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 
 const config = loadConfig();
-const app = Fastify({ logger: true });
+const app = Fastify({
+  logger: true,
+  ...(config.tls && { https: { cert: config.tls.cert, key: config.tls.key } }),
+});
 const pool = createPool(config);
 const agentManager = new AgentManager(pool, app.log, config);
 const terminalTokenStore = new TerminalTokenStore(60_000);
@@ -1233,10 +1236,12 @@ async function start() {
   startGitContextRefreshLoop();
   await registerRoutes();
 
+  const protocol = config.tls ? "https" : "http";
   await app.listen({
     host: config.host,
     port: config.port
   });
+  app.log.info(`Dispatch listening on ${protocol}://${config.host}:${config.port}`);
 }
 
 start().catch(async (error) => {


### PR DESCRIPTION
## Summary
- Adds native HTTPS support to the Fastify server, enabled via `TLS_CERT` and `TLS_KEY` environment variables
- When neither is set, the server starts on plain HTTP (no change for dev)
- Updates all bin scripts (`dispatch-deploy`, `dispatch-event`, `dispatch-stream`, `dispatch-share`, `dispatch-release`, `dispatch-server`) to auto-detect HTTP/HTTPS and accept self-signed certs
- Passes `DISPATCH_SCHEME` env var to agent subprocesses so bin scripts know which protocol to use

## Setup
```bash
brew install mkcert
mkcert -install
mkdir -p ~/.dispatch/tls
mkcert -cert-file ~/.dispatch/tls/cert.pem -key-file ~/.dispatch/tls/key.pem <LAN-IP> localhost 127.0.0.1
```

Then add to production `.env`:
```
TLS_CERT=~/.dispatch/tls/cert.pem
TLS_KEY=~/.dispatch/tls/key.pem
```

## Test plan
- [ ] Verify server starts on HTTP when TLS env vars are unset (dev mode)
- [ ] Verify server starts on HTTPS when TLS env vars point to valid cert/key
- [ ] Verify error is thrown if only one of TLS_CERT/TLS_KEY is set
- [ ] Verify deploy health check works with HTTPS enabled
- [ ] Verify agent bin scripts (dispatch-event, dispatch-share, etc.) work over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)