### PR TITLE
Add ghost-primary, ghost-info, ghost-destructive button variants

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -226,8 +226,7 @@ export function AgentSidebarContent({
                         <TooltipTrigger asChild>
                           <Button
                             size="icon"
-                            variant="ghost"
-                            className="text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200"
+                            variant="ghost-primary"
                             data-agent-control="true"
                             onClick={() => {
                               if (closeOnSessionAction) {
@@ -248,8 +247,7 @@ export function AgentSidebarContent({
                             <TooltipTrigger asChild>
                               <Button
                                 size="icon"
-                                variant="ghost"
-                                className="text-sky-300 hover:bg-sky-500/15 hover:text-sky-200"
+                                variant="ghost-info"
                                 data-agent-control="true"
                                 onClick={detachTerminal}
                               >
@@ -263,8 +261,7 @@ export function AgentSidebarContent({
                             <TooltipTrigger asChild>
                               <Button
                                 size="icon"
-                                variant="ghost"
-                                className="text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200"
+                                variant="ghost-primary"
                                 data-agent-control="true"
                                 onClick={() => {
                                   if (closeOnSessionAction) {
@@ -284,8 +281,7 @@ export function AgentSidebarContent({
                           <TooltipTrigger asChild>
                             <Button
                               size="icon"
-                              variant="ghost"
-                              className="text-red-300 hover:bg-red-500/15 hover:text-red-200"
+                              variant="ghost-destructive"
                               data-agent-control="true"
                               onClick={() => void stopAgent(agent)}
                             >

--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -100,8 +100,7 @@ export function AppHeader({
         {isAttached ? (
           <Button
             size="sm"
-            variant="ghost"
-            className="text-sky-300 hover:bg-sky-500/15 hover:text-sky-200"
+            variant="ghost-info"
             onClick={detachTerminal}
             title="Detach from session"
             data-testid="detach-button"
@@ -112,8 +111,7 @@ export function AppHeader({
         ) : canAttachSelected ? (
           <Button
             size="sm"
-            variant="ghost"
-            className="text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200"
+            variant="ghost-primary"
             onClick={attachSelectedAgent}
             title="Attach to session"
             data-testid="attach-button"

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -12,7 +12,13 @@ const buttonVariants = cva(
         default: "bg-muted text-foreground hover:bg-muted/80 border border-border",
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        ghost: "hover:bg-muted/70"
+        ghost: "hover:bg-muted/70",
+        "ghost-primary":
+          "text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200",
+        "ghost-info":
+          "text-sky-300 hover:bg-sky-500/15 hover:text-sky-200",
+        "ghost-destructive":
+          "text-red-300 hover:bg-red-500/15 hover:text-red-200"
       },
       size: {
         default: "h-9 px-3 py-2",


### PR DESCRIPTION
## Summary
- Adds three new button variants (`ghost-primary`, `ghost-info`, `ghost-destructive`) to the shadcn Button component using CVA
- Replaces 6 instances of inline Tailwind color overrides on ghost buttons in `agent-sidebar.tsx` and `app-header.tsx`
- No visual change — same colors, now managed through the variant system

## Test plan
- [x] `npm run finalize:web` — type check + production build pass
- [x] `npm run test:e2e` — 26/26 Playwright tests pass
- [ ] Visual spot-check: start/attach (emerald), detach (sky), and stop (red) buttons in sidebar and header

🤖 Generated with [Claude Code](https://claude.com/claude-code)