### PR TITLE
Fix Codex MCP auth by using bearer token env var

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -817,6 +817,7 @@ export class AgentManager {
     const envPrefix = envPrefixParts.join(" ");
     const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
     const dispatchMcpUrl = this.dispatchMcpUrl(agentId);
+    const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
 
     if (type === "claude") {
       const mcpConfig = this.shellEscape(JSON.stringify({
@@ -856,13 +857,14 @@ export class AgentManager {
       "-c",
       this.shellEscape(`mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`),
       "-c",
-      this.shellEscape(`mcp_servers.dispatch.headers.Authorization=${JSON.stringify(`Bearer ${this.config.authToken}`)}`)
+      this.shellEscape(`mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`)
     ].join(" ");
+    const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${this.shellEscape(this.config.authToken)}`;
     if (args.length === 0) {
-      return `${envPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(launchGuidance)}`;
+      return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(launchGuidance)}`;
     }
     const escaped = args.map((arg) => this.shellEscape(arg)).join(" ");
-    return `${envPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(launchGuidance)}`;
+    return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(launchGuidance)}`;
   }
 
   private dispatchMcpUrl(agentId: string): string {

--- a/test/db/agent-manager.test.ts
+++ b/test/db/agent-manager.test.ts
@@ -168,6 +168,8 @@ describe("AgentManager", () => {
       const wrappedCommand = newSessionCall![1][newSessionCall![1].length - 1];
       expect(wrappedCommand).toContain("mcp_servers.dispatch.url=");
       expect(wrappedCommand).toContain(`/api/mcp/${agent.id}`);
+      expect(wrappedCommand).toContain("mcp_servers.dispatch.bearer_token_env_var=");
+      expect(wrappedCommand).toContain("DISPATCH_AUTH_TOKEN=");
     });
 
     it("should inject an agent-scoped MCP URL into Claude launches", async () => {


### PR DESCRIPTION
## Summary
- switch Codex launch wiring from `mcp_servers.dispatch.headers.Authorization` to `mcp_servers.dispatch.bearer_token_env_var`
- export `DISPATCH_AUTH_TOKEN` in the Codex launch env so auth is passed using Codex-supported HTTP MCP auth
- add regression coverage in `agent-manager` tests for the new Codex launch flags/env

## Why
Codex currently supports bearer token auth for streamable HTTP MCP via `bearer_token_env_var`; injecting raw HTTP headers in config does not authenticate the server connection reliably, which can cause Dispatch MCP tools to be missing.

## Validation
- `npm run check`
- `npm run test:e2e`
- `npm test`
