### PR TITLE
Add media lightbox navigation

### DIFF
--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -33,4 +33,40 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar).toContainText("2 items", { timeout: 10_000 });
     await expect(mediaSidebar.getByText("Second image")).toBeVisible();
   });
+
+  test("navigates between fullscreen media items", async ({ page, request }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-lightbox-${Date.now()}` });
+
+    await uploadMediaViaAPI(request, agent.id, "First image", "first-image.png");
+    await uploadMediaViaAPI(request, agent.id, "Second image", "second-image.png");
+
+    await loadApp(page);
+
+    await page.getByText(agent.name, { exact: true }).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await expect(mediaSidebar).toContainText("2 items");
+
+    await mediaSidebar.getByRole("button", { name: "Second image" }).click();
+
+    const lightbox = page.getByTestId("media-lightbox");
+    await expect(lightbox).toBeVisible();
+    await expect(lightbox).toContainText("1 / 2");
+    await expect(lightbox).toContainText("Second image");
+
+    await page.getByTestId("media-lightbox-next").click();
+    await expect(lightbox).toContainText("2 / 2");
+    await expect(lightbox).toContainText("First image");
+
+    await page.getByTestId("media-lightbox-prev").click();
+    await expect(lightbox).toContainText("1 / 2");
+    await expect(lightbox).toContainText("Second image");
+
+    await page.keyboard.press("ArrowRight");
+    await expect(lightbox).toContainText("2 / 2");
+
+    await lightbox.getByRole("button", { name: "Close" }).click();
+    await expect(lightbox).toBeHidden();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -150,9 +150,9 @@ export function App(): JSX.Element {
     setSeenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
-    lightboxSrc,
-    lightboxCaption,
-    setLightboxSrc,
+    lightboxIndex,
+    lightboxItem,
+    setLightboxIndex,
     openLightbox,
     mediaViewportRef,
     refreshMedia,
@@ -586,9 +586,10 @@ export function App(): JSX.Element {
       <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} onLogout={handleLogout} />
 
       <MediaLightbox
-        lightboxSrc={lightboxSrc}
-        lightboxCaption={lightboxCaption}
-        setLightboxSrc={setLightboxSrc}
+        item={lightboxItem}
+        currentIndex={lightboxIndex}
+        totalItems={mediaFiles.length}
+        setLightboxIndex={setLightboxIndex}
       />
 
       <div className="sr-only" aria-live="polite">

--- a/web/src/components/app/media-lightbox.tsx
+++ b/web/src/components/app/media-lightbox.tsx
@@ -1,20 +1,39 @@
-import { useEffect } from "react";
+import { type TouchEvent, useEffect, useRef } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
-type MediaLightboxProps = {
-  lightboxSrc: string | null;
-  lightboxCaption: string;
-  setLightboxSrc: (src: string | null) => void;
+type MediaLightboxItem = {
+  src: string;
+  caption: string;
+  file: {
+    name: string;
+    source?: "screenshot" | "stream" | "simulator";
+  };
 };
 
+type MediaLightboxProps = {
+  item: MediaLightboxItem | null;
+  currentIndex: number;
+  totalItems: number;
+  setLightboxIndex: (nextIndex: number | null) => void;
+};
+
+const SWIPE_THRESHOLD_PX = 48;
+
 export function MediaLightbox({
-  lightboxSrc,
-  lightboxCaption,
-  setLightboxSrc
+  item,
+  currentIndex,
+  totalItems,
+  setLightboxIndex
 }: MediaLightboxProps): JSX.Element | null {
+  const touchStartXRef = useRef<number | null>(null);
+
+  const canGoPrev = currentIndex > 0;
+  const canGoNext = currentIndex >= 0 && currentIndex < totalItems - 1;
+
   useEffect(() => {
-    if (!lightboxSrc) {
+    if (!item) {
       return;
     }
 
@@ -22,7 +41,21 @@ export function MediaLightbox({
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();
-        setLightboxSrc(null);
+        setLightboxIndex(null);
+        return;
+      }
+
+      if (event.key === "ArrowLeft" && canGoPrev) {
+        event.preventDefault();
+        event.stopPropagation();
+        setLightboxIndex(currentIndex - 1);
+        return;
+      }
+
+      if (event.key === "ArrowRight" && canGoNext) {
+        event.preventDefault();
+        event.stopPropagation();
+        setLightboxIndex(currentIndex + 1);
       }
     };
 
@@ -30,41 +63,117 @@ export function MediaLightbox({
     return () => {
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [lightboxSrc, setLightboxSrc]);
+  }, [canGoNext, canGoPrev, currentIndex, item, setLightboxIndex]);
 
-  if (!lightboxSrc) {
+  if (!item) {
     return null;
   }
 
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    touchStartXRef.current = event.changedTouches[0]?.clientX ?? null;
+  };
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    if (touchStartXRef.current === null) {
+      return;
+    }
+
+    const endX = event.changedTouches[0]?.clientX ?? touchStartXRef.current;
+    const deltaX = endX - touchStartXRef.current;
+    touchStartXRef.current = null;
+
+    if (deltaX <= -SWIPE_THRESHOLD_PX && canGoNext) {
+      setLightboxIndex(currentIndex + 1);
+      return;
+    }
+
+    if (deltaX >= SWIPE_THRESHOLD_PX && canGoPrev) {
+      setLightboxIndex(currentIndex - 1);
+    }
+  };
+
   return (
     <div
-      className="fixed inset-0 z-[120] grid grid-rows-[auto_1fr_auto] gap-3 bg-black/90 p-4"
+      className="fixed inset-0 z-[120] grid grid-rows-[auto_1fr_auto] gap-3 bg-black/90 p-4 sm:p-6"
+      data-testid="media-lightbox"
       onClick={(event) => {
         if (event.target === event.currentTarget) {
-          setLightboxSrc(null);
+          setLightboxIndex(null);
         }
       }}
     >
-      <div className="flex justify-end">
-        <Button onClick={() => setLightboxSrc(null)}>Close</Button>
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
+          {totalItems > 0 ? `${currentIndex + 1} / ${totalItems}` : ""}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            aria-label="Previous media item"
+            data-testid="media-lightbox-prev"
+            disabled={!canGoPrev}
+            size="icon"
+            variant="ghost"
+            onClick={() => setLightboxIndex(currentIndex - 1)}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => setLightboxIndex(null)}>Close</Button>
+          <Button
+            aria-label="Next media item"
+            data-testid="media-lightbox-next"
+            disabled={!canGoNext}
+            size="icon"
+            variant="ghost"
+            onClick={() => setLightboxIndex(currentIndex + 1)}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
-      <div className="grid min-h-0 place-items-center">
-        {/\.mp4/i.test(lightboxSrc) ? (
+      <div
+        className="relative grid min-h-0 grid-cols-[minmax(0,1fr)] place-items-center overflow-hidden"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        <button
+          aria-label="Previous media item"
+          className="absolute left-0 top-0 z-10 hidden h-full w-1/5 min-w-12 items-center justify-start bg-gradient-to-r from-black/35 to-transparent pl-2 text-white/70 transition hover:text-white disabled:pointer-events-none disabled:opacity-0 sm:flex"
+          disabled={!canGoPrev}
+          onClick={() => setLightboxIndex(currentIndex - 1)}
+          type="button"
+        >
+          <ChevronLeft className="h-8 w-8" />
+        </button>
+
+        {/\.mp4/i.test(item.src) ? (
           <video
-            src={lightboxSrc}
+            src={item.src}
             controls
             playsInline
-            className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain"
+            className="max-h-[calc(100vh-10rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain sm:max-h-[calc(100vh-9rem)] sm:max-w-[calc(100vw-6rem)]"
           />
         ) : (
           <img
-            src={lightboxSrc}
-            alt={lightboxCaption}
-            className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain"
+            src={item.src}
+            alt={item.caption}
+            className="max-h-[calc(100vh-10rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain sm:max-h-[calc(100vh-9rem)] sm:max-w-[calc(100vw-6rem)]"
           />
         )}
+
+        <button
+          aria-label="Next media item"
+          className="absolute right-0 top-0 z-10 hidden h-full w-1/5 min-w-12 items-center justify-end bg-gradient-to-l from-black/35 to-transparent pr-2 text-white/70 transition hover:text-white disabled:pointer-events-none disabled:opacity-0 sm:flex"
+          disabled={!canGoNext}
+          onClick={() => setLightboxIndex(currentIndex + 1)}
+          type="button"
+        >
+          <ChevronRight className="h-8 w-8" />
+        </button>
       </div>
-      <div className="text-center text-sm text-muted-foreground">{lightboxCaption}</div>
+      <div className="flex items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+        <span>{item.caption}</span>
+        {item.file.source ? <span className="text-xs uppercase tracking-wide">{item.file.source}</span> : null}
+      </div>
     </div>
   );
 }

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -12,7 +12,7 @@ type MediaSidebarSharedProps = {
   animatingMediaKeys: Set<string>;
   seenMediaKeys: Set<string>;
   mediaViewportRef: RefObject<HTMLDivElement>;
-  openLightbox: (src: string, caption: string) => void;
+  openLightbox: (file: MediaFile) => void;
   hasStream: boolean;
   streamUrl: string | null;
 };
@@ -145,7 +145,7 @@ export function MediaSidebarContent({
                       "block w-full overflow-hidden border-2 bg-black/60",
                       unseen ? "media-thumb-unseen" : "media-thumb-seen"
                     )}
-                    onClick={() => openLightbox(cacheBustUrl, file.description || "")}
+                    onClick={() => openLightbox(file)}
                   >
                     <img src={cacheBustUrl} alt={file.description || ""} className="max-h-[260px] w-full object-contain" />
                   </button>

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -8,8 +8,7 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
 
   const [seenMediaKeys, setSeenMediaKeys] = useState<Set<string>>(new Set());
   const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
-  const [lightboxCaption, setLightboxCaption] = useState("");
+  const [lightboxMediaKey, setLightboxMediaKey] = useState<string | null>(null);
   const mediaViewportRef = useRef<HTMLDivElement>(null);
   const previousMediaKeysRef = useRef<Set<string>>(new Set());
   const clearMediaAnimTimerRef = useRef<number | null>(null);
@@ -49,6 +48,7 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
   useEffect(() => {
     setSeenMediaKeys(new Set());
     previousMediaKeysRef.current = new Set();
+    setLightboxMediaKey(null);
   }, [selectedAgentId]);
 
   // Clear media when no agent selected.
@@ -149,10 +149,42 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     return mediaFiles.filter((file) => !seenMediaKeys.has(`${file.name}:${file.updatedAt}`)).length;
   }, [mediaFiles, seenMediaKeys]);
 
-  const openLightbox = useCallback((src: string, caption: string) => {
-    setLightboxSrc(src);
-    setLightboxCaption(caption);
+  const openLightbox = useCallback((file: MediaFile) => {
+    setLightboxMediaKey(`${file.name}:${file.updatedAt}`);
   }, []);
+
+  const lightboxItems = useMemo(
+    () => mediaFiles.map((file) => ({
+      key: `${file.name}:${file.updatedAt}`,
+      src: `${file.url}?t=${encodeURIComponent(file.updatedAt)}`,
+      caption: file.description || "",
+      file,
+    })),
+    [mediaFiles]
+  );
+
+  const lightboxIndex = useMemo(() => {
+    if (!lightboxMediaKey) return -1;
+    return lightboxItems.findIndex((item) => item.key === lightboxMediaKey);
+  }, [lightboxItems, lightboxMediaKey]);
+
+  const lightboxItem = lightboxIndex >= 0 ? lightboxItems[lightboxIndex] : null;
+
+  const setLightboxIndex = useCallback(
+    (nextIndex: number | null) => {
+      if (nextIndex === null) {
+        setLightboxMediaKey(null);
+        return;
+      }
+
+      if (nextIndex < 0 || nextIndex >= lightboxItems.length) {
+        return;
+      }
+
+      setLightboxMediaKey(lightboxItems[nextIndex].key);
+    },
+    [lightboxItems]
+  );
 
   const refreshMedia = useCallback(
     (agentId?: string | null) => {
@@ -170,9 +202,9 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     setSeenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
-    lightboxSrc,
-    lightboxCaption,
-    setLightboxSrc,
+    lightboxIndex,
+    lightboxItem,
+    setLightboxIndex,
     openLightbox,
     mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
     refreshMedia,
@@ -181,8 +213,9 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     seenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
-    lightboxSrc,
-    lightboxCaption,
+    lightboxIndex,
+    lightboxItem,
+    setLightboxIndex,
     openLightbox,
     refreshMedia,
   ]);


### PR DESCRIPTION
## Summary
- track the currently opened media item by list position instead of only storing a raw URL
- add fullscreen previous/next controls, arrow-key navigation, item counts, and touch swipe support in the media lightbox
- cover fullscreen media navigation with Playwright

## Details
The fullscreen media viewer previously only supported close. This change lets users move through the current media stream without dropping back to the sidebar each time. The lightbox now understands the active item in the fetched media list, which enables directional navigation while keeping the existing cache-busted media URLs.

## Validation
- `npm run check`
- `npm run finalize:web`
- `npm run test:e2e`
- Playwright validation against the isolated dev stack (`http://127.0.0.1:51956`) with a screenshot published to the media stream