### PR TITLE
Add MCP PR tools

### DIFF
--- a/src/github/pr.ts
+++ b/src/github/pr.ts
@@ -1,0 +1,360 @@
+import { runCommand, type RunCommandResult } from "../lib/run-command.js";
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; allowedExitCodes?: number[]; timeoutMs?: number }
+) => Promise<RunCommandResult>;
+
+export type CreatePrInput = {
+  cwd: string;
+  baseBranch?: string;
+  title?: string;
+  body?: string;
+  draft?: boolean;
+  fillFromCommits?: boolean;
+};
+
+export type CreatePrResult = {
+  repoRoot: string;
+  branchName: string;
+  baseBranch: string;
+  prNumber: number | null;
+  url: string;
+  title: string | null;
+  isDraft: boolean | null;
+};
+
+export type EnablePrAutomergeInput = {
+  cwd: string;
+  prNumber?: number;
+  mergeMethod?: "squash" | "merge" | "rebase";
+  deleteBranch?: boolean;
+};
+
+export type EnablePrAutomergeResult = {
+  prNumber: number | null;
+  url: string | null;
+  mergeMethod: "squash" | "merge" | "rebase";
+  autoMergeEnabled: boolean;
+};
+
+export type MergePrNowInput = {
+  cwd: string;
+  prNumber?: number;
+  mergeMethod?: "squash" | "merge" | "rebase";
+  deleteBranch?: boolean;
+};
+
+export type MergePrNowResult = {
+  prNumber: number | null;
+  url: string | null;
+  mergeMethod: "squash" | "merge" | "rebase";
+  merged: boolean;
+};
+
+export type GetPrStatusInput = {
+  cwd: string;
+  prNumber?: number;
+};
+
+export type GetPrStatusResult = {
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  mergeStateStatus: string | null;
+  mergeable: string | null;
+  autoMergeEnabled: boolean;
+  headRefName: string;
+  baseRefName: string;
+  statusSummary: Array<{ name: string; status: string; conclusion: string | null }>;
+};
+
+export class GitHubPrError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode = 400) {
+    super(message);
+    this.name = "GitHubPrError";
+    this.statusCode = statusCode;
+  }
+}
+
+export async function createPr(
+  input: CreatePrInput,
+  commandRunner: CommandRunner = runCommand
+): Promise<CreatePrResult> {
+  const cwd = requireString(input.cwd, "cwd");
+  const repoRoot = await resolveRepoRoot(cwd, commandRunner);
+  const baseBranch = (input.baseBranch?.trim() || "main");
+  const branchName = await resolveCurrentBranch(repoRoot, commandRunner);
+
+  if (!branchName) {
+    throw new GitHubPrError("Current checkout is in detached HEAD state.", 409);
+  }
+  if (branchName === baseBranch) {
+    throw new GitHubPrError(`Current branch is already "${baseBranch}". Create the PR from a feature branch instead.`, 409);
+  }
+
+  await ensureBaseBranchHasDiff(repoRoot, baseBranch, commandRunner);
+  await ensureRemoteBranch(repoRoot, branchName, commandRunner);
+
+  const args = ["pr", "create", "--base", baseBranch, "--head", branchName];
+  if (input.draft ?? false) {
+    args.push("--draft");
+  }
+  if (input.fillFromCommits ?? false) {
+    args.push("--fill");
+  }
+  if (input.title?.trim()) {
+    args.push("--title", input.title.trim());
+  }
+  if (input.body?.trim()) {
+    args.push("--body", input.body.trim());
+  }
+
+  if (!args.includes("--title") && !args.includes("--fill")) {
+    throw new GitHubPrError("create_pr requires title or fillFromCommits to avoid interactive gh prompts.", 400);
+  }
+  if (!args.includes("--body") && !args.includes("--fill")) {
+    throw new GitHubPrError("create_pr requires body or fillFromCommits to avoid interactive gh prompts.", 400);
+  }
+
+  const createResult = await commandRunner("gh", args, { cwd: repoRoot });
+  const url = firstNonEmptyLine(createResult.stdout);
+  if (!url) {
+    throw new GitHubPrError("gh pr create did not return a PR URL.", 500);
+  }
+
+  const status = await getPrStatus({ cwd: repoRoot, prNumber: undefined }, commandRunner);
+  return {
+    repoRoot,
+    branchName,
+    baseBranch,
+    prNumber: status.number,
+    url,
+    title: status.title,
+    isDraft: status.isDraft
+  };
+}
+
+export async function enablePrAutomerge(
+  input: EnablePrAutomergeInput,
+  commandRunner: CommandRunner = runCommand
+): Promise<EnablePrAutomergeResult> {
+  const cwd = requireString(input.cwd, "cwd");
+  const repoRoot = await resolveRepoRoot(cwd, commandRunner);
+  const mergeMethod = normalizeMergeMethod(input.mergeMethod);
+  const prSelector = input.prNumber ? String(input.prNumber) : undefined;
+
+  const args = ["pr", "merge"];
+  if (prSelector) {
+    args.push(prSelector);
+  }
+  args.push("--auto", mergeMethodFlag(mergeMethod));
+  if (input.deleteBranch ?? true) {
+    args.push("--delete-branch");
+  }
+
+  await commandRunner("gh", args, { cwd: repoRoot });
+  const status = await getPrStatus({ cwd: repoRoot, prNumber: input.prNumber }, commandRunner);
+  return {
+    prNumber: status.number,
+    url: status.url,
+    mergeMethod,
+    autoMergeEnabled: status.autoMergeEnabled
+  };
+}
+
+export async function mergePrNow(
+  input: MergePrNowInput,
+  commandRunner: CommandRunner = runCommand
+): Promise<MergePrNowResult> {
+  const cwd = requireString(input.cwd, "cwd");
+  const repoRoot = await resolveRepoRoot(cwd, commandRunner);
+  const mergeMethod = normalizeMergeMethod(input.mergeMethod);
+  const prSelector = input.prNumber ? String(input.prNumber) : undefined;
+
+  const args = ["pr", "merge"];
+  if (prSelector) {
+    args.push(prSelector);
+  }
+  args.push(mergeMethodFlag(mergeMethod));
+  if (input.deleteBranch ?? true) {
+    args.push("--delete-branch");
+  }
+
+  await commandRunner("gh", args, { cwd: repoRoot });
+  const status = await getPrStatus({ cwd: repoRoot, prNumber: input.prNumber }, commandRunner);
+  return {
+    prNumber: status.number,
+    url: status.url,
+    mergeMethod,
+    merged: status.state === "MERGED"
+  };
+}
+
+export async function getPrStatus(
+  input: GetPrStatusInput,
+  commandRunner: CommandRunner = runCommand
+): Promise<GetPrStatusResult> {
+  const cwd = requireString(input.cwd, "cwd");
+  const repoRoot = await resolveRepoRoot(cwd, commandRunner);
+
+  const args = [
+    "pr", "view",
+    "--json",
+    "number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup"
+  ];
+  if (input.prNumber) {
+    args.splice(2, 0, String(input.prNumber));
+  }
+
+  const result = await commandRunner("gh", args, { cwd: repoRoot });
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+
+  return {
+    number: numberField(parsed.number, "number"),
+    url: stringField(parsed.url, "url"),
+    title: stringField(parsed.title, "title"),
+    state: stringField(parsed.state, "state"),
+    isDraft: booleanField(parsed.isDraft, "isDraft"),
+    reviewDecision: optionalStringField(parsed.reviewDecision),
+    mergeStateStatus: optionalStringField(parsed.mergeStateStatus),
+    mergeable: optionalStringField(parsed.mergeable),
+    autoMergeEnabled: parsed.autoMergeRequest !== null && parsed.autoMergeRequest !== undefined,
+    headRefName: stringField(parsed.headRefName, "headRefName"),
+    baseRefName: stringField(parsed.baseRefName, "baseRefName"),
+    statusSummary: parseStatusCheckRollup(parsed.statusCheckRollup)
+  };
+}
+
+async function resolveRepoRoot(cwd: string, commandRunner: CommandRunner): Promise<string> {
+  try {
+    return (
+      await commandRunner("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { allowedExitCodes: [0] })
+    ).stdout;
+  } catch {
+    throw new GitHubPrError("No git repository found for the provided working directory.", 404);
+  }
+}
+
+async function resolveCurrentBranch(repoRoot: string, commandRunner: CommandRunner): Promise<string | null> {
+  const result = await commandRunner(
+    "git",
+    ["-C", repoRoot, "symbolic-ref", "--short", "-q", "HEAD"],
+    { allowedExitCodes: [0, 1] }
+  );
+
+  return result.exitCode === 0 && result.stdout ? result.stdout : null;
+}
+
+async function ensureBaseBranchHasDiff(repoRoot: string, baseBranch: string, commandRunner: CommandRunner): Promise<void> {
+  await commandRunner("git", ["-C", repoRoot, "fetch", "origin", baseBranch, "--quiet"]);
+  const diffCount = (
+    await commandRunner("git", ["-C", repoRoot, "rev-list", "--count", `origin/${baseBranch}..HEAD`])
+  ).stdout;
+  if (Number(diffCount) <= 0) {
+    throw new GitHubPrError(`Current branch has no commits ahead of origin/${baseBranch}.`, 409);
+  }
+}
+
+async function ensureRemoteBranch(repoRoot: string, branchName: string, commandRunner: CommandRunner): Promise<void> {
+  const hasUpstream = await commandRunner(
+    "git",
+    ["-C", repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    { allowedExitCodes: [0, 128] }
+  );
+
+  if (hasUpstream.exitCode !== 0 || !hasUpstream.stdout) {
+    await commandRunner("git", ["-C", repoRoot, "push", "--set-upstream", "origin", branchName]);
+    return;
+  }
+
+  await commandRunner("git", ["-C", repoRoot, "push", "origin", branchName]);
+}
+
+function normalizeMergeMethod(value: string | undefined): "squash" | "merge" | "rebase" {
+  if (!value) {
+    return "squash";
+  }
+  if (value === "squash" || value === "merge" || value === "rebase") {
+    return value;
+  }
+  throw new GitHubPrError("mergeMethod must be squash, merge, or rebase.", 400);
+}
+
+function mergeMethodFlag(method: "squash" | "merge" | "rebase"): "--squash" | "--merge" | "--rebase" {
+  if (method === "merge") {
+    return "--merge";
+  }
+  if (method === "rebase") {
+    return "--rebase";
+  }
+  return "--squash";
+}
+
+function requireString(value: string | undefined, fieldName: string): string {
+  const normalized = value?.trim() ?? "";
+  if (!normalized) {
+    throw new GitHubPrError(`${fieldName} is required.`, 400);
+  }
+  return normalized;
+}
+
+function firstNonEmptyLine(value: string): string | null {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? null;
+}
+
+function stringField(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || !value) {
+    throw new GitHubPrError(`Expected ${fieldName} in gh response.`, 500);
+  }
+  return value;
+}
+
+function optionalStringField(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function booleanField(value: unknown, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new GitHubPrError(`Expected ${fieldName} in gh response.`, 500);
+  }
+  return value;
+}
+
+function numberField(value: unknown, fieldName: string): number {
+  if (typeof value !== "number") {
+    throw new GitHubPrError(`Expected ${fieldName} in gh response.`, 500);
+  }
+  return value;
+}
+
+function parseStatusCheckRollup(value: unknown): Array<{ name: string; status: string; conclusion: string | null }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") {
+      return [];
+    }
+
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string"
+      ? record.name
+      : typeof record.context === "string"
+        ? record.context
+        : "unknown";
+    const status = typeof record.status === "string" ? record.status : "UNKNOWN";
+    const conclusion = typeof record.conclusion === "string" ? record.conclusion : null;
+    return [{ name, status, conclusion }];
+  });
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,13 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import * as z from "zod/v4";
 
 import {
+  createPr,
+  enablePrAutomerge,
+  getPrStatus,
+  GitHubPrError,
+  mergePrNow
+} from "../github/pr.js";
+import {
   GitWorktreeError,
   cleanupGitWorktree,
   createGitWorktree
@@ -95,11 +102,107 @@ function createDispatchMcpServer(): McpServer {
     }
   );
 
