### PR TITLE
Fix terminal flashing: memoize TerminalPane + decompose App.tsx with React Query

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-query": "^5.91.2",
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
@@ -3573,6 +3574,32 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.91.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.91.2.tgz",
+      "integrity": "sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.91.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.91.2.tgz",
+      "integrity": "sha512-GClLPzbM57iFXv+FlvOUL56XVe00PxuTaVEyj1zAObhRiKF008J5vedmaq7O6ehs+VmPHe8+PUQhMuEyv8d9wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.91.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {
@@ -11431,6 +11458,19 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "5.91.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.91.2.tgz",
+      "integrity": "sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw=="
+    },
+    "@tanstack/react-query": {
+      "version": "5.91.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.91.2.tgz",
+      "integrity": "sha512-GClLPzbM57iFXv+FlvOUL56XVe00PxuTaVEyj1zAObhRiKF008J5vedmaq7O6ehs+VmPHe8+PUQhMuEyv8d9wQ==",
+      "requires": {
+        "@tanstack/query-core": "5.91.2"
       }
     },
     "@types/babel__core": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-query": "^5.91.2",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Terminal as XTerm } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { ClipboardAddon } from "@xterm/addon-clipboard";
 import "@xterm/xterm/css/xterm.css";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
@@ -18,63 +15,37 @@ import { TerminalPane } from "@/components/app/terminal-pane";
 import {
   type Agent,
   type AgentVisualState,
-  type AuthState,
-  type ConnState,
-  type MediaFile,
-  type ServiceState
+  type ServiceState,
 } from "@/components/app/types";
 import { MobileSlidePanel } from "@/components/ui/mobile-slide-panel";
 import { cn } from "@/lib/utils";
-import {
-  initEnergyMetrics,
-  recordSSEEvent,
-  recordSSEReconnect,
-  recordWSReconnect,
-  recordHTTPRequest,
-  recordHealthPollFire,
-  recordHealthPollSkip,
-} from "@/lib/energy-metrics";
+import { initEnergyMetrics } from "@/lib/energy-metrics";
+import { api } from "@/lib/api";
+import { useAuth } from "@/hooks/use-auth";
+import { useHealth } from "@/hooks/use-health";
+import { useLayout } from "@/hooks/use-layout";
+import { useAgents } from "@/hooks/use-agents";
+import { useSSE } from "@/hooks/use-sse";
+import { useMedia } from "@/hooks/use-media";
+import { useTerminal } from "@/hooks/use-terminal";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
-const LEFT_SIDEBAR_KEY = "dispatch:leftSidebarOpen";
-const LEFT_SIDEBAR_LEGACY_KEY = "hostess:leftSidebarOpen";
-const MEDIA_SIDEBAR_KEY = "dispatch:mediaSidebarOpen";
-const MEDIA_SIDEBAR_LEGACY_KEY = "hostess:mediaSidebarOpen";
 const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
 const CWD_HISTORY_KEY = "dispatch:cwdHistory";
 const CWD_HISTORY_MAX = 20;
-const ACTIVE_SHELL_AGENT_KEY = "dispatch:activeShellAgentId";
-// Chrome Device Toolbar can emulate mobile with a wider layout viewport in some modes.
-// Treat coarse/non-hover input as mobile as well so drawer behavior stays consistent.
-const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px), (pointer: coarse), (hover: none)";
-
-/** Strip terminal line-wrap artifacts from copied text. */
-function cleanCopiedText(text: string): string {
-  const joined = text.replace(/[ \t]*\r?\n[ \t]*/g, "");
-  if (/^https?:\/\//.test(joined) || (/\S/.test(joined) && !joined.includes(" "))) {
-    return joined;
-  }
-  return text;
-}
 
 function readLastUsedCwd(): string {
-  if (typeof window === "undefined") {
-    return "";
-  }
+  if (typeof window === "undefined") return "";
   const stored = window.localStorage.getItem(LAST_USED_CWD_KEY)?.trim();
   return stored && stored.length > 0 ? stored : "~/";
 }
 
 function readCwdHistory(): string[] {
-  if (typeof window === "undefined") {
-    return [];
-  }
+  if (typeof window === "undefined") return [];
   try {
     const raw = window.localStorage.getItem(CWD_HISTORY_KEY);
-    if (!raw) {
-      return [];
-    }
+    if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0) : [];
   } catch {
@@ -84,73 +55,11 @@ function readCwdHistory(): string[] {
 
 function addToCwdHistory(cwd: string): string[] {
   const trimmed = cwd.trim();
-  if (!trimmed) {
-    return readCwdHistory();
-  }
+  if (!trimmed) return readCwdHistory();
   const existing = readCwdHistory().filter((entry) => entry !== trimmed);
   const updated = [trimmed, ...existing].slice(0, CWD_HISTORY_MAX);
   window.localStorage.setItem(CWD_HISTORY_KEY, JSON.stringify(updated));
   return updated;
-}
-
-function readActiveShellAgentId(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  const stored = window.localStorage.getItem(ACTIVE_SHELL_AGENT_KEY)?.trim();
-  return stored && stored.length > 0 ? stored : null;
-}
-
-function persistActiveShellAgentId(agentId: string | null): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-  if (agentId) {
-    window.localStorage.setItem(ACTIVE_SHELL_AGENT_KEY, agentId);
-    return;
-  }
-  window.localStorage.removeItem(ACTIVE_SHELL_AGENT_KEY);
-}
-
-type UiEvent =
-  | { type: "snapshot"; agents: Agent[] }
-  | { type: "agent.upsert"; agent: Agent }
-  | { type: "agent.deleted"; agentId: string }
-  | { type: "media.changed"; agentId: string }
-  | { type: "media.seen"; agentId: string; keys: string[] }
-  | { type: "stream.started"; agentId: string }
-  | { type: "stream.stopped"; agentId: string };
-
-function sortAgentsByCreatedAtDesc(items: Agent[], activeAgentId?: string | null): Agent[] {
-  const eventPriority = (agent: Agent): number => {
-    // The actively connected agent always sorts first.
-    if (activeAgentId && agent.id === activeAgentId) {
-      return -1;
-    }
-    if (agent.latestEvent?.type === "blocked") {
-      return 0;
-    }
-    if (agent.latestEvent?.type === "waiting_user") {
-      return 1;
-    }
-    // Agents with an active session (attachable) sort above stopped/errored ones.
-    if (agent.status === "running" || agent.status === "creating" || agent.status === "stopping") {
-      return 2;
-    }
-    return 3;
-  };
-
-  const latestActivityAt = (agent: Agent): string => {
-    return agent.latestEvent?.updatedAt ?? agent.updatedAt ?? agent.createdAt;
-  };
-
-  return [...items].sort((a, b) => {
-    const priorityDelta = eventPriority(a) - eventPriority(b);
-    if (priorityDelta !== 0) {
-      return priorityDelta;
-    }
-    return latestActivityAt(b).localeCompare(latestActivityAt(a));
-  });
 }
 
 function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): boolean {
@@ -162,28 +71,38 @@ function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): bo
 }
 
 export function App(): JSX.Element {
-  const [authState, setAuthState] = useState<AuthState>("loading");
-  const [agents, setAgents] = useState<Agent[]>([]);
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
-  const [restoreShellAgentId, setRestoreShellAgentId] = useState<string | null>(() => readActiveShellAgentId());
-  const [agentsLoaded, setAgentsLoaded] = useState(false);
+  // ── Auth ──────────────────────────────────────────────────────────────
+  const { authState, handleAuthenticated, handleLogout } = useAuth();
 
-  const [connState, setConnState] = useState<ConnState>("disconnected");
-  const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
-  const [terminalMode, setTerminalMode] = useState<"tmux" | "inert" | null>(null);
-  const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<string | null>(null);
-  const connectedAgentIdRef = useRef<string | null>(null);
-  connectedAgentIdRef.current = connectedAgentId;
+  // ── Layout ────────────────────────────────────────────────────────────
+  const {
+    isMobile,
+    leftOpen,
+    mediaOpen,
+    leftPanelOpen,
+    mediaPanelOpen,
+    mobileLeftOpen,
+    mobileMediaOpen,
+    setLeftOpen,
+    setMediaOpen,
+    setMobileLeftOpen,
+    setMobileMediaOpen,
+    handleSetLeftPanelOpen,
+    handleSetMediaPanelOpen,
+  } = useLayout();
 
-  // Re-sort agents when the connected agent changes so it floats to the top.
-  useEffect(() => {
-    setAgents((current) => sortAgentsByCreatedAtDesc(current, connectedAgentId));
-  }, [connectedAgentId]);
+  // ── Health ────────────────────────────────────────────────────────────
+  const { apiState, dbState } = useHealth(authState === "authenticated");
 
-  const [statusMessage, setStatusMessage] = useState("Starting...");
+  // ── Media ─────────────────────────────────────────────────────────────
+  // (selectedAgentId comes from useAgents below — we forward-declare the ref)
+  const selectedAgentIdRef = useRef<string | null>(null);
 
-  const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
-  const [docsPaneOpen, setDocsPaneOpen] = useState(false);
+  // We need selectedAgentId before calling useMedia, but useAgents needs
+  // connectedAgentId from useTerminal.  Break the cycle by keeping
+  // connectedAgentId in a ref from useTerminal.
+
+  // ── Create dialog state ───────────────────────────────────────────────
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createCwd, setCreateCwd] = useState(() => readLastUsedCwd());
@@ -193,89 +112,169 @@ export function App(): JSX.Element {
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
 
+  // ── Delete dialog state ───────────────────────────────────────────────
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
-  const [leftOpen, setLeftOpen] = useState<boolean>(() => {
-    if (typeof window === "undefined") {
-      return true;
-    }
-    const stored =
-      window.localStorage.getItem(LEFT_SIDEBAR_KEY) ??
-      window.localStorage.getItem(LEFT_SIDEBAR_LEGACY_KEY);
-    return stored === null ? true : stored === "true";
-  });
-  const [mediaOpen, setMediaOpen] = useState<boolean>(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-    const stored =
-      window.localStorage.getItem(MEDIA_SIDEBAR_KEY) ??
-      window.localStorage.getItem(MEDIA_SIDEBAR_LEGACY_KEY);
-    return stored === null ? false : stored === "true";
-  });
-  const [isMobile, setIsMobile] = useState<boolean>(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-    return window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches;
-  });
-  const [mobileLeftOpen, setMobileLeftOpen] = useState(false);
-  const [mobileMediaOpen, setMobileMediaOpen] = useState(false);
-  const leftPanelOpen = isMobile ? mobileLeftOpen : leftOpen;
-  const mediaPanelOpen = isMobile ? mobileMediaOpen : mediaOpen;
-  const [overflowAgentId, setOverflowAgentId] = useState<string | null>(null);
-  const [mediaFiles, setMediaFiles] = useState<MediaFile[]>([]);
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
-  const [lightboxCaption, setLightboxCaption] = useState("");
-  const [seenMediaKeys, setSeenMediaKeys] = useState<Set<string>>(new Set());
-  const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
-  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(new Set());
 
-  const [apiState, setApiState] = useState<ServiceState>("checking");
-  const [dbState, setDbState] = useState<ServiceState>("checking");
-  const [_mediaState, setMediaState] = useState<ServiceState>("checking");
+  // ── Panes ─────────────────────────────────────────────────────────────
+  const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
+  const [docsPaneOpen, setDocsPaneOpen] = useState(false);
 
-  const terminalHostRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<XTerm | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const ctrlPendingRef = useRef(false);
-  const mediaViewportRef = useRef<HTMLDivElement>(null);
+  // ── Agents (placeholder connectedAgentId — filled by terminal hook) ──
+  // We use a temporary variable; useAgents only needs connectedAgentId for
+  // sorting/visual state.  useTerminal returns it.  We'll resolve this by
+  // lifting connectedAgentId as shared state.
+  const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<string | null>(null);
+  const [sharedConnState, setSharedConnState] = useState<"disconnected" | "reconnecting" | "connected">("disconnected");
 
-  const wsRef = useRef<WebSocket | null>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
-  const selectedAgentIdRef = useRef<string | null>(null);
-  const shouldKeepAttachedRef = useRef(false);
-  const reconnectTimerRef = useRef<number | null>(null);
-  const reconnectAttemptsRef = useRef(0);
-  const attachNonceRef = useRef(0);
-  const healthPollTimerRef = useRef<number | null>(null);
-  const clearMediaAnimTimerRef = useRef<number | null>(null);
-  const previousMediaKeysRef = useRef<Set<string>>(new Set());
+  const {
+    agents,
+    agentsLoaded,
+    selectedAgentId,
+    setSelectedAgentId,
+    selectedAgent,
+    connectedAgent,
+    overflowAgentId,
+    setOverflowAgentId,
+    streamingAgentIds,
+    setStreamingAgentIds,
+    agentVisualState,
+    resortAgents,
+  } = useAgents(sharedConnectedAgentId, sharedConnState, authState === "authenticated");
 
-  const selectedAgent = useMemo(
-    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
-    [agents, selectedAgentId]
-  );
+  selectedAgentIdRef.current = selectedAgentId;
 
-  const connectedAgent = useMemo(
-    () => agents.find((agent) => agent.id === connectedAgentId) ?? null,
-    [agents, connectedAgentId]
-  );
+  const {
+    mediaFiles,
+    seenMediaKeys,
+    setSeenMediaKeys,
+    animatingMediaKeys,
+    unseenMediaCount,
+    lightboxSrc,
+    lightboxCaption,
+    setLightboxSrc,
+    setLightboxCaption,
+    openLightbox,
+    mediaViewportRef,
+    refreshMedia,
+  } = useMedia(selectedAgentId, mediaPanelOpen);
 
   const selectedAgentHasStream = selectedAgentId ? streamingAgentIds.has(selectedAgentId) : false;
   const selectedAgentStreamUrl = selectedAgentId ? `/api/v1/agents/${selectedAgentId}/stream` : null;
 
