### PR TITLE
Add OLED Black, Solarized Dark, and Light themes

### DIFF
--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light";
 
 export type ThemeDefinition = {
   id: ThemeId;
@@ -21,6 +21,24 @@ export const THEMES: ThemeDefinition[] = [
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
+  },
+  {
+    id: "oled-black",
+    label: "OLED Black",
+    description: "True black for OLED screens",
+    swatches: ["#000000", "#34d399", "#f0f0f0", "#222222"],
+  },
+  {
+    id: "solarized-dark",
+    label: "Solarized Dark",
+    description: "Classic Ethan Schoonover palette",
+    swatches: ["#002b36", "#268bd2", "#859900", "#b58900"],
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Clean light theme for bright environments",
+    swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
   },
 ];
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -62,6 +62,93 @@
   --terminal-bg: 225 16% 7%;
 }
 
+[data-theme="oled-black"] {
+  --background: 0 0% 0%;
+  --foreground: 0 0% 94%;
+  --card: 0 0% 4%;
+  --card-foreground: 0 0% 94%;
+  --popover: 0 0% 4%;
+  --popover-foreground: 0 0% 94%;
+  --primary: 160 84% 39%;
+  --primary-foreground: 0 0% 0%;
+  --muted: 0 0% 8%;
+  --muted-foreground: 0 0% 55%;
+  --accent: 0 0% 8%;
+  --accent-foreground: 0 0% 94%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 14%;
+  --input: 0 0% 14%;
+  --ring: 160 84% 39%;
+
+  --status-working: 160 72% 52%;
+  --status-blocked: 0 84% 60%;
+  --status-waiting: 45 93% 58%;
+  --status-done: 198 93% 60%;
+  --status-idle: 0 0% 35%;
+
+  --surface: 0 0% 2%;
+  --terminal-bg: 0 0% 0%;
+}
+
+[data-theme="solarized-dark"] {
+  --background: 192 100% 11%;
+  --foreground: 186 8% 62%;
+  --card: 192 81% 14%;
+  --card-foreground: 186 8% 62%;
+  --popover: 192 81% 14%;
+  --popover-foreground: 186 8% 62%;
+  --primary: 205 82% 45%;
+  --primary-foreground: 44 87% 94%;
+  --muted: 192 81% 14%;
+  --muted-foreground: 194 14% 40%;
+  --accent: 192 81% 14%;
+  --accent-foreground: 186 8% 62%;
+  --destructive: 1 71% 52%;
+  --destructive-foreground: 44 87% 94%;
+  --border: 192 40% 23%;
+  --input: 192 40% 23%;
+  --ring: 205 82% 45%;
+
+  --status-working: 68 100% 30%;
+  --status-blocked: 1 71% 52%;
+  --status-waiting: 45 100% 35%;
+  --status-done: 205 82% 45%;
+  --status-idle: 194 14% 40%;
+
+  --surface: 192 100% 8%;
+  --terminal-bg: 192 100% 11%;
+}
+
+[data-theme="light"] {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 9%;
+  --card: 0 0% 98%;
+  --card-foreground: 0 0% 9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 9%;
+  --primary: 153 78% 27%;
+  --primary-foreground: 0 0% 100%;
+  --muted: 40 10% 92%;
+  --muted-foreground: 0 0% 40%;
+  --accent: 40 10% 92%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 0 0% 85%;
+  --input: 0 0% 85%;
+  --ring: 153 78% 27%;
+
+  --status-working: 142 71% 35%;
+  --status-blocked: 0 72% 51%;
+  --status-waiting: 46 97% 42%;
+  --status-done: 217 91% 50%;
+  --status-idle: 0 0% 60%;
+
+  --surface: 40 20% 96%;
+  --terminal-bg: 40 10% 96%;
+}
+
 * {
   @apply border-border;
 }


### PR DESCRIPTION
## Summary
- **OLED Black**: True `#000000` background, minimal surface colors, emerald accents — battery-friendly on OLED screens
- **Solarized Dark**: Classic Ethan Schoonover palette (`#002b36` base) with his original accent colors — chartreuse working, blue primary, gold warning, red blocked
- **Light**: White/off-white background with forest green primary (`#0d7d4d`), saturated status colors tuned for light background contrast

Only 2 files changed — `index.css` (CSS variable blocks) and `use-theme.ts` (theme registry). The theme infrastructure from PR #100 made this straightforward.

## Test plan
- [x] `npm run finalize:web` — type check + production build pass
- [x] `npm run test:e2e` — 30/30 pass
- [x] Visual validation: Playwright screenshots of all 3 new themes + settings picker with all 5 options
- [ ] Manual: verify theme persistence across reload for each new theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)