### PR TITLE
Instruct agent to cd into worktree after creation

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -73,7 +73,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           content: [
             {
               type: "text",
-              text: `Created worktree ${result.worktreeName} on branch ${result.branchName} at ${result.worktreePath}.`
+              text: `Created worktree ${result.worktreeName} on branch ${result.branchName} at ${result.worktreePath}. You MUST now cd into the worktree: cd ${result.worktreePath}`
             }
           ],
           structuredContent: result


### PR DESCRIPTION
## Summary
- Updates the `create_worktree` MCP tool response to tell the agent to `cd` into the new worktree directory
- Fixes stale git status display for agents — previously the agent stayed in the main project directory so git context probes showed the wrong branch

## Test plan
- [ ] Create an agent, have it use `create_worktree`, verify it cds into the worktree
- [ ] Confirm Dispatch's git context probe picks up the correct branch after the agent cds

🤖 Generated with [Claude Code](https://claude.com/claude-code)