### PR TITLE
Remove npm cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "npm"
-          cache-dependency-path: |
-            package-lock.json
-            web/package-lock.json
 
       - name: Start Postgres
         id: postgres


### PR DESCRIPTION
## Summary
- Remove `cache: "npm"` from `actions/setup-node` in the release workflow
- The self-hosted runner doesn't benefit from GitHub Actions cache — the post-job cache upload step just adds overhead
- Matches `ci.yml` which already skipped this

## Test plan
- [x] Verify CI passes
- [ ] Next release run should skip the slow cache upload step

🤖 Generated with [Claude Code](https://claude.com/claude-code)