### PR TITLE
Improve tmux terminal reconnect recovery

### DIFF
--- a/docs/tmux-reconnect-recovery-plan.md
+++ b/docs/tmux-reconnect-recovery-plan.md
@@ -1,0 +1,278 @@
+# Tmux Reconnect Recovery Plan
+
+## Problem Summary
+
+Dispatch can take several seconds to recover terminal connectivity after the app returns from the background or when switching back to a long-lived session.
+
+Live investigation on a clean tmux-backed dev stack showed the primary issue is not tmux attach latency. Fresh terminal attach is fast when the client knows it needs a new websocket. The visible delay comes from client-side reconnect coordination in `web/src/hooks/use-terminal.ts`.
+
+## Observed Failure Modes
+
+### 1. Resume before network recovery
+
+When the app becomes visible before the browser/network stack is fully usable:
+
+- `visibilitychange` triggers `ensureTerminalConnected()`
+- `focus` also triggers `ensureTerminalConnected()`
+- both issue preflight `GET /api/v1/agents/:id?includeGitContext=false`
+- if those fetches fail, Dispatch immediately schedules reconnect retries with backoff
+- when network recovers shortly after, Dispatch waits for the queued retry instead of reconnecting immediately
+
+This is the most likely explanation for the normal "takes several seconds, then recovers" user experience.
+
+### 2. Existing websocket can remain `OPEN` while unhealthy
+
+During transient connectivity loss, the terminal websocket can remain `readyState === OPEN` for seconds even though terminal liveness is degraded.
+
+The current reconnect path treats `OPEN` as sufficient to skip a real reconnect. That is too weak. Terminal heartbeats must be the authority for whether an existing websocket is healthy enough to reuse.
+
+### 3. UI can remain in stale `reconnecting` state
+
+If the client falls into reconnect mode and later reaches the "same agent + websocket still open" branch, the current code only calls `sendResize()` and returns. It does not explicitly restore:
+
+- `connState = "connected"`
+- `connectedAgentId`
+- connected status text
+
+That can leave the UI in a false reconnect state even after transport health returns.
+
+### 4. Resume handlers duplicate work
+
+Foreground recovery currently has overlapping triggers:
+
+- `visibilitychange`
+- `focus`
+- reconnect timer callbacks
+- manual attach
+
+Without stronger coordination, those can overlap and produce duplicate:
+
+- agent preflight fetches
+- token requests
+- state transitions
+
+### 5. Token lifecycle can break reconnect recovery
+
+Terminal websocket tokens are short-lived and single-use.
+
+That means reconnect can fail even when the tmux session is still healthy if:
+
+- a queued reconnect waits long enough for the issued token to expire
+- duplicate reconnect attempts race and one attempt consumes the token first
+- the app resumes from sleep/background with stale reconnect work still pending
+
+The recovery plan must treat token invalidation as part of reconnect coordination, not as proof that the terminal session is gone.
+
+## Non-Goals
+
+- Do not change backend tmux attach behavior unless new evidence shows it is a meaningful source of latency.
+- Do not add backend polling for terminal health when the websocket heartbeat already provides the needed signal.
+- Do not couple terminal recovery to media refresh completion.
+
+## Proposed Fix
+
+## 1. Make heartbeat freshness the terminal liveness source of truth
+
+Track on the client:
+
+- `lastHeartbeatAt`
+- `lastOutputAt`
+- `lastHealthyAt`
+- whether the current websocket is considered healthy enough to reuse
+
+Rules:
+
+- Do not treat `readyState === OPEN` by itself as proof of health.
+- A newly opened websocket must count as fresh immediately, without waiting for the first heartbeat.
+- Receiving terminal output should refresh liveness in the same way heartbeat does.
+- If websocket is `OPEN` and recent liveness is within a freshness threshold, reuse it.
+- If websocket is `OPEN` but liveness is stale, force-close it and perform a real reconnect.
+- Evaluate heartbeat freshness on recovery triggers such as `visibilitychange`, `focus`, `online`, reconnect timer callbacks, and manual attach, rather than from a separate hidden-tab enforcement loop.
+- Hidden/background timer throttling should not by itself force a disconnect while the app is not actively trying to recover.
+
+Suggested starting threshold:
+
+- stale after `> 25s`
+
+This should be derived from the current 20s heartbeat interval with a small grace window. If heartbeat cadence is reduced later, the threshold should be recalibrated rather than hard-coded independently.
+
+## 2. Add a single reconnect coordinator
+
+Add a dedicated reconnect state machine in `use-terminal.ts` so only one reconnect attempt per target agent can be active at a time.
+
+Requirements:
+
+- maintain a per-target-agent in-flight guard for dedupe
+- maintain a separate attach generation token / nonce for cancellation
+- user-initiated attach to a different agent must preempt older attempts
+- older timer callbacks must no-op once superseded
+- `visibilitychange`, `focus`, retry timers, and manual attach must funnel through the same coordinator
+
+The existing nonce mechanism is helpful but not sufficient by itself. The implementation should also prevent duplicate in-flight preflight fetches and duplicate token requests. Dedupe identity and cancellation generation should stay separate so repeated resume triggers for the same agent can coalesce cleanly while still allowing a newer user-initiated attach to supersede older work.
+
+The coordinator should also own token lifecycle:
+
+- a reconnect attempt should fetch at most one token for its active generation
+- if a token is invalidated by delay or duplicate consumption, recovery should fetch a fresh token when the session still exists
+- token invalidation during reconnect should not by itself clear attachment intent
+
+## 3. Heal UI state when an existing websocket is still valid
+
+If recovery succeeds via the existing websocket, explicitly restore connected UI state.
+
+When reusing an existing healthy websocket for the same agent:
+
+- set `connState` to `"connected"`
+- set `connectedAgentId`
+- set connected status text
+- clear reconnect timer
+- reset reconnect attempt count
+
+This path should not rely on the websocket `open` event, because that event already happened.
+
+## 4. Retry immediately on `online`
+
+The current retry schedule is useful for repeated failures, but it is too slow once the browser reports connectivity again.
+
+On `online`:
+
+- clear any pending reconnect timer
+- invalidate older reconnect attempts if needed
+- immediately run the reconnect coordinator
+
+This should reduce the common "network came back, but Dispatch waited for the 2.4s retry" case.
+
+## 4a. Clarify retriable vs terminal attach failures
+
+Reconnect behavior needs an explicit client/server contract for websocket attach failures.
+
+Required behavior:
+
+- invalid or expired terminal token should be treated as retriable during reconnect
+- attach-time failures should distinguish "tmux session is gone" from transient attach/setup failure where a fresh token or immediate retry may succeed
+- only confirmed session loss should clear terminal attachment intent and leave the UI detached
+
+Client-side coordination is still the main fix, but this contract may require a small server-side follow-up if current websocket close codes are too coarse to support correct recovery behavior.
+
+## 5. Collapse foreground resume triggers
+
+Keep both `visibilitychange` and `focus` listeners if needed for cross-browser reliability, but route them through a very small dedupe window.
+
+Suggested behavior:
+
+- foreground resume requests within the same tick or short window should coalesce into one reconnect attempt
+- if a reconnect attempt is already in flight for the same agent, later resume triggers should return early
+
+## 6. Decouple terminal recovery from media refresh
+
+Media refresh should not gate terminal reconnect.
+
+If media fetch runs on the same resume path, it must remain independent. Terminal recovery should not wait for media fetch completion or share retry state with it.
+
+## Implementation Notes
+
+Likely client-side changes:
+
+- `web/src/hooks/use-terminal.ts`
+  - add heartbeat tracking
+  - add reconnect coordinator / in-flight guard
+  - update same-agent-open-socket branch to heal UI state
+  - add `online` recovery handling
+  - dedupe visibility/focus resume triggers
+- optionally add a small helper module if the reconnect logic becomes easier to reason about outside the hook
+
+Potential server-side changes:
+
+- none required for the first client-side pass if the existing error contract proves sufficient during implementation
+- if websocket close codes/messages are too coarse to separate retriable token/attach failures from real session loss, add a small follow-up to make those cases distinguishable
+
+The server heartbeat already exists and should be sufficient for the first pass.
+
+## Testing Plan
+
+### Automated tests to add
+
+Add coverage for the exact races observed during live validation.
+
+#### Terminal reconnect tests
+
+Extend `e2e/terminal-live.spec.ts` with cases for:
+
+- reconnect after hidden websocket closes
+- foreground resume where `visibilitychange` and `focus` fire together
+- resume before network recovery, then online recovery
+- healthy existing websocket resumes from `reconnecting` back to `connected` without opening a new websocket
+- no duplicate token requests on a single resume
+- expired token during reconnect fetches a fresh token and recovers
+- duplicate resume triggers do not permanently fail reconnect by consuming the same token generation
+- attach-time failure is retried when the tmux session still exists
+- confirmed session loss exits reconnect cleanly without infinite retry
+
+#### Visibility-aware tests
+
+Extend `e2e/energy-visibility.spec.ts` or a new reconnect-specific spec for:
+
+- hidden -> visible without disconnect should not cause unnecessary reattach
+- stale heartbeat while websocket still reports `OPEN` should force real reconnect
+- hidden-tab timer throttling does not by itself force disconnect while the app remains backgrounded
+
+### Manual validation checklist
+
+On a live tmux stack:
+
+1. Attach to a running agent.
+2. Background the app briefly, return while network remains healthy.
+3. Background the app, disable network, foreground before network returns, then restore network.
+4. Switch between two long-lived sessions repeatedly.
+5. Confirm:
+   - reconnect is immediate when websocket is already healthy
+   - reconnect happens immediately on `online`
+   - no duplicate attach/token activity
+   - UI does not stay stuck on `reconnecting`
+   - token-expiry or duplicate-token races do not strand a healthy tmux session
+
+## Success Criteria
+
+- Typical background/foreground recovery completes without visible multi-second delay once network is available.
+- Foreground resume does not issue duplicate reconnect work for the same agent.
+- Existing healthy websocket reuse restores connected UI state immediately.
+- Stale `OPEN` websocket is detected from heartbeat age and replaced with a fresh connection.
+- Session switching remains fast and stable.
+- Token invalidation during reconnect does not strand a recoverable tmux session.
+
+## Risks
+
+### Over-eager reconnects
+
+If heartbeat freshness threshold is too aggressive, Dispatch may reconnect unnecessarily during brief pauses.
+
+Mitigation:
+
+- choose a threshold above the heartbeat interval
+- confirm behavior under normal idle sessions
+
+### User-initiated switch races
+
+A reconnect guard can accidentally block a real agent switch if keyed too broadly.
+
+Mitigation:
+
+- scope coordination by target agent id and attach nonce
+- user-initiated attach to a new agent must preempt old work
+
+### Hidden browser behavior differs by platform
+
+Safari/PWA behavior may differ from Chromium.
+
+Mitigation:
+
+- keep resume triggers browser-tolerant
+- rely on dedupe and heartbeat health instead of assuming one event model
+
+## Recommended Order
+
+1. Add heartbeat freshness tracking and connected-state healing for reused websocket.
+2. Add reconnect coordinator and dedupe visibility/focus/manual/timer triggers.
+3. Add immediate `online` retry behavior.
+4. Add regression tests for delayed-resume and duplicate-trigger cases.
+5. Re-run live validation against the tmux dev stack.

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -15,7 +15,7 @@ async function createAndStartAgent(
 ): Promise<{ id: string; name: string }> {
   const createRes = await request.post("/api/v1/agents", {
     headers: authHeaders(),
-    data: { name, type: "shell", cwd: "/tmp" },
+    data: { name, type: "codex", cwd: "/tmp" },
   });
   const { agent } = (await createRes.json()) as { agent: { id: string; name: string } };
 
@@ -31,6 +31,39 @@ async function waitForTerminalConnected(page: Page, timeoutMs = 10_000): Promise
   await expect(
     page.getByTestId("detach-button")
   ).toBeVisible({ timeout: timeoutMs });
+}
+
+async function simulateHidden(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+async function simulateVisibleWithFocus(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+  });
 }
 
 test.describe("Terminal live connection", () => {
@@ -148,6 +181,36 @@ test.describe("Terminal live connection", () => {
 
     // After all switching, the final connection should stabilize
     await waitForTerminalConnected(page, 5_000);
+  });
+
+  test("healthy resume does not fetch a duplicate terminal token", async ({ page, request }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    let tokenRequests = 0;
+    page.on("request", (req) => {
+      if (req.method() === "POST" && req.url().includes(`/api/v1/agents/${agent.id}/terminal/token`)) {
+        tokenRequests += 1;
+      }
+    });
+
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await agentCard.getByText(agent.name).click();
+    const attachBtn = agentCard.locator('[data-agent-control="true"]').first();
+    await attachBtn.click();
+    await waitForTerminalConnected(page, 5_000);
+    await expect.poll(() => tokenRequests).toBe(1);
+
+    await simulateHidden(page);
+    await page.waitForTimeout(100);
+    await simulateVisibleWithFocus(page);
+    await page.waitForTimeout(500);
+
+    await waitForTerminalConnected(page, 5_000);
+    await expect.poll(() => tokenRequests).toBe(1);
   });
 
   test("terminal-features not duplicated across attaches", async ({ request }) => {

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -8,6 +8,33 @@ import { recordWSReconnect } from "@/lib/energy-metrics";
 import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
 
 const ACTIVE_SHELL_AGENT_KEY = "dispatch:activeShellAgentId";
+const TERMINAL_HEARTBEAT_INTERVAL_MS = 20_000;
+const TERMINAL_LIVENESS_GRACE_MS = 5_000;
+const TERMINAL_FRESHNESS_MS = TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
+const RESUME_RECONNECT_DEDUPE_MS = 150;
+
+type TerminalSocketMessage =
+  | { type: "heartbeat"; ts: number }
+  | { type: "output"; data: string }
+  | { type: "error"; message: string }
+  | { type: "exit"; exitCode?: number };
+
+function isTerminalSessionGone(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("session no longer exists") ||
+    normalized.includes("session is not available") ||
+    normalized.includes("tmux session is no longer running")
+  );
+}
+
+function isRetriableTerminalFailure(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("invalid or expired terminal token") ||
+    normalized.includes("attach failed")
+  );
+}
 
 function readActiveShellAgentId(): string | null {
   if (typeof window === "undefined") return null;
@@ -89,6 +116,19 @@ export function useTerminal(args: {
   const reconnectTimerRef = useRef<number | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const attachNonceRef = useRef(0);
+  const reconnectInFlightRef = useRef<{
+    agentId: string;
+    promise: Promise<void>;
+  } | null>(null);
+  const lastResumeTriggerAtRef = useRef(0);
+  const socketHealthRef = useRef({
+    lastHeartbeatAt: 0,
+    lastOutputAt: 0,
+    lastHealthyAt: 0,
+    lastOpenAt: 0,
+    lastErrorMessage: null as string | null,
+    sessionGone: false,
+  });
 
   // Ref for agents so ensureTerminalConnected doesn't get recreated on every
   // SSE-driven agents array update (which would trigger the visibility/focus
@@ -103,6 +143,43 @@ export function useTerminal(args: {
     ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
   }, []);
 
+  const clearSocketHealth = useCallback(() => {
+    socketHealthRef.current = {
+      lastHeartbeatAt: 0,
+      lastOutputAt: 0,
+      lastHealthyAt: 0,
+      lastOpenAt: 0,
+      lastErrorMessage: null,
+      sessionGone: false,
+    };
+  }, []);
+
+  const markSocketHealthy = useCallback((source: "open" | "heartbeat" | "output") => {
+    const now = Date.now();
+    if (source === "open") {
+      socketHealthRef.current.lastOpenAt = now;
+    } else if (source === "heartbeat") {
+      socketHealthRef.current.lastHeartbeatAt = now;
+    } else {
+      socketHealthRef.current.lastOutputAt = now;
+    }
+    socketHealthRef.current.lastHealthyAt = now;
+    socketHealthRef.current.lastErrorMessage = null;
+    socketHealthRef.current.sessionGone = false;
+  }, []);
+
+  const noteTerminalError = useCallback((message: string) => {
+    socketHealthRef.current.lastErrorMessage = message;
+    socketHealthRef.current.sessionGone = isTerminalSessionGone(message);
+  }, []);
+
+  const hasFreshSocket = useCallback((agentId: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    if (connectedAgentIdRef.current !== agentId) return false;
+    return Date.now() - socketHealthRef.current.lastHealthyAt <= TERMINAL_FRESHNESS_MS;
+  }, []);
+
   const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current) {
       window.clearTimeout(reconnectTimerRef.current);
@@ -114,11 +191,26 @@ export function useTerminal(args: {
     attachNonceRef.current += 1;
   }, []);
 
-  const closeSocket = useCallback((announce = true) => {
+  const closeSocketTransport = useCallback(() => {
     if (wsRef.current) {
       try { wsRef.current.close(); } catch {}
       wsRef.current = null;
     }
+    clearSocketHealth();
+  }, [clearSocketHealth]);
+
+  const restoreConnectedState = useCallback((agent: Agent, mode: "tmux" | "inert", message?: string) => {
+    clearReconnectTimer();
+    reconnectAttemptsRef.current = 0;
+    setConnState("connected");
+    setConnectedAgentId(agent.id);
+    setTerminalMode(mode);
+    setTerminalPlaceholderMessage(mode === "tmux" ? null : message ?? null);
+    setStatusMessage(message ?? `Connected to session ${agent.name}`);
+  }, [clearReconnectTimer]);
+
+  const closeSocket = useCallback((announce = true) => {
+    closeSocketTransport();
     setConnectedAgentId(null);
     setTerminalMode(null);
     setTerminalPlaceholderMessage(null);
@@ -127,7 +219,7 @@ export function useTerminal(args: {
       setStatusMessage("Session disconnected.");
       setConnState("disconnected");
     }
-  }, []);
+  }, [closeSocketTransport]);
 
   const ensureTerminalConnected = useCallback(
     async (clearScreen = false, userInitiated = false, targetAgentId?: string) => {
@@ -138,66 +230,17 @@ export function useTerminal(args: {
       const resolvedAgentId = targetAgentId ?? selectedAgentId;
       if (!shouldKeepAttachedRef.current || !resolvedAgentId) return;
 
-      let agent: Agent | null = userInitiated
-        ? (agentsRef.current.find((item) => item.id === resolvedAgentId) ?? null)
-        : null;
-
-      if (!agent || agent.status !== "running") {
-        try {
-          const payload = await api<{ agent: Agent }>(`/api/v1/agents/${resolvedAgentId}?includeGitContext=false`);
-          agent = payload.agent;
-        } catch {
-          if (!shouldKeepAttachedRef.current) return;
-          clearReconnectTimer();
-          reconnectAttemptsRef.current += 1;
-          recordWSReconnect();
-          const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
-          setConnState("reconnecting");
-          setStatusMessage("Session disconnected, reconnecting...");
-          reconnectTimerRef.current = window.setTimeout(() => {
-            reconnectTimerRef.current = null;
-            if (document.hidden) return;
-            void ensureTerminalConnected(false, false, resolvedAgentId);
-          }, delay);
-          return;
-        }
-        if (!shouldKeepAttachedRef.current) return;
-      }
-
-      if (agent.status !== "running") {
-        setConnState("disconnected");
+       if (!userInitiated && reconnectInFlightRef.current?.agentId === resolvedAgentId) {
+        await reconnectInFlightRef.current.promise;
         return;
       }
 
-      // If already connected to this agent, just resize — don't invalidate the
-      // current attach nonce, which would cause the existing WS message handler
-      // to silently drop all incoming output.
-      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        if (connectedAgentIdRef.current === agent.id) {
-          sendResize();
-          return;
-        }
-      }
-
-      // We're actually establishing a new connection — now invalidate prior attempts.
-      const attachNonce = ++attachNonceRef.current;
+      const attemptNonce = ++attachNonceRef.current;
       const isCurrentAttempt = () =>
-        shouldKeepAttachedRef.current && attachNonce === attachNonceRef.current;
-
-      clearReconnectTimer();
-      closeSocket(false);
-
-      if (clearScreen) {
-        terminalRef.current?.clear();
-      }
-
-      fitAddonRef.current?.fit();
-      setConnState("reconnecting");
-      setStatusMessage(`Connecting to session ${agent.name}...`);
+        shouldKeepAttachedRef.current && attemptNonce === attachNonceRef.current;
 
       const scheduleReconnect = (message: string) => {
-        if (!isCurrentAttempt()) {
-          setConnState("disconnected");
+        if (!isCurrentAttempt() || !shouldKeepAttachedRef.current) {
           return;
         }
 
@@ -206,103 +249,199 @@ export function useTerminal(args: {
         const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
         setConnState("reconnecting");
         setStatusMessage(message);
-
+        clearReconnectTimer();
         reconnectTimerRef.current = window.setTimeout(() => {
           reconnectTimerRef.current = null;
-          if (document.hidden) return;
+          if (!shouldKeepAttachedRef.current || document.hidden) return;
           void ensureTerminalConnected(false, false, resolvedAgentId);
         }, delay);
       };
 
-      try {
-        const terminalSession = await api<
-          | { mode: "tmux"; token: string; wsUrl: string }
-          | { mode: "inert"; message: string }
-        >(
-          `/api/v1/agents/${agent.id}/terminal/token`,
-          { method: "POST", body: JSON.stringify({}) }
-        );
+      const connectPromise = (async () => {
+        let agent: Agent | null = userInitiated
+          ? (agentsRef.current.find((item) => item.id === resolvedAgentId) ?? null)
+          : null;
 
-        if (!isCurrentAttempt()) {
+        if (!agent || agent.status !== "running") {
+          try {
+            const payload = await api<{ agent: Agent }>(`/api/v1/agents/${resolvedAgentId}?includeGitContext=false`);
+            agent = payload.agent;
+          } catch {
+            if (!isCurrentAttempt()) return;
+            scheduleReconnect("Session disconnected, reconnecting...");
+            return;
+          }
+        }
+
+        if (!isCurrentAttempt() || !agent) return;
+
+        if (agent.status !== "running") {
+          shouldKeepAttachedRef.current = false;
+          clearReconnectTimer();
+          closeSocket(false);
+          setConnState("disconnected");
+          setStatusMessage("Session ended.");
           return;
         }
 
-        if (terminalSession.mode === "inert") {
-          reconnectAttemptsRef.current = 0;
-          setConnState("connected");
-          setConnectedAgentId(agent.id);
-          setTerminalMode("inert");
-          setTerminalPlaceholderMessage(terminalSession.message);
-          setStatusMessage(terminalSession.message);
+        if (hasFreshSocket(agent.id)) {
+          restoreConnectedState(agent, "tmux");
+          sendResize();
           return;
         }
 
-        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-        const term = terminalRef.current;
-        const cols = term?.cols ?? 140;
-        const rows = term?.rows ?? 42;
-        setTerminalMode("tmux");
-        setTerminalPlaceholderMessage(null);
-        const ws = new WebSocket(
-          `${protocol}//${window.location.host}${terminalSession.wsUrl}&cols=${cols}&rows=${rows}`
-        );
-        wsRef.current = ws;
+        if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && connectedAgentIdRef.current === agent.id) {
+          closeSocketTransport();
+        }
 
-        ws.addEventListener("open", () => {
-          if (wsRef.current !== ws || !isCurrentAttempt()) {
-            try { ws.close(); } catch {}
+        clearReconnectTimer();
+        closeSocket(false);
+
+        if (clearScreen) {
+          terminalRef.current?.clear();
+        }
+
+        fitAddonRef.current?.fit();
+        setConnState("reconnecting");
+        setStatusMessage(`Connecting to session ${agent.name}...`);
+
+        try {
+          const terminalSession = await api<
+            | { mode: "tmux"; token: string; wsUrl: string }
+            | { mode: "inert"; message: string }
+          >(
+            `/api/v1/agents/${agent.id}/terminal/token`,
+            { method: "POST", body: JSON.stringify({}) }
+          );
+
+          if (!isCurrentAttempt()) {
             return;
           }
-          reconnectAttemptsRef.current = 0;
-          setConnState("connected");
-          setConnectedAgentId(agent.id);
-          setStatusMessage(`Connected to session ${agent.name}`);
-          terminalRef.current?.focus();
-        });
 
-        ws.addEventListener("message", (event) => {
-          if (wsRef.current !== ws || !isCurrentAttempt()) {
+          if (terminalSession.mode === "inert") {
+            restoreConnectedState(agent, "inert", terminalSession.message);
             return;
           }
-          const payload = JSON.parse(String(event.data)) as
-            | { type: "output"; data: string }
-            | { type: "error"; message: string }
-            | { type: "exit" };
 
-          if (payload.type === "output") {
-            terminalRef.current?.write(payload.data);
-          } else if (payload.type === "error") {
-            const normalized = payload.message.toLowerCase();
-            if (
-              normalized.includes("session no longer exists") ||
-              normalized.includes("attach failed") ||
-              normalized.includes("invalid or expired terminal token")
-            ) {
-              shouldKeepAttachedRef.current = false;
+          const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+          const term = terminalRef.current;
+          const cols = term?.cols ?? 140;
+          const rows = term?.rows ?? 42;
+          setTerminalMode("tmux");
+          setTerminalPlaceholderMessage(null);
+          const ws = new WebSocket(
+            `${protocol}//${window.location.host}${terminalSession.wsUrl}&cols=${cols}&rows=${rows}`
+          );
+          wsRef.current = ws;
+
+          ws.addEventListener("open", () => {
+            if (wsRef.current !== ws || !isCurrentAttempt()) {
+              try { ws.close(); } catch {}
+              return;
             }
-            setStatusMessage(`Session error: ${payload.message}`);
-          } else if (payload.type === "exit") {
-            setStatusMessage("Session ended.");
-          }
-        });
+            markSocketHealthy("open");
+            restoreConnectedState(agent, "tmux");
+            terminalRef.current?.focus();
+          });
 
-        ws.addEventListener("close", (event) => {
-          if (wsRef.current !== ws || !isCurrentAttempt()) return;
-          wsRef.current = null;
+          ws.addEventListener("message", (event) => {
+            if (wsRef.current !== ws || !isCurrentAttempt()) {
+              return;
+            }
+            const payload = JSON.parse(String(event.data)) as TerminalSocketMessage;
 
-          if (event.code === 1008 || event.code === 1011) {
+            if (payload.type === "heartbeat") {
+              markSocketHealthy("heartbeat");
+              return;
+            }
+
+            if (payload.type === "output") {
+              markSocketHealthy("output");
+              terminalRef.current?.write(payload.data);
+              return;
+            }
+
+            if (payload.type === "error") {
+              noteTerminalError(payload.message);
+              setStatusMessage(`Session error: ${payload.message}`);
+              if (isTerminalSessionGone(payload.message)) {
+                shouldKeepAttachedRef.current = false;
+              }
+              return;
+            }
+
+            noteTerminalError("Session ended.");
+            socketHealthRef.current.sessionGone = true;
             shouldKeepAttachedRef.current = false;
-            setConnState("disconnected");
+            setStatusMessage("Session ended.");
+          });
+
+          ws.addEventListener("close", (event) => {
+            if (wsRef.current !== ws || !isCurrentAttempt()) return;
+            wsRef.current = null;
+            const lastErrorMessage = socketHealthRef.current.lastErrorMessage;
+            const sessionGone = socketHealthRef.current.sessionGone;
+            clearSocketHealth();
+
+            if (sessionGone) {
+              shouldKeepAttachedRef.current = false;
+              setConnectedAgentId(null);
+              setTerminalMode(null);
+              setConnState("disconnected");
+              return;
+            }
+
+            if (event.code === 1008 && lastErrorMessage && isRetriableTerminalFailure(lastErrorMessage)) {
+              scheduleReconnect("Session token expired, retrying...");
+              return;
+            }
+
+            scheduleReconnect("Session disconnected, reconnecting...");
+          });
+        } catch (error) {
+          if (!isCurrentAttempt()) {
             return;
           }
 
-          scheduleReconnect("Session disconnected, reconnecting...");
-        });
-      } catch {
-        scheduleReconnect("Session connection failed, retrying...");
+          const message = error instanceof Error ? error.message : "Session connection failed.";
+          if (isTerminalSessionGone(message)) {
+            shouldKeepAttachedRef.current = false;
+            clearReconnectTimer();
+            closeSocket(false);
+            setConnState("disconnected");
+            setStatusMessage(message);
+            return;
+          }
+
+          scheduleReconnect(
+            isRetriableTerminalFailure(message)
+              ? "Session token expired, retrying..."
+              : "Session connection failed, retrying..."
+          );
+        }
+      })();
+
+      reconnectInFlightRef.current = { agentId: resolvedAgentId, promise: connectPromise };
+      try {
+        await connectPromise;
+      } finally {
+        if (reconnectInFlightRef.current?.promise === connectPromise) {
+          reconnectInFlightRef.current = null;
+        }
       }
     },
-    [clearReconnectTimer, closeSocket, selectedAgentId, sendResize]
+    [
+      clearReconnectTimer,
+      clearSocketHealth,
+      closeSocket,
+      closeSocketTransport,
+      hasFreshSocket,
+      markSocketHealthy,
+      noteTerminalError,
+      restoreConnectedState,
+      selectedAgentId,
+      sendResize,
+    ]
   );
 
   const detachTerminal = useCallback(() => {
@@ -464,24 +603,42 @@ export function useTerminal(args: {
 
   // Reconnect on visibility/focus.
   useEffect(() => {
+    const requestForegroundReconnect = () => {
+      const targetAgentId = connectedAgentIdRef.current ?? selectedAgentId ?? undefined;
+      if (!targetAgentId) return;
+      const now = Date.now();
+      if (now - lastResumeTriggerAtRef.current < RESUME_RECONNECT_DEDUPE_MS) {
+        return;
+      }
+      lastResumeTriggerAtRef.current = now;
+      void ensureTerminalConnected(false, false, targetAgentId);
+    };
+
     const onVisible = () => {
       if (!document.hidden) {
-        void ensureTerminalConnected(false, false, connectedAgentIdRef.current ?? selectedAgentId ?? undefined);
+        requestForegroundReconnect();
       }
     };
 
     const onFocus = () => {
+      requestForegroundReconnect();
+    };
+
+    const onOnline = () => {
+      clearReconnectTimer();
       void ensureTerminalConnected(false, false, connectedAgentIdRef.current ?? selectedAgentId ?? undefined);
     };
 
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onFocus);
+    window.addEventListener("online", onOnline);
 
     return () => {
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onFocus);
+      window.removeEventListener("online", onOnline);
     };
-  }, [connectedAgentId, ensureTerminalConnected, selectedAgentId]);
+  }, [clearReconnectTimer, ensureTerminalConnected, selectedAgentId]);
 
   // Fit on layout change.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- make terminal reconnect logic use heartbeat/output freshness instead of raw websocket OPEN state
- add a single reconnect coordinator with deduped resume handling and immediate `online` recovery
- extend live terminal coverage with a healthy-resume duplicate-token regression test and document the recovery plan

## Validation
- npm run check
- npm run finalize:web
- npm run test:e2e
- manual live tmux validation against a worktree dev stack at `http://127.0.0.1:50831`

## Notes
- manual live validation showed healthy hidden->visible resume stayed connected and did not trigger a second `/terminal/token` request
- the opt-in `e2e/terminal-live.spec.ts` suite remains partially brittle in live mode, but the harness issue is separate from the reconnect hook changes