### PR TITLE
Add periodic agent status reconciliation

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -292,14 +292,34 @@ export class AgentManager {
   }
 
   async reconcileAgents(): Promise<void> {
+    await this.reconcileAgentStatuses();
+  }
+
+  async reconcileAgentStatuses(): Promise<AgentRecord[]> {
     const result = await this.pool.query(
-      "SELECT id, tmux_session AS \"tmuxSession\" FROM agents WHERE status IN ('running', 'creating', 'unknown')"
+      "SELECT id, tmux_session AS \"tmuxSession\", status FROM agents WHERE status IN ('running', 'stopping', 'creating')"
     );
 
-    for (const row of result.rows as Array<{ id: string; tmuxSession: string | null }>) {
+    const reconciled: AgentRecord[] = [];
+
+    for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string }>) {
       const exists = row.tmuxSession ? await this.tmuxHasSession(row.tmuxSession) : false;
-      await this.setAgentStatus(row.id, exists ? "running" : "stopped", null, row.tmuxSession ?? undefined);
+
+      if (!exists) {
+        await this.setAgentStatus(row.id, "stopped", null, row.tmuxSession ?? undefined);
+        await this.setSystemLatestEvent(row.id, {
+          type: "idle",
+          message: "Session ended unexpectedly.",
+          metadata: { source: "system" }
+        });
+        const agent = await this.getAgent(row.id);
+        if (agent) {
+          reconciled.push(agent);
+        }
+      }
     }
+
+    return reconciled;
   }
 
   private async startTmuxSession(

--- a/src/server.ts
+++ b/src/server.ts
@@ -151,6 +151,9 @@ const gitRefreshCounters = {
 };
 let gitContextRefreshTimer: NodeJS.Timeout | null = null;
 
+const AGENT_STATUS_RECONCILE_INTERVAL_MS = 30_000;
+let agentStatusReconcileTimer: NodeJS.Timeout | null = null;
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const webDistDir = path.resolve(__dirname, "../web/dist");
@@ -1234,6 +1237,7 @@ async function start() {
   const agents = await agentManager.listAgents();
   queueGitContextRefresh(agents.map((agent) => agent.id));
   startGitContextRefreshLoop();
+  startAgentStatusReconcileLoop();
   await registerRoutes();
 
   const protocol = config.tls ? "https" : "http";
@@ -1394,6 +1398,35 @@ function stopGitContextRefreshLoop(): void {
   }
   clearInterval(gitContextRefreshTimer);
   gitContextRefreshTimer = null;
+}
+
+function startAgentStatusReconcileLoop(): void {
+  if (agentStatusReconcileTimer) {
+    return;
+  }
+  agentStatusReconcileTimer = setInterval(() => {
+    void runAgentStatusReconciliation();
+  }, AGENT_STATUS_RECONCILE_INTERVAL_MS);
+}
+
+function stopAgentStatusReconcileLoop(): void {
+  if (!agentStatusReconcileTimer) {
+    return;
+  }
+  clearInterval(agentStatusReconcileTimer);
+  agentStatusReconcileTimer = null;
+}
+
+async function runAgentStatusReconciliation(): Promise<void> {
+  try {
+    const reconciled = await agentManager.reconcileAgentStatuses();
+    for (const agent of reconciled) {
+      console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+    }
+  } catch (error) {
+    app.log.warn({ err: error }, "Agent status reconciliation failed.");
+  }
 }
 
 async function refreshAllAgentGitContexts(): Promise<void> {
@@ -1791,6 +1824,7 @@ async function shutdown(code: number): Promise<void> {
 
   streamManager.stopAll();
   stopGitContextRefreshLoop();
+  stopAgentStatusReconcileLoop();
   await pool.end().catch(() => null);
   await app.close().catch(() => null);
   process.exit(code);


### PR DESCRIPTION
## Summary
- Adds `reconcileAgentStatuses()` method to `AgentManager` that queries agents with active statuses (running, stopping, creating), checks if their tmux session still exists, and corrects orphaned agents to stopped status with an appropriate latest event.
- Wires up a 30-second `setInterval` in `server.ts` that runs reconciliation and publishes SSE `agent.upsert` events for any corrected agents so the UI updates in real time.
- Cleans up the interval on server shutdown.

## Test plan
- [ ] Verify type check passes (`npm run check`)
- [ ] Start an agent, kill its tmux session manually (`tmux kill-session -t <session>`), and confirm the agent transitions to stopped within 30 seconds
- [ ] Confirm the UI reflects the status change via SSE without a page refresh
- [ ] Verify agents already in stopped/error status are not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)