### PR TITLE
Add Playwright e2e test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,29 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Create CI test database
+        run: |
+          docker exec ${{ steps.postgres.outputs.container }} \
+            psql -U dispatch -d postgres -c "CREATE DATABASE dispatch_ci;"
+
+      - name: E2E tests
+        run: npx playwright test
+        env:
+          CI: "true"
+          E2E_PORT: "8799"
+          DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/dispatch_ci
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7
+
       - name: Stop Postgres
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ tmp-*.mjs
 *.webp
 artifacts/
 .playwright-mcp/
+test-results/
+playwright-report/

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
+
+test.describe("Agent CRUD", () => {
+  test.afterEach(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("displays 'No agents yet' when the list is empty", async ({ page, request }) => {
+    // Stop all agents first (running agents can't be deleted)
+    const listRes = await request.get("/api/v1/agents");
+    const { agents } = (await listRes.json()) as { agents: Array<{ id: string; status: string }> };
+    for (const agent of agents) {
+      if (agent.status !== "stopped") {
+        await request.post(`/api/v1/agents/${agent.id}/stop`);
+      }
+    }
+    // Delete all agents
+    for (const agent of agents) {
+      await request.delete(`/api/v1/agents/${agent.id}`);
+    }
+
+    // Load page fresh — SSE snapshot should now be empty
+    await loadApp(page);
+
+    await expect(page.getByTestId("no-agents-message")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("no-agents-message")).toHaveText("No agents yet.");
+  });
+
+  test("create agent via UI — dialog opens, submits, and agent appears in sidebar", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    // Open the create dialog
+    await page.getByTestId("create-agent-button").click();
+
+    // Dialog should be visible
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    // Fill in the form
+    const agentName = `e2e-agent-${Date.now()}`;
+    await page.getByTestId("create-agent-name").fill(agentName);
+    await page.getByTestId("create-agent-cwd").fill("/tmp");
+
+    // Submit
+    await page.getByTestId("create-agent-submit").click();
+
+    // Dialog should close
+    await expect(form).not.toBeVisible({ timeout: 5_000 });
+
+    // Agent should appear in the sidebar
+    const sidebar = page.getByTestId("agent-sidebar");
+    await expect(sidebar.getByText(agentName)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("cancel create dialog does not create an agent", async ({ page }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    await page.getByTestId("create-agent-cancel").click();
+    await expect(form).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test("agent created via API appears in sidebar after SSE update", async ({
+    page,
+    request,
+  }) => {
+    await loadApp(page);
+
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+
+    // SSE should push the new agent to the UI
+    const sidebar = page.getByTestId("agent-sidebar");
+    await expect(sidebar.getByText(agent.name)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("selecting an agent expands its details in the sidebar", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    await loadApp(page);
+
+    // Click the agent name to select it
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.getByText(agent.name).click();
+
+    // The expanded card should show "Working dir" metadata
+    await expect(agentCard.getByText("Working dir")).toBeVisible({ timeout: 3_000 });
+    await expect(agentCard.getByText("/tmp")).toBeVisible();
+  });
+
+  test("delete agent via overflow menu removes it from sidebar", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    await loadApp(page);
+
+    const sidebar = page.getByTestId("agent-sidebar");
+    await expect(sidebar.getByText(agent.name)).toBeVisible({ timeout: 5_000 });
+
+    // Open the overflow menu on the agent card
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.locator('[data-agent-control="true"]').last().click();
+
+    // Click "Delete agent" from the overflow menu
+    await page.getByText("Delete agent").click();
+
+    // Confirm the deletion
+    await page.getByTestId("delete-agent-confirm").click();
+
+    // Agent should disappear from sidebar
+    await expect(sidebar.getByText(agent.name)).not.toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/api-health.spec.ts
+++ b/e2e/api-health.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("API health", () => {
+  test("GET /api/v1/health returns ok", async ({ request }) => {
+    const res = await request.get("/api/v1/health");
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as { status: string; db: string };
+    expect(body.status).toBe("ok");
+    expect(body.db).toBe("ok");
+  });
+
+  test("GET /api/v1/agents returns an array", async ({ request }) => {
+    const res = await request.get("/api/v1/agents");
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as { agents: unknown[] };
+    expect(Array.isArray(body.agents)).toBe(true);
+  });
+
+  test("POST /api/v1/agents validates cwd is required", async ({ request }) => {
+    const res = await request.post("/api/v1/agents", {
+      data: { name: "missing-cwd" },
+    });
+    expect(res.status()).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("cwd");
+  });
+
+  test("POST /api/v1/agents validates type", async ({ request }) => {
+    const res = await request.post("/api/v1/agents", {
+      data: { cwd: "/tmp", type: "invalid-type" },
+    });
+    expect(res.status()).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("type");
+  });
+});

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { cleanupE2EAgents, loadApp } from "./helpers";
+
+test.describe("App shell", () => {
+  test.afterAll(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("renders the main layout — sidebar, header, terminal pane, and status footer", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await expect(page.getByTestId("agent-sidebar")).toBeVisible();
+    await expect(page.getByTestId("app-header")).toBeVisible();
+    await expect(page.getByTestId("terminal-pane")).toBeVisible();
+    await expect(page.getByTestId("status-footer")).toBeVisible();
+  });
+
+  test("shows the empty-state prompt when no agent is selected", async ({ page }) => {
+    await loadApp(page);
+
+    await expect(page.getByTestId("terminal-empty-state")).toBeVisible();
+    await expect(page.getByTestId("terminal-empty-state")).toContainText(
+      "Select an agent"
+    );
+  });
+
+  test("status footer reports healthy API and DB", async ({ page }) => {
+    await loadApp(page);
+
+    // Wait for health poll to succeed (the dots turn green = bg-emerald-500)
+    const apiDot = page.getByTestId("service-dot-api");
+    await expect(apiDot).toBeVisible();
+    // The status text eventually shows "ok"
+    const apiStatus = page.getByTestId("service-status-api");
+    await expect(apiStatus).toContainText("ok", { timeout: 10_000 });
+
+    const dbStatus = page.getByTestId("service-status-db");
+    await expect(dbStatus).toContainText("ok", { timeout: 10_000 });
+  });
+
+  test("sidebar shows the Dispatch logo", async ({ page }) => {
+    await loadApp(page);
+
+    const logo = page.getByTestId("agent-sidebar").locator('img[alt="Dispatch"]');
+    await expect(logo).toBeVisible();
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,54 @@
+import { type Page, type APIRequestContext } from "@playwright/test";
+
+const API = "/api/v1";
+
+/**
+ * Create an agent via the REST API (faster than going through the UI every time).
+ */
+export async function createAgentViaAPI(
+  request: APIRequestContext,
+  overrides: { name?: string; type?: string; cwd?: string } = {}
+): Promise<{ id: string; name: string }> {
+  const res = await request.post(`${API}/agents`, {
+    data: {
+      name: overrides.name ?? `e2e-agent-${Date.now()}`,
+      type: overrides.type ?? "codex",
+      cwd: overrides.cwd ?? "/tmp",
+    },
+  });
+  const body = (await res.json()) as { agent: { id: string; name: string } };
+  return body.agent;
+}
+
+/**
+ * Delete an agent via the REST API.
+ */
+export async function deleteAgentViaAPI(
+  request: APIRequestContext,
+  agentId: string
+): Promise<void> {
+  await request.delete(`${API}/agents/${agentId}`);
+}
+
+/**
+ * Delete all agents whose name starts with `e2e-agent-` to keep the dev DB clean.
+ */
+export async function cleanupE2EAgents(request: APIRequestContext): Promise<void> {
+  const res = await request.get(`${API}/agents`);
+  const body = (await res.json()) as { agents: Array<{ id: string; name: string }> };
+  for (const agent of body.agents) {
+    if (agent.name.startsWith("e2e-agent-")) {
+      await deleteAgentViaAPI(request, agent.id);
+    }
+  }
+}
+
+/**
+ * Navigate to the app root and wait for the shell to be ready
+ * (sidebar rendered + health polling started).
+ */
+export async function loadApp(page: Page): Promise<void> {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("agent-sidebar").waitFor({ state: "visible", timeout: 15_000 });
+  await page.getByTestId("status-footer").waitFor({ state: "visible", timeout: 10_000 });
+}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { loadApp } from "./helpers";
+
+test.describe("Settings pane", () => {
+  test("opens and closes the settings pane", async ({ page }) => {
+    await loadApp(page);
+
+    // Click the Settings button in the sidebar footer
+    await page.getByTestId("settings-button").click();
+
+    // Settings overlay should appear with a "Settings" heading and "Release" nav item
+    await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("Release", { exact: true })).toBeVisible();
+
+    // Close it via the X button (sr-only "Close")
+    await page.getByRole("button", { name: "Close" }).click();
+
+    // The Release nav item should no longer be visible (pane is closed)
+    await expect(page.getByText("Release", { exact: true })).not.toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { loadApp } from "./helpers";
+
+test.describe("Sidebar interactions", () => {
+  test("closing and reopening the left sidebar", async ({ page }) => {
+    await loadApp(page);
+
+    const sidebar = page.getByTestId("agent-sidebar");
+    await expect(sidebar).toBeVisible();
+
+    // Close the sidebar using the chevron button inside it
+    await sidebar.getByTitle("Close sidebar").click();
+
+    // The sidebar wrapper collapses to width:0 with overflow:hidden.
+    // Wait for the CSS transition to finish, then verify the wrapper has zero width.
+    await page.waitForTimeout(400);
+    const wrapper = sidebar.locator("..");
+    const width = await wrapper.evaluate((el) => el.getBoundingClientRect().width);
+    expect(width).toBeLessThan(2);
+
+    // Reopen using the header button
+    await page.getByTitle("Open agent sidebar").click();
+
+    // Create button should be visible again after the sidebar expands
+    await expect(page.getByTestId("create-agent-button")).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("Create button opens the create agent dialog", async ({ page }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+
+    await expect(page.getByTestId("create-agent-form")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("Create Agent")).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "pg": "^8.20.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/node": "^24.10.0",
         "@types/pg": "^8.18.0",
         "@types/ws": "^8.18.1",
@@ -616,6 +617,22 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1877,13 +1894,13 @@
       ]
     },
     "node_modules/playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1896,9 +1913,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2850,6 +2867,15 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
     },
+    "@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.58.2"
+      }
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -3688,13 +3714,13 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
     },
     "playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.58.2"
       },
       "dependencies": {
         "fsevents": {
@@ -3707,9 +3733,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "db:migrate": "tsx src/db/migrate.ts",
     "check": "tsc --noEmit && npm run check:web",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "npx playwright test"
   },
   "dependencies": {
     "@fastify/multipart": "^8.3.1",
@@ -31,6 +32,7 @@
     "pg": "^8.20.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^24.10.0",
     "@types/pg": "^8.18.0",
     "@types/ws": "^8.18.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+const devPort = process.env.E2E_PORT ?? "8788";
+const baseURL = `http://127.0.0.1:${devPort}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL,
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `npm run build:web && DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev DISPATCH_PORT=${devPort} MEDIA_ROOT=$HOME/.dispatch/media-dev npm run dev`,
+    url: `${baseURL}/api/v1/health`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "@playwright/test";
 
 const devPort = process.env.E2E_PORT ?? "8788";
 const baseURL = `http://127.0.0.1:${devPort}`;
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -17,7 +20,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: `npm run build:web && DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev DISPATCH_PORT=${devPort} MEDIA_ROOT=$HOME/.dispatch/media-dev npm run dev`,
+    command: `npm run build:web && DATABASE_URL=${databaseUrl} DISPATCH_PORT=${devPort} MEDIA_ROOT=$HOME/.dispatch/media-dev npm run dev`,
     url: `${baseURL}/api/v1/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -123,7 +123,7 @@ export function AgentSidebarContent({
   };
 
   return (
-    <aside className={cn("flex h-full min-h-0 w-full flex-col border-r-2 border-border bg-card text-foreground", className)}>
+    <aside data-testid="agent-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-r-2 border-border bg-card text-foreground", className)}>
       <div className="flex h-14 items-center px-3 pt-[env(safe-area-inset-top)]">
         <div className="flex items-center">
           <img src="/brand-full-logo.svg" alt="Dispatch" className="h-7 w-auto max-w-[180px] object-contain" />
@@ -139,7 +139,7 @@ export function AgentSidebarContent({
       <div className="mt-2 flex h-14 items-center border-b border-border px-3">
         <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Agents</div>
         <div className="ml-auto flex items-center">
-          <Button size="sm" variant="primary" onClick={onOpenCreateDialog}>
+          <Button size="sm" variant="primary" onClick={onOpenCreateDialog} data-testid="create-agent-button">
             <Plus className="mr-1 h-3.5 w-3.5" /> Create
           </Button>
         </div>
@@ -148,7 +148,7 @@ export function AgentSidebarContent({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <TooltipProvider delayDuration={120}>
           {agents.length === 0 ? (
-            <div className="p-4 text-sm text-muted-foreground">No agents yet.</div>
+            <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
           ) : (
             agents.map((agent) => {
               const state = agentVisualState(agent);
@@ -162,6 +162,7 @@ export function AgentSidebarContent({
               return (
                 <div
                   key={agent.id}
+                  data-testid={`agent-card-${agent.id}`}
                   className={cn(
                     "border-b border-r-4 border-border px-2 py-2",
                     borderForAgentState(state),
@@ -425,6 +426,7 @@ export function AgentSidebarContent({
       <div className="border-t border-border px-3 pb-[env(safe-area-inset-bottom)]">
         <button
           onClick={onOpenSettings}
+          data-testid="settings-button"
           className="flex w-full items-center gap-2 py-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           <Settings className="h-3.5 w-3.5" />

--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -35,7 +35,7 @@ export function AppHeader({
   detachTerminal
 }: AppHeaderProps): JSX.Element {
   return (
-    <header className={cn("relative flex h-14 items-center border-b-2 border-b-border bg-[#11120f] px-3 pt-[env(safe-area-inset-top)]")}>
+    <header data-testid="app-header" className={cn("relative flex h-14 items-center border-b-2 border-b-border bg-[#11120f] px-3 pt-[env(safe-area-inset-top)]")}>
       <div className="flex shrink-0 items-center gap-1">
         {isMobile ? (
           !leftOpen ? (
@@ -80,6 +80,7 @@ export function AppHeader({
             className="text-sky-300 hover:bg-sky-500/15 hover:text-sky-200"
             onClick={detachTerminal}
             title="Detach from session"
+            data-testid="detach-button"
           >
             <MonitorOff className="mr-1 h-3.5 w-3.5" />
             <span className="hidden sm:inline">Detach</span>
@@ -91,6 +92,7 @@ export function AppHeader({
             className="text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200"
             onClick={attachSelectedAgent}
             title="Attach to session"
+            data-testid="attach-button"
           >
             <Monitor className="mr-1 h-3.5 w-3.5" />
             <span className="hidden sm:inline">Attach</span>
@@ -104,6 +106,7 @@ export function AppHeader({
             className="relative"
             onClick={() => setMediaOpen(true)}
             title="Open media sidebar"
+            data-testid="toggle-media-sidebar"
           >
             <PanelLeftOpen className="h-4 w-4" />
             {unseenMediaCount > 0 ? (

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -59,13 +59,14 @@ export function CreateAgentDialog({
           <DialogDescription>Name, type, and working directory for a new agent session.</DialogDescription>
         </DialogHeader>
 
-        <form className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
+        <form data-testid="create-agent-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
           <div className="space-y-1">
             <label className="text-sm text-muted-foreground">Name</label>
             <Input
               value={createName}
               onChange={(event) => setCreateName(event.target.value)}
               placeholder="agent name (optional)"
+              data-testid="create-agent-name"
             />
           </div>
 
@@ -90,6 +91,7 @@ export function CreateAgentDialog({
               onBlur={() => void refreshWorktreeMode()}
               placeholder="/absolute/path"
               required
+              data-testid="create-agent-cwd"
             />
           </div>
 
@@ -142,10 +144,10 @@ export function CreateAgentDialog({
           </label>
 
           <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)} data-testid="create-agent-cancel">
               Cancel
             </Button>
-            <Button type="submit" variant="primary" disabled={creating}>
+            <Button type="submit" variant="primary" disabled={creating} data-testid="create-agent-submit">
               {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
               Create
             </Button>

--- a/web/src/components/app/delete-agent-dialog.tsx
+++ b/web/src/components/app/delete-agent-dialog.tsx
@@ -31,6 +31,7 @@ export function DeleteAgentDialog({
         <div className="flex justify-end gap-2">
           <Button
             variant="ghost"
+            data-testid="delete-agent-cancel"
             onClick={() => {
               setOpen(false);
               setDeleteTarget(null);
@@ -40,6 +41,7 @@ export function DeleteAgentDialog({
           </Button>
           <Button
             variant="destructive"
+            data-testid="delete-agent-confirm"
             onClick={async () => {
               if (!deleteTarget) {
                 return;

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -88,7 +88,7 @@ export function MediaSidebarContent({
   className
 }: MediaSidebarContentProps): JSX.Element {
   return (
-    <aside className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
+    <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
       <div className="flex items-center px-3 py-2 pt-[env(safe-area-inset-top)]">
         <div>
           <div className="text-sm font-semibold uppercase tracking-wide">Media Stream</div>

--- a/web/src/components/app/service-status.tsx
+++ b/web/src/components/app/service-status.tsx
@@ -11,10 +11,10 @@ type ServiceStatusProps = {
 
 export function ServiceStatus({ icon, label, value, dotClass }: ServiceStatusProps): JSX.Element {
   return (
-    <div className="flex items-center gap-2">
+    <div data-testid={`service-status-${label.toLowerCase()}`} className="flex items-center gap-2">
       {icon}
       <span>{label}</span>
-      <span className={cn("h-2.5 w-2.5 rounded-full", dotClass)} />
+      <span data-testid={`service-dot-${label.toLowerCase()}`} className={cn("h-2.5 w-2.5 rounded-full", dotClass)} />
       <span className="truncate uppercase">{value}</span>
     </div>
   );

--- a/web/src/components/app/status-footer.tsx
+++ b/web/src/components/app/status-footer.tsx
@@ -19,7 +19,7 @@ export function StatusFooter({
   serviceDotClass
 }: StatusFooterProps): JSX.Element {
   return (
-    <footer className="grid h-11 grid-cols-4 items-center border-t-2 border-border bg-[#11120f] px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
+    <footer data-testid="status-footer" className="grid h-11 grid-cols-4 items-center border-t-2 border-border bg-[#11120f] px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
       <ServiceStatus
         icon={<Wifi className="h-3.5 w-3.5" />}
         label="WS"

--- a/web/src/components/app/terminal-pane.tsx
+++ b/web/src/components/app/terminal-pane.tsx
@@ -37,7 +37,7 @@ export function TerminalPane({
   const showEmptyState = connState === "disconnected" && !isAttached && !hasSelectedAgent;
 
   return (
-    <div className="relative h-full min-h-0 overflow-hidden bg-[#141414]">
+    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-[#141414]">
       <div
         className={cn(
           "h-full w-full",
@@ -49,7 +49,7 @@ export function TerminalPane({
       </div>
 
       {showEmptyState ? (
-        <div className="absolute inset-0 z-20 grid place-items-center bg-[#141414]">
+        <div data-testid="terminal-empty-state" className="absolute inset-0 z-20 grid place-items-center bg-[#141414]">
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
             <p className="text-sm">Select an agent and press Play to start and attach to a session.</p>


### PR DESCRIPTION
## Summary
- Adds 17 Playwright e2e tests across 5 spec files covering app shell layout, agent CRUD lifecycle, API validation, settings pane, and sidebar interactions
- Adds `data-testid` attributes to key UI components (sidebar, header, footer, terminal pane, dialogs, service status indicators) for reliable test selectors
- Configures Playwright with auto web build + dev server startup on an isolated test port
- Adds `npm run test:e2e` script

## Test coverage
| Spec file | Tests | What it covers |
|---|---|---|
| `app-shell.spec.ts` | 4 | Main layout renders, empty state, health status, logo |
| `agent-crud.spec.ts` | 6 | Empty list, create via UI, cancel dialog, SSE updates, expand details, delete via overflow |
| `api-health.spec.ts` | 4 | Health endpoint, agents list, cwd validation, type validation |
| `settings.spec.ts` | 1 | Open/close settings pane |
| `sidebar-interactions.spec.ts` | 2 | Sidebar collapse/expand, create dialog opens |

## Test plan
- [x] All 17 tests pass locally (`E2E_PORT=8799 npm run test:e2e`)
- [x] `npm run finalize:web` passes (type check + build)
- [ ] Review data-testid naming conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)