### PR TITLE
Reuse ports on dispatch-dev restart

### DIFF
--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -155,7 +155,7 @@ cmd_up() {
     fi
 
     DEV_CONTAINER_SUFFIX="$SUFFIX"
-    DEV_DB_PORT="$(find_free_port)"
+    DEV_DB_PORT="${RESTART_DB_PORT:-$(find_free_port)}"
     DEV_COMPOSE_PROJECT="dispatch-dev-${SUFFIX}"
 
     echo "Starting database on port ${DEV_DB_PORT}..."
@@ -167,7 +167,7 @@ cmd_up() {
   fi
 
   # --- API Server ---
-  DEV_API_PORT="$(find_free_port)"
+  DEV_API_PORT="${RESTART_API_PORT:-$(find_free_port)}"
 
   # Build environment
   (
@@ -219,7 +219,7 @@ cmd_up() {
   done
 
   # --- Vite Frontend ---
-  DEV_VITE_PORT="$(find_free_port)"
+  DEV_VITE_PORT="${RESTART_VITE_PORT:-$(find_free_port)}"
 
   (
     cd "$cwd"
@@ -446,11 +446,15 @@ case "$CMD" in
   up)       cmd_up ;;
   down)     cmd_down ;;
   restart)
-    # Restore flags from previous state if not explicitly set
+    # Restore flags and ports from previous state if not explicitly set
     if load_state 2>/dev/null; then
       [ "$OPT_LIVE" = "0" ] && [ "${DEV_LIVE:-0}" = "1" ] && OPT_LIVE="1"
       [ "$OPT_NO_DB" = "0" ] && [ "${DEV_NO_DB:-0}" = "1" ] && OPT_NO_DB="1"
       [ -z "$OPT_CWD" ] && [ -n "${DEV_CWD:-}" ] && OPT_CWD="$DEV_CWD"
+      # Preserve ports so restart reuses them
+      RESTART_DB_PORT="${DEV_DB_PORT:-}"
+      RESTART_API_PORT="${DEV_API_PORT:-}"
+      RESTART_VITE_PORT="${DEV_VITE_PORT:-}"
     fi
     cmd_down 2>/dev/null || true
     cmd_up


### PR DESCRIPTION
## Summary
- `dispatch-dev restart` now reuses the same DB, API, and Vite ports from the previous session instead of allocating new ones
- Fresh `dispatch-dev up` still allocates new ports via `find_free_port()` as before
- Ports are saved from the loaded state before `cmd_down` and passed through to `cmd_up` via `RESTART_*` variables

## Test plan
- [ ] `dispatch-dev up` — verify ports are auto-selected as before
- [ ] `dispatch-dev restart` — verify all three ports (DB, API, Vite) match the previous session
- [ ] `dispatch-dev down && dispatch-dev up` — verify new ports are allocated (no stale reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)