### PR TITLE
Pad the Agents settings section

### DIFF
--- a/web/src/components/app/agent-type-settings.tsx
+++ b/web/src/components/app/agent-type-settings.tsx
@@ -92,7 +92,7 @@ export function AgentTypeSettings({
   }
 
   return (
-    <div>
+    <div className="flex flex-col gap-6 p-6">
       <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
         Available agent types
       </h3>


### PR DESCRIPTION
## Summary
- add consistent padding around the Agent type toggles so the Agents section matches other settings panes
- keep the existing behavior intact and only touch layout (no new backend or API changes)

## Testing
- npm run check
- npm run finalize:web
- npm test
- npm run test:e2e