### PR TITLE
Add theme system with settings picker

### DIFF
--- a/docs/14-theming.md
+++ b/docs/14-theming.md
@@ -1,0 +1,179 @@
+# Theming
+
+Dispatch supports multiple color themes. Themes are defined as sets of CSS custom properties and can be switched at runtime via the Settings > Appearance picker. The user's choice persists in `localStorage` and is applied before React mounts to avoid a flash of wrong colors.
+
+## Architecture overview
+
+```
+web/src/index.css          ← Theme CSS variable definitions (:root + [data-theme="..."])
+web/tailwind.config.ts     ← Maps CSS vars to Tailwind color utilities
+web/src/hooks/use-theme.ts ← React hook + theme registry (ThemeId, THEMES array)
+web/src/components/app/settings-pane.tsx ← Appearance UI (theme picker)
+web/index.html             ← Inline script for flash-free theme on load
+```
+
+## CSS custom properties
+
+All theme colors live in `web/src/index.css`. The default theme is defined on `:root`. Additional themes use `[data-theme="<id>"]` selectors.
+
+### Base tokens (shadcn/ui standard)
+
+These are the standard shadcn tokens. Every theme must define all of them:
+
+| Variable | Purpose |
+|---|---|
+| `--background` | Page background |
+| `--foreground` | Default text color |
+| `--card` / `--card-foreground` | Card surfaces |
+| `--popover` / `--popover-foreground` | Popover/dropdown surfaces |
+| `--primary` / `--primary-foreground` | Primary action color (buttons, links) |
+| `--muted` / `--muted-foreground` | Muted/secondary surfaces and text |
+| `--accent` / `--accent-foreground` | Accent highlight |
+| `--destructive` / `--destructive-foreground` | Destructive/error actions |
+| `--border` | Border color |
+| `--input` | Input field border |
+| `--ring` | Focus ring color |
+
+### Status tokens
+
+These control agent state indicators, badges, buttons, and status dots throughout the UI:
+
+| Variable | Purpose | Default theme | Example usage |
+|---|---|---|---|
+| `--status-working` | Active/success state | Emerald | Agent working indicator, "running" badge, service OK dot |
+| `--status-blocked` | Error/blocked state | Red | Agent blocked, error badge, live stream indicator |
+| `--status-waiting` | Warning/pending state | Amber | Waiting for user, reconnect indicator, full-access warning |
+| `--status-done` | Info/complete state | Sky blue | Agent done, transitional badge, info buttons |
+| `--status-idle` | Neutral/idle state | Zinc gray | Idle agent border |
+
+### Surface tokens
+
+| Variable | Purpose |
+|---|---|
+| `--surface` | Header, footer, and toolbar background (slightly darker than `--background`) |
+| `--terminal-bg` | Terminal pane and xterm background |
+
+### Value format
+
+All values use **bare HSL components** without the `hsl()` wrapper — this allows Tailwind's opacity modifier syntax to work:
+
+```css
+--status-working: 158 64% 52%;   /* ✓ correct */
+--status-working: hsl(158, 64%, 52%);  /* ✗ wrong — breaks Tailwind opacity */
+```
+
+## Tailwind integration
+
+`web/tailwind.config.ts` maps CSS vars to Tailwind utilities. The status colors use `<alpha-value>` for opacity support:
+
+```ts
+status: {
+  working: "hsl(var(--status-working) / <alpha-value>)",
+  blocked: "hsl(var(--status-blocked) / <alpha-value>)",
+  waiting: "hsl(var(--status-waiting) / <alpha-value>)",
+  done:    "hsl(var(--status-done) / <alpha-value>)",
+  idle:    "hsl(var(--status-idle) / <alpha-value>)",
+}
+```
+
+This means you can use standard Tailwind patterns:
+
+```tsx
+<span className="text-status-working" />           // solid color
+<span className="bg-status-working/15" />           // 15% opacity background
+<span className="border-status-blocked/50" />       // 50% opacity border
+```
+
+The `surface` and `terminal-bg` colors are also available as `bg-surface` and `bg-terminal-bg`.
+
+## How to add a new theme
+
+### Step 1: Define the CSS variables
+
+Add a new `[data-theme="your-theme-id"]` block in `web/src/index.css`. You must define **every** variable listed above. Copy an existing theme block as a starting point:
+
+```css
+[data-theme="midnight"] {
+  /* Base tokens */
+  --background: 240 20% 4%;
+  --foreground: 0 0% 95%;
+  --card: 240 18% 7%;
+  --card-foreground: 0 0% 95%;
+  --popover: 240 18% 7%;
+  --popover-foreground: 0 0% 95%;
+  --primary: 270 80% 60%;
+  --primary-foreground: 240 20% 4%;
+  --muted: 240 12% 12%;
+  --muted-foreground: 240 8% 60%;
+  --accent: 240 12% 12%;
+  --accent-foreground: 0 0% 95%;
+  --destructive: 0 80% 55%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 10% 18%;
+  --input: 240 10% 18%;
+  --ring: 270 80% 60%;
+
+  /* Status tokens */
+  --status-working: 140 60% 50%;
+  --status-blocked: 0 80% 55%;
+  --status-waiting: 50 90% 60%;
+  --status-done: 210 90% 60%;
+  --status-idle: 240 5% 45%;
+
+  /* Surface tokens */
+  --surface: 240 20% 3%;
+  --terminal-bg: 240 20% 3%;
+}
+```
+
+### Step 2: Register the theme in use-theme.ts
+
+1. Add the new ID to the `ThemeId` union type:
+
+```ts
+export type ThemeId = "default" | "crumbstream" | "midnight";
+```
+
+2. Add an entry to the `THEMES` array with a label, description, and 4 representative hex swatches (shown in the picker UI):
+
+```ts
+{
+  id: "midnight",
+  label: "Midnight",
+  description: "Deep purple with violet accents",
+  swatches: ["#0a0a14", "#9966ff", "#f0f0f0", "#2d2d3d"],
+},
+```
+
+That's it — the theme picker, localStorage persistence, and flash-free loading all work automatically.
+
+### Step 3: Validate
+
+1. Run `npm run finalize:web` to verify the build compiles.
+2. Start a dev server and visually check: sidebar, status footer, badges, buttons, terminal pane, settings pane, and the create-agent dialog.
+3. Run `npm run test:e2e` to confirm no regressions.
+
+## Color design tips
+
+- **Background** should be very dark (lightness 4–8%). The `--surface` should be slightly darker than `--background` for the header/footer strip.
+- **Primary** is the most prominent accent — used on the Create button, selected states, and focus rings. Pick something that pops against the background.
+- **Status colors** should be visually distinct from each other. They appear as small dots and text labels, so they need good contrast against both `--background` and `--card`.
+- **Border** should be subtle — lightness around 18–22% works well for dark themes.
+- **Terminal background** (`--terminal-bg`) is usually the same as `--background` or `--surface`. The terminal ANSI palette (red, green, blue, etc.) is currently hardcoded to a Monokai-inspired set and shared across themes — only the terminal `background` and `foreground` colors are theme-aware.
+
+## What NOT to do
+
+- **Don't use hardcoded Tailwind color classes** like `text-emerald-400` or `bg-red-500` for anything that should change with the theme. Use the semantic `status-*` utilities or the base tokens (`primary`, `destructive`, etc.) instead.
+- **Don't use hardcoded hex values** for backgrounds like `bg-[#141414]`. Use `bg-terminal-bg`, `bg-surface`, or `bg-background`.
+- **Don't wrap CSS var values in `hsl()`** — the bare `H S% L%` format is required for Tailwind opacity support.
+- **Don't forget to define all variables** — a missing variable will cause that color to disappear (transparent) in your theme.
+
+## File reference
+
+| File | What to edit |
+|---|---|
+| `web/src/index.css` | Add `[data-theme="..."]` CSS variable block |
+| `web/src/hooks/use-theme.ts` | Add to `ThemeId` type and `THEMES` array |
+| `web/tailwind.config.ts` | Only if adding new semantic color tokens (rarely needed) |
+| `web/src/components/app/settings-pane.tsx` | Only if changing the picker UI itself |
+| `web/index.html` | Only if changing the flash-prevention script |

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -24,7 +24,7 @@ test.describe("Settings pane", () => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByRole("navigation").getByText("App").click();
+    await page.getByRole("navigation").getByText("App", { exact: true }).click();
 
     await expect(page.getByTestId("app-version-card")).toBeVisible();
     await expect(page.getByTestId("app-version-semver")).not.toHaveText("");

--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,10 @@
     />
   </head>
   <body>
+    <script>
+      // Apply saved theme before first paint to avoid flash
+      (function(){var t=localStorage.getItem('dispatch:theme');if(t&&t!=='default')document.documentElement.setAttribute('data-theme',t)})();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import { useAgents } from "@/hooks/use-agents";
 import { useSSE } from "@/hooks/use-sse";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
+import { useTheme } from "@/hooks/use-theme";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
@@ -71,6 +72,9 @@ function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): bo
 }
 
 export function App(): JSX.Element {
+  // ── Theme ─────────────────────────────────────────────────────────────
+  const { theme, setTheme } = useTheme();
+
   // ── Auth ──────────────────────────────────────────────────────────────
   const { authState, handleAuthenticated, handleLogout } = useAuth();
 
@@ -382,15 +386,15 @@ export function App(): JSX.Element {
   }, [attachToAgent, selectedAgent]);
 
   const borderForAgentState = (state: AgentVisualState): string => {
-    if (state === "active") return "border-r-emerald-500";
-    if (state === "idle") return "border-r-sky-300";
-    return "border-r-zinc-500";
+    if (state === "active") return "border-r-status-working";
+    if (state === "idle") return "border-r-status-done";
+    return "border-r-status-idle";
   };
 
   const serviceDotClass = (state: ServiceState): string => {
-    if (state === "ok") return "bg-emerald-500";
-    if (state === "down") return "bg-red-500";
-    return "bg-amber-500";
+    if (state === "ok") return "bg-status-working";
+    if (state === "down") return "bg-status-blocked";
+    return "bg-status-waiting";
   };
 
   // ── Render ────────────────────────────────────────────────────────────
