### PR TITLE
Fix media seen state race condition

### DIFF
--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -69,4 +69,28 @@ test.describe("Media sidebar", () => {
     await lightbox.getByRole("button", { name: "Close" }).click();
     await expect(lightbox).toBeHidden();
   });
+
+  test("marks visible media as seen and persists to server", async ({ page, request }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-seen-${Date.now()}` });
+
+    await uploadMediaViaAPI(request, agent.id, "Seen test image", "seen-test.png");
+
+    await loadApp(page);
+    await page.getByText(agent.name, { exact: true }).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await expect(mediaSidebar).toContainText("1 items");
+
+    // The item should flip to "seen" once visible (IntersectionObserver fires).
+    const thumb = mediaSidebar.locator(".media-thumb-seen");
+    await expect(thumb).toBeVisible({ timeout: 5_000 });
+
+    // Verify it persisted to the server.
+    const res = await request.get(`/api/v1/agents/${agent.id}/media`, {
+      headers: { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` },
+    });
+    const body = (await res.json()) as { files: Array<{ seen?: boolean }> };
+    expect(body.files[0].seen).toBe(true);
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -146,8 +146,6 @@ export function App(): JSX.Element {
 
   const {
     mediaFiles,
-    seenMediaKeys,
-    setSeenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
     lightboxIndex,
@@ -156,6 +154,7 @@ export function App(): JSX.Element {
     openLightbox,
     mediaViewportRef,
     refreshMedia,
+    markSeenInCache,
   } = useMedia(selectedAgentId, mediaPanelOpen);
 
   const selectedAgentHasStream = selectedAgentId ? streamingAgentIds.has(selectedAgentId) : false;
@@ -210,7 +209,7 @@ export function App(): JSX.Element {
   connectedAgentIdRef.current = connectedAgentId;
 
   // ── SSE ───────────────────────────────────────────────────────────────
-  useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, setSeenMediaKeys);
+  useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, markSeenInCache);
 
   // ── Energy metrics ────────────────────────────────────────────────────
   useEffect(() => {
@@ -489,7 +488,7 @@ export function App(): JSX.Element {
             selectedAgentId={selectedAgentId}
             selectedAgentName={selectedAgent?.name ?? null}
             animatingMediaKeys={animatingMediaKeys}
-            seenMediaKeys={seenMediaKeys}
+
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
             hasStream={selectedAgentHasStream}
@@ -548,7 +547,7 @@ export function App(): JSX.Element {
               selectedAgentId={selectedAgentId}
               selectedAgentName={selectedAgent?.name ?? null}
               animatingMediaKeys={animatingMediaKeys}
-              seenMediaKeys={seenMediaKeys}
+  
               mediaViewportRef={mediaViewportRef}
               hasStream={selectedAgentHasStream}
               streamUrl={selectedAgentStreamUrl}

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -10,7 +10,6 @@ type MediaSidebarSharedProps = {
   selectedAgentId: string | null;
   selectedAgentName: string | null;
   animatingMediaKeys: Set<string>;
-  seenMediaKeys: Set<string>;
   mediaViewportRef: RefObject<HTMLDivElement>;
   openLightbox: (file: MediaFile) => void;
   hasStream: boolean;
@@ -67,7 +66,6 @@ export function MediaSidebarContent({
   selectedAgentId,
   selectedAgentName,
   animatingMediaKeys,
-  seenMediaKeys,
   mediaViewportRef,
   openLightbox,
   hasStream,
@@ -109,7 +107,7 @@ export function MediaSidebarContent({
             const mediaKey = `${file.name}:${file.updatedAt}`;
             const cacheBustUrl = `${file.url}?t=${encodeURIComponent(file.updatedAt)}`;
             const animating = animatingMediaKeys.has(mediaKey);
-            const unseen = !seenMediaKeys.has(mediaKey);
+            const unseen = !file.seen;
 
             const isStream = file.source === "stream";
 

--- a/web/src/hooks/use-media.ts
+++ b/web/src/hooks/use-media.ts
@@ -6,7 +6,6 @@ import { api } from "@/lib/api";
 export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean) {
   const queryClient = useQueryClient();
 
-  const [seenMediaKeys, setSeenMediaKeys] = useState<Set<string>>(new Set());
   const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
   const [lightboxMediaKey, setLightboxMediaKey] = useState<string | null>(null);
   const mediaViewportRef = useRef<HTMLDivElement>(null);
@@ -31,22 +30,8 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     void refetchMedia();
   }, [mediaPanelOpen, refetchMedia, selectedAgentId]);
 
-  // Sync seenMediaKeys from fetched data.
+  // Reset on agent change.
   useEffect(() => {
-    if (mediaFiles.length > 0) {
-      setSeenMediaKeys(
-        new Set(
-          mediaFiles
-            .filter((file) => file.seen === true)
-            .map((file) => `${file.name}:${file.updatedAt}`)
-        )
-      );
-    }
-  }, [mediaFiles]);
-
-  // Reset seen keys when selected agent changes.
-  useEffect(() => {
-    setSeenMediaKeys(new Set());
     previousMediaKeysRef.current = new Set();
     setLightboxMediaKey(null);
   }, [selectedAgentId]);
@@ -88,20 +73,21 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     };
   }, [mediaFiles]);
 
-  // IntersectionObserver for marking media as seen.
-  const markMediaSeen = useCallback(
-    async (agentId: string, keys: string[]) => {
-      if (keys.length === 0) return;
-      try {
-        await api<{ ok: boolean; updated: number }>(`/api/v1/agents/${agentId}/media/seen`, {
-          method: "POST",
-          body: JSON.stringify({ keys }),
+  // Optimistically mark files as seen in the query cache.
+  const markSeenInCache = useCallback(
+    (agentId: string, keys: Set<string>) => {
+      queryClient.setQueryData<MediaFile[]>(["media", agentId], (old) => {
+        if (!old) return old;
+        return old.map((file) => {
+          const key = `${file.name}:${file.updatedAt}`;
+          return keys.has(key) && !file.seen ? { ...file, seen: true } : file;
         });
-      } catch {}
+      });
     },
-    []
+    [queryClient]
   );
 
+  // IntersectionObserver for marking media as seen.
   useEffect(() => {
     if (!mediaPanelOpen) return;
 
@@ -112,26 +98,29 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     const observer = new IntersectionObserver(
       (entries) => {
         const newlySeen: string[] = [];
-        setSeenMediaKeys((current) => {
-          let changed = false;
-          const next = new Set(current);
 
-          for (const entry of entries) {
-            if (entry.isIntersecting) {
-              const mediaKey = (entry.target as HTMLElement).dataset.mediaKey;
-              if (mediaKey && !next.has(mediaKey)) {
-                next.add(mediaKey);
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const mediaKey = (entry.target as HTMLElement).dataset.mediaKey;
+            if (mediaKey) {
+              // Check if already seen in current cache data
+              const cached = queryClient.getQueryData<MediaFile[]>(["media", selected]);
+              const file = cached?.find((f) => `${f.name}:${f.updatedAt}` === mediaKey);
+              if (file && !file.seen) {
                 newlySeen.push(mediaKey);
-                changed = true;
               }
             }
           }
-
-          return changed ? next : current;
-        });
+        }
 
         if (newlySeen.length > 0) {
-          void markMediaSeen(selected, newlySeen);
+          // Optimistic cache update
+          markSeenInCache(selected, new Set(newlySeen));
+          // Persist to server
+          void api(`/api/v1/agents/${selected}/media/seen`, {
+            method: "POST",
+            body: JSON.stringify({ keys: newlySeen }),
+          }).catch(() => {});
         }
       },
       { root, threshold: 0.65 }
@@ -143,11 +132,11 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     return () => {
       observer.disconnect();
     };
-  }, [markMediaSeen, mediaFiles, mediaPanelOpen, selectedAgentId]);
+  }, [markSeenInCache, mediaFiles, mediaPanelOpen, queryClient, selectedAgentId]);
 
   const unseenMediaCount = useMemo(() => {
-    return mediaFiles.filter((file) => !seenMediaKeys.has(`${file.name}:${file.updatedAt}`)).length;
-  }, [mediaFiles, seenMediaKeys]);
+    return mediaFiles.filter((file) => !file.seen).length;
+  }, [mediaFiles]);
 
   const openLightbox = useCallback((file: MediaFile) => {
     setLightboxMediaKey(`${file.name}:${file.updatedAt}`);
@@ -198,8 +187,6 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
 
   return useMemo(() => ({
     mediaFiles,
-    seenMediaKeys,
-    setSeenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
     lightboxIndex,
@@ -208,9 +195,9 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     openLightbox,
     mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
     refreshMedia,
+    markSeenInCache,
   }), [
     mediaFiles,
-    seenMediaKeys,
     animatingMediaKeys,
     unseenMediaCount,
     lightboxIndex,
@@ -218,5 +205,6 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     setLightboxIndex,
     openLightbox,
     refreshMedia,
+    markSeenInCache,
   ]);
 }

--- a/web/src/hooks/use-sse.ts
+++ b/web/src/hooks/use-sse.ts
@@ -18,7 +18,7 @@ export function useSSE(
   connectedAgentIdRef: React.RefObject<string | null>,
   selectedAgentIdRef: React.RefObject<string | null>,
   setStreamingAgentIds: React.Dispatch<React.SetStateAction<Set<string>>>,
-  setSeenMediaKeys: React.Dispatch<React.SetStateAction<Set<string>>>,
+  markSeenInCache: (agentId: string, keys: Set<string>) => void,
 ): void {
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -87,18 +87,8 @@ export function useSSE(
           return;
         }
 
-        if (payload.type === "media.seen" && payload.agentId === selectedAgentIdRef.current) {
-          setSeenMediaKeys((current) => {
-            const next = new Set(current);
-            let changed = false;
-            for (const key of payload.keys) {
-              if (!next.has(key)) {
-                next.add(key);
-                changed = true;
-              }
-            }
-            return changed ? next : current;
-          });
+        if (payload.type === "media.seen") {
+          markSeenInCache(payload.agentId, new Set(payload.keys));
         }
       } catch {}
     };
@@ -138,5 +128,5 @@ export function useSSE(
       document.removeEventListener("visibilitychange", onVisChange);
       closeSSE();
     };
-  }, [authState, connectedAgentIdRef, queryClient, selectedAgentIdRef, setSeenMediaKeys, setStreamingAgentIds]);
+  }, [authState, connectedAgentIdRef, markSeenInCache, queryClient, selectedAgentIdRef, setStreamingAgentIds]);
 }


### PR DESCRIPTION
## Summary
- Fix media seen state race condition: the local `seenMediaKeys` set was racing with server refetches, causing items to flip back to unseen.
- Use `file.seen` from the React Query cache as the sole source of truth, with optimistic cache updates when items become visible in the viewport.
- Add E2E test verifying media items are marked as seen and persisted to the server.

## Test plan
- [x] `npm run check` — types pass
- [x] `npm run finalize:web` — production build passes
- [x] `npm run test:e2e` — 30/30 pass (including new media seen test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)