### PR TITLE
Sort recent project path options

### DIFF
--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -43,4 +43,28 @@ test.describe("Create agent dialog", () => {
     await page.getByTestId("create-agent-cancel").click();
     await expect(form).not.toBeVisible({ timeout: 3_000 });
   });
+
+  test("recent directories remain visible while typing a new path", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "dispatch:cwdHistory",
+        JSON.stringify(["/tmp/existing-project", "/Users/brad/dev/apps/dispatch"])
+      );
+    });
+
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    const cwdInput = form.getByTestId("create-agent-cwd");
+    await cwdInput.fill("/brand/new/path");
+    const recentOptions = form.getByTestId("create-agent-cwd-history-option");
+
+    await expect(page.getByRole("button", { name: "/Users/brad/dev/apps/dispatch" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "/tmp/existing-project" })).toBeVisible();
+    await expect(recentOptions).toHaveText(["/tmp/existing-project", "/Users/brad/dev/apps/dispatch"]);
+    await expect(cwdInput).toHaveValue("/brand/new/path");
+  });
 });

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -40,10 +40,7 @@ export function CreateAgentDialog({
 }: CreateAgentDialogProps): JSX.Element {
   const [cwdDropdownOpen, setCwdDropdownOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const filteredHistory = cwdHistory.filter(
-    (dir) => !createCwd || dir.toLowerCase().includes(createCwd.toLowerCase())
-  );
+  const sortedCwdHistory = [...cwdHistory].sort((left, right) => left.localeCompare(right));
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -119,13 +116,17 @@ export function CreateAgentDialog({
                 </button>
               ) : null}
             </div>
-            {cwdDropdownOpen && filteredHistory.length > 0 ? (
-              <div className="absolute left-0 right-0 z-10 mt-1 max-h-[160px] overflow-y-auto rounded-md border border-border bg-background shadow-md">
+            {cwdDropdownOpen && sortedCwdHistory.length > 0 ? (
+              <div
+                className="absolute left-0 right-0 z-10 mt-1 max-h-[160px] overflow-y-auto rounded-md border border-border bg-background shadow-md"
+                data-testid="create-agent-cwd-history"
+              >
                 <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Recent directories</div>
-                {filteredHistory.map((dir) => (
+                {sortedCwdHistory.map((dir) => (
                   <button
                     key={dir}
                     type="button"
+                    data-testid="create-agent-cwd-history-option"
                     className="w-full truncate px-2 py-1.5 text-left font-mono text-xs text-foreground hover:bg-muted/70"
                     onMouseDown={(event) => {
                       event.preventDefault();


### PR DESCRIPTION
## Summary
- keep recent working directory options visible while typing a new path
- sort recent project paths alphabetically before rendering
- add e2e coverage for visible and ordered recent path options

## Testing
- npm run check
- npm run finalize:web
- npm run test:e2e