@@ -582,7 +586,7 @@ export function App(): JSX.Element {
       />
 
       <DocsPane open={docsPaneOpen} onClose={() => setDocsPaneOpen(false)} />
-      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} onLogout={handleLogout} />
+      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} onLogout={handleLogout} theme={theme} setTheme={setTheme} />
 
       <MediaLightbox
         item={lightboxItem}

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -109,10 +109,10 @@ export function AgentSidebarContent({
   };
 
   const latestEventColor = (type: NonNullable<Agent["latestEvent"]>["type"]): string => {
-    if (type === "working") return "text-emerald-400";
-    if (type === "blocked") return "text-red-400";
-    if (type === "waiting_user") return "text-amber-400";
-    if (type === "done") return "text-sky-400";
+    if (type === "working") return "text-status-working";
+    if (type === "blocked") return "text-status-blocked";
+    if (type === "waiting_user") return "text-status-waiting";
+    if (type === "done") return "text-status-done";
     return "text-foreground/80";
   };
 
@@ -183,7 +183,7 @@ export function AgentSidebarContent({
                   className={cn(
                     "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
                     borderForAgentState(state),
-                    isActive && "bg-emerald-500/10",
+                    isActive && "bg-status-working/10",
                     isStopped && "opacity-60",
                     isSelected && "bg-muted/60"
                   )}
@@ -214,7 +214,7 @@ export function AgentSidebarContent({
 
                     {needsAttention ? (
                       <Badge
-                        className="border-red-400/45 bg-red-500/15 text-red-200"
+                        className="border-status-blocked/45 bg-status-blocked/15 text-status-blocked"
                         title={agent.lastError ?? "Agent entered an error state and may need attention."}
                       >
                         Attention
@@ -417,7 +417,7 @@ export function AgentSidebarContent({
                               className={cn(
                                 "inline-flex w-fit items-center gap-1.5 px-1.5 py-0.5 text-foreground",
                                 fullAccessEnabled &&
-                                  "border border-amber-400/45 bg-amber-500/15 text-amber-200"
+                                  "border border-status-waiting/45 bg-status-waiting/15 text-status-waiting"
                               )}
                             >
                               {fullAccessEnabled ? <AlertTriangle className="h-3.5 w-3.5" /> : null}

--- a/web/src/components/app/agent-type-icon.tsx
+++ b/web/src/components/app/agent-type-icon.tsx
@@ -11,10 +11,10 @@ type AgentTypeIconProps = {
 };
 
 const eventColorClass: Record<AgentEventType, string> = {
-  working: "text-emerald-400 border-emerald-400/50 bg-emerald-500/15",
-  blocked: "text-red-400 border-red-400/50 bg-red-500/15",
-  waiting_user: "text-amber-400 border-amber-400/50 bg-amber-500/15",
-  done: "text-sky-400 border-sky-400/50 bg-sky-500/15",
+  working: "text-status-working border-status-working/50 bg-status-working/15",
+  blocked: "text-status-blocked border-status-blocked/50 bg-status-blocked/15",
+  waiting_user: "text-status-waiting border-status-waiting/50 bg-status-waiting/15",
+  done: "text-status-done border-status-done/50 bg-status-done/15",
   idle: "",
 };
 

--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -40,7 +40,7 @@ export function AppHeader({
     <header
       data-testid="app-header"
       className={cn(
-        "relative flex min-h-14 min-w-0 items-center gap-2 border-b-2 border-b-border bg-[#11120f] px-3 py-2 pt-[env(safe-area-inset-top)]"
+        "relative flex min-h-14 min-w-0 items-center gap-2 border-b-2 border-b-border bg-surface px-3 py-2 pt-[env(safe-area-inset-top)]"
       )}
     >
       <div
@@ -142,7 +142,7 @@ export function AppHeader({
 
       {showReconnectIndicator ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden">
-          <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-amber-400 to-transparent" />
+          <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
         </div>
       ) : null}
     </header>

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -39,8 +39,8 @@ function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; 
   return (
     <div className="border-b-2 border-border">
       <div className="flex items-center gap-2 px-3 py-2">
-        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-red-500" />
-        <span className="text-xs font-semibold uppercase tracking-wide text-red-400">Live Stream</span>
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-status-blocked" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">Live Stream</span>
         <div className="ml-auto">
           <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs" onClick={popOut}>
             <ExternalLink className="h-3 w-3" />
@@ -117,14 +117,14 @@ export function MediaSidebarContent({
                 data-media-key={mediaKey}
                 className={cn(
                   "border-b-2 border-border px-3 py-3",
-                  isStream && "border-l-2 border-l-red-500/60 bg-red-500/5",
+                  isStream && "border-l-2 border-l-status-blocked/60 bg-status-blocked/5",
                   animating && "animate-media-in-slow"
                 )}
               >
                 {isStream ? (
                   <div className="mb-2 flex items-center gap-1.5">
-                    <MonitorPlay className="h-3.5 w-3.5 text-red-400" />
-                    <span className="text-xs font-semibold uppercase tracking-wide text-red-400">Stream recording</span>
+                    <MonitorPlay className="h-3.5 w-3.5 text-status-blocked" />
+                    <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">Stream recording</span>
                     <span className="ml-auto text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</span>
                   </div>
                 ) : (

--- a/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -56,7 +56,7 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
 
   return (
     <>
-      <div className="border-t-2 border-border bg-[#12130f] px-2 py-2 md:hidden">
+      <div className="border-t-2 border-border bg-surface px-2 py-2 md:hidden">
         {/* Row 1: modifier + action keys + keyboard button */}
         <div className="flex justify-center gap-2">
           <Button

--- a/web/src/components/app/notification-settings.tsx
+++ b/web/src/components/app/notification-settings.tsx
@@ -194,7 +194,7 @@ export function NotificationSettings(): JSX.Element {
       <div className="max-w-lg">
         {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
         {message && (
-          <p className="mb-3 text-sm text-emerald-500">{message}</p>
+          <p className="mb-3 text-sm text-status-working">{message}</p>
         )}
         <div className="flex gap-2">
           <Button

--- a/web/src/components/app/release-manager.tsx
+++ b/web/src/components/app/release-manager.tsx
@@ -53,17 +53,17 @@ const VERSION_CONFIG: Record<ReleaseVersionType, {
 }> = {
   patch: {
     icon: ShieldCheck,
-    color: "text-emerald-400",
-    border: "border-emerald-500/30",
-    bg: "bg-emerald-500/10",
-    hover: "hover:border-emerald-500/60 hover:bg-emerald-500/20"
+    color: "text-status-working",
+    border: "border-status-working/30",
+    bg: "bg-status-working/10",
+    hover: "hover:border-status-working/60 hover:bg-status-working/20"
   },
   minor: {
     icon: Sparkles,
-    color: "text-blue-400",
-    border: "border-blue-500/30",
-    bg: "bg-blue-500/10",
-    hover: "hover:border-blue-500/60 hover:bg-blue-500/20"
+    color: "text-status-done",
+    border: "border-status-done/30",
+    bg: "bg-status-done/10",
+    hover: "hover:border-status-done/60 hover:bg-status-done/20"
   },
   major: {
     icon: Zap,
@@ -377,7 +377,7 @@ export function ReleaseManager(): JSX.Element {
                     <div className="text-[10px] uppercase tracking-widest text-muted-foreground">Create release</div>
 
                     {info.refMissing ? (
-                      <div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
+                      <div className="rounded border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-sm text-status-waiting">
                         Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
                       </div>
                     ) : info.unreleasedCount === 0 ? (
@@ -453,8 +453,8 @@ export function ReleaseManager(): JSX.Element {
                     <div key={phase} className="flex items-center gap-3">
                       <div className={cn(
                         "h-2 w-2 rounded-full shrink-0",
-                        done && "bg-green-500",
-                        current && !isFailed && "animate-pulse bg-amber-500",
+                        done && "bg-status-working",
+                        current && !isFailed && "animate-pulse bg-status-waiting",
                         current && isFailed && "bg-destructive",
                         !done && !current && "bg-muted"
                       )} />

--- a/web/src/components/app/security-settings.tsx
+++ b/web/src/components/app/security-settings.tsx
@@ -137,7 +137,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
           />
           {mismatch && <p className="text-sm text-destructive">Passwords do not match.</p>}
           {error && <p className="text-sm text-destructive">{error}</p>}
-          {message && <p className="text-sm text-emerald-500">{message}</p>}
+          {message && <p className="text-sm text-status-working">{message}</p>}
           <Button
             type="submit"
             variant="primary"

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,19 +1,21 @@
 import { useCallback, useEffect, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { Bell, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, RefreshCw, Shield, X } from "lucide-react";
+import { Bell, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, Palette, RefreshCw, Shield, X } from "lucide-react";
 
 import { NotificationSettings } from "@/components/app/notification-settings";
 import { ReleaseManager } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
+import { type ThemeId, THEMES } from "@/hooks/use-theme";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release" | "security" | "notifications" | "app";
+type SettingsSection = "release" | "security" | "notifications" | "appearance" | "app";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
   { id: "release", label: "Updates", icon: ArrowDownToLine },
   { id: "security", label: "Security", icon: Shield },
   { id: "notifications", label: "Notifications", icon: Bell },
+  { id: "appearance", label: "Appearance", icon: Palette },
   { id: "app", label: "App", icon: RefreshCw }
 ];
 
@@ -148,13 +150,58 @@ function AppSettings(): JSX.Element {
   );
 }
 
+function AppearanceSettings({ theme, setTheme }: { theme: ThemeId; setTheme: (id: ThemeId) => void }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Theme
+        </div>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Choose a color theme for the interface.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {THEMES.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTheme(t.id)}
+              className={cn(
+                "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
+                theme === t.id
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:border-muted-foreground/30"
+              )}
+            >
+              <div className="mt-0.5 flex gap-1">
+                {t.swatches.map((color, i) => (
+                  <span
+                    key={i}
+                    className="block h-4 w-4 rounded-full border border-white/10"
+                    style={{ backgroundColor: color }}
+                  />
+                ))}
+              </div>
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">{t.label}</div>
+                <div className="text-xs text-muted-foreground">{t.description}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 type SettingsPaneProps = {
   open: boolean;
   onClose: () => void;
   onLogout: () => void;
+  theme: ThemeId;
+  setTheme: (id: ThemeId) => void;
 };
 
-export function SettingsPane({ open, onClose, onLogout }: SettingsPaneProps): JSX.Element {
+export function SettingsPane({ open, onClose, onLogout, theme, setTheme }: SettingsPaneProps): JSX.Element {
   const [activeSection, setActiveSection] = useState<SettingsSection | null>("release");
 
   return (
@@ -239,6 +286,7 @@ export function SettingsPane({ open, onClose, onLogout }: SettingsPaneProps): JS
               {activeSection === "release" && <ReleaseManager />}
               {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
               {activeSection === "notifications" && <NotificationSettings />}
+              {activeSection === "appearance" && <AppearanceSettings theme={theme} setTheme={setTheme} />}
               {activeSection === "app" && <AppSettings />}
             </div>
           </div>

--- a/web/src/components/app/status-footer.tsx
+++ b/web/src/components/app/status-footer.tsx
@@ -17,7 +17,7 @@ export function StatusFooter({
   serviceDotClass
 }: StatusFooterProps): JSX.Element {
   return (
-    <footer data-testid="status-footer" className="flex h-11 items-center justify-around border-t-2 border-border bg-[#11120f] px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
+    <footer data-testid="status-footer" className="flex h-11 items-center justify-around border-t-2 border-border bg-surface px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
       <ServiceStatus
         icon={<Wifi className="h-3.5 w-3.5" />}
         label="WS"

--- a/web/src/components/app/terminal-pane.tsx
+++ b/web/src/components/app/terminal-pane.tsx
@@ -42,7 +42,7 @@ export const TerminalPane = memo(function TerminalPane({
   const showInertState = terminalMode === "inert" && isAttached;
 
   return (
-    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-[#141414]">
+    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-terminal-bg">
       <div
         className={cn(
           "h-full w-full",
@@ -54,7 +54,7 @@ export const TerminalPane = memo(function TerminalPane({
       </div>
 
       {showEmptyState ? (
-        <div data-testid="terminal-empty-state" className="absolute inset-0 z-20 grid place-items-center bg-[#141414]">
+        <div data-testid="terminal-empty-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
             <p className="text-sm">Select an agent and press Play to start and attach to a session.</p>
@@ -63,11 +63,11 @@ export const TerminalPane = memo(function TerminalPane({
       ) : null}
 
       {showInertState ? (
-        <div data-testid="terminal-inert-state" className="absolute inset-0 z-20 grid place-items-center bg-[#141414]">
-          <div className="flex max-w-xl flex-col items-center gap-3 px-6 text-center text-zinc-300">
-            <TerminalSquare className="h-9 w-9 text-amber-300" />
-            <p className="text-base font-medium text-zinc-100">Agent running in inert mode</p>
-            <p className="text-sm leading-6 text-zinc-400">
+        <div data-testid="terminal-inert-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
+          <div className="flex max-w-xl flex-col items-center gap-3 px-6 text-center text-muted-foreground">
+            <TerminalSquare className="h-9 w-9 text-status-waiting" />
+            <p className="text-base font-medium text-foreground">Agent running in inert mode</p>
+            <p className="text-sm leading-6 text-muted-foreground">
               {terminalPlaceholderMessage ??
                 "This environment does not launch a real tmux session or CLI process. Agent lifecycle flows are simulated for UI validation."}
             </p>
@@ -77,7 +77,7 @@ export const TerminalPane = memo(function TerminalPane({
 
       {showReconnectOverlay ? (
         <div className="absolute inset-0 z-30 grid place-items-center bg-black/70 backdrop-blur-sm">
-          <div className="flex flex-col items-center gap-2 text-sm text-amber-200">
+          <div className="flex flex-col items-center gap-2 text-sm text-status-waiting">
             <Loader2 className="h-5 w-5 animate-spin" />
             <span>{statusMessage}</span>
           </div>

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -9,10 +9,10 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "border-border bg-muted text-muted-foreground",
-        running: "border-green-400/40 bg-green-500/15 text-green-200",
-        stopped: "border-yellow-400/35 bg-yellow-500/15 text-yellow-200",
-        error: "border-red-400/40 bg-red-500/15 text-red-200",
-        transitional: "border-blue-400/35 bg-blue-500/15 text-blue-200"
+        running: "border-status-working/40 bg-status-working/15 text-status-working",
+        stopped: "border-status-waiting/35 bg-status-waiting/15 text-status-waiting",
+        error: "border-status-blocked/40 bg-status-blocked/15 text-status-blocked",
+        transitional: "border-status-done/35 bg-status-done/15 text-status-done"
       }
     },
     defaultVariants: {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -14,11 +14,11 @@ const buttonVariants = cva(
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "hover:bg-muted/70",
         "ghost-primary":
-          "text-emerald-300 hover:bg-emerald-500/15 hover:text-emerald-200",
+          "text-status-working hover:bg-status-working/15 hover:text-status-working",
         "ghost-info":
-          "text-sky-300 hover:bg-sky-500/15 hover:text-sky-200",
+          "text-status-done hover:bg-status-done/15 hover:text-status-done",
         "ghost-destructive":
-          "text-red-300 hover:bg-red-500/15 hover:text-red-200"
+          "text-status-blocked hover:bg-status-blocked/15 hover:text-status-blocked"
       },
       size: {
         default: "h-9 px-3 py-2",

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -23,6 +23,22 @@ function persistActiveShellAgentId(agentId: string | null): void {
   window.localStorage.removeItem(ACTIVE_SHELL_AGENT_KEY);
 }
 
+/** Read a CSS custom property as an hsl() hex string. */
+function cssHsl(prop: string): string {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(prop).trim();
+  if (!raw) return "";
+  // raw is like "0 0% 8%" — convert to hsl(0, 0%, 8%) then to hex via a temp element
+  const el = document.createElement("div");
+  el.style.color = `hsl(${raw.replace(/ /g, ", ")})`;
+  document.body.appendChild(el);
+  const computed = getComputedStyle(el).color;
+  el.remove();
+  // computed is rgb(r, g, b), convert to hex
+  const match = computed.match(/(\d+)/g);
+  if (!match || match.length < 3) return "";
+  return "#" + match.slice(0, 3).map((n) => Number(n).toString(16).padStart(2, "0")).join("");
+}
+
 /** Strip terminal line-wrap artifacts from copied text. */
 function cleanCopiedText(text: string): string {
   const joined = text.replace(/[ \t]*\r?\n[ \t]*/g, "");
@@ -336,13 +352,13 @@ export function useTerminal(args: {
       macOptionClickForcesSelection: true,
       screenReaderMode: isTouchDevice,
       theme: {
-        foreground: "#f8f8f2",
-        background: "#141414",
+        foreground: cssHsl("--foreground") || "#f8f8f2",
+        background: cssHsl("--terminal-bg") || "#141414",
         cursor: "#f8f8f0",
-        cursorAccent: "#141414",
+        cursorAccent: cssHsl("--terminal-bg") || "#141414",
         selectionBackground: "#49483e",
         selectionInactiveBackground: "#3e3d32",
-        black: "#141414",
+        black: cssHsl("--terminal-bg") || "#141414",
         red: "#f92672",
         green: "#a6e22e",
         yellow: "#f4bf75",

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ThemeId = "default" | "crumbstream";
+
+export type ThemeDefinition = {
+  id: ThemeId;
+  label: string;
+  description: string;
+  swatches: string[];
+};
+
+export const THEMES: ThemeDefinition[] = [
+  {
+    id: "default",
+    label: "Warm Dark",
+    description: "Warm charcoal with emerald accents",
+    swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
+  },
+  {
+    id: "crumbstream",
+    label: "Cool Navy",
+    description: "Cool navy with cyan & pink accents",
+    swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
+  },
+];
+
+const STORAGE_KEY = "dispatch:theme";
+
+function getStoredTheme(): ThemeId {
+  if (typeof window === "undefined") return "default";
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored && THEMES.some((t) => t.id === stored)) return stored as ThemeId;
+  return "default";
+}
+
+function applyTheme(themeId: ThemeId): void {
+  const root = document.documentElement;
+  if (themeId === "default") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", themeId);
+  }
+}
+
+export function useTheme(): {
+  theme: ThemeId;
+  setTheme: (id: ThemeId) => void;
+} {
+  const [theme, setThemeState] = useState<ThemeId>(getStoredTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((id: ThemeId) => {
+    window.localStorage.setItem(STORAGE_KEY, id);
+    setThemeState(id);
+  }, []);
+
+  return { theme, setTheme };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -20,6 +20,46 @@
   --border: 40 10% 18%;
   --input: 40 10% 18%;
   --ring: 192 85% 64%;
+
+  /* Semantic status colors */
+  --status-working: 158 64% 52%;
+  --status-blocked: 0 84% 60%;
+  --status-waiting: 45 96% 64%;
+  --status-done: 198 93% 60%;
+  --status-idle: 240 4% 46%;
+
+  /* Surface & terminal */
+  --surface: 50 15% 5%;
+  --terminal-bg: 0 0% 8%;
+}
+
+[data-theme="crumbstream"] {
+  --background: 222 18% 7%;
+  --foreground: 224 13% 95%;
+  --card: 222 16% 9%;
+  --card-foreground: 224 13% 95%;
+  --popover: 222 16% 9%;
+  --popover-foreground: 224 13% 95%;
+  --primary: 207 100% 67%;
+  --primary-foreground: 222 40% 8%;
+  --muted: 220 10% 14%;
+  --muted-foreground: 220 8% 67%;
+  --accent: 220 10% 14%;
+  --accent-foreground: 224 13% 95%;
+  --destructive: 330 100% 68%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 220 11% 21%;
+  --input: 220 11% 21%;
+  --ring: 207 100% 67%;
+
+  --status-working: 150 57% 59%;
+  --status-blocked: 330 100% 68%;
+  --status-waiting: 55 87% 63%;
+  --status-done: 207 100% 67%;
+  --status-idle: 220 8% 50%;
+
+  --surface: 225 16% 7%;
+  --terminal-bg: 225 16% 7%;
 }
 
 * {
@@ -50,7 +90,7 @@ body {
 .xterm,
 .xterm .xterm-viewport,
 .xterm .xterm-screen {
-  background-color: #141414 !important;
+  background-color: hsl(var(--terminal-bg)) !important;
 }
 
 /* Mobile: enable native long-press text selection via the xterm
@@ -81,10 +121,10 @@ body {
 }
 
 .media-thumb-unseen {
-  border-color: rgba(13, 131, 88, 0.45);
+  border-color: hsl(var(--status-working) / 0.45);
   box-shadow:
-    inset 0 0 0 1px rgba(13, 131, 88, 0.28),
-    0 0 14px rgba(13, 131, 88, 0.2);
+    inset 0 0 0 1px hsl(var(--status-working) / 0.28),
+    0 0 14px hsl(var(--status-working) / 0.2);
   transition:
     border-color 1600ms ease-out,
     box-shadow 1600ms ease-out;
@@ -93,8 +133,8 @@ body {
 .media-thumb-seen {
   border-color: hsl(var(--border));
   box-shadow:
-    inset 0 0 0 1px rgba(13, 131, 88, 0),
-    0 0 0 rgba(13, 131, 88, 0);
+    inset 0 0 0 1px hsl(var(--status-working) / 0),
+    0 0 0 hsl(var(--status-working) / 0);
   transition:
     border-color 1600ms ease-out,
     box-shadow 1600ms ease-out;

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -11,6 +11,8 @@ export default {
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        surface: "hsl(var(--surface))",
+        "terminal-bg": "hsl(var(--terminal-bg))",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))"
@@ -26,6 +28,13 @@ export default {
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))"
+        },
+        status: {
+          working: "hsl(var(--status-working) / <alpha-value>)",
+          blocked: "hsl(var(--status-blocked) / <alpha-value>)",
+          waiting: "hsl(var(--status-waiting) / <alpha-value>)",
+          done: "hsl(var(--status-done) / <alpha-value>)",
+          idle: "hsl(var(--status-idle) / <alpha-value>)"
         }
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- Adds a theme infrastructure using CSS custom properties with `[data-theme]` selectors
- Migrates ~60 hardcoded Tailwind accent colors (emerald, sky, red, amber, zinc) to semantic `--status-*` CSS variables so themes fully transform the palette
- Adds `--surface` and `--terminal-bg` CSS vars for header/footer/terminal backgrounds
- Ships two themes: **Warm Dark** (current default) and **Cool Navy** (inspired by CrumbStream's cyan/pink/yellow palette)
- Adds an **Appearance** section in Settings with a visual theme picker showing color swatches
- Theme persists to localStorage and applies before first paint (inline script in index.html) to avoid flash
- Terminal background/foreground reads from CSS vars; ANSI palette stays stable across themes

## Test plan
- [x] `npm run check` — TypeScript passes
- [x] `npm run finalize:web` — production build succeeds
- [x] `npm run test:e2e` — 30/30 pass (fixed settings test selector for new Appearance nav item)
- [x] Visual validation: screenshots of both themes captured via Playwright
- [ ] Manual: verify theme persists across page reload
- [ ] Manual: verify on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)