### PR TITLE
Fix sidebar event line to always show relative time

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -338,13 +338,24 @@ export function AgentSidebarContent({
                   </div>
 
                   {agent.latestEvent ? (
-                    <div className="mt-1 truncate text-xs text-muted-foreground">
-                      <span className={cn("font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
-                      <span className="mx-1.5 text-muted-foreground/70">•</span>
-                      <span>{agent.latestEvent.message}</span>
-                      <span className="mx-1.5 text-muted-foreground/70">•</span>
-                      <span>{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
-                    </div>
+                    isExpanded ? (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        <div className="flex items-baseline">
+                          <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
+                          <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+                          <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
+                        </div>
+                        <div className="mt-0.5 leading-relaxed text-muted-foreground">{agent.latestEvent.message}</div>
+                      </div>
+                    ) : (
+                      <div className="mt-1 flex min-w-0 items-baseline text-xs text-muted-foreground">
+                        <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
+                        <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+                        <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
+                        <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+                        <span className="min-w-0 truncate">{agent.latestEvent.message}</span>
+                      </div>
+                    )
                   ) : null}
 
                   <div


### PR DESCRIPTION
## Summary
- Reorders the agent event line from **Status · Message · Time** to **Status · Time · Message** so the relative timestamp is never clipped off
- **Collapsed**: status and time are flex-shrink-0 (always visible), message truncates with ellipsis
- **Expanded**: status and time on top line, full message wraps below with no truncation

## Test plan
- [x] `npm run finalize:web` — type check + production build pass
- [x] `npm run test:e2e` — 30/30 passed (5 pre-existing skips)
- [ ] Visual verification: collapsed agents show `Working · 3m ago · message...`
- [ ] Visual verification: expanded agents show full unwrapped message below status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)