### PR TITLE
Add dev database docs, fix .env paths, default Vite to 0.0.0.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@ HOST=0.0.0.0
 DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=change-me
-MEDIA_ROOT=~/.dispatch/media
+MEDIA_ROOT=/Users/you/.dispatch/media
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem
+
+# Development overrides (used in worktrees / dev servers):
+# DISPATCH_PORT=8788
+# DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev
+# MEDIA_ROOT=/Users/you/.dispatch/media-dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,9 @@
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, run a separate backend instance on a different port (for example `DISPATCH_PORT=8788 npm run dev`) and point validation tooling to that port.
 - Only operate on production (`:6767`) when explicitly requested by the user.
+
+## Development Database
+- Production uses the `dispatch` database. Development and worktrees use `dispatch_dev`.
+- When running dev servers, set `DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev` to avoid touching production data.
+- Worktree `.env` files should already be configured with the dev database, dev port (8788), and a separate media root (`~/.dispatch/media-dev`).
+- Migrations run automatically on server start, so the dev database schema stays up to date.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,9 @@
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, run a separate backend instance on a different port (for example `DISPATCH_PORT=8788 npm run dev`) and point validation tooling to that port.
 - Only operate on production (`:6767`) when explicitly requested by the user.
+
+## Development Database
+- Production uses the `dispatch` database. Development and worktrees use `dispatch_dev`.
+- When running dev servers, set `DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev` to avoid touching production data.
+- Worktree `.env` files should already be configured with the dev database, dev port (8788), and a separate media root (`~/.dispatch/media-dev`).
+- Migrations run automatically on server start, so the dev database schema stays up to date.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -47,7 +47,8 @@ export default defineConfig({
     })
   ],
   server: {
-    host: "127.0.0.1",
+    host: "0.0.0.0",
+    allowedHosts: true,
     proxy: {
       "/api": {
         target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 6767}`,


### PR DESCRIPTION
## Summary
- Document `dispatch_dev` database for development/worktree use in CLAUDE.md and AGENTS.md
- Update `.env.example` to use absolute `MEDIA_ROOT` path (tilde causes Node's `mkdir` to create a literal `~` directory) and add commented dev overrides
- Default Vite dev server to `host: "0.0.0.0"` with `allowedHosts: true` so it's accessible via local network hostnames (e.g. `studio.local`)

## Test plan
- [ ] Verify Vite dev server is accessible from local network hostname
- [ ] Verify new agents created with absolute MEDIA_ROOT write to correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)