### PR TITLE
Add vaporwave & midnight themes, sort theme list

### DIFF
--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -113,6 +113,32 @@ const LIGHT: TerminalPalette = {
   brightWhite: "#333333",
 };
 
+/** Vaporwave — neon pink, cyan & purple on deep purple-black */
+const VAPORWAVE: TerminalPalette = {
+  foreground: "#e0d0f0",
+  background: "#110720",
+  cursor: "#ff71ce",
+  cursorAccent: "#110720",
+  selectionBackground: "#2e1450",
+  selectionInactiveBackground: "#241040",
+  black: "#110720",
+  red: "#ff71ce",
+  green: "#05ffa1",
+  yellow: "#fffb96",
+  blue: "#01cdfe",
+  magenta: "#b967ff",
+  cyan: "#01cdfe",
+  white: "#e0d0f0",
+  brightBlack: "#6a5a8a",
+  brightRed: "#ff9ade",
+  brightGreen: "#50ffbe",
+  brightYellow: "#fffcb5",
+  brightBlue: "#50dfff",
+  brightMagenta: "#d094ff",
+  brightCyan: "#50dfff",
+  brightWhite: "#f0e4ff",
+};
+
 export const THEMES: ThemeDefinition[] = [
   {
     id: "default",
@@ -148,6 +174,13 @@ export const THEMES: ThemeDefinition[] = [
     description: "Clean light theme for bright environments",
     swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
     terminal: LIGHT,
+  },
+  {
+    id: "vaporwave",
+    label: "Vaporwave",
+    description: "Neon pink & cyan on deep purple",
+    swatches: ["#1a0a2e", "#ff71ce", "#01cdfe", "#b967ff"],
+    terminal: VAPORWAVE,
   },
 ];
 

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "midnight";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -125,34 +125,41 @@ const VAPORWAVE: TerminalPalette = {
   red: "#ff71ce",
   green: "#05ffa1",
   yellow: "#fffb96",
-  blue: "#01cdfe",
-  magenta: "#b967ff",
+  blue: "#b967ff",
+  magenta: "#ff71ce",
   cyan: "#01cdfe",
   white: "#e0d0f0",
   brightBlack: "#6a5a8a",
   brightRed: "#ff9ade",
   brightGreen: "#50ffbe",
   brightYellow: "#fffcb5",
-  brightBlue: "#50dfff",
-  brightMagenta: "#d094ff",
+  brightBlue: "#d094ff",
+  brightMagenta: "#ff9ade",
   brightCyan: "#50dfff",
   brightWhite: "#f0e4ff",
 };
 
 export const THEMES: ThemeDefinition[] = [
   {
-    id: "default",
-    label: "Warm Dark",
-    description: "Warm charcoal with emerald accents",
-    swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
-    terminal: MONOKAI,
-  },
-  {
     id: "crumbstream",
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
     terminal: { ...MONOKAI, background: "#0e1014", cursorAccent: "#0e1014", black: "#0e1014" },
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Clean light theme for bright environments",
+    swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
+    terminal: LIGHT,
+  },
+  {
+    id: "midnight",
+    label: "Midnight",
+    description: "OLED black with vibrant cyan & pink",
+    swatches: ["#000000", "#58b8ff", "#ff5db1", "#f1e84f"],
+    terminal: { ...MONOKAI, background: "#000000", cursorAccent: "#000000", black: "#000000" },
   },
   {
     id: "oled-black",
@@ -169,18 +176,18 @@ export const THEMES: ThemeDefinition[] = [
     terminal: SOLARIZED_DARK,
   },
   {
-    id: "light",
-    label: "Light",
-    description: "Clean light theme for bright environments",
-    swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
-    terminal: LIGHT,
-  },
-  {
     id: "vaporwave",
     label: "Vaporwave",
     description: "Neon pink & cyan on deep purple",
-    swatches: ["#1a0a2e", "#ff71ce", "#01cdfe", "#b967ff"],
+    swatches: ["#110720", "#ff71ce", "#01cdfe", "#b967ff"],
     terminal: VAPORWAVE,
+  },
+  {
+    id: "default",
+    label: "Warm Dark",
+    description: "Warm charcoal with emerald accents",
+    swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
+    terminal: MONOKAI,
   },
 ];
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -149,6 +149,35 @@
   --terminal-bg: 40 10% 96%;
 }
 
+[data-theme="vaporwave"] {
+  --background: 262 52% 6%;
+  --foreground: 270 50% 90%;
+  --card: 262 48% 8%;
+  --card-foreground: 270 50% 90%;
+  --popover: 262 48% 8%;
+  --popover-foreground: 270 50% 90%;
+  --primary: 325 100% 72%;
+  --primary-foreground: 262 60% 6%;
+  --muted: 262 30% 12%;
+  --muted-foreground: 270 20% 58%;
+  --accent: 262 30% 12%;
+  --accent-foreground: 270 50% 90%;
+  --destructive: 325 100% 62%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 262 30% 18%;
+  --input: 262 30% 18%;
+  --ring: 191 99% 50%;
+
+  --status-working: 160 100% 50%;
+  --status-blocked: 325 100% 62%;
+  --status-waiting: 57 100% 79%;
+  --status-done: 191 99% 50%;
+  --status-idle: 262 20% 45%;
+
+  --surface: 262 52% 4%;
+  --terminal-bg: 262 52% 6%;
+}
+
 * {
   @apply border-border;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -178,6 +178,35 @@
   --terminal-bg: 262 52% 6%;
 }
 
+[data-theme="midnight"] {
+  --background: 0 0% 0%;
+  --foreground: 224 13% 95%;
+  --card: 220 18% 4%;
+  --card-foreground: 224 13% 95%;
+  --popover: 220 18% 4%;
+  --popover-foreground: 224 13% 95%;
+  --primary: 207 100% 67%;
+  --primary-foreground: 0 0% 0%;
+  --muted: 220 10% 8%;
+  --muted-foreground: 220 8% 60%;
+  --accent: 220 10% 8%;
+  --accent-foreground: 224 13% 95%;
+  --destructive: 330 100% 68%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 220 11% 14%;
+  --input: 220 11% 14%;
+  --ring: 207 100% 67%;
+
+  --status-working: 150 57% 59%;
+  --status-blocked: 330 100% 68%;
+  --status-waiting: 55 87% 63%;
+  --status-done: 207 100% 67%;
+  --status-idle: 220 8% 40%;
+
+  --surface: 0 0% 2%;
+  --terminal-bg: 0 0% 0%;
+}
+
 * {
   @apply border-border;
 }


### PR DESCRIPTION
## Summary
- Adds **Vaporwave** theme: neon pink & cyan on deep purple background
- Adds **Midnight** theme: OLED black backgrounds blended with Cool Navy's vibrant cyan & pink accents
- Sorts theme picker alphabetically by label

## Test plan
- [x] `npm run check` passes (backend + web type check)
- [x] `npm run finalize:web` passes (type check + production build)
- [x] `npm run test:e2e` — 30/30 passing (5 pre-existing skips)
- [x] Validated both themes in browser via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)