### PR TITLE
Only clean up tmux sessions known to this database

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -410,13 +410,12 @@ export class AgentManager {
         continue;
       }
 
-      // No matching DB record — kill if session older than 5 minutes (avoids race with creation)
+      // No DB record — leave it alone. The session may belong to another
+      // server instance (e.g. a dispatch-dev API server running against
+      // its own isolated database). Only clean up sessions that *this*
+      // database definitively knows about.
       if (!status) {
-        const ageSeconds = now - session.createdAt;
-        if (ageSeconds > ORPHAN_AGE_THRESHOLD_S) {
-          this.logger.info({ session: session.name, agentId, ageSeconds }, "Killing orphaned tmux session (no DB record)");
-          toKill.push(session.name);
-        }
+        this.logger.debug({ session: session.name, agentId }, "Ignoring tmux session with no matching DB record");
       }
     }
 


### PR DESCRIPTION
## Summary
- Stop killing tmux sessions that have no record in the current database
- Previously, the orphan cleanup would kill any `dispatch_agt_*` session not in the DB after 5 minutes — this caused dev server instances (with their own isolated DB) to kill the production agent's session on startup
- Now only sessions for agents in terminal states (`stopped`/`error`) are cleaned up

## Root cause
When an agent ran `dispatch-dev up`, the new API server started against an empty database. On startup, the reconciler found the agent's tmux session, saw no matching DB record, and killed it as an "orphan."

## Test plan
- [x] `npm run check` — type checks pass
- [x] `npm test` — 25/25 unit tests pass
- [x] `npm run test:e2e` — 23/23 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)