### PR TITLE
Add MP4 video support to media sharing

### DIFF
--- a/bin/dispatch-share
+++ b/bin/dispatch-share
@@ -64,8 +64,8 @@ if [[ ! -f "$SOURCE_PATH" ]]; then
 fi
 
 lower_name="$(basename "$SOURCE_PATH" | tr '[:upper:]' '[:lower:]')"
-if [[ ! "$lower_name" =~ \.(png|jpg|jpeg|gif|webp)$ ]]; then
-  echo "dispatch-share: unsupported file type. Use png/jpg/jpeg/gif/webp." >&2
+if [[ ! "$lower_name" =~ \.(png|jpg|jpeg|gif|webp|mp4)$ ]]; then
+  echo "dispatch-share: unsupported file type. Use png/jpg/jpeg/gif/webp/mp4." >&2
   exit 4
 fi
 

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -111,7 +111,7 @@ export async function runMigrations(): Promise<void> {
   }
 }
 
-const IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp)$/i;
+const MEDIA_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|mp4)$/i;
 
 async function migrateExistingMedia(
   pool: import("pg").Pool,
@@ -132,7 +132,7 @@ async function migrateExistingMedia(
     }
 
     for (const entry of entries) {
-      if (!entry.isFile() || !IMAGE_EXTENSIONS.test(entry.name)) {
+      if (!entry.isFile() || !MEDIA_EXTENSIONS.test(entry.name)) {
         continue;
       }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -286,12 +286,12 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       "dispatch_share",
       {
         description:
-          "Upload an image file to Dispatch for sharing. Supports png, jpg, jpeg, gif, and webp. Use source 'simulator' with a simulator UDID to capture a screenshot directly from an iOS Simulator.",
+          "Upload a media file to Dispatch for sharing. Supports png, jpg, jpeg, gif, webp, and mp4. Use source 'simulator' with a simulator UDID to capture a screenshot directly from an iOS Simulator.",
         inputSchema: {
           filePath: z
             .string()
             .optional()
-            .describe("Absolute path to the image file to upload. Not required when source is 'simulator'."),
+            .describe("Absolute path to the media file to upload. Not required when source is 'simulator'."),
           description: z.string().describe("A short description of the shared media."),
           source: z
             .enum(["screenshot", "simulator"])

--- a/src/server.ts
+++ b/src/server.ts
@@ -1164,8 +1164,8 @@ async function registerRoutes() {
     }
 
     const fileName = data.filename;
-    if (!isImageFile(fileName)) {
-      return reply.code(400).send({ error: "Unsupported file type. Use png/jpg/jpeg/gif/webp." });
+    if (!isMediaFile(fileName)) {
+      return reply.code(400).send({ error: "Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4." });
     }
 
     const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? "screenshot";
@@ -2145,8 +2145,8 @@ async function markSeenMediaKeys(agentId: string, keys: string[]): Promise<void>
   );
 }
 
-function isImageFile(name: string): boolean {
-  return /\.(png|jpg|jpeg|gif|webp)$/i.test(name);
+function isMediaFile(name: string): boolean {
+  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name);
 }
 
 function mimeType(name: string): string {
@@ -2164,6 +2164,10 @@ function mimeType(name: string): string {
 
   if (/\.webp$/i.test(name)) {
     return "image/webp";
+  }
+
+  if (/\.mp4$/i.test(name)) {
+    return "video/mp4";
   }
 
   return "application/octet-stream";
@@ -2215,8 +2219,8 @@ async function mcpShareMedia(
   const agent = await agentManager.getAgent(agentId);
   if (!agent) throw new Error("Agent not found.");
 
-  if (!isImageFile(opts.filePath)) {
-    throw new Error("Unsupported file type. Use png/jpg/jpeg/gif/webp.");
+  if (!isMediaFile(opts.filePath)) {
+    throw new Error("Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4.");
   }
 
   const validSources = ["screenshot", "stream", "simulator"];
@@ -2225,7 +2229,9 @@ async function mcpShareMedia(
   const buffer = await readFile(opts.filePath);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
   const baseName = opts.name ?? path.basename(opts.filePath);
-  const safeName = baseName.replace(/ /g, "-").replace(/[^A-Za-z0-9._-]/g, "") || `shared-${timestamp}.png`;
+  const ext0 = path.extname(baseName).toLowerCase();
+  const fallbackExt = ext0 === ".mp4" ? ".mp4" : ".png";
+  const safeName = baseName.replace(/ /g, "-").replace(/[^A-Za-z0-9._-]/g, "") || `shared-${timestamp}${fallbackExt}`;
   const ext = path.extname(safeName);
   const base = path.basename(safeName, ext);
   const fileName = `${base}-${timestamp}${ext}`;

--- a/web/src/components/app/media-lightbox.tsx
+++ b/web/src/components/app/media-lightbox.tsx
@@ -49,11 +49,20 @@ export function MediaLightbox({
         <Button onClick={() => setLightboxSrc(null)}>Close</Button>
       </div>
       <div className="grid min-h-0 place-items-center">
-        <img
-          src={lightboxSrc}
-          alt={lightboxCaption}
-          className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain"
-        />
+        {/\.mp4/i.test(lightboxSrc) ? (
+          <video
+            src={lightboxSrc}
+            controls
+            playsInline
+            className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain"
+          />
+        ) : (
+          <img
+            src={lightboxSrc}
+            alt={lightboxCaption}
+            className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain"
+          />
+        )}
       </div>
       <div className="text-center text-sm text-muted-foreground">{lightboxCaption}</div>
     </div>

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -132,15 +132,24 @@ export function MediaSidebarContent({
                 ) : (
                   <div className="mb-2 text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</div>
                 )}
-                <button
-                  className={cn(
+                {/\.mp4$/i.test(file.name) ? (
+                  <div className={cn(
                     "block w-full overflow-hidden border-2 bg-black/60",
                     unseen ? "media-thumb-unseen" : "media-thumb-seen"
-                  )}
-                  onClick={() => openLightbox(cacheBustUrl, file.description || "")}
-                >
-                  <img src={cacheBustUrl} alt={file.description || ""} className="max-h-[260px] w-full object-contain" />
-                </button>
+                  )}>
+                    <video src={cacheBustUrl} controls muted playsInline preload="metadata" className="max-h-[260px] w-full object-contain" />
+                  </div>
+                ) : (
+                  <button
+                    className={cn(
+                      "block w-full overflow-hidden border-2 bg-black/60",
+                      unseen ? "media-thumb-unseen" : "media-thumb-seen"
+                    )}
+                    onClick={() => openLightbox(cacheBustUrl, file.description || "")}
+                  >
+                    <img src={cacheBustUrl} alt={file.description || ""} className="max-h-[260px] w-full object-contain" />
+                  </button>
+                )}
                 <div className="mt-2 text-xs text-muted-foreground">
                   {file.description ? <div>{file.description}</div> : null}
                   <div className={file.description ? "mt-1" : ""}>{Math.max(1, Math.round(file.size / 1024))} KB</div>


### PR DESCRIPTION
## Summary
- Adds `.mp4` as a supported media file type across the full pipeline (MCP tool, API upload, shell script, migration, frontend)
- Videos render with native playback controls in the sidebar (no autoplay, muted) and in the fullscreen lightbox
- Images continue to work exactly as before — video rendering is conditional on `.mp4` extension

## Changes
- **`src/server.ts`** — Renamed `isImageFile` → `isMediaFile`, added `video/mp4` MIME type, updated error messages, fixed fallback filename extension
- **`src/mcp/server.ts`** — Updated tool description to mention mp4
- **`bin/dispatch-share`** — Added mp4 to shell validation regex
- **`src/db/migrate.ts`** — Renamed `IMAGE_EXTENSIONS` → `MEDIA_EXTENSIONS`, added mp4
- **`web/src/components/app/media-sidebar.tsx`** — Renders `<video controls>` for mp4 files (outside the lightbox button wrapper)
- **`web/src/components/app/media-lightbox.tsx`** — Renders `<video controls>` for mp4 in the fullscreen modal

## Test plan
- [x] `npm run finalize:web` — type check + production build pass
- [x] `npm run test:e2e` — all 26 tests pass
- [x] Live validation: uploaded a real 16-second MP4 via API, confirmed sidebar shows video with controls and lightbox plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)