### PR TITLE
Colorize agent sidebar icons by dispatch event status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,21 +3,23 @@
 <!-- Keep behavioral rules in sync with CLAUDE.md (used by Claude Code agents). -->
 
 ## CRITICAL: Dispatch Status Events (Mandatory)
-- You MUST call the `dispatch_event` MCP tool for every task turn that involves analysis, tool use, or file changes.
-- Required checkpoints:
-  1. First action in the turn:
-     `dispatch_event` with type `working` and message describing what you are starting
-  2. If blocked by error/tool/env:
-     `dispatch_event` with type `blocked` and message describing the reason
-  3. If waiting for user input/decision:
-     `dispatch_event` with type `waiting_user` and message describing what is needed
-  4. Final action before final response:
-     - Success: `dispatch_event` with type `done` and message describing what was completed
-     - No-op/informational turn: `dispatch_event` with type `idle` and message describing why no actions were taken
-- Hard requirements:
+- You MUST call the `dispatch_event` MCP tool throughout every task turn. These events drive the agent status indicator in the Dispatch UI — the more frequently and accurately you report, the more useful the dashboard becomes.
+- **Event types and when to use them:**
+  - `working` — You are actively making progress: reading files, writing code, running commands, researching. Use a short message describing the current activity (e.g., "Reading agent-sidebar.tsx", "Running E2E tests", "Refactoring auth middleware").
+  - `blocked` — You hit an error, a failing test, a missing dependency, or any obstacle you are actively trying to resolve. Message should describe the blocker (e.g., "Type error in agent-type-icon.tsx", "E2E test 'sidebar toggle' failing").
+  - `waiting_user` — You need a decision, clarification, or approval before continuing. Message should describe what you need (e.g., "Should I delete the legacy endpoint?", "Need confirmation on color palette").
+  - `done` — The task is complete and all checks pass. Message should summarize what was accomplished.
+  - `idle` — No meaningful action was taken this turn (e.g., an informational question was answered).
+- **Required checkpoints (minimum):**
+  1. **Start of turn**: `working` with what you are about to do.
+  2. **Phase transitions**: Call `working` again with an updated message whenever your activity shifts to a distinct phase (e.g., moving from research → implementation → testing → validation). This keeps the UI status current.
+  3. **On error or obstacle**: Switch to `blocked` immediately. When you unblock yourself, switch back to `working`.
+  4. **Before final response**: Emit a terminal event — `done`, `idle`, `waiting_user`, or `blocked`.
+- **Hard requirements:**
   - Do not send a final response unless `done`, `waiting_user`, `blocked`, or `idle` has been emitted in the same turn.
   - If `dispatch_event` fails, report that failure explicitly in the response.
   - Include a `Status log` section in the final response with the result from each `dispatch_event` call.
+  - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation
 - For any UI/layout/style interaction change, validate behavior in Playwright before marking the task complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,21 +3,23 @@
 <!-- Keep behavioral rules in sync with AGENTS.md (used by Codex agents). -->
 
 ## CRITICAL: Dispatch Status Events (Mandatory)
-- You MUST call the `dispatch_event` MCP tool for every task turn that involves analysis, tool use, or file changes.
-- Required checkpoints:
-  1. First action in the turn:
-     `dispatch_event` with type `working` and message describing what you are starting
-  2. If blocked by error/tool/env:
-     `dispatch_event` with type `blocked` and message describing the reason
-  3. If waiting for user input/decision:
-     `dispatch_event` with type `waiting_user` and message describing what is needed
-  4. Final action before final response:
-     - Success: `dispatch_event` with type `done` and message describing what was completed
-     - No-op/informational turn: `dispatch_event` with type `idle` and message describing why no actions were taken
-- Hard requirements:
+- You MUST call the `dispatch_event` MCP tool throughout every task turn. These events drive the agent status indicator in the Dispatch UI — the more frequently and accurately you report, the more useful the dashboard becomes.
+- **Event types and when to use them:**
+  - `working` — You are actively making progress: reading files, writing code, running commands, researching. Use a short message describing the current activity (e.g., "Reading agent-sidebar.tsx", "Running E2E tests", "Refactoring auth middleware").
+  - `blocked` — You hit an error, a failing test, a missing dependency, or any obstacle you are actively trying to resolve. Message should describe the blocker (e.g., "Type error in agent-type-icon.tsx", "E2E test 'sidebar toggle' failing").
+  - `waiting_user` — You need a decision, clarification, or approval before continuing. Message should describe what you need (e.g., "Should I delete the legacy endpoint?", "Need confirmation on color palette").
+  - `done` — The task is complete and all checks pass. Message should summarize what was accomplished.
+  - `idle` — No meaningful action was taken this turn (e.g., an informational question was answered).
+- **Required checkpoints (minimum):**
+  1. **Start of turn**: `working` with what you are about to do.
+  2. **Phase transitions**: Call `working` again with an updated message whenever your activity shifts to a distinct phase (e.g., moving from research → implementation → testing → validation). This keeps the UI status current.
+  3. **On error or obstacle**: Switch to `blocked` immediately. When you unblock yourself, switch back to `working`.
+  4. **Before final response**: Emit a terminal event — `done`, `idle`, `waiting_user`, or `blocked`.
+- **Hard requirements:**
   - Do not send a final response unless `done`, `waiting_user`, `blocked`, or `idle` has been emitted in the same turn.
   - If `dispatch_event` fails, report that failure explicitly in the response.
   - Include a `Status log` section in the final response with the result from each `dispatch_event` call.
