### PR TITLE
Add Matrix-inspired Dispatch theme

### DIFF
--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -139,6 +139,33 @@ const VAPORWAVE: TerminalPalette = {
   brightWhite: "#f0e4ff",
 };
 
+/** Matrix — restrained phosphor green on deep black */
+const MATRIX: TerminalPalette = {
+  minimumContrastRatio: 4.5,
+  foreground: "#b7ffc9",
+  background: "#020403",
+  cursor: "#6bff8f",
+  cursorAccent: "#020403",
+  selectionBackground: "#174d28",
+  selectionInactiveBackground: "#102d1a",
+  black: "#020403",
+  red: "#a63a3a",
+  green: "#1fa34a",
+  yellow: "#c6a94a",
+  blue: "#3fbf7f",
+  magenta: "#5bd47f",
+  cyan: "#7ceea3",
+  white: "#b7ffc9",
+  brightBlack: "#3d5b45",
+  brightRed: "#cf6666",
+  brightGreen: "#6bff8f",
+  brightYellow: "#e4cf7d",
+  brightBlue: "#6ff0ab",
+  brightMagenta: "#97ffb6",
+  brightCyan: "#c8ffda",
+  brightWhite: "#effff2",
+};
+
 export const THEMES: ThemeDefinition[] = [
   {
     id: "default",
@@ -181,6 +208,13 @@ export const THEMES: ThemeDefinition[] = [
     description: "Neon pink & cyan on deep purple",
     swatches: ["#1a0a2e", "#ff71ce", "#01cdfe", "#b967ff"],
     terminal: VAPORWAVE,
+  },
+  {
+    id: "matrix",
+    label: "Matrix",
+    description: "Phosphor green on near-black terminal glass",
+    swatches: ["#020403", "#0a0f0b", "#1fa34a", "#6bff8f"],
+    terminal: MATRIX,
   },
 ];
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -178,6 +178,35 @@
   --terminal-bg: 262 52% 6%;
 }
 
+[data-theme="matrix"] {
+  --background: 150 20% 1.5%;
+  --foreground: 136 100% 92%;
+  --card: 145 22% 4%;
+  --card-foreground: 136 100% 92%;
+  --popover: 145 22% 4%;
+  --popover-foreground: 136 100% 92%;
+  --primary: 136 79% 36%;
+  --primary-foreground: 150 20% 2%;
+  --muted: 142 18% 8%;
+  --muted-foreground: 133 37% 72%;
+  --accent: 142 18% 8%;
+  --accent-foreground: 136 100% 92%;
+  --destructive: 0 49% 44%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 137 24% 16%;
+  --input: 137 24% 16%;
+  --ring: 136 100% 71%;
+
+  --status-working: 136 100% 71%;
+  --status-blocked: 0 49% 44%;
+  --status-waiting: 46 52% 54%;
+  --status-done: 153 76% 64%;
+  --status-idle: 132 12% 40%;
+
+  --surface: 145 24% 2%;
+  --terminal-bg: 150 20% 1.5%;
+}
+
 * {
   @apply border-border;
 }
@@ -194,9 +223,45 @@ body {
   font-family: "JetBrains Mono", Menlo, monospace;
 }
 
+html[data-theme="matrix"] body {
+  background-image:
+    radial-gradient(circle at top, hsl(var(--primary) / 0.12), transparent 34%),
+    linear-gradient(180deg, hsl(var(--background)), hsl(var(--surface)));
+}
+
+html[data-theme="matrix"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(to bottom, hsl(var(--primary) / 0.045), transparent 22%, transparent 78%, hsl(var(--primary) / 0.03)),
+    linear-gradient(to right, hsl(var(--primary) / 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(var(--primary) / 0.035) 1px, transparent 1px);
+  background-size:
+    100% 100%,
+    32px 32px,
+    32px 32px;
+  opacity: 0.5;
+}
+
+html[data-theme="matrix"] body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 50% -10%, hsl(var(--status-working) / 0.08), transparent 40%),
+    radial-gradient(circle at 50% 120%, hsl(var(--status-working) / 0.06), transparent 34%);
+}
+
 #root {
   @apply h-dvh;
   overflow: hidden;
+  position: relative;
+  z-index: 1;
 }
 
 .terminal-font {
@@ -207,6 +272,26 @@ body {
 .xterm .xterm-viewport,
 .xterm .xterm-screen {
   background-color: hsl(var(--terminal-bg)) !important;
+}
+
+html[data-theme="matrix"] .xterm {
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--primary) / 0.12),
+    0 0 28px hsl(var(--primary) / 0.08);
+}
+
+html[data-theme="matrix"] aside,
+html[data-theme="matrix"] [role="dialog"],
+html[data-theme="matrix"] [data-radix-popper-content-wrapper] > * {
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--primary) / 0.05),
+    0 0 24px hsl(var(--primary) / 0.06);
+  backdrop-filter: blur(10px);
+}
+
+html[data-theme="matrix"] button,
+html[data-theme="matrix"] [role="button"] {
+  text-shadow: 0 0 10px hsl(var(--primary) / 0.12);
 }
 
 /* Mobile: enable native long-press text selection via the xterm


### PR DESCRIPTION
## Summary
- add a first-class Matrix theme to the Dispatch theme registry
- add a matching green-on-black terminal palette for xterm
- add restrained Matrix-specific shell styling for the app background, panels, and terminal glow

## Validation
- `npm run check`
- `npm run finalize:web`
- `npm run test:e2e`

## Screenshots
- Settings pane: `/api/v1/agents/agt_cf0a3f275beb/media/dispatch-matrix-settings-2026-03-24-19-25-56-111.png`
- Main shell: `/api/v1/agents/agt_cf0a3f275beb/media/dispatch-matrix-shell-2026-03-24-19-26-06-783.png`

## Notes
- Local validation stack was run from the worktree at `http://127.0.0.1:52523` with API at `http://127.0.0.1:52518`.
- `npm run test:e2e` passed with 30 tests passing and 5 existing live-terminal tests skipped.