### PR TITLE
Add Agents settings section for agent-type toggles

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -38,6 +38,20 @@ export async function setAgentLatestEventViaAPI(
   });
 }
 
+export async function setEnabledAgentTypesViaAPI(
+  request: APIRequestContext,
+  enabledAgentTypes: string[]
+): Promise<void> {
+  const res = await request.post(`${API}/app/settings/agent-types`, {
+    headers: authHeaders(),
+    data: { enabledAgentTypes },
+  });
+
+  if (!res.ok()) {
+    throw new Error(`Failed to update agent type settings: ${res.status()}`);
+  }
+}
+
 export async function uploadMediaViaAPI(
   request: APIRequestContext,
   agentId: string,

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { loadApp } from "./helpers";
+import { loadApp, setEnabledAgentTypesViaAPI } from "./helpers";
 
 test.describe("Settings pane", () => {
+  test.afterEach(async ({ request }) => {
+    await setEnabledAgentTypesViaAPI(request, ["codex", "claude", "opencode"]);
+  });
+
   test("opens and closes the settings pane", async ({ page }) => {
     await loadApp(page);
 
@@ -30,5 +34,32 @@ test.describe("Settings pane", () => {
     await expect(page.getByTestId("app-version-semver")).not.toHaveText("");
     await expect(page.getByTestId("app-version-git-sha")).not.toHaveText("");
     await expect(page.getByTestId("app-version-release-notes")).not.toHaveText("");
+  });
+
+  test("agent type settings filter the create-agent dialog", async ({ page }) => {
+    await loadApp(page);
+
+    await page.getByTestId("settings-button").click();
+    await page.getByRole("navigation").getByText("Agents", { exact: true }).click();
+
+    const claudeToggle = page.getByTestId("agent-type-toggle-claude");
+    await expect(claudeToggle).toBeChecked();
+    await claudeToggle.uncheck();
+    await page.getByTestId("save-agent-type-settings").click();
+    await expect(page.getByText("Agent type settings saved.")).toBeVisible();
+
+    await page.getByRole("button", { name: "Close" }).click();
+
+    await page.getByTestId("create-agent-button").click();
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    const typeTrigger = form.getByRole("combobox").first();
+    await expect(typeTrigger).toContainText("Codex");
+    await typeTrigger.click();
+
+    await expect(page.getByRole("option", { name: "Codex" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "OpenCode" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "Claude" })).not.toBeVisible();
   });
 });

--- a/src/agent-type-settings.ts
+++ b/src/agent-type-settings.ts
@@ -1,0 +1,40 @@
+import type { Pool } from "pg";
+
+import { getSetting, setSetting } from "./db/settings.js";
+
+export const AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export type AgentType = (typeof AGENT_TYPES)[number];
+
+const ENABLED_AGENT_TYPES_KEY = "enabled_agent_types";
+
+function isAgentType(value: unknown): value is AgentType {
+  return typeof value === "string" && AGENT_TYPES.includes(value as AgentType);
+}
+
+export function sanitizeEnabledAgentTypes(value: unknown): AgentType[] {
+  if (!Array.isArray(value)) {
+    return [...AGENT_TYPES];
+  }
+
+  const unique = value.filter(isAgentType).filter((type, index, types) => types.indexOf(type) === index);
+  return unique.length > 0 ? unique : [...AGENT_TYPES];
+}
+
+export async function getEnabledAgentTypes(pool: Pool): Promise<AgentType[]> {
+  const raw = await getSetting(pool, ENABLED_AGENT_TYPES_KEY);
+  if (!raw) {
+    return [...AGENT_TYPES];
+  }
+
+  try {
+    return sanitizeEnabledAgentTypes(JSON.parse(raw));
+  } catch {
+    return [...AGENT_TYPES];
+  }
+}
+
+export async function setEnabledAgentTypes(pool: Pool, agentTypes: AgentType[]): Promise<AgentType[]> {
+  const sanitized = sanitizeEnabledAgentTypes(agentTypes);
+  await setSetting(pool, ENABLED_AGENT_TYPES_KEY, JSON.stringify(sanitized));
+  return sanitized;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
 import { SlackNotifier } from "./notifications/slack.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
+import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 
 const config = loadConfig();
 const app = Fastify({
@@ -1057,6 +1058,38 @@ async function registerRoutes() {
     return slackNotifier.sendTestMessage(url);
   });
 
+  app.get("/api/v1/app/settings/agent-types", async () => {
+    return {
+      enabledAgentTypes: await getEnabledAgentTypes(pool)
+    };
+  });
+
+  app.post("/api/v1/app/settings/agent-types", async (request, reply) => {
+    const body = request.body as { enabledAgentTypes?: unknown } | null;
+
+    if (!Array.isArray(body?.enabledAgentTypes)) {
+      return reply.code(400).send({ error: "enabledAgentTypes must be an array." });
+    }
+
+    const uniqueTypes = body.enabledAgentTypes
+      .filter((value): value is typeof AGENT_TYPES[number] => typeof value === "string" && AGENT_TYPES.includes(value as typeof AGENT_TYPES[number]))
+      .filter((value, index, values) => values.indexOf(value) === index);
+
+    if (uniqueTypes.length === 0) {
+      return reply.code(400).send({ error: "At least one agent type must remain enabled." });
+    }
+
+    if (uniqueTypes.length !== body.enabledAgentTypes.length) {
+      return reply
+        .code(400)
+        .send({ error: `enabledAgentTypes must only include ${AGENT_TYPES.join(", ")}.` });
+    }
+
+    return {
+      enabledAgentTypes: await setEnabledAgentTypes(pool, uniqueTypes)
+    };
+  });
+
   // --- Energy metrics beacon (PWA diagnostics) ---
   app.post("/api/v1/energy-report", async (request, reply) => {
     try {
@@ -1474,6 +1507,11 @@ async function registerRoutes() {
 
     const agentArgs = providedAgentArgs as string[] | undefined;
     const agentType = body.type === "claude" ? "claude" : body.type === "opencode" ? "opencode" : "codex";
+    const enabledAgentTypes = await getEnabledAgentTypes(pool);
+    if (!enabledAgentTypes.includes(agentType)) {
+      return reply.code(400).send({ error: `${agentType} agents are disabled in settings.` });
+    }
+
     const fullAccessArg =
       agentType === "claude"
         ? CLAUDE_FULL_ACCESS_ARG

--- a/test/agent-type-settings.test.ts
+++ b/test/agent-type-settings.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_TYPES, sanitizeEnabledAgentTypes } from "../src/agent-type-settings.js";
+
+describe("sanitizeEnabledAgentTypes", () => {
+  it("returns defaults when the value is not an array", () => {
+    expect(sanitizeEnabledAgentTypes(undefined)).toEqual(AGENT_TYPES);
+  });
+
+  it("filters unknown values and removes duplicates", () => {
+    expect(sanitizeEnabledAgentTypes(["codex", "claude", "codex", "unknown"])).toEqual([
+      "codex",
+      "claude",
+    ]);
+  });
+
+  it("falls back to defaults when the array has no valid types", () => {
+    expect(sanitizeEnabledAgentTypes(["unknown"])).toEqual(AGENT_TYPES);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { useSSE } from "@/hooks/use-sse";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useTheme } from "@/hooks/use-theme";
+import { AGENT_TYPES, type AgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
@@ -111,7 +112,8 @@ export function App(): JSX.Element {
   const [createName, setCreateName] = useState("");
   const [createCwd, setCreateCwd] = useState(() => readLastUsedCwd());
   const [createCwdInitialized, setCreateCwdInitialized] = useState(() => readLastUsedCwd().trim().length > 0);
-  const [createType, setCreateType] = useState("codex");
+  const [enabledAgentTypes, setEnabledAgentTypes] = useState<AgentType[]>([...AGENT_TYPES]);
+  const [createType, setCreateType] = useState<AgentType>("codex");
   const [createFullAccess, setCreateFullAccess] = useState(false);
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
@@ -258,6 +260,30 @@ export function App(): JSX.Element {
     return () => { cancelled = true; };
   }, [createCwdInitialized]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    void api<{ enabledAgentTypes: AgentType[] }>("/api/v1/app/settings/agent-types")
+      .then((payload) => {
+        if (cancelled) return;
+        setEnabledAgentTypes(sanitizeEnabledAgentTypes(payload.enabledAgentTypes));
+      })
+      .catch(() => {
+        if (cancelled) return;
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (enabledAgentTypes.includes(createType)) {
+      return;
+    }
+    setCreateType(enabledAgentTypes[0] ?? "codex");
+  }, [createType, enabledAgentTypes]);
+
   // ── Derived values ────────────────────────────────────────────────────
   const isAttached = connState === "connected" && Boolean(connectedAgentId);
   const canAttachSelected = Boolean(selectedAgent && selectedAgent.status === "running" && !isAttached);
@@ -288,8 +314,9 @@ export function App(): JSX.Element {
 
   const openCreateDialog = useCallback(() => {
     setCreateCwd(resolveCreateDefaultCwd());
+    setCreateType((current) => (enabledAgentTypes.includes(current) ? current : enabledAgentTypes[0] ?? "codex"));
     setCreateOpen(true);
-  }, [resolveCreateDefaultCwd]);
+  }, [enabledAgentTypes, resolveCreateDefaultCwd]);
 
   const toggleAgentDetails = useCallback(
     (agentId: string) => {
@@ -569,6 +596,7 @@ export function App(): JSX.Element {
         createFullAccess={createFullAccess}
         creating={creating}
         cwdHistory={cwdHistory}
+        enabledAgentTypes={enabledAgentTypes}
         setOpen={setCreateOpen}
         setCreateName={setCreateName}
         setCreateType={setCreateType}
@@ -586,7 +614,15 @@ export function App(): JSX.Element {
       />
 
       <DocsPane open={docsPaneOpen} onClose={() => setDocsPaneOpen(false)} />
-      <SettingsPane open={settingsPaneOpen} onClose={() => setSettingsPaneOpen(false)} onLogout={handleLogout} theme={theme} setTheme={setTheme} />
+      <SettingsPane
+        open={settingsPaneOpen}
+        onClose={() => setSettingsPaneOpen(false)}
+        onLogout={handleLogout}
+        theme={theme}
+        setTheme={setTheme}
+        enabledAgentTypes={enabledAgentTypes}
+        onEnabledAgentTypesChange={setEnabledAgentTypes}
+      />
 
       <MediaLightbox
         item={lightboxItem}

--- a/web/src/components/app/agent-type-settings.tsx
+++ b/web/src/components/app/agent-type-settings.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import { AGENT_TYPES, AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+
+type AgentTypeSettingsResponse = {
+  enabledAgentTypes: AgentType[];
+};
+
+type AgentTypeSettingsProps = {
+  enabledAgentTypes: AgentType[];
+  onChange: (agentTypes: AgentType[]) => void;
+};
+
+export function AgentTypeSettings({
+  enabledAgentTypes,
+  onChange,
+}: AgentTypeSettingsProps): JSX.Element {
+  const [draftAgentTypes, setDraftAgentTypes] = useState<AgentType[]>(enabledAgentTypes);
+  const [savedAgentTypes, setSavedAgentTypes] = useState<AgentType[]>(enabledAgentTypes);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setDraftAgentTypes(enabledAgentTypes);
+    setSavedAgentTypes(enabledAgentTypes);
+  }, [enabledAgentTypes]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void api<AgentTypeSettingsResponse>("/api/v1/app/settings/agent-types")
+      .then((data) => {
+        if (cancelled) return;
+        setDraftAgentTypes(data.enabledAgentTypes);
+        setSavedAgentTypes(data.enabledAgentTypes);
+        onChange(data.enabledAgentTypes);
+        setError("");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load agent type settings.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [onChange]);
+
+  const hasChanges =
+    JSON.stringify([...draftAgentTypes].sort()) !== JSON.stringify([...savedAgentTypes].sort());
+
+  const toggleAgentType = useCallback((agentType: AgentType) => {
+    setMessage("");
+    setError("");
+    setDraftAgentTypes((current) => {
+      if (current.includes(agentType)) {
+        return current.filter((item) => item !== agentType);
+      }
+      return [...current, agentType];
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setMessage("");
+    setError("");
+    try {
+      const data = await api<AgentTypeSettingsResponse>("/api/v1/app/settings/agent-types", {
+        method: "POST",
+        body: JSON.stringify({ enabledAgentTypes: draftAgentTypes }),
+      });
+      setDraftAgentTypes(data.enabledAgentTypes);
+      setSavedAgentTypes(data.enabledAgentTypes);
+      onChange(data.enabledAgentTypes);
+      setMessage("Agent type settings saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save agent type settings.");
+    } finally {
+      setSaving(false);
+    }
+  }, [draftAgentTypes, onChange]);
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Available agent types
+      </h3>
+      <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
+        Choose which agent runtimes can be created from the app. Disabled types are removed from the create-agent dialog.
+      </p>
+
+      <div className="max-w-lg space-y-2">
+        {AGENT_TYPES.map((agentType) => {
+          const checked = draftAgentTypes.includes(agentType);
+          const disabled = checked && draftAgentTypes.length === 1;
+          return (
+            <label
+              key={agentType}
+              className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50"
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => toggleAgentType(agentType)}
+                className="h-4 w-4 rounded border-border accent-primary"
+                data-testid={`agent-type-toggle-${agentType}`}
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">{AGENT_TYPE_LABELS[agentType]}</div>
+                <div className="text-xs text-muted-foreground">
+                  {disabled ? "At least one agent type must stay enabled." : "Available in the create-agent dialog."}
+                </div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      {error ? <p className="mt-3 text-sm text-destructive">{error}</p> : null}
+      {message ? <p className="mt-3 text-sm text-status-working">{message}</p> : null}
+
+      <div className="mt-4">
+        <Button
+          variant="primary"
+          disabled={saving || !hasChanges}
+          onClick={() => void handleSave()}
+          data-testid="save-agent-type-settings"
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -5,19 +5,21 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { cn } from "@/lib/utils";
 
 type CreateAgentDialogProps = {
   open: boolean;
   createName: string;
-  createType: string;
+  createType: AgentType;
   createCwd: string;
   createFullAccess: boolean;
   creating: boolean;
   cwdHistory: string[];
+  enabledAgentTypes: AgentType[];
   setOpen: (open: boolean) => void;
   setCreateName: (name: string) => void;
-  setCreateType: (value: string) => void;
+  setCreateType: (value: AgentType) => void;
   setCreateCwd: (cwd: string) => void;
   setCreateFullAccess: (value: boolean | ((current: boolean) => boolean)) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
@@ -31,6 +33,7 @@ export function CreateAgentDialog({
   createFullAccess,
   creating,
   cwdHistory,
+  enabledAgentTypes,
   setOpen,
   setCreateName,
   setCreateType,
@@ -63,14 +66,16 @@ export function CreateAgentDialog({
 
           <div className="space-y-1">
             <label className="text-sm text-muted-foreground">Type</label>
-            <Select value={createType} onValueChange={setCreateType}>
+            <Select value={createType} onValueChange={(value) => setCreateType(value as AgentType)}>
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="codex">Codex</SelectItem>
-                <SelectItem value="claude">Claude</SelectItem>
-                <SelectItem value="opencode">OpenCode</SelectItem>
+                {enabledAgentTypes.map((agentType) => (
+                  <SelectItem key={agentType} value={agentType}>
+                    {AGENT_TYPE_LABELS[agentType]}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/web/src/components/app/settings-pane.tsx
+++ b/web/src/components/app/settings-pane.tsx
@@ -1,22 +1,25 @@
 import { useCallback, useEffect, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { Bell, ChevronDown, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, Palette, RefreshCw, Shield, Trash2, X } from "lucide-react";
+import { Bell, ChevronDown, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, Palette, RefreshCw, Shield, Trash2, Users, X } from "lucide-react";
 
+import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { NotificationSettings } from "@/components/app/notification-settings";
 import { ReleaseManager } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { type ThemeId, THEMES } from "@/hooks/use-theme";
+import { type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release" | "security" | "notifications" | "appearance" | "app";
+type SettingsSection = "release" | "security" | "notifications" | "appearance" | "agents" | "app";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
   { id: "release", label: "Updates", icon: ArrowDownToLine },
   { id: "security", label: "Security", icon: Shield },
   { id: "notifications", label: "Notifications", icon: Bell },
   { id: "appearance", label: "Appearance", icon: Palette },
+  { id: "agents", label: "Agents", icon: Users },
   { id: "app", label: "App", icon: RefreshCw }
 ];
 
@@ -226,9 +229,19 @@ type SettingsPaneProps = {
   onLogout: () => void;
   theme: ThemeId;
   setTheme: (id: ThemeId) => void;
+  enabledAgentTypes: AgentType[];
+  onEnabledAgentTypesChange: (agentTypes: AgentType[]) => void;
 };
 
-export function SettingsPane({ open, onClose, onLogout, theme, setTheme }: SettingsPaneProps): JSX.Element {
+export function SettingsPane({
+  open,
+  onClose,
+  onLogout,
+  theme,
+  setTheme,
+  enabledAgentTypes,
+  onEnabledAgentTypesChange,
+}: SettingsPaneProps): JSX.Element {
   const [activeSection, setActiveSection] = useState<SettingsSection | null>("release");
 
   return (
@@ -314,6 +327,12 @@ export function SettingsPane({ open, onClose, onLogout, theme, setTheme }: Setti
               {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
               {activeSection === "notifications" && <NotificationSettings />}
               {activeSection === "appearance" && <AppearanceSettings theme={theme} setTheme={setTheme} />}
+              {activeSection === "agents" && (
+                <AgentTypeSettings
+                  enabledAgentTypes={enabledAgentTypes}
+                  onChange={onEnabledAgentTypesChange}
+                />
+              )}
               {activeSection === "app" && <AppSettings />}
             </div>
           </div>

--- a/web/src/lib/agent-types.ts
+++ b/web/src/lib/agent-types.ts
@@ -1,0 +1,25 @@
+export const AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+
+export type AgentType = (typeof AGENT_TYPES)[number];
+
+export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
+  codex: "Codex",
+  claude: "Claude",
+  opencode: "OpenCode"
+};
+
+export function isAgentType(value: string): value is AgentType {
+  return AGENT_TYPES.includes(value as AgentType);
+}
+
+export function sanitizeEnabledAgentTypes(value: unknown): AgentType[] {
+  if (!Array.isArray(value)) {
+    return [...AGENT_TYPES];
+  }
+
+  const unique = value
+    .filter((item): item is AgentType => typeof item === "string" && isAgentType(item))
+    .filter((item, index, items) => items.indexOf(item) === index);
+
+  return unique.length > 0 ? unique : [...AGENT_TYPES];
+}


### PR DESCRIPTION
## Summary
- persist enabled agent types on the backend, block disabled types server-side, and expose them via a new app settings endpoint
- move the agent-type toggles into a dedicated Agents section, keep App settings focused on version metadata, and respect enabled types when creating agents
- cover the new flow with tests, type checking, and UI validation

## Testing
- npm run check
- npm run finalize:web
- npm test
- npm run test:e2e