+  // ── Terminal ──────────────────────────────────────────────────────────
+  const onAgentSelected = useCallback(
+    (agentId: string) => {
+      setSelectedAgentId(agentId);
+    },
+    [setSelectedAgentId]
+  );
+
+  const terminal = useTerminal({
+    authState,
+    agents,
+    agentsLoaded,
+    selectedAgentId,
+    isMobile,
+    leftOpen,
+    mediaOpen,
+    onAgentSelected,
+    refreshMedia,
+  });
+
+  // Sync terminal's connectedAgentId/connState into shared state for useAgents.
+  useEffect(() => {
+    setSharedConnectedAgentId(terminal.connectedAgentId);
+  }, [terminal.connectedAgentId]);
+
+  useEffect(() => {
+    setSharedConnState(terminal.connState);
+  }, [terminal.connState]);
+
+  // Re-sort agents when connected agent changes.
+  useEffect(() => {
+    resortAgents();
+  }, [terminal.connectedAgentId, resortAgents]);
+
+  const connectedAgentIdRef = useRef<string | null>(null);
+  connectedAgentIdRef.current = terminal.connectedAgentId;
+
+  // ── SSE ───────────────────────────────────────────────────────────────
+  useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, setSeenMediaKeys);
+
+  // ── Energy metrics ────────────────────────────────────────────────────
+  useEffect(() => {
+    return initEnergyMetrics();
+  }, []);
+
+  // ── Overflow menu close on outside click ──────────────────────────────
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest("[data-radix-popper-content-wrapper]") && !target.closest("[data-agent-control='true']")) {
+        setOverflowAgentId(null);
+      }
+    };
+    window.addEventListener("pointerdown", handlePointerDown);
+    return () => window.removeEventListener("pointerdown", handlePointerDown);
+  }, [setOverflowAgentId]);
+
+  // ── Persist last-used CWD ─────────────────────────────────────────────
+  useEffect(() => {
+    const lastUsedCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
+    if (lastUsedCwd) {
+      window.localStorage.setItem(LAST_USED_CWD_KEY, lastUsedCwd);
+    }
+  }, [connectedAgent, selectedAgent]);
+
+  // ── Fetch system defaults for create dialog CWD ───────────────────────
+  useEffect(() => {
+    if (createCwdInitialized) return;
+    let cancelled = false;
+    void api<{ homeDir: string }>("/api/v1/system/defaults")
+      .then((payload) => {
+        if (cancelled) return;
+        setCreateCwd(payload.homeDir);
+        setCreateCwdInitialized(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCreateCwdInitialized(true);
+      });
+    return () => { cancelled = true; };
+  }, [createCwdInitialized]);
+
+  // ── Initial data load ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (authState !== "authenticated") return;
+    terminal.ensureTerminalConnected;
+  }, [authState, terminal.ensureTerminalConnected]);
+
+  // ── Derived values ────────────────────────────────────────────────────
+  const isAttached = terminal.connState === "connected" && Boolean(terminal.connectedAgentId);
+  const canAttachSelected = Boolean(selectedAgent && selectedAgent.status === "running" && !isAttached);
+  const showHeaderStatus = terminal.connState !== "disconnected";
+
+  const statusText = useMemo(() => {
+    if (terminal.connState === "reconnecting") {
+      if (connectedAgent) return `Reconnecting to session ${connectedAgent.name}...`;
+      return "Reconnecting session...";
+    }
+    if (terminal.connState === "connected" && connectedAgent) {
+      if (connectedAgent.latestEvent?.message) return connectedAgent.latestEvent.message;
+      return `Connected to session ${connectedAgent.name}`;
+    }
+    if (apiState === "down") return "Unable to reach API service.";
+    if (selectedAgent) return `Ready to attach to session ${selectedAgent.name}`;
+    return "Select an agent to open a session.";
+  }, [apiState, connectedAgent, terminal.connState, selectedAgent]);
+
+  // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
     const activeCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
-    if (activeCwd) {
-      return activeCwd;
-    }
-
+    if (activeCwd) return activeCwd;
     const latestAgentCwd = agents[0]?.cwd?.trim();
-    if (latestAgentCwd) {
-      return latestAgentCwd;
-    }
-
+    if (latestAgentCwd) return latestAgentCwd;
     return readLastUsedCwd();
   }, [agents, connectedAgent, selectedAgent]);
 
@@ -284,362 +283,22 @@ export function App(): JSX.Element {
     setCreateOpen(true);
   }, [resolveCreateDefaultCwd]);
 