+  - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation
 - For any UI/layout/style/feature change, validate behavior in Playwright before marking the task complete.

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -104,6 +104,14 @@ export function AgentSidebarContent({
     return "Idle";
   };
 
+  const latestEventColor = (type: NonNullable<Agent["latestEvent"]>["type"]): string => {
+    if (type === "working") return "text-emerald-400";
+    if (type === "blocked") return "text-red-400";
+    if (type === "waiting_user") return "text-amber-400";
+    if (type === "done") return "text-sky-400";
+    return "text-foreground/80";
+  };
+
   const formatRelativeTime = (value: string): string => {
     const date = new Date(value);
     const time = date.getTime();
@@ -193,7 +201,7 @@ export function AgentSidebarContent({
                           className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold"
                           onClick={() => toggleAgentDetails(agent.id)}
                         >
-                          <AgentTypeIcon type={agent.type} />
+                          <AgentTypeIcon type={agent.type} eventType={agent.status === "running" ? agent.latestEvent?.type : null} />
                           <span className="truncate">{agent.name}</span>
                         </button>
                       </TooltipTrigger>
@@ -334,7 +342,7 @@ export function AgentSidebarContent({
 
                   {agent.latestEvent ? (
                     <div className="mt-1 truncate text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground/80">{latestEventLabel(agent.latestEvent.type)}</span>
+                      <span className={cn("font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
                       <span className="mx-1.5 text-muted-foreground/70">•</span>
                       <span>{agent.latestEvent.message}</span>
                       <span className="mx-1.5 text-muted-foreground/70">•</span>

--- a/web/src/components/app/agent-type-icon.tsx
+++ b/web/src/components/app/agent-type-icon.tsx
@@ -2,9 +2,20 @@ import { siClaude } from "simple-icons";
 
 import { cn } from "@/lib/utils";
 
+type AgentEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
+
 type AgentTypeIconProps = {
   type?: string | null;
   className?: string;
+  eventType?: AgentEventType | null;
+};
+
+const eventColorClass: Record<AgentEventType, string> = {
+  working: "text-emerald-400 border-emerald-400/50 bg-emerald-500/15",
+  blocked: "text-red-400 border-red-400/50 bg-red-500/15",
+  waiting_user: "text-amber-400 border-amber-400/50 bg-amber-500/15",
+  done: "text-sky-400 border-sky-400/50 bg-sky-500/15",
+  idle: "",
 };
 
 const CODEX_LOGO_PATH =
@@ -23,16 +34,22 @@ function normalizeAgentType(type?: string | null): "codex" | "claude" | "opencod
   return "unknown";
 }
 
-export function AgentTypeIcon({ type, className }: AgentTypeIconProps): JSX.Element {
+export function AgentTypeIcon({ type, className, eventType }: AgentTypeIconProps): JSX.Element {
   const normalizedType = normalizeAgentType(type);
   const label =
     normalizedType === "claude" ? "Claude" : normalizedType === "opencode" ? "OpenCode" : "Codex";
+  const statusClass = eventType ? eventColorClass[eventType] : "";
+  const baseClass = statusClass
+    ? "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors duration-300"
+    : "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border bg-muted/40 text-muted-foreground transition-colors duration-300";
 
   if (normalizedType === "opencode") {
     return (
       <span
         className={cn(
-          "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border bg-muted/40 text-[9px] font-semibold tracking-[0.08em] text-muted-foreground",
+          baseClass,
+          statusClass,
+          "text-[9px] font-semibold tracking-[0.08em]",
           className
         )}
         title={`${label} agent`}
@@ -48,10 +65,7 @@ export function AgentTypeIcon({ type, className }: AgentTypeIconProps): JSX.Elem
 
   return (
     <span
-      className={cn(
-        "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border bg-muted/40 text-muted-foreground",
-        className
-      )}
+      className={cn(baseClass, statusClass, className)}
       title={`${label} agent`}
       aria-label={`${label} agent`}
     >


### PR DESCRIPTION
## Summary
- Agent type icons in the sidebar now change color based on the agent's latest dispatch event: emerald (working), red (blocked), amber (waiting), sky blue (done), muted (idle/stopped)
- Event label text matches the icon color for visual consistency
- Improved CLAUDE.md and AGENTS.md dispatch_event instructions to encourage more frequent, granular status reporting with concrete examples

## Test plan
- [x] `npm run finalize:web` passes (type check + production build)
- [x] All 25 E2E tests pass
- [ ] Create agents in the UI and verify icon colors change as agents report different statuses
- [ ] Verify stopped agents revert to muted default styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)