### PR TITLE
Add tmux incident diagnostics

### DIFF
--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -180,6 +180,108 @@ What to look for:
 - `counters.timedOut` increasing quickly: git probes are timing out
 - Many agents with `lastResult` of `probe_error` or `failed`: metadata may be stale
 
+### Sessions Disappeared
+
+If agents were `running` and then suddenly reconcile changed them to `stopped`, start here.
+
+Dispatch now writes host-side tmux diagnostics to:
+
+```bash
+~/.dispatch/diagnostics/tmux-inventory.jsonl
+~/.dispatch/diagnostics/*-missing-session-<agentId>.json
+```
+
+What these files mean:
+
+- `tmux-inventory.jsonl`: periodic snapshots taken during reconcile
+- `*-missing-session-<agentId>.json`: incident bundle written when reconcile expects a tmux session but `tmux has-session` fails
+
+Recommended incident workflow:
+
+1. Confirm what Dispatch observed.
+
+```bash
+tail -n 200 ~/.dispatch/logs/dispatch.log
+```
+
+Look for lines like:
+
+- `status corrected to stopped`
+- `Agent process exited with code ...`
+- repeated reconcile corrections across multiple agents in the same minute
+
+2. Inspect the most recent missing-session incident bundle.
+
+```bash
+ls -1t ~/.dispatch/diagnostics/*-missing-session-*.json | head
+jq . ~/.dispatch/diagnostics/<timestamp>-missing-session-<agentId>.json
+```
+
+Important fields:
+
+- `agent`: which agent was affected, what status it had, and whether an exit code file existed
+- `tmux.serverPid`: whether Dispatch could still find a tmux server process
+- `tmux.sessions` and `tmux.panes`: whether `tmux list-sessions` / `list-panes` still worked at incident time
+- `processes.stdout`: point-in-time process list
+- `launchctl.stdout`: current `com.dispatch.server` launchd state
+
+3. Check whether the tmux server disappeared entirely or just Dispatch sessions.
+
+```bash
+tail -n 20 ~/.dispatch/diagnostics/tmux-inventory.jsonl | jq .
+```
+
+What to look for:
+
+- `serverPid` changed or became `null`: tmux server likely exited or was killed
+- `sessions.exitCode` changed from `0` to `1`: tmux had no reachable server/socket
+- non-Dispatch sessions still present but Dispatch sessions gone: cleanup bug or targeted session removal
+- all sessions gone at once: host/session-level event is more likely than app logic
+
+4. Check launchd state for the server itself.
+
+```bash
+launchctl print gui/$(id -u)/com.dispatch.server
+```
+
+What to look for:
+
+- `last exit code`
+- `last terminating signal`
+- recent restart timing that lines up with the incident
+
+5. Pull macOS unified logs around the incident window.
+
+Use a tight window around when the sessions disappeared.
+
+```bash
+log show --style compact --start "2026-03-13 12:57:30" --end "2026-03-13 12:59:30" --predicate '(process == "tmux") || (process == "launchd") || (eventMessage CONTAINS[c] "com.dispatch.server") || (eventMessage CONTAINS[c] "logout") || (eventMessage CONTAINS[c] "Aqua")'
+```
+
+If needed, run narrower follow-ups:
+
+```bash
+log show --style compact --start "<start>" --end "<end>" --predicate '(process == "kernel") || (eventMessage CONTAINS[c] "SIGKILL") || (eventMessage CONTAINS[c] "killed") || (eventMessage CONTAINS[c] "jetsam")'
+log show --style compact --start "<start>" --end "<end>" --predicate '(process == "loginwindow") || (eventMessage CONTAINS[c] "logout") || (eventMessage CONTAINS[c] "user session")'
+```
+
+Interpretation:
+
+- Dispatch restarted but tmux stayed up: app restart only, agent sessions should have survived
+- Dispatch and tmux both disappeared: something outside Dispatch likely killed a broader user-scoped context
+- logout / Aqua / loginwindow activity: user session event likely killed tmux
+- `SIGKILL` or kernel kill messages near the same time: external kill or resource pressure
+
+6. Check for same-user interference.
+
+If self-hosted GitHub Actions runners or other automation run under the same macOS user, treat that as a suspect until proven otherwise. `tmux` and `launchd` state are user-scoped, so same-user automation has a much larger blast radius than automation running under a separate account.
+
+Known limits:
+
+- Dispatch can now tell you much more about what the host looked like when sessions vanished
+- Dispatch still cannot prove the killer if macOS did not log it or if the evidence aged out before inspection
+- If the host logged out, rebooted, or aggressively reaped processes, unified logs are still the source of truth
+
 ## File Locations
 
 | Path | Description |
@@ -188,4 +290,6 @@ What to look for:
 | `~/.dispatch/server/.env` | Server environment config |
 | `~/.dispatch/logs/dispatch.log` | Live server log |
 | `~/.dispatch/logs/last-release-failure.log` | Last deploy failure details |
