### PR TITLE
Rename sidebar Docs link to Documentation

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -436,7 +436,7 @@ export function AgentSidebarContent({
           className="flex w-full items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground md:text-xs"
         >
           <BookOpenText className="h-4 w-4 md:h-3.5 md:w-3.5" />
-          Docs
+          Documentation
         </button>
         <button
           onClick={onOpenSettings}


### PR DESCRIPTION
## Summary
- Renames the "Docs" button in the agent sidebar to "Documentation" for clarity.

## Test plan
- [x] Verified the label change renders correctly in the sidebar via Playwright screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)