### PR TITLE
Pass NODE_EXTRA_CA_CERTS to agents for TLS cert trust

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -686,6 +686,13 @@ export class AgentManager {
       `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`
     ];
 
+    // When TLS is enabled, tell agent CLI tools to trust the server's cert
+    // so loopback MCP connections don't fail certificate verification.
+    const tlsCertPath = process.env.TLS_CERT;
+    if (this.config.tls && tlsCertPath) {
+      envPrefixParts.push(`NODE_EXTRA_CA_CERTS=${this.shellEscape(tlsCertPath)}`);
+    }
+
     if (type === "opencode" && fullAccess) {
       envPrefixParts.push(
         `OPENCODE_PERMISSION=${this.shellEscape(


### PR DESCRIPTION
## Summary
- When TLS is enabled, agent CLI tools (Claude Code, Codex) fail to connect to the MCP server with "unable to verify the first certificate"
- Fix: pass the server's own `TLS_CERT` path as `NODE_EXTRA_CA_CERTS` in the agent launch environment so Node trusts the self-signed cert on loopback

## Test plan
- [x] `npm run check` passes
- [ ] Deploy and verify Claude agent connects to MCP server without cert errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)