### PR TITLE
Add inert runtime for tmux-free e2e

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=change-me
 MEDIA_ROOT=/Users/you/.dispatch/media
+DISPATCH_AGENT_RUNTIME=inert
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem
 

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -59,6 +59,8 @@ test.describe("Agent CRUD", () => {
     // Agent should appear in the sidebar
     const sidebar = page.getByTestId("agent-sidebar");
     await expect(sidebar.getByText(agentName)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("terminal-inert-state")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("terminal-inert-state")).toContainText("Agent running in inert mode");
   });
 
   test("cancel create dialog does not create an agent", async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
   },
   webServer: {
     command: process.env.E2E_SKIP_WEB_BUILD
-      ? `DATABASE_URL=${databaseUrl} DISPATCH_PORT=${devPort} MEDIA_ROOT=${mediaRoot} npm run dev`
-      : `npm run build:web && DATABASE_URL=${databaseUrl} DISPATCH_PORT=${devPort} MEDIA_ROOT=${mediaRoot} npm run dev`,
+      ? `DATABASE_URL=${databaseUrl} DISPATCH_PORT=${devPort} MEDIA_ROOT=${mediaRoot} DISPATCH_AGENT_RUNTIME=inert npm run dev`
+      : `npm run build:web && DATABASE_URL=${databaseUrl} DISPATCH_PORT=${devPort} MEDIA_ROOT=${mediaRoot} DISPATCH_AGENT_RUNTIME=inert npm run dev`,
     url: `${baseURL}/api/v1/health`,
     reuseExistingServer: false,
     timeout: 60_000,

--- a/scripts/e2e-isolated.sh
+++ b/scripts/e2e-isolated.sh
@@ -45,12 +45,6 @@ mkdir -p "$MEDIA_ROOT"
 
 cleanup() {
   echo "==> Tearing down isolated environment"
-  # Kill tmux sessions created by e2e test agents. These are named like
-  # dispatch_agt_xxxx_e2e-agent-*, so we can match them by the e2e prefix
-  # without needing to query the (possibly empty) test database.
-  tmux list-sessions -F '#{session_name}' 2>/dev/null \
-    | grep '^dispatch_agt_.*e2e-agent' \
-    | while read -r s; do tmux kill-session -t "$s" 2>/dev/null || true; done
   $COMPOSE -p "$PROJECT" down -v 2>/dev/null || true
   rm -rf "$MEDIA_ROOT"
 }

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -72,6 +72,10 @@ type AgentLatestEventInput = {
   metadata?: Record<string, unknown>;
 };
 
+export type AgentTerminalAccess =
+  | { mode: "tmux"; sessionName: string }
+  | { mode: "inert"; message: string };
+
 export class AgentError extends Error {
   statusCode: number;
 
@@ -86,6 +90,7 @@ export class AgentManager {
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
+  private readonly runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
   private lastTmuxInventoryAt = 0;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
@@ -125,7 +130,7 @@ export class AgentManager {
 
     try {
       await this.ensureNoExistingSession(tmuxSession);
-      await this.startTmuxSession(tmuxSession, cwd, mediaDir, type, agentArgs, fullAccess);
+      await this.startAgentSession(tmuxSession, cwd, mediaDir, type, agentArgs, fullAccess);
       await this.setAgentStatus(id, "running", null);
       await this.setSystemLatestEvent(id, {
         type: "working",
@@ -148,7 +153,7 @@ export class AgentManager {
   async startAgent(id: string): Promise<AgentRecord> {
     const agent = await this.getRequiredAgent(id);
     const tmuxSession = agent.tmuxSession ?? this.toSessionName(agent.id, agent.name);
-    const hasSession = await this.tmuxHasSession(tmuxSession);
+    const hasSession = await this.hasAgentSession(tmuxSession);
 
     if (hasSession) {
       await this.setAgentStatus(id, "running", null, tmuxSession);
@@ -162,7 +167,7 @@ export class AgentManager {
     await this.setAgentStatus(id, "creating", null);
 
     try {
-      await this.startTmuxSession(
+      await this.startAgentSession(
         tmuxSession,
         agent.cwd,
         agent.mediaDir ?? this.defaultMediaDir(id),
@@ -189,7 +194,7 @@ export class AgentManager {
     return (await this.getAgent(id)) as AgentRecord;
   }
 
-  async getTerminalSession(id: string): Promise<string> {
+  async getTerminalAccess(id: string): Promise<AgentTerminalAccess> {
     const agent = await this.getRequiredAgent(id);
     if (agent.status !== "running") {
       throw new AgentError("Agent is not running.", 409);
@@ -199,13 +204,20 @@ export class AgentManager {
       throw new AgentError("Agent is missing tmux session metadata.", 500);
     }
 
-    const hasSession = await this.tmuxHasSession(agent.tmuxSession);
+    if (this.config.agentRuntime === "inert") {
+      return {
+        mode: "inert",
+        message: "Agent is running in inert mode. No tmux session or CLI process is attached in this environment."
+      };
+    }
+
+    const hasSession = await this.hasAgentSession(agent.tmuxSession);
     if (!hasSession) {
       await this.setAgentStatus(id, "stopped", "Agent tmux session is no longer running.", agent.tmuxSession);
       throw new AgentError("Agent session is not available. Start the agent again.", 409);
     }
 
-    return agent.tmuxSession;
+    return { mode: "tmux", sessionName: agent.tmuxSession };
   }
 
   async stopAgent(id: string, input: StopAgentInput = {}): Promise<AgentRecord> {
@@ -220,15 +232,8 @@ export class AgentManager {
     await this.setAgentStatus(id, "stopping", null, tmuxSession ?? undefined);
 
     try {
-      if (tmuxSession && (await this.tmuxHasSession(tmuxSession))) {
-        if (!force) {
-          await runCommand("tmux", ["send-keys", "-t", tmuxSession, "C-c"]);
-          await this.sleep(1200);
-        }
-
-        if (await this.tmuxHasSession(tmuxSession)) {
-          await runCommand("tmux", ["kill-session", "-t", tmuxSession]);
-        }
+      if (tmuxSession && (await this.hasAgentSession(tmuxSession))) {
+        await this.stopAgentSession(tmuxSession, force);
       }
 
       await this.setAgentStatus(id, "stopped", null, tmuxSession ?? undefined);
@@ -252,7 +257,7 @@ export class AgentManager {
 
   async deleteAgent(id: string, force = false): Promise<void> {
     const agent = await this.getRequiredAgent(id);
-    const sessionExists = agent.tmuxSession ? await this.tmuxHasSession(agent.tmuxSession) : false;
+    const sessionExists = agent.tmuxSession ? await this.hasAgentSession(agent.tmuxSession) : false;
 
     // If tmux is already gone, treat the agent as effectively stopped even if status is stale.
     if (agent.status === "running" && sessionExists && !force) {
@@ -264,7 +269,7 @@ export class AgentManager {
     }
 
     if (agent.tmuxSession && sessionExists) {
-      await runCommand("tmux", ["kill-session", "-t", agent.tmuxSession]);
+      await this.stopAgentSession(agent.tmuxSession, true);
     }
 
     await this.pool.query("DELETE FROM agents WHERE id = $1", [id]);
@@ -301,7 +306,9 @@ export class AgentManager {
 
   async reconcileAgents(): Promise<void> {
     await this.reconcileAgentStatuses();
-    await this.cleanupOrphanedSessions();
+    if (this.config.agentRuntime === "tmux") {
+      await this.cleanupOrphanedSessions();
+    }
   }
 
   async reconcileAgentStatuses(): Promise<AgentRecord[]> {
@@ -314,11 +321,13 @@ export class AgentManager {
     const reconciled: AgentRecord[] = [];
 
     for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string; updatedAt: string }>) {
-      const exists = row.tmuxSession ? await this.tmuxHasSession(row.tmuxSession) : false;
+      const exists = row.tmuxSession ? await this.hasAgentSession(row.tmuxSession) : false;
 
       if (!exists) {
-        const exitInfo = row.tmuxSession ? await this.readExitFile(row.tmuxSession) : null;
-        if (row.tmuxSession) {
+        const exitInfo = this.config.agentRuntime === "tmux" && row.tmuxSession
+          ? await this.readExitFile(row.tmuxSession)
+          : null;
+        if (this.config.agentRuntime === "tmux" && row.tmuxSession) {
           await this.captureMissingSessionIncident({
             agentId: row.id,
             tmuxSession: row.tmuxSession,
@@ -541,7 +550,41 @@ export class AgentManager {
     }
   }
 
-  private async startTmuxSession(
+  async resolveRuntimeCwd(agent: AgentRecord): Promise<string> {
+    const fallback = agent.cwd;
+    const session = agent.tmuxSession?.trim();
+    if (!session || this.config.agentRuntime !== "tmux") {
+      return fallback;
+    }
+
+    if (agent.status !== "running" && agent.status !== "creating") {
+      return fallback;
+    }
+
+    const cacheKey = `${agent.id}:${session}`;
+    const cached = this.runtimeCwdCache.get(cacheKey);
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+
+    try {
+      const result = await runCommand("tmux", ["display-message", "-p", "-t", session, "#{pane_current_path}"], {
+        allowedExitCodes: [0, 1],
+        timeoutMs: 800
+      });
+      const cwd = result.stdout.trim();
+      if (result.exitCode !== 0 || !cwd) {
+        return fallback;
+      }
+      this.runtimeCwdCache.set(cacheKey, { value: cwd, expiresAt: now + 10_000 });
+      return cwd;
+    } catch {
+      return fallback;
+    }
+  }
+
+  private async startAgentSession(
     sessionName: string,
     cwd: string,
     mediaDir: string,
@@ -549,6 +592,11 @@ export class AgentManager {
     agentArgs: string[],
     fullAccess: boolean
   ): Promise<void> {
+    if (this.config.agentRuntime === "inert") {
+      await mkdir(mediaDir, { recursive: true });
+      return;
+    }
+
     await mkdir(mediaDir, { recursive: true });
     const agentCommand = this.buildAgentCommand(type, agentArgs, mediaDir, sessionName, fullAccess);
     const exitFile = `/tmp/dispatch_${sessionName}.exit`;
@@ -560,22 +608,45 @@ export class AgentManager {
 
     // Detect fast-fail launches (for example, missing codex executable) so status
     // is not left as "running" with no backing tmux session.
-    if (!(await this.tmuxHasSession(sessionName))) {
+    if (!(await this.hasAgentSession(sessionName))) {
       throw new Error("tmux session exited immediately after launch");
     }
   }
 
   private async ensureNoExistingSession(sessionName: string): Promise<void> {
-    if (await this.tmuxHasSession(sessionName)) {
+    if (this.config.agentRuntime !== "tmux") {
+      return;
+    }
+
+    if (await this.hasAgentSession(sessionName)) {
       await runCommand("tmux", ["kill-session", "-t", sessionName]);
     }
   }
 
-  private async tmuxHasSession(sessionName: string): Promise<boolean> {
+  private async hasAgentSession(sessionName: string): Promise<boolean> {
+    if (this.config.agentRuntime === "inert") {
+      return sessionName.trim().length > 0;
+    }
+
     const result = await runCommand("tmux", ["has-session", "-t", sessionName], {
       allowedExitCodes: [0, 1]
     });
     return result.exitCode === 0;
+  }
+
+  private async stopAgentSession(sessionName: string, force: boolean): Promise<void> {
+    if (this.config.agentRuntime === "inert") {
+      return;
+    }
+
+    if (!force) {
+      await runCommand("tmux", ["send-keys", "-t", sessionName, "C-c"]);
+      await this.sleep(1200);
+    }
+
+    if (await this.hasAgentSession(sessionName)) {
+      await runCommand("tmux", ["kill-session", "-t", sessionName]);
+    }
   }
 
   private buildAgentCommand(

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type AppConfig = {
   codexBin: string;
   claudeBin: string;
   opencodeBin: string;
+  agentRuntime: "tmux" | "inert";
   tls: TlsConfig | null;
 };
 
@@ -64,6 +65,7 @@ export function loadConfig(): AppConfig {
       process.env.HOSTESS_OPENCODE_BIN ??
       process.env.OPENCODE_BIN ??
       "opencode",
+    agentRuntime: process.env.DISPATCH_AGENT_RUNTIME === "tmux" ? "tmux" : "inert",
     tls: loadTls(),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -116,8 +116,6 @@ const streamManager = new StreamManager(
     uiEventBroker.publish({ type: "media.changed", agentId });
   }
 );
-const runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
-const RUNTIME_CWD_CACHE_TTL_MS = 10_000;
 const PROBE_COMMAND_TIMEOUT_MS = 800;
 const GIT_CONTEXT_REFRESH_INTERVAL_MS = 120_000;
 const GIT_CONTEXT_REFRESH_CONCURRENCY = 1;
@@ -1148,23 +1146,21 @@ async function registerRoutes() {
     const id = params.id ?? "";
 
     try {
-      const agent = await agentManager.getAgent(id);
-      if (!agent) {
-        return reply.code(404).send({ error: "Agent not found." });
-      }
-      if (agent.status !== "running") {
-        return reply.code(409).send({ error: "Agent is not running." });
-      }
-      if (!agent.tmuxSession) {
-        return reply.code(500).send({ error: "Agent is missing tmux session metadata." });
+      const access = await agentManager.getTerminalAccess(id);
+      if (access.mode === "inert") {
+        return {
+          mode: "inert" as const,
+          message: access.message
+        };
       }
       const token = terminalTokenStore.issue(id);
       return {
+        mode: "tmux" as const,
         token,
         wsUrl: `/api/v1/agents/${id}/terminal/ws?token=${token}`
       };
     } catch (error) {
-      // Keep UI state in sync when getTerminalSession corrected a stale running status.
+      // Keep UI state in sync when terminal access lookup corrected a stale running status.
       const refreshed = await agentManager.getAgent(id);
       if (refreshed) {
         queueGitContextRefresh([refreshed.id]);
@@ -1192,7 +1188,11 @@ async function registerRoutes() {
 
       let tmuxSession: string;
       try {
-        tmuxSession = await agentManager.getTerminalSession(agentId);
+        const access = await agentManager.getTerminalAccess(agentId);
+        if (access.mode !== "tmux") {
+          throw new Error(access.message);
+        }
+        tmuxSession = access.sessionName;
         await runCommand("tmux", ["set-option", "-t", tmuxSession, "mouse", "on"], {
           allowedExitCodes: [0]
         });
@@ -1615,37 +1615,7 @@ function areGitContextsEqual(
 }
 
 async function resolveAgentGitCwd(agent: AgentRecord): Promise<string> {
-  const fallback = agent.cwd;
-  const session = agent.tmuxSession?.trim();
-  if (!session) {
-    return fallback;
-  }
-
-  if (agent.status !== "running" && agent.status !== "creating") {
-    return fallback;
-  }
-
-  const cacheKey = `${agent.id}:${session}`;
-  const cached = runtimeCwdCache.get(cacheKey);
-  const now = Date.now();
-  if (cached && cached.expiresAt > now) {
-    return cached.value;
-  }
-
-  try {
-    const result = await runCommand("tmux", ["display-message", "-p", "-t", session, "#{pane_current_path}"], {
-      allowedExitCodes: [0, 1],
-      timeoutMs: PROBE_COMMAND_TIMEOUT_MS
-    });
-    const cwd = result.stdout.trim();
-    if (result.exitCode !== 0 || !cwd) {
-      return fallback;
-    }
-    runtimeCwdCache.set(cacheKey, { value: cwd, expiresAt: now + RUNTIME_CWD_CACHE_TTL_MS });
-    return cwd;
-  } catch {
-    return fallback;
-  }
+  return agentManager.resolveRuntimeCwd(agent);
 }
 
 async function probeGitContext(

--- a/test/db/agent-manager.test.ts
+++ b/test/db/agent-manager.test.ts
@@ -46,7 +46,13 @@ const testConfig = {
   codexBin: "echo",
   claudeBin: "echo",
   opencodeBin: "echo",
+  agentRuntime: "tmux",
   tls: null,
+} satisfies import("../../src/config.js").AppConfig;
+
+const inertTestConfig = {
+  ...testConfig,
+  agentRuntime: "inert",
 } satisfies import("../../src/config.js").AppConfig;
 
 let manager: InstanceType<typeof AgentManager>;
@@ -137,6 +143,17 @@ describe("AgentManager", () => {
         manager.createAgent({ cwd: "/nonexistent-dispatch-test-dir" })
       ).rejects.toThrow("does not exist");
     });
+
+    it("should create inert agents without invoking tmux", async () => {
+      const { runCommand } = await import("../../src/lib/run-command.js");
+      const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
+      vi.mocked(runCommand).mockClear();
+
+      const agent = await inertManager.createAgent({ cwd: "/tmp" });
+
+      expect(agent.status).toBe("running");
+      expect(vi.mocked(runCommand)).not.toHaveBeenCalled();
+    });
   });
 
   describe("getAgent / listAgents", () => {
@@ -162,6 +179,18 @@ describe("AgentManager", () => {
       expect(fetched).not.toBeNull();
       expect(fetched!.id).toBe(created.id);
       expect(fetched!.name).toBe("fetch-me");
+    });
+  });
+
+  describe("getTerminalAccess", () => {
+    it("should return inert terminal metadata for inert runtime agents", async () => {
+      const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
+      const agent = await inertManager.createAgent({ cwd: "/tmp" });
+
+      const access = await inertManager.getTerminalAccess(agent.id);
+
+      expect(access.mode).toBe("inert");
+      expect(access.message).toContain("inert mode");
     });
   });
 
@@ -293,6 +322,18 @@ describe("AgentManager", () => {
 
       const result = await manager.stopAgent(agent.id);
       expect(result.status).toBe("stopped");
+    });
+
+    it("should stop inert agents without invoking tmux", async () => {
+      const { runCommand } = await import("../../src/lib/run-command.js");
+      const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
+      const agent = await inertManager.createAgent({ cwd: "/tmp" });
+      vi.mocked(runCommand).mockClear();
+
+      const stopped = await inertManager.stopAgent(agent.id, { force: true });
+
+      expect(stopped.status).toBe("stopped");
+      expect(vi.mocked(runCommand)).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -140,6 +140,8 @@ export function App(): JSX.Element {
 
   const [connState, setConnState] = useState<ConnState>("disconnected");
   const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
+  const [terminalMode, setTerminalMode] = useState<"tmux" | "inert" | null>(null);
+  const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<string | null>(null);
   const connectedAgentIdRef = useRef<string | null>(null);
   connectedAgentIdRef.current = connectedAgentId;
 
@@ -390,8 +392,10 @@ export function App(): JSX.Element {
         wsRef.current.close();
       } catch {}
       wsRef.current = null;
-      setConnectedAgentId(null);
     }
+    setConnectedAgentId(null);
+    setTerminalMode(null);
+    setTerminalPlaceholderMessage(null);
 
     if (announce) {
       setStatusMessage("Session disconnected.");
@@ -505,16 +509,33 @@ export function App(): JSX.Element {
       };
 
       try {
-        const token = await api<{ token: string; wsUrl: string }>(
+        const terminalSession = await api<
+          | { mode: "tmux"; token: string; wsUrl: string }
+          | { mode: "inert"; message: string }
+        >(
           `/api/v1/agents/${agent.id}/terminal/token`,
           { method: "POST", body: JSON.stringify({}) }
         );
+
+        if (terminalSession.mode === "inert") {
+          reconnectAttemptsRef.current = 0;
+          setConnState("connected");
+          setConnectedAgentId(agent.id);
+          setTerminalMode("inert");
+          setTerminalPlaceholderMessage(terminalSession.message);
+          setStatusMessage(terminalSession.message);
+          return;
+        }
 
         const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
         const term = terminalRef.current;
         const cols = term?.cols ?? 140;
         const rows = term?.rows ?? 42;
-        const ws = new WebSocket(`${protocol}//${window.location.host}${token.wsUrl}&cols=${cols}&rows=${rows}`);
+        setTerminalMode("tmux");
+        setTerminalPlaceholderMessage(null);
+        const ws = new WebSocket(
+          `${protocol}//${window.location.host}${terminalSession.wsUrl}&cols=${cols}&rows=${rows}`
+        );
         wsRef.current = ws;
 
         ws.addEventListener("open", () => {
@@ -1652,6 +1673,8 @@ export function App(): JSX.Element {
               hasSelectedAgent={Boolean(selectedAgentId)}
               connState={connState}
               statusMessage={statusMessage}
+              terminalMode={terminalMode}
+              terminalPlaceholderMessage={terminalPlaceholderMessage}
               terminalHostRef={terminalHostRef}
             />
 

--- a/web/src/components/app/terminal-pane.tsx
+++ b/web/src/components/app/terminal-pane.tsx
@@ -9,6 +9,8 @@ type TerminalPaneProps = {
   hasSelectedAgent: boolean;
   connState: ConnState;
   statusMessage: string;
+  terminalMode: "tmux" | "inert" | null;
+  terminalPlaceholderMessage: string | null;
   terminalHostRef: RefObject<HTMLDivElement>;
 };
 
@@ -17,6 +19,8 @@ export function TerminalPane({
   hasSelectedAgent,
   connState,
   statusMessage,
+  terminalMode,
+  terminalPlaceholderMessage,
   terminalHostRef
 }: TerminalPaneProps): JSX.Element {
   const [showReconnectOverlay, setShowReconnectOverlay] = useState(false);
@@ -35,13 +39,14 @@ export function TerminalPane({
   }, [connState]);
 
   const showEmptyState = connState === "disconnected" && !isAttached && !hasSelectedAgent;
+  const showInertState = terminalMode === "inert" && isAttached;
 
   return (
     <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-[#141414]">
       <div
         className={cn(
           "h-full w-full",
-          !isAttached && connState !== "reconnecting" && "invisible",
+          (!isAttached || showInertState) && connState !== "reconnecting" && "invisible",
           showReconnectOverlay && "blur-[1.5px]"
         )}
       >
@@ -53,6 +58,19 @@ export function TerminalPane({
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
             <p className="text-sm">Select an agent and press Play to start and attach to a session.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {showInertState ? (
+        <div data-testid="terminal-inert-state" className="absolute inset-0 z-20 grid place-items-center bg-[#141414]">
+          <div className="flex max-w-xl flex-col items-center gap-3 px-6 text-center text-zinc-300">
+            <TerminalSquare className="h-9 w-9 text-amber-300" />
+            <p className="text-base font-medium text-zinc-100">Agent running in inert mode</p>
+            <p className="text-sm leading-6 text-zinc-400">
+              {terminalPlaceholderMessage ??
+                "This environment does not launch a real tmux session or CLI process. Agent lifecycle flows are simulated for UI validation."}
+            </p>
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- add an inert agent runtime so Playwright e2e never creates tmux sessions
- render an explicit inert terminal placeholder instead of attempting websocket attach
- make inert the default runtime, while keeping production env explicitly pinned to tmux

## Validation
- npm run check
- npm test
- npm run finalize:web
- npm run test:e2e
