### PR TITLE
Fix dispatch-dev workflow: worktree cwd, param passthrough, PID tracking

### DIFF
--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -3,7 +3,11 @@
     {
       "name": "dev_up",
       "description": "Start the repo's isolated dev environment (DB + API server + Vite frontend on free ports).",
-      "command": ["./bin/dispatch-dev", "up"]
+      "command": ["./bin/dispatch-dev", "up"],
+      "params": [
+        { "name": "cwd", "type": "string", "flag": "--cwd", "description": "Working directory override (e.g. a worktree path)." },
+        { "name": "live", "type": "boolean", "flag": "--live", "description": "Enable live agent runtime (tmux) instead of inert mode." }
+      ]
     },
     {
       "name": "dev_down",

--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -10,6 +10,15 @@
       ]
     },
     {
+      "name": "dev_restart",
+      "description": "Restart the repo's dev environment, picking up code changes (reuses ports and DB).",
+      "command": ["./bin/dispatch-dev", "restart"],
+      "params": [
+        { "name": "cwd", "type": "string", "flag": "--cwd", "description": "Working directory override (e.g. a worktree path)." },
+        { "name": "live", "type": "boolean", "flag": "--live", "description": "Enable live agent runtime (tmux) instead of inert mode." }
+      ]
+    },
+    {
       "name": "dev_down",
       "description": "Stop the repo's dev environment and remove its database container.",
       "command": ["./bin/dispatch-dev", "down"]

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -125,6 +125,25 @@ kill_tree() {
   kill -"$sig" "$pid" 2>/dev/null || true
 }
 
+# Tree-kill a service PID, wait for exit, then force-kill if needed.
+stop_service() {
+  local pid="${1:-}"
+  local name="${2:-service}"
+  if ! pid_alive "$pid"; then
+    return 0
+  fi
+  kill_tree "$pid"
+  local i=0
+  while [ $i -lt 10 ] && pid_alive "$pid"; do
+    sleep 0.5
+    i=$((i + 1))
+  done
+  if pid_alive "$pid"; then
+    kill_tree "$pid" 9
+  fi
+  echo "Stopped ${name} (PID ${pid})"
+}
+
 # Detect docker compose command
 detect_compose() {
   if docker compose version &>/dev/null; then
@@ -276,34 +295,8 @@ cmd_down() {
     return 0
   fi
 
-  # Kill API server (tree-kill to catch npm → tsx → node children)
-  if pid_alive "${DEV_API_PID:-}"; then
-    kill_tree "$DEV_API_PID"
-    # Wait briefly for clean exit, then force-kill survivors
-    local i=0
-    while [ $i -lt 10 ] && pid_alive "$DEV_API_PID"; do
-      sleep 0.5
-      i=$((i + 1))
-    done
-    if pid_alive "$DEV_API_PID"; then
-      kill_tree "$DEV_API_PID" 9
-    fi
-    echo "Stopped API server (PID ${DEV_API_PID})"
-  fi
-
-  # Kill Vite server (tree-kill to catch npm → vite children)
-  if pid_alive "${DEV_VITE_PID:-}"; then
-    kill_tree "$DEV_VITE_PID"
-    local i=0
-    while [ $i -lt 10 ] && pid_alive "$DEV_VITE_PID"; do
-      sleep 0.5
-      i=$((i + 1))
-    done
-    if pid_alive "$DEV_VITE_PID"; then
-      kill_tree "$DEV_VITE_PID" 9
-    fi
-    echo "Stopped Vite server (PID ${DEV_VITE_PID})"
-  fi
+  stop_service "${DEV_API_PID:-}" "API server"
+  stop_service "${DEV_VITE_PID:-}" "Vite server"
 
   # Stop the DB container
   if [ -n "${DEV_COMPOSE_PROJECT:-}" ] && [ "${DEV_NO_DB:-0}" != "1" ]; then

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -236,6 +236,9 @@ cmd_up() {
   # --- Vite Frontend ---
   DEV_VITE_PORT="${RESTART_VITE_PORT:-$(find_free_port)}"
 
+  # Clear stale Vite dep optimizer cache to prevent white-page on fresh worktrees
+  rm -rf "${cwd}/web/node_modules/.vite" 2>/dev/null || true
+
   (
     cd "$cwd"
     # Tell Vite's proxy where the API server is

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -110,6 +110,21 @@ pid_alive() {
   [ -n "${1:-}" ] && kill -0 "$1" 2>/dev/null
 }
 
+# Recursively kill a process and all its descendants (depth-first).
+# This ensures child processes spawned by npm/tsx are cleaned up even
+# when signals don't propagate through the wrapper chain.
+kill_tree() {
+  local pid="${1:-}"
+  local sig="${2:-TERM}"
+  [ -z "$pid" ] && return 0
+  local children
+  children=$(pgrep -P "$pid" 2>/dev/null) || true
+  for child in $children; do
+    kill_tree "$child" "$sig"
+  done
+  kill -"$sig" "$pid" 2>/dev/null || true
+}
+
 # Detect docker compose command
 detect_compose() {
   if docker compose version &>/dev/null; then
@@ -258,31 +273,31 @@ cmd_down() {
     return 0
   fi
 
-  # Kill API server
+  # Kill API server (tree-kill to catch npm → tsx → node children)
   if pid_alive "${DEV_API_PID:-}"; then
-    kill "$DEV_API_PID" 2>/dev/null || true
-    # Wait briefly for clean exit, then force
+    kill_tree "$DEV_API_PID"
+    # Wait briefly for clean exit, then force-kill survivors
     local i=0
     while [ $i -lt 10 ] && pid_alive "$DEV_API_PID"; do
       sleep 0.5
       i=$((i + 1))
     done
     if pid_alive "$DEV_API_PID"; then
-      kill -9 "$DEV_API_PID" 2>/dev/null || true
+      kill_tree "$DEV_API_PID" 9
     fi
     echo "Stopped API server (PID ${DEV_API_PID})"
   fi
 
-  # Kill Vite server
+  # Kill Vite server (tree-kill to catch npm → vite children)
   if pid_alive "${DEV_VITE_PID:-}"; then
-    kill "$DEV_VITE_PID" 2>/dev/null || true
+    kill_tree "$DEV_VITE_PID"
     local i=0
     while [ $i -lt 10 ] && pid_alive "$DEV_VITE_PID"; do
       sleep 0.5
       i=$((i + 1))
     done
     if pid_alive "$DEV_VITE_PID"; then
-      kill -9 "$DEV_VITE_PID" 2>/dev/null || true
+      kill_tree "$DEV_VITE_PID" 9
     fi
     echo "Stopped Vite server (PID ${DEV_VITE_PID})"
   fi

--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -20,10 +20,18 @@ type RepoToolFile = {
   tools?: unknown;
 };
 
+type RepoToolParam = {
+  name: string;
+  type: "string" | "boolean";
+  flag: string;
+  description: string;
+};
+
 type RepoToolConfig = {
   name: string;
   description: string;
   command: string[];
+  params?: RepoToolParam[];
 };
 
 export type RepoToolResult = {
@@ -36,10 +44,13 @@ export type RepoToolResult = {
   message: string;
 };
 
+export type { RepoToolParam };
+
 export type RepoToolDefinition = {
   name: string;
   description: string;
-  run: (context: { agentId: string; repoRoot: string }) => Promise<RepoToolResult>;
+  params?: RepoToolParam[];
+  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown> }) => Promise<RepoToolResult>;
 };
 
 export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinition[]> {
@@ -52,8 +63,23 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
     return {
       name: prefixedName,
       description: tool.description,
-      run: async ({ agentId, repoRoot: currentRepoRoot }) => {
+      params: tool.params,
+      run: async ({ agentId, repoRoot: currentRepoRoot, params }) => {
         const [command, ...args] = tool.command;
+
+        // Append CLI flags from params
+        if (tool.params && params) {
+          for (const param of tool.params) {
+            const value = params[param.name];
+            if (value === undefined || value === null) continue;
+            if (param.type === "boolean" && value === true) {
+              args.push(param.flag);
+            } else if (param.type === "string" && typeof value === "string" && value) {
+              args.push(param.flag, value);
+            }
+          }
+        }
+
         const result = await runCommand(command, args, {
           cwd: currentRepoRoot,
           env: {
@@ -112,5 +138,27 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
     throw new Error(`Repo tool "${name}" must include a non-empty command array.`);
   }
 
-  return { name, description, command };
+  const params = parseRepoToolParams(rawTool.params);
+
+  return { name, description, command, params };
+}
+
+function parseRepoToolParams(raw: unknown): RepoToolParam[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+
+  return raw.map((entry, i) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`Invalid param at index ${i}.`);
+    }
+    const p = entry as Record<string, unknown>;
+    const name = typeof p.name === "string" ? p.name.trim() : "";
+    const type = p.type === "string" || p.type === "boolean" ? p.type : "";
+    const flag = typeof p.flag === "string" ? p.flag.trim() : "";
+    const description = typeof p.description === "string" ? p.description.trim() : "";
+
+    if (!name || !type || !flag) {
+      throw new Error(`Param at index ${i} must have name, type (string|boolean), and flag.`);
+    }
+    return { name, type, flag, description };
+  });
 }

--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -20,7 +20,7 @@ type RepoToolFile = {
   tools?: unknown;
 };
 
-type RepoToolParam = {
+export type RepoToolParam = {
   name: string;
   type: "string" | "boolean";
   flag: string;
@@ -43,8 +43,6 @@ export type RepoToolResult = {
   stderr: string;
   message: string;
 };
-
-export type { RepoToolParam };
 
 export type RepoToolDefinition = {
   name: string;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,7 +17,7 @@ import {
   cleanupGitWorktree,
   createGitWorktree
 } from "../git/worktree.js";
-import { loadRepoTools } from "./repo-tools.js";
+import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 
 export type MediaResult = {
   fileName: string;
@@ -357,17 +357,19 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   if (context.agent && toolsRoot) {
     const repoTools = await loadRepoTools(toolsRoot);
     for (const tool of repoTools) {
+      const inputSchema = buildParamSchema(tool.params);
       server.registerTool(
         tool.name,
         {
           description: tool.description,
-          inputSchema: {}
+          inputSchema
         },
-        async () => {
+        async (args) => {
           try {
             const result = await tool.run({
               agentId: context.agent!.id,
-              repoRoot: context.repoRoot!
+              repoRoot: toolsRoot,
+              params: args as Record<string, unknown>
             });
             return {
               content: [{ type: "text", text: result.message }],
@@ -397,6 +399,19 @@ function resolveCwd(value: string | undefined, defaultCwd: string | undefined): 
     throw new Error("cwd is required.");
   }
   return cwd;
+}
+
+function buildParamSchema(params?: RepoToolParam[]): Record<string, z.ZodType> {
+  const schema: Record<string, z.ZodType> = {};
+  if (!params) return schema;
+  for (const param of params) {
+    if (param.type === "boolean") {
+      schema[param.name] = z.boolean().optional().describe(param.description);
+    } else {
+      schema[param.name] = z.string().optional().describe(param.description);
+    }
+  }
+  return schema;
 }
 
 function toToolError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -51,6 +51,71 @@ describe("loadRepoTools", () => {
     }));
   });
 
+  it("appends CLI flags from params when provided", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+    tempDirs.push(repoRoot);
+    await mkdir(path.join(repoRoot, ".dispatch"));
+    await writeFile(
+      path.join(repoRoot, ".dispatch", "tools.json"),
+      JSON.stringify({
+        tools: [
+          {
+            name: "dev_up",
+            description: "Start the repo dev stack.",
+            command: ["dispatch-dev", "up"],
+            params: [
+              { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
+              { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
+            ]
+          }
+        ]
+      })
+    );
+
+    const [tool] = await loadRepoTools(repoRoot);
+    expect(tool.params).toHaveLength(2);
+
+    // Call with both params set
+    await tool.run({ agentId: "agt_test", repoRoot, params: { cwd: "/tmp/wt", live: true } });
+    expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
+      "dispatch-dev",
+      ["up", "--cwd", "/tmp/wt", "--live"],
+      expect.objectContaining({ cwd: repoRoot })
+    );
+  });
+
+  it("skips unset or false params", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+    tempDirs.push(repoRoot);
+    await mkdir(path.join(repoRoot, ".dispatch"));
+    await writeFile(
+      path.join(repoRoot, ".dispatch", "tools.json"),
+      JSON.stringify({
+        tools: [
+          {
+            name: "dev_up",
+            description: "Start the repo dev stack.",
+            command: ["dispatch-dev", "up"],
+            params: [
+              { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
+              { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
+            ]
+          }
+        ]
+      })
+    );
+
+    const [tool] = await loadRepoTools(repoRoot);
+
+    // Call with live=false and no cwd
+    await tool.run({ agentId: "agt_test", repoRoot, params: { live: false } });
+    expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
+      "dispatch-dev",
+      ["up"],
+      expect.objectContaining({ cwd: repoRoot })
+    );
+  });
+
   it("sanitizes dots in repo tool names to underscores", async () => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
     tempDirs.push(repoRoot);

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -13,6 +13,19 @@ const { runCommand } = await import("../src/lib/run-command.js");
 
 const tempDirs: string[] = [];
 
+const DEV_PARAMS = [
+  { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
+  { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
+];
+
+async function createToolsRepo(tools: unknown[]): Promise<string> {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+  tempDirs.push(repoRoot);
+  await mkdir(path.join(repoRoot, ".dispatch"));
+  await writeFile(path.join(repoRoot, ".dispatch", "tools.json"), JSON.stringify({ tools }));
+  return repoRoot;
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   vi.mocked(runCommand).mockClear();
@@ -21,21 +34,9 @@ afterEach(async () => {
 
 describe("loadRepoTools", () => {
   it("auto-prefixes repo tools with repo_ namespace", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
-    tempDirs.push(repoRoot);
-    await mkdir(path.join(repoRoot, ".dispatch"));
-    await writeFile(
-      path.join(repoRoot, ".dispatch", "tools.json"),
-      JSON.stringify({
-        tools: [
-          {
-            name: "dev_up",
-            description: "Start the repo dev stack.",
-            command: ["dispatch-dev", "up"]
-          }
-        ]
-      })
-    );
+    const repoRoot = await createToolsRepo([
+      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"] }
+    ]);
 
     const [tool] = await loadRepoTools(repoRoot);
     const result = await tool.run({ agentId: "agt_test", repoRoot });
@@ -52,30 +53,13 @@ describe("loadRepoTools", () => {
   });
 
   it("appends CLI flags from params when provided", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
-    tempDirs.push(repoRoot);
-    await mkdir(path.join(repoRoot, ".dispatch"));
-    await writeFile(
-      path.join(repoRoot, ".dispatch", "tools.json"),
-      JSON.stringify({
-        tools: [
-          {
-            name: "dev_up",
-            description: "Start the repo dev stack.",
-            command: ["dispatch-dev", "up"],
-            params: [
-              { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
-              { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
-            ]
-          }
-        ]
-      })
-    );
+    const repoRoot = await createToolsRepo([
+      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"], params: DEV_PARAMS }
+    ]);
 
     const [tool] = await loadRepoTools(repoRoot);
     expect(tool.params).toHaveLength(2);
 
-    // Call with both params set
     await tool.run({ agentId: "agt_test", repoRoot, params: { cwd: "/tmp/wt", live: true } });
     expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
       "dispatch-dev",
@@ -85,29 +69,12 @@ describe("loadRepoTools", () => {
   });
 
   it("skips unset or false params", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
-    tempDirs.push(repoRoot);
-    await mkdir(path.join(repoRoot, ".dispatch"));
-    await writeFile(
-      path.join(repoRoot, ".dispatch", "tools.json"),
-      JSON.stringify({
-        tools: [
-          {
-            name: "dev_up",
-            description: "Start the repo dev stack.",
-            command: ["dispatch-dev", "up"],
-            params: [
-              { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
-              { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
-            ]
-          }
-        ]
-      })
-    );
+    const repoRoot = await createToolsRepo([
+      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"], params: DEV_PARAMS }
+    ]);
 
     const [tool] = await loadRepoTools(repoRoot);
 
-    // Call with live=false and no cwd
     await tool.run({ agentId: "agt_test", repoRoot, params: { live: false } });
     expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
       "dispatch-dev",
@@ -117,21 +84,9 @@ describe("loadRepoTools", () => {
   });
 
   it("sanitizes dots in repo tool names to underscores", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
-    tempDirs.push(repoRoot);
-    await mkdir(path.join(repoRoot, ".dispatch"));
-    await writeFile(
-      path.join(repoRoot, ".dispatch", "tools.json"),
-      JSON.stringify({
-        tools: [
-          {
-            name: "project.dev_up",
-            description: "Start the repo dev stack.",
-            command: ["dispatch-dev", "up"]
-          }
-        ]
-      })
-    );
+    const repoRoot = await createToolsRepo([
+      { name: "project.dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"] }
+    ]);
 
     const [tool] = await loadRepoTools(repoRoot);
     expect(tool.name).toBe("repo_project_dev_up");

--- a/web/src/components/app/docs-pane.tsx
+++ b/web/src/components/app/docs-pane.tsx
@@ -151,6 +151,42 @@ const SECTIONS: SectionDef[] = [
         </Section>
 
         <Section>
+          <H3>Tool parameters</H3>
+          <P>
+            Tools can declare optional parameters that agents pass at call time.
+            Each parameter maps to a CLI flag appended to the command. Supported
+            types are <Code>string</Code> (appends <Code>--flag value</Code>)
+            and <Code>boolean</Code> (appends <Code>--flag</Code> when true).
+          </P>
+          <CodeBlock>{`
+{
+  "name": "dev_up",
+  "description": "Start the dev environment",
+  "command": ["./bin/dev", "up"],
+  "params": [
+    {
+      "name": "cwd",
+      "type": "string",
+      "flag": "--cwd",
+      "description": "Working directory override"
+    },
+    {
+      "name": "live",
+      "type": "boolean",
+      "flag": "--live",
+      "description": "Enable live mode"
+    }
+  ]
+}`}</CodeBlock>
+          <P>
+            When an agent calls <Code>repo.dev_up</Code> with{" "}
+            <Code>{"{ cwd: \"/path\", live: true }"}</Code>, Dispatch
+            runs <Code>./bin/dev up --cwd /path --live</Code>.
+            Parameters that are omitted or false are skipped.
+          </P>
+        </Section>
+
+        <Section>
           <H3>Built-in tools</H3>
           <P>
             Dispatch also provides built-in tools that are always available,


### PR DESCRIPTION
## Summary

- **Worktree cwd bug**: `server.ts` passed `context.repoRoot` to repo `tool.run()` even when the agent was in a worktree — dispatch-dev ran from the main checkout instead of the worktree. Now uses `toolsRoot` (`worktreeRoot ?? repoRoot`).
- **Param passthrough**: Repo tools now support a `params` field in `tools.json` that declares optional parameters mapping to CLI flags. `dev_up` exposes `--cwd` and `--live` params so agents can pass worktree paths and enable live tmux mode through MCP.
- **PID tracking**: `dispatch-dev down` used bare `kill` which didn't reach child processes spawned by npm → tsx → node. Added `kill_tree` helper that recursively kills process descendants via `pgrep -P`.

## Test plan

- [x] `npm run check` — TypeScript passes
- [x] `npm test` — 51 unit tests pass (including 2 new param tests)
- [x] `npm run test:e2e` — 30 E2E tests pass
- [x] `dispatch-dev` integration tests verify start/stop/status lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)