### PR TITLE
Fix setup docs and add agent type config to setup prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 MEDIA_ROOT=~/.dispatch/media
 
+# Authentication token for API access (generate with: openssl rand -hex 32)
+AUTH_TOKEN=
+
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Give this prompt to a coding agent to get Dispatch installed as a local service 
 > Clone https://github.com/selfcontained/dispatch.git and install it as a launchd service on this Mac. Steps:
 >
 > 1. Clone the repo to `~/.dispatch/server`.
-> 2. Run `bin/preflight` to check dependencies — install anything it flags as failed (nvm, Node 22+, PostgreSQL, tmux).
-> 3. Set up PostgreSQL — either use a local install (`createuser dispatch; createdb -O dispatch dispatch`) or run `docker compose up -d postgres` to use the bundled Docker Postgres.
-> 4. Copy `.env.example` to `.env` and configure: set `DATABASE_URL` to match the Postgres setup, set `MEDIA_ROOT` to `~/.dispatch/media`, and generate a random `AUTH_TOKEN`.
+> 2. Run `bin/preflight` to check dependencies — install anything it flags as failed (nvm, Node 22+, PostgreSQL 17, tmux).
+> 3. Start PostgreSQL (`brew services start postgresql@17`) and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
+> 4. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The other defaults are usually fine.
 > 5. Run `bin/install-launchd` — this builds the project and registers a launchd service that starts automatically.
 > 6. Verify: `curl http://127.0.0.1:6767/api/v1/health`
+> 7. Check which agent CLIs are installed (`claude --version`, `codex --version`, `opencode --version`). In the Dispatch UI under Settings, disable any agent types whose CLI is not installed.
 
 ## Features
 
