### PR TITLE
Fix release log repeating instead of updating in place

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -249,13 +249,14 @@ function setReleasePhase(job: ReleaseJob, phase: ReleasePhase, error?: string): 
 function streamProcess(
   command: string,
   args: string[],
-  options: { cwd?: string },
+  options: { cwd?: string; env?: Record<string, string> },
   job: ReleaseJob,
   onLine?: (line: string) => void
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: options.cwd,
+      env: { ...process.env, ...options.env },
       stdio: ["ignore", "pipe", "pipe"]
     });
 
@@ -488,7 +489,7 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
     // Watch the workflow
     setReleasePhase(job, "watching");
     try {
-      await streamProcess("gh", ["run", "watch", runId, "--repo", repo], {}, job);
+      await streamProcess("gh", ["run", "watch", runId, "--repo", repo], { env: { GH_FORCE_TTY: "120" } }, job);
     } catch {
       throw new Error(`GitHub Actions workflow failed. See ${runUrl}`);
     }


### PR DESCRIPTION
## Summary
- `streamProcess` spawns `gh run watch` with piped stdout, so `gh` detects it's not a TTY and skips cursor-up (`ESC[<N>A`) sequences — falling back to appending each refresh block as new output
- Set `GH_FORCE_TTY=120` so `gh` emits terminal-style redraws that the existing rewind logic can process correctly
- Extended `streamProcess` options to accept an `env` parameter merged with `process.env`

## Test plan
- [x] Existing `stream-process.test.ts` passes
- [x] Type check (`npm run check`) passes
- [ ] Trigger a release and verify the log panel updates in place instead of repeating

🤖 Generated with [Claude Code](https://claude.com/claude-code)