### PR TITLE
Fix terminal freeze: remove nonce from fetch path

### DIFF
--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -140,13 +140,11 @@ export function useTerminal(args: {
         : null;
 
       if (!agent || agent.status !== "running") {
-        // Invalidate prior attempts before the async fetch
-        const fetchNonce = ++attachNonceRef.current;
         try {
           const payload = await api<{ agent: Agent }>(`/api/v1/agents/${resolvedAgentId}?includeGitContext=false`);
           agent = payload.agent;
         } catch {
-          if (!shouldKeepAttachedRef.current || fetchNonce !== attachNonceRef.current) return;
+          if (!shouldKeepAttachedRef.current) return;
           clearReconnectTimer();
           reconnectAttemptsRef.current += 1;
           recordWSReconnect();
@@ -160,7 +158,7 @@ export function useTerminal(args: {
           }, delay);
           return;
         }
-        if (!shouldKeepAttachedRef.current || fetchNonce !== attachNonceRef.current) return;
+        if (!shouldKeepAttachedRef.current) return;
       }
 
       if (agent.status !== "running") {


### PR DESCRIPTION
## Summary
- Follow-up to #93 — the previous fix was incomplete and the terminal still froze on tab return
- Root cause: when `visibilitychange` and `focus` both fire on tab return, two concurrent `ensureTerminalConnected` calls enter the fetch branch, each incrementing `attachNonceRef`. Even though both eventually hit the "already connected" early return, the nonce is now stale relative to the WS message handler's closure, silently dropping all output.
- Fix: remove the nonce from the fetch path entirely. The fetch only needs `shouldKeepAttachedRef` as a guard — the "already connected" check and the WS-creation nonce handle all race conditions.

## Test plan
- [x] `npm run check` — passes
- [x] `npm run finalize:web` — passes
- [x] `npm run test:e2e` — 29/29 passing
- [x] Playwright validation: attached to live agent, simulated tab switch, typed text — output rendered correctly
- [x] Playwright validation: 3 rapid tab switches — output still rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)