### PR TITLE
Fix mobile sidebar: overflow menu hidden behind slide panel

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1465,29 +1465,31 @@ export function App(): JSX.Element {
   return (
     <div className="h-full min-h-0 overflow-hidden bg-background text-foreground">
       <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
-        <div className="hidden shrink-0 md:block">
-          <AgentSidebar
-            leftOpen={leftOpen}
-            agents={agents}
-            selectedAgentId={selectedAgentId}
-            overflowAgentId={overflowAgentId}
-            setLeftOpen={setLeftOpen}
-            onOpenCreateDialog={openCreateDialog}
-            onOpenDocs={() => setDocsPaneOpen(true)}
-            onOpenSettings={() => setSettingsPaneOpen(true)}
-            setOverflowAgentId={setOverflowAgentId}
-            setDeleteTarget={setDeleteTarget}
-            setDeleteConfirmOpen={setDeleteConfirmOpen}
-            agentVisualState={agentVisualState}
-            borderForAgentState={borderForAgentState}
-            toggleAgentDetails={toggleAgentDetails}
-            isFullAccessEnabled={isFullAccessEnabled}
-            detachTerminal={detachTerminal}
-            attachToAgent={attachToAgent}
-            stopAgent={stopAgent}
-            startAgent={startAgent}
-          />
-        </div>
+        {!isMobile ? (
+          <div className="shrink-0">
+            <AgentSidebar
+              leftOpen={leftOpen}
+              agents={agents}
+              selectedAgentId={selectedAgentId}
+              overflowAgentId={overflowAgentId}
+              setLeftOpen={setLeftOpen}
+              onOpenCreateDialog={openCreateDialog}
+              onOpenDocs={() => setDocsPaneOpen(true)}
+              onOpenSettings={() => setSettingsPaneOpen(true)}
+              setOverflowAgentId={setOverflowAgentId}
+              setDeleteTarget={setDeleteTarget}
+              setDeleteConfirmOpen={setDeleteConfirmOpen}
+              agentVisualState={agentVisualState}
+              borderForAgentState={borderForAgentState}
+              toggleAgentDetails={toggleAgentDetails}
+              isFullAccessEnabled={isFullAccessEnabled}
+              detachTerminal={detachTerminal}
+              attachToAgent={attachToAgent}
+              stopAgent={stopAgent}
+              startAgent={startAgent}
+            />
+          </div>
+        ) : null}
 
         <main
           className={cn("min-h-0 min-w-0 flex-1 overflow-hidden", mediaOpen && !isMobile && "border-r-2 border-border")}

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -303,21 +303,17 @@ export function AgentSidebarContent({
                         setOverflowAgentId(open ? agent.id : null)
                       }
                     >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              data-agent-control="true"
-                              className="ml-auto"
-                            >
-                              <EllipsisVertical className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                        </TooltipTrigger>
-                        <TooltipContent>More actions</TooltipContent>
-                      </Tooltip>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          data-agent-control="true"
+                          className="ml-auto"
+                          title="More actions"
+                        >
+                          <EllipsisVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
 
                       <DropdownMenuContent align="end">
                         {!isStopped ? (

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -15,7 +15,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[180px] overflow-hidden rounded-md border-2 border-border bg-card p-1.5 text-foreground shadow-xl",
+        "z-[70] min-w-[180px] overflow-hidden rounded-md border-2 border-border bg-card p-1.5 text-foreground shadow-xl",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",


### PR DESCRIPTION
## Summary
- **Conditional sidebar rendering**: Desktop `AgentSidebar` was always rendered (hidden via CSS `hidden md:block`) causing duplicate agent cards, shared dropdown state conflicts, and potential touch event interference on mobile. Changed to `{!isMobile ? ... : null}`.
- **Dropdown z-index fix**: `DropdownMenuContent` portaled at `z-50` rendered behind `MobileSlidePanel` at `z-[60]`. Bumped to `z-[70]`.
- **Tooltip/DropdownTrigger conflict**: Removed `Tooltip` wrapper from `DropdownMenuTrigger` (double `asChild` nesting can interfere with touch events). Replaced with native `title` attribute.

## Test plan
- [x] Type checking passes (`npm run check`)
- [x] Web finalization passes (`npm run finalize:web`)
- [x] All 26 E2E tests pass (`npm run test:e2e`)
- [x] Verified overflow menu opens and "Delete agent" is visible on mobile (390x844 viewport)
- [x] Verified delete confirmation dialog opens from mobile overflow menu
- [x] Verified desktop overflow menu still works correctly
- [x] Only 1 sidebar instance renders on mobile (was 2 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)