-  const api = useCallback(async <T,>(path: string, init?: RequestInit): Promise<T> => {
-    const hasBody = init?.body !== undefined && init?.body !== null;
-    const res = await fetch(path, {
-      credentials: "include",
-      headers: {
-        ...(hasBody ? { "content-type": "application/json" } : {}),
-        ...(init?.headers ?? {})
-      },
-      ...init
-    });
-
-    if (res.status === 401) {
-      setAuthState("needs-login");
-      throw new Error("Authentication required.");
-    }
-
-    if (!res.ok) {
-      let message = `${res.status} ${res.statusText}`;
-      try {
-        const payload = (await res.json()) as { error?: string };
-        if (payload.error) {
-          message = payload.error;
-        }
-      } catch {}
-      throw new Error(message);
-    }
-
-    if (res.status === 204) {
-      return null as T;
-    }
-
-    return (await res.json()) as T;
-  }, []);
-
-  const refreshAgents = useCallback(async () => {
-    const payload = await api<{ agents: Agent[] }>("/api/v1/agents");
-    setAgents(sortAgentsByCreatedAtDesc(payload.agents, connectedAgentIdRef.current));
-
-    setSelectedAgentId((current) => {
-      if (current && payload.agents.some((agent) => agent.id === current)) {
-        return current;
-      }
-      return null;
-    });
-  }, [api]);
-
-  const refreshMedia = useCallback(
-    async (agentId?: string | null) => {
-      const id = agentId ?? selectedAgentId;
-      if (!id) {
-        setMediaFiles([]);
-        setSeenMediaKeys(new Set());
-        setMediaState("checking");
-        return;
-      }
-
-      try {
-        const payload = await api<{ files: MediaFile[] }>(`/api/v1/agents/${id}/media`);
-        const files = payload.files ?? [];
-        setMediaFiles(files);
-        setSeenMediaKeys(
-          new Set(
-            files
-              .filter((file) => file.seen === true)
-              .map((file) => `${file.name}:${file.updatedAt}`)
-          )
-        );
-        setMediaState("ok");
-      } catch {
-        setMediaFiles([]);
-        setSeenMediaKeys(new Set());
-        setMediaState("down");
-      }
-    },
-    [api, selectedAgentId]
-  );
-
-  const markMediaSeen = useCallback(
-    async (agentId: string, keys: string[]) => {
-      if (keys.length === 0) {
-        return;
-      }
-
-      try {
-        await api<{ ok: boolean; updated: number }>(`/api/v1/agents/${agentId}/media/seen`, {
-          method: "POST",
-          body: JSON.stringify({ keys })
-        });
-      } catch {}
-    },
-    [api]
-  );
-
-  const pollHealth = useCallback(async () => {
-    if (document.hidden) {
-      recordHealthPollSkip();
-      return;
-    }
-    recordHealthPollFire();
-    recordHTTPRequest();
-    try {
-      const health = await api<{ status: string; db: string }>("/api/v1/health");
-      setApiState(health.status === "ok" ? "ok" : "down");
-      setDbState(health.db === "ok" ? "ok" : "down");
-    } catch {
-      setApiState("down");
-      setDbState("down");
-    }
-  }, [api]);
-
-  const clearReconnectTimer = useCallback(() => {
-    if (reconnectTimerRef.current) {
-      window.clearTimeout(reconnectTimerRef.current);
-      reconnectTimerRef.current = null;
-    }
-  }, []);
-
-  const closeSocket = useCallback((announce = true) => {
-    if (wsRef.current) {
-      try {
-        wsRef.current.close();
-      } catch {}
-      wsRef.current = null;
-    }
-    setConnectedAgentId(null);
-    setTerminalMode(null);
-    setTerminalPlaceholderMessage(null);
-
-    if (announce) {
-      setStatusMessage("Session disconnected.");
-      setConnState("disconnected");
-    }
-  }, []);
-
-  const sendResize = useCallback(() => {
-    const ws = wsRef.current;
-    const term = terminalRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN || !term) {
-      return;
-    }
-
-    ws.send(
-      JSON.stringify({
-        type: "resize",
-        cols: term.cols,
-        rows: term.rows
-      })
-    );
-  }, []);
-
-  const ensureTerminalConnected = useCallback(
-    async (clearScreen = false, userInitiated = false, targetAgentId?: string) => {
-      if (userInitiated) {
-        shouldKeepAttachedRef.current = true;
-      }
-
-      const resolvedAgentId = targetAgentId ?? selectedAgentId;
-      if (!shouldKeepAttachedRef.current || !resolvedAgentId) {
-        return;
-      }
-
-      // For user-initiated attaches the local cache is always fresh (current render).
-      // For timer/focus-driven reconnects the useCallback closure may be stale
-      // (e.g. after a server restart the SSE snapshot updates `agents` but the
-      // reconnect timer still holds an old closure showing "running").  Always
-      // hit the API for reconnects so we can detect a stopped agent and exit
-      // the loop instead of looping on 409s forever.
-      let agent: Agent | null = userInitiated
-        ? (agents.find((item) => item.id === resolvedAgentId) ?? null)
-        : null;
-      if (!agent || agent.status !== "running") {
-        try {
-          const payload = await api<{ agent: Agent }>(
-            `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
-          );
-          agent = payload.agent;
-        } catch {
-          // Server is temporarily unreachable (e.g. mid-deploy). Schedule a
-          // retry so reconnection continues once the server is back up.
-          if (!shouldKeepAttachedRef.current) return;
-          clearReconnectTimer();
-          reconnectAttemptsRef.current += 1;
-          recordWSReconnect();
-          const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
-          setConnState("reconnecting");
-          setStatusMessage("Session disconnected, reconnecting...");
-          reconnectTimerRef.current = window.setTimeout(() => {
-            reconnectTimerRef.current = null;
-            // Don't reconnect while hidden — will resume on visibility change
-            if (document.hidden) return;
-            void ensureTerminalConnected(false, false, resolvedAgentId);
-          }, delay);
-          return;
-        }
-      }
-
-      if (agent.status !== "running") {
-        setConnState("disconnected");
-        return;
-      }
-
-      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        if (connectedAgentId === agent.id) {
-          sendResize();
-          return;
-        }
-      }
-
-      clearReconnectTimer();
-      closeSocket(false);
-
-      if (clearScreen) {
-        terminalRef.current?.clear();
-      }
-
-      fitAddonRef.current?.fit();
-      const attachNonce = ++attachNonceRef.current;
-      setConnState("reconnecting");
-      setStatusMessage(`Connecting to session ${agent.name}...`);
-      const scheduleReconnect = (message: string) => {
-        if (!shouldKeepAttachedRef.current || attachNonce !== attachNonceRef.current) {
-          setConnState("disconnected");
-          return;
-        }
-
-        reconnectAttemptsRef.current += 1;
-        recordWSReconnect();
-        const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
-        setConnState("reconnecting");
-        setStatusMessage(message);
-
-        reconnectTimerRef.current = window.setTimeout(() => {
-          reconnectTimerRef.current = null;
-          // Don't reconnect while hidden — will resume on visibility change
-          if (document.hidden) return;
-          void ensureTerminalConnected(false, false, resolvedAgentId);
-        }, delay);
-      };
-
-      try {
-        const terminalSession = await api<
-          | { mode: "tmux"; token: string; wsUrl: string }
-          | { mode: "inert"; message: string }
-        >(
-          `/api/v1/agents/${agent.id}/terminal/token`,
-          { method: "POST", body: JSON.stringify({}) }
-        );
-
-        if (terminalSession.mode === "inert") {
-          reconnectAttemptsRef.current = 0;
-          setConnState("connected");
-          setConnectedAgentId(agent.id);
-          setTerminalMode("inert");
-          setTerminalPlaceholderMessage(terminalSession.message);
-          setStatusMessage(terminalSession.message);
-          return;
-        }
-
-        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-        const term = terminalRef.current;
-        const cols = term?.cols ?? 140;
-        const rows = term?.rows ?? 42;
-        setTerminalMode("tmux");
-        setTerminalPlaceholderMessage(null);
-        const ws = new WebSocket(
-          `${protocol}//${window.location.host}${terminalSession.wsUrl}&cols=${cols}&rows=${rows}`
-        );
-        wsRef.current = ws;
-
-        ws.addEventListener("open", () => {
-          reconnectAttemptsRef.current = 0;
-          setConnState("connected");
-          setConnectedAgentId(agent.id);
-          setStatusMessage(`Connected to session ${agent.name}`);
-          terminalRef.current?.focus();
-        });
-
-        ws.addEventListener("message", (event) => {
-          const payload = JSON.parse(String(event.data)) as
-            | { type: "output"; data: string }
-            | { type: "error"; message: string }
-            | { type: "exit" };
-
-          if (payload.type === "output") {
-            terminalRef.current?.write(payload.data);
-          } else if (payload.type === "error") {
-            const normalized = payload.message.toLowerCase();
-            if (
-              normalized.includes("session no longer exists") ||
-              normalized.includes("attach failed") ||
-              normalized.includes("invalid or expired terminal token")
-            ) {
-              shouldKeepAttachedRef.current = false;
-            }
-            setStatusMessage(`Session error: ${payload.message}`);
-          } else if (payload.type === "exit") {
-            setStatusMessage("Session ended.");
-          }
-        });
-
-        ws.addEventListener("close", (event) => {
-          if (wsRef.current !== ws) {
-            return;
-          }
-
-          wsRef.current = null;
-
-          if (event.code === 1008 || event.code === 1011) {
-            shouldKeepAttachedRef.current = false;
-            setConnState("disconnected");
-            return;
-          }
-
-          scheduleReconnect("Session disconnected, reconnecting...");
-        });
-      } catch {
-        scheduleReconnect("Session connection failed, retrying...");
-      }
-    },
-    [
-      agents,
-      api,
-      clearReconnectTimer,
-      closeSocket,
-      connectedAgentId,
-      selectedAgentId,
-      sendResize
-    ]
-  );
-
-  const detachTerminal = useCallback(() => {
-    shouldKeepAttachedRef.current = false;
-    persistActiveShellAgentId(null);
-    setRestoreShellAgentId(null);
-    clearReconnectTimer();
-    closeSocket(false);
-    setConnState("disconnected");
-    setStatusMessage("Detached from session.");
-  }, [clearReconnectTimer, closeSocket]);
-
   const toggleAgentDetails = useCallback(
     (agentId: string) => {
       const nextId = selectedAgentId === agentId ? null : agentId;
       setSelectedAgentId(nextId);
-      void refreshMedia(nextId);
+      refreshMedia(nextId);
     },
-    [refreshMedia, selectedAgentId]
+    [refreshMedia, selectedAgentId, setSelectedAgentId]
   );
 
   const attachToAgent = useCallback(
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
-      void refreshMedia(agent.id);
-      await ensureTerminalConnected(true, true, agent.id);
+      refreshMedia(agent.id);
+      await terminal.ensureTerminalConnected(true, true, agent.id);
     },
-    [ensureTerminalConnected, refreshMedia]
+    [terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const startAgent = useCallback(
@@ -647,37 +306,25 @@ export function App(): JSX.Element {
       setSelectedAgentId(agent.id);
       await api(`/api/v1/agents/${agent.id}/start`, {
         method: "POST",
-        body: JSON.stringify({})
+        body: JSON.stringify({}),
       });
-      void refreshMedia(agent.id);
-      await ensureTerminalConnected(true, true, agent.id);
-      void refreshAgents();
-      setStatusMessage(`Started ${agent.name} and attached to session.`);
+      refreshMedia(agent.id);
+      await terminal.ensureTerminalConnected(true, true, agent.id);
     },
-    [api, ensureTerminalConnected, refreshAgents, refreshMedia]
+    [terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const stopAgent = useCallback(
     async (agent: Agent) => {
-      if (connectedAgentId === agent.id) {
-        detachTerminal();
+      if (terminal.connectedAgentId === agent.id) {
+        terminal.detachTerminal();
       }
-
       await api(`/api/v1/agents/${agent.id}/stop`, {
         method: "POST",
-        body: JSON.stringify({ force: true })
+        body: JSON.stringify({ force: true }),
       });
-
-      if (selectedAgentId === agent.id) {
-        closeSocket(false);
-        setConnState("disconnected");
-      }
-
-      await refreshAgents();
-      await refreshMedia();
-      setStatusMessage(`Stopped ${agent.name}.`);
     },
-    [api, closeSocket, connectedAgentId, detachTerminal, refreshAgents, refreshMedia, selectedAgentId]
+    [terminal.connectedAgentId, terminal.detachTerminal]
   );
 
   const deleteAgent = useCallback(
@@ -685,28 +332,18 @@ export function App(): JSX.Element {
       if (agent.status === "running") {
         await api(`/api/v1/agents/${agent.id}/stop`, {
           method: "POST",
-          body: JSON.stringify({ force: true })
+          body: JSON.stringify({ force: true }),
         });
       }
-
       await api(`/api/v1/agents/${agent.id}`, { method: "DELETE" });
-      if (selectedAgentId === agent.id) {
-        closeSocket(false);
-      }
-
-      await refreshAgents();
-      await refreshMedia();
-      setStatusMessage(`Deleted ${agent.name}.`);
     },
-    [api, closeSocket, refreshAgents, refreshMedia, selectedAgentId]
+    []
   );
 
   const handleCreateAgent = useCallback(
     async (event: React.FormEvent) => {
       event.preventDefault();
-      if (!createCwd.trim()) {
-        return;
-      }
+      if (!createCwd.trim()) return;
 
       setCreating(true);
 
@@ -717,8 +354,8 @@ export function App(): JSX.Element {
             name: createName.trim(),
             cwd: createCwd.trim(),
             type: createType,
-            fullAccess: createFullAccess
-          })
+            fullAccess: createFullAccess,
+          }),
         });
 
         setCreateOpen(false);
@@ -727,729 +364,33 @@ export function App(): JSX.Element {
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         setCwdHistory(addToCwdHistory(payload.agent.cwd));
         setSelectedAgentId(payload.agent.id);
-        void refreshMedia(payload.agent.id);
-        await ensureTerminalConnected(true, true, payload.agent.id);
-        void refreshAgents();
-        setStatusMessage(`Created ${payload.agent.name} and attached to session.`);
+        refreshMedia(payload.agent.id);
+        await terminal.ensureTerminalConnected(true, true, payload.agent.id);
       } finally {
         setCreating(false);
       }
     },
-    [api, createCwd, createFullAccess, createName, createType, ensureTerminalConnected, refreshAgents, refreshMedia]
+    [createCwd, createFullAccess, createName, createType, terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
-
-  useEffect(() => {
-    if (createCwdInitialized) {
-      return;
-    }
-
-    let cancelled = false;
-    void api<{ homeDir: string }>("/api/v1/system/defaults")
-      .then((payload) => {
-        if (cancelled) {
-          return;
-        }
-        setCreateCwd(payload.homeDir);
-        setCreateCwdInitialized(true);
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-        setCreateCwdInitialized(true);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [api, createCwdInitialized]);
-
-  useEffect(() => {
-    const host = terminalHostRef.current;
-    if (!host) {
-      return;
-    }
-
-    const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
-
-    const term = new XTerm({
-      convertEol: false,
-      cursorBlink: true,
-      fontFamily: "JetBrains Mono, Menlo, monospace",
-      fontSize: 13,
-      scrollback: 5000,
-      macOptionClickForcesSelection: true,
-      screenReaderMode: isTouchDevice,
-      theme: {
-        foreground: "#f8f8f2",
-        background: "#141414",
-        cursor: "#f8f8f0",
-        cursorAccent: "#141414",
-        selectionBackground: "#49483e",
-        selectionInactiveBackground: "#3e3d32",
-        black: "#141414",
-        red: "#f92672",
-        green: "#a6e22e",
-        yellow: "#f4bf75",
-        blue: "#66d9ef",
-        magenta: "#ae81ff",
-        cyan: "#a1efe4",
-        white: "#f8f8f2",
-        brightBlack: "#75715e",
-        brightRed: "#f92672",
-        brightGreen: "#a6e22e",
-        brightYellow: "#f4bf75",
-        brightBlue: "#66d9ef",
-        brightMagenta: "#ae81ff",
-        brightCyan: "#a1efe4",
-        brightWhite: "#f9f8f5"
-      }
-    });
-
-    const fit = new FitAddon();
-
-    terminalRef.current = term;
-    fitAddonRef.current = fit;
-    term.loadAddon(fit);
-    try { term.loadAddon(new ClipboardAddon()); } catch (e) { console.warn("ClipboardAddon failed:", e); }
-    term.open(host);
-    fit.fit();
-
-    // Intercept copy event to clean terminal line-wrap artifacts
-    const handleCopy = (e: ClipboardEvent) => {
-      if (term.hasSelection()) {
-        e.preventDefault();
-        e.stopPropagation();
-        e.clipboardData?.setData("text/plain", cleanCopiedText(term.getSelection()));
-      }
-    };
-    host.addEventListener("copy", handleCopy, true);
-
-    // Touch scroll: .xterm sets touch-action:none which prevents native
-    // scrolling on mobile. Convert finger drags into synthetic WheelEvents
-    // so tmux enters copy-mode and scrolls its scrollback buffer.
-    const screenEl = host.querySelector(".xterm-screen") as HTMLElement | null;
-    let touchY = 0;
-    let touchAccum = 0;
-    const SCROLL_SENSITIVITY = 30; // px per wheel tick
-    const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length === 1) {
-        touchY = e.touches[0].clientY;
-        touchAccum = 0;
-      }
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      if (e.touches.length !== 1 || !screenEl) return;
-      const currentY = e.touches[0].clientY;
-      const delta = touchY - currentY; // positive = finger up = scroll down
-      touchY = currentY;
-      touchAccum += delta;
-      while (Math.abs(touchAccum) >= SCROLL_SENSITIVITY) {
-        const direction = touchAccum > 0 ? 1 : -1;
-        touchAccum -= direction * SCROLL_SENSITIVITY;
-        screenEl.dispatchEvent(new WheelEvent("wheel", {
-          deltaY: direction * 100,
-          deltaMode: 0,
-          bubbles: true,
-          cancelable: true,
-        }));
-      }
-    };
-    host.addEventListener("touchstart", onTouchStart, { passive: true });
-    host.addEventListener("touchmove", onTouchMove, { passive: true });
-
-    // Enable text selection: intercept mousedown on the terminal screen
-    // and re-dispatch with modifier keys that tell xterm.js to handle
-    // selection locally instead of forwarding mouse events to tmux.
-    // xterm.js shouldForceSelection() checks:
-    //   Mac:     event.altKey && macOptionClickForcesSelection
-    //   Non-Mac: event.shiftKey
-    // We inject both so it works on all platforms.
-    // Wheel events are unaffected — tmux scrollback scrolling still works.
-    let dispatchingMouseDown = false;
-    const onMouseDown = (e: MouseEvent) => {
-      if (dispatchingMouseDown) return;
-      if (e.button !== 0 || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
-      e.stopPropagation();
-      e.preventDefault();
-      dispatchingMouseDown = true;
-      (e.target as HTMLElement).dispatchEvent(new MouseEvent("mousedown", {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        detail: e.detail,
-        screenX: e.screenX,
-        screenY: e.screenY,
-        clientX: e.clientX,
-        clientY: e.clientY,
-        button: e.button,
-        buttons: e.buttons,
-        relatedTarget: e.relatedTarget,
-        shiftKey: true,
-        altKey: true,
-      }));
-      dispatchingMouseDown = false;
-    };
-    if (screenEl) {
-      screenEl.addEventListener("mousedown", onMouseDown, true);
-    }
-
-    const disposable = term.onData((data) => {
-      const ws = wsRef.current;
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
-      if (ctrlPendingRef.current && data.length === 1) {
-        const code = data.toUpperCase().charCodeAt(0);
-        if (code >= 65 && code <= 90) {
-          ctrlPendingRef.current = false;
-          window.dispatchEvent(new Event("ctrl-consumed"));
-          ws.send(JSON.stringify({ type: "input", data: String.fromCharCode(code - 64) }));
-          return;
-        }
-      }
-      ws.send(JSON.stringify({ type: "input", data }));
-    });
-
-    const onResize = () => {
-      fit.fit();
-      sendResize();
-    };
-
-    window.addEventListener("resize", onResize);
-
-    return () => {
-      disposable.dispose();
-      host.removeEventListener("copy", handleCopy, true);
-      host.removeEventListener("touchstart", onTouchStart);
-      host.removeEventListener("touchmove", onTouchMove);
-      if (screenEl) screenEl.removeEventListener("mousedown", onMouseDown, true);
-      window.removeEventListener("resize", onResize);
-      term.dispose();
-      terminalRef.current = null;
-      fitAddonRef.current = null;
-    };
-  }, [authState, sendResize]);
-
-  useEffect(() => {
-    const query = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
-    const onChange = () => setIsMobile(query.matches);
-    onChange();
-    query.addEventListener("change", onChange);
-    return () => {
-      query.removeEventListener("change", onChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    void (async () => {
-      try {
-        const res = await fetch("/api/v1/auth/status", { credentials: "include" });
-        if (!res.ok) {
-          setAuthState("needs-login");
-          return;
-        }
-        const data = (await res.json()) as { passwordSet: boolean; authenticated: boolean };
-        if (data.passwordSet && !data.authenticated) {
-          setAuthState("needs-login");
-        } else {
-          // No password set = open access; or already authenticated.
-          setAuthState("authenticated");
-        }
-      } catch {
-        // Server unreachable — let the main app render so health polling shows the issue.
-        setAuthState("authenticated");
-      }
-    })();
-  }, []);
-
-  useEffect(() => {
-    if (authState !== "authenticated") return;
-    void (async () => {
-      await Promise.all([pollHealth(), refreshAgents()]);
-      setAgentsLoaded(true);
-      setStatusMessage("Select an agent to open a session.");
-    })();
-  }, [authState, pollHealth, refreshAgents]);
-
-  // Energy metrics tracker — persists to localStorage and beacons to backend
-  useEffect(() => {
-    return initEnergyMetrics();
-  }, []);
-
-  useEffect(() => {
-    if (!agentsLoaded || !restoreShellAgentId) {
-      return;
-    }
-
-    const restoreTarget = agents.find((agent) => agent.id === restoreShellAgentId);
-    if (!restoreTarget || restoreTarget.status !== "running") {
-      persistActiveShellAgentId(null);
-      setRestoreShellAgentId(null);
-      return;
-    }
-
-    setSelectedAgentId(restoreTarget.id);
-    void refreshMedia(restoreTarget.id);
-    void ensureTerminalConnected(true, true, restoreTarget.id);
-    setStatusMessage(`Restored session for ${restoreTarget.name}.`);
-    setRestoreShellAgentId(null);
-  }, [agents, agentsLoaded, ensureTerminalConnected, refreshMedia, restoreShellAgentId]);
-
-  useEffect(() => {
-    void refreshMedia();
-  }, [refreshMedia]);
-
-  useEffect(() => {
-    const startPoll = () => {
-      if (healthPollTimerRef.current) {
-        window.clearInterval(healthPollTimerRef.current);
-      }
-      healthPollTimerRef.current = window.setInterval(() => {
-        void pollHealth();
-      }, 8000);
-    };
-
-    const stopPoll = () => {
-      if (healthPollTimerRef.current) {
-        window.clearInterval(healthPollTimerRef.current);
-        healthPollTimerRef.current = null;
-      }
-    };
-
-    // Start polling only when visible
-    if (!document.hidden) {
-      startPoll();
-    }
-
-    const onVisChange = () => {
-      if (document.hidden) {
-        stopPoll();
-      } else {
-        void pollHealth(); // immediate check on resume
-        startPoll();
-      }
-    };
-
-    document.addEventListener("visibilitychange", onVisChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVisChange);
-      stopPoll();
-    };
-  }, [pollHealth]);
-
-  useEffect(() => {
-    selectedAgentIdRef.current = selectedAgentId;
-  }, [selectedAgentId]);
-
-  useEffect(() => {
-    const handleSSEMessage = (event: MessageEvent) => {
-      try {
-        recordSSEEvent();
-        const payload = JSON.parse(event.data) as UiEvent;
-
-        if (payload.type === "snapshot") {
-          setAgents(sortAgentsByCreatedAtDesc(payload.agents, connectedAgentIdRef.current));
-          setStreamingAgentIds(
-            new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
-          );
-          return;
-        }
-
-        if (payload.type === "agent.upsert") {
-          setAgents((current) => {
-            const index = current.findIndex((agent) => agent.id === payload.agent.id);
-            if (index === -1) {
-              return sortAgentsByCreatedAtDesc([payload.agent, ...current], connectedAgentIdRef.current);
-            }
-            const next = [...current];
-            next[index] = payload.agent;
-            return sortAgentsByCreatedAtDesc(next, connectedAgentIdRef.current);
-          });
-          return;
-        }
-
-        if (payload.type === "agent.deleted") {
-          setAgents((current) => current.filter((agent) => agent.id !== payload.agentId));
-          return;
-        }
-
-        if (payload.type === "media.changed" && payload.agentId === selectedAgentIdRef.current) {
-          void refreshMedia(payload.agentId);
-          return;
-        }
-
-        if (payload.type === "stream.started") {
-          setStreamingAgentIds((current) => {
-            if (current.has(payload.agentId)) return current;
-            const next = new Set(current);
-            next.add(payload.agentId);
-            return next;
-          });
-          return;
-        }
-
-        if (payload.type === "stream.stopped") {
-          setStreamingAgentIds((current) => {
-            if (!current.has(payload.agentId)) return current;
-            const next = new Set(current);
-            next.delete(payload.agentId);
-            return next;
-          });
-          return;
-        }
-
-        if (payload.type === "media.seen" && payload.agentId === selectedAgentIdRef.current) {
-          setSeenMediaKeys((current) => {
-            const next = new Set(current);
-            let changed = false;
-
-            for (const key of payload.keys) {
-              if (!next.has(key)) {
-                next.add(key);
-                changed = true;
-              }
-            }
-
-            return changed ? next : current;
-          });
-        }
-      } catch {}
-    };
-
-    const openSSE = () => {
-      if (eventSourceRef.current) return;
-      const source = new EventSource("/api/v1/events", { withCredentials: true });
-      eventSourceRef.current = source;
-      source.onmessage = handleSSEMessage;
-      source.onerror = () => {
-        recordSSEReconnect();
-      };
-    };
-
-    const closeSSE = () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
-      }
-    };
-
-    // Only connect when visible and authenticated
-    if (!document.hidden && authState === "authenticated") {
-      openSSE();
-    }
-
-    const onVisChange = () => {
-      if (document.hidden || authState !== "authenticated") {
-        closeSSE();
-      } else {
-        openSSE();
-      }
-    };
-
-    document.addEventListener("visibilitychange", onVisChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVisChange);
-      closeSSE();
-    };
-  }, [authState, refreshMedia]);
-
-  useEffect(() => {
-    setSelectedAgentId((current) => {
-      if (current && agents.some((agent) => agent.id === current)) {
-        return current;
-      }
-      return null;
-    });
-  }, [agents]);
-
-  useEffect(() => {
-    const onVisible = () => {
-      if (!document.hidden) {
-        void ensureTerminalConnected(false, false, connectedAgentId ?? selectedAgentId ?? undefined);
-      }
-    };
-
-    const onFocus = () => {
-      void ensureTerminalConnected(false, false, connectedAgentId ?? selectedAgentId ?? undefined);
-    };
-
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", onFocus);
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [connectedAgentId, ensureTerminalConnected, selectedAgentId]);
-
-  useEffect(() => {
-    if (isMobile) {
-      return;
-    }
-    const fitNow = () => {
-      fitAddonRef.current?.fit();
-      sendResize();
-    };
-
-    fitNow();
-    const timer = window.setTimeout(fitNow, 340);
-    return () => window.clearTimeout(timer);
-  }, [isMobile, leftOpen, mediaOpen, sendResize]);
-
-  useEffect(() => {
-    setSeenMediaKeys(new Set());
-  }, [selectedAgentId]);
-
-  useEffect(() => {
-    const nextKeys = mediaFiles.map((file) => `${file.name}:${file.updatedAt}`);
-    const prevKeys = previousMediaKeysRef.current;
-
-    if (prevKeys.size > 0) {
-      const incoming = nextKeys.filter((key) => !prevKeys.has(key));
-      if (incoming.length > 0) {
-        setAnimatingMediaKeys(new Set(incoming));
-
-        if (clearMediaAnimTimerRef.current) {
-          window.clearTimeout(clearMediaAnimTimerRef.current);
-        }
-        clearMediaAnimTimerRef.current = window.setTimeout(() => {
-          setAnimatingMediaKeys(new Set());
-          clearMediaAnimTimerRef.current = null;
-        }, 2200);
-      }
-    }
-
-    previousMediaKeysRef.current = new Set(nextKeys);
-
-    return () => {
-      if (clearMediaAnimTimerRef.current) {
-        window.clearTimeout(clearMediaAnimTimerRef.current);
-        clearMediaAnimTimerRef.current = null;
-      }
-    };
-  }, [mediaFiles]);
-
-  useEffect(() => {
-    if (!mediaPanelOpen) {
-      return;
-    }
-
-    const root = mediaViewportRef.current;
-    const selected = selectedAgentId;
-    if (!root || !selected) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const newlySeen: string[] = [];
-        setSeenMediaKeys((current) => {
-          let changed = false;
-          const next = new Set(current);
-
-          for (const entry of entries) {
-            if (entry.isIntersecting) {
-              const mediaKey = (entry.target as HTMLElement).dataset.mediaKey;
-              if (mediaKey && !next.has(mediaKey)) {
-                next.add(mediaKey);
-                newlySeen.push(mediaKey);
-                changed = true;
-              }
-            }
-          }
-
-          return changed ? next : current;
-        });
-
-        if (newlySeen.length > 0) {
-          void markMediaSeen(selected, newlySeen);
-        }
-      },
-      {
-        root,
-        threshold: 0.65
-      }
-    );
-
-    const nodes = root.querySelectorAll<HTMLElement>("[data-media-key]");
-    nodes.forEach((node) => observer.observe(node));
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [markMediaSeen, mediaFiles, mediaPanelOpen, selectedAgentId]);
-
-  useEffect(() => {
-    // Close the overflow menu when the user clicks outside of it.
-    // Radix DropdownMenu handles portal-rendered content internally,
-    // so we only need to clear our synced state on outside clicks.
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target as HTMLElement;
-      if (!target.closest("[data-radix-popper-content-wrapper]") && !target.closest("[data-agent-control='true']")) {
-        setOverflowAgentId(null);
-      }
-    };
-
-    window.addEventListener("pointerdown", handlePointerDown);
-    return () => {
-      window.removeEventListener("pointerdown", handlePointerDown);
-    };
-  }, []);
-
-  useEffect(() => {
-    const lastUsedCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
-    if (lastUsedCwd) {
-      window.localStorage.setItem(LAST_USED_CWD_KEY, lastUsedCwd);
-    }
-  }, [connectedAgent, selectedAgent]);
-
-  useEffect(() => {
-    const value = String(leftOpen);
-    window.localStorage.setItem(LEFT_SIDEBAR_KEY, value);
-    window.localStorage.setItem(LEFT_SIDEBAR_LEGACY_KEY, value);
-  }, [leftOpen]);
-
-  useEffect(() => {
-    const value = String(mediaOpen);
-    window.localStorage.setItem(MEDIA_SIDEBAR_KEY, value);
-    window.localStorage.setItem(MEDIA_SIDEBAR_LEGACY_KEY, value);
-  }, [mediaOpen]);
-
-  useEffect(() => {
-    if (connState === "connected" && connectedAgentId) {
-      persistActiveShellAgentId(connectedAgentId);
-      return;
-    }
-    if (connState === "disconnected" && !restoreShellAgentId) {
-      persistActiveShellAgentId(null);
-    }
-  }, [connState, connectedAgentId, restoreShellAgentId]);
-
-  const isAttached = connState === "connected" && Boolean(connectedAgentId);
-  const canAttachSelected = Boolean(selectedAgent && selectedAgent.status === "running" && !isAttached);
-  const showHeaderStatus = connState !== "disconnected";
-
-  const handleSetLeftPanelOpen = useCallback(
-    (open: boolean) => {
-      if (isMobile) {
-        if (open) {
-          setMobileMediaOpen(false);
-        }
-        setMobileLeftOpen(open);
-        return;
-      }
-      setLeftOpen(open);
-    },
-    [isMobile]
-  );
-
-  const handleSetMediaPanelOpen = useCallback(
-    (open: boolean) => {
-      if (isMobile) {
-        if (open) {
-          setMobileLeftOpen(false);
-        }
-        setMobileMediaOpen(open);
-        return;
-      }
-      setMediaOpen(open);
-    },
-    [isMobile]
-  );
-
-  useEffect(() => {
-    if (!isMobile) {
-      setMobileLeftOpen(false);
-      setMobileMediaOpen(false);
-    }
-  }, [isMobile]);
-
-  const statusText = useMemo(() => {
-    if (connState === "reconnecting") {
-      if (connectedAgent) {
-        return `Reconnecting to session ${connectedAgent.name}...`;
-      }
-      return "Reconnecting session...";
-    }
-
-    if (connState === "connected" && connectedAgent) {
-      if (connectedAgent.latestEvent?.message) {
-        return connectedAgent.latestEvent.message;
-      }
-      return `Connected to session ${connectedAgent.name}`;
-    }
-
-    if (apiState === "down") {
-      return "Unable to reach API service.";
-    }
-
-    if (selectedAgent) {
-      return `Ready to attach to session ${selectedAgent.name}`;
-    }
-
-    return "Select an agent to open a session.";
-  }, [apiState, connectedAgent, connState, selectedAgent]);
 
   const attachSelectedAgent = useCallback(() => {
-    if (!selectedAgent || selectedAgent.status !== "running") {
-      return;
-    }
+    if (!selectedAgent || selectedAgent.status !== "running") return;
     void attachToAgent(selectedAgent);
   }, [attachToAgent, selectedAgent]);
 
-  const sendTerminalInput = useCallback((data: string) => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      return;
-    }
-    ws.send(JSON.stringify({ type: "input", data }));
-    terminalRef.current?.focus();
-  }, []);
-
-  const agentVisualState = useCallback(
-    (agent: Agent): AgentVisualState => {
-      if (agent.status !== "running") {
-        return "stopped";
-      }
-      if (connState === "connected" && connectedAgentId === agent.id) {
-        return "active";
-      }
-      return "idle";
-    },
-    [connState, connectedAgentId]
-  );
-
   const borderForAgentState = (state: AgentVisualState): string => {
-    if (state === "active") {
-      return "border-r-emerald-500";
-    }
-    if (state === "idle") {
-      return "border-r-sky-300";
-    }
+    if (state === "active") return "border-r-emerald-500";
+    if (state === "idle") return "border-r-sky-300";
     return "border-r-zinc-500";
   };
 