@@ -33,9 +34,16 @@ Give this prompt to a coding agent to get Dispatch installed as a local service 
 | **Xcode CLI Tools** | Build tools for native npm modules (node-pty) | `xcode-select --install` |
 | **Homebrew** | Package manager | [brew.sh](https://brew.sh) |
 | **Node.js 22+** | Runtime | `nvm install 22` (see `.nvmrc`) |
-| **Docker Desktop** | Postgres database | `brew install --cask docker` |
+| **PostgreSQL 17** | Database (production) | `brew install postgresql@17` |
 | **tmux** | Agent session management | `brew install tmux` |
 | **At least one agent CLI** | The agents Dispatch runs | See below |
+
+### Optional
+
+| Dependency | Purpose | Install |
+|---|---|---|
+| **Docker Desktop** | Isolated dev databases via `dispatch-dev` | `brew install --cask docker` |
+| **Xcode** (full) | iOS Simulator, `xcrun simctl` | App Store |
 
 ### Agent CLIs
 

--- a/bin/preflight
+++ b/bin/preflight
@@ -95,6 +95,13 @@ else
   warn "codex — needed to spawn Codex agents: npm install -g codex"
 fi
 
+# OpenCode CLI
+if command -v opencode &>/dev/null; then
+  ok "opencode ($(which opencode))"
+else
+  warn "opencode — needed to spawn OpenCode agents: npm install -g opencode"
+fi
+
 # Playwright browsers
 PW_CHROMIUM_DIR="$HOME/Library/Caches/ms-playwright"
 if [[ -d "$PW_CHROMIUM_DIR" ]] && ls "$PW_CHROMIUM_DIR"/chromium-* &>/dev/null 2>&1; then

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -32,19 +32,18 @@ Copy and paste this prompt to a Claude agent on the new machine to kick off setu
 ```
 Set up Dispatch on this machine. The repo is at https://github.com/selfcontained/dispatch.git
 
-1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Playwright browsers.
-2. Install agent CLIs: check which of claude, codex, and opencode are available (claude --version, codex --version, opencode --version). Install any that are needed (npm install -g @anthropic-ai/claude-code, npm install -g codex, npm install -g opencode).
-3. Clone the repo to ~/dev/apps/dispatch.
-4. Run bin/preflight and fix any failures it reports.
-5. Start Postgres: brew services start postgresql@17
-6. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
-7. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
-8. Run: nvm use && npm ci && npm --prefix web ci && npm run build
-9. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
-10. Install the launchd service: bin/install-launchd --port 6767
-11. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
-12. Configure enabled agent types: check which agent CLIs are actually installed, then use the API to set only those types as enabled: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to include only installed CLIs).
-13. Run gh auth login to authenticate GitHub CLI for releases.
+1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Playwright browsers. Do NOT install agent CLIs (claude, codex, opencode) — the user will install those themselves.
+2. Clone the repo to ~/dev/apps/dispatch.
+3. Run bin/preflight and fix any failures it reports.
+4. Start Postgres: brew services start postgresql@17
+5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
+6. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
+7. Run: nvm use && npm ci && npm --prefix web ci && npm run build
+8. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
+9. Install the launchd service: bin/install-launchd --port 6767
+10. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
+11. Configure enabled agent types: check which agent CLIs are already installed (claude --version, codex --version, opencode --version), then use the API to enable only those types: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to match installed CLIs).
+12. Run gh auth login to authenticate GitHub CLI for releases.
 
 Read docs/12-new-machine-setup.md for full details and troubleshooting. Report any issues you hit.
 ```

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -15,8 +15,7 @@ The new machine needs:
 | **tmux** | Agent session management | `brew install tmux` |
 | **Git** | Source control | Included with Xcode CLI Tools |
 | **GitHub CLI** | Release automation | `brew install gh` |
-| **Claude CLI** | Agent runtime (Claude agents) | `npm install -g @anthropic-ai/claude-code` |
-| **Codex CLI** | Agent runtime (Codex agents) | `npm install -g codex` |
+| **At least one agent CLI** | Agent runtime — install any you plan to use | See [Agent CLIs](#8-agent-clis) |
 | **Playwright browsers** | Headless Chrome for agent UI validation | `npx playwright install chromium` |
 
 ### Optional
@@ -33,17 +32,19 @@ Copy and paste this prompt to a Claude agent on the new machine to kick off setu
 ```
 Set up Dispatch on this machine. The repo is at https://github.com/selfcontained/dispatch.git
 
-1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Claude CLI, Codex CLI, Playwright browsers.
-2. Clone the repo to ~/dev/apps/dispatch.
-3. Run bin/preflight and fix any failures it reports.
-4. Start Postgres: brew services start postgresql@17
-5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
-6. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
-7. Run: nvm use && npm ci && npm --prefix web ci && npm run build
-8. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
-9. Install the launchd service: bin/install-launchd --port 6767
-10. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
-11. Run gh auth login to authenticate GitHub CLI for releases.
+1. Install system dependencies if missing: Homebrew, nvm, Node 22 LTS, tmux, PostgreSQL 17 (via brew), GitHub CLI, Playwright browsers.
+2. Install agent CLIs: check which of claude, codex, and opencode are available (claude --version, codex --version, opencode --version). Install any that are needed (npm install -g @anthropic-ai/claude-code, npm install -g codex, npm install -g opencode).
+3. Clone the repo to ~/dev/apps/dispatch.
+4. Run bin/preflight and fix any failures it reports.
+5. Start Postgres: brew services start postgresql@17
+6. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
+7. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
+8. Run: nvm use && npm ci && npm --prefix web ci && npm run build
+9. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
+10. Install the launchd service: bin/install-launchd --port 6767
+11. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
+12. Configure enabled agent types: check which agent CLIs are actually installed, then use the API to set only those types as enabled: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to include only installed CLIs).
+13. Run gh auth login to authenticate GitHub CLI for releases.
 
 Read docs/12-new-machine-setup.md for full details and troubleshooting. Report any issues you hit.
 ```
@@ -174,21 +175,32 @@ This is needed for `bin/dispatch-release` to trigger GitHub Actions workflows.
 
 ### 8. Agent CLIs
 
-Dispatch spawns agents via Claude CLI and/or Codex CLI:
+Dispatch spawns agents via their CLI tools. Install whichever you plan to use:
 
 ```bash
 # Claude CLI
 npm install -g @anthropic-ai/claude-code
-which claude
 claude --version
 
 # Codex CLI
 npm install -g codex
-which codex
 codex --version
+
+# OpenCode CLI
+npm install -g opencode
+opencode --version
 ```
 
-The config defaults to `claude` and `codex` on PATH. To override, set `DISPATCH_CLAUDE_BIN` or `DISPATCH_CODEX_BIN` in `.env`.
+The config defaults to `claude`, `codex`, and `opencode` on PATH. To override, set `DISPATCH_CLAUDE_BIN`, `DISPATCH_CODEX_BIN`, or `DISPATCH_OPENCODE_BIN` in `.env`.
+
+After setup, configure which agent types are available in the create-agent dialog. In the Dispatch UI go to **Settings > Agent Types** and enable only the CLIs you have installed. Or use the API:
+
+```bash
+# Example: only Claude and Codex are installed
+curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types \
+  -H 'Content-Type: application/json' \
+  -d '{"enabledAgentTypes": ["claude", "codex"]}'
+```
 
 ### 9. Playwright browsers
 


### PR DESCRIPTION
## Summary

- **`.env.example`**: Add missing `AUTH_TOKEN` field (referenced in setup docs and `src/config.ts` but was absent from the example)
- **README prerequisites**: Fix table — PostgreSQL 17 is required (not Docker), Docker is optional (for dev databases only). Add OpenCode to agent CLIs.
- **Quick Install prompt**: Fix Postgres setup command to match actual `createdb` + `CREATE ROLE` flow, add step 7 to configure enabled agent types based on installed CLIs
- **`bin/preflight`**: Add missing OpenCode CLI check alongside Claude and Codex
- **`docs/12-new-machine-setup.md`**: Update agent setup prompt with agent type detection step, update agent CLIs section with OpenCode + agent type settings API instructions

## Test plan

- [x] `npm run check` passes
- [x] E2E tests pass (32/32, 6 skipped terminal-live)
- [ ] Verify Quick Install prompt reads correctly for a fresh setup
- [ ] Verify `bin/preflight` reports opencode status

🤖 Generated with [Claude Code](https://claude.com/claude-code)