### PR TITLE
Remove redundant npm cache from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "npm"
-          cache-dependency-path: |
-            package-lock.json
-            web/package-lock.json
 
       - name: Start Postgres
         id: postgres


### PR DESCRIPTION
## Summary
- Removes `cache: "npm"` from `actions/setup-node` in the CI workflow
- On the self-hosted runner, `~/.npm` persists naturally between runs, making the GitHub cache upload redundant
- The cache save post-step was taking ~65s per run uploading to GitHub's cache service

## Test plan
- [ ] CI run on this PR completes without the ~65s `Post Run actions/setup-node` delay
- [ ] `npm ci` still works (uses local ~/.npm cache on the runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)