### PR TITLE
Mobile QoL: input fixes + PWA force reload

### DIFF
--- a/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -38,7 +38,11 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
 
   const openInput = useCallback(() => {
     setInputOpen(true);
-    requestAnimationFrame(() => inputRef.current?.focus());
+    // Double-rAF ensures the modal is rendered and laid out before focusing,
+    // which avoids iOS failing to open the keyboard on the first tap.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    });
   }, []);
 
   const submitInput = useCallback(() => {
@@ -183,17 +187,9 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
           <div className="flex-1 p-4">
             <textarea
               ref={inputRef}
-              className="h-full w-full resize-none rounded-lg border border-border bg-card p-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              className="h-full w-full resize-none rounded-lg border border-border bg-card p-3 font-mono text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               placeholder="Type command here..."
               autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  submitInput();
-                }
-              }}
             />
           </div>
           <div className="flex gap-3 border-t border-border px-4 py-3">

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,17 +1,62 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ChevronRight, ArrowLeft, ArrowDownToLine, Shield, X } from "lucide-react";
+import { ChevronRight, ArrowLeft, ArrowDownToLine, RefreshCw, Shield, X } from "lucide-react";
 
 import { ReleaseManager } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release" | "security";
+type SettingsSection = "release" | "security" | "app";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
   { id: "release", label: "Updates", icon: ArrowDownToLine },
-  { id: "security", label: "Security", icon: Shield }
+  { id: "security", label: "Security", icon: Shield },
+  { id: "app", label: "App", icon: RefreshCw }
 ];
+
+function AppSettings(): JSX.Element {
+  const [reloading, setReloading] = useState(false);
+
+  const handleForceReload = useCallback(async () => {
+    setReloading(true);
+    try {
+      // Unregister all service workers and clear their caches
+      if ("serviceWorker" in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((r) => r.unregister()));
+      }
+      if ("caches" in window) {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      }
+      window.location.reload();
+    } catch {
+      // If anything fails, just reload anyway
+      window.location.reload();
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Force reload
+        </div>
+        <p className="mb-3 text-sm text-muted-foreground">
+          If the app feels stuck on an old version, this will clear all cached data and reload with the latest version.
+        </p>
+        <button
+          onClick={() => void handleForceReload()}
+          disabled={reloading}
+          className="inline-flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCw className={cn("h-3.5 w-3.5", reloading && "animate-spin")} />
+          {reloading ? "Reloading…" : "Clear cache & reload"}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 type SettingsPaneProps = {
   open: boolean;
@@ -103,6 +148,7 @@ export function SettingsPane({ open, onClose, onLogout }: SettingsPaneProps): JS
             <div className={cn("min-h-0 min-w-0 flex-1", activeSection === null && "hidden md:block")}>
               {activeSection === "release" && <ReleaseManager />}
               {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
+              {activeSection === "app" && <AppSettings />}
             </div>
           </div>
         </DialogPrimitive.Content>


### PR DESCRIPTION
## Summary
- **Focus reliability**: Double `requestAnimationFrame` so iOS reliably opens the keyboard when tapping the keyboard icon
- **No zoom on focus**: Textarea font bumped from 14px to 16px — iOS auto-zooms inputs below 16px
- **Enter adds newline**: Enter key now inserts a newline in the fullscreen input instead of submitting; use the Send buttons to submit
- **Keyboard autocomplete**: Removed `autoCorrect="off"` and `spellCheck={false}` so the OS keyboard shows suggestions
- **PWA force reload**: New "App" section in Settings with a "Clear cache & reload" button that unregisters service workers, clears caches, and reloads

## Test plan
- [ ] On iOS/mobile: tap keyboard icon, verify keyboard opens on first tap
- [ ] Verify no page zoom when the fullscreen input focuses
- [ ] Type multiline text with Enter in fullscreen input, confirm it adds newlines
- [ ] Verify keyboard autocomplete/suggestions appear in fullscreen input
- [ ] Open Settings > App, tap "Clear cache & reload", confirm page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)