### PR TITLE
Add password authentication gate

### DIFF
--- a/docs/auth-test-plan.md
+++ b/docs/auth-test-plan.md
@@ -1,0 +1,228 @@
+# Authentication Test Plan
+
+Covers the password gate, cookie sessions, Bearer token auth, and frontend auth flows.
+
+## Prerequisites
+
+- `dispatch-dev up --live` with a fresh DB (no password set)
+- Note the web and API URLs from the output
+
+---
+
+## 1. First-Run Open Access (No Password Set)
+
+### 1a. App loads without auth gate
+- Navigate to the web URL
+- **Expected:** Main app renders immediately (sidebar, terminal pane, status footer)
+- **Expected:** No login screen, no setup screen
+- **Expected:** Zero console errors
+
+### 1b. All API routes are open
+- `curl <api>/api/v1/agents` (no auth header)
+- **Expected:** 200 with `{"agents": [...]}`
+
+### 1c. Health endpoint always open
+- `curl <api>/api/v1/health`
+- **Expected:** 200 with `{"status": "ok", "db": "ok", ...}`
+
+### 1d. Auth status reports no password
+- `curl <api>/api/v1/auth/status`
+- **Expected:** `{"passwordSet": false, "authenticated": true}`
+
+### 1e. MCP endpoint is open
+- Send MCP initialize request to `<api>/api/mcp` (no auth header)
+- **Expected:** Successful MCP response (not 401)
+
+### 1f. Settings → Security shows "Set Password" form
+- Open Settings → Security
+- **Expected:** Heading says "Set Password"
+- **Expected:** Explanatory text about open access
+- **Expected:** No "Log out" button visible
+- **Expected:** No "Current password" field
+
+---
+
+## 2. Password Setup (via Settings)
+
+### 2a. Validation — password too short
+- In Security settings, enter a 3-character password + confirm
+- **Expected:** "Set password" button remains disabled
+
+### 2b. Validation — passwords don't match
+- Enter "abcd" in password, "abce" in confirm
+- **Expected:** "Passwords do not match" error shown
+
+### 2c. Successful setup
+- Enter matching password (4+ chars) and click "Set password"
+- **Expected:** Success message "Password set successfully."
+- **Expected:** Form switches to "Change Password" with current/new/confirm fields
+- **Expected:** "Log out" button appears under "Session" heading
+- **Expected:** Session cookie `dispatch_session` is set (check DevTools → Cookies)
+
+### 2d. Setup endpoint rejects second call
+- `curl -X POST <api>/api/v1/auth/setup -H 'Content-Type: application/json' -d '{"password":"another"}'`
+- **Expected:** 400 `{"error": "Password is already set."}`
+
+---
+
+## 3. Auth Hook Enforcement (Password Set)
+
+### 3a. Unauthenticated API calls get 401
+- `curl <api>/api/v1/agents` (no auth header, no cookie)
+- **Expected:** 401 `{"error": "Authentication required."}`
+
+### 3b. Health endpoint still open
+- `curl <api>/api/v1/health`
+- **Expected:** 200
+
+### 3c. Auth status still open
+- `curl <api>/api/v1/auth/status`
+- **Expected:** 200 `{"passwordSet": true, "authenticated": false}`
+
+### 3d. Bearer token grants access
+- `curl -H "Authorization: Bearer <AUTH_TOKEN>" <api>/api/v1/agents`
+- **Expected:** 200 with agents list
+
+### 3e. Invalid Bearer token rejected
+- `curl -H "Authorization: Bearer wrong-token" <api>/api/v1/agents`
+- **Expected:** 401
+
+### 3f. MCP with Bearer token works
+- Send MCP initialize to `<api>/api/mcp` with `Authorization: Bearer <AUTH_TOKEN>`
+- **Expected:** Successful MCP response
+
+### 3g. MCP without auth rejected
+- Send MCP initialize to `<api>/api/mcp` (no auth)
+- **Expected:** 401
+
+### 3h. SSE /api/v1/events without auth rejected
+- `curl <api>/api/v1/events` (no auth)
+- **Expected:** 401
+
+### 3i. WebSocket terminal/ws endpoint open (uses its own token auth)
+- The `/api/v1/agents/:id/terminal/ws` endpoint should not be blocked by the auth hook
+- (It uses short-lived tokens issued by the authenticated `/terminal/token` POST)
+
+---
+
+## 4. Login Flow
+
+### 4a. Logout shows login page
+- Click "Log out" in Settings → Security (or navigate after clearing cookies)
+- **Expected:** Login page renders with "Dispatch" title, password field, "Sign in" button
+- **Expected:** Sign in button disabled when password field empty
+
+### 4b. Wrong password rejected
+- Enter wrong password, click "Sign in"
+- **Expected:** Error message "Invalid password."
+- **Expected:** Stays on login page
+
+### 4c. Correct password succeeds
+- Enter correct password, click "Sign in"
+- **Expected:** Main app loads with sidebar, terminal pane, status footer
+- **Expected:** API/DB status shows "ok"
+- **Expected:** SSE connection established (agent updates work)
+
+### 4d. Terminal renders after login
+- Create or select an agent after logging in
+- **Expected:** Terminal canvas renders with agent CLI output (not blank/black)
+- **Expected:** WS status shows "connected"
+
+### 4e. Session persists across page reload
+- After login, hard-reload the page (Cmd+R)
+- **Expected:** App loads directly (no login screen)
+- **Expected:** Auth status returns `authenticated: true`
+
+---
+
+## 5. Change Password
+
+### 5a. Change password form validation
+- Open Settings → Security (while logged in with password set)
+- **Expected:** Shows "Change Password" heading with current/new/confirm fields
+
+### 5b. Wrong current password rejected
+- Enter wrong current password, valid new password + confirm
+- **Expected:** Error "Current password is incorrect."
+
+### 5c. New password too short
+- Enter correct current password, 3-char new password
+- **Expected:** "Change password" button remains disabled
+
+### 5d. Successful change
+- Enter correct current password, valid new password (4+ chars) + confirm
+- **Expected:** Success message "Password changed successfully."
+- **Expected:** Form fields reset
+
+### 5e. Old password no longer works
+- Log out, try logging in with old password
+- **Expected:** "Invalid password."
+
+### 5f. New password works
+- Log in with new password
+- **Expected:** App loads successfully
+
+---
+
+## 6. Agent + MCP Integration
+
+### 6a. Create agent with password set
+- With password set and logged in, create an agent via the UI
+- **Expected:** Agent appears in sidebar
+- **Expected:** Terminal connects (WS: connected) and renders CLI output
+
+### 6b. Agent MCP tools work
+- The spawned agent's MCP connection to Dispatch should authenticate via Bearer token
+- **Expected:** No 401s in server logs for `/api/mcp/<agentId>` requests
+- **Expected:** Agent can call `dispatch_event` (status updates appear in UI)
+- **Expected:** Agent can call `dispatch_share` (media appears in sidebar)
+
+### 6c. SSE delivers agent updates
+- Create an agent via API with Bearer token
+- **Expected:** Agent appears in UI sidebar via SSE push (no page reload needed)
+
+---
+
+## 7. Edge Cases
+
+### 7a. Expired session
+- Manually delete the session from the `sessions` table
+- Reload the page
+- **Expected:** Redirected to login page
+
+### 7b. API returns 401 mid-session
+- While using the app, manually delete session from DB
+- Trigger any API call (e.g., create agent)
+- **Expected:** App redirects to login page (authState → "needs-login")
+
+### 7c. Multiple browser tabs
+- Log in on tab A, open tab B to same URL
+- **Expected:** Tab B loads authenticated (shares same session cookie)
+- Log out on tab A, trigger action on tab B
+- **Expected:** Tab B redirects to login on next API call
+
+### 7d. Concurrent agents
+- With password set, create multiple agents
+- **Expected:** All agents' MCP connections authenticate successfully
+- **Expected:** All terminals render correctly
+
+---
+
+## 8. Existing Test Suites
+
+### 8a. E2E tests
+- `npm run test:e2e`
+- **Expected:** All 25 tests pass
+- (E2E uses fresh DB with no password — open access mode)
+
+### 8b. Unit tests
+- `npm test`
+- **Expected:** All tests pass
+
+### 8c. Type checking
+- `npm run check`
+- **Expected:** No errors
+
+### 8d. Web build
+- `npm run finalize:web`
+- **Expected:** Clean build

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -7,17 +7,18 @@ test.describe("Agent CRUD", () => {
   });
 
   test("displays 'No agents yet' when the list is empty", async ({ page, request }) => {
+    const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
     // Stop and delete only e2e-prefixed agents (never touch real agents)
-    const listRes = await request.get("/api/v1/agents");
+    const listRes = await request.get("/api/v1/agents", { headers: authHeader });
     const { agents } = (await listRes.json()) as { agents: Array<{ id: string; name: string; status: string }> };
     const e2eAgents = agents.filter((a) => a.name.startsWith("e2e-agent-"));
     for (const agent of e2eAgents) {
       if (agent.status !== "stopped") {
-        await request.post(`/api/v1/agents/${agent.id}/stop`);
+        await request.post(`/api/v1/agents/${agent.id}/stop`, { headers: authHeader });
       }
     }
     for (const agent of e2eAgents) {
-      await request.delete(`/api/v1/agents/${agent.id}`);
+      await request.delete(`/api/v1/agents/${agent.id}`, { headers: authHeader });
     }
 
     // Skip empty-state assertion if non-e2e agents remain

--- a/e2e/api-health.spec.ts
+++ b/e2e/api-health.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
 test.describe("API health", () => {
   test("GET /api/v1/health returns ok", async ({ request }) => {
     const res = await request.get("/api/v1/health");
@@ -11,7 +13,7 @@ test.describe("API health", () => {
   });
 
   test("GET /api/v1/agents returns an array", async ({ request }) => {
-    const res = await request.get("/api/v1/agents");
+    const res = await request.get("/api/v1/agents", { headers: authHeader });
     expect(res.ok()).toBeTruthy();
 
     const body = (await res.json()) as { agents: unknown[] };
@@ -20,6 +22,7 @@ test.describe("API health", () => {
 
   test("POST /api/v1/agents validates cwd is required", async ({ request }) => {
     const res = await request.post("/api/v1/agents", {
+      headers: authHeader,
       data: { name: "missing-cwd" },
     });
     expect(res.status()).toBe(400);
@@ -30,6 +33,7 @@ test.describe("API health", () => {
 
   test("POST /api/v1/agents validates type", async ({ request }) => {
     const res = await request.post("/api/v1/agents", {
+      headers: authHeader,
       data: { cwd: "/tmp", type: "invalid-type" },
     });
     expect(res.status()).toBe(400);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,12 @@
 import { type Page, type APIRequestContext } from "@playwright/test";
 
 const API = "/api/v1";
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
+
+/** Return Authorization header for API requests. */
+function authHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${AUTH_TOKEN}` };
+}
 
 /**
  * Create an agent via the REST API (faster than going through the UI every time).
@@ -10,6 +16,7 @@ export async function createAgentViaAPI(
   overrides: { name?: string; type?: string; cwd?: string } = {}
 ): Promise<{ id: string; name: string }> {
   const res = await request.post(`${API}/agents`, {
+    headers: authHeaders(),
     data: {
       name: overrides.name ?? `e2e-agent-${Date.now()}`,
       type: overrides.type ?? "codex",
@@ -26,6 +33,7 @@ export async function setAgentLatestEventViaAPI(
   event: { type: "working" | "blocked" | "waiting_user" | "done" | "idle"; message: string }
 ): Promise<void> {
   await request.post(`${API}/agents/${agentId}/latest-event`, {
+    headers: authHeaders(),
     data: event
   });
 }
@@ -37,15 +45,16 @@ export async function deleteAgentViaAPI(
   request: APIRequestContext,
   agentId: string
 ): Promise<void> {
-  await request.delete(`${API}/agents/${agentId}`);
+  await request.delete(`${API}/agents/${agentId}`, { headers: authHeaders() });
 }
 
 /**
  * Delete all agents whose name starts with `e2e-agent-` to keep the dev DB clean.
  */
 export async function cleanupE2EAgents(request: APIRequestContext): Promise<void> {
-  const res = await request.get(`${API}/agents`);
-  const body = (await res.json()) as { agents: Array<{ id: string; name: string }> };
+  const res = await request.get(`${API}/agents`, { headers: authHeaders() });
+  const body = (await res.json()) as { agents?: Array<{ id: string; name: string }> };
+  if (!body.agents) return;
   for (const agent of body.agents) {
     if (agent.name.startsWith("e2e-agent-")) {
       await deleteAgentViaAPI(request, agent.id);
@@ -59,6 +68,23 @@ export async function cleanupE2EAgents(request: APIRequestContext): Promise<void
  */
 export async function loadApp(page: Page): Promise<void> {
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await page.getByTestId("agent-sidebar").waitFor({ state: "visible", timeout: 15_000 });
+
+  // On a fresh DB with no password, the app loads directly.
+  // If a password is set and user isn't authenticated, the login page shows.
+  const loginInput = page.getByTestId("login-password");
+  const sidebar = page.getByTestId("agent-sidebar");
+
+  await Promise.race([
+    loginInput.waitFor({ state: "visible", timeout: 15_000 }).catch(() => null),
+    sidebar.waitFor({ state: "visible", timeout: 15_000 }).catch(() => null)
+  ]);
+
+  // If login page is showing, that's unexpected in e2e (fresh DB = no password).
+  // But handle it gracefully just in case.
+  if (await loginInput.isVisible().catch(() => false)) {
+    throw new Error("Unexpected login page in e2e test — DB should have no password set.");
+  }
+
+  await sidebar.waitFor({ state: "visible", timeout: 15_000 });
   await page.getByTestId("status-footer").waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "dispatch",
       "version": "0.2.37",
       "dependencies": {
+        "@fastify/cookie": "^9.4.0",
         "@fastify/multipart": "^8.3.1",
         "@fastify/static": "^6.12.0",
         "@fastify/websocket": "^8.3.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "bcryptjs": "^3.0.3",
         "dotenv": "^17.3.1",
         "fastify": "^4.29.1",
         "node-pty": "^1.0.0",
@@ -20,6 +22,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^24.10.0",
         "@types/pg": "^8.18.0",
         "@types/ws": "^8.18.1",
@@ -497,6 +500,16 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-9.4.0.tgz",
+      "integrity": "sha512-Th+pt3kEkh4MQD/Q2q1bMuJIB5NX/D5SwSpOKu3G/tjoGbwfpurIMJsWSPS0SJJ4eyjtmQ8OipDQspf8RbUOlg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.1.0",
+        "fastify-plugin": "^4.0.0"
+      }
     },
     "node_modules/@fastify/deepmerge": {
       "version": "2.0.2",
@@ -1062,6 +1075,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1324,6 +1344,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -3781,6 +3810,15 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
     },
+    "@fastify/cookie": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-9.4.0.tgz",
+      "integrity": "sha512-Th+pt3kEkh4MQD/Q2q1bMuJIB5NX/D5SwSpOKu3G/tjoGbwfpurIMJsWSPS0SJJ4eyjtmQ8OipDQspf8RbUOlg==",
+      "requires": {
+        "cookie-signature": "^1.1.0",
+        "fastify-plugin": "^4.0.0"
+      }
+    },
     "@fastify/deepmerge": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-2.0.2.tgz",
@@ -4107,6 +4145,12 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
+    "@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4293,6 +4337,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="
     },
     "body-parser": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "test:e2e": "bash scripts/e2e-isolated.sh"
   },
   "dependencies": {
+    "@fastify/cookie": "^9.4.0",
     "@fastify/multipart": "^8.3.1",
     "@fastify/static": "^6.12.0",
     "@fastify/websocket": "^8.3.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^17.3.1",
     "fastify": "^4.29.1",
     "node-pty": "^1.0.0",
@@ -35,6 +37,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^24.10.0",
     "@types/pg": "^8.18.0",
     "@types/ws": "^8.18.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+    },
   },
   webServer: {
     command: process.env.E2E_SKIP_WEB_BUILD

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -812,7 +812,10 @@ export class AgentManager {
         mcpServers: {
           dispatch: {
             type: "http",
-            url: dispatchMcpUrl
+            url: dispatchMcpUrl,
+            headers: {
+              Authorization: `Bearer ${this.config.authToken}`
+            }
           }
         }
       }));
@@ -840,7 +843,9 @@ export class AgentManager {
     // Codex: positional arg — AGENTS.md is auto-loaded by Codex CLI and provides authority.
     const codexMcpFlags = [
       "-c",
-      this.shellEscape(`mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`)
+      this.shellEscape(`mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`),
+      "-c",
+      this.shellEscape(`mcp_servers.dispatch.headers.Authorization=${JSON.stringify(`Bearer ${this.config.authToken}`)}`)
     ].join(" ");
     if (args.length === 0) {
       return `${envPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(launchGuidance)}`;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,68 @@
+import crypto from "node:crypto";
+import type { Pool } from "pg";
+import bcrypt from "bcryptjs";
+
+const BCRYPT_COST = 12;
+const SESSION_TTL_DAYS = 30;
+
+export async function isPasswordSet(pool: Pool): Promise<boolean> {
+  const result = await pool.query(
+    "SELECT 1 FROM settings WHERE key = 'password_hash'"
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function setPassword(pool: Pool, password: string): Promise<void> {
+  const hash = await bcrypt.hash(password, BCRYPT_COST);
+  await pool.query(
+    `INSERT INTO settings (key, value, updated_at)
+     VALUES ('password_hash', $1, NOW())
+     ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+    [hash]
+  );
+}
+
+export async function verifyPassword(pool: Pool, password: string): Promise<boolean> {
+  const result = await pool.query<{ value: string }>(
+    "SELECT value FROM settings WHERE key = 'password_hash'"
+  );
+  if (result.rowCount === 0) return false;
+  return bcrypt.compare(password, result.rows[0].value);
+}
+
+export async function createSession(pool: Pool): Promise<string> {
+  const token = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
+  await pool.query(
+    "INSERT INTO sessions (token, expires_at) VALUES ($1, $2)",
+    [token, expiresAt]
+  );
+  return token;
+}
+
+export async function validateSession(pool: Pool, token: string): Promise<boolean> {
+  const result = await pool.query(
+    "SELECT 1 FROM sessions WHERE token = $1 AND expires_at > NOW()",
+    [token]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function deleteSession(pool: Pool, token: string): Promise<void> {
+  await pool.query("DELETE FROM sessions WHERE token = $1", [token]);
+}
+
+export async function changePassword(
+  pool: Pool,
+  currentPassword: string,
+  newPassword: string
+): Promise<boolean> {
+  const valid = await verifyPassword(pool, currentPassword);
+  if (!valid) return false;
+  await setPassword(pool, newPassword);
+  return true;
+}
+
+export async function cleanExpiredSessions(pool: Pool): Promise<void> {
+  await pool.query("DELETE FROM sessions WHERE expires_at <= NOW()");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +22,7 @@ export type AppConfig = {
   claudeBin: string;
   opencodeBin: string;
   agentRuntime: "tmux" | "inert";
+  cookieSecret: string;
   tls: TlsConfig | null;
 };
 
@@ -66,6 +68,7 @@ export function loadConfig(): AppConfig {
       process.env.OPENCODE_BIN ??
       "opencode",
     agentRuntime: process.env.DISPATCH_AGENT_RUNTIME === "tmux" ? "tmux" : "inert",
+    cookieSecret: process.env.COOKIE_SECRET ?? crypto.randomUUID(),
     tls: loadTls(),
   };
 }

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -88,6 +88,18 @@ export async function runMigrations(): Promise<void> {
 
     ALTER TABLE media
       ADD COLUMN IF NOT EXISTS description TEXT;
+
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      token TEXT PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      expires_at TIMESTAMPTZ NOT NULL
+    );
   `;
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
+import fastifyCookie from "@fastify/cookie";
 import fastifyMultipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import fastifyWebsocket from "@fastify/websocket";
@@ -15,6 +16,16 @@ import pty from "node-pty";
 
 import { AgentError, AgentManager } from "./agents/manager.js";
 import type { AgentGitContext, AgentRecord } from "./agents/manager.js";
+import {
+  isPasswordSet,
+  setPassword,
+  verifyPassword,
+  createSession,
+  validateSession,
+  deleteSession,
+  changePassword,
+  cleanExpiredSessions
+} from "./auth.js";
 import { loadConfig } from "./config.js";
 import { createPool } from "./db/client.js";
 import { runMigrations } from "./db/migrate.js";
@@ -503,7 +514,25 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
   }
 }
 
+// In-memory cache: null = unknown, true/false = password set/not-set.
+let passwordSetCache: boolean | null = null;
+
+async function isPasswordSetCached(): Promise<boolean> {
+  if (passwordSetCache === null) {
+    passwordSetCache = await isPasswordSet(pool);
+  }
+  return passwordSetCache;
+}
+
+function invalidatePasswordSetCache(): void {
+  passwordSetCache = null;
+}
+
+const SESSION_COOKIE = "dispatch_session";
+const SESSION_MAX_AGE_S = 30 * 24 * 60 * 60; // 30 days
+
 async function registerRoutes() {
+  await app.register(fastifyCookie, { secret: config.cookieSecret });
   await app.register(fastifyMultipart, { limits: { fileSize: 20 * 1024 * 1024 } });
   await app.register(fastifyWebsocket);
 
@@ -511,6 +540,144 @@ async function registerRoutes() {
     root: staticDir,
     prefix: "/"
   });
+
+  // ---------------------------------------------------------------------------
+  // Auth hook — runs before every /api/ route except auth + health endpoints
+  // ---------------------------------------------------------------------------
+  app.addHook("onRequest", async (request, reply) => {
+    const url = request.url.split("?")[0];
+
+    // Static files, auth endpoints, health check, and WebSocket endpoints are always open.
+    // (WebSocket terminal uses its own short-lived token for auth.)
+    if (!url.startsWith("/api/")) return;
+    if (url.startsWith("/api/v1/auth/")) return;
+    if (url === "/api/v1/health") return;
+    if (url.endsWith("/terminal/ws")) return;
+
+    // If no password is set, all routes are open (first-run mode).
+    if (!(await isPasswordSetCached())) return;
+
+    // Bearer token is accepted on all API routes (for MCP agents, scripts, etc.)
+    const authHeader = request.headers.authorization;
+    if (authHeader?.startsWith("Bearer ")) {
+      const token = authHeader.slice(7);
+      if (token === config.authToken) {
+        return;
+      }
+    }
+
+    // Session cookie
+    const signed = request.cookies[SESSION_COOKIE];
+    if (signed) {
+      const unsigned = request.unsignCookie(signed);
+      if (unsigned.valid && unsigned.value && await validateSession(pool, unsigned.value)) {
+        return;
+      }
+    }
+
+    return reply.code(401).send({ error: "Authentication required." });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auth routes
+  // ---------------------------------------------------------------------------
+
+  app.get("/api/v1/auth/status", async (request) => {
+    const hasPassword = await isPasswordSetCached();
+    let authenticated = false;
+    if (hasPassword) {
+      const signed = request.cookies[SESSION_COOKIE];
+      if (signed) {
+        const unsigned = request.unsignCookie(signed);
+        if (unsigned.valid && unsigned.value) {
+          authenticated = await validateSession(pool, unsigned.value);
+        }
+      }
+    } else {
+      // No password set — everyone is considered authenticated.
+      authenticated = true;
+    }
+    return { passwordSet: hasPassword, authenticated };
+  });
+
+  app.post("/api/v1/auth/setup", async (request, reply) => {
+    if (await isPasswordSetCached()) {
+      return reply.code(400).send({ error: "Password is already set." });
+    }
+    const body = request.body as { password?: string } | null;
+    const password = body?.password;
+    if (!password || typeof password !== "string" || password.length < 4) {
+      return reply.code(400).send({ error: "Password must be at least 4 characters." });
+    }
+    await setPassword(pool, password);
+    invalidatePasswordSetCache();
+    const token = await createSession(pool);
+    reply.setCookie(SESSION_COOKIE, token, {
+      path: "/",
+      httpOnly: true,
+      signed: true,
+      sameSite: "lax",
+      secure: config.tls !== null,
+      maxAge: SESSION_MAX_AGE_S
+    });
+    return { ok: true };
+  });
+
+  app.post("/api/v1/auth/login", async (request, reply) => {
+    const body = request.body as { password?: string } | null;
+    const password = body?.password;
+    if (!password || typeof password !== "string") {
+      return reply.code(400).send({ error: "Password is required." });
+    }
+    if (!(await verifyPassword(pool, password))) {
+      return reply.code(401).send({ error: "Invalid password." });
+    }
+    const token = await createSession(pool);
+    reply.setCookie(SESSION_COOKIE, token, {
+      path: "/",
+      httpOnly: true,
+      signed: true,
+      sameSite: "lax",
+      secure: config.tls !== null,
+      maxAge: SESSION_MAX_AGE_S
+    });
+    return { ok: true };
+  });
+
+  app.post("/api/v1/auth/logout", async (request, reply) => {
+    const signed = request.cookies[SESSION_COOKIE];
+    if (signed) {
+      const unsigned = request.unsignCookie(signed);
+      if (unsigned.valid && unsigned.value) {
+        await deleteSession(pool, unsigned.value);
+      }
+    }
+    reply.clearCookie(SESSION_COOKIE, { path: "/" });
+    return { ok: true };
+  });
+
+  app.post("/api/v1/auth/change-password", async (request, reply) => {
+    // Requires valid session (enforced by hook).
+    const body = request.body as { currentPassword?: string; newPassword?: string } | null;
+    const currentPassword = body?.currentPassword;
+    const newPassword = body?.newPassword;
+    if (!currentPassword || !newPassword || typeof currentPassword !== "string" || typeof newPassword !== "string") {
+      return reply.code(400).send({ error: "currentPassword and newPassword are required." });
+    }
+    if (newPassword.length < 4) {
+      return reply.code(400).send({ error: "New password must be at least 4 characters." });
+    }
+    const changed = await changePassword(pool, currentPassword, newPassword);
+    if (!changed) {
+      return reply.code(401).send({ error: "Current password is incorrect." });
+    }
+    invalidatePasswordSetCache();
+    return { ok: true };
+  });
+
+  // ---------------------------------------------------------------------------
+  // MCP routes
+  // ---------------------------------------------------------------------------
 
   app.post("/api/mcp", async (request, reply) => {
     reply.hijack();
@@ -1412,6 +1579,7 @@ async function start() {
   queueGitContextRefresh(agents.map((agent) => agent.id));
   startGitContextRefreshLoop();
   startAgentStatusReconcileLoop();
+  startSessionCleanupTimer();
   await registerRoutes();
 
   const protocol = config.tls ? "https" : "http";
@@ -1581,6 +1749,21 @@ function stopAgentStatusReconcileLoop(): void {
   }
   clearInterval(agentStatusReconcileTimer);
   agentStatusReconcileTimer = null;
+}
+
+let sessionCleanupTimer: NodeJS.Timeout | null = null;
+
+function startSessionCleanupTimer(): void {
+  if (sessionCleanupTimer) return;
+  sessionCleanupTimer = setInterval(() => {
+    void cleanExpiredSessions(pool).catch(() => null);
+  }, 60 * 60 * 1000); // every hour
+}
+
+function stopSessionCleanupTimer(): void {
+  if (!sessionCleanupTimer) return;
+  clearInterval(sessionCleanupTimer);
+  sessionCleanupTimer = null;
 }
 
 async function runAgentStatusReconciliation(): Promise<void> {
@@ -1983,6 +2166,7 @@ async function shutdown(code: number): Promise<void> {
   streamManager.stopAll();
   stopGitContextRefreshLoop();
   stopAgentStatusReconcileLoop();
+  stopSessionCleanupTimer();
   await pool.end().catch(() => null);
   await app.close().catch(() => null);
   process.exit(code);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import "@xterm/xterm/css/xterm.css";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
 import { DocsPane } from "@/components/app/docs-pane";
+import { LoginPage } from "@/components/app/login-page";
 import { SettingsPane } from "@/components/app/settings-pane";
 import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
 import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
@@ -17,6 +18,7 @@ import { TerminalPane } from "@/components/app/terminal-pane";
 import {
   type Agent,
   type AgentVisualState,
+  type AuthState,
   type ConnState,
   type MediaFile,
   type ServiceState
@@ -160,6 +162,7 @@ function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): bo
 }
 
 export function App(): JSX.Element {
+  const [authState, setAuthState] = useState<AuthState>("loading");
   const [agents, setAgents] = useState<Agent[]>([]);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [restoreShellAgentId, setRestoreShellAgentId] = useState<string | null>(() => readActiveShellAgentId());
@@ -284,12 +287,18 @@ export function App(): JSX.Element {
   const api = useCallback(async <T,>(path: string, init?: RequestInit): Promise<T> => {
     const hasBody = init?.body !== undefined && init?.body !== null;
     const res = await fetch(path, {
+      credentials: "include",
       headers: {
         ...(hasBody ? { "content-type": "application/json" } : {}),
         ...(init?.headers ?? {})
       },
       ...init
     });
+
+    if (res.status === 401) {
+      setAuthState("needs-login");
+      throw new Error("Authentication required.");
+    }
 
     if (!res.ok) {
       let message = `${res.status} ${res.statusText}`;
@@ -918,7 +927,7 @@ export function App(): JSX.Element {
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [sendResize]);
+  }, [authState, sendResize]);
 
   useEffect(() => {
     const query = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
@@ -932,11 +941,34 @@ export function App(): JSX.Element {
 
   useEffect(() => {
     void (async () => {
+      try {
+        const res = await fetch("/api/v1/auth/status", { credentials: "include" });
+        if (!res.ok) {
+          setAuthState("needs-login");
+          return;
+        }
+        const data = (await res.json()) as { passwordSet: boolean; authenticated: boolean };
+        if (data.passwordSet && !data.authenticated) {
+          setAuthState("needs-login");
+        } else {
+          // No password set = open access; or already authenticated.
+          setAuthState("authenticated");
+        }
+      } catch {
+        // Server unreachable — let the main app render so health polling shows the issue.
+        setAuthState("authenticated");
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (authState !== "authenticated") return;
+    void (async () => {
       await Promise.all([pollHealth(), refreshAgents()]);
       setAgentsLoaded(true);
       setStatusMessage("Select an agent to open a session.");
     })();
-  }, [pollHealth, refreshAgents]);
+  }, [authState, pollHealth, refreshAgents]);
 
   // Energy metrics tracker — persists to localStorage and beacons to backend
   useEffect(() => {
@@ -1086,7 +1118,7 @@ export function App(): JSX.Element {
 
     const openSSE = () => {
       if (eventSourceRef.current) return;
-      const source = new EventSource("/api/v1/events");
+      const source = new EventSource("/api/v1/events", { withCredentials: true });
       eventSourceRef.current = source;
       source.onmessage = handleSSEMessage;
       source.onerror = () => {
@@ -1101,13 +1133,13 @@ export function App(): JSX.Element {
       }
     };
 
-    // Only connect when visible
-    if (!document.hidden) {
+    // Only connect when visible and authenticated
+    if (!document.hidden && authState === "authenticated") {
       openSSE();
     }
 
     const onVisChange = () => {
-      if (document.hidden) {
+      if (document.hidden || authState !== "authenticated") {
         closeSSE();
       } else {
         openSSE();
@@ -1120,7 +1152,7 @@ export function App(): JSX.Element {
       document.removeEventListener("visibilitychange", onVisChange);
       closeSSE();
     };
-  }, [refreshMedia]);
+  }, [authState, refreshMedia]);
 
   useEffect(() => {
     setSelectedAgentId((current) => {
@@ -1409,6 +1441,24 @@ export function App(): JSX.Element {
     return "bg-amber-500";
   };
 
+  const handleAuthenticated = useCallback(() => setAuthState("authenticated"), []);
+  const handleLogout = useCallback(async () => {
+    await fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" });
+    setAuthState("needs-login");
+  }, []);
+
+  if (authState === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
+        <span className="text-sm">Loading...</span>
+      </div>
+    );
+  }
+
+  if (authState === "needs-login") {
+    return <LoginPage onAuthenticated={handleAuthenticated} />;
+  }
+
   return (
     <div className="h-full min-h-0 overflow-hidden bg-background text-foreground">
       <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
@@ -1593,7 +1643,7 @@ export function App(): JSX.Element {
       />
 
       <DocsPane open={docsPaneOpen} onClose={() => setDocsPaneOpen(false)} />
-      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} />
+      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} onLogout={handleLogout} />
 
       <MediaLightbox
         lightboxSrc={lightboxSrc}

--- a/web/src/components/app/login-page.tsx
+++ b/web/src/components/app/login-page.tsx
@@ -1,0 +1,65 @@
+import { useState, type FormEvent } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+type LoginPageProps = {
+  onAuthenticated: () => void;
+};
+
+export function LoginPage({ onAuthenticated }: LoginPageProps): JSX.Element {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ password })
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        setError(body.error ?? "Login failed.");
+        return;
+      }
+      onAuthenticated();
+    } catch {
+      setError("Unable to reach the server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Dispatch</CardTitle>
+          <CardDescription>Enter your password to continue.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoFocus
+              data-testid="login-password"
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" variant="primary" className="w-full" disabled={loading || !password}>
+              {loading ? "Signing in..." : "Sign in"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/components/app/security-settings.tsx
+++ b/web/src/components/app/security-settings.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+type SecuritySettingsProps = {
+  onLogout: () => void;
+};
+
+export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Element {
+  const [passwordSet, setPasswordSet] = useState<boolean | null>(null);
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/v1/auth/status", { credentials: "include" });
+        if (res.ok) {
+          const data = (await res.json()) as { passwordSet: boolean };
+          setPasswordSet(data.passwordSet);
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  const resetForm = () => {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setError("");
+  };
+
+  const handleSetPassword = async (e: FormEvent) => {
+    e.preventDefault();
+    if (newPassword.length < 4 || newPassword !== confirmPassword) return;
+    setError("");
+    setMessage("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/auth/setup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ password: newPassword })
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        setError(body.error ?? "Failed to set password.");
+        return;
+      }
+      setMessage("Password set successfully.");
+      setPasswordSet(true);
+      resetForm();
+    } catch {
+      setError("Unable to reach the server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChangePassword = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!currentPassword || newPassword.length < 4 || newPassword !== confirmPassword) return;
+    setError("");
+    setMessage("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/auth/change-password", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ currentPassword, newPassword })
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        setError(body.error ?? "Failed to change password.");
+        return;
+      }
+      setMessage("Password changed successfully.");
+      resetForm();
+    } catch {
+      setError("Unable to reach the server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const mismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+
+  if (passwordSet === null) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading...</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 overflow-y-auto p-6">
+      <div>
+        <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {passwordSet ? "Change Password" : "Set Password"}
+        </h3>
+        {!passwordSet && (
+          <p className="mb-4 text-sm text-muted-foreground">
+            No password is set. Anyone who can reach this server has full access. Set a password to require authentication.
+          </p>
+        )}
+        <form onSubmit={passwordSet ? handleChangePassword : handleSetPassword} className="max-w-sm space-y-3">
+          {passwordSet && (
+            <Input
+              type="password"
+              placeholder="Current password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              data-testid="change-current-password"
+            />
+          )}
+          <Input
+            type="password"
+            placeholder={passwordSet ? "New password (min 4 characters)" : "Password (min 4 characters)"}
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            data-testid="security-new-password"
+          />
+          <Input
+            type="password"
+            placeholder="Confirm password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            data-testid="security-confirm-password"
+          />
+          {mismatch && <p className="text-sm text-destructive">Passwords do not match.</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {message && <p className="text-sm text-emerald-500">{message}</p>}
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={loading || newPassword.length < 4 || newPassword !== confirmPassword || (passwordSet && !currentPassword)}
+          >
+            {loading ? (passwordSet ? "Changing..." : "Setting up...") : (passwordSet ? "Change password" : "Set password")}
+          </Button>
+        </form>
+      </div>
+
+      {passwordSet && (
+        <div>
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Session
+          </h3>
+          <Button variant="destructive" onClick={onLogout} data-testid="logout-button">
+            Log out
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,22 +1,25 @@
 import { useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ChevronRight, ArrowLeft, ArrowDownToLine, X } from "lucide-react";
+import { ChevronRight, ArrowLeft, ArrowDownToLine, Shield, X } from "lucide-react";
 
 import { ReleaseManager } from "@/components/app/release-manager";
+import { SecuritySettings } from "@/components/app/security-settings";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release";
+type SettingsSection = "release" | "security";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
-  { id: "release", label: "Updates", icon: ArrowDownToLine }
+  { id: "release", label: "Updates", icon: ArrowDownToLine },
+  { id: "security", label: "Security", icon: Shield }
 ];
 
 type SettingsPaneProps = {
   open: boolean;
   onClose: () => void;
+  onLogout: () => void;
 };
 
-export function SettingsPane({ open, onClose }: SettingsPaneProps): JSX.Element {
+export function SettingsPane({ open, onClose, onLogout }: SettingsPaneProps): JSX.Element {
   const [activeSection, setActiveSection] = useState<SettingsSection | null>("release");
 
   return (
@@ -99,6 +102,7 @@ export function SettingsPane({ open, onClose }: SettingsPaneProps): JSX.Element 
             {/* Content */}
             <div className={cn("min-h-0 min-w-0 flex-1", activeSection === null && "hidden md:block")}>
               {activeSection === "release" && <ReleaseManager />}
+              {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
             </div>
           </div>
         </DialogPrimitive.Content>

--- a/web/src/components/app/types.ts
+++ b/web/src/components/app/types.ts
@@ -42,3 +42,4 @@ export type MediaFile = {
 export type ConnState = "connected" | "reconnecting" | "disconnected";
 export type ServiceState = "ok" | "down" | "checking";
 export type AgentVisualState = "stopped" | "idle" | "active";
+export type AuthState = "loading" | "needs-login" | "authenticated";


### PR DESCRIPTION
## Summary
- Adds optional password protection to Dispatch with cookie sessions and Bearer token auth
- When no password is set, server remains fully open (backward compatible)
- Once a password is configured via Settings → Security, all API routes (except health/auth status) require authentication
- Includes login page, password setup/change UI, session management, and auth middleware
- Updated E2E tests to pass auth headers for authenticated API calls

## Test plan
- [x] Ran full auth test plan (`docs/auth-test-plan.md`) — 37 tests across 8 sections, all pass
- [x] Type checking (`npm run check`) — no errors
- [x] Unit tests (`npm test`) — 49/49 pass
- [x] E2E tests (`npm run test:e2e`) — 25/25 pass
- [x] Web build (`npm run finalize:web`) — clean build
- [x] Validated all UI flows in Playwright (login, setup, change password, logout, session expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)