### PR TITLE
Right-align status footer indicators

### DIFF
--- a/web/src/components/app/status-footer.tsx
+++ b/web/src/components/app/status-footer.tsx
@@ -15,7 +15,7 @@ export function StatusFooter({
   serviceDotClass
 }: StatusFooterProps): JSX.Element {
   return (
-    <footer data-testid="status-footer" className="flex h-11 items-center gap-6 border-t-2 border-border bg-surface px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
+    <footer data-testid="status-footer" className="flex h-11 items-center justify-end gap-8 border-t-2 border-border bg-surface px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
       <ServiceStatus icon={<Server className="h-3.5 w-3.5" />} label="API" value={apiState} dotClass={serviceDotClass(apiState)} />
       <ServiceStatus
         icon={<Database className="h-3.5 w-3.5" />}


### PR DESCRIPTION
## Summary
- Right-align API and DB status indicators in the footer (`justify-end`)
- Increase spacing between indicators (`gap-6` → `gap-8`)

## Test plan
- [x] `npm run finalize:web` — type check + production build passes
- [x] `npm run test:e2e` — all 30 tests pass
- [x] Visual validation via Playwright — indicators are right-aligned and vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)