### PR TITLE
Add dual-mode release management: update + create

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -8,15 +8,15 @@ test.describe("Settings pane", () => {
     // Click the Settings button in the sidebar footer
     await page.getByTestId("settings-button").click();
 
-    // Settings overlay should appear with a "Settings" heading and "Release" nav item
+    // Settings overlay should appear with a "Settings" heading and "Updates" nav item
     await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 3_000 });
-    const releaseNav = page.getByRole("navigation").getByText("Release");
+    const releaseNav = page.getByRole("navigation").getByText("Updates");
     await expect(releaseNav).toBeVisible();
 
     // Close it via the X button (sr-only "Close")
     await page.getByRole("button", { name: "Close" }).click();
 
-    // The Release nav item should no longer be visible (pane is closed)
+    // The Updates nav item should no longer be visible (pane is closed)
     await expect(releaseNav).not.toBeVisible({ timeout: 3_000 });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,10 +169,12 @@ function withStreamFlag<T extends AgentRecord>(agent: T): T & { hasStream: boole
 
 const RELEASE_VERSION_TYPES = ["patch", "minor", "major"] as const;
 type ReleaseVersionType = (typeof RELEASE_VERSION_TYPES)[number];
-type ReleasePhase = "preflight" | "triggering" | "watching" | "deploying" | "restarting" | "done" | "failed";
+type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
+type ReleaseJobType = "create" | "update";
 
 type ReleaseJob = {
-  versionType: ReleaseVersionType;
+  jobType: ReleaseJobType;
+  versionType: ReleaseVersionType | null;
   phase: ReleasePhase;
   startedAt: string;
   log: string[];
@@ -324,6 +326,110 @@ async function getGitHubRepo(): Promise<string> {
   return "selfcontained/dispatch";
 }
 
+// Cached admin permission check — lasts for the server process lifetime
+let cachedIsAdmin: boolean | null = null;
+
+async function checkIsAdmin(): Promise<boolean> {
+  if (cachedIsAdmin !== null) return cachedIsAdmin;
+  try {
+    await runCommand("gh", ["--version"]);
+    const repo = await getGitHubRepo();
+    const result = await runCommand("gh", [
+      "repo", "view", repo,
+      "--json", "viewerPermission",
+      "--jq", ".viewerPermission"
+    ]);
+    cachedIsAdmin = result.stdout.trim() === "ADMIN";
+  } catch {
+    cachedIsAdmin = false;
+  }
+  return cachedIsAdmin;
+}
+
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function fetchLatestReleaseMetadata(tag: string): Promise<{ tag: string; publishedAt: string; url: string } | null> {
+  try {
+    const repo = await getGitHubRepo();
+    const result = await runCommand("gh", [
+      "release", "view", tag,
+      "--repo", repo,
+      "--json", "tagName,publishedAt,url"
+    ]);
+    const data = JSON.parse(result.stdout) as { tagName: string; publishedAt: string; url: string };
+    return { tag: data.tagName, publishedAt: data.publishedAt, url: data.url };
+  } catch {
+    return null;
+  }
+}
+
+/** Shared deploy logic: checkout tag, install, build, write record, restart */
+async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
+  setReleasePhase(job, "deploying");
+
+  appendReleaseLog(job, `==> checking out ${tag}`);
+  await runCommand("git", ["-C", serverDir, "checkout", tag]);
+
+  appendReleaseLog(job, "==> installing dependencies");
+  await streamProcess("npm", ["ci", "--silent"], { cwd: serverDir }, job);
+  await streamProcess("npm", ["--prefix", "web", "ci", "--silent"], { cwd: serverDir }, job);
+
+  appendReleaseLog(job, "==> building");
+  await streamProcess("npm", ["run", "build"], { cwd: serverDir }, job);
+
+  // Write release record BEFORE the restart — after the restart our
+  // process is dead and can't write anything.
+  await writeReleaseStore({ tag, deployedAt: new Date().toISOString() });
+  appendReleaseLog(job, `==> wrote release record for ${tag}`);
+
+  // Tell SSE clients we're about to restart
+  setReleasePhase(job, "restarting");
+  appendReleaseLog(job, "==> restarting service");
+
+  // Trigger the restart. launchctl kill sends SIGKILL to this process
+  // (and its process group). KeepAlive ensures launchd restarts it
+  // with the newly built code. The UI health-poll takes over from here.
+  const uid = process.getuid?.() ?? 501;
+  spawn("launchctl", ["kill", "SIGKILL", `gui/${uid}/com.dispatch.server`], {
+    detached: true,
+    stdio: "ignore"
+  }).unref();
+}
+
+async function runUpdateJob(job: ReleaseJob): Promise<void> {
+  try {
+    const tag = job.tag!;
+
+    setReleasePhase(job, "fetching");
+    appendReleaseLog(job, "==> fetching tags from origin");
+    await runCommand("git", ["-C", serverDir, "fetch", "--tags", "--quiet"]);
+
+    // Verify the tag exists
+    try {
+      await runCommand("git", ["-C", serverDir, "rev-parse", "--verify", tag]);
+    } catch {
+      throw new Error(`Tag ${tag} not found after fetching`);
+    }
+
+    await deployTag(job, tag);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    if (activeReleaseJob) {
+      activeReleaseJob.error = error;
+    }
+    setReleasePhase(job, "failed", error);
+  }
+}
+
 async function runReleaseJob(job: ReleaseJob): Promise<void> {
   try {
     // Preflight: check gh CLI is available
@@ -393,38 +499,7 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
     broadcastReleaseEvent({ type: "tag", tag });
     appendReleaseLog(job, `==> release workflow produced tag: ${tag}`);
 
-    // Deploy — build inline instead of shelling out to dispatch-deploy,
-    // because dispatch-deploy would be killed as part of the server's
-    // process group when launchd restarts the service.
-    setReleasePhase(job, "deploying");
-
-    appendReleaseLog(job, `==> checking out ${tag}`);
-    await runCommand("git", ["-C", serverDir, "checkout", tag]);
-
-    appendReleaseLog(job, "==> installing dependencies");
-    await streamProcess("npm", ["ci", "--silent"], { cwd: serverDir }, job);
-    await streamProcess("npm", ["--prefix", "web", "ci", "--silent"], { cwd: serverDir }, job);
-
-    appendReleaseLog(job, "==> building");
-    await streamProcess("npm", ["run", "build"], { cwd: serverDir }, job);
-
-    // Write release record BEFORE the restart — after the restart our
-    // process is dead and can't write anything.
-    await writeReleaseStore({ tag, deployedAt: new Date().toISOString() });
-    appendReleaseLog(job, `==> wrote release record for ${tag}`);
-
-    // Tell SSE clients we're about to restart
-    setReleasePhase(job, "restarting");
-    appendReleaseLog(job, "==> restarting service");
-
-    // Trigger the restart. launchctl kill sends SIGKILL to this process
-    // (and its process group). KeepAlive ensures launchd restarts it
-    // with the newly built code. The UI health-poll takes over from here.
-    const uid = process.getuid?.() ?? 501;
-    spawn("launchctl", ["kill", "SIGKILL", `gui/${uid}/com.dispatch.server`], {
-      detached: true,
-      stdio: "ignore"
-    }).unref();
+    await deployTag(job, tag);
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     if (activeReleaseJob) {
@@ -496,54 +571,78 @@ async function registerRoutes() {
 
   app.get("/api/v1/release/info", async (_, reply) => {
     try {
-      await runCommand("git", ["-C", serverDir, "fetch", "origin", "--quiet"]);
+      await runCommand("git", ["-C", serverDir, "fetch", "origin", "--tags", "--quiet"]);
 
       // Current deployed tag from store (fast)
       const record = await readReleaseStore();
       const currentTag = record?.tag ?? null;
 
-      if (!currentTag) {
-        return { currentTag: null, unreleasedCount: 0, commits: [] };
+      // Check admin permissions (cached for process lifetime)
+      const isAdmin = await checkIsAdmin();
+
+      // Find latest tag from origin
+      const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
+      const latestTag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
+
+      const updateAvailable = !!(currentTag && latestTag && compareSemver(latestTag, currentTag) > 0);
+
+      // Try to enrich with GitHub Release metadata
+      let latestRelease: { tag: string; publishedAt: string; url: string } | null = null;
+      if (latestTag && updateAvailable) {
+        latestRelease = await fetchLatestReleaseMetadata(latestTag);
       }
 
-      // Verify the ref exists locally (tags may not be present in dev checkouts)
-      const refCheck = await runCommand(
-        "git", ["-C", serverDir, "rev-parse", "--verify", currentTag],
-        { allowedExitCodes: [0, 128] }
-      );
-      if (refCheck.exitCode !== 0) {
-        return { currentTag, unreleasedCount: 0, commits: [], refMissing: true };
-      }
-
-      // Count and list commits between current tag and origin/main
-      const countResult = await runCommand("git", [
-        "-C", serverDir,
-        "rev-list", `${currentTag}..origin/main`, "--count"
-      ]);
-      const unreleasedCount = Number(countResult.stdout) || 0;
-
+      // Admin-only: unreleased commits on main
+      let unreleasedCount = 0;
       let commits: Array<{ sha: string; subject: string }> = [];
-      if (unreleasedCount > 0) {
-        const logResult = await runCommand("git", [
-          "-C", serverDir,
-          "log", `${currentTag}..origin/main`,
-          "--no-merges",
-          "--format=%H\t%s",
-          "--max-count=20"
-        ]);
-        commits = logResult.stdout
-          .split("\n")
-          .filter((l) => l.trim())
-          .map((line) => {
-            const tab = line.indexOf("\t");
-            return {
-              sha: line.slice(0, tab).slice(0, 7),
-              subject: line.slice(tab + 1)
-            };
-          });
+      let refMissing = false;
+
+      if (isAdmin && currentTag) {
+        const refCheck = await runCommand(
+          "git", ["-C", serverDir, "rev-parse", "--verify", currentTag],
+          { allowedExitCodes: [0, 128] }
+        );
+        if (refCheck.exitCode !== 0) {
+          refMissing = true;
+        } else {
+          const countResult = await runCommand("git", [
+            "-C", serverDir,
+            "rev-list", `${currentTag}..origin/main`, "--count"
+          ]);
+          unreleasedCount = Number(countResult.stdout) || 0;
+
+          if (unreleasedCount > 0) {
+            const logResult = await runCommand("git", [
+              "-C", serverDir,
+              "log", `${currentTag}..origin/main`,
+              "--no-merges",
+              "--format=%H\t%s",
+              "--max-count=20"
+            ]);
+            commits = logResult.stdout
+              .split("\n")
+              .filter((l) => l.trim())
+              .map((line) => {
+                const tab = line.indexOf("\t");
+                return {
+                  sha: line.slice(0, tab).slice(0, 7),
+                  subject: line.slice(tab + 1)
+                };
+              });
+          }
+        }
       }
 
-      return { currentTag, unreleasedCount, commits };
+      return {
+        currentTag,
+        isAdmin,
+        latestTag,
+        updateAvailable,
+        latestRelease,
+        unreleasedCount,
+        commits,
+        refMissing
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       return reply.code(500).send({ error: message });
@@ -572,6 +671,7 @@ async function registerRoutes() {
     }
 
     const job: ReleaseJob = {
+      jobType: "create",
       versionType,
       phase: "preflight",
       startedAt: new Date().toISOString(),
@@ -584,6 +684,38 @@ async function registerRoutes() {
 
     // Run async — do not await
     void runReleaseJob(job);
+
+    return reply.code(202).send({ ok: true });
+  });
+
+  app.post("/api/v1/release/update", async (request, reply) => {
+    const body = request.body as { tag?: unknown } | undefined;
+
+    if (!body?.tag || typeof body.tag !== "string" || !body.tag.startsWith("v")) {
+      return reply.code(400).send({ error: "tag is required and must be a version tag (e.g. v0.2.31)" });
+    }
+
+    const tag = body.tag as string;
+
+    // Only one release/update at a time
+    if (activeReleaseJob && activeReleaseJob.phase !== "done" && activeReleaseJob.phase !== "failed") {
+      return reply.code(409).send({ error: "A release or update is already in progress." });
+    }
+
+    const job: ReleaseJob = {
+      jobType: "update",
+      versionType: null,
+      phase: "fetching",
+      startedAt: new Date().toISOString(),
+      log: [],
+      runUrl: null,
+      tag,
+      error: null
+    };
+    activeReleaseJob = job;
+
+    // Run async — do not await
+    void runUpdateJob(job);
 
     return reply.code(202).send({ ok: true });
   });

--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap, XCircle } from "lucide-react";
+import { ArrowDownToLine, CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap, XCircle } from "lucide-react";
 import { recordReleaseManagerPollFire } from "@/lib/energy-metrics";
 
 import { cn } from "@/lib/utils";
 
 type ReleaseVersionType = "patch" | "minor" | "major";
-type ReleasePhase = "preflight" | "triggering" | "watching" | "deploying" | "restarting" | "done" | "failed";
+type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
+type ReleaseJobType = "create" | "update";
 
 type ReleaseStatus = {
   tag: string | null;
@@ -14,13 +15,18 @@ type ReleaseStatus = {
 
 type ReleaseInfo = {
   currentTag: string | null;
+  isAdmin: boolean;
+  latestTag: string | null;
+  updateAvailable: boolean;
+  latestRelease: { tag: string; publishedAt: string; url: string } | null;
   unreleasedCount: number;
   commits: Array<{ sha: string; subject: string }>;
   refMissing?: boolean;
 };
 
 type ReleaseJob = {
-  versionType: ReleaseVersionType;
+  jobType: ReleaseJobType;
+  versionType: ReleaseVersionType | null;
   phase: ReleasePhase;
   startedAt: string;
   log: string[];
@@ -72,13 +78,15 @@ const PHASE_LABELS: Record<ReleasePhase, string> = {
   preflight: "Pre-flight",
   triggering: "Trigger workflow",
   watching: "CI running",
+  fetching: "Fetching",
   deploying: "Deploying",
   restarting: "Restarting",
   done: "Complete",
   failed: "Failed"
 };
 
-const PHASES_ORDER: ReleasePhase[] = ["preflight", "triggering", "watching", "deploying", "restarting", "done"];
+const CREATE_PHASES: ReleasePhase[] = ["preflight", "triggering", "watching", "deploying", "restarting", "done"];
+const UPDATE_PHASES: ReleasePhase[] = ["fetching", "deploying", "restarting", "done"];
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString(undefined, {
@@ -228,6 +236,22 @@ export function ReleaseManager(): JSX.Element {
     }
   };
 
+  const handleUpdate = async (tag: string) => {
+    setReleaseError(null);
+    const res = await fetch("/api/v1/release/update", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tag })
+    });
+    if (!res.ok) {
+      const err = (await res.json()) as { error?: string };
+      setReleaseError(cleanError(err.error ?? "Failed to start update"));
+      return;
+    }
+    setJob({ jobType: "update", versionType: null, phase: "fetching", startedAt: new Date().toISOString(), log: [], runUrl: null, tag, error: null });
+    connectStream();
+  };
+
   const handleRelease = async (versionType: ReleaseVersionType) => {
     setReleaseError(null);
     const res = await fetch("/api/v1/release", {
@@ -240,16 +264,18 @@ export function ReleaseManager(): JSX.Element {
       setReleaseError(cleanError(err.error ?? "Failed to start release"));
       return;
     }
-    setJob({ versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
+    setJob({ jobType: "create", versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
     connectStream();
   };
 
-  const isReleasing = job !== null && !["done", "failed"].includes(job.phase) && !postRestartPolling;
+  const isActive = job !== null && !["done", "failed"].includes(job.phase) && !postRestartPolling;
   const isDone = job?.phase === "done" || (!postRestartPolling && job?.phase === "restarting" && status?.tag === job?.tag);
   const isFailed = job?.phase === "failed";
   const isRestarting = job?.phase === "restarting" || postRestartPolling;
   const showLog = job !== null;
-  const phaseIndex = job ? PHASES_ORDER.indexOf(job.phase) : -1;
+
+  const phasesOrder = job?.jobType === "update" ? UPDATE_PHASES : CREATE_PHASES;
+  const phaseIndex = job ? phasesOrder.indexOf(job.phase) : -1;
 
   return (
     <div className="flex h-full min-h-0 flex-col md:flex-row">
@@ -271,8 +297,8 @@ export function ReleaseManager(): JSX.Element {
           )}
         </div>
 
-        {/* Check for updates / info — hidden while a release is active */}
-        {!isReleasing && !isDone && (
+        {/* Check for updates / info — hidden while an operation is active */}
+        {!isActive && !isDone && (
           <div className="flex flex-col gap-4">
             {!info && !infoLoading && (
               <button
@@ -298,78 +324,129 @@ export function ReleaseManager(): JSX.Element {
 
             {info && (
               <>
-                {info.refMissing ? (
-                  <div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
-                    Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
-                  </div>
-                ) : info.unreleasedCount === 0 ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
-                    Up to date
-                  </div>
-                ) : (
-                  <div>
-                    <div className="mb-2 text-xs text-muted-foreground">
-                      {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
-                      <span className="font-mono">main</span>
-                    </div>
-                    <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
-                      {info.commits.map((c) => (
-                        <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
-                          <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
-                          <span className="text-foreground">{c.subject}</span>
-                        </div>
-                      ))}
-                      {info.unreleasedCount > info.commits.length && (
-                        <div className="mt-1 text-xs text-muted-foreground">
-                          +{info.unreleasedCount - info.commits.length} more
-                        </div>
+                {/* Update section — always visible */}
+                {info.updateAvailable && info.latestTag ? (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center gap-2">
+                      <ArrowDownToLine className="h-4 w-4 text-blue-400" />
+                      <span className="text-sm text-foreground">
+                        <span className="font-mono font-semibold">{info.latestTag}</span> available
+                      </span>
+                      {info.latestRelease?.publishedAt && (
+                        <span className="text-xs text-muted-foreground">
+                          · {formatDate(info.latestRelease.publishedAt)}
+                        </span>
                       )}
                     </div>
-                  </div>
-                )}
 
-                {(info.refMissing || info.unreleasedCount > 0) && (
-                  <>
+                    {info.latestRelease?.url && (
+                      <a
+                        href={info.latestRelease.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                        View release on GitHub
+                      </a>
+                    )}
+
                     {releaseError && (
                       <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                         {releaseError}
                       </div>
                     )}
 
-                    <div className="flex flex-col gap-2">
-                      <div className="mb-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release type</div>
-                      {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
-                        const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
-                        return (
-                          <button
-                            key={type}
-                            onClick={() => void handleRelease(type)}
-                            className={cn(
-                              "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
-                              border, bg, hover
-                            )}
-                          >
-                            <Icon className={cn("h-5 w-5", color)} />
-                            <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </>
+                    <button
+                      onClick={() => void handleUpdate(info.latestTag!)}
+                      className="self-start rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
+                    >
+                      Update to {info.latestTag}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    Up to date
+                  </div>
+                )}
+
+                {/* Create release section — admin only */}
+                {info.isAdmin && (
+                  <div className="flex flex-col gap-4 border-t border-border pt-4">
+                    <div className="text-[10px] uppercase tracking-widest text-muted-foreground">Create release</div>
+
+                    {info.refMissing ? (
+                      <div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
+                        Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
+                      </div>
+                    ) : info.unreleasedCount === 0 ? (
+                      <div className="text-xs text-muted-foreground">No unreleased commits on main</div>
+                    ) : (
+                      <div>
+                        <div className="mb-2 text-xs text-muted-foreground">
+                          {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
+                          <span className="font-mono">main</span>
+                        </div>
+                        <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
+                          {info.commits.map((c) => (
+                            <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
+                              <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
+                              <span className="text-foreground">{c.subject}</span>
+                            </div>
+                          ))}
+                          {info.unreleasedCount > info.commits.length && (
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              +{info.unreleasedCount - info.commits.length} more
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {(info.refMissing || info.unreleasedCount > 0) && (
+                      <>
+                        {releaseError && (
+                          <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                            {releaseError}
+                          </div>
+                        )}
+
+                        <div className="flex flex-col gap-2">
+                          <div className="mb-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release type</div>
+                          {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
+                            const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
+                            return (
+                              <button
+                                key={type}
+                                onClick={() => void handleRelease(type)}
+                                className={cn(
+                                  "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
+                                  border, bg, hover
+                                )}
+                              >
+                                <Icon className={cn("h-5 w-5", color)} />
+                                <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </>
+                    )}
+                  </div>
                 )}
               </>
             )}
           </div>
         )}
 
-        {/* Phase progress — shown when a release is running or finished */}
+        {/* Phase progress — shown when a release/update is running or finished */}
         {job && (
           <div className="flex flex-col gap-4">
             <div>
               <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Progress</div>
               <div className="flex flex-col gap-2">
-                {PHASES_ORDER.filter((p) => p !== "done").map((phase, i) => {
+                {phasesOrder.filter((p) => p !== "done").map((phase, i) => {
                   const current = phaseIndex === i;
                   const done = phaseIndex > i || job.phase === "done";
                   return (
@@ -415,7 +492,8 @@ export function ReleaseManager(): JSX.Element {
               <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
                 <CheckCircle2 className="h-4 w-4 shrink-0" />
                 <span>
-                  Deployed <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
+                  {job.jobType === "update" ? "Updated to" : "Deployed"}{" "}
+                  <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
                 </span>
               </div>
             )}
@@ -423,7 +501,7 @@ export function ReleaseManager(): JSX.Element {
             {isFailed && (
               <div className="flex items-start gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
                 <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                <span>{job.error ? cleanError(job.error) : "Release failed"}</span>
+                <span>{job.error ? cleanError(job.error) : "Operation failed"}</span>
               </div>
             )}
           </div>
@@ -451,7 +529,7 @@ export function ReleaseManager(): JSX.Element {
           </div>
         ) : (
           <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground/40">
-            Log output will appear here during a release
+            Log output will appear here
           </div>
         )}
       </div>

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ChevronRight, ArrowLeft, Rocket, X } from "lucide-react";
+import { ChevronRight, ArrowLeft, ArrowDownToLine, X } from "lucide-react";
 
 import { ReleaseManager } from "@/components/app/release-manager";
 import { cn } from "@/lib/utils";
 
 type SettingsSection = "release";
 
-const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof Rocket }> = [
-  { id: "release", label: "Release", icon: Rocket }
+const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
+  { id: "release", label: "Updates", icon: ArrowDownToLine }
 ];
 
 type SettingsPaneProps = {


### PR DESCRIPTION
## Summary
- **Update flow (everyone)**: "Check for updates" now compares the deployed tag against the latest git tag from origin. If a newer version exists, shows an "Update to vX.Y.Z" button that fetches, builds, and restarts — no GitHub Actions workflow needed. When `gh` CLI is available, enriches with release metadata (published date, link).
- **Create release flow (admin only)**: Detected automatically via `gh repo view --json viewerPermission`. Only users with ADMIN access see the "Create Release" section with unreleased commits and patch/minor/major buttons.
- **Shared deploy logic**: Extracted `deployTag()` function used by both create and update flows, reducing duplication.
- **Settings nav**: Renamed from "Release" (rocket icon) to "Updates" (download arrow icon).

## Test plan
- [x] `npm run check` passes
- [x] `npm run finalize:web` passes
- [x] All 25 e2e tests pass (`npm run test:e2e`)
- [x] Visual validation via Playwright — settings pane renders correctly with "Updates" nav, "Check for updates" button, and admin "Create Release" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)