### PR TITLE
Fix dispatch-dev stealing agent terminal focus

### DIFF
--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -201,8 +201,10 @@ cmd_up() {
     db_url_override="DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:${DEV_DB_PORT}/dispatch_${DEV_CONTAINER_SUFFIX} "
   fi
 
+  # -d flag creates windows without switching focus, so the agent's
+  # Claude session stays in the foreground.
   local api_cmd="${nvm_init}${env_exports}${db_url_override}DISPATCH_PORT=${DEV_API_PORT} npm run dev"
-  tmux new-window -t "$session" -n "dev-server" -c "$cwd" "$api_cmd"
+  tmux new-window -d -t "$session" -n "dev-server" -c "$cwd" "$api_cmd"
 
   echo "API server starting on port ${DEV_API_PORT}"
 
@@ -215,7 +217,7 @@ cmd_up() {
     fi
 
     local vite_cmd="${nvm_init}npm --prefix web run dev -- --port ${DEV_VITE_PORT}"
-    tmux new-window -t "$session" -n "vite-dev" -c "$cwd" "$vite_cmd"
+    tmux new-window -d -t "$session" -n "vite-dev" -c "$cwd" "$vite_cmd"
 
     echo "Vite dev server starting on port ${DEV_VITE_PORT}"
   fi


### PR DESCRIPTION
## Summary
- Add `-d` flag to `tmux new-window` calls in `dispatch-dev` so dev-server and vite-dev windows are created in the background
- Prevents the agent's Claude terminal session from losing focus when `dispatch-dev up` starts services

## Test plan
- [x] Type checks pass (`npm run check`)
- [x] Unit tests pass (`npm test`)
- [x] E2e tests pass (`npm run test:e2e`) — 23/23

🤖 Generated with [Claude Code](https://claude.com/claude-code)