### PR TITLE
Add base branch selection and improve create agent dialog UX

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -69,6 +69,7 @@ type CreateAgentInput = {
   fullAccess?: boolean;
   useWorktree?: boolean;
   worktreeBranch?: string;
+  baseBranch?: string;
   worktreeLocation?: WorktreeLocation;
 };
 
@@ -188,6 +189,7 @@ export class AgentManager {
             cwd: originalCwd,
             name,
             branchName: worktreeBranchName,
+            baseBranch: input.baseBranch,
             worktreePath: worktreePathOverride,
           });
           worktreePath = result.worktreePath;
@@ -223,6 +225,7 @@ export class AgentManager {
           originalCwd,
           useWorktree,
           worktreeBranchName,
+          baseBranch: input.baseBranch,
           worktreePathOverride,
           agentName: name,
           agentCommand,
@@ -1241,6 +1244,7 @@ export class AgentManager {
     originalCwd: string;
     useWorktree: boolean;
     worktreeBranchName?: string;
+    baseBranch?: string;
     worktreePathOverride?: string;
     agentName: string;
     agentCommand: string;
@@ -1314,7 +1318,7 @@ export class AgentManager {
         : "";
 
       // We need to compute the worktree path. Use git worktree add directly.
-      // First fetch origin/main
+      const effectiveBaseBranch = params.baseBranch || "main";
       lines.push(
         `REPO_ROOT=$(git -C "${originalCwd}" rev-parse --show-toplevel 2>/dev/null) || {`,
         `  warn "Not a git repository — skipping worktree"`,
@@ -1323,12 +1327,12 @@ export class AgentManager {
         `}`,
         ``,
         `if [ "\${exec_agent:-}" != "true" ]; then`,
-        `  info "Fetching origin/main..."`,
-        `  git -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null || true`,
+        `  info "Fetching origin/${effectiveBaseBranch}..."`,
+        `  git -C "$REPO_ROOT" fetch origin "${effectiveBaseBranch}" --quiet 2>/dev/null || true`,
         ``,
-        `  BASE_REF="origin/main"`,
+        `  BASE_REF="origin/${effectiveBaseBranch}"`,
         `  git -C "$REPO_ROOT" rev-parse --verify "$BASE_REF" > /dev/null 2>&1 || {`,
-        `    BASE_REF="main"`,
+        `    BASE_REF="${effectiveBaseBranch}"`,
         `  }`,
         ``,
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1022,6 +1022,38 @@ async function registerRoutes() {
     };
   });
 
+  // --- Git helpers ---
+  app.get("/api/v1/git/branches", async (request, reply) => {
+    const query = request.query as { cwd?: unknown };
+    if (typeof query?.cwd !== "string" || !query.cwd.trim()) {
+      return reply.code(400).send({ error: "cwd query parameter is required." });
+    }
+    try {
+      const rawCwd = query.cwd.trim();
+      const cwd = rawCwd.startsWith("~/") ? path.join(os.homedir(), rawCwd.slice(2)) : rawCwd === "~" ? os.homedir() : rawCwd;
+      const result = await runCommand("git", ["-C", cwd, "ls-remote", "--heads", "origin"], {
+        timeoutMs: 15_000,
+      });
+      if (result.exitCode !== 0) {
+        return reply.code(500).send({ error: "Failed to list remote branches." });
+      }
+      const branches = result.stdout
+        .split("\n")
+        .map((line) => line.replace(/^.*refs\/heads\//, "").trim())
+        .filter(Boolean)
+        .sort((a, b) => {
+          if (a === "main") return -1;
+          if (b === "main") return 1;
+          if (a === "master") return -1;
+          if (b === "master") return 1;
+          return a.localeCompare(b);
+        });
+      return { branches };
+    } catch {
+      return reply.code(500).send({ error: "Failed to list remote branches." });
+    }
+  });
+
   // --- Agent worktree settings ---
   const WORKTREE_LOCATION_KEY = "worktree_location";
   type WorktreeLocation = "sibling" | "nested";
@@ -1513,6 +1545,7 @@ async function registerRoutes() {
       fullAccess?: unknown;
       useWorktree?: unknown;
       worktreeBranch?: unknown;
+      baseBranch?: unknown;
     };
 
     if (typeof body?.cwd !== "string") {
@@ -1542,6 +1575,10 @@ async function registerRoutes() {
 
     if (body.worktreeBranch !== undefined && typeof body.worktreeBranch !== "string") {
       return reply.code(400).send({ error: "worktreeBranch must be a string when provided." });
+    }
+
+    if (body.baseBranch !== undefined && typeof body.baseBranch !== "string") {
+      return reply.code(400).send({ error: "baseBranch must be a string when provided." });
     }
 
     const agentArgs = providedAgentArgs as string[] | undefined;
@@ -1577,6 +1614,7 @@ async function registerRoutes() {
         fullAccess: body.fullAccess === true,
         useWorktree: typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
         worktreeBranch: typeof body.worktreeBranch === "string" ? body.worktreeBranch : undefined,
+        baseBranch: typeof body.baseBranch === "string" ? body.baseBranch : undefined,
         worktreeLocation
       });
       queueGitContextRefresh([agent.id]);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "framer-motion": "^12.35.2",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
@@ -4592,6 +4593,22 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {
@@ -12118,6 +12135,17 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
+    "cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      }
     },
     "color-convert": {
       "version": "2.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "framer-motion": "^12.35.2",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,6 +117,7 @@ export function App(): JSX.Element {
   const [createFullAccess, setCreateFullAccess] = useState(false);
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
+  const [createBaseBranch, setCreateBaseBranch] = useState("main");
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
 
@@ -399,6 +400,7 @@ export function App(): JSX.Element {
             fullAccess: createFullAccess,
             useWorktree: createUseWorktree,
             worktreeBranch: createWorktreeBranch.trim() || undefined,
+            baseBranch: createBaseBranch !== "main" ? createBaseBranch : undefined,
           }),
         });
 
@@ -407,6 +409,7 @@ export function App(): JSX.Element {
         setCreateFullAccess(false);
         setCreateUseWorktree(true);
         setCreateWorktreeBranch("");
+        setCreateBaseBranch("main");
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         setCwdHistory(addToCwdHistory(createCwd.trim()));
         setSelectedAgentId(payload.agent.id);
@@ -417,7 +420,7 @@ export function App(): JSX.Element {
         setCreating(false);
       }
     },
-    [createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const attachSelectedAgent = useCallback(() => {
@@ -608,6 +611,7 @@ export function App(): JSX.Element {
         createFullAccess={createFullAccess}
         createUseWorktree={createUseWorktree}
         createWorktreeBranch={createWorktreeBranch}
+        createBaseBranch={createBaseBranch}
         creating={creating}
         cwdHistory={cwdHistory}
         enabledAgentTypes={enabledAgentTypes}
@@ -618,6 +622,7 @@ export function App(): JSX.Element {
         setCreateFullAccess={setCreateFullAccess}
         setCreateUseWorktree={setCreateUseWorktree}
         setCreateWorktreeBranch={setCreateWorktreeBranch}
+        setCreateBaseBranch={setCreateBaseBranch}
         onSubmit={handleCreateAgent}
       />
 

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, GitBranch, Loader2, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,19 @@ import { Input } from "@/components/ui/input";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
+
+function useClickOutside(ref: React.RefObject<HTMLElement | null>, isOpen: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [ref, isOpen, onClose]);
+}
 
 type CreateAgentDialogProps = {
   open: boolean;
@@ -62,32 +75,23 @@ export function CreateAgentDialog({
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!typeDropdownOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (typeCmdRef.current && !typeCmdRef.current.contains(e.target as Node)) {
-        setTypeDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [typeDropdownOpen]);
+  const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
+  useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
 
   // --- Base branch combobox state ---
   const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [branchesLoading, setBranchesLoading] = useState(false);
-  // Track which cwd the branches were fetched for so we re-fetch on change
   const [branchesFetchedForCwd, setBranchesFetchedForCwd] = useState<string | null>(null);
   const branchCmdRef = useRef<HTMLDivElement>(null);
   const branchTriggerRef = useRef<HTMLButtonElement>(null);
   const branchInputRef = useRef<HTMLInputElement>(null);
+  const closeBranchDropdown = useCallback(() => setBranchDropdownOpen(false), []);
+  useClickOutside(branchCmdRef, branchDropdownOpen, closeBranchDropdown);
 
   const fetchBranches = useCallback(async () => {
     const cwd = createCwd.trim();
     if (!cwd) return;
-    if (branchesFetchedForCwd === cwd) return;
     setBranchesLoading(true);
     setRemoteBranches([]);
     try {
@@ -99,29 +103,20 @@ export function CreateAgentDialog({
       setBranchesLoading(false);
       setBranchesFetchedForCwd(cwd);
     }
-  }, [createCwd, branchesFetchedForCwd]);
+  }, [createCwd]);
 
   const openBranchDropdown = useCallback(() => {
     setBranchDropdownOpen(true);
-    void fetchBranches();
-    // Focus the cmdk input after the dropdown renders
+    if (branchesFetchedForCwd !== createCwd.trim()) {
+      void fetchBranches();
+    }
     requestAnimationFrame(() => branchInputRef.current?.focus());
-  }, [fetchBranches]);
+  }, [fetchBranches, branchesFetchedForCwd, createCwd]);
 
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    if (!branchDropdownOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (branchCmdRef.current && !branchCmdRef.current.contains(e.target as Node)) {
-        setBranchDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [branchDropdownOpen]);
-
-  // Build branch list — always include "main" even if not in remote list
-  const allBranches = remoteBranches.includes("main") ? remoteBranches : ["main", ...remoteBranches];
+  const allBranches = useMemo(
+    () => remoteBranches.includes("main") ? remoteBranches : ["main", ...remoteBranches],
+    [remoteBranches]
+  );
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -1,11 +1,12 @@
-import { type FormEvent, useRef, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { Check, ChevronDown, GitBranch, Loader2, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandLoading } from "@/components/ui/command";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 type CreateAgentDialogProps = {
@@ -16,6 +17,7 @@ type CreateAgentDialogProps = {
   createFullAccess: boolean;
   createUseWorktree: boolean;
   createWorktreeBranch: string;
+  createBaseBranch: string;
   creating: boolean;
   cwdHistory: string[];
   enabledAgentTypes: AgentType[];
@@ -26,6 +28,7 @@ type CreateAgentDialogProps = {
   setCreateFullAccess: (value: boolean | ((current: boolean) => boolean)) => void;
   setCreateUseWorktree: (value: boolean | ((current: boolean) => boolean)) => void;
   setCreateWorktreeBranch: (value: string) => void;
+  setCreateBaseBranch: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 };
 
@@ -37,6 +40,7 @@ export function CreateAgentDialog({
   createFullAccess,
   createUseWorktree,
   createWorktreeBranch,
+  createBaseBranch,
   creating,
   cwdHistory,
   enabledAgentTypes,
@@ -47,11 +51,77 @@ export function CreateAgentDialog({
   setCreateFullAccess,
   setCreateUseWorktree,
   setCreateWorktreeBranch,
+  setCreateBaseBranch,
   onSubmit
 }: CreateAgentDialogProps): JSX.Element {
   const [cwdDropdownOpen, setCwdDropdownOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const sortedCwdHistory = [...cwdHistory].sort((left, right) => left.localeCompare(right));
+
+  // --- Agent type dropdown state ---
+  const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
+  const typeCmdRef = useRef<HTMLDivElement>(null);
+  const typeTriggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!typeDropdownOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (typeCmdRef.current && !typeCmdRef.current.contains(e.target as Node)) {
+        setTypeDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [typeDropdownOpen]);
+
+  // --- Base branch combobox state ---
+  const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
+  const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+  // Track which cwd the branches were fetched for so we re-fetch on change
+  const [branchesFetchedForCwd, setBranchesFetchedForCwd] = useState<string | null>(null);
+  const branchCmdRef = useRef<HTMLDivElement>(null);
+  const branchTriggerRef = useRef<HTMLButtonElement>(null);
+  const branchInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchBranches = useCallback(async () => {
+    const cwd = createCwd.trim();
+    if (!cwd) return;
+    if (branchesFetchedForCwd === cwd) return;
+    setBranchesLoading(true);
+    setRemoteBranches([]);
+    try {
+      const result = await api<{ branches: string[] }>(`/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`);
+      setRemoteBranches(result.branches);
+    } catch {
+      setRemoteBranches([]);
+    } finally {
+      setBranchesLoading(false);
+      setBranchesFetchedForCwd(cwd);
+    }
+  }, [createCwd, branchesFetchedForCwd]);
+
+  const openBranchDropdown = useCallback(() => {
+    setBranchDropdownOpen(true);
+    void fetchBranches();
+    // Focus the cmdk input after the dropdown renders
+    requestAnimationFrame(() => branchInputRef.current?.focus());
+  }, [fetchBranches]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!branchDropdownOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (branchCmdRef.current && !branchCmdRef.current.contains(e.target as Node)) {
+        setBranchDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [branchDropdownOpen]);
+
+  // Build branch list — always include "main" even if not in remote list
+  const allBranches = remoteBranches.includes("main") ? remoteBranches : ["main", ...remoteBranches];
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -72,20 +142,53 @@ export function CreateAgentDialog({
             />
           </div>
 
-          <div className="space-y-1">
+          <div className="relative space-y-1" ref={typeCmdRef}>
             <label className="text-sm text-muted-foreground">Type</label>
-            <Select value={createType} onValueChange={(value) => setCreateType(value as AgentType)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {enabledAgentTypes.map((agentType) => (
-                  <SelectItem key={agentType} value={agentType}>
-                    {AGENT_TYPE_LABELS[agentType]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <button
+              ref={typeTriggerRef}
+              type="button"
+              role="combobox"
+              tabIndex={0}
+              aria-expanded={typeDropdownOpen}
+              onClick={() => setTypeDropdownOpen((prev) => !prev)}
+              onKeyDown={(e) => {
+                if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  if (!typeDropdownOpen) setTypeDropdownOpen(true);
+                }
+              }}
+              className={cn(
+                "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm",
+                "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+              )}
+            >
+              {AGENT_TYPE_LABELS[createType]}
+              <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", typeDropdownOpen && "rotate-180")} />
+            </button>
+            {typeDropdownOpen ? (
+              <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
+                <Command shouldFilter={false} ref={(el) => { if (el) requestAnimationFrame(() => el.focus()); }} onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); setTypeDropdownOpen(false); requestAnimationFrame(() => typeTriggerRef.current?.focus()); } }}>
+                  <CommandList>
+                    <CommandGroup>
+                      {enabledAgentTypes.map((agentType) => (
+                        <CommandItem
+                          key={agentType}
+                          value={agentType}
+                          onSelect={() => {
+                            setCreateType(agentType);
+                            setTypeDropdownOpen(false);
+                            requestAnimationFrame(() => typeTriggerRef.current?.focus());
+                          }}
+                        >
+                          <Check className={cn("mr-2 h-3 w-3 shrink-0", agentType === createType ? "opacity-100" : "opacity-0")} />
+                          {AGENT_TYPE_LABELS[agentType]}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </div>
+            ) : null}
           </div>
 
           <div className="relative space-y-1">
@@ -155,12 +258,14 @@ export function CreateAgentDialog({
           </div>
 
           <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-            <label className="flex cursor-pointer items-start gap-3">
+            <div className="flex cursor-pointer items-start gap-3" onClick={() => setCreateUseWorktree((current) => !current)}>
               <button
                 type="button"
                 role="checkbox"
+                tabIndex={0}
                 aria-checked={createUseWorktree}
-                onClick={() => setCreateUseWorktree((current) => !current)}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => { if (e.key === " " || e.key === "Enter") { e.preventDefault(); setCreateUseWorktree((current) => !current); } }}
                 className={cn(
                   "mt-0.5 inline-flex h-5 w-5 items-center justify-center border text-foreground transition-colors",
                   createUseWorktree ? "border-primary bg-primary text-primary-foreground" : "border-border bg-background"
@@ -179,24 +284,100 @@ export function CreateAgentDialog({
                   Creates an isolated worktree and branch for this agent.
                 </span>
               </span>
-            </label>
+            </div>
             {createUseWorktree ? (
-              <Input
-                value={createWorktreeBranch}
-                onChange={(event) => setCreateWorktreeBranch(event.target.value)}
-                placeholder="branch name (auto-generated if empty)"
-                data-testid="create-agent-worktree-branch"
-                className="ml-8 w-[calc(100%-2rem)]"
-              />
+              <div className="ml-8 w-[calc(100%-2rem)] space-y-2">
+                <div className="relative" ref={branchCmdRef}>
+                  <label className="mb-1 block text-xs text-muted-foreground">Base branch</label>
+                  <button
+                    ref={branchTriggerRef}
+                    type="button"
+                    role="combobox"
+                    tabIndex={0}
+                    aria-expanded={branchDropdownOpen}
+                    data-testid="create-agent-base-branch"
+                    onClick={() => branchDropdownOpen ? setBranchDropdownOpen(false) : openBranchDropdown()}
+                    onKeyDown={(e) => {
+                      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        if (!branchDropdownOpen) openBranchDropdown();
+                      }
+                    }}
+                    className={cn(
+                      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 font-mono text-xs",
+                      "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+                    )}
+                  >
+                    {createBaseBranch}
+                    {branchesLoading ? (
+                      <Loader2 className="ml-2 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                    ) : (
+                      <ChevronDown className={cn("ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform", branchDropdownOpen && "rotate-180")} />
+                    )}
+                  </button>
+                  {branchDropdownOpen ? (
+                    <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
+                      <Command
+                        onKeyDown={(e) => {
+                          if (e.key === "Escape") {
+                            e.preventDefault();
+                            setBranchDropdownOpen(false);
+                            requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                          }
+                        }}
+                      >
+                        <CommandInput ref={branchInputRef} placeholder="Search branches..." className="font-mono text-xs" />
+                        <CommandList>
+                          {branchesLoading ? (
+                            <CommandLoading>
+                              <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                                Loading branches...
+                              </div>
+                            </CommandLoading>
+                          ) : null}
+                          <CommandEmpty>No matching branches.</CommandEmpty>
+                          <CommandGroup>
+                            {allBranches.map((branch) => (
+                              <CommandItem
+                                key={branch}
+                                value={branch}
+                                data-testid="create-agent-base-branch-option"
+                                className="font-mono"
+                                onSelect={() => {
+                                  setCreateBaseBranch(branch);
+                                  setBranchDropdownOpen(false);
+                                  requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                                }}
+                              >
+                                <Check className={cn("mr-2 h-3 w-3 shrink-0", branch === createBaseBranch ? "opacity-100" : "opacity-0")} />
+                                {branch}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </div>
+                  ) : null}
+                </div>
+                <Input
+                  value={createWorktreeBranch}
+                  onChange={(event) => setCreateWorktreeBranch(event.target.value)}
+                  placeholder="branch name (auto-generated if empty)"
+                  data-testid="create-agent-worktree-branch"
+                />
+              </div>
             ) : null}
           </div>
 
-          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+          <div className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3" onClick={() => setCreateFullAccess((current) => !current)}>
             <button
               type="button"
               role="checkbox"
+              tabIndex={0}
               aria-checked={createFullAccess}
-              onClick={() => setCreateFullAccess((current) => !current)}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => { if (e.key === " " || e.key === "Enter") { e.preventDefault(); setCreateFullAccess((current) => !current); } }}
               className={cn(
                 "mt-0.5 inline-flex h-5 w-5 items-center justify-center border text-foreground transition-colors",
                 createFullAccess ? "border-primary bg-primary text-primary-foreground" : "border-border bg-background"
@@ -211,13 +392,13 @@ export function CreateAgentDialog({
                 Starts the selected agent with its most permissive supported execution mode.
               </span>
             </span>
-          </label>
+          </div>
 
           <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="ghost" onClick={() => setOpen(false)} data-testid="create-agent-cancel">
+            <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)} data-testid="create-agent-cancel">
               Cancel
             </Button>
-            <Button type="submit" variant="primary" disabled={creating} data-testid="create-agent-submit">
+            <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-submit">
               {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
               Create
             </Button>

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+
+import { cn } from "@/lib/utils";
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn("flex h-full w-full flex-col overflow-hidden rounded-md bg-background text-foreground", className)}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b border-border px-2">
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-9 w-full rounded-md bg-transparent py-2 text-sm outline-none",
+        "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[200px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty ref={ref} className="px-2 py-4 text-center text-xs text-muted-foreground" {...props} />
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn("overflow-hidden p-1 text-foreground", className)}
+    {...props}
+  />
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none",
+      "data-[selected=true]:bg-primary/20 data-[selected=true]:text-foreground",
+      "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandLoading = CommandPrimitive.Loading;
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandLoading,
+};


### PR DESCRIPTION
## Summary
- Add optional `baseBranch` parameter to agent creation — agents can now branch from any remote branch, not just main
- New `GET /api/v1/git/branches` endpoint that lazily fetches remote branches (with tilde path resolution)
- Replace Radix Select/Popover with inline cmdk-based dropdowns for agent type and base branch, fixing portal-in-dialog focus trap issues on Safari/iOS
- Add `tabIndex={0}` to button elements in the dialog to fix Safari tab order
- Proper keyboard navigation: arrow keys, Enter to select, Escape to close, focus return to trigger

## Test plan
- [x] `npm run check` — types clean
- [x] `npm run finalize:web` — production build succeeds
- [x] `npm run test:e2e` — 56/56 passed
- [x] Validated in Playwright: branch dropdown loads, filters, arrow key highlight visible, selection works
- [x] Tab focus order verified via screenshots: Name → Type → Working dir → Worktree checkbox → Base branch → Branch name → Full access → Cancel → Create
- [ ] Manual test on Safari/iPad: tab focus, arrow keys, scroll, branch loading with tilde paths