### PR TITLE
Probe open WebSocket before tearing down on resume

### DIFF
--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -12,6 +12,7 @@ const TERMINAL_HEARTBEAT_INTERVAL_MS = 20_000;
 const TERMINAL_LIVENESS_GRACE_MS = 5_000;
 const TERMINAL_FRESHNESS_MS = TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
 const RESUME_RECONNECT_DEDUPE_MS = 150;
+const SOCKET_PROBE_TIMEOUT_MS = 1_500;
 
 type TerminalSocketMessage =
   | { type: "heartbeat"; ts: number }
@@ -180,6 +181,41 @@ export function useTerminal(args: {
     return Date.now() - socketHealthRef.current.lastHealthyAt <= TERMINAL_FRESHNESS_MS;
   }, []);
 
+  /** Probe an open-but-stale socket: send a resize and wait for any server message. */
+  const probeSocket = useCallback((agentId: string): Promise<boolean> => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return Promise.resolve(false);
+    if (connectedAgentIdRef.current !== agentId) return Promise.resolve(false);
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const settle = (alive: boolean) => {
+        if (settled) return;
+        settled = true;
+        ws.removeEventListener("message", onMsg);
+        ws.removeEventListener("close", onClose);
+        clearTimeout(timer);
+        resolve(alive);
+      };
+
+      const onMsg = () => {
+        markSocketHealthy("heartbeat");
+        settle(true);
+      };
+      const onClose = () => settle(false);
+      const timer = setTimeout(() => settle(false), SOCKET_PROBE_TIMEOUT_MS);
+
+      ws.addEventListener("message", onMsg);
+      ws.addEventListener("close", onClose);
+
+      // Trigger server activity by sending a resize.
+      const term = terminalRef.current;
+      if (term) {
+        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+      }
+    });
+  }, [markSocketHealthy]);
+
   const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current) {
       window.clearTimeout(reconnectTimerRef.current);
@@ -291,6 +327,18 @@ export function useTerminal(args: {
           restoreConnectedState(agent, "tmux");
           sendResize();
           return;
+        }
+
+        // Socket is open but stale (no heartbeat during background throttle).
+        // Probe it before tearing down — avoids a full reconnect cycle.
+        if (wsRef.current?.readyState === WebSocket.OPEN && connectedAgentIdRef.current === agent.id) {
+          const alive = await probeSocket(agent.id);
+          if (!isCurrentAttempt()) return;
+          if (alive) {
+            restoreConnectedState(agent, "tmux");
+            sendResize();
+            return;
+          }
         }
 
         // We're about to create a new WebSocket — NOW increment the nonce to
@@ -445,6 +493,7 @@ export function useTerminal(args: {
       hasFreshSocket,
       markSocketHealthy,
       noteTerminalError,
+      probeSocket,
       restoreConnectedState,
       selectedAgentId,
       sendResize,


### PR DESCRIPTION
## Summary
- When returning to a backgrounded tab, the existing WebSocket is often still alive but appears "stale" because browser throttling prevented heartbeats from arriving
- Previously this triggered a full reconnect cycle (agent API → token API → new WebSocket) taking 5-10 seconds with a visible "Reconnecting session..." overlay
- Now sends a resize message and waits up to 1.5s for any server response before tearing down — if the socket is still alive, reconnection is near-instant with no overlay

## How it works
- After `hasFreshSocket` returns false, checks if the WebSocket is still in `OPEN` state
- If so, sends a resize (which triggers tmux redraw) and listens for any message within 1.5s
- If a message arrives, reuses the existing socket immediately
- If nothing comes back (socket is truly dead), falls through to the existing full reconnect flow

## Test plan
- [ ] Open Dispatch, connect to an agent terminal session
- [ ] Switch to another app/tab for 30+ seconds
- [ ] Switch back — terminal should reconnect near-instantly without the "Reconnecting session..." overlay (when socket is still alive)
- [ ] Kill the server while away, switch back — should still fall through to full reconnect gracefully
- [ ] E2E tests pass (56/56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)