### PR TITLE
Fix terminal copy/select and mobile scroll

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,15 +13,16 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@xterm/addon-clipboard": "^0.2.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "simple-icons": "^16.11.0",
-        "tailwind-merge": "^2.5.4",
-        "xterm": "^5.3.0",
-        "xterm-addon-fit": "^0.8.0"
+        "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -3814,6 +3815,30 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xterm/addon-clipboard": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
+      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6340,6 +6365,12 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -9099,21 +9130,6 @@
         "workbox-core": "7.4.0"
       }
     },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -11419,6 +11435,24 @@
         "react-refresh": "^0.17.0"
       }
     },
+    "@xterm/addon-clipboard": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
+      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
+      "requires": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="
+    },
+    "@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="
+    },
     "acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -13146,6 +13180,11 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true
+    },
+    "js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -15005,17 +15044,6 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.0"
       }
-    },
-    "xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg=="
-    },
-    "xterm-addon-fit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-      "requires": {}
     },
     "yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -16,15 +16,16 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@xterm/addon-clipboard": "^0.2.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "simple-icons": "^16.11.0",
-    "tailwind-merge": "^2.5.4",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0"
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -752,6 +752,8 @@ export function App(): JSX.Element {
       return;
     }
 
+    const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
+
     const term = new XTerm({
       convertEol: false,
       cursorBlink: true,
@@ -759,6 +761,7 @@ export function App(): JSX.Element {
       fontSize: 13,
       scrollback: 5000,
       macOptionClickForcesSelection: true,
+      screenReaderMode: isTouchDevice,
       theme: {
         foreground: "#f8f8f2",
         background: "#141414",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -198,7 +198,7 @@ export function App(): JSX.Element {
 
   const [apiState, setApiState] = useState<ServiceState>("checking");
   const [dbState, setDbState] = useState<ServiceState>("checking");
-  const [mediaState, setMediaState] = useState<ServiceState>("checking");
+  const [_mediaState, setMediaState] = useState<ServiceState>("checking");
 
   const terminalHostRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Terminal as XTerm } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
-import "xterm/css/xterm.css";
+import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { ClipboardAddon } from "@xterm/addon-clipboard";
+import "@xterm/xterm/css/xterm.css";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
 import { SettingsPane } from "@/components/app/settings-pane";
@@ -46,6 +47,15 @@ const DEFAULT_WORKTREE_MODE: WorktreeMode = "ask";
 // Chrome Device Toolbar can emulate mobile with a wider layout viewport in some modes.
 // Treat coarse/non-hover input as mobile as well so drawer behavior stays consistent.
 const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px), (pointer: coarse), (hover: none)";
+
+/** Strip terminal line-wrap artifacts from copied text. */
+function cleanCopiedText(text: string): string {
+  const joined = text.replace(/[ \t]*\r?\n[ \t]*/g, "");
+  if (/^https?:\/\//.test(joined) || (/\S/.test(joined) && !joined.includes(" "))) {
+    return joined;
+  }
+  return text;
+}
 
 function readLastUsedCwd(): string {
   if (typeof window === "undefined") {
@@ -748,6 +758,7 @@ export function App(): JSX.Element {
       fontFamily: "JetBrains Mono, Menlo, monospace",
       fontSize: 13,
       scrollback: 5000,
+      macOptionClickForcesSelection: true,
       theme: {
         foreground: "#f8f8f2",
         background: "#141414",
@@ -779,8 +790,88 @@ export function App(): JSX.Element {
     terminalRef.current = term;
     fitAddonRef.current = fit;
     term.loadAddon(fit);
+    try { term.loadAddon(new ClipboardAddon()); } catch (e) { console.warn("ClipboardAddon failed:", e); }
     term.open(host);
     fit.fit();
+
+    // Intercept copy event to clean terminal line-wrap artifacts
+    const handleCopy = (e: ClipboardEvent) => {
+      if (term.hasSelection()) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.clipboardData?.setData("text/plain", cleanCopiedText(term.getSelection()));
+      }
+    };
+    host.addEventListener("copy", handleCopy, true);
+
+    // Touch scroll: .xterm sets touch-action:none which prevents native
+    // scrolling on mobile. Convert finger drags into synthetic WheelEvents
+    // so tmux enters copy-mode and scrolls its scrollback buffer.
+    const screenEl = host.querySelector(".xterm-screen") as HTMLElement | null;
+    let touchY = 0;
+    let touchAccum = 0;
+    const SCROLL_SENSITIVITY = 30; // px per wheel tick
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        touchY = e.touches[0].clientY;
+        touchAccum = 0;
+      }
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 1 || !screenEl) return;
+      const currentY = e.touches[0].clientY;
+      const delta = touchY - currentY; // positive = finger up = scroll down
+      touchY = currentY;
+      touchAccum += delta;
+      while (Math.abs(touchAccum) >= SCROLL_SENSITIVITY) {
+        const direction = touchAccum > 0 ? 1 : -1;
+        touchAccum -= direction * SCROLL_SENSITIVITY;
+        screenEl.dispatchEvent(new WheelEvent("wheel", {
+          deltaY: direction * 100,
+          deltaMode: 0,
+          bubbles: true,
+          cancelable: true,
+        }));
+      }
+    };
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: true });
+
+    // Enable text selection: intercept mousedown on the terminal screen
+    // and re-dispatch with modifier keys that tell xterm.js to handle
+    // selection locally instead of forwarding mouse events to tmux.
+    // xterm.js shouldForceSelection() checks:
+    //   Mac:     event.altKey && macOptionClickForcesSelection
+    //   Non-Mac: event.shiftKey
+    // We inject both so it works on all platforms.
+    // Wheel events are unaffected — tmux scrollback scrolling still works.
+    let dispatchingMouseDown = false;
+    const onMouseDown = (e: MouseEvent) => {
+      if (dispatchingMouseDown) return;
+      if (e.button !== 0 || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      e.stopPropagation();
+      e.preventDefault();
+      dispatchingMouseDown = true;
+      (e.target as HTMLElement).dispatchEvent(new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        detail: e.detail,
+        screenX: e.screenX,
+        screenY: e.screenY,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        button: e.button,
+        buttons: e.buttons,
+        relatedTarget: e.relatedTarget,
+        shiftKey: true,
+        altKey: true,
+      }));
+      dispatchingMouseDown = false;
+    };
+    if (screenEl) {
+      screenEl.addEventListener("mousedown", onMouseDown, true);
+    }
 
     const disposable = term.onData((data) => {
       const ws = wsRef.current;
@@ -798,6 +889,10 @@ export function App(): JSX.Element {
 
     return () => {
       disposable.dispose();
+      host.removeEventListener("copy", handleCopy, true);
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      if (screenEl) screenEl.removeEventListener("mousedown", onMouseDown, true);
       window.removeEventListener("resize", onResize);
       term.dispose();
       terminalRef.current = null;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -203,6 +203,7 @@ export function App(): JSX.Element {
   const terminalHostRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const ctrlPendingRef = useRef(false);
   const mediaViewportRef = useRef<HTMLDivElement>(null);
 
   const wsRef = useRef<WebSocket | null>(null);
@@ -878,9 +879,17 @@ export function App(): JSX.Element {
 
     const disposable = term.onData((data) => {
       const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: "input", data }));
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      if (ctrlPendingRef.current && data.length === 1) {
+        const code = data.toUpperCase().charCodeAt(0);
+        if (code >= 65 && code <= 90) {
+          ctrlPendingRef.current = false;
+          window.dispatchEvent(new Event("ctrl-consumed"));
+          ws.send(JSON.stringify({ type: "input", data: String.fromCharCode(code - 64) }));
+          return;
+        }
       }
+      ws.send(JSON.stringify({ type: "input", data }));
     });
 
     const onResize = () => {
@@ -1555,13 +1564,12 @@ export function App(): JSX.Element {
               terminalHostRef={terminalHostRef}
             />
 
-            {isMobile ? <MobileTerminalToolbar onSendInput={sendTerminalInput} /> : null}
+            {isMobile ? <MobileTerminalToolbar onSendInput={sendTerminalInput} ctrlPendingRef={ctrlPendingRef} /> : null}
 
             <StatusFooter
               connState={connState}
               apiState={apiState}
               dbState={dbState}
-              mediaState={mediaState}
               serviceDotClass={serviceDotClass}
             />
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1442,6 +1442,9 @@ export function App(): JSX.Element {
     }
 
     if (connState === "connected" && connectedAgent) {
+      if (connectedAgent.latestEvent?.message) {
+        return connectedAgent.latestEvent.message;
+      }
       return `Connected to session ${connectedAgent.name}`;
     }
 

--- a/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -1,42 +1,228 @@
+import { type MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-
-type TerminalHelper = {
-  label: string;
-  keyInput: string;
-  ariaLabel: string;
-};
-
-const TERMINAL_HELPERS: TerminalHelper[] = [
-  { label: "Ctrl+C", keyInput: "\u0003", ariaLabel: "Send Control C" },
-  { label: "Tab", keyInput: "\t", ariaLabel: "Send Tab" },
-  { label: "Esc", keyInput: "\u001b", ariaLabel: "Send Escape" },
-  { label: "\u2191", keyInput: "\u001b[A", ariaLabel: "Send Arrow Up" },
-  { label: "\u2193", keyInput: "\u001b[B", ariaLabel: "Send Arrow Down" },
-  { label: "Enter", keyInput: "\r", ariaLabel: "Send Enter" }
-];
+import { cn } from "@/lib/utils";
 
 type MobileTerminalToolbarProps = {
   onSendInput: (data: string) => void;
+  ctrlPendingRef: MutableRefObject<boolean>;
 };
 
-export function MobileTerminalToolbar({ onSendInput }: MobileTerminalToolbarProps): JSX.Element {
+export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTerminalToolbarProps): JSX.Element {
+  const [inputOpen, setInputOpen] = useState(false);
+  const [ctrlActive, setCtrlActive] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Clear visual state when the terminal onData handler consumes the ctrl modifier
+  useEffect(() => {
+    const onConsumed = () => setCtrlActive(false);
+    window.addEventListener("ctrl-consumed", onConsumed);
+    return () => window.removeEventListener("ctrl-consumed", onConsumed);
+  }, []);
+
+  const toggleCtrl = useCallback(() => {
+    setCtrlActive((v) => {
+      const next = !v;
+      ctrlPendingRef.current = next;
+      return next;
+    });
+  }, [ctrlPendingRef]);
+
+  const sendKey = useCallback((key: string) => {
+    onSendInput(key);
+    // After any toolbar key press, clear ctrl
+    if (ctrlActive) {
+      setCtrlActive(false);
+      ctrlPendingRef.current = false;
+    }
+  }, [ctrlActive, ctrlPendingRef, onSendInput]);
+
+  const openInput = useCallback(() => {
+    setInputOpen(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  const submitInput = useCallback(() => {
+    const text = inputRef.current?.value;
+    if (text) {
+      onSendInput(text + "\r");
+      if (inputRef.current) inputRef.current.value = "";
+    }
+    setInputOpen(false);
+  }, [onSendInput]);
+
   return (
-    <div className="border-t-2 border-border bg-[#12130f] px-2 py-2 md:hidden">
-      <div className="flex gap-2 overflow-x-auto pb-1">
-        {TERMINAL_HELPERS.map((helper) => (
+    <>
+      <div className="border-t-2 border-border bg-[#12130f] px-2 py-2 md:hidden">
+        {/* Row 1: modifier + action keys + keyboard button */}
+        <div className="flex justify-center gap-2">
           <Button
-            key={helper.label}
+            type="button"
+            size="sm"
+            variant="default"
+            className={cn(
+              "h-8 shrink-0 px-3 text-xs",
+              ctrlActive && "ring-2 ring-primary bg-primary/20 text-primary"
+            )}
+            aria-label="Toggle Control modifier"
+            aria-pressed={ctrlActive}
+            onPointerDown={(e) => {
+              e.preventDefault();
+              toggleCtrl();
+            }}
+          >
+            Ctrl
+          </Button>
+          <Button
             type="button"
             size="sm"
             variant="default"
             className="h-8 shrink-0 px-3 text-xs"
-            aria-label={helper.ariaLabel}
-            onClick={() => onSendInput(helper.keyInput)}
+            aria-label="Send Tab"
+            onClick={() => sendKey("\t")}
           >
-            {helper.label}
+            Tab
           </Button>
-        ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 shrink-0 px-3 text-xs"
+            aria-label="Send Escape"
+            onClick={() => sendKey("\u001b")}
+          >
+            Esc
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 shrink-0 px-3 text-xs"
+            aria-label="Send Enter"
+            onClick={() => sendKey("\r")}
+          >
+            Enter
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 shrink-0 px-3 text-xs"
+            aria-label="Open text input"
+            onClick={openInput}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+              <rect x="2" y="4" width="20" height="16" rx="2" />
+              <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M6 16h8" />
+            </svg>
+          </Button>
+        </div>
+
+        {/* Row 2: arrow keys */}
+        <div className="mt-2 flex justify-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 w-10 shrink-0 px-0 text-base"
+            aria-label="Send Arrow Left"
+            onClick={() => sendKey("\u001b[D")}
+          >
+            ←
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 w-10 shrink-0 px-0 text-base"
+            aria-label="Send Arrow Up"
+            onClick={() => sendKey("\u001b[A")}
+          >
+            ↑
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 w-10 shrink-0 px-0 text-base"
+            aria-label="Send Arrow Down"
+            onClick={() => sendKey("\u001b[B")}
+          >
+            ↓
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-8 w-10 shrink-0 px-0 text-base"
+            aria-label="Send Arrow Right"
+            onClick={() => sendKey("\u001b[C")}
+          >
+            →
+          </Button>
+        </div>
       </div>
-    </div>
+
+      {/* Full-screen text input modal */}
+      {inputOpen ? (
+        <div className="fixed inset-0 z-50 flex flex-col bg-background/95 backdrop-blur-sm">
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <button
+              className="text-sm text-muted-foreground"
+              onClick={() => setInputOpen(false)}
+            >
+              Cancel
+            </button>
+            <span className="text-sm font-medium text-foreground">Terminal Input</span>
+            <button
+              className="text-sm font-medium text-primary"
+              onClick={submitInput}
+            >
+              Send
+            </button>
+          </div>
+          <div className="flex-1 p-4">
+            <textarea
+              ref={inputRef}
+              className="h-full w-full resize-none rounded-lg border border-border bg-card p-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="Type command here..."
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  submitInput();
+                }
+              }}
+            />
+          </div>
+          <div className="flex gap-3 border-t border-border px-4 py-3">
+            <Button
+              type="button"
+              variant="default"
+              className="flex-1"
+              onClick={submitInput}
+            >
+              Send + Enter
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="flex-1"
+              onClick={() => {
+                const text = inputRef.current?.value;
+                if (text) {
+                  onSendInput(text);
+                  if (inputRef.current) inputRef.current.value = "";
+                }
+                setInputOpen(false);
+              }}
+            >
+              Send Raw
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/web/src/components/app/service-status.tsx
+++ b/web/src/components/app/service-status.tsx
@@ -15,7 +15,7 @@ export function ServiceStatus({ icon, label, value, dotClass }: ServiceStatusPro
       {icon}
       <span>{label}</span>
       <span data-testid={`service-dot-${label.toLowerCase()}`} className={cn("h-2.5 w-2.5 rounded-full", dotClass)} />
-      <span className="truncate uppercase">{value}</span>
+      <span className="hidden truncate uppercase sm:inline">{value}</span>
     </div>
   );
 }

--- a/web/src/components/app/status-footer.tsx
+++ b/web/src/components/app/status-footer.tsx
@@ -1,4 +1,4 @@
-import { Database, Image as ImageIcon, Server, Wifi } from "lucide-react";
+import { Database, Server, Wifi } from "lucide-react";
 
 import { ServiceStatus } from "@/components/app/service-status";
 import { type ConnState, type ServiceState } from "@/components/app/types";
@@ -7,7 +7,6 @@ type StatusFooterProps = {
   connState: ConnState;
   apiState: ServiceState;
   dbState: ServiceState;
-  mediaState: ServiceState;
   serviceDotClass: (state: ServiceState) => string;
 };
 
@@ -15,11 +14,10 @@ export function StatusFooter({
   connState,
   apiState,
   dbState,
-  mediaState,
   serviceDotClass
 }: StatusFooterProps): JSX.Element {
   return (
-    <footer data-testid="status-footer" className="grid h-11 grid-cols-4 items-center border-t-2 border-border bg-[#11120f] px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
+    <footer data-testid="status-footer" className="flex h-11 items-center justify-around border-t-2 border-border bg-[#11120f] px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
       <ServiceStatus
         icon={<Wifi className="h-3.5 w-3.5" />}
         label="WS"
@@ -34,12 +32,6 @@ export function StatusFooter({
         label="DB"
         value={dbState}
         dotClass={serviceDotClass(dbState)}
-      />
-      <ServiceStatus
-        icon={<ImageIcon className="h-3.5 w-3.5" />}
-        label="Media"
-        value={mediaState}
-        dotClass={serviceDotClass(mediaState)}
       />
     </footer>
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -53,6 +53,18 @@ body {
   background-color: #141414 !important;
 }
 
+/* Mobile: enable native long-press text selection via the xterm
+   accessibility tree, which contains invisible positioned text over
+   the canvas.  pointer-events:auto lets long-press reach that text;
+   user-select is already "text" in xterm's own CSS.  The accessibility
+   layer sits above the canvas so it receives the touch, while our
+   custom touchstart/touchmove handlers still drive scrolling. */
+@media (pointer: coarse) {
+  .xterm .xterm-accessibility {
+    pointer-events: auto !important;
+  }
+}
+
 @keyframes media-in-slow {
   from {
     opacity: 0;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -26,6 +26,13 @@
   @apply border-border;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
 body {
   @apply bg-background text-foreground antialiased;
   font-family: "JetBrains Mono", Menlo, monospace;
@@ -33,6 +40,7 @@ body {
 
 #root {
   @apply h-dvh;
+  overflow: hidden;
 }
 
 .terminal-font {


### PR DESCRIPTION
## Summary
- **Upgrade xterm v5 → @xterm/xterm v6** with `@xterm/addon-clipboard` for proper clipboard integration
- **Fix selection clearing on mouseup** — intercept mousedown on `.xterm-screen` and re-dispatch with shift+alt to force local selection mode instead of forwarding mouse events to tmux
- **Add mobile touch scrolling** — convert finger drags into synthetic WheelEvents since xterm sets `touch-action: none`
- **Enable mobile long-press text selection** — activate `screenReaderMode` on touch devices and allow pointer-events on the accessibility text layer
- **Disable pull-to-refresh** — `overscroll-behavior: none` on html/body

## Trade-offs
- Desktop: mouse clicks in the terminal always trigger text selection instead of being forwarded to tmux mouse mode (TUI apps like htop). Acceptable since the terminal is primarily used to watch agent output.
- Mobile: `screenReaderMode` is enabled on touch devices to render the accessibility text layer for long-press selection. Minimal performance impact.

## Test plan
- [x] Desktop: select text in terminal, release mouse — selection persists
- [x] Desktop: Cmd+C copies selected text
- [x] Mobile: swipe up/down scrolls terminal output
- [x] Mobile: long-press on text triggers native selection UI
- [x] Mobile: pull-down no longer triggers refresh
- [x] Type check passes (`npm run check`)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)