### PR TITLE
Reduce terminal flashing with tmux sync output and scrollback reduction

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -690,6 +690,11 @@ export class AgentManager {
     await runCommand("tmux", ["set-option", "-t", sessionName, "status", "off"], {
       allowedExitCodes: [0, 1]
     });
+    // Allow DCS passthrough so agent CLIs that wrap escape sequences
+    // (e.g. synchronized output) can reach the outer terminal directly.
+    await runCommand("tmux", ["set-option", "-t", sessionName, "allow-passthrough", "on"], {
+      allowedExitCodes: [0, 1]
+    });
 
     // Detect fast-fail launches (for example, missing codex executable) so status
     // is not left as "running" with no backing tmux session.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1494,6 +1494,11 @@ async function registerRoutes() {
         await runCommand("tmux", ["set-option", "-t", tmuxSession, "mouse", "on"], {
           allowedExitCodes: [0]
         });
+        // Tell tmux the outer terminal (xterm.js) supports synchronized output
+        // so tmux wraps its own frame rendering in DEC 2026 sequences.
+        await runCommand("tmux", ["set-option", "-as", "terminal-features", "xterm-256color:sync"], {
+          allowedExitCodes: [0, 1]
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : "Terminal attach failed.";
         socket.send(JSON.stringify({ type: "error", message }));

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -302,7 +302,7 @@ export function useTerminal(args: {
       cursorBlink: true,
       fontFamily: "JetBrains Mono, Menlo, monospace",
       fontSize: 13,
-      scrollback: 5000,
+      scrollback: 1000,
       macOptionClickForcesSelection: true,
       screenReaderMode: isTouchDevice,
       theme: {


### PR DESCRIPTION
## Summary

- **Enable `allow-passthrough on`** on tmux sessions so agent CLIs that wrap escape sequences in DCS passthrough can reach xterm.js directly
- **Advertise sync capability** via `terminal-features xterm-256color:sync` so tmux wraps its own frame rendering in DEC 2026 synchronized output sequences
- **Reduce xterm.js scrollback** from 5000 to 1000 lines to reduce DOM node count during repaints

Note: Full incoming DEC 2026 buffering (where tmux buffers app redraws atomically) requires tmux 3.7+ — the commit landed in tmux master 12 days after 3.6a shipped. These changes help with tmux's own outgoing rendering and reduce DOM pressure.

## Test plan
- [x] `npm run check` — type check passes
- [x] `npm run test:e2e` — 26/26 tests pass
- [ ] Manual testing with live agents to evaluate flashing reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)