-  const unseenMediaCount = useMemo(() => {
-    return mediaFiles.filter((file) => !seenMediaKeys.has(`${file.name}:${file.updatedAt}`)).length;
-  }, [mediaFiles, seenMediaKeys]);
-
   const serviceDotClass = (state: ServiceState): string => {
-    if (state === "ok") {
-      return "bg-emerald-500";
-    }
-    if (state === "down") {
-      return "bg-red-500";
-    }
+    if (state === "ok") return "bg-emerald-500";
+    if (state === "down") return "bg-red-500";
     return "bg-amber-500";
   };
 
-  const handleAuthenticated = useCallback(() => setAuthState("authenticated"), []);
-  const handleLogout = useCallback(async () => {
-    await fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" });
-    setAuthState("needs-login");
-  }, []);
-
+  // ── Render ────────────────────────────────────────────────────────────
   if (authState === "loading") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
@@ -1483,7 +424,7 @@ export function App(): JSX.Element {
               borderForAgentState={borderForAgentState}
               toggleAgentDetails={toggleAgentDetails}
               isFullAccessEnabled={isFullAccessEnabled}
-              detachTerminal={detachTerminal}
+              detachTerminal={terminal.detachTerminal}
               attachToAgent={attachToAgent}
               stopAgent={stopAgent}
               startAgent={startAgent}
@@ -1506,30 +447,30 @@ export function App(): JSX.Element {
               isMobile={isMobile}
               showHeaderStatus={showHeaderStatus}
               statusText={statusText}
-              showReconnectIndicator={connState === "reconnecting"}
+              showReconnectIndicator={terminal.connState === "reconnecting"}
               isAttached={isAttached}
               canAttachSelected={canAttachSelected}
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}
               setMediaOpen={handleSetMediaPanelOpen}
               attachSelectedAgent={attachSelectedAgent}
-              detachTerminal={detachTerminal}
+              detachTerminal={terminal.detachTerminal}
             />
 
             <TerminalPane
               isAttached={isAttached}
               hasSelectedAgent={Boolean(selectedAgentId)}
-              connState={connState}
-              statusMessage={statusMessage}
-              terminalMode={terminalMode}
-              terminalPlaceholderMessage={terminalPlaceholderMessage}
-              terminalHostRef={terminalHostRef}
+              connState={terminal.connState}
+              statusMessage={terminal.statusMessage}
+              terminalMode={terminal.terminalMode}
+              terminalPlaceholderMessage={terminal.terminalPlaceholderMessage}
+              terminalHostRef={terminal.terminalHostRef}
             />
 
-            {isMobile ? <MobileTerminalToolbar onSendInput={sendTerminalInput} ctrlPendingRef={ctrlPendingRef} /> : null}
+            {isMobile ? <MobileTerminalToolbar onSendInput={terminal.sendTerminalInput} ctrlPendingRef={terminal.ctrlPendingRef} /> : null}
 
             <StatusFooter
-              connState={connState}
+              connState={terminal.connState}
               apiState={apiState}
               dbState={dbState}
               serviceDotClass={serviceDotClass}
@@ -1549,10 +490,7 @@ export function App(): JSX.Element {
             setMediaOpen={setMediaOpen}
             hasStream={selectedAgentHasStream}
             streamUrl={selectedAgentStreamUrl}
-            openLightbox={(src, caption) => {
-              setLightboxSrc(src);
-              setLightboxCaption(caption);
-            }}
+            openLightbox={openLightbox}
           />
         </div>
       </div>
@@ -1563,9 +501,7 @@ export function App(): JSX.Element {
           side="left"
           label="Agent sidebar"
           onOpenChange={(open) => {
-            if (open) {
-              setMobileMediaOpen(false);
-            }
+            if (open) setMobileMediaOpen(false);
             setMobileLeftOpen(open);
           }}
         >
@@ -1583,7 +519,7 @@ export function App(): JSX.Element {
             borderForAgentState={borderForAgentState}
             toggleAgentDetails={toggleAgentDetails}
             isFullAccessEnabled={isFullAccessEnabled}
-            detachTerminal={detachTerminal}
+            detachTerminal={terminal.detachTerminal}
             attachToAgent={attachToAgent}
             stopAgent={stopAgent}
             startAgent={startAgent}
@@ -1599,9 +535,7 @@ export function App(): JSX.Element {
           side="right"
           label="Media sidebar"
           onOpenChange={(open) => {
-            if (open) {
-              setMobileLeftOpen(false);
-            }
+            if (open) setMobileLeftOpen(false);
             setMobileMediaOpen(open);
           }}
         >
@@ -1614,10 +548,7 @@ export function App(): JSX.Element {
               mediaViewportRef={mediaViewportRef}
               hasStream={selectedAgentHasStream}
               streamUrl={selectedAgentStreamUrl}
-              openLightbox={(src, caption) => {
-                setLightboxSrc(src);
-                setLightboxCaption(caption);
-              }}
+              openLightbox={openLightbox}
               onRequestClose={() => setMobileMediaOpen(false)}
             />
         </MobileSlidePanel>
@@ -1657,7 +588,7 @@ export function App(): JSX.Element {
       />
 
       <div className="sr-only" aria-live="polite">
-        {statusMessage}
+        {terminal.statusMessage}
       </div>
     </div>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -153,7 +153,6 @@ export function App(): JSX.Element {
     lightboxSrc,
     lightboxCaption,
     setLightboxSrc,
-    setLightboxCaption,
     openLightbox,
     mediaViewportRef,
     refreshMedia,
@@ -170,7 +169,18 @@ export function App(): JSX.Element {
     [setSelectedAgentId]
   );
 
-  const terminal = useTerminal({
+  const {
+    connState,
+    connectedAgentId,
+    terminalMode,
+    terminalPlaceholderMessage,
+    statusMessage,
+    terminalHostRef,
+    ctrlPendingRef,
+    ensureTerminalConnected,
+    detachTerminal,
+    sendTerminalInput,
+  } = useTerminal({
     authState,
     agents,
     agentsLoaded,
@@ -184,20 +194,20 @@ export function App(): JSX.Element {
 
   // Sync terminal's connectedAgentId/connState into shared state for useAgents.
   useEffect(() => {
-    setSharedConnectedAgentId(terminal.connectedAgentId);
-  }, [terminal.connectedAgentId]);
+    setSharedConnectedAgentId(connectedAgentId);
+  }, [connectedAgentId]);
 
   useEffect(() => {
-    setSharedConnState(terminal.connState);
-  }, [terminal.connState]);
+    setSharedConnState(connState);
+  }, [connState]);
 
   // Re-sort agents when connected agent changes.
   useEffect(() => {
     resortAgents();
-  }, [terminal.connectedAgentId, resortAgents]);
+  }, [connectedAgentId, resortAgents]);
 
   const connectedAgentIdRef = useRef<string | null>(null);
-  connectedAgentIdRef.current = terminal.connectedAgentId;
+  connectedAgentIdRef.current = connectedAgentId;
 
   // ── SSE ───────────────────────────────────────────────────────────────
   useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, setSeenMediaKeys);
@@ -244,30 +254,24 @@ export function App(): JSX.Element {
     return () => { cancelled = true; };
   }, [createCwdInitialized]);
 
-  // ── Initial data load ─────────────────────────────────────────────────
-  useEffect(() => {
-    if (authState !== "authenticated") return;
-    terminal.ensureTerminalConnected;
-  }, [authState, terminal.ensureTerminalConnected]);
-
   // ── Derived values ────────────────────────────────────────────────────
-  const isAttached = terminal.connState === "connected" && Boolean(terminal.connectedAgentId);
+  const isAttached = connState === "connected" && Boolean(connectedAgentId);
   const canAttachSelected = Boolean(selectedAgent && selectedAgent.status === "running" && !isAttached);
-  const showHeaderStatus = terminal.connState !== "disconnected";
+  const showHeaderStatus = connState !== "disconnected";
 
   const statusText = useMemo(() => {
-    if (terminal.connState === "reconnecting") {
+    if (connState === "reconnecting") {
       if (connectedAgent) return `Reconnecting to session ${connectedAgent.name}...`;
       return "Reconnecting session...";
     }
-    if (terminal.connState === "connected" && connectedAgent) {
+    if (connState === "connected" && connectedAgent) {
       if (connectedAgent.latestEvent?.message) return connectedAgent.latestEvent.message;
       return `Connected to session ${connectedAgent.name}`;
     }
     if (apiState === "down") return "Unable to reach API service.";
     if (selectedAgent) return `Ready to attach to session ${selectedAgent.name}`;
     return "Select an agent to open a session.";
-  }, [apiState, connectedAgent, terminal.connState, selectedAgent]);
+  }, [apiState, connectedAgent, connState, selectedAgent]);
 
   // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
@@ -296,9 +300,9 @@ export function App(): JSX.Element {
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
       refreshMedia(agent.id);
-      await terminal.ensureTerminalConnected(true, true, agent.id);
+      await ensureTerminalConnected(true, true, agent.id);
     },
-    [terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const startAgent = useCallback(
@@ -309,22 +313,22 @@ export function App(): JSX.Element {
         body: JSON.stringify({}),
       });
       refreshMedia(agent.id);
-      await terminal.ensureTerminalConnected(true, true, agent.id);
+      await ensureTerminalConnected(true, true, agent.id);
     },
-    [terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const stopAgent = useCallback(
     async (agent: Agent) => {
-      if (terminal.connectedAgentId === agent.id) {
-        terminal.detachTerminal();
+      if (connectedAgentId === agent.id) {
+        detachTerminal();
       }
       await api(`/api/v1/agents/${agent.id}/stop`, {
         method: "POST",
         body: JSON.stringify({ force: true }),
       });
     },
-    [terminal.connectedAgentId, terminal.detachTerminal]
+    [connectedAgentId, detachTerminal]
   );
 
   const deleteAgent = useCallback(
@@ -365,12 +369,12 @@ export function App(): JSX.Element {
         setCwdHistory(addToCwdHistory(payload.agent.cwd));
         setSelectedAgentId(payload.agent.id);
         refreshMedia(payload.agent.id);
-        await terminal.ensureTerminalConnected(true, true, payload.agent.id);
+        await ensureTerminalConnected(true, true, payload.agent.id);
       } finally {
         setCreating(false);
       }
     },
-    [createCwd, createFullAccess, createName, createType, terminal.ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [createCwd, createFullAccess, createName, createType, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const attachSelectedAgent = useCallback(() => {
@@ -424,7 +428,7 @@ export function App(): JSX.Element {
               borderForAgentState={borderForAgentState}
               toggleAgentDetails={toggleAgentDetails}
               isFullAccessEnabled={isFullAccessEnabled}
-              detachTerminal={terminal.detachTerminal}
+              detachTerminal={detachTerminal}
               attachToAgent={attachToAgent}
               stopAgent={stopAgent}
               startAgent={startAgent}
@@ -447,30 +451,30 @@ export function App(): JSX.Element {
               isMobile={isMobile}
               showHeaderStatus={showHeaderStatus}
               statusText={statusText}
-              showReconnectIndicator={terminal.connState === "reconnecting"}
+              showReconnectIndicator={connState === "reconnecting"}
               isAttached={isAttached}
               canAttachSelected={canAttachSelected}
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}
               setMediaOpen={handleSetMediaPanelOpen}
               attachSelectedAgent={attachSelectedAgent}
-              detachTerminal={terminal.detachTerminal}
+              detachTerminal={detachTerminal}
             />
 
             <TerminalPane
               isAttached={isAttached}
               hasSelectedAgent={Boolean(selectedAgentId)}
-              connState={terminal.connState}
-              statusMessage={terminal.statusMessage}
-              terminalMode={terminal.terminalMode}
-              terminalPlaceholderMessage={terminal.terminalPlaceholderMessage}
-              terminalHostRef={terminal.terminalHostRef}
+              connState={connState}
+              statusMessage={statusMessage}
+              terminalMode={terminalMode}
+              terminalPlaceholderMessage={terminalPlaceholderMessage}
+              terminalHostRef={terminalHostRef}
             />
 
-            {isMobile ? <MobileTerminalToolbar onSendInput={terminal.sendTerminalInput} ctrlPendingRef={terminal.ctrlPendingRef} /> : null}
+            {isMobile ? <MobileTerminalToolbar onSendInput={sendTerminalInput} ctrlPendingRef={ctrlPendingRef} /> : null}
 
             <StatusFooter
-              connState={terminal.connState}
+              connState={connState}
               apiState={apiState}
               dbState={dbState}
               serviceDotClass={serviceDotClass}
@@ -519,7 +523,7 @@ export function App(): JSX.Element {
             borderForAgentState={borderForAgentState}
             toggleAgentDetails={toggleAgentDetails}
             isFullAccessEnabled={isFullAccessEnabled}
-            detachTerminal={terminal.detachTerminal}
+            detachTerminal={detachTerminal}
             attachToAgent={attachToAgent}
             stopAgent={stopAgent}
             startAgent={startAgent}
@@ -588,7 +592,7 @@ export function App(): JSX.Element {
       />
 
       <div className="sr-only" aria-live="polite">
-        {terminal.statusMessage}
+        {statusMessage}
       </div>
     </div>
   );

--- a/web/src/components/app/terminal-pane.tsx
+++ b/web/src/components/app/terminal-pane.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useState } from "react";
+import { memo, type RefObject, useEffect, useState } from "react";
 import { Loader2, TerminalSquare } from "lucide-react";
 
 import { type ConnState } from "@/components/app/types";
@@ -14,7 +14,7 @@ type TerminalPaneProps = {
   terminalHostRef: RefObject<HTMLDivElement>;
 };
 
-export function TerminalPane({
+export const TerminalPane = memo(function TerminalPane({
   isAttached,
   hasSelectedAgent,
   connState,
@@ -85,4 +85,4 @@ export function TerminalPane({
       ) : null}
     </div>
   );
-}
+});

--- a/web/src/hooks/use-agents.ts
+++ b/web/src/hooks/use-agents.ts
@@ -1,0 +1,107 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type Agent,
+  type AgentVisualState,
+  type ConnState,
+} from "@/components/app/types";
+import { api } from "@/lib/api";
+
+function sortAgentsByCreatedAtDesc(items: Agent[], activeAgentId?: string | null): Agent[] {
+  const eventPriority = (agent: Agent): number => {
+    if (activeAgentId && agent.id === activeAgentId) return -1;
+    if (agent.latestEvent?.type === "blocked") return 0;
+    if (agent.latestEvent?.type === "waiting_user") return 1;
+    if (agent.status === "running" || agent.status === "creating" || agent.status === "stopping") return 2;
+    return 3;
+  };
+
+  const latestActivityAt = (agent: Agent): string =>
+    agent.latestEvent?.updatedAt ?? agent.updatedAt ?? agent.createdAt;
+
+  return [...items].sort((a, b) => {
+    const priorityDelta = eventPriority(a) - eventPriority(b);
+    if (priorityDelta !== 0) return priorityDelta;
+    return latestActivityAt(b).localeCompare(latestActivityAt(a));
+  });
+}
+
+export { sortAgentsByCreatedAtDesc };
+
+export function useAgents(
+  connectedAgentId: string | null,
+  connState: ConnState,
+  enabled: boolean,
+) {
+  const queryClient = useQueryClient();
+  const connectedAgentIdRef = useRef(connectedAgentId);
+  connectedAgentIdRef.current = connectedAgentId;
+
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [overflowAgentId, setOverflowAgentId] = useState<string | null>(null);
+  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(new Set());
+
+  const { data: agents = [], isSuccess: agentsLoaded } = useQuery<Agent[]>({
+    queryKey: ["agents"],
+    queryFn: async () => {
+      const payload = await api<{ agents: Agent[] }>("/api/v1/agents");
+      return payload.agents;
+    },
+    select: (data) => sortAgentsByCreatedAtDesc(data, connectedAgentIdRef.current),
+    enabled,
+  });
+
+  // Re-sort when connected agent changes (so it floats to top).
+  const resortAgents = useCallback(() => {
+    queryClient.setQueryData<Agent[]>(["agents"], (old) =>
+      old ? sortAgentsByCreatedAtDesc(old, connectedAgentIdRef.current) : old
+    );
+  }, [queryClient]);
+
+  // Validate selectedAgentId against current agent list.
+  const validatedSelectedAgentId = useMemo(() => {
+    if (selectedAgentId && agents.some((a) => a.id === selectedAgentId)) {
+      return selectedAgentId;
+    }
+    return null;
+  }, [agents, selectedAgentId]);
+
+  // If validation changed the value, sync local state.
+  if (validatedSelectedAgentId !== selectedAgentId) {
+    setSelectedAgentId(validatedSelectedAgentId);
+  }
+
+  const selectedAgent = useMemo(
+    () => agents.find((a) => a.id === validatedSelectedAgentId) ?? null,
+    [agents, validatedSelectedAgentId]
+  );
+
+  const connectedAgent = useMemo(
+    () => agents.find((a) => a.id === connectedAgentId) ?? null,
+    [agents, connectedAgentId]
+  );
+
+  const agentVisualState = useCallback(
+    (agent: Agent): AgentVisualState => {
+      if (agent.status !== "running") return "stopped";
+      if (connState === "connected" && connectedAgentId === agent.id) return "active";
+      return "idle";
+    },
+    [connState, connectedAgentId]
+  );
+
+  return {
+    agents,
+    agentsLoaded,
+    selectedAgentId: validatedSelectedAgentId,
+    setSelectedAgentId,
+    selectedAgent,
+    connectedAgent,
+    overflowAgentId,
+    setOverflowAgentId,
+    streamingAgentIds,
+    setStreamingAgentIds,
+    agentVisualState,
+    resortAgents,
+  };
+}

--- a/web/src/hooks/use-agents.ts
+++ b/web/src/hooks/use-agents.ts
@@ -70,7 +70,7 @@ export function useAgents(
     [connState, connectedAgentId]
   );
 
-  return {
+  return useMemo(() => ({
     agents,
     agentsLoaded,
     selectedAgentId: validatedSelectedAgentId,
@@ -83,5 +83,15 @@ export function useAgents(
     setStreamingAgentIds,
     agentVisualState,
     resortAgents,
-  };
+  }), [
+    agents,
+    agentsLoaded,
+    validatedSelectedAgentId,
+    selectedAgent,
+    connectedAgent,
+    overflowAgentId,
+    streamingAgentIds,
+    agentVisualState,
+    resortAgents,
+  ]);
 }

--- a/web/src/hooks/use-agents.ts
+++ b/web/src/hooks/use-agents.ts
@@ -5,28 +5,8 @@ import {
   type AgentVisualState,
   type ConnState,
 } from "@/components/app/types";
+import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { api } from "@/lib/api";
-
-function sortAgentsByCreatedAtDesc(items: Agent[], activeAgentId?: string | null): Agent[] {
-  const eventPriority = (agent: Agent): number => {
-    if (activeAgentId && agent.id === activeAgentId) return -1;
-    if (agent.latestEvent?.type === "blocked") return 0;
-    if (agent.latestEvent?.type === "waiting_user") return 1;
-    if (agent.status === "running" || agent.status === "creating" || agent.status === "stopping") return 2;
-    return 3;
-  };
-
-  const latestActivityAt = (agent: Agent): string =>
-    agent.latestEvent?.updatedAt ?? agent.updatedAt ?? agent.createdAt;
-
-  return [...items].sort((a, b) => {
-    const priorityDelta = eventPriority(a) - eventPriority(b);
-    if (priorityDelta !== 0) return priorityDelta;
-    return latestActivityAt(b).localeCompare(latestActivityAt(a));
-  });
-}
-
-export { sortAgentsByCreatedAtDesc };
 
 export function useAgents(
   connectedAgentId: string | null,

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+import { type AuthState } from "@/components/app/types";
+import { authEvents } from "@/lib/api";
+
+export function useAuth(): {
+  authState: AuthState;
+  handleAuthenticated: () => void;
+  handleLogout: () => Promise<void>;
+} {
+  const [authState, setAuthState] = useState<AuthState>("loading");
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/v1/auth/status", { credentials: "include" });
+        if (!res.ok) {
+          setAuthState("needs-login");
+          return;
+        }
+        const data = (await res.json()) as { passwordSet: boolean; authenticated: boolean };
+        if (data.passwordSet && !data.authenticated) {
+          setAuthState("needs-login");
+        } else {
+          setAuthState("authenticated");
+        }
+      } catch {
+        setAuthState("authenticated");
+      }
+    })();
+  }, []);
+
+  // Listen for 401s from the shared api() utility.
+  useEffect(() => {
+    const onUnauthenticated = () => setAuthState("needs-login");
+    authEvents.addEventListener("unauthenticated", onUnauthenticated);
+    return () => authEvents.removeEventListener("unauthenticated", onUnauthenticated);
+  }, []);
+
+  const handleAuthenticated = useCallback(() => setAuthState("authenticated"), []);
+
+  const handleLogout = useCallback(async () => {
+    await fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" });
+    setAuthState("needs-login");
+  }, []);
+
+  return { authState, handleAuthenticated, handleLogout };
+}

--- a/web/src/hooks/use-health.ts
+++ b/web/src/hooks/use-health.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { type ServiceState } from "@/components/app/types";
+import { api } from "@/lib/api";
+import { recordHealthPollFire, recordHealthPollSkip } from "@/lib/energy-metrics";
+
+type HealthData = { apiState: ServiceState; dbState: ServiceState };
+
+export function useHealth(enabled: boolean): HealthData {
+  const { data } = useQuery<HealthData>({
+    queryKey: ["health"],
+    queryFn: async () => {
+      if (document.hidden) {
+        recordHealthPollSkip();
+        throw new Error("skipped — tab hidden");
+      }
+      recordHealthPollFire();
+      const health = await api<{ status: string; db: string }>("/api/v1/health");
+      return {
+        apiState: health.status === "ok" ? "ok" : "down",
+        dbState: health.db === "ok" ? "ok" : "down",
+      };
+    },
+    enabled,
+    refetchInterval: 8000,
+  });
+
+  return data ?? { apiState: "checking", dbState: "checking" };
+}

--- a/web/src/hooks/use-layout.ts
+++ b/web/src/hooks/use-layout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const LEFT_SIDEBAR_KEY = "dispatch:leftSidebarOpen";
 const LEFT_SIDEBAR_LEGACY_KEY = "hostess:leftSidebarOpen";
@@ -78,7 +78,7 @@ export function useLayout() {
     [isMobile]
   );
 
-  return {
+  return useMemo(() => ({
     isMobile,
     leftOpen,
     mediaOpen,
@@ -92,5 +92,15 @@ export function useLayout() {
     setMobileMediaOpen,
     handleSetLeftPanelOpen,
     handleSetMediaPanelOpen,
-  };
+  }), [
+    isMobile,
+    leftOpen,
+    mediaOpen,
+    leftPanelOpen,
+    mediaPanelOpen,
+    mobileLeftOpen,
+    mobileMediaOpen,
+    handleSetLeftPanelOpen,
+    handleSetMediaPanelOpen,
+  ]);
 }

--- a/web/src/hooks/use-layout.ts
+++ b/web/src/hooks/use-layout.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from "react";
+
+const LEFT_SIDEBAR_KEY = "dispatch:leftSidebarOpen";
+const LEFT_SIDEBAR_LEGACY_KEY = "hostess:leftSidebarOpen";
+const MEDIA_SIDEBAR_KEY = "dispatch:mediaSidebarOpen";
+const MEDIA_SIDEBAR_LEGACY_KEY = "hostess:mediaSidebarOpen";
+const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px), (pointer: coarse), (hover: none)";
+
+function readBool(key: string, legacyKey: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  const stored = window.localStorage.getItem(key) ?? window.localStorage.getItem(legacyKey);
+  return stored === null ? fallback : stored === "true";
+}
+
+export function useLayout() {
+  const [leftOpen, setLeftOpen] = useState(() => readBool(LEFT_SIDEBAR_KEY, LEFT_SIDEBAR_LEGACY_KEY, true));
+  const [mediaOpen, setMediaOpen] = useState(() => readBool(MEDIA_SIDEBAR_KEY, MEDIA_SIDEBAR_LEGACY_KEY, false));
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches : false
+  );
+  const [mobileLeftOpen, setMobileLeftOpen] = useState(false);
+  const [mobileMediaOpen, setMobileMediaOpen] = useState(false);
+
+  const leftPanelOpen = isMobile ? mobileLeftOpen : leftOpen;
+  const mediaPanelOpen = isMobile ? mobileMediaOpen : mediaOpen;
+
+  // Media query listener for mobile breakpoint.
+  useEffect(() => {
+    const query = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
+    const onChange = () => setIsMobile(query.matches);
+    onChange();
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  // Persist sidebar state to localStorage.
+  useEffect(() => {
+    const value = String(leftOpen);
+    window.localStorage.setItem(LEFT_SIDEBAR_KEY, value);
+    window.localStorage.setItem(LEFT_SIDEBAR_LEGACY_KEY, value);
+  }, [leftOpen]);
+
+  useEffect(() => {
+    const value = String(mediaOpen);
+    window.localStorage.setItem(MEDIA_SIDEBAR_KEY, value);
+    window.localStorage.setItem(MEDIA_SIDEBAR_LEGACY_KEY, value);
+  }, [mediaOpen]);
+
+  // Reset mobile panels when switching to desktop.
+  useEffect(() => {
+    if (!isMobile) {
+      setMobileLeftOpen(false);
+      setMobileMediaOpen(false);
+    }
+  }, [isMobile]);
+
+  const handleSetLeftPanelOpen = useCallback(
+    (open: boolean) => {
+      if (isMobile) {
+        if (open) setMobileMediaOpen(false);
+        setMobileLeftOpen(open);
+        return;
+      }
+      setLeftOpen(open);
+    },
+    [isMobile]
+  );
+
+  const handleSetMediaPanelOpen = useCallback(
+    (open: boolean) => {
+      if (isMobile) {
+        if (open) setMobileLeftOpen(false);
+        setMobileMediaOpen(open);
+        return;
+      }
+      setMediaOpen(open);
+    },
+    [isMobile]
+  );
+
+  return {
+    isMobile,
+    leftOpen,
+    mediaOpen,
+    leftPanelOpen,
+    mediaPanelOpen,
+    mobileLeftOpen,
+    mobileMediaOpen,
+    setLeftOpen,
+    setMediaOpen,
+    setMobileLeftOpen,
+    setMobileMediaOpen,
+    handleSetLeftPanelOpen,
+    handleSetMediaPanelOpen,
+  };
+}

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -164,7 +164,6 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     lightboxSrc,
     lightboxCaption,
     setLightboxSrc,
-    setLightboxCaption,
     openLightbox,
     mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
     refreshMedia,

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -1,0 +1,172 @@
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type MediaFile } from "@/components/app/types";
+import { api } from "@/lib/api";
+
+export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean) {
+  const queryClient = useQueryClient();
+
+  const [seenMediaKeys, setSeenMediaKeys] = useState<Set<string>>(new Set());
+  const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [lightboxCaption, setLightboxCaption] = useState("");
+  const mediaViewportRef = useRef<HTMLDivElement>(null);
+  const previousMediaKeysRef = useRef<Set<string>>(new Set());
+  const clearMediaAnimTimerRef = useRef<number | null>(null);
+
+  const { data: mediaFiles = [] } = useQuery<MediaFile[]>({
+    queryKey: ["media", selectedAgentId],
+    queryFn: async () => {
+      const payload = await api<{ files: MediaFile[] }>(`/api/v1/agents/${selectedAgentId}/media`);
+      return payload.files ?? [];
+    },
+    enabled: !!selectedAgentId,
+  });
+
+  // Sync seenMediaKeys from fetched data.
+  useEffect(() => {
+    if (mediaFiles.length > 0) {
+      setSeenMediaKeys(
+        new Set(
+          mediaFiles
+            .filter((file) => file.seen === true)
+            .map((file) => `${file.name}:${file.updatedAt}`)
+        )
+      );
+    }
+  }, [mediaFiles]);
+
+  // Reset seen keys when selected agent changes.
+  useEffect(() => {
+    setSeenMediaKeys(new Set());
+    previousMediaKeysRef.current = new Set();
+  }, [selectedAgentId]);
+
+  // Clear media when no agent selected.
+  useEffect(() => {
+    if (!selectedAgentId) {
+      queryClient.setQueryData(["media", null], []);
+    }
+  }, [queryClient, selectedAgentId]);
+
+  // Animation for new media items.
+  useEffect(() => {
+    const nextKeys = mediaFiles.map((file) => `${file.name}:${file.updatedAt}`);
+    const prevKeys = previousMediaKeysRef.current;
+
+    if (prevKeys.size > 0) {
+      const incoming = nextKeys.filter((key) => !prevKeys.has(key));
+      if (incoming.length > 0) {
+        setAnimatingMediaKeys(new Set(incoming));
+
+        if (clearMediaAnimTimerRef.current) {
+          window.clearTimeout(clearMediaAnimTimerRef.current);
+        }
+        clearMediaAnimTimerRef.current = window.setTimeout(() => {
+          setAnimatingMediaKeys(new Set());
+          clearMediaAnimTimerRef.current = null;
+        }, 2200);
+      }
+    }
+
+    previousMediaKeysRef.current = new Set(nextKeys);
+
+    return () => {
+      if (clearMediaAnimTimerRef.current) {
+        window.clearTimeout(clearMediaAnimTimerRef.current);
+        clearMediaAnimTimerRef.current = null;
+      }
+    };
+  }, [mediaFiles]);
+
+  // IntersectionObserver for marking media as seen.
+  const markMediaSeen = useCallback(
+    async (agentId: string, keys: string[]) => {
+      if (keys.length === 0) return;
+      try {
+        await api<{ ok: boolean; updated: number }>(`/api/v1/agents/${agentId}/media/seen`, {
+          method: "POST",
+          body: JSON.stringify({ keys }),
+        });
+      } catch {}
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!mediaPanelOpen) return;
+
+    const root = mediaViewportRef.current;
+    const selected = selectedAgentId;
+    if (!root || !selected) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const newlySeen: string[] = [];
+        setSeenMediaKeys((current) => {
+          let changed = false;
+          const next = new Set(current);
+
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              const mediaKey = (entry.target as HTMLElement).dataset.mediaKey;
+              if (mediaKey && !next.has(mediaKey)) {
+                next.add(mediaKey);
+                newlySeen.push(mediaKey);
+                changed = true;
+              }
+            }
+          }
+
+          return changed ? next : current;
+        });
+
+        if (newlySeen.length > 0) {
+          void markMediaSeen(selected, newlySeen);
+        }
+      },
+      { root, threshold: 0.65 }
+    );
+
+    const nodes = root.querySelectorAll<HTMLElement>("[data-media-key]");
+    nodes.forEach((node) => observer.observe(node));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [markMediaSeen, mediaFiles, mediaPanelOpen, selectedAgentId]);
+
+  const unseenMediaCount = useMemo(() => {
+    return mediaFiles.filter((file) => !seenMediaKeys.has(`${file.name}:${file.updatedAt}`)).length;
+  }, [mediaFiles, seenMediaKeys]);
+
+  const openLightbox = useCallback((src: string, caption: string) => {
+    setLightboxSrc(src);
+    setLightboxCaption(caption);
+  }, []);
+
+  const refreshMedia = useCallback(
+    (agentId?: string | null) => {
+      const id = agentId ?? selectedAgentId;
+      if (id) {
+        void queryClient.invalidateQueries({ queryKey: ["media", id] });
+      }
+    },
+    [queryClient, selectedAgentId]
+  );
+
+  return {
+    mediaFiles,
+    seenMediaKeys,
+    setSeenMediaKeys,
+    animatingMediaKeys,
+    unseenMediaCount,
+    lightboxSrc,
+    lightboxCaption,
+    setLightboxSrc,
+    setLightboxCaption,
+    openLightbox,
+    mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
+    refreshMedia,
+  };
+}

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -155,7 +155,7 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     [queryClient, selectedAgentId]
   );
 
-  return {
+  return useMemo(() => ({
     mediaFiles,
     seenMediaKeys,
     setSeenMediaKeys,
@@ -167,5 +167,14 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     openLightbox,
     mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
     refreshMedia,
-  };
+  }), [
+    mediaFiles,
+    seenMediaKeys,
+    animatingMediaKeys,
+    unseenMediaCount,
+    lightboxSrc,
+    lightboxCaption,
+    openLightbox,
+    refreshMedia,
+  ]);
 }

