### PR TITLE
Fix sessions invalidated on server restart

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -66,3 +66,43 @@ export async function changePassword(
 export async function cleanExpiredSessions(pool: Pool): Promise<void> {
   await pool.query("DELETE FROM sessions WHERE expires_at <= NOW()");
 }
+
+/**
+ * Returns a stable cookie-signing secret, persisted in the settings table.
+ * If COOKIE_SECRET env var is set, that value is used (and persisted).
+ * Otherwise, the DB value is returned — or a new one is generated on first run.
+ */
+export async function getOrCreateCookieSecret(pool: Pool): Promise<string> {
+  const envSecret = process.env.COOKIE_SECRET;
+
+  const result = await pool.query<{ value: string }>(
+    "SELECT value FROM settings WHERE key = 'cookie_secret'"
+  );
+
+  if (envSecret) {
+    // Env var always wins — persist it so the cookie plugin and DB agree.
+    if (result.rowCount === 0 || result.rows[0].value !== envSecret) {
+      await pool.query(
+        `INSERT INTO settings (key, value, updated_at)
+         VALUES ('cookie_secret', $1, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+        [envSecret]
+      );
+    }
+    return envSecret;
+  }
+
+  if ((result.rowCount ?? 0) > 0) {
+    return result.rows[0].value;
+  }
+
+  // First run without env var — generate and persist a secret.
+  const secret = crypto.randomUUID();
+  await pool.query(
+    `INSERT INTO settings (key, value, updated_at)
+     VALUES ('cookie_secret', $1, NOW())
+     ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+    [secret]
+  );
+  return secret;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,7 +21,6 @@ export type AppConfig = {
   claudeBin: string;
   opencodeBin: string;
   agentRuntime: "tmux" | "inert";
-  cookieSecret: string;
   tls: TlsConfig | null;
 };
 
@@ -68,7 +66,6 @@ export function loadConfig(): AppConfig {
       process.env.OPENCODE_BIN ??
       "opencode",
     agentRuntime: process.env.DISPATCH_AGENT_RUNTIME === "tmux" ? "tmux" : "inert",
-    cookieSecret: process.env.COOKIE_SECRET ?? crypto.randomUUID(),
     tls: loadTls(),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,8 @@ import {
   validateSession,
   deleteSession,
   changePassword,
-  cleanExpiredSessions
+  cleanExpiredSessions,
+  getOrCreateCookieSecret
 } from "./auth.js";
 import { loadConfig } from "./config.js";
 import { createPool } from "./db/client.js";
@@ -532,7 +533,8 @@ const SESSION_COOKIE = "dispatch_session";
 const SESSION_MAX_AGE_S = 30 * 24 * 60 * 60; // 30 days
 
 async function registerRoutes() {
-  await app.register(fastifyCookie, { secret: config.cookieSecret });
+  const cookieSecret = await getOrCreateCookieSecret(pool);
+  await app.register(fastifyCookie, { secret: cookieSecret });
   await app.register(fastifyMultipart, { limits: { fileSize: 20 * 1024 * 1024 } });
   await app.register(fastifyWebsocket);
 


### PR DESCRIPTION
## Summary
- **Root cause:** `cookieSecret` in `config.ts` was set to `crypto.randomUUID()` on every server start when `COOKIE_SECRET` env var was not set. This meant all existing signed session cookies became unverifiable after a restart.
- **Fix:** Persist the cookie-signing secret in the `settings` table (key `cookie_secret`). On first boot, a UUID is generated and stored; subsequent boots load the same secret from the DB.
- `COOKIE_SECRET` env var still works as an override — if set, it takes precedence and is synced to the DB.

## Test plan
- [x] `npm run check` — type checks pass
- [x] `npm test` — 49 unit tests pass
- [x] `npm run test:e2e` — 26 E2E tests pass
- [x] Manual validation: set password → log in → restart API server (DB persists) → reload page → **session survived, no re-login required**

🤖 Generated with [Claude Code](https://claude.com/claude-code)