### PR TITLE
Fix tmux session leaks and protect agents from e2e interference

### DIFF
--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -7,17 +7,23 @@ test.describe("Agent CRUD", () => {
   });
 
   test("displays 'No agents yet' when the list is empty", async ({ page, request }) => {
-    // Stop all agents first (running agents can't be deleted)
+    // Stop and delete only e2e-prefixed agents (never touch real agents)
     const listRes = await request.get("/api/v1/agents");
-    const { agents } = (await listRes.json()) as { agents: Array<{ id: string; status: string }> };
-    for (const agent of agents) {
+    const { agents } = (await listRes.json()) as { agents: Array<{ id: string; name: string; status: string }> };
+    for (const agent of agents.filter((a) => a.name.startsWith("e2e-agent-"))) {
       if (agent.status !== "stopped") {
         await request.post(`/api/v1/agents/${agent.id}/stop`);
       }
     }
-    // Delete all agents
-    for (const agent of agents) {
+    for (const agent of agents.filter((a) => a.name.startsWith("e2e-agent-"))) {
       await request.delete(`/api/v1/agents/${agent.id}`);
+    }
+
+    // Skip empty-state assertion if non-e2e agents remain
+    const remainingAgents = agents.filter((a) => !a.name.startsWith("e2e-agent-"));
+    if (remainingAgents.length > 0) {
+      test.skip();
+      return;
     }
 
     // Load page fresh — SSE snapshot should now be empty

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -10,18 +10,18 @@ test.describe("Agent CRUD", () => {
     // Stop and delete only e2e-prefixed agents (never touch real agents)
     const listRes = await request.get("/api/v1/agents");
     const { agents } = (await listRes.json()) as { agents: Array<{ id: string; name: string; status: string }> };
-    for (const agent of agents.filter((a) => a.name.startsWith("e2e-agent-"))) {
+    const e2eAgents = agents.filter((a) => a.name.startsWith("e2e-agent-"));
+    for (const agent of e2eAgents) {
       if (agent.status !== "stopped") {
         await request.post(`/api/v1/agents/${agent.id}/stop`);
       }
     }
-    for (const agent of agents.filter((a) => a.name.startsWith("e2e-agent-"))) {
+    for (const agent of e2eAgents) {
       await request.delete(`/api/v1/agents/${agent.id}`);
     }
 
     // Skip empty-state assertion if non-e2e agents remain
-    const remainingAgents = agents.filter((a) => !a.name.startsWith("e2e-agent-"));
-    if (remainingAgents.length > 0) {
+    if (agents.length > e2eAgents.length) {
       test.skip();
       return;
     }

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -325,7 +325,7 @@ export class AgentManager {
           await this.setAgentStatus(row.id, "running", null, row.tmuxSession ?? undefined);
           await this.setSystemLatestEvent(row.id, {
             type: "working",
-            message: "Recovered from stuck stopping state.",
+            message: "Stop timed out — agent reverted to running. Try force stop.",
             metadata: { source: "system" }
           });
           const agent = await this.getAgent(row.id);
@@ -360,7 +360,9 @@ export class AgentManager {
       .split("\n")
       .filter(Boolean)
       .map((line) => {
-        const [name, createdStr] = line.split(":");
+        const colonIdx = line.lastIndexOf(":");
+        const name = line.substring(0, colonIdx);
+        const createdStr = line.substring(colonIdx + 1);
         return { name, createdAt: parseInt(createdStr, 10) };
       })
       .filter((s) => s.name.startsWith(SESSION_PREFIX));

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -318,9 +318,9 @@ export class AgentManager {
           reconciled.push(agent);
         }
       } else if (row.status === "stopping") {
-        // If stuck in "stopping" for > 60s with a live tmux session, revert to running
+        const STUCK_STOPPING_TIMEOUT_S = 60;
         const stuckSeconds = (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
-        if (stuckSeconds > 60) {
+        if (stuckSeconds > STUCK_STOPPING_TIMEOUT_S) {
           this.logger.warn({ id: row.id, stuckSeconds }, "Agent stuck in stopping state, reverting to running");
           await this.setAgentStatus(row.id, "running", null, row.tmuxSession ?? undefined);
           await this.setSystemLatestEvent(row.id, {
@@ -381,7 +381,9 @@ export class AgentManager {
       dbAgents.set(row.id, row.status);
     }
 
+    const ORPHAN_AGE_THRESHOLD_S = 300;
     const now = Math.floor(Date.now() / 1000);
+    const toKill: string[] = [];
 
     for (const session of sessions) {
       const agentId = session.name.replace(/^dispatch_/, "");
@@ -390,19 +392,23 @@ export class AgentManager {
       // Agent in terminal state — session is definitely orphaned
       if (status === "stopped" || status === "error") {
         this.logger.info({ session: session.name, agentId, status }, "Killing orphaned tmux session (agent in terminal state)");
-        await runCommand("tmux", ["kill-session", "-t", session.name]).catch(() => {});
+        toKill.push(session.name);
         continue;
       }
 
       // No matching DB record — kill if session older than 5 minutes (avoids race with creation)
       if (!status) {
         const ageSeconds = now - session.createdAt;
-        if (ageSeconds > 300) {
+        if (ageSeconds > ORPHAN_AGE_THRESHOLD_S) {
           this.logger.info({ session: session.name, agentId, ageSeconds }, "Killing orphaned tmux session (no DB record)");
-          await runCommand("tmux", ["kill-session", "-t", session.name]).catch(() => {});
+          toKill.push(session.name);
         }
       }
     }
+
+    await Promise.all(
+      toKill.map((name) => runCommand("tmux", ["kill-session", "-t", name]).catch(() => {}))
+    );
   }
 
   private async startTmuxSession(

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -255,7 +255,7 @@ export class AgentManager {
       await this.setAgentStatus(id, "stopped", null, agent.tmuxSession ?? undefined);
     }
 
-    if (force && agent.tmuxSession && sessionExists) {
+    if (agent.tmuxSession && sessionExists) {
       await runCommand("tmux", ["kill-session", "-t", agent.tmuxSession]);
     }
 
@@ -293,16 +293,17 @@ export class AgentManager {
 
   async reconcileAgents(): Promise<void> {
     await this.reconcileAgentStatuses();
+    await this.cleanupOrphanedSessions();
   }
 
   async reconcileAgentStatuses(): Promise<AgentRecord[]> {
     const result = await this.pool.query(
-      "SELECT id, tmux_session AS \"tmuxSession\", status FROM agents WHERE status IN ('running', 'stopping', 'creating')"
+      "SELECT id, tmux_session AS \"tmuxSession\", status, updated_at AS \"updatedAt\" FROM agents WHERE status IN ('running', 'stopping', 'creating')"
     );
 
     const reconciled: AgentRecord[] = [];
 
-    for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string }>) {
+    for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string; updatedAt: string }>) {
       const exists = row.tmuxSession ? await this.tmuxHasSession(row.tmuxSession) : false;
 
       if (!exists) {
@@ -316,10 +317,92 @@ export class AgentManager {
         if (agent) {
           reconciled.push(agent);
         }
+      } else if (row.status === "stopping") {
+        // If stuck in "stopping" for > 60s with a live tmux session, revert to running
+        const stuckSeconds = (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
+        if (stuckSeconds > 60) {
+          this.logger.warn({ id: row.id, stuckSeconds }, "Agent stuck in stopping state, reverting to running");
+          await this.setAgentStatus(row.id, "running", null, row.tmuxSession ?? undefined);
+          await this.setSystemLatestEvent(row.id, {
+            type: "working",
+            message: "Recovered from stuck stopping state.",
+            metadata: { source: "system" }
+          });
+          const agent = await this.getAgent(row.id);
+          if (agent) {
+            reconciled.push(agent);
+          }
+        }
       }
     }
 
     return reconciled;
+  }
+
+  private async cleanupOrphanedSessions(): Promise<void> {
+    const SESSION_PREFIX = "dispatch_agt_";
+
+    let stdout: string | undefined;
+    try {
+      const result = await runCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], {
+        allowedExitCodes: [0, 1]
+      });
+      stdout = result.stdout;
+    } catch {
+      // tmux not running or no sessions
+      return;
+    }
+
+    if (!stdout?.trim()) return;
+
+    const sessions = stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [name, createdStr] = line.split(":");
+        return { name, createdAt: parseInt(createdStr, 10) };
+      })
+      .filter((s) => s.name.startsWith(SESSION_PREFIX));
+
+    if (sessions.length === 0) return;
+
+    // Extract agent IDs from session names
+    const agentIds = sessions.map((s) => s.name.replace(/^dispatch_/, ""));
+
+    // Query DB for these agent IDs
+    const placeholders = agentIds.map((_, i) => `$${i + 1}`).join(", ");
+    const dbResult = await this.pool.query(
+      `SELECT id, status FROM agents WHERE id IN (${placeholders})`,
+      agentIds
+    );
+    const dbAgents = new Map<string, string>();
+    for (const row of dbResult.rows as Array<{ id: string; status: string }>) {
+      dbAgents.set(row.id, row.status);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const session of sessions) {
+      const agentId = session.name.replace(/^dispatch_/, "");
+      const status = dbAgents.get(agentId);
+
+      // Agent in terminal state — session is definitely orphaned
+      if (status === "stopped" || status === "error") {
+        this.logger.info({ session: session.name, agentId, status }, "Killing orphaned tmux session (agent in terminal state)");
+        await runCommand("tmux", ["kill-session", "-t", session.name]).catch(() => {});
+        continue;
+      }
+
+      // No matching DB record — kill if session older than 5 minutes (avoids race with creation)
+      if (!status) {
+        const ageSeconds = now - session.createdAt;
+        if (ageSeconds > 300) {
+          this.logger.info({ session: session.name, agentId, ageSeconds }, "Killing orphaned tmux session (no DB record)");
+          await runCommand("tmux", ["kill-session", "-t", session.name]).catch(() => {});
+        }
+      }
+    }
   }
 
   private async startTmuxSession(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1067,6 +1067,8 @@ async function registerRoutes() {
     const body = request.body as { force?: unknown } | undefined;
     const id = params.id ?? "";
 
+    app.log.info({ agentId: id, force: body?.force ?? false }, "Stop agent requested");
+
     if (body?.force !== undefined && typeof body.force !== "boolean") {
       return reply.code(400).send({ error: "force must be a boolean when provided." });
     }


### PR DESCRIPTION
## Summary
- **Always kill tmux session on agent delete** — previously only killed with `force=true`, leaving orphaned sessions after normal deletes
- **Add orphan session cleanup** — reconciliation now finds `dispatch_agt_*` tmux sessions with no matching DB record (or in terminal state) and kills them
- **Recover stuck `stopping` agents** — agents stuck in `stopping` for >60s with a live tmux session are reverted to `running` during reconciliation
- **Scope e2e empty-state test** — only stops/deletes `e2e-agent-*` prefixed agents, preventing interference with real agents regardless of which server/DB the tests hit
- **Add stop endpoint logging** — logs agent ID and force flag for diagnostics

## Test plan
- [x] `npm run check` — type checking passes
- [x] `npm test` — 25 unit tests pass
- [x] `npm run test:e2e` — 23/23 e2e tests pass (run against dedicated worktree dev server on port 8799)
- [ ] Manual: create agent → delete it → verify tmux session is gone
- [ ] Manual: verify `tmux list-sessions` count stays stable over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)