--- a/web/src/hooks/use-sse.ts
+++ b/web/src/hooks/use-sse.ts
@@ -1,0 +1,142 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type Agent, type AuthState } from "@/components/app/types";
+import { sortAgentsByCreatedAtDesc } from "@/hooks/use-agents";
+import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
+
+type UiEvent =
+  | { type: "snapshot"; agents: Agent[] }
+  | { type: "agent.upsert"; agent: Agent }
+  | { type: "agent.deleted"; agentId: string }
+  | { type: "media.changed"; agentId: string }
+  | { type: "media.seen"; agentId: string; keys: string[] }
+  | { type: "stream.started"; agentId: string }
+  | { type: "stream.stopped"; agentId: string };
+
+export function useSSE(
+  authState: AuthState,
+  connectedAgentIdRef: React.RefObject<string | null>,
+  selectedAgentIdRef: React.RefObject<string | null>,
+  setStreamingAgentIds: React.Dispatch<React.SetStateAction<Set<string>>>,
+  setSeenMediaKeys: React.Dispatch<React.SetStateAction<Set<string>>>,
+): void {
+  const queryClient = useQueryClient();
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    const handleSSEMessage = (event: MessageEvent) => {
+      try {
+        recordSSEEvent();
+        const payload = JSON.parse(event.data) as UiEvent;
+
+        if (payload.type === "snapshot") {
+          queryClient.setQueryData<Agent[]>(
+            ["agents"],
+            sortAgentsByCreatedAtDesc(payload.agents, connectedAgentIdRef.current)
+          );
+          setStreamingAgentIds(
+            new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
+          );
+          return;
+        }
+
+        if (payload.type === "agent.upsert") {
+          queryClient.setQueryData<Agent[]>(["agents"], (old) => {
+            if (!old) return [payload.agent];
+            const index = old.findIndex((a) => a.id === payload.agent.id);
+            if (index === -1) {
+              return sortAgentsByCreatedAtDesc([payload.agent, ...old], connectedAgentIdRef.current);
+            }
+            const next = [...old];
+            next[index] = payload.agent;
+            return sortAgentsByCreatedAtDesc(next, connectedAgentIdRef.current);
+          });
+          return;
+        }
+
+        if (payload.type === "agent.deleted") {
+          queryClient.setQueryData<Agent[]>(
+            ["agents"],
+            (old) => old?.filter((a) => a.id !== payload.agentId) ?? []
+          );
+          return;
+        }
+
+        if (payload.type === "media.changed" && payload.agentId === selectedAgentIdRef.current) {
+          void queryClient.invalidateQueries({ queryKey: ["media", payload.agentId] });
+          return;
+        }
+
+        if (payload.type === "stream.started") {
+          setStreamingAgentIds((current) => {
+            if (current.has(payload.agentId)) return current;
+            const next = new Set(current);
+            next.add(payload.agentId);
+            return next;
+          });
+          return;
+        }
+
+        if (payload.type === "stream.stopped") {
+          setStreamingAgentIds((current) => {
+            if (!current.has(payload.agentId)) return current;
+            const next = new Set(current);
+            next.delete(payload.agentId);
+            return next;
+          });
+          return;
+        }
+
+        if (payload.type === "media.seen" && payload.agentId === selectedAgentIdRef.current) {
+          setSeenMediaKeys((current) => {
+            const next = new Set(current);
+            let changed = false;
+            for (const key of payload.keys) {
+              if (!next.has(key)) {
+                next.add(key);
+                changed = true;
+              }
+            }
+            return changed ? next : current;
+          });
+        }
+      } catch {}
+    };
+
+    const openSSE = () => {
+      if (eventSourceRef.current) return;
+      const source = new EventSource("/api/v1/events", { withCredentials: true });
+      eventSourceRef.current = source;
+      source.onmessage = handleSSEMessage;
+      source.onerror = () => {
+        recordSSEReconnect();
+      };
+    };
+
+    const closeSSE = () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    };
+
+    if (!document.hidden && authState === "authenticated") {
+      openSSE();
+    }
+
+    const onVisChange = () => {
+      if (document.hidden || authState !== "authenticated") {
+        closeSSE();
+      } else {
+        openSSE();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisChange);
+      closeSSE();
+    };
+  }, [authState, connectedAgentIdRef, queryClient, selectedAgentIdRef, setSeenMediaKeys, setStreamingAgentIds]);
+}

