### PR TITLE
Add vaporwave theme

### DIFF
--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -113,6 +113,32 @@ const LIGHT: TerminalPalette = {
   brightWhite: "#333333",
 };
 
+/** Vaporwave — neon pink, cyan & purple on deep purple-black */
+const VAPORWAVE: TerminalPalette = {
+  foreground: "#e0d0f0",
+  background: "#110720",
+  cursor: "#ff71ce",
+  cursorAccent: "#110720",
+  selectionBackground: "#2e1450",
+  selectionInactiveBackground: "#241040",
+  black: "#110720",
+  red: "#ff71ce",
+  green: "#05ffa1",
+  yellow: "#fffb96",
+  blue: "#01cdfe",
+  magenta: "#b967ff",
+  cyan: "#01cdfe",
+  white: "#e0d0f0",
+  brightBlack: "#6a5a8a",
+  brightRed: "#ff9ade",
+  brightGreen: "#50ffbe",
+  brightYellow: "#fffcb5",
+  brightBlue: "#50dfff",
+  brightMagenta: "#d094ff",
+  brightCyan: "#50dfff",
+  brightWhite: "#f0e4ff",
+};
+
 export const THEMES: ThemeDefinition[] = [
   {
     id: "default",
@@ -148,6 +174,13 @@ export const THEMES: ThemeDefinition[] = [
     description: "Clean light theme for bright environments",
     swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
     terminal: LIGHT,
+  },
+  {
+    id: "vaporwave",
+    label: "Vaporwave",
+    description: "Neon pink & cyan on deep purple",
+    swatches: ["#1a0a2e", "#ff71ce", "#01cdfe", "#b967ff"],
+    terminal: VAPORWAVE,
   },
 ];
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -149,6 +149,35 @@
   --terminal-bg: 40 10% 96%;
 }
 
+[data-theme="vaporwave"] {
+  --background: 262 52% 6%;
+  --foreground: 270 50% 90%;
+  --card: 262 48% 8%;
+  --card-foreground: 270 50% 90%;
+  --popover: 262 48% 8%;
+  --popover-foreground: 270 50% 90%;
+  --primary: 325 100% 72%;
+  --primary-foreground: 262 60% 6%;
+  --muted: 262 30% 12%;
+  --muted-foreground: 270 20% 58%;
+  --accent: 262 30% 12%;
+  --accent-foreground: 270 50% 90%;
+  --destructive: 325 100% 62%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 262 30% 18%;
+  --input: 262 30% 18%;
+  --ring: 191 99% 50%;
+
+  --status-working: 160 100% 50%;
+  --status-blocked: 325 100% 62%;
+  --status-waiting: 57 100% 79%;
+  --status-done: 191 99% 50%;
+  --status-idle: 262 20% 45%;
+
+  --surface: 262 52% 4%;
+  --terminal-bg: 262 52% 6%;
+}
+
 * {
   @apply border-border;
 }


### PR DESCRIPTION
## Summary
- Adds a new **Vaporwave** theme with neon pink (`#ff71ce`), cyan (`#01cdfe`), and purple (`#b967ff`) accents on deep purple-black backgrounds
- Includes full terminal ANSI palette with matching vaporwave colors
- Colors sourced from canonical vaporwave palettes (color-hex.com, eggradients.com)

## Test plan
- [x] `npm run finalize:web` — type check + production build pass
- [x] `npm run test:e2e` — 30 passed, 5 skipped (pre-existing)
- [x] Visual validation via Playwright — theme picker, main UI screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)