### PR TITLE
Animated sidebar agent list with state-based styling

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dispatch-web",
       "version": "0.2.13",
       "dependencies": {
+        "@formkit/auto-animate": "^0.9.0",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-scroll-area": "^1.2.0",
         "@radix-ui/react-select": "^2.2.6",
@@ -2183,6 +2184,12 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@formkit/auto-animate": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.9.0.tgz",
+      "integrity": "sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -10505,6 +10512,11 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
+    },
+    "@formkit/auto-animate": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.9.0.tgz",
+      "integrity": "sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA=="
     },
     "@humanfs/core": {
       "version": "0.19.1",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.35.2",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5506,6 +5507,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.35.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.2.tgz",
+      "integrity": "sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.35.2",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -6667,6 +6695,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.35.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.2.tgz",
+      "integrity": "sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12631,6 +12674,16 @@
       "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true
     },
+    "framer-motion": {
+      "version": "12.35.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.2.tgz",
+      "integrity": "sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA==",
+      "requires": {
+        "motion-dom": "^12.35.2",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -13414,6 +13467,19 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true
+    },
+    "motion-dom": {
+      "version": "12.35.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.2.tgz",
+      "integrity": "sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg==",
+      "requires": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="
     },
     "ms": {
       "version": "2.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.35.2",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@formkit/auto-animate": "^0.9.0",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-select": "^2.2.6",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -93,8 +93,12 @@ type UiEvent =
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string };
 
-function sortAgentsByCreatedAtDesc(items: Agent[]): Agent[] {
+function sortAgentsByCreatedAtDesc(items: Agent[], activeAgentId?: string | null): Agent[] {
   const eventPriority = (agent: Agent): number => {
+    // The actively connected agent always sorts first.
+    if (activeAgentId && agent.id === activeAgentId) {
+      return -1;
+    }
     if (agent.latestEvent?.type === "blocked") {
       return 0;
     }
@@ -133,6 +137,14 @@ export function App(): JSX.Element {
 
   const [connState, setConnState] = useState<ConnState>("disconnected");
   const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
+  const connectedAgentIdRef = useRef<string | null>(null);
+  connectedAgentIdRef.current = connectedAgentId;
+
+  // Re-sort agents when the connected agent changes so it floats to the top.
+  useEffect(() => {
+    setAgents((current) => sortAgentsByCreatedAtDesc(current, connectedAgentId));
+  }, [connectedAgentId]);
+
   const [statusMessage, setStatusMessage] = useState("Starting...");
 
   const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
@@ -286,7 +298,7 @@ export function App(): JSX.Element {
 
   const refreshAgents = useCallback(async () => {
     const payload = await api<{ agents: Agent[] }>("/api/v1/agents");
-    setAgents(sortAgentsByCreatedAtDesc(payload.agents));
+    setAgents(sortAgentsByCreatedAtDesc(payload.agents, connectedAgentIdRef.current));
 
     setSelectedAgentId((current) => {
       if (current && payload.agents.some((agent) => agent.id === current)) {
@@ -1008,7 +1020,7 @@ export function App(): JSX.Element {
         const payload = JSON.parse(event.data) as UiEvent;
 
         if (payload.type === "snapshot") {
-          setAgents(sortAgentsByCreatedAtDesc(payload.agents));
+          setAgents(sortAgentsByCreatedAtDesc(payload.agents, connectedAgentIdRef.current));
           setStreamingAgentIds(
             new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
           );
@@ -1019,11 +1031,11 @@ export function App(): JSX.Element {
           setAgents((current) => {
             const index = current.findIndex((agent) => agent.id === payload.agent.id);
             if (index === -1) {
-              return sortAgentsByCreatedAtDesc([payload.agent, ...current]);
+              return sortAgentsByCreatedAtDesc([payload.agent, ...current], connectedAgentIdRef.current);
             }
             const next = [...current];
             next[index] = payload.agent;
-            return sortAgentsByCreatedAtDesc(next);
+            return sortAgentsByCreatedAtDesc(next, connectedAgentIdRef.current);
           });
           return;
         }

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -19,6 +19,7 @@ import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { cn } from "@/lib/utils";
 
 type AgentSidebarSharedProps = {
@@ -76,6 +77,8 @@ export function AgentSidebarContent({
   closeButtonIcon = "x",
   className
 }: AgentSidebarContentProps): JSX.Element {
+  const [animateRef] = useAutoAnimate();
+
   const agentTypeLabel = (type?: string): string => {
     if (type === "claude") {
       return "Claude";
@@ -150,7 +153,8 @@ export function AgentSidebarContent({
           {agents.length === 0 ? (
             <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
           ) : (
-            agents.map((agent) => {
+            <div ref={animateRef}>
+            {agents.map((agent) => {
               const state = agentVisualState(agent);
               const isSelected = selectedAgentId === agent.id;
               const isStopped = state === "stopped";
@@ -419,7 +423,8 @@ export function AgentSidebarContent({
                   </div>
                 </div>
               );
-            })
+            })}
+            </div>
           )}
         </TooltipProvider>
       </div>

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -19,7 +19,7 @@ import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { LayoutGroup, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 type AgentSidebarSharedProps = {
@@ -77,8 +77,6 @@ export function AgentSidebarContent({
   closeButtonIcon = "x",
   className
 }: AgentSidebarContentProps): JSX.Element {
-  const [animateRef] = useAutoAnimate();
-
   const agentTypeLabel = (type?: string): string => {
     if (type === "claude") {
       return "Claude";
@@ -153,7 +151,7 @@ export function AgentSidebarContent({
           {agents.length === 0 ? (
             <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
           ) : (
-            <div ref={animateRef}>
+            <LayoutGroup>
             {agents.map((agent) => {
               const state = agentVisualState(agent);
               const isSelected = selectedAgentId === agent.id;
@@ -164,8 +162,10 @@ export function AgentSidebarContent({
               const needsAttention = agent.status === "error";
 
               return (
-                <div
+                <motion.div
                   key={agent.id}
+                  layout
+                  transition={{ duration: 0.3, ease: "easeInOut" }}
                   data-testid={`agent-card-${agent.id}`}
                   className={cn(
                     "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
@@ -423,10 +423,10 @@ export function AgentSidebarContent({
                       </div>
                     </div>
                   </div>
-                </div>
+                </motion.div>
               );
             })}
-            </div>
+            </LayoutGroup>
           )}
         </TooltipProvider>
       </div>

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -171,7 +171,6 @@ export function AgentSidebarContent({
                     "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
                     borderForAgentState(state),
                     isActive && "bg-emerald-500/10",
-                    !isActive && !isStopped && "bg-sky-500/[0.06]",
                     isStopped && "opacity-60",
                     isSelected && "bg-muted/60"
                   )}

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -168,8 +168,11 @@ export function AgentSidebarContent({
                   key={agent.id}
                   data-testid={`agent-card-${agent.id}`}
                   className={cn(
-                    "border-b border-r-4 border-border px-2 py-2",
+                    "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
                     borderForAgentState(state),
+                    isActive && "bg-emerald-500/10",
+                    !isActive && !isStopped && "bg-sky-500/[0.06]",
+                    isStopped && "opacity-60",
                     isSelected && "bg-muted/60"
                   )}
                 >


### PR DESCRIPTION
## Summary
- Adds smooth layout animations (framer-motion) when agents reorder in the sidebar, so position changes are visually clear instead of jarring instant swaps
- Active (connected) agent gets a subtle emerald background tint; stopped agents are muted at 60% opacity
- Connected agent always sorts to the top of the list, above blocked/waiting/idle agents

## Test plan
- [ ] Connect to an agent — verify it animates to the top with emerald tint
- [ ] Detach — verify it animates back to its priority position and loses the tint
- [ ] Stop an agent — verify it animates down and becomes muted
- [ ] Trigger a blocked/waiting event — verify it animates to the correct position
- [ ] Verify no layout glitches when expanding/collapsing agent detail panels during reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)