### PR TITLE
Fix media stream refresh behavior

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -38,6 +38,35 @@ export async function setAgentLatestEventViaAPI(
   });
 }
 
+export async function uploadMediaViaAPI(
+  request: APIRequestContext,
+  agentId: string,
+  description: string,
+  fileName = `media-${Date.now()}.png`
+): Promise<void> {
+  const pngBytes = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9VE3D7wAAAAASUVORK5CYII=",
+    "base64"
+  );
+
+  const res = await request.post(`${API}/agents/${agentId}/media`, {
+    headers: authHeaders(),
+    multipart: {
+      description,
+      source: "screenshot",
+      file: {
+        name: fileName,
+        mimeType: "image/png",
+        buffer: pngBytes,
+      },
+    },
+  });
+
+  if (!res.ok()) {
+    throw new Error(`Media upload failed with ${res.status()}`);
+  }
+}
+
 /**
  * Delete an agent via the REST API.
  */

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+import { cleanupE2EAgents, createAgentViaAPI, loadApp, uploadMediaViaAPI } from "./helpers";
+
+test.describe("Media sidebar", () => {
+  test.afterAll(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("refreshes cached media when switching back to an agent", async ({ page, request }) => {
+    const firstAgent = await createAgentViaAPI(request, { name: `e2e-agent-media-a-${Date.now()}` });
+    const secondAgent = await createAgentViaAPI(request, { name: `e2e-agent-media-b-${Date.now()}` });
+
+    await uploadMediaViaAPI(request, firstAgent.id, "First image", "first-image.png");
+
+    await loadApp(page);
+
+    await page.getByText(firstAgent.name, { exact: true }).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await expect(mediaSidebar).toBeVisible();
+    await expect(mediaSidebar).toContainText(firstAgent.name);
+    await expect(mediaSidebar).toContainText("1 items");
+    await expect(mediaSidebar.getByText("First image")).toBeVisible();
+
+    await page.getByText(secondAgent.name, { exact: true }).click();
+    await expect(mediaSidebar).toContainText(secondAgent.name);
+    await uploadMediaViaAPI(request, firstAgent.id, "Second image", "second-image.png");
+    await page.getByText(firstAgent.name, { exact: true }).click();
+    await expect(mediaSidebar).toContainText(firstAgent.name);
+
+    await expect(mediaSidebar).toContainText("2 items", { timeout: 10_000 });
+    await expect(mediaSidebar.getByText("Second image")).toBeVisible();
+  });
+});

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -34,11 +34,7 @@ async function waitForTerminalConnected(page: Page, timeoutMs = 10_000): Promise
 }
 
 test.describe("Terminal live connection", () => {
-  test.beforeAll(() => {
-    if (!IS_LIVE) {
-      test.skip();
-    }
-  });
+  test.skip(!IS_LIVE, "Requires --live agent runtime");
 
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);

--- a/scripts/e2e-isolated.sh
+++ b/scripts/e2e-isolated.sh
@@ -57,4 +57,4 @@ echo "==> Building web bundle"
 npm run build:web
 
 echo "==> Running Playwright tests (API port: ${API_PORT})"
-E2E_SKIP_WEB_BUILD=1 npx playwright test "$@"
+DISPATCH_AGENT_RUNTIME=inert E2E_SKIP_WEB_BUILD=1 npx playwright test "$@"

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -14,14 +14,23 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
   const previousMediaKeysRef = useRef<Set<string>>(new Set());
   const clearMediaAnimTimerRef = useRef<number | null>(null);
 
-  const { data: mediaFiles = [] } = useQuery<MediaFile[]>({
+  const { data: mediaFiles = [], refetch: refetchMedia } = useQuery<MediaFile[]>({
     queryKey: ["media", selectedAgentId],
     queryFn: async () => {
       const payload = await api<{ files: MediaFile[] }>(`/api/v1/agents/${selectedAgentId}/media`);
       return payload.files ?? [];
     },
     enabled: !!selectedAgentId,
+    staleTime: 0,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
+
+  useEffect(() => {
+    if (!selectedAgentId || !mediaPanelOpen) return;
+    void refetchMedia();
+  }, [mediaPanelOpen, refetchMedia, selectedAgentId]);
 
   // Sync seenMediaKeys from fetched data.
   useEffect(() => {

--- a/web/src/hooks/use-sse.ts
+++ b/web/src/hooks/use-sse.ts
@@ -62,8 +62,8 @@ export function useSSE(
           return;
         }
 
-        if (payload.type === "media.changed" && payload.agentId === selectedAgentIdRef.current) {
-          void queryClient.invalidateQueries({ queryKey: ["media", payload.agentId] });
+        if (payload.type === "media.changed") {
+          void queryClient.invalidateQueries({ queryKey: ["media", payload.agentId], exact: true });
           return;
         }
 


### PR DESCRIPTION
## Summary
- invalidate media query caches for any agent when `media.changed` SSE events arrive
- make the media query revalidate aggressively on mount, focus, reconnect, and panel open
- add an e2e regression for switching away from an agent, receiving new media, and switching back without a reload
- force isolated e2e runs to stay on the inert runtime so live terminal specs skip correctly

## Root cause
The media sidebar query was inheriting the app-wide `staleTime` and did not revalidate when revisiting an agent with cached media. At the same time, SSE invalidation only ran for the currently selected agent, so media added while viewing another agent could leave that agent's cache stale until a hard reload.

## Validation
- `npm run check`
- `npm run finalize:web`
- `npm run test:e2e`
- Playwright validation against the isolated dev stack (`http://127.0.0.1:50453`) with screenshots published to the media stream