### PR TITLE
Fix terminal freeze when returning from background

### DIFF
--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -235,7 +235,10 @@ export function useTerminal(args: {
         return;
       }
 
-      const attemptNonce = ++attachNonceRef.current;
+      // Nonce is incremented later (just before opening a new WebSocket) so
+      // that reusing a fresh socket doesn't invalidate its existing message
+      // handler.  Read the current value here for the in-flight guard only.
+      let attemptNonce = attachNonceRef.current;
       const isCurrentAttempt = () =>
         shouldKeepAttachedRef.current && attemptNonce === attachNonceRef.current;
 
@@ -289,6 +292,10 @@ export function useTerminal(args: {
           sendResize();
           return;
         }
+
+        // We're about to create a new WebSocket — NOW increment the nonce to
+        // invalidate any previous handler that is still attached.
+        attemptNonce = ++attachNonceRef.current;
 
         if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && connectedAgentIdRef.current === agent.id) {
           closeSocketTransport();


### PR DESCRIPTION
## Summary
- The attach nonce was incremented at the top of `ensureTerminalConnected()`, before checking whether the existing socket was still fresh
- When the app returned from background, the visibility handler bumped the nonce then took the `hasFreshSocket()` early-return — leaving the existing WebSocket message handler with a stale nonce
- Every subsequent output message was silently dropped, freezing the display while input still worked (typed characters registered in tmux but weren't rendered)
- Fix: defer the nonce increment to just before the new WebSocket is created, so reusing a fresh socket doesn't invalidate its own handler

## Test plan
- [x] `npm run finalize:web` — type-check + production build passes
- [x] `npm run test:e2e` — 56 passed, 6 skipped (terminal-live tests that need real tmux)
- [ ] Manual: connect to a terminal, background the app for 30+ seconds, return — terminal should remain responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)