### PR TITLE
Clean up test agent tmux sessions in e2e teardown

### DIFF
--- a/scripts/e2e-isolated.sh
+++ b/scripts/e2e-isolated.sh
@@ -45,6 +45,17 @@ mkdir -p "$MEDIA_ROOT"
 
 cleanup() {
   echo "==> Tearing down isolated environment"
+  # Kill tmux sessions for agents created by this test run.
+  # Query the test DB for agent IDs before tearing it down.
+  local agent_ids
+  agent_ids="$(psql -tA "$DATABASE_URL" -c "SELECT id FROM agents" 2>/dev/null || true)"
+  if [ -n "$agent_ids" ]; then
+    while read -r aid; do
+      tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep "^dispatch_${aid}" \
+        | while read -r s; do tmux kill-session -t "$s" 2>/dev/null || true; done
+    done <<< "$agent_ids"
+  fi
   $COMPOSE -p "$PROJECT" down -v 2>/dev/null || true
   rm -rf "$MEDIA_ROOT"
 }


### PR DESCRIPTION
## Summary
- Query the test database for agent IDs before tearing it down, then kill their corresponding tmux sessions
- Prevents orphaned `dispatch_agt_*` tmux sessions from lingering after e2e runs
- Only kills sessions belonging to agents from the test run (safe when real agents are running)

## Test plan
- [x] `npm run test:e2e` — 23/23 pass
- [x] Verified zero orphan tmux sessions after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)