### PR TITLE
Increase settings button tap target on mobile

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -423,13 +423,13 @@ export function AgentSidebarContent({
           )}
         </TooltipProvider>
       </div>
-      <div className="border-t border-border px-3 pb-[env(safe-area-inset-bottom)]">
+      <div className="border-t border-border px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         <button
           onClick={onOpenSettings}
           data-testid="settings-button"
-          className="flex w-full items-center gap-2 py-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          className="flex w-full items-center gap-2 py-4 md:py-2.5 text-sm md:text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
-          <Settings className="h-3.5 w-3.5" />
+          <Settings className="h-4 w-4 md:h-3.5 md:w-3.5" />
           Settings
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Increase settings button padding from `py-2.5` to `py-4` on mobile for a larger tap target
- Bump text from `text-xs` to `text-sm` and icon from `h-3.5` to `h-4` on mobile
- Ensure minimum `0.5rem` bottom padding even when `safe-area-inset-bottom` is zero
- Desktop layout unchanged (keeps compact `py-2.5` / `text-xs` sizing)

## Test plan
- [ ] On mobile, verify the Settings button at the bottom of the sidebar is easy to tap
- [ ] On desktop, verify the Settings button looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)