+  server.registerTool(
+    "create_pr",
+    {
+      description: "Create a GitHub pull request for the current branch.",
+      inputSchema: {
+        cwd: z.string().describe("Absolute path inside the git repository."),
+        baseBranch: z.string().default("main").describe("Base branch to target."),
+        title: z.string().optional().describe("Explicit PR title."),
+        body: z.string().optional().describe("Explicit PR body."),
+        draft: z.boolean().default(false).describe("Create the PR as a draft."),
+        fillFromCommits: z.boolean().default(false).describe("Let gh derive title/body from commits.")
+      }
+    },
+    async (args) => {
+      try {
+        const result = await createPr(args);
+        return {
+          content: [{ type: "text", text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.` }],
+          structuredContent: result
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "enable_pr_automerge",
+    {
+      description: "Enable GitHub auto-merge for a pull request once required checks pass.",
+      inputSchema: {
+        cwd: z.string().describe("Absolute path inside the git repository."),
+        prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch."),
+        mergeMethod: z.enum(["squash", "merge", "rebase"]).default("squash").describe("Merge strategy to use once GitHub merges the PR."),
+        deleteBranch: z.boolean().default(true).describe("Delete the branch after merge.")
+      }
+    },
+    async (args) => {
+      try {
+        const result = await enablePrAutomerge(args);
+        return {
+          content: [{ type: "text", text: `Enabled auto-merge for PR ${result.prNumber ?? "current"} using ${result.mergeMethod}.` }],
+          structuredContent: result
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "merge_pr_now",
+    {
+      description: "Merge a GitHub pull request immediately if it is mergeable right now.",
+      inputSchema: {
+        cwd: z.string().describe("Absolute path inside the git repository."),
+        prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch."),
+        mergeMethod: z.enum(["squash", "merge", "rebase"]).default("squash").describe("Merge strategy to use."),
+        deleteBranch: z.boolean().default(true).describe("Delete the branch after merge.")
+      }
+    },
+    async (args) => {
+      try {
+        const result = await mergePrNow(args);
+        return {
+          content: [{ type: "text", text: `Merged PR ${result.prNumber ?? "current"} using ${result.mergeMethod}.` }],
+          structuredContent: result
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_pr_status",
+    {
+      description: "Fetch status details for a pull request.",
+      inputSchema: {
+        cwd: z.string().describe("Absolute path inside the git repository."),
+        prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch.")
+      }
+    },
+    async (args) => {
+      try {
+        const result = await getPrStatus(args);
+        return {
+          content: [{ type: "text", text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.` }],
+          structuredContent: result
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+
   return server;
 }
 
 function toToolError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  const message = error instanceof GitWorktreeError
+  const message = error instanceof GitWorktreeError || error instanceof GitHubPrError
     ? error.message
     : error instanceof Error
       ? error.message

--- a/test/github-pr.test.ts
+++ b/test/github-pr.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createPr,
+  enablePrAutomerge,
+  getPrStatus,
+  GitHubPrError,
+  mergePrNow
+} from "../src/github/pr.js";
+
+describe("github pr services", () => {
+  it("creates a PR after pushing the current branch", async () => {
+    const repoRoot = "/tmp/repo";
+    const runner = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `-C ${repoRoot} symbolic-ref --short -q HEAD`:
+          return { exitCode: 0, stdout: "feature/pr-tools", stderr: "" };
+        case `-C ${repoRoot} fetch origin main --quiet`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `-C ${repoRoot} rev-list --count origin/main..HEAD`:
+          return { exitCode: 0, stdout: "2", stderr: "" };
+        case `-C ${repoRoot} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`:
+          return { exitCode: 128, stdout: "", stderr: "" };
+        case `-C ${repoRoot} push --set-upstream origin feature/pr-tools`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `pr create --base main --head feature/pr-tools --fill`:
+          return { exitCode: 0, stdout: "https://github.com/selfcontained/dispatch/pull/99", stderr: "" };
+        case `pr view --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              number: 99,
+              url: "https://github.com/selfcontained/dispatch/pull/99",
+              title: "Add PR MCP tools",
+              state: "OPEN",
+              isDraft: false,
+              reviewDecision: null,
+              mergeStateStatus: "UNSTABLE",
+              mergeable: "MERGEABLE",
+              autoMergeRequest: null,
+              headRefName: "feature/pr-tools",
+              baseRefName: "main",
+              statusCheckRollup: []
+            }),
+            stderr: ""
+          };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const result = await createPr({
+      cwd: repoRoot,
+      fillFromCommits: true
+    }, runner);
+
+    expect(result.url).toBe("https://github.com/selfcontained/dispatch/pull/99");
+    expect(result.branchName).toBe("feature/pr-tools");
+    expect(result.prNumber).toBe(99);
+  });
+
+  it("rejects create_pr without non-interactive title/body settings", async () => {
+    const repoRoot = "/tmp/repo";
+    const runner = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `-C ${repoRoot} symbolic-ref --short -q HEAD`:
+          return { exitCode: 0, stdout: "feature/pr-tools", stderr: "" };
+        case `-C ${repoRoot} fetch origin main --quiet`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `-C ${repoRoot} rev-list --count origin/main..HEAD`:
+          return { exitCode: 0, stdout: "1", stderr: "" };
+        case `-C ${repoRoot} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`:
+          return { exitCode: 0, stdout: "origin/feature/pr-tools", stderr: "" };
+        case `-C ${repoRoot} push origin feature/pr-tools`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    await expect(createPr({ cwd: repoRoot }, runner)).rejects.toBeInstanceOf(GitHubPrError);
+  });
+
+  it("enables auto-merge for the current branch PR", async () => {
+    const repoRoot = "/tmp/repo";
+    const runner = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `pr merge --auto --squash --delete-branch`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `pr view --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              number: 99,
+              url: "https://github.com/selfcontained/dispatch/pull/99",
+              title: "Add PR MCP tools",
+              state: "OPEN",
+              isDraft: false,
+              reviewDecision: "APPROVED",
+              mergeStateStatus: "BLOCKED",
+              mergeable: "MERGEABLE",
+              autoMergeRequest: { enabledAt: "2026-03-13T00:00:00Z" },
+              headRefName: "feature/pr-tools",
+              baseRefName: "main",
+              statusCheckRollup: [{ name: "ci", status: "IN_PROGRESS", conclusion: null }]
+            }),
+            stderr: ""
+          };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const result = await enablePrAutomerge({ cwd: repoRoot }, runner);
+    expect(result.autoMergeEnabled).toBe(true);
+    expect(result.mergeMethod).toBe("squash");
+  });
+
+  it("reports PR status details", async () => {
+    const repoRoot = "/tmp/repo";
+    const runner = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `pr view 99 --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              number: 99,
+              url: "https://github.com/selfcontained/dispatch/pull/99",
+              title: "Add PR MCP tools",
+              state: "OPEN",
+              isDraft: false,
+              reviewDecision: "APPROVED",
+              mergeStateStatus: "CLEAN",
+              mergeable: "MERGEABLE",
+              autoMergeRequest: null,
+              headRefName: "feature/pr-tools",
+              baseRefName: "main",
+              statusCheckRollup: [
+                { context: "ci", status: "COMPLETED", conclusion: "SUCCESS" }
+              ]
+            }),
+            stderr: ""
+          };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const result = await getPrStatus({ cwd: repoRoot, prNumber: 99 }, runner);
+    expect(result.number).toBe(99);
+    expect(result.statusSummary).toEqual([{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS" }]);
+  });
+
+  it("merges a PR immediately", async () => {
+    const repoRoot = "/tmp/repo";
+    const runner = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `pr merge 99 --squash --delete-branch`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `pr view 99 --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              number: 99,
+              url: "https://github.com/selfcontained/dispatch/pull/99",
+              title: "Add PR MCP tools",
+              state: "MERGED",
+              isDraft: false,
+              reviewDecision: "APPROVED",
+              mergeStateStatus: "UNKNOWN",
+              mergeable: "UNKNOWN",
+              autoMergeRequest: null,
+              headRefName: "feature/pr-tools",
+              baseRefName: "main",
+              statusCheckRollup: []
+            }),
+            stderr: ""
+          };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const result = await mergePrNow({ cwd: repoRoot, prNumber: 99 }, runner);
+    expect(result.merged).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add MCP tools for PR creation, status checks, immediate merge, and enabling auto-merge
- wrap gh and git command flows in a shared GitHub PR service module
- add tests for the new PR service behavior and guardrails

## Validation
- npm run check
- npm test
- npm run test:e2e
- manual MCP smoke test against local /api/mcp for tools/list, get_pr_status, and create_pr guardrails