### PR TITLE
Add Slack notifications for agent status changes

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -85,18 +85,26 @@ export class AgentError extends Error {
   }
 }
 
+export type AgentEventListener = (agent: AgentRecord) => void;
+
 export class AgentManager {
   private static readonly TMUX_INVENTORY_INTERVAL_MS = 60_000;
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
   private readonly runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
+  private readonly eventListeners: AgentEventListener[] = [];
   private lastTmuxInventoryAt = 0;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
     this.logger = logger;
     this.config = config;
+  }
+
+  /** Register a callback invoked after every upsertLatestEvent. */
+  onLatestEvent(listener: AgentEventListener): void {
+    this.eventListeners.push(listener);
   }
 
   async listAgents(): Promise<AgentRecord[]> {
@@ -301,7 +309,15 @@ export class AgentManager {
       throw new AgentError("Agent not found.", 404);
     }
 
-    return (await this.getAgent(id)) as AgentRecord;
+    const agent = (await this.getAgent(id)) as AgentRecord;
+    for (const listener of this.eventListeners) {
+      try {
+        listener(agent);
+      } catch (err) {
+        this.logger.warn({ err }, "Agent event listener threw");
+      }
+    }
+    return agent;
   }
 
   async reconcileAgents(): Promise<void> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,32 +2,24 @@ import crypto from "node:crypto";
 import type { Pool } from "pg";
 import bcrypt from "bcryptjs";
 
+import { getSetting, setSetting } from "./db/settings.js";
+
 const BCRYPT_COST = 12;
 const SESSION_TTL_DAYS = 30;
 
 export async function isPasswordSet(pool: Pool): Promise<boolean> {
-  const result = await pool.query(
-    "SELECT 1 FROM settings WHERE key = 'password_hash'"
-  );
-  return (result.rowCount ?? 0) > 0;
+  return (await getSetting(pool, "password_hash")) !== null;
 }
 
 export async function setPassword(pool: Pool, password: string): Promise<void> {
   const hash = await bcrypt.hash(password, BCRYPT_COST);
-  await pool.query(
-    `INSERT INTO settings (key, value, updated_at)
-     VALUES ('password_hash', $1, NOW())
-     ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
-    [hash]
-  );
+  await setSetting(pool, "password_hash", hash);
 }
 
 export async function verifyPassword(pool: Pool, password: string): Promise<boolean> {
-  const result = await pool.query<{ value: string }>(
-    "SELECT value FROM settings WHERE key = 'password_hash'"
-  );
-  if (result.rowCount === 0) return false;
-  return bcrypt.compare(password, result.rows[0].value);
+  const hash = await getSetting(pool, "password_hash");
+  if (!hash) return false;
+  return bcrypt.compare(password, hash);
 }
 
 export async function createSession(pool: Pool): Promise<string> {
@@ -74,35 +66,18 @@ export async function cleanExpiredSessions(pool: Pool): Promise<void> {
  */
 export async function getOrCreateCookieSecret(pool: Pool): Promise<string> {
   const envSecret = process.env.COOKIE_SECRET;
-
-  const result = await pool.query<{ value: string }>(
-    "SELECT value FROM settings WHERE key = 'cookie_secret'"
-  );
+  const stored = await getSetting(pool, "cookie_secret");
 
   if (envSecret) {
-    // Env var always wins — persist it so the cookie plugin and DB agree.
-    if (result.rowCount === 0 || result.rows[0].value !== envSecret) {
-      await pool.query(
-        `INSERT INTO settings (key, value, updated_at)
-         VALUES ('cookie_secret', $1, NOW())
-         ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
-        [envSecret]
-      );
+    if (stored !== envSecret) {
+      await setSetting(pool, "cookie_secret", envSecret);
     }
     return envSecret;
   }
 
-  if ((result.rowCount ?? 0) > 0) {
-    return result.rows[0].value;
-  }
+  if (stored) return stored;
 
-  // First run without env var — generate and persist a secret.
   const secret = crypto.randomUUID();