--- a/web/src/hooks/use-sse.ts
+++ b/web/src/hooks/use-sse.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { type Agent, type AuthState } from "@/components/app/types";
-import { sortAgentsByCreatedAtDesc } from "@/hooks/use-agents";
+import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
 
 type UiEvent =

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -1,0 +1,520 @@
+import { type MutableRefObject, type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { ClipboardAddon } from "@xterm/addon-clipboard";
+import { type Agent, type AuthState, type ConnState } from "@/components/app/types";
+import { api } from "@/lib/api";
+import { recordWSReconnect } from "@/lib/energy-metrics";
+
+const ACTIVE_SHELL_AGENT_KEY = "dispatch:activeShellAgentId";
+
+function readActiveShellAgentId(): string | null {
+  if (typeof window === "undefined") return null;
+  const stored = window.localStorage.getItem(ACTIVE_SHELL_AGENT_KEY)?.trim();
+  return stored && stored.length > 0 ? stored : null;
+}
+
+function persistActiveShellAgentId(agentId: string | null): void {
+  if (typeof window === "undefined") return;
+  if (agentId) {
+    window.localStorage.setItem(ACTIVE_SHELL_AGENT_KEY, agentId);
+    return;
+  }
+  window.localStorage.removeItem(ACTIVE_SHELL_AGENT_KEY);
+}
+
+/** Strip terminal line-wrap artifacts from copied text. */
+function cleanCopiedText(text: string): string {
+  const joined = text.replace(/[ \t]*\r?\n[ \t]*/g, "");
+  if (/^https?:\/\//.test(joined) || (/\S/.test(joined) && !joined.includes(" "))) {
+    return joined;
+  }
+  return text;
+}
+
+export function useTerminal(args: {
+  authState: AuthState;
+  agents: Agent[];
+  agentsLoaded: boolean;
+  selectedAgentId: string | null;
+  isMobile: boolean;
+  leftOpen: boolean;
+  mediaOpen: boolean;
+  onAgentSelected: (agentId: string) => void;
+  refreshMedia: (agentId?: string | null) => void;
+}): {
+  connState: ConnState;
+  connectedAgentId: string | null;
+  terminalMode: "tmux" | "inert" | null;
+  terminalPlaceholderMessage: string | null;
+  statusMessage: string;
+  terminalHostRef: RefObject<HTMLDivElement>;
+  ctrlPendingRef: MutableRefObject<boolean>;
+  ensureTerminalConnected: (clearScreen?: boolean, userInitiated?: boolean, targetAgentId?: string) => Promise<void>;
+  detachTerminal: () => void;
+  sendTerminalInput: (data: string) => void;
+} {
+  const {
+    authState,
+    agents,
+    agentsLoaded,
+    selectedAgentId,
+    isMobile,
+    leftOpen,
+    mediaOpen,
+    onAgentSelected,
+    refreshMedia,
+  } = args;
+
+  const [connState, setConnState] = useState<ConnState>("disconnected");
+  const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
+  const [terminalMode, setTerminalMode] = useState<"tmux" | "inert" | null>(null);
+  const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState("Starting...");
+  const [restoreShellAgentId, setRestoreShellAgentId] = useState<string | null>(() => readActiveShellAgentId());
+
+  const connectedAgentIdRef = useRef<string | null>(null);
+  connectedAgentIdRef.current = connectedAgentId;
+
+  const terminalHostRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<XTerm | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const ctrlPendingRef = useRef(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const shouldKeepAttachedRef = useRef(false);
+  const reconnectTimerRef = useRef<number | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const attachNonceRef = useRef(0);
+
+  const sendResize = useCallback(() => {
+    const ws = wsRef.current;
+    const term = terminalRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || !term) return;
+    ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+  }, []);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      window.clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const closeSocket = useCallback((announce = true) => {
+    if (wsRef.current) {
+      try { wsRef.current.close(); } catch {}
+      wsRef.current = null;
+    }
+    setConnectedAgentId(null);
+    setTerminalMode(null);
+    setTerminalPlaceholderMessage(null);
+
+    if (announce) {
+      setStatusMessage("Session disconnected.");
+      setConnState("disconnected");
+    }
+  }, []);
+
+  const ensureTerminalConnected = useCallback(
+    async (clearScreen = false, userInitiated = false, targetAgentId?: string) => {
+      if (userInitiated) {
+        shouldKeepAttachedRef.current = true;
+      }
+
+      const resolvedAgentId = targetAgentId ?? selectedAgentId;
+      if (!shouldKeepAttachedRef.current || !resolvedAgentId) return;
+
+      let agent: Agent | null = userInitiated
+        ? (agents.find((item) => item.id === resolvedAgentId) ?? null)
+        : null;
+
+      if (!agent || agent.status !== "running") {
+        try {
+          const payload = await api<{ agent: Agent }>(`/api/v1/agents/${resolvedAgentId}?includeGitContext=false`);
+          agent = payload.agent;
+        } catch {
+          if (!shouldKeepAttachedRef.current) return;
+          clearReconnectTimer();
+          reconnectAttemptsRef.current += 1;
+          recordWSReconnect();
+          const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
+          setConnState("reconnecting");
+          setStatusMessage("Session disconnected, reconnecting...");
+          reconnectTimerRef.current = window.setTimeout(() => {
+            reconnectTimerRef.current = null;
+            if (document.hidden) return;
+            void ensureTerminalConnected(false, false, resolvedAgentId);
+          }, delay);
+          return;
+        }
+      }
+
+      if (agent.status !== "running") {
+        setConnState("disconnected");
+        return;
+      }
+
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        if (connectedAgentIdRef.current === agent.id) {
+          sendResize();
+          return;
+        }
+      }
+
+      clearReconnectTimer();
+      closeSocket(false);
+
+      if (clearScreen) {
+        terminalRef.current?.clear();
+      }
+
+      fitAddonRef.current?.fit();
+      const attachNonce = ++attachNonceRef.current;
+      setConnState("reconnecting");
+      setStatusMessage(`Connecting to session ${agent.name}...`);
+
+      const scheduleReconnect = (message: string) => {
+        if (!shouldKeepAttachedRef.current || attachNonce !== attachNonceRef.current) {
+          setConnState("disconnected");
+          return;
+        }
+
+        reconnectAttemptsRef.current += 1;
+        recordWSReconnect();
+        const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
+        setConnState("reconnecting");
+        setStatusMessage(message);
+
+        reconnectTimerRef.current = window.setTimeout(() => {
+          reconnectTimerRef.current = null;
+          if (document.hidden) return;
+          void ensureTerminalConnected(false, false, resolvedAgentId);
+        }, delay);
+      };
+
+      try {
+        const terminalSession = await api<
+          | { mode: "tmux"; token: string; wsUrl: string }
+          | { mode: "inert"; message: string }
+        >(
+          `/api/v1/agents/${agent.id}/terminal/token`,
+          { method: "POST", body: JSON.stringify({}) }
+        );
+
+        if (terminalSession.mode === "inert") {
+          reconnectAttemptsRef.current = 0;
+          setConnState("connected");
+          setConnectedAgentId(agent.id);
+          setTerminalMode("inert");
+          setTerminalPlaceholderMessage(terminalSession.message);
+          setStatusMessage(terminalSession.message);
+          return;
+        }
+
+        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const term = terminalRef.current;
+        const cols = term?.cols ?? 140;
+        const rows = term?.rows ?? 42;
+        setTerminalMode("tmux");
+        setTerminalPlaceholderMessage(null);
+        const ws = new WebSocket(
+          `${protocol}//${window.location.host}${terminalSession.wsUrl}&cols=${cols}&rows=${rows}`
+        );
+        wsRef.current = ws;
+
+        ws.addEventListener("open", () => {
+          reconnectAttemptsRef.current = 0;
+          setConnState("connected");
+          setConnectedAgentId(agent.id);
+          setStatusMessage(`Connected to session ${agent.name}`);
+          terminalRef.current?.focus();
+        });
+
+        ws.addEventListener("message", (event) => {
+          const payload = JSON.parse(String(event.data)) as
+            | { type: "output"; data: string }
+            | { type: "error"; message: string }
+            | { type: "exit" };
+
+          if (payload.type === "output") {
+            terminalRef.current?.write(payload.data);
+          } else if (payload.type === "error") {
+            const normalized = payload.message.toLowerCase();
+            if (
+              normalized.includes("session no longer exists") ||
+              normalized.includes("attach failed") ||
+              normalized.includes("invalid or expired terminal token")
+            ) {
+              shouldKeepAttachedRef.current = false;
+            }
+            setStatusMessage(`Session error: ${payload.message}`);
+          } else if (payload.type === "exit") {
+            setStatusMessage("Session ended.");
+          }
+        });
+
+        ws.addEventListener("close", (event) => {
+          if (wsRef.current !== ws) return;
+          wsRef.current = null;
+
+          if (event.code === 1008 || event.code === 1011) {
+            shouldKeepAttachedRef.current = false;
+            setConnState("disconnected");
+            return;
+          }
+
+          scheduleReconnect("Session disconnected, reconnecting...");
+        });
+      } catch {
+        scheduleReconnect("Session connection failed, retrying...");
+      }
+    },
+    [agents, clearReconnectTimer, closeSocket, selectedAgentId, sendResize]
+  );
+
+  const detachTerminal = useCallback(() => {
+    shouldKeepAttachedRef.current = false;
+    persistActiveShellAgentId(null);
+    setRestoreShellAgentId(null);
+    clearReconnectTimer();
+    closeSocket(false);
+    setConnState("disconnected");
+    setStatusMessage("Detached from session.");
+  }, [clearReconnectTimer, closeSocket]);
+
+  const sendTerminalInput = useCallback((data: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ type: "input", data }));
+    terminalRef.current?.focus();
+  }, []);
+
+  // xterm initialization.
+  useEffect(() => {
+    const host = terminalHostRef.current;
+    if (!host) return;
+
+    const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
+
+    const term = new XTerm({
+      convertEol: false,
+      cursorBlink: true,
+      fontFamily: "JetBrains Mono, Menlo, monospace",
+      fontSize: 13,
+      scrollback: 5000,
+      macOptionClickForcesSelection: true,
+      screenReaderMode: isTouchDevice,
+      theme: {
+        foreground: "#f8f8f2",
+        background: "#141414",
+        cursor: "#f8f8f0",
+        cursorAccent: "#141414",
+        selectionBackground: "#49483e",
+        selectionInactiveBackground: "#3e3d32",
+        black: "#141414",
+        red: "#f92672",
+        green: "#a6e22e",
+        yellow: "#f4bf75",
+        blue: "#66d9ef",
+        magenta: "#ae81ff",
+        cyan: "#a1efe4",
+        white: "#f8f8f2",
+        brightBlack: "#75715e",
+        brightRed: "#f92672",
+        brightGreen: "#a6e22e",
+        brightYellow: "#f4bf75",
+        brightBlue: "#66d9ef",
+        brightMagenta: "#ae81ff",
+        brightCyan: "#a1efe4",
+        brightWhite: "#f9f8f5",
+      },
+    });
+
+    const fit = new FitAddon();
+
+    terminalRef.current = term;
+    fitAddonRef.current = fit;
+    term.loadAddon(fit);
+    try { term.loadAddon(new ClipboardAddon()); } catch (e) { console.warn("ClipboardAddon failed:", e); }
+    term.open(host);
+    fit.fit();
+
+    const handleCopy = (e: ClipboardEvent) => {
+      if (term.hasSelection()) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.clipboardData?.setData("text/plain", cleanCopiedText(term.getSelection()));
+      }
+    };
+    host.addEventListener("copy", handleCopy, true);
+
+    const screenEl = host.querySelector(".xterm-screen") as HTMLElement | null;
+    let touchY = 0;
+    let touchAccum = 0;
+    const SCROLL_SENSITIVITY = 30;
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        touchY = e.touches[0].clientY;
+        touchAccum = 0;
+      }
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 1 || !screenEl) return;
+      const currentY = e.touches[0].clientY;
+      const delta = touchY - currentY;
+      touchY = currentY;
+      touchAccum += delta;
+      while (Math.abs(touchAccum) >= SCROLL_SENSITIVITY) {
+        const direction = touchAccum > 0 ? 1 : -1;
+        touchAccum -= direction * SCROLL_SENSITIVITY;
+        screenEl.dispatchEvent(new WheelEvent("wheel", {
+          deltaY: direction * 100,
+          deltaMode: 0,
+          bubbles: true,
+          cancelable: true,
+        }));
+      }
+    };
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: true });
+
+    let dispatchingMouseDown = false;
+    const onMouseDown = (e: MouseEvent) => {
+      if (dispatchingMouseDown) return;
+      if (e.button !== 0 || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      e.stopPropagation();
+      e.preventDefault();
+      dispatchingMouseDown = true;
+      (e.target as HTMLElement).dispatchEvent(new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        detail: e.detail,
+        screenX: e.screenX,
+        screenY: e.screenY,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        button: e.button,
+        buttons: e.buttons,
+        relatedTarget: e.relatedTarget,
+        shiftKey: true,
+        altKey: true,
+      }));
+      dispatchingMouseDown = false;
+    };
+    if (screenEl) {
+      screenEl.addEventListener("mousedown", onMouseDown, true);
+    }
+
+    const disposable = term.onData((data) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      if (ctrlPendingRef.current && data.length === 1) {
+        const code = data.toUpperCase().charCodeAt(0);
+        if (code >= 65 && code <= 90) {
+          ctrlPendingRef.current = false;
+          window.dispatchEvent(new Event("ctrl-consumed"));
+          ws.send(JSON.stringify({ type: "input", data: String.fromCharCode(code - 64) }));
+          return;
+        }
+      }
+      ws.send(JSON.stringify({ type: "input", data }));
+    });
+
+    const onResize = () => {
+      fit.fit();
+      sendResize();
+    };
+
+    window.addEventListener("resize", onResize);
+
+    return () => {
+      disposable.dispose();
+      host.removeEventListener("copy", handleCopy, true);
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      if (screenEl) screenEl.removeEventListener("mousedown", onMouseDown, true);
+      window.removeEventListener("resize", onResize);
+      term.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [authState, sendResize]);
+
+  // Reconnect on visibility/focus.
+  useEffect(() => {
+    const onVisible = () => {
+      if (!document.hidden) {
+        void ensureTerminalConnected(false, false, connectedAgentIdRef.current ?? selectedAgentId ?? undefined);
+      }
+    };
+
+    const onFocus = () => {
+      void ensureTerminalConnected(false, false, connectedAgentIdRef.current ?? selectedAgentId ?? undefined);
+    };
+
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [connectedAgentId, ensureTerminalConnected, selectedAgentId]);
+
+  // Fit on layout change.
+  useEffect(() => {
+    if (isMobile) return;
+    const fitNow = () => {
+      fitAddonRef.current?.fit();
+      sendResize();
+    };
+    fitNow();
+    const timer = window.setTimeout(fitNow, 340);
+    return () => window.clearTimeout(timer);
+  }, [isMobile, leftOpen, mediaOpen, sendResize]);
+
+  // Persist active shell agent.
+  useEffect(() => {
+    if (connState === "connected" && connectedAgentId) {
+      persistActiveShellAgentId(connectedAgentId);
+      return;
+    }
+    if (connState === "disconnected" && !restoreShellAgentId) {
+      persistActiveShellAgentId(null);
+    }
+  }, [connState, connectedAgentId, restoreShellAgentId]);
+
+  // Restore session on load.
+  useEffect(() => {
+    if (!agentsLoaded || !restoreShellAgentId) return;
+
+    const restoreTarget = agents.find((agent) => agent.id === restoreShellAgentId);
+    if (!restoreTarget || restoreTarget.status !== "running") {
+      persistActiveShellAgentId(null);
+      setRestoreShellAgentId(null);
+      return;
+    }
+
+    onAgentSelected(restoreTarget.id);
+    refreshMedia(restoreTarget.id);
+    void ensureTerminalConnected(true, true, restoreTarget.id);
+    setStatusMessage(`Restored session for ${restoreTarget.name}.`);
+    setRestoreShellAgentId(null);
+  }, [agents, agentsLoaded, ensureTerminalConnected, onAgentSelected, refreshMedia, restoreShellAgentId]);
+
+
+  return {
+    connState,
+    connectedAgentId,
+    terminalMode,
+    terminalPlaceholderMessage,
+    statusMessage,
+    terminalHostRef: terminalHostRef as RefObject<HTMLDivElement>,
+    ctrlPendingRef,
+    ensureTerminalConnected,
+    detachTerminal,
+    sendTerminalInput,
+  };
+}

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type MutableRefObject, type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
@@ -505,7 +505,7 @@ export function useTerminal(args: {
   }, [agents, agentsLoaded, ensureTerminalConnected, onAgentSelected, refreshMedia, restoreShellAgentId]);
 
 