+| `~/.dispatch/diagnostics/tmux-inventory.jsonl` | Periodic tmux inventory snapshots from reconcile |
+| `~/.dispatch/diagnostics/*-missing-session-<agentId>.json` | Incident bundle for missing tmux sessions |
 | `~/Library/LaunchAgents/com.dispatch.server.plist` | launchd service definition |

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rm, stat, unlink } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import type { FastifyBaseLogger } from "fastify";
@@ -78,9 +79,11 @@ export class AgentError extends Error {
 }
 
 export class AgentManager {
+  private static readonly TMUX_INVENTORY_INTERVAL_MS = 60_000;
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
+  private lastTmuxInventoryAt = 0;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
@@ -297,6 +300,8 @@ export class AgentManager {
   }
 
   async reconcileAgentStatuses(): Promise<AgentRecord[]> {
+    await this.maybeCaptureTmuxInventory();
+
     const result = await this.pool.query(
       "SELECT id, tmux_session AS \"tmuxSession\", status, updated_at AS \"updatedAt\" FROM agents WHERE status IN ('running', 'stopping', 'creating')"
     );
@@ -308,6 +313,15 @@ export class AgentManager {
 
       if (!exists) {
         const exitInfo = row.tmuxSession ? await this.readExitFile(row.tmuxSession) : null;
+        if (row.tmuxSession) {
+          await this.captureMissingSessionIncident({
+            agentId: row.id,
+            tmuxSession: row.tmuxSession,
+            status: row.status,
+            updatedAt: row.updatedAt,
+            exitInfo
+          });
+        }
         if (exitInfo !== null) {
           this.logger.info({ id: row.id, exitCode: exitInfo }, "Agent process exited with code %d", exitInfo);
         }
@@ -413,6 +427,113 @@ export class AgentManager {
     await Promise.all(
       toKill.map((name) => runCommand("tmux", ["kill-session", "-t", name]).catch(() => {}))
     );
+  }
+
+  private diagnosticsRoot(): string {
+    return path.join(os.homedir(), ".dispatch", "diagnostics");
+  }
+
+  private async maybeCaptureTmuxInventory(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastTmuxInventoryAt < AgentManager.TMUX_INVENTORY_INTERVAL_MS) {
+      return;
+    }
+    this.lastTmuxInventoryAt = now;
+
+    try {
+      await mkdir(this.diagnosticsRoot(), { recursive: true });
+      const payload = {
+        capturedAt: new Date(now).toISOString(),
+        source: "reconcile",
+        tmux: {
+          serverPid: await this.detectTmuxServerPid(),
+          sessions: await this.captureCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], [0, 1]),
+          panes: await this.captureCommand(
+            "tmux",
+            ["list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}"],
+            [0, 1]
+          )
+        }
+      };
+      await appendFile(
+        path.join(this.diagnosticsRoot(), "tmux-inventory.jsonl"),
+        `${JSON.stringify(payload)}\n`,
+        "utf-8"
+      );
+    } catch (error) {
+      this.logger.warn({ err: error }, "Failed to capture tmux inventory.");
+    }
+  }
+
+  private async captureMissingSessionIncident(input: {
+    agentId: string;
+    tmuxSession: string;
+    status: string;
+    updatedAt: string;
+    exitInfo: number | null;
+  }): Promise<void> {
+    try {
+      await mkdir(this.diagnosticsRoot(), { recursive: true });
+      const capturedAt = new Date().toISOString();
+      const safeTs = capturedAt.replaceAll(":", "-");
+      const payload = {
+        capturedAt,
+        incident: "missing_tmux_session",
+        agent: input,
+        tmux: {
+          serverPid: await this.detectTmuxServerPid(),
+          sessions: await this.captureCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], [0, 1]),
+          panes: await this.captureCommand(
+            "tmux",
+            ["list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}"],
+            [0, 1]
+          )
+        },
+        processes: await this.captureCommand("ps", ["-axo", "pid,ppid,pgid,user,command"], [0]),
+        launchctl: await this.captureCommand(
+          "launchctl",
+          ["print", `gui/${process.getuid?.() ?? -1}/com.dispatch.server`],
+          [0, 113]
+        )
+      };
+      const fileName = `${safeTs}-missing-session-${input.agentId}.json`;
+      await writeFile(path.join(this.diagnosticsRoot(), fileName), JSON.stringify(payload, null, 2), "utf-8");
+    } catch (error) {
+      this.logger.warn({ err: error, agentId: input.agentId }, "Failed to capture missing tmux session incident.");
+    }
+  }
+
+  private async detectTmuxServerPid(): Promise<number | null> {
+    const processes = await this.captureCommand("ps", ["-axo", "pid=,comm="], [0]);
+    if (processes.exitCode !== 0) {
+      return null;
+    }
+    const pidLine = processes.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => /\btmux$/.test(line));
+    if (!pidLine) {
+      return null;
+    }
+    const [pidText] = pidLine.split(/\s+/, 1);
+    const pid = Number(pidText);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  }
+
+  private async captureCommand(
+    command: string,
+    args: string[],
+    allowedExitCodes: number[]
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    try {
+      return await runCommand(command, args, { allowedExitCodes });
+    } catch (error) {
+      return {
+        exitCode: -1,
+        stdout: "",
+        stderr: this.errorMessage(error)
+      };
+    }
   }
 
   private async startTmuxSession(

--- a/test/db/agent-manager.test.ts
+++ b/test/db/agent-manager.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import type { Pool } from "pg";
 
@@ -61,6 +65,14 @@ beforeEach(async () => {
   await pool.query("DELETE FROM media_seen");
   await pool.query("DELETE FROM media");
   await pool.query("DELETE FROM agents");
+
+  const { runCommand } = await import("../../src/lib/run-command.js");
+  vi.mocked(runCommand).mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args[0] === "has-session") {
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
 });
 
 describe("AgentManager", () => {
@@ -277,9 +289,18 @@ describe("AgentManager", () => {
       // Now make tmux report no session
       const { runCommand } = await import("../../src/lib/run-command.js");
       const mockRunCommand = vi.mocked(runCommand);
-      mockRunCommand.mockImplementationOnce(async (_cmd, args) => {
+      mockRunCommand.mockImplementation(async (_cmd, args) => {
         if (args[0] === "has-session") {
           return { exitCode: 1, stdout: "", stderr: "" };
+        }
+        if (args[0] === "list-sessions" || args[0] === "list-panes") {
+          return { exitCode: 1, stdout: "", stderr: "no server running" };
+        }
+        if (_cmd === "ps") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (_cmd === "launchctl") {
+          return { exitCode: 113, stdout: "", stderr: "service not found" };
         }
         return { exitCode: 0, stdout: "", stderr: "" };
       });
@@ -288,6 +309,66 @@ describe("AgentManager", () => {
 
       const reconciled = await manager.getAgent(agent.id);
       expect(reconciled!.status).toBe("stopped");
+    });
+
+    it("should capture a missing-session diagnostic snapshot", async () => {
+      const tempHome = await mkdtemp(path.join(os.tmpdir(), "dispatch-agent-manager-home-"));
+      const previousHome = process.env.HOME;
+      process.env.HOME = tempHome;
+
+      try {
+        const agent = await manager.createAgent({ cwd: "/tmp" });
+
+        const { runCommand } = await import("../../src/lib/run-command.js");
+        const mockRunCommand = vi.mocked(runCommand);
+        mockRunCommand.mockClear();
+        mockRunCommand.mockImplementation(async (_cmd, args) => {
+          if (args[0] === "has-session") {
+            return { exitCode: 1, stdout: "", stderr: "" };
+          }
+          if (args[0] === "list-sessions") {
+            return { exitCode: 1, stdout: "", stderr: "no server running" };
+          }
+          if (args[0] === "list-panes") {
+            return { exitCode: 1, stdout: "", stderr: "no server running" };
+          }
+          if (_cmd === "ps" && args[1] === "pid=,comm=") {
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+          if (_cmd === "ps") {
+            return { exitCode: 0, stdout: "  PID  PPID  PGID USER COMMAND\n", stderr: "" };
+          }
+          if (_cmd === "launchctl") {
+            return { exitCode: 0, stdout: "launchctl snapshot", stderr: "" };
+          }
+          return { exitCode: 0, stdout: "", stderr: "" };
+        });
+
+        await manager.reconcileAgentStatuses();
+
+        const diagnosticsDir = path.join(tempHome, ".dispatch", "diagnostics");
+        const files = await readdir(diagnosticsDir);
+        const incidentFile = files.find((file) => file.includes(`missing-session-${agent.id}.json`));
+        expect(incidentFile).toBeTruthy();
+
+        const incidentRaw = await readFile(path.join(diagnosticsDir, incidentFile!), "utf-8");
+        const incident = JSON.parse(incidentRaw) as {
+          incident: string;
+          agent: { agentId: string; tmuxSession: string; exitInfo: number | null };
+          tmux: { sessions: { exitCode: number; stderr: string } };
+          launchctl: { stdout: string };
+        };
+
+        expect(incident.incident).toBe("missing_tmux_session");
+        expect(incident.agent.agentId).toBe(agent.id);
+        expect(incident.agent.tmuxSession).toBe(agent.tmuxSession);
+        expect(incident.agent.exitInfo).toBeNull();
+        expect(incident.tmux.sessions.exitCode).toBe(1);
+        expect(incident.launchctl.stdout).toContain("launchctl snapshot");
+      } finally {
+        process.env.HOME = previousHome;
+        await rm(tempHome, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- capture periodic tmux inventory snapshots during agent reconciliation
- write a diagnostic incident bundle when reconcile finds a missing tmux session
- add backend coverage for the missing-session snapshot path

## Testing
- npm run check
- npm test
- npm run test:e2e