### PR TITLE
Replace dots with underscores in MCP tool names

### DIFF
--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 import { runCommand } from "../lib/run-command.js";
 
 const REPO_TOOL_MANIFEST_PATH = path.join(".dispatch", "tools.json");
-const REPO_TOOL_PREFIX = "repo.";
+const REPO_TOOL_PREFIX = "repo_";
 const BUILTIN_TOOL_NAMES = new Set([
   "create_worktree",
   "cleanup_worktree",
@@ -90,18 +90,17 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
   }
 
   const rawTool = value as Record<string, unknown>;
-  const name = typeof rawTool.name === "string" ? rawTool.name.trim() : "";
+  const rawName = typeof rawTool.name === "string" ? rawTool.name.trim() : "";
   const description = typeof rawTool.description === "string" ? rawTool.description.trim() : "";
   const command = Array.isArray(rawTool.command) && rawTool.command.every((part) => typeof part === "string")
     ? rawTool.command.map((part) => part.trim()).filter(Boolean)
     : [];
 
-  if (!name) {
+  if (!rawName) {
     throw new Error(`Repo tool at index ${index} must have a non-empty name.`);
   }
-  if (name.includes(".")) {
-    throw new Error(`Repo tool "${name}" must not contain dots. Dispatch automatically prefixes repo tools with "${REPO_TOOL_PREFIX}".`);
-  }
+  // Strip dots from tool names — MCP clients (e.g. Claude) don't support dots in tool names.
+  const name = rawName.replaceAll(".", "_");
   const prefixedName = `${REPO_TOOL_PREFIX}${name}`;
   if (BUILTIN_TOOL_NAMES.has(prefixedName)) {
     throw new Error(`Repo tool "${name}" collides with a built-in Dispatch MCP tool when prefixed as "${prefixedName}".`);

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
 });
 
 describe("loadRepoTools", () => {
-  it("auto-prefixes repo tools with repo. namespace", async () => {
+  it("auto-prefixes repo tools with repo_ namespace", async () => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
     tempDirs.push(repoRoot);
     await mkdir(path.join(repoRoot, ".dispatch"));
@@ -40,7 +40,7 @@ describe("loadRepoTools", () => {
     const [tool] = await loadRepoTools(repoRoot);
     const result = await tool.run({ agentId: "agt_test", repoRoot });
 
-    expect(tool.name).toBe("repo.dev_up");
+    expect(tool.name).toBe("repo_dev_up");
     expect(result.agentId).toBe("agt_test");
     expect(vi.mocked(runCommand)).toHaveBeenCalledWith("dispatch-dev", ["up"], expect.objectContaining({
       cwd: repoRoot,
@@ -51,7 +51,7 @@ describe("loadRepoTools", () => {
     }));
   });
 
-  it("rejects repo tools whose names contain dots", async () => {
+  it("sanitizes dots in repo tool names to underscores", async () => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
     tempDirs.push(repoRoot);
     await mkdir(path.join(repoRoot, ".dispatch"));
@@ -68,6 +68,7 @@ describe("loadRepoTools", () => {
       })
     );
 
-    await expect(loadRepoTools(repoRoot)).rejects.toThrow("must not contain dots");
+    const [tool] = await loadRepoTools(repoRoot);
+    expect(tool.name).toBe("repo_project_dev_up");
   });
 });


### PR DESCRIPTION
## Summary
- Changes repo tool prefix from `repo.` to `repo_` since Claude doesn't support dots in MCP tool names
- Dots in user-defined tool names are now sanitized to underscores instead of being rejected

## Test plan
- [x] Unit tests updated and passing
- [x] Type check passing