### PR TITLE
Fix PWA energy kills with visibility-aware background pausing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,15 @@
 - Prefer shadcn/ui components over hand-rolled UI when an equivalent shadcn option exists.
 - Only hand-roll when there is no suitable shadcn primitive or composition path.
 
+## Pre-Completion Checks (Mandatory)
+Before marking any task as done, run the following checks and fix any failures:
+1. **Type checking**: `npm run check` (runs `tsc --noEmit` for backend + web).
+2. **Web finalization**: If any files under `web/` changed, run `npm run finalize:web` (type check + production build).
+3. **E2E tests**: `npm run test:e2e` (Playwright). Use `E2E_PORT=<port>` if a dev server is already running.
+4. **Unit tests**: `npm test` (Vitest) if backend logic changed.
+- Do not consider a task complete until all applicable checks pass.
+- If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
+
 ## Web Finalization
 - If any files under `web/` changed, run `npm run finalize:web` before marking the task complete.
 - After running `npm run finalize:web`, verify the served app once (not only Vite dev server) when the task affects UI/theme/rendering behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,15 @@
 - Prefer shadcn/ui components over hand-rolled UI when an equivalent shadcn option exists.
 - Only hand-roll when there is no suitable shadcn primitive or composition path.
 
+## Pre-Completion Checks (Mandatory)
+Before marking any task as done, run the following checks and fix any failures:
+1. **Type checking**: `npm run check` (runs `tsc --noEmit` for backend + web).
+2. **Web finalization**: If any files under `web/` changed, run `npm run finalize:web` (type check + production build).
+3. **E2E tests**: `npm run test:e2e` (Playwright). Use `E2E_PORT=<port>` if a dev server is already running.
+4. **Unit tests**: `npm test` (Vitest) if backend logic changed.
+- Do not consider a task complete until all applicable checks pass.
+- If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
+
 ## Web Finalization
 - If any files under `web/` changed, run `npm run finalize:web` before marking the task complete.
 - After running `npm run finalize:web`, verify the served app once (not only Vite dev server) when the task affects UI/theme/rendering behavior.

--- a/e2e/energy-visibility.spec.ts
+++ b/e2e/energy-visibility.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, type Page } from "@playwright/test";
+import { loadApp } from "./helpers";
+
+/**
+ * Simulate the page becoming hidden and trigger the visibilitychange event.
+ * This also triggers a metrics save to localStorage via the beacon path.
+ */
+async function simulateHidden(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+async function simulateVisible(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+/**
+ * Read energy metrics from localStorage. Going hidden triggers a save,
+ * so call simulateHidden first if you need fresh data.
+ */
+async function readMetrics(page: Page): Promise<Record<string, unknown> | null> {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("dispatch:energyMetrics");
+    return raw ? JSON.parse(raw) : null;
+  });
+}
+
+test.describe("Energy / visibility-aware pausing", () => {
+  test("SSE connection closes when page is hidden and reopens when visible", async ({
+    page,
+  }) => {
+    await loadApp(page);
+    await page.waitForTimeout(1000);
+
+    // Simulate page going hidden
+    await simulateHidden(page);
+
+    // data-hidden attribute should be set on <html>
+    await expect(page.locator("html[data-hidden]")).toBeAttached();
+
+    await page.waitForTimeout(500);
+
+    // Simulate page becoming visible again
+    await simulateVisible(page);
+
+    // data-hidden should be removed
+    await expect(page.locator("html[data-hidden]")).not.toBeAttached();
+
+    // Health poll should resume — check API status still shows ok
+    const apiStatus = page.getByTestId("service-status-api");
+    await expect(apiStatus).toContainText("ok", { timeout: 15_000 });
+  });
+
+  test("energy metrics are persisted to localStorage on visibility change", async ({
+    page,
+  }) => {
+    await loadApp(page);
+    await page.waitForTimeout(1000);
+
+    // Going hidden triggers save() via beacon
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+
+    const metrics = await readMetrics(page);
+    expect(metrics).not.toBeNull();
+    expect(metrics).toHaveProperty("windowStart");
+    expect(metrics).toHaveProperty("sseEventsReceived");
+    expect(metrics).toHaveProperty("visibilityChanges");
+    expect(metrics).toHaveProperty("totalHiddenMs");
+    expect(typeof metrics!.sseEventsReceived).toBe("number");
+  });
+
+  test("energy metrics record SSE events", async ({ page }) => {
+    await loadApp(page);
+
+    // SSE snapshot fires immediately on connect — wait for it
+    await page.waitForTimeout(2000);
+
+    // Trigger save via hidden
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+
+    const metrics = await readMetrics(page);
+    expect(metrics).not.toBeNull();
+    // The SSE connection receives at least a snapshot event on connect
+    expect(metrics!.sseEventsReceived).toBeGreaterThanOrEqual(1);
+  });
+
+  test("visibility changes are recorded in metrics", async ({ page }) => {
+    await loadApp(page);
+    await page.waitForTimeout(500);
+
+    // hidden → visible → hidden (to trigger the save)
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+    await simulateVisible(page);
+    await page.waitForTimeout(200);
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+
+    const metrics = await readMetrics(page);
+    expect(metrics).not.toBeNull();
+    // At least 2 transitions recorded (hidden→visible cycle)
+    expect((metrics!.visibilityChanges as unknown[]).length).toBeGreaterThanOrEqual(2);
+    expect(metrics!.totalHiddenMs).toBeGreaterThan(0);
+  });
+
+  test("health poll timer does not fire while hidden", async ({ page }) => {
+    await loadApp(page);
+
+    // Wait for initial health poll to complete
+    await page.waitForTimeout(1000);
+
+    // Trigger a save to get baseline
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+    const beforeMetrics = await readMetrics(page);
+    const pollsBefore = (beforeMetrics?.healthPollFires as number) ?? 0;
+
+    // Stay hidden longer than the 8s health poll interval
+    await page.waitForTimeout(9000);
+
+    // Read metrics again (still in localStorage from the beacon)
+    // Trigger another save by going visible then hidden
+    await simulateVisible(page);
+    await page.waitForTimeout(200);
+    await simulateHidden(page);
+    await page.waitForTimeout(200);
+
+    const afterMetrics = await readMetrics(page);
+    const pollsAfter = (afterMetrics?.healthPollFires as number) ?? 0;
+
+    // At most 1 extra poll from the simulateVisible→immediate health check
+    // but no 8s interval fires while hidden
+    expect(pollsAfter - pollsBefore).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -581,6 +581,17 @@ async function registerRoutes() {
     };
   });
 
+  // --- Energy metrics beacon (PWA diagnostics) ---
+  app.post("/api/v1/energy-report", async (request, reply) => {
+    try {
+      const metrics = request.body;
+      app.log.info({ energyMetrics: metrics }, "PWA energy metrics report");
+    } catch {
+      // Beacon payloads are fire-and-forget; don't fail loudly
+    }
+    return reply.status(204).send();
+  });
+
   app.get("/api/v1/diagnostics/git-context", async () => {
     const now = Date.now();
     const pendingAges = Array.from(pendingGitRefreshEnqueuedAt.values()).map((queuedAt) =>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,6 @@ import {
   recordHTTPRequest,
   recordHealthPollFire,
   recordHealthPollSkip,
-  recordError as recordEnergyError,
 } from "@/lib/energy-metrics";
 
 const DEFAULT_CWD = "/Users/bharris/dev/apps/dispatch";

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,16 @@ import {
 } from "@/components/app/types";
 import { MobileSlidePanel } from "@/components/ui/mobile-slide-panel";
 import { cn } from "@/lib/utils";
+import {
+  initEnergyMetrics,
+  recordSSEEvent,
+  recordSSEReconnect,
+  recordWSReconnect,
+  recordHTTPRequest,
+  recordHealthPollFire,
+  recordHealthPollSkip,
+  recordError as recordEnergyError,
+} from "@/lib/energy-metrics";
 
 const DEFAULT_CWD = "/Users/bharris/dev/apps/dispatch";
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -324,7 +334,12 @@ export function App(): JSX.Element {
   );
 
   const pollHealth = useCallback(async () => {
-    if (document.hidden) return;
+    if (document.hidden) {
+      recordHealthPollSkip();
+      return;
+    }
+    recordHealthPollFire();
+    recordHTTPRequest();
     try {
       const health = await api<{ status: string; db: string }>("/api/v1/health");
       setApiState(health.status === "ok" ? "ok" : "down");
@@ -405,11 +420,14 @@ export function App(): JSX.Element {
           if (!shouldKeepAttachedRef.current) return;
           clearReconnectTimer();
           reconnectAttemptsRef.current += 1;
+          recordWSReconnect();
           const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
           setConnState("reconnecting");
           setStatusMessage("Session disconnected, reconnecting...");
           reconnectTimerRef.current = window.setTimeout(() => {
             reconnectTimerRef.current = null;
+            // Don't reconnect while hidden — will resume on visibility change
+            if (document.hidden) return;
             void ensureTerminalConnected(false, false, resolvedAgentId);
           }, delay);
           return;
@@ -446,12 +464,15 @@ export function App(): JSX.Element {
         }
 
         reconnectAttemptsRef.current += 1;
+        recordWSReconnect();
         const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
         setConnState("reconnecting");
         setStatusMessage(message);
 
         reconnectTimerRef.current = window.setTimeout(() => {
           reconnectTimerRef.current = null;
+          // Don't reconnect while hidden — will resume on visibility change
+          if (document.hidden) return;
           void ensureTerminalConnected(false, false, resolvedAgentId);
         }, delay);
       };
@@ -803,6 +824,11 @@ export function App(): JSX.Element {
     })();
   }, [pollHealth, refreshAgents]);
 
+  // Energy metrics tracker — persists to localStorage and beacons to backend
+  useEffect(() => {
+    return initEnergyMetrics();
+  }, []);
+
   useEffect(() => {
     if (!agentsLoaded || !restoreShellAgentId) {
       return;
@@ -827,18 +853,41 @@ export function App(): JSX.Element {
   }, [refreshMedia]);
 
   useEffect(() => {
-    if (healthPollTimerRef.current) {
-      window.clearInterval(healthPollTimerRef.current);
-    }
-    healthPollTimerRef.current = window.setInterval(() => {
-      void pollHealth();
-    }, 8000);
+    const startPoll = () => {
+      if (healthPollTimerRef.current) {
+        window.clearInterval(healthPollTimerRef.current);
+      }
+      healthPollTimerRef.current = window.setInterval(() => {
+        void pollHealth();
+      }, 8000);
+    };
 
-    return () => {
+    const stopPoll = () => {
       if (healthPollTimerRef.current) {
         window.clearInterval(healthPollTimerRef.current);
         healthPollTimerRef.current = null;
       }
+    };
+
+    // Start polling only when visible
+    if (!document.hidden) {
+      startPoll();
+    }
+
+    const onVisChange = () => {
+      if (document.hidden) {
+        stopPoll();
+      } else {
+        void pollHealth(); // immediate check on resume
+        startPoll();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisChange);
+      stopPoll();
     };
   }, [pollHealth]);
 
@@ -847,11 +896,9 @@ export function App(): JSX.Element {
   }, [selectedAgentId]);
 
   useEffect(() => {
-    const source = new EventSource("/api/v1/events");
-    eventSourceRef.current = source;
-
-    source.onmessage = (event) => {
+    const handleSSEMessage = (event: MessageEvent) => {
       try {
+        recordSSEEvent();
         const payload = JSON.parse(event.data) as UiEvent;
 
         if (payload.type === "snapshot") {
@@ -923,11 +970,41 @@ export function App(): JSX.Element {
       } catch {}
     };
 
-    return () => {
-      source.close();
-      if (eventSourceRef.current === source) {
+    const openSSE = () => {
+      if (eventSourceRef.current) return;
+      const source = new EventSource("/api/v1/events");
+      eventSourceRef.current = source;
+      source.onmessage = handleSSEMessage;
+      source.onerror = () => {
+        recordSSEReconnect();
+      };
+    };
+
+    const closeSSE = () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+    };
+
+    // Only connect when visible
+    if (!document.hidden) {
+      openSSE();
+    }
+
+    const onVisChange = () => {
+      if (document.hidden) {
+        closeSSE();
+      } else {
+        openSSE();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisChange);
+      closeSSE();
     };
   }, [refreshMedia]);
 

--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap, XCircle } from "lucide-react";
+import { recordReleaseManagerPollFire } from "@/lib/energy-metrics";
 
 import { cn } from "@/lib/utils";
 
@@ -133,6 +134,8 @@ export function ReleaseManager(): JSX.Element {
     if (healthPollRef.current) clearInterval(healthPollRef.current);
 
     healthPollRef.current = setInterval(async () => {
+      if (document.hidden) return; // skip polls while hidden
+      recordReleaseManagerPollFire();
       try {
         const res = await fetch("/api/v1/release/status");
         if (res.ok) {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -100,3 +100,12 @@ body {
     transform: translateX(140%);
   }
 }
+
+/* Pause GPU-composited animations when the page is hidden to reduce energy */
+html[data-hidden] .dispatch-reconnect-scan {
+  animation-play-state: paused;
+  will-change: auto;
+}
+html[data-hidden] .animate-spin {
+  animation-play-state: paused;
+}

--- a/web/src/lib/energy-metrics.ts
+++ b/web/src/lib/energy-metrics.ts
@@ -1,0 +1,212 @@
+/**
+ * Lightweight energy-usage metrics tracker for diagnosing Safari PWA kills.
+ *
+ * Safari terminates PWAs that consume "significant energy" in the background.
+ * This module tracks network activity, timer fires, and visibility transitions
+ * so we can diagnose what was happening before a kill.
+ *
+ * Data is persisted to localStorage on a rolling basis and beaconed to the
+ * backend on visibilitychange→hidden, so it survives forced reloads.
+ */
+
+const STORAGE_KEY = "dispatch:energyMetrics";
+const BEACON_PATH = "/api/v1/energy-report";
+const FLUSH_INTERVAL_MS = 30_000;
+const MAX_VISIBILITY_CHANGES = 20;
+const MAX_ERRORS = 10;
+
+export interface EnergyMetrics {
+  windowStart: number;
+  windowEnd: number;
+  visibilityState: string;
+
+  sseEventsReceived: number;
+  sseReconnects: number;
+  wsReconnects: number;
+  httpRequests: number;
+
+  healthPollFires: number;
+  healthPollSkips: number;
+  releaseManagerPollFires: number;
+
+  visibilityChanges: { at: number; to: string }[];
+
+  totalHiddenMs: number;
+  longestHiddenMs: number;
+
+  errors: { at: number; msg: string }[];
+}
+
+function createEmpty(): EnergyMetrics {
+  return {
+    windowStart: Date.now(),
+    windowEnd: Date.now(),
+    visibilityState: document.visibilityState,
+    sseEventsReceived: 0,
+    sseReconnects: 0,
+    wsReconnects: 0,
+    httpRequests: 0,
+    healthPollFires: 0,
+    healthPollSkips: 0,
+    releaseManagerPollFires: 0,
+    visibilityChanges: [],
+    totalHiddenMs: 0,
+    longestHiddenMs: 0,
+    errors: [],
+  };
+}
+
+let metrics: EnergyMetrics = createEmpty();
+let hiddenSince: number | null = document.hidden ? Date.now() : null;
+let flushTimer: number | null = null;
+
+function save(): void {
+  metrics.windowEnd = Date.now();
+  metrics.visibilityState = document.visibilityState;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(metrics));
+  } catch {
+    // Storage full or unavailable — ignore
+  }
+}
+
+function beacon(): void {
+  // Flush hidden-time before sending
+  if (hiddenSince !== null) {
+    const elapsed = Date.now() - hiddenSince;
+    metrics.totalHiddenMs += elapsed;
+    if (elapsed > metrics.longestHiddenMs) {
+      metrics.longestHiddenMs = elapsed;
+    }
+    hiddenSince = Date.now(); // reset for continued tracking
+  }
+  save();
+  try {
+    const body = JSON.stringify(metrics);
+    navigator.sendBeacon(BEACON_PATH, body);
+  } catch {
+    // sendBeacon not available or failed — data is still in localStorage
+  }
+}
+
+// --- Public API ---
+
+export function recordSSEEvent(): void {
+  metrics.sseEventsReceived++;
+}
+
+export function recordSSEReconnect(): void {
+  metrics.sseReconnects++;
+}
+
+export function recordWSReconnect(): void {
+  metrics.wsReconnects++;
+}
+
+export function recordHTTPRequest(): void {
+  metrics.httpRequests++;
+}
+
+export function recordHealthPollFire(): void {
+  metrics.healthPollFires++;
+}
+
+export function recordHealthPollSkip(): void {
+  metrics.healthPollSkips++;
+}
+
+export function recordReleaseManagerPollFire(): void {
+  metrics.releaseManagerPollFires++;
+}
+
+export function recordError(msg: string): void {
+  metrics.errors.push({ at: Date.now(), msg });
+  if (metrics.errors.length > MAX_ERRORS) {
+    metrics.errors = metrics.errors.slice(-MAX_ERRORS);
+  }
+}
+
+/**
+ * Read the previous session's metrics from localStorage (e.g. after a
+ * Safari-forced reload). Returns null if no data is stored.
+ */
+export function readPreviousMetrics(): EnergyMetrics | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as EnergyMetrics;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Initialize the metrics tracker. Call once on app mount.
+ * Returns a cleanup function.
+ */
+export function initEnergyMetrics(): () => void {
+  // Log previous session metrics if they exist (helps debugging after a kill)
+  const prev = readPreviousMetrics();
+  if (prev) {
+    const age = Date.now() - prev.windowEnd;
+    // Only log if the previous session ended recently (< 5 min ago),
+    // which suggests a Safari kill rather than a normal close
+    if (age < 5 * 60 * 1000) {
+      console.warn(
+        "[dispatch:energy] Previous session metrics (possible Safari kill):",
+        prev
+      );
+    }
+  }
+
+  // Reset for this session
+  metrics = createEmpty();
+
+  // Toggle data-hidden attribute on <html> for CSS animation pausing
+  const syncHiddenAttr = () => {
+    if (document.hidden) {
+      document.documentElement.setAttribute("data-hidden", "");
+    } else {
+      document.documentElement.removeAttribute("data-hidden");
+    }
+  };
+  syncHiddenAttr();
+
+  const onVisibilityChange = () => {
+    const now = Date.now();
+    syncHiddenAttr();
+    if (document.hidden) {
+      hiddenSince = now;
+      beacon();
+    } else {
+      if (hiddenSince !== null) {
+        const elapsed = now - hiddenSince;
+        metrics.totalHiddenMs += elapsed;
+        if (elapsed > metrics.longestHiddenMs) {
+          metrics.longestHiddenMs = elapsed;
+        }
+        hiddenSince = null;
+      }
+    }
+
+    metrics.visibilityChanges.push({ at: now, to: document.visibilityState });
+    if (metrics.visibilityChanges.length > MAX_VISIBILITY_CHANGES) {
+      metrics.visibilityChanges = metrics.visibilityChanges.slice(
+        -MAX_VISIBILITY_CHANGES
+      );
+    }
+  };
+
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  // Periodic flush to localStorage
+  flushTimer = window.setInterval(save, FLUSH_INTERVAL_MS);
+
+  return () => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    if (flushTimer !== null) {
+      window.clearInterval(flushTimer);
+      flushTimer = null;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- **Close SSE EventSource when page is hidden**, reopen on visible — prevents Safari from seeing sustained network activity in background PWAs
- **Clear health poll interval when hidden** (instead of just skipping inside the callback) — eliminates 8s timer fires entirely while backgrounded
- **Guard WebSocket reconnect timers** with `document.hidden` check — prevents reconnect loops from firing in the background
- **Add visibility check to release manager 2s polling** — stops aggressive polling when tab is hidden
- **Pause CSS animations when hidden** via `html[data-hidden]` attribute — stops GPU-composited `will-change: transform` animation from consuming energy
- **Add energy metrics tracker** (`web/src/lib/energy-metrics.ts`) that records SSE events, reconnects, HTTP requests, health poll fires/skips, visibility transitions, and hidden duration. Persists to `localStorage` every 30s and beacons to `/api/v1/energy-report` on visibility change to hidden — survives Safari's forced reload for post-mortem diagnostics
- **Add backend `/api/v1/energy-report` endpoint** that logs beacon payloads for server-side inspection
- **Add mandatory pre-completion checks** to `CLAUDE.md` and `AGENTS.md` — agents must now run type checking, web finalization, e2e tests, and unit tests before marking any task as done

## Context
Safari's energy watchdog kills PWAs that consume "significant energy" while backgrounded. The app had several sources of continuous background activity: an always-open SSE connection, 8s health poll timer, WebSocket reconnect loops, and infinite CSS animations with `will-change: transform`.

## Test plan
- [x] `npm run finalize:web` passes (TypeScript check + production build)
- [x] All 5 new e2e tests pass (`e2e/energy-visibility.spec.ts`)
- [x] All 22 e2e tests pass (1 pre-existing flaky sidebar width test was also passing at time of final run)
- [x] Verified `data-hidden` attribute toggles correctly via Playwright
- [x] Verified energy metrics persist to localStorage with correct counters
- [ ] Manual PWA test on iOS Safari to confirm the energy kill no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)