### PR TITLE
Add midnight theme and sort theme list alphabetically

### DIFF
--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix";
+export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -168,18 +168,32 @@ const MATRIX: TerminalPalette = {
 
 export const THEMES: ThemeDefinition[] = [
   {
-    id: "default",
-    label: "Warm Dark",
-    description: "Warm charcoal with emerald accents",
-    swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
-    terminal: MONOKAI,
-  },
-  {
     id: "crumbstream",
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
     terminal: { ...MONOKAI, background: "#0e1014", cursorAccent: "#0e1014", black: "#0e1014" },
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Clean light theme for bright environments",
+    swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
+    terminal: LIGHT,
+  },
+  {
+    id: "matrix",
+    label: "Matrix",
+    description: "Phosphor green on near-black terminal glass",
+    swatches: ["#020403", "#0a0f0b", "#1fa34a", "#6bff8f"],
+    terminal: MATRIX,
+  },
+  {
+    id: "midnight",
+    label: "Midnight",
+    description: "OLED black with vibrant cyan & pink",
+    swatches: ["#000000", "#58b8ff", "#ff5db1", "#f1e84f"],
+    terminal: { ...MONOKAI, background: "#000000", cursorAccent: "#000000", black: "#000000" },
   },
   {
     id: "oled-black",
@@ -196,13 +210,6 @@ export const THEMES: ThemeDefinition[] = [
     terminal: SOLARIZED_DARK,
   },
   {
-    id: "light",
-    label: "Light",
-    description: "Clean light theme for bright environments",
-    swatches: ["#ffffff", "#0d7d4d", "#1a1a1a", "#e2e2e2"],
-    terminal: LIGHT,
-  },
-  {
     id: "vaporwave",
     label: "Vaporwave",
     description: "Neon pink & cyan on deep purple",
@@ -210,11 +217,11 @@ export const THEMES: ThemeDefinition[] = [
     terminal: VAPORWAVE,
   },
   {
-    id: "matrix",
-    label: "Matrix",
-    description: "Phosphor green on near-black terminal glass",
-    swatches: ["#020403", "#0a0f0b", "#1fa34a", "#6bff8f"],
-    terminal: MATRIX,
+    id: "default",
+    label: "Warm Dark",
+    description: "Warm charcoal with emerald accents",
+    swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
+    terminal: MONOKAI,
   },
 ];
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -178,6 +178,35 @@
   --terminal-bg: 262 52% 6%;
 }
 
+[data-theme="midnight"] {
+  --background: 0 0% 0%;
+  --foreground: 224 13% 95%;
+  --card: 220 18% 4%;
+  --card-foreground: 224 13% 95%;
+  --popover: 220 18% 4%;
+  --popover-foreground: 224 13% 95%;
+  --primary: 207 100% 67%;
+  --primary-foreground: 0 0% 0%;
+  --muted: 220 10% 8%;
+  --muted-foreground: 220 8% 60%;
+  --accent: 220 10% 8%;
+  --accent-foreground: 224 13% 95%;
+  --destructive: 330 100% 68%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 220 11% 14%;
+  --input: 220 11% 14%;
+  --ring: 207 100% 67%;
+
+  --status-working: 150 57% 59%;
+  --status-blocked: 330 100% 68%;
+  --status-waiting: 55 87% 63%;
+  --status-done: 207 100% 67%;
+  --status-idle: 220 8% 40%;
+
+  --surface: 0 0% 2%;
+  --terminal-bg: 0 0% 0%;
+}
+
 [data-theme="matrix"] {
   --background: 150 20% 1.5%;
   --foreground: 136 100% 92%;


### PR DESCRIPTION
## Summary
- Adds **Midnight** theme: OLED black backgrounds blended with Cool Navy's vibrant cyan & pink accents
- Sorts theme picker alphabetically by label (Cool Navy, Light, Matrix, Midnight, OLED Black, Solarized Dark, Vaporwave, Warm Dark)

## Test plan
- [x] `npm run finalize:web` passes (type check + production build)
- [x] `npm run test:e2e` — 30/30 passing (5 pre-existing skips)
- [x] Validated theme in browser via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)