-  return {
+  return useMemo(() => ({
     connState,
     connectedAgentId,
     terminalMode,
@@ -516,5 +516,14 @@ export function useTerminal(args: {
     ensureTerminalConnected,
     detachTerminal,
     sendTerminalInput,
-  };
+  }), [
+    connState,
+    connectedAgentId,
+    terminalMode,
+    terminalPlaceholderMessage,
+    statusMessage,
+    ensureTerminalConnected,
+    detachTerminal,
+    sendTerminalInput,
+  ]);
 }

--- a/web/src/lib/agent-sort.ts
+++ b/web/src/lib/agent-sort.ts
@@ -1,0 +1,20 @@
+import { type Agent } from "@/components/app/types";
+
+export function sortAgentsByCreatedAtDesc(items: Agent[], activeAgentId?: string | null): Agent[] {
+  const eventPriority = (agent: Agent): number => {
+    if (activeAgentId && agent.id === activeAgentId) return -1;
+    if (agent.latestEvent?.type === "blocked") return 0;
+    if (agent.latestEvent?.type === "waiting_user") return 1;
+    if (agent.status === "running" || agent.status === "creating" || agent.status === "stopping") return 2;
+    return 3;
+  };
+
+  const latestActivityAt = (agent: Agent): string =>
+    agent.latestEvent?.updatedAt ?? agent.updatedAt ?? agent.createdAt;
+
+  return [...items].sort((a, b) => {
+    const priorityDelta = eventPriority(a) - eventPriority(b);
+    if (priorityDelta !== 0) return priorityDelta;
+    return latestActivityAt(b).localeCompare(latestActivityAt(a));
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,58 @@
+import { recordHTTPRequest } from "@/lib/energy-metrics";
+
+/**
+ * Lightweight event target for auth failures.  Components (or hooks) can
+ * subscribe via `authEvents.addEventListener("unauthenticated", ...)` to
+ * react when a 401 is received from any API call.
+ */
+export const authEvents = new EventTarget();
+
+export class UnauthenticatedError extends Error {
+  constructor() {
+    super("Authentication required.");
+    this.name = "UnauthenticatedError";
+  }
+}
+
+/**
+ * Shared fetch wrapper used by React Query queryFn / mutationFn
+ * implementations as well as imperative callers (e.g. the terminal hook).
+ *
+ * On 401 it dispatches an "unauthenticated" event so the auth hook can
+ * transition to the login screen.
+ */
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  recordHTTPRequest();
+
+  const hasBody = init?.body !== undefined && init?.body !== null;
+  const res = await fetch(path, {
+    credentials: "include",
+    headers: {
+      ...(hasBody ? { "content-type": "application/json" } : {}),
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (res.status === 401) {
+    authEvents.dispatchEvent(new Event("unauthenticated"));
+    throw new UnauthenticatedError();
+  }
+
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const payload = (await res.json()) as { error?: string };
+      if (payload.error) {
+        message = payload.error;
+      }
+    } catch {}
+    throw new Error(message);
+  }
+
+  if (res.status === 204) {
+    return null as T;
+  }
+
+  return (await res.json()) as T;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,20 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { registerSW } from "virtual:pwa-register";
 
 import { App } from "./App";
 import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 if (import.meta.env.PROD) {
   registerSW({ immediate: true });
@@ -17,6 +28,8 @@ if (import.meta.env.PROD) {
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary

- **Memoize `TerminalPane`** with `React.memo` to prevent unnecessary re-renders from SSE events (agent create/stop/delete). Verified: 0 terminal re-renders during agent lifecycle events vs 20+ previously.
- **Decompose `App.tsx`** (1664 → 595 lines) by extracting domain-specific hooks and adopting React Query for server state:
  - `useAuth` — auth status + logout
  - `useHealth` — health polling via React Query `refetchInterval`
  - `useLayout` — sidebar/panel toggle state + localStorage persistence
  - `useAgents` — agent list via React Query cache
  - `useSSE` — EventSource lifecycle, dispatches to `queryClient.setQueryData`
  - `useMedia` — media files via React Query + IntersectionObserver
  - `useTerminal` — WebSocket terminal, xterm setup, reconnection
  - `lib/api.ts` — shared fetch wrapper with 401 event dispatching
- SSE agent updates now only re-render subscribers of the agents query — terminal, footer, and media sidebar are untouched

## Test plan
- [x] `npm run check` — type check passes
- [x] `npm run finalize:web` — production build clean
- [x] `npm run test:e2e` — 26/26 Playwright tests pass
- [x] Verified TerminalPane re-render count before/after with console.log instrumentation
- [x] Manual validation on dev instance — all UI elements render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)