-  await pool.query(
-    `INSERT INTO settings (key, value, updated_at)
-     VALUES ('cookie_secret', $1, NOW())
-     ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
-    [secret]
-  );
+  await setSetting(pool, "cookie_secret", secret);
   return secret;
 }

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -1,0 +1,25 @@
+import type { Pool } from "pg";
+
+/** Read a single value from the settings table. Returns null if unset. */
+export async function getSetting(pool: Pool, key: string): Promise<string | null> {
+  const result = await pool.query<{ value: string }>(
+    "SELECT value FROM settings WHERE key = $1",
+    [key]
+  );
+  return result.rows[0]?.value ?? null;
+}
+
+/** Upsert a value in the settings table. */
+export async function setSetting(pool: Pool, key: string, value: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO settings (key, value, updated_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()`,
+    [key, value]
+  );
+}
+
+/** Remove a value from the settings table. */
+export async function deleteSetting(pool: Pool, key: string): Promise<void> {
+  await pool.query("DELETE FROM settings WHERE key = $1", [key]);
+}

--- a/src/notifications/slack.ts
+++ b/src/notifications/slack.ts
@@ -1,0 +1,211 @@
+import type { Pool } from "pg";
+import type { FastifyBaseLogger } from "fastify";
+
+import type { AgentRecord } from "../agents/manager.js";
+import { getSetting, setSetting, deleteSetting } from "../db/settings.js";
+
+type SlackBlock =
+  | { type: "section"; text: { type: "mrkdwn"; text: string } }
+  | { type: "context"; elements: Array<{ type: "mrkdwn"; text: string }> };
+
+const NOTIFY_EVENT_TYPES = ["done", "waiting_user", "blocked"] as const;
+type NotifyEventType = (typeof NOTIFY_EVENT_TYPES)[number];
+
+const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color: string }> = {
+  done: { emoji: "\u2705", verb: "finished", color: "#22c55e" },
+  waiting_user: { emoji: "\ud83d\udfe1", verb: "needs your input", color: "#f59e0b" },
+  blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
+};
+
+const SETTING_WEBHOOK_URL = "slack_webhook_url";
+const SETTING_NOTIFY_EVENTS = "slack_notify_events";
+
+/** Short-lived cache to avoid DB reads on every agent event. */
+const CACHE_TTL_MS = 10_000;
+
+type CachedSettings = {
+  webhookUrl: string | null;
+  notifyEvents: NotifyEventType[];
+  expiresAt: number;
+};
+
+export class SlackNotifier {
+  private cachedSettings: CachedSettings | null = null;
+
+  constructor(
+    private pool: Pool,
+    private log: FastifyBaseLogger
+  ) {}
+
+  async getWebhookUrl(): Promise<string | null> {
+    return getSetting(this.pool, SETTING_WEBHOOK_URL);
+  }
+
+  async setWebhookUrl(url: string): Promise<void> {
+    if (!url) {
+      await deleteSetting(this.pool, SETTING_WEBHOOK_URL);
+    } else {
+      await setSetting(this.pool, SETTING_WEBHOOK_URL, url);
+    }
+    this.invalidateCache();
+  }
+
+  async getNotifyEvents(): Promise<NotifyEventType[]> {
+    const raw = await getSetting(this.pool, SETTING_NOTIFY_EVENTS);
+    if (!raw) return [...NOTIFY_EVENT_TYPES];
+    try {
+      const parsed = JSON.parse(raw) as string[];
+      return parsed.filter((e): e is NotifyEventType =>
+        NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+      );
+    } catch {
+      return [...NOTIFY_EVENT_TYPES];
+    }
+  }
+
+  async setNotifyEvents(events: string[]): Promise<void> {
+    const filtered = events.filter((e): e is NotifyEventType =>
+      NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+    );
+    await setSetting(this.pool, SETTING_NOTIFY_EVENTS, JSON.stringify(filtered));
+    this.invalidateCache();
+  }
+
+  async getSettings(): Promise<{
+    webhookUrl: string;
+    notifyEvents: NotifyEventType[];
+  }> {
+    const [webhookUrl, notifyEvents] = await Promise.all([
+      this.getWebhookUrl(),
+      this.getNotifyEvents(),
+    ]);
+    return { webhookUrl: webhookUrl ?? "", notifyEvents };
+  }
+
+  /**
+   * Called on every agent event upsert. Uses a short-lived cache to avoid
+   * hitting the DB on the hot path (most events are "working"/"idle" and
+   * are filtered out before the cache is even checked).
+   */
+  async onAgentEvent(agent: AgentRecord): Promise<void> {
+    const event = agent.latestEvent;
+    if (!event) return;
+    if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return;
+
+    try {
+      const settings = await this.getCachedSettings();
+      if (!settings.webhookUrl) return;
+      if (!settings.notifyEvents.includes(event.type as NotifyEventType)) return;
+
+      const cfg = EVENT_CONFIG[event.type as NotifyEventType];
+      await this.sendSlackMessage(settings.webhookUrl, agent, event, cfg);
+    } catch (err) {
+      this.log.warn({ err, agentId: agent.id }, "Failed to send Slack notification");
+    }
+  }
+
+  async sendTestMessage(webhookUrl: string): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const res = await this.postToSlack(webhookUrl, {
+        username: "Dispatch",
+        text: "Dispatch test notification — your Slack webhook is working!",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "\u2705 *Dispatch test notification*\nYour Slack webhook is configured and working!",
+            },
+          },
+        ],
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        return { ok: false, error: `Slack returned ${res.status}: ${body}` };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
+    }
+  }
+
+  private async getCachedSettings(): Promise<{ webhookUrl: string | null; notifyEvents: NotifyEventType[] }> {
+    if (this.cachedSettings && Date.now() < this.cachedSettings.expiresAt) {
+      return this.cachedSettings;
+    }
+    const [webhookUrl, notifyEvents] = await Promise.all([
+      this.getWebhookUrl(),
+      this.getNotifyEvents(),
+    ]);
+    this.cachedSettings = { webhookUrl, notifyEvents, expiresAt: Date.now() + CACHE_TTL_MS };
+    return this.cachedSettings;
+  }
+
+  private invalidateCache(): void {
+    this.cachedSettings = null;
+  }
+
+  private async postToSlack(webhookUrl: string, payload: Record<string, unknown>): Promise<Response> {
+    return fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  private async sendSlackMessage(
+    webhookUrl: string,
+    agent: AgentRecord,
+    event: { type: string; message: string },
+    cfg: { emoji: string; verb: string; color: string }
+  ): Promise<void> {
+    const agentName = agent.name || agent.id.slice(0, 8);
+    const branch = agent.gitContext?.branch;
+    const elapsed = this.formatElapsed(agent.createdAt);
+    const agentType = agent.type ? agent.type.charAt(0).toUpperCase() + agent.type.slice(1) : "Agent";
+
+    const blocks: SlackBlock[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${cfg.emoji} *Agent "${agentName}" ${cfg.verb}*\n_${event.message}_`,
+        },
+      },
+    ];
+
+    const contextParts: string[] = [];
+    if (branch) contextParts.push(`Branch: \`${branch}\``);
+    contextParts.push(agentType);
+    contextParts.push(elapsed);
+
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: contextParts.join("  \u00b7  ") }],
+    });
+
+    const fallback = `${cfg.emoji} Agent "${agentName}" ${cfg.verb}: ${event.message}`;
+
+    const res = await this.postToSlack(webhookUrl, {
+      username: "Dispatch",
+      text: fallback,
+      attachments: [{ color: cfg.color, blocks }],
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      this.log.warn({ status: res.status, body }, "Slack webhook returned error");
+    }
+  }
+
+  private formatElapsed(createdAt: string): string {
+    const ms = Date.now() - new Date(createdAt).getTime();
+    const mins = Math.floor(ms / 60_000);
+    if (mins < 1) return "just started";
+    if (mins < 60) return `running ${mins}m`;
+    const hours = Math.floor(mins / 60);
+    const remainMins = mins % 60;
+    return remainMins > 0 ? `running ${hours}h ${remainMins}m` : `running ${hours}h`;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import { runCommand } from "./lib/run-command.js";
 import { handleMcpRequest } from "./mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
+import { SlackNotifier } from "./notifications/slack.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 
 const config = loadConfig();
@@ -43,6 +44,8 @@ const app = Fastify({
 });
 const pool = createPool(config);
 const agentManager = new AgentManager(pool, app.log, config);
+const slackNotifier = new SlackNotifier(pool, app.log);
+agentManager.onLatestEvent((agent) => void slackNotifier.onAgentEvent(agent));
 const terminalTokenStore = new TerminalTokenStore(60_000);
 
 const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", "idle"] as const;
@@ -1015,6 +1018,43 @@ async function registerRoutes() {
     return {
       homeDir: os.homedir()
     };
+  });
+
+  // --- Notification settings ---
+  app.get("/api/v1/notifications/settings", async () => {
+    return slackNotifier.getSettings();
+  });
+
+  app.post("/api/v1/notifications/settings", async (request, reply) => {
+    const body = request.body as {
+      webhookUrl?: unknown;
+      notifyEvents?: unknown;
+    } | null;
+
+    if (body?.webhookUrl !== undefined) {
+      if (typeof body.webhookUrl !== "string") {
+        return reply.code(400).send({ error: "webhookUrl must be a string." });
+      }
+      await slackNotifier.setWebhookUrl(body.webhookUrl);
+    }
+
+    if (body?.notifyEvents !== undefined) {
+      if (!Array.isArray(body.notifyEvents)) {
+        return reply.code(400).send({ error: "notifyEvents must be an array." });
+      }
+      await slackNotifier.setNotifyEvents(body.notifyEvents as string[]);
+    }
+
+    return slackNotifier.getSettings();
+  });
+
+  app.post("/api/v1/notifications/test", async (request, reply) => {
+    const body = request.body as { webhookUrl?: unknown } | null;
+    const url = typeof body?.webhookUrl === "string" ? body.webhookUrl : await slackNotifier.getWebhookUrl();
+    if (!url) {
+      return reply.code(400).send({ error: "No webhook URL provided or configured." });
+    }
+    return slackNotifier.sendTestMessage(url);
   });
 
   // --- Energy metrics beacon (PWA diagnostics) ---

--- a/web/src/components/app/notification-settings.tsx
+++ b/web/src/components/app/notification-settings.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+
+type NotifyEventType = "done" | "waiting_user" | "blocked";
+
+type NotificationSettingsResponse = {
+  webhookUrl: string;
+  notifyEvents: NotifyEventType[];
+};
+
+const EVENT_OPTIONS: Array<{ id: NotifyEventType; label: string; description: string }> = [
+  { id: "done", label: "Done", description: "Agent finished its task" },
+  { id: "waiting_user", label: "Waiting for input", description: "Agent needs your response" },
+  { id: "blocked", label: "Blocked", description: "Agent hit an error or obstacle" },
+];
+
+export function NotificationSettings(): JSX.Element {
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [savedUrl, setSavedUrl] = useState("");
+  const [notifyEvents, setNotifyEvents] = useState<NotifyEventType[]>([
+    "done",
+    "waiting_user",
+    "blocked",
+  ]);
+  const [savedEvents, setSavedEvents] = useState<NotifyEventType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await api<NotificationSettingsResponse>(
+          "/api/v1/notifications/settings"
+        );
+        if (cancelled) return;
+        setWebhookUrl(data.webhookUrl);
+        setSavedUrl(data.webhookUrl);
+        setNotifyEvents(data.notifyEvents);
+        setSavedEvents(data.notifyEvents);
+      } catch {
+        // ignore — first load may fail if server is starting
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasChanges =
+    webhookUrl !== savedUrl ||
+    JSON.stringify([...notifyEvents].sort()) !==
+      JSON.stringify([...savedEvents].sort());
+
+  const handleSave = useCallback(async () => {
+    setError("");
+    setMessage("");
+    setSaving(true);
+    try {
+      const data = await api<NotificationSettingsResponse>(
+        "/api/v1/notifications/settings",
+        {
+          method: "POST",
+          body: JSON.stringify({ webhookUrl, notifyEvents }),
+        }
+      );
+      setSavedUrl(data.webhookUrl);
+      setSavedEvents(data.notifyEvents);
+      setWebhookUrl(data.webhookUrl);
+      setNotifyEvents(data.notifyEvents);
+      setMessage("Settings saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  }, [webhookUrl, notifyEvents]);
+
+  const handleTest = useCallback(async () => {
+    setError("");
+    setMessage("");
+    setTesting(true);
+    try {
+      const result = await api<{ ok: boolean; error?: string }>(
+        "/api/v1/notifications/test",
+        {
+          method: "POST",
+          body: JSON.stringify({ webhookUrl: webhookUrl || undefined }),
+        }
+      );
+      if (result.ok) {
+        setMessage("Test message sent — check your Slack channel!");
+      } else {
+        setError(result.error ?? "Test failed.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send test.");
+    } finally {
+      setTesting(false);
+    }
+  }, [webhookUrl]);
+
+  const toggleEvent = useCallback((eventType: NotifyEventType) => {
+    setNotifyEvents((prev) =>
+      prev.includes(eventType)
+        ? prev.filter((e) => e !== eventType)
+        : [...prev, eventType]
+    );
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading...</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 overflow-y-auto p-6">
+      {/* Slack Webhook */}
+      <div>
+        <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Slack Webhook
+        </h3>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Receive notifications in Slack when agents finish, need input, or get blocked.
+          Create an{" "}
+          <a
+            href="https://api.slack.com/messaging/webhooks"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:underline"
+          >
+            Incoming Webhook
+          </a>{" "}
+          in your Slack workspace and paste the URL below.
+        </p>
+        <div className="max-w-lg space-y-3">
+          <Input
+            type="url"
+            placeholder="https://hooks.slack.com/services/..."
+            value={webhookUrl}
+            onChange={(e) => {
+              setWebhookUrl(e.target.value);
+              setMessage("");
+              setError("");
+            }}
+            data-testid="slack-webhook-url"
+          />
+        </div>
+      </div>
+
+      {/* Event toggles */}
+      <div>
+        <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Notify on
+        </h3>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Choose which agent status changes trigger a Slack notification.
+        </p>
+        <div className="max-w-lg space-y-2">
+          {EVENT_OPTIONS.map(({ id, label, description }) => (
+            <label
+              key={id}
+              className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50"
+            >
+              <input
+                type="checkbox"
+                checked={notifyEvents.includes(id)}
+                onChange={() => toggleEvent(id)}
+                className="h-4 w-4 rounded border-border accent-primary"
+                data-testid={`notify-event-${id}`}
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">
+                  {label}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {description}
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="max-w-lg">
+        {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
+        {message && (
+          <p className="mb-3 text-sm text-emerald-500">{message}</p>
+        )}
+        <div className="flex gap-2">
+          <Button
+            variant="primary"
+            disabled={saving || !hasChanges}
+            onClick={() => void handleSave()}
+            data-testid="save-notification-settings"
+          >
+            {saving ? "Saving..." : "Save"}
+          </Button>
+          <Button
+            variant="default"
+            disabled={testing || !webhookUrl}
+            onClick={() => void handleTest()}
+            data-testid="test-slack-webhook"
+          >
+            {testing ? "Sending..." : "Send test"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,17 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, RefreshCw, Shield, X } from "lucide-react";
+import { Bell, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, RefreshCw, Shield, X } from "lucide-react";
 
+import { NotificationSettings } from "@/components/app/notification-settings";
 import { ReleaseManager } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release" | "security" | "app";
+type SettingsSection = "release" | "security" | "notifications" | "app";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
   { id: "release", label: "Updates", icon: ArrowDownToLine },
   { id: "security", label: "Security", icon: Shield },
+  { id: "notifications", label: "Notifications", icon: Bell },
   { id: "app", label: "App", icon: RefreshCw }
 ];
 
@@ -236,6 +238,7 @@ export function SettingsPane({ open, onClose, onLogout }: SettingsPaneProps): JS
             <div className={cn("min-h-0 min-w-0 flex-1", activeSection === null && "hidden md:block")}>
               {activeSection === "release" && <ReleaseManager />}
               {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
+              {activeSection === "notifications" && <NotificationSettings />}
               {activeSection === "app" && <AppSettings />}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Send Slack webhook notifications when agents transition to `done`, `waiting_user`, or `blocked` states with rich formatted messages (agent name, event message, git branch, agent type, elapsed time)
- Add **Notifications** section to Settings pane with webhook URL input, event type toggles, and "Send test" button
- Extract shared `getSetting`/`setSetting`/`deleteSetting` helpers (`src/db/settings.ts`) and refactor `auth.ts` to use them
- Add `AgentManager.onLatestEvent()` listener pattern so notifications hook in once, covering all event upsert paths
- 10s TTL cache in `SlackNotifier` to avoid DB queries on the hot path

## Test plan
- [x] Type checks pass (`npm run check`)
- [x] Production build passes (`npm run finalize:web`)
- [x] E2E tests pass (29/29)
- [x] Validated Settings > Notifications UI in Playwright
- [x] Tested live Slack webhook delivery on a dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)