### PR TITLE
Require description for shared media

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,9 @@
   - Include a `Status log` section in the final response with the exact stdout lines from each `dispatch-event` call.
 
 ## UI Validation
-- For any UI/layout/style interaction change, validate behavior in Playwright before marking the task complete.
+- For any UI/layout/style/feature change, validate behavior in Playwright before marking the task complete.
 - Include at least one Playwright interaction that covers the changed UI path (for example: open/close panes, modal flow, or action button state changes).
+- Capture at least one screenshot per validation flow and publish it with `dispatch-share <image-path> "description"`. Never leave screenshots local-only.
 - For pages with SSE/WebSocket activity, do not use Playwright `waitUntil: "networkidle"` for readiness checks.
 - Use `waitUntil: "domcontentloaded"` (or `"load"`) and wait for concrete UI-ready signals (visible control/text/state) instead.
 

--- a/bin/dispatch-share
+++ b/bin/dispatch-share
@@ -4,15 +4,17 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  dispatch-share <image-path> [name] [-d "description"]
-  dispatch-share --sim [udid] [name] [-d "description"]
+  dispatch-share <image-path> "description"
+  dispatch-share <image-path> "description" [name]
+  dispatch-share --sim "description" [udid] [name]
+
+A short description of the shared media is required.
 
 Examples:
-  dispatch-share ./artifacts/homepage.png
-  dispatch-share ./artifacts/homepage.png playwright-home.png
-  dispatch-share ./artifacts/homepage.png -d "Homepage after login flow"
-  dispatch-share --sim
-  dispatch-share --sim booted ios-home.png
+  dispatch-share ./artifacts/homepage.png "Homepage after login flow"
+  dispatch-share ./artifacts/homepage.png "Login page screenshot" login.png
+  dispatch-share --sim "Current simulator state"
+  dispatch-share --sim "iOS home screen" booted ios-home.png
 USAGE
 }
 
@@ -26,23 +28,6 @@ fi
 
 timestamp="$(date +%Y%m%d-%H%M%S)"
 
-# Extract -d/--description from args
-DESCRIPTION=""
-ARGS=()
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -d|--description)
-      DESCRIPTION="${2:-}"
-      shift 2
-      ;;
-    *)
-      ARGS+=("$1")
-      shift
-      ;;
-  esac
-done
-set -- "${ARGS[@]}"
-
 SOURCE_PATH=""
 SOURCE_TYPE="screenshot"
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "" ]]; then
@@ -51,14 +36,26 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "" ]]; then
 fi
 
 if [[ "${1:-}" == "--sim" ]]; then
-  udid="${2:-booted}"
-  out_name="${3:-sim-${timestamp}.png}"
+  DESCRIPTION="${2:-}"
+  if [[ -z "$DESCRIPTION" ]]; then
+    echo "dispatch-share: description is required." >&2
+    usage
+    exit 1
+  fi
+  udid="${3:-booted}"
+  out_name="${4:-sim-${timestamp}.png}"
   tmp="${TMPDIR:-/tmp}/${out_name}"
   xcrun simctl io "$udid" screenshot --type=png "$tmp" >/dev/null
   SOURCE_PATH="$tmp"
   SOURCE_TYPE="simulator"
 else
   SOURCE_PATH="$1"
+  DESCRIPTION="${2:-}"
+  if [[ -z "$DESCRIPTION" ]]; then
+    echo "dispatch-share: description is required." >&2
+    usage
+    exit 1
+  fi
 fi
 
 if [[ ! -f "$SOURCE_PATH" ]]; then
@@ -73,9 +70,9 @@ if [[ ! "$lower_name" =~ \.(png|jpg|jpeg|gif|webp)$ ]]; then
 fi
 
 if [[ "${1:-}" == "--sim" ]]; then
-  preferred_name="${3:-$(basename "$SOURCE_PATH")}"
+  preferred_name="${4:-$(basename "$SOURCE_PATH")}"
 else
-  preferred_name="${2:-$(basename "$SOURCE_PATH")}"
+  preferred_name="${3:-$(basename "$SOURCE_PATH")}"
 fi
 
 safe_name="$(echo "$preferred_name" | tr ' ' '-' | tr -cd '[:alnum:]._-')"
@@ -90,11 +87,9 @@ upload_name="${base}-${timestamp}.${ext}"
 CURL_ARGS=(
   -fsS -k -X POST
   -F "source=${SOURCE_TYPE}"
+  -F "description=${DESCRIPTION}"
+  -F "file=@${SOURCE_PATH};filename=${upload_name}"
 )
-if [[ -n "$DESCRIPTION" ]]; then
-  CURL_ARGS+=(-F "description=${DESCRIPTION}")
-fi
-CURL_ARGS+=(-F "file=@${SOURCE_PATH};filename=${upload_name}")
 
 response="$(curl "${CURL_ARGS[@]}" "${API_BASE}/api/v1/agents/${AGENT_ID}/media")"
 

--- a/bin/dispatch-stream
+++ b/bin/dispatch-stream
@@ -5,12 +5,13 @@ usage() {
   cat <<'USAGE'
 Usage:
   dispatch-stream start --playwright <port>
-  dispatch-stream stop [-d "description"]
+  dispatch-stream stop "description"
+
+A short description is required when stopping a stream.
 
 Examples:
   dispatch-stream start --playwright 62816
-  dispatch-stream stop
-  dispatch-stream stop -d "Browsing bradharris.dev homepage"
+  dispatch-stream stop "Browsing bradharris.dev homepage"
 USAGE
 }
 
@@ -45,25 +46,15 @@ case "$ACTION" in
     PAYLOAD="{\"type\":\"playwright\",\"port\":${CDP_PORT}}"
     ;;
   stop)
-    DESCRIPTION=""
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        -d|--description)
-          DESCRIPTION="${2:-}"
-          shift 2
-          ;;
-        *)
-          shift
-          ;;
-      esac
-    done
-    if [ -n "$DESCRIPTION" ]; then
-      # Escape double quotes in description for JSON
-      ESCAPED="$(echo "$DESCRIPTION" | sed 's/"/\\"/g')"
-      PAYLOAD="{\"type\":\"stop\",\"description\":\"${ESCAPED}\"}"
-    else
-      PAYLOAD='{"type":"stop"}'
+    DESCRIPTION="${1:-}"
+    if [ -z "$DESCRIPTION" ]; then
+      echo "dispatch-stream: description is required when stopping a stream." >&2
+      usage
+      exit 1
     fi
+    # Escape double quotes in description for JSON
+    ESCAPED="$(echo "$DESCRIPTION" | sed 's/"/\\"/g')"
+    PAYLOAD="{\"type\":\"stop\",\"description\":\"${ESCAPED}\"}"
     ;;
   *)
     echo "Invalid action: $ACTION" >&2

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -362,7 +362,7 @@ export class AgentManager {
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
     const launchGuidance =
       "Dispatch startup rules: Playwright default is headless unless the user explicitly asks for headed mode. " +
-      "Capture at least one screenshot per UI validation flow; publish every screenshot with dispatch-share <image-path> for Playwright or dispatch-share --sim [udid] for iOS Simulator — never leave screenshots local-only. " +
+      "Capture at least one screenshot per UI validation flow; publish every screenshot with dispatch-share <image-path> \"description\" for Playwright or dispatch-share --sim \"description\" [udid] for iOS Simulator — never leave screenshots local-only. " +
       "Call dispatch-event at the start of each turn (working), when blocked or waiting for input (blocked/waiting_user), and before your final response (done on success, idle for no-op turns). Never send a final response without a terminal status event. " +
       "For SSE/WebSocket pages, never use waitUntil: \"networkidle\"; use \"domcontentloaded\" or \"load\" and explicit UI-ready checks.";
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -840,6 +840,9 @@ async function registerRoutes() {
     const validSources = ["screenshot", "stream", "simulator"];
     const source = validSources.includes(sourceField) ? sourceField : "screenshot";
     const description = (data.fields.description as { value?: string } | undefined)?.value ?? null;
+    if (!description) {
+      return reply.code(400).send({ error: "A description field is required." });
+    }
 
     const mediaDir = resolveMediaDir(agent.id, agent.mediaDir);
     await mkdir(mediaDir, { recursive: true });

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -5,17 +5,6 @@ import { type MediaFile } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-function mediaSourceLabel(file: MediaFile): string {
-  switch (file.source) {
-    case "stream":
-      return "Stream recording";
-    case "simulator":
-      return `Simulator: ${file.name}`;
-    default:
-      return `Shared: ${file.name}`;
-  }
-}
-
 type MediaSidebarSharedProps = {
   mediaFiles: MediaFile[];
   selectedAgentId: string | null;
@@ -148,14 +137,13 @@ export function MediaSidebarContent({
                     "block w-full overflow-hidden border-2 bg-black/60",
                     unseen ? "media-thumb-unseen" : "media-thumb-seen"
                   )}
-                  onClick={() => openLightbox(cacheBustUrl, file.name)}
+                  onClick={() => openLightbox(cacheBustUrl, file.description || "")}
                 >
-                  <img src={cacheBustUrl} alt={file.name} className="max-h-[260px] w-full object-contain" />
+                  <img src={cacheBustUrl} alt={file.description || ""} className="max-h-[260px] w-full object-contain" />
                 </button>
                 <div className="mt-2 text-xs text-muted-foreground">
-                  {isStream ? null : <div>{mediaSourceLabel(file)}</div>}
-                  {file.description ? <div className={isStream ? "" : "mt-1"}>{file.description}</div> : null}
-                  <div className={file.description || !isStream ? "mt-1" : ""}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
+                  {file.description ? <div>{file.description}</div> : null}
+                  <div className={file.description ? "mt-1" : ""}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
                 </div>
               </article>
             );


### PR DESCRIPTION
## Summary
- `dispatch-share` and `dispatch-stream stop` now require a short description as a positional argument
- Backend rejects media uploads missing a description (400)
- Media sidebar displays descriptions instead of filenames; lightbox caption uses description
- CLAUDE.md updated to require screenshot sharing via `dispatch-share` for UI validation

## Test plan
- [x] Backend: upload without description returns 400, with description returns 201
- [x] CLI: `dispatch-share` and `dispatch-stream stop` exit with error if description is missing
- [x] UI: media sidebar shows description text, no filenames
- [x] UI: lightbox caption shows description
- [x] Legacy items (no description) degrade gracefully — show only file size
- [x] Web build passes (`npm run finalize:web`)
- [x] Backend type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)