### PR TITLE
Add path autocomplete, validation, and history curation to working directory input

### DIFF
--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -62,9 +62,9 @@ test.describe("Create agent dialog", () => {
     await cwdInput.fill("/brand/new/path");
     const recentOptions = form.getByTestId("create-agent-cwd-history-option");
 
-    await expect(page.getByRole("button", { name: "/Users/brad/dev/apps/dispatch" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "/tmp/existing-project" })).toBeVisible();
-    await expect(recentOptions).toHaveText(["/tmp/existing-project", "/Users/brad/dev/apps/dispatch"]);
+    await expect(page.getByRole("option", { name: "/Users/brad/dev/apps/dispatch" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "/tmp/existing-project" })).toBeVisible();
+    await expect(recentOptions).toHaveCount(2);
     await expect(cwdInput).toHaveValue("/brand/new/path");
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
@@ -1020,6 +1020,84 @@ async function registerRoutes() {
     return {
       homeDir: os.homedir()
     };
+  });
+
+  function resolveTildePath(raw: string): string {
+    if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
+    if (raw === "~") return os.homedir();
+    return raw;
+  }
+
+  app.get("/api/v1/system/path-info", async (request, reply) => {
+    const query = request.query as { path?: unknown };
+    if (typeof query?.path !== "string" || !query.path.trim()) {
+      return reply.code(400).send({ error: "path query parameter is required." });
+    }
+    const resolved = resolveTildePath(query.path.trim());
+    if (!path.isAbsolute(resolved)) {
+      return { exists: false, isDirectory: false, isGitRepo: false, resolvedPath: resolved };
+    }
+    try {
+      const info = await stat(resolved).catch(() => null);
+      const exists = info !== null;
+      const isDirectory = exists && info.isDirectory();
+      let isGitRepo = false;
+      if (isDirectory) {
+        const result = await runCommand("git", ["-C", resolved, "rev-parse", "--is-inside-work-tree"], {
+          timeoutMs: 3_000,
+          allowedExitCodes: [0, 1, 128],
+        });
+        isGitRepo = result.exitCode === 0 && result.stdout.trim() === "true";
+      }
+      return { exists, isDirectory, isGitRepo, resolvedPath: resolved };
+    } catch {
+      return { exists: false, isDirectory: false, isGitRepo: false, resolvedPath: resolved };
+    }
+  });
+
+  app.get("/api/v1/system/path-completions", async (request, reply) => {
+    const query = request.query as { prefix?: unknown };
+    if (typeof query?.prefix !== "string" || !query.prefix.trim()) {
+      return reply.code(400).send({ error: "prefix query parameter is required." });
+    }
+    const raw = query.prefix.trim();
+    const resolved = resolveTildePath(raw);
+    if (!path.isAbsolute(resolved)) {
+      return { completions: [] };
+    }
+    try {
+      const parentDir = path.dirname(resolved);
+      const partial = path.basename(resolved).toLowerCase();
+
+      // If the prefix ends with /, list children of that directory instead
+      const isExactDir = raw.endsWith("/");
+      const searchDir = isExactDir ? resolved : parentDir;
+      const searchPartial = isExactDir ? "" : partial;
+
+      const entries = await readdir(searchDir, { withFileTypes: true });
+      const dirs = entries
+        .filter((entry) => {
+          if (!entry.isDirectory()) return false;
+          // Skip hidden dirs unless the partial starts with "."
+          if (entry.name.startsWith(".") && !searchPartial.startsWith(".")) return false;
+          return entry.name.toLowerCase().startsWith(searchPartial);
+        })
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .slice(0, 20)
+        .map((entry) => path.join(searchDir, entry.name));
+
+      // Convert back to tilde paths if the input used tilde
+      const homeDir = os.homedir();
+      const completions = dirs.map((dir) =>
+        raw.startsWith("~") && dir.startsWith(homeDir)
+          ? "~" + dir.slice(homeDir.length)
+          : dir
+      );
+
+      return { completions };
+    } catch {
+      return { completions: [] };
+    }
   });
 
   // --- Git helpers ---

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <meta name="theme-color" content="#0B1220" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,12 @@ function addToCwdHistory(cwd: string): string[] {
   return updated;
 }
 
+function removeCwdFromHistory(cwd: string): string[] {
+  const current = readCwdHistory().filter((entry) => entry !== cwd);
+  window.localStorage.setItem(CWD_HISTORY_KEY, JSON.stringify(current));
+  return current;
+}
+
 function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): boolean {
   return (
     agent.fullAccess ||
@@ -383,6 +389,10 @@ export function App(): JSX.Element {
     []
   );
 
+  const handleRemoveCwdHistory = useCallback((cwd: string) => {
+    setCwdHistory(removeCwdFromHistory(cwd));
+  }, []);
+
   const handleCreateAgent = useCallback(
     async (event: React.FormEvent) => {
       event.preventDefault();
@@ -624,6 +634,7 @@ export function App(): JSX.Element {
         setCreateWorktreeBranch={setCreateWorktreeBranch}
         setCreateBaseBranch={setCreateBaseBranch}
         onSubmit={handleCreateAgent}
+        onRemoveCwdHistory={handleRemoveCwdHistory}
       />
 
       <DeleteAgentDialog

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -264,7 +264,32 @@ export function CreateAgentDialog({
           </div>
 
           <div className="relative" ref={cwdCmdRef}>
-            <label className="mb-1 block text-sm text-muted-foreground">Working directory</label>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="text-sm text-muted-foreground">Working directory</label>
+              <div className="flex items-center gap-1 text-xs">
+                {validating ? (
+                  <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                ) : pathValidation && createCwd.trim() ? (
+                  pathValidation.isDirectory && pathValidation.isGitRepo ? (
+                    <>
+                      <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                      <GitBranch className="h-3 w-3 text-emerald-500" />
+                      <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
+                    </>
+                  ) : pathValidation.isDirectory ? (
+                    <>
+                      <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                      <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
+                    </>
+                  ) : (
+                    <>
+                      <AlertCircle className="h-3 w-3 text-amber-500" />
+                      <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
+                    </>
+                  )
+                ) : null}
+              </div>
+            </div>
             <div className="relative">
               {/* Ghost autocomplete overlay */}
               {ghostSuffix && createCwd.trim() ? (
@@ -323,32 +348,8 @@ export function CreateAgentDialog({
                 </button>
               ) : null}
             </div>
-            {/* Reserved-height validation feedback */}
-            <div className="flex h-5 items-center gap-1 text-xs">
-              {validating ? (
-                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-              ) : pathValidation && createCwd.trim() ? (
-                pathValidation.isDirectory && pathValidation.isGitRepo ? (
-                  <>
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    <GitBranch className="h-3 w-3 text-emerald-500" />
-                    <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
-                  </>
-                ) : pathValidation.isDirectory ? (
-                  <>
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
-                  </>
-                ) : (
-                  <>
-                    <AlertCircle className="h-3 w-3 text-amber-500" />
-                    <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
-                  </>
-                )
-              ) : null}
-            </div>
             {cwdDropdownOpen && sortedCwdHistory.length > 0 ? (
-              <div className="absolute left-0 right-0 z-[60] rounded-md border border-border bg-background shadow-md" data-testid="create-agent-cwd-history">
+              <div className="absolute left-0 right-0 z-[60] mt-1.5 rounded-md border border-border bg-background p-1 shadow-md" data-testid="create-agent-cwd-history">
                 <Command shouldFilter={false} onKeyDown={(e) => {
                   if (e.key === "Escape") {
                     e.preventDefault();
@@ -357,7 +358,7 @@ export function CreateAgentDialog({
                   }
                 }}>
                   <CommandList>
-                    <CommandGroup heading="Recent directories">
+                    <CommandGroup heading="Recent">
                       {sortedCwdHistory.map((dir) => (
                         <CommandItem
                           key={dir}

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -285,16 +285,15 @@ export function CreateAgentDialog({
                     setCwdDropdownOpen(true);
                   }
                 }}
-                onFocus={() => {
-                  if (cwdHistory.length > 0) {
-                    setCwdDropdownOpen(true);
-                  }
-                }}
                 onKeyDown={(e) => {
                   if (e.key === "Escape" && cwdDropdownOpen) {
                     e.preventDefault();
                     e.stopPropagation();
                     setCwdDropdownOpen(false);
+                  }
+                  if ((e.key === "Enter" || e.key === "ArrowDown") && !cwdDropdownOpen && cwdHistory.length > 0) {
+                    e.preventDefault();
+                    setCwdDropdownOpen(true);
                   }
                   if (e.key === "Tab" && ghostSuffix) {
                     e.preventDefault();
@@ -368,7 +367,7 @@ export function CreateAgentDialog({
                           onSelect={() => {
                             setCreateCwd(dir);
                             setCwdDropdownOpen(false);
-                            requestAnimationFrame(() => cwdInputRef.current?.focus());
+                            cwdInputRef.current?.focus();
                           }}
                         >
                           <span className="truncate">{dir}</span>

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -84,9 +84,8 @@ export function CreateAgentDialog({
   const [pathValidation, setPathValidation] = useState<PathInfo | null>(null);
   const [validating, setValidating] = useState(false);
 
-  // --- Path completions state ---
-  const [completions, setCompletions] = useState<string[]>([]);
-  const [completionsLoading, setCompletionsLoading] = useState(false);
+  // --- Inline ghost autocomplete ---
+  const [ghostSuffix, setGhostSuffix] = useState("");
 
   // Debounced path validation
   useEffect(() => {
@@ -107,28 +106,38 @@ export function CreateAgentDialog({
     return () => { clearTimeout(timer); setValidating(false); };
   }, [createCwd]);
 
-  // Debounced path completions
+  // Debounced inline ghost completion
   useEffect(() => {
     const trimmed = createCwd.trim();
     if (!trimmed || (!trimmed.startsWith("/") && !trimmed.startsWith("~"))) {
-      setCompletions([]);
+      setGhostSuffix("");
       return;
     }
-    setCompletionsLoading(true);
     const timer = setTimeout(() => {
       api<{ completions: string[] }>(`/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`)
-        .then((result) => setCompletions(result.completions))
-        .catch(() => setCompletions([]))
-        .finally(() => setCompletionsLoading(false));
-    }, 250);
-    return () => { clearTimeout(timer); setCompletionsLoading(false); };
+        .then((result) => {
+          if (result.completions.length > 0) {
+            const best = result.completions[0];
+            // Show only the part after what the user already typed
+            if (best.startsWith(trimmed.replace(/\/$/, ""))) {
+              setGhostSuffix(best.slice(trimmed.replace(/\/$/, "").length));
+            } else {
+              setGhostSuffix("");
+            }
+          } else {
+            setGhostSuffix("");
+          }
+        })
+        .catch(() => setGhostSuffix(""));
+    }, 150);
+    return () => clearTimeout(timer);
   }, [createCwd]);
 
-  // Reset validation/completions when dialog closes
+  // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
       setPathValidation(null);
-      setCompletions([]);
+      setGhostSuffix("");
       setCwdDropdownOpen(false);
     }
   }, [open]);
@@ -248,125 +257,73 @@ export function CreateAgentDialog({
             ) : null}
           </div>
 
-          <div className="relative space-y-1" ref={cwdCmdRef}>
-            <label className="text-sm text-muted-foreground">Working directory</label>
+          <div className="relative" ref={cwdCmdRef}>
+            <label className="mb-1 block text-sm text-muted-foreground">Working directory</label>
             <div className="relative">
+              {/* Ghost autocomplete overlay */}
+              {ghostSuffix && createCwd.trim() ? (
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0 flex h-9 items-center overflow-hidden rounded-md border border-transparent px-3 py-2 font-mono text-xs"
+                >
+                  <span className="invisible whitespace-pre">{createCwd}</span>
+                  <span className="whitespace-pre text-muted-foreground/40">{ghostSuffix}</span>
+                </div>
+              ) : null}
               <Input
                 ref={cwdInputRef}
                 value={createCwd}
                 onChange={(event) => {
                   setCreateCwd(event.target.value);
-                  setCwdDropdownOpen(true);
+                  if (cwdHistory.length > 0) {
+                    setCwdDropdownOpen(true);
+                  }
                 }}
-                onFocus={() => setCwdDropdownOpen(true)}
+                onFocus={() => {
+                  if (cwdHistory.length > 0) {
+                    setCwdDropdownOpen(true);
+                  }
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Escape" && cwdDropdownOpen) {
                     e.preventDefault();
                     e.stopPropagation();
                     setCwdDropdownOpen(false);
                   }
-                  if (e.key === "Tab" && cwdDropdownOpen && completions.length > 0) {
+                  if (e.key === "Tab" && ghostSuffix) {
                     e.preventDefault();
-                    setCreateCwd(completions[0] + "/");
+                    e.stopPropagation();
+                    const accepted = createCwd.replace(/\/$/, "") + ghostSuffix + "/";
+                    setCreateCwd(accepted);
+                    setGhostSuffix("");
                   }
                 }}
                 placeholder="~/path/to/project"
                 required
                 data-testid="create-agent-cwd"
-                className="pr-8 font-mono text-xs"
+                className="bg-transparent pr-8 font-mono text-xs"
               />
-              <button
-                type="button"
-                tabIndex={-1}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  setCwdDropdownOpen((prev) => !prev);
-                  cwdInputRef.current?.focus();
-                }}
-              >
-                {validating ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <ChevronDown className={cn("h-4 w-4 transition-transform", cwdDropdownOpen && "rotate-180")} />
-                )}
-              </button>
-            </div>
-            {cwdDropdownOpen && (completions.length > 0 || sortedCwdHistory.length > 0) ? (
-              <div className="absolute left-0 right-0 z-[60] mt-1 rounded-md border border-border bg-background shadow-md">
-                <Command shouldFilter={false} onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    setCwdDropdownOpen(false);
+              {cwdHistory.length > 0 ? (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    setCwdDropdownOpen((prev) => !prev);
                     cwdInputRef.current?.focus();
-                  }
-                }}>
-                  <CommandList>
-                    {completions.length > 0 ? (
-                      <CommandGroup heading="Directories">
-                        {completionsLoading ? (
-                          <CommandLoading>
-                            <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
-                              <Loader2 className="h-3 w-3 animate-spin" />
-                              Loading...
-                            </div>
-                          </CommandLoading>
-                        ) : null}
-                        {completions.map((dir) => (
-                          <CommandItem
-                            key={dir}
-                            value={dir}
-                            data-testid="create-agent-cwd-completion"
-                            className="font-mono text-xs"
-                            onSelect={() => {
-                              setCreateCwd(dir + "/");
-                              setCwdDropdownOpen(true);
-                              requestAnimationFrame(() => cwdInputRef.current?.focus());
-                            }}
-                          >
-                            {dir}
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    ) : null}
-                    {sortedCwdHistory.length > 0 ? (
-                      <CommandGroup heading="Recent directories">
-                        {sortedCwdHistory.map((dir) => (
-                          <CommandItem
-                            key={dir}
-                            value={`history:${dir}`}
-                            data-testid="create-agent-cwd-history-option"
-                            className="group font-mono text-xs"
-                            onSelect={() => {
-                              setCreateCwd(dir);
-                              setCwdDropdownOpen(false);
-                              requestAnimationFrame(() => cwdInputRef.current?.focus());
-                            }}
-                          >
-                            <span className="truncate">{dir}</span>
-                            <button
-                              type="button"
-                              className="ml-auto shrink-0 p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-data-[selected=true]:opacity-100"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onRemoveCwdHistory(dir);
-                              }}
-                              title="Remove from history"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    ) : null}
-                  </CommandList>
-                </Command>
-              </div>
-            ) : null}
-            {!validating && pathValidation && createCwd.trim() ? (
-              <div className="flex items-center gap-1 text-xs">
-                {pathValidation.isDirectory && pathValidation.isGitRepo ? (
+                  }}
+                >
+                  <ChevronDown className={cn("h-4 w-4 transition-transform", cwdDropdownOpen && "rotate-180")} />
+                </button>
+              ) : null}
+            </div>
+            {/* Reserved-height validation feedback */}
+            <div className="flex h-5 items-center gap-1 text-xs">
+              {validating ? (
+                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+              ) : pathValidation && createCwd.trim() ? (
+                pathValidation.isDirectory && pathValidation.isGitRepo ? (
                   <>
                     <CheckCircle2 className="h-3 w-3 text-emerald-500" />
                     <GitBranch className="h-3 w-3 text-emerald-500" />
@@ -382,7 +339,50 @@ export function CreateAgentDialog({
                     <AlertCircle className="h-3 w-3 text-amber-500" />
                     <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
                   </>
-                )}
+                )
+              ) : null}
+            </div>
+            {cwdDropdownOpen && sortedCwdHistory.length > 0 ? (
+              <div className="absolute left-0 right-0 z-[60] rounded-md border border-border bg-background shadow-md" data-testid="create-agent-cwd-history">
+                <Command shouldFilter={false} onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setCwdDropdownOpen(false);
+                    cwdInputRef.current?.focus();
+                  }
+                }}>
+                  <CommandList>
+                    <CommandGroup heading="Recent directories">
+                      {sortedCwdHistory.map((dir) => (
+                        <CommandItem
+                          key={dir}
+                          value={dir}
+                          data-testid="create-agent-cwd-history-option"
+                          className="group font-mono text-xs"
+                          onSelect={() => {
+                            setCreateCwd(dir);
+                            setCwdDropdownOpen(false);
+                            requestAnimationFrame(() => cwdInputRef.current?.focus());
+                          }}
+                        >
+                          <span className="truncate">{dir}</span>
+                          <button
+                            type="button"
+                            className="ml-auto shrink-0 p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-data-[selected=true]:opacity-100"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              onRemoveCwdHistory(dir);
+                            }}
+                            title="Remove from history"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
               </div>
             ) : null}
           </div>

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -191,7 +191,13 @@ export function CreateAgentDialog({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent>
+      <DialogContent
+        onEscapeKeyDown={(e) => {
+          if (cwdDropdownOpen || typeDropdownOpen || branchDropdownOpen) {
+            e.preventDefault();
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Create Agent</DialogTitle>
           <DialogDescription>Name, type, and working directory for a new agent session.</DialogDescription>

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -120,7 +120,11 @@ export function CreateAgentDialog({
             const best = result.completions[0];
             // Show only the part after what the user already typed
             if (best.startsWith(trimmed.replace(/\/$/, ""))) {
-              setGhostSuffix(best.slice(trimmed.replace(/\/$/, "").length));
+              let suffix = best.slice(trimmed.replace(/\/$/, "").length);
+              if (trimmed.endsWith("/") && suffix.startsWith("/")) {
+                suffix = suffix.slice(1);
+              }
+              setGhostSuffix(suffix);
             } else {
               setGhostSuffix("");
             }

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, GitBranch, Loader2, Plus } from "lucide-react";
+import { AlertCircle, Check, CheckCircle2, ChevronDown, GitBranch, Loader2, Plus, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandLoading } from "@/components/ui/command";
@@ -43,6 +43,7 @@ type CreateAgentDialogProps = {
   setCreateWorktreeBranch: (value: string) => void;
   setCreateBaseBranch: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
+  onRemoveCwdHistory: (dir: string) => void;
 };
 
 export function CreateAgentDialog({
@@ -65,11 +66,72 @@ export function CreateAgentDialog({
   setCreateUseWorktree,
   setCreateWorktreeBranch,
   setCreateBaseBranch,
-  onSubmit
+  onSubmit,
+  onRemoveCwdHistory
 }: CreateAgentDialogProps): JSX.Element {
   const [cwdDropdownOpen, setCwdDropdownOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const sortedCwdHistory = [...cwdHistory].sort((left, right) => left.localeCompare(right));
+  const cwdCmdRef = useRef<HTMLDivElement>(null);
+  const cwdInputRef = useRef<HTMLInputElement>(null);
+  const closeCwdDropdown = useCallback(() => setCwdDropdownOpen(false), []);
+  useClickOutside(cwdCmdRef, cwdDropdownOpen, closeCwdDropdown);
+  const sortedCwdHistory = useMemo(
+    () => [...cwdHistory].sort((left, right) => left.localeCompare(right)),
+    [cwdHistory]
+  );
+
+  // --- Path validation state ---
+  type PathInfo = { exists: boolean; isDirectory: boolean; isGitRepo: boolean };
+  const [pathValidation, setPathValidation] = useState<PathInfo | null>(null);
+  const [validating, setValidating] = useState(false);
+
+  // --- Path completions state ---
+  const [completions, setCompletions] = useState<string[]>([]);
+  const [completionsLoading, setCompletionsLoading] = useState(false);
+
+  // Debounced path validation
+  useEffect(() => {
+    const trimmed = createCwd.trim();
+    if (!trimmed) {
+      setPathValidation(null);
+      return;
+    }
+    setValidating(true);
+    const timer = setTimeout(() => {
+      api<PathInfo & { resolvedPath: string }>(`/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`)
+        .then((result) => {
+          setPathValidation({ exists: result.exists, isDirectory: result.isDirectory, isGitRepo: result.isGitRepo });
+        })
+        .catch(() => setPathValidation(null))
+        .finally(() => setValidating(false));
+    }, 400);
+    return () => { clearTimeout(timer); setValidating(false); };
+  }, [createCwd]);
+
+  // Debounced path completions
+  useEffect(() => {
+    const trimmed = createCwd.trim();
+    if (!trimmed || (!trimmed.startsWith("/") && !trimmed.startsWith("~"))) {
+      setCompletions([]);
+      return;
+    }
+    setCompletionsLoading(true);
+    const timer = setTimeout(() => {
+      api<{ completions: string[] }>(`/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`)
+        .then((result) => setCompletions(result.completions))
+        .catch(() => setCompletions([]))
+        .finally(() => setCompletionsLoading(false));
+    }, 250);
+    return () => { clearTimeout(timer); setCompletionsLoading(false); };
+  }, [createCwd]);
+
+  // Reset validation/completions when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setPathValidation(null);
+      setCompletions([]);
+      setCwdDropdownOpen(false);
+    }
+  }, [open]);
 
   // --- Agent type dropdown state ---
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
@@ -186,68 +248,141 @@ export function CreateAgentDialog({
             ) : null}
           </div>
 
-          <div className="relative space-y-1">
+          <div className="relative space-y-1" ref={cwdCmdRef}>
             <label className="text-sm text-muted-foreground">Working directory</label>
             <div className="relative">
               <Input
-                ref={inputRef}
+                ref={cwdInputRef}
                 value={createCwd}
                 onChange={(event) => {
                   setCreateCwd(event.target.value);
-                  if (cwdHistory.length > 0) {
-                    setCwdDropdownOpen(true);
-                  }
+                  setCwdDropdownOpen(true);
                 }}
-                onFocus={() => {
-                  if (cwdHistory.length > 0) {
-                    setCwdDropdownOpen(true);
+                onFocus={() => setCwdDropdownOpen(true)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape" && cwdDropdownOpen) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setCwdDropdownOpen(false);
                   }
-                }}
-                onBlur={() => {
-                  // Delay closing so click on dropdown item registers first
-                  setTimeout(() => setCwdDropdownOpen(false), 150);
+                  if (e.key === "Tab" && cwdDropdownOpen && completions.length > 0) {
+                    e.preventDefault();
+                    setCreateCwd(completions[0] + "/");
+                  }
                 }}
                 placeholder="~/path/to/project"
                 required
                 data-testid="create-agent-cwd"
-                className="pr-8"
+                className="pr-8 font-mono text-xs"
               />
-              {cwdHistory.length > 0 ? (
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    setCwdDropdownOpen((prev) => !prev);
-                    inputRef.current?.focus();
-                  }}
-                >
-                  <ChevronDown className={cn("h-4 w-4 transition-transform", cwdDropdownOpen && "rotate-180")} />
-                </button>
-              ) : null}
-            </div>
-            {cwdDropdownOpen && sortedCwdHistory.length > 0 ? (
-              <div
-                className="absolute left-0 right-0 z-10 mt-1 max-h-[160px] overflow-y-auto rounded-md border border-border bg-background shadow-md"
-                data-testid="create-agent-cwd-history"
+              <button
+                type="button"
+                tabIndex={-1}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  setCwdDropdownOpen((prev) => !prev);
+                  cwdInputRef.current?.focus();
+                }}
               >
-                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Recent directories</div>
-                {sortedCwdHistory.map((dir) => (
-                  <button
-                    key={dir}
-                    type="button"
-                    data-testid="create-agent-cwd-history-option"
-                    className="w-full truncate px-2 py-1.5 text-left font-mono text-xs text-foreground hover:bg-muted/70"
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      setCreateCwd(dir);
-                      setCwdDropdownOpen(false);
-                    }}
-                  >
-                    {dir}
-                  </button>
-                ))}
+                {validating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ChevronDown className={cn("h-4 w-4 transition-transform", cwdDropdownOpen && "rotate-180")} />
+                )}
+              </button>
+            </div>
+            {cwdDropdownOpen && (completions.length > 0 || sortedCwdHistory.length > 0) ? (
+              <div className="absolute left-0 right-0 z-[60] mt-1 rounded-md border border-border bg-background shadow-md">
+                <Command shouldFilter={false} onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setCwdDropdownOpen(false);
+                    cwdInputRef.current?.focus();
+                  }
+                }}>
+                  <CommandList>
+                    {completions.length > 0 ? (
+                      <CommandGroup heading="Directories">
+                        {completionsLoading ? (
+                          <CommandLoading>
+                            <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                              Loading...
+                            </div>
+                          </CommandLoading>
+                        ) : null}
+                        {completions.map((dir) => (
+                          <CommandItem
+                            key={dir}
+                            value={dir}
+                            data-testid="create-agent-cwd-completion"
+                            className="font-mono text-xs"
+                            onSelect={() => {
+                              setCreateCwd(dir + "/");
+                              setCwdDropdownOpen(true);
+                              requestAnimationFrame(() => cwdInputRef.current?.focus());
+                            }}
+                          >
+                            {dir}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    ) : null}
+                    {sortedCwdHistory.length > 0 ? (
+                      <CommandGroup heading="Recent directories">
+                        {sortedCwdHistory.map((dir) => (
+                          <CommandItem
+                            key={dir}
+                            value={`history:${dir}`}
+                            data-testid="create-agent-cwd-history-option"
+                            className="group font-mono text-xs"
+                            onSelect={() => {
+                              setCreateCwd(dir);
+                              setCwdDropdownOpen(false);
+                              requestAnimationFrame(() => cwdInputRef.current?.focus());
+                            }}
+                          >
+                            <span className="truncate">{dir}</span>
+                            <button
+                              type="button"
+                              className="ml-auto shrink-0 p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-data-[selected=true]:opacity-100"
+                              onMouseDown={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onRemoveCwdHistory(dir);
+                              }}
+                              title="Remove from history"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    ) : null}
+                  </CommandList>
+                </Command>
+              </div>
+            ) : null}
+            {!validating && pathValidation && createCwd.trim() ? (
+              <div className="flex items-center gap-1 text-xs">
+                {pathValidation.isDirectory && pathValidation.isGitRepo ? (
+                  <>
+                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                    <GitBranch className="h-3 w-3 text-emerald-500" />
+                    <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
+                  </>
+                ) : pathValidation.isDirectory ? (
+                  <>
+                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                    <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
+                  </>
+                ) : (
+                  <>
+                    <AlertCircle className="h-3 w-3 text-amber-500" />
+                    <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
+                  </>
+                )}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary
- **Inline ghost text autocomplete**: As you type a path, a faded ghost completion appears inline. Press Tab to accept and drill deeper.
- **Validation feedback**: Right-aligned on the "Working directory" label, shows whether the typed path is a valid directory and/or a git repository (green check + git icon), or if it doesn't exist (amber alert).
- **History curation**: Each item in the "Recent" dropdown has an X button to remove it from localStorage history.
- **cmdk-based dropdown**: Replaced the plain dropdown with a `Command` (cmdk) listbox, giving built-in keyboard navigation (arrow keys, Enter to select, Escape to close).
- **Two new backend endpoints**: `GET /api/v1/system/path-info` (validates paths, checks git status) and `GET /api/v1/system/path-completions` (lists matching child directories for autocomplete).

### Bug fixes
- Fix Escape key closing the entire dialog when the CWD dropdown is open — now closes just the dropdown first
- Fix dropdown re-opening immediately after selecting a history item — removed auto-open on focus, added Enter/ArrowDown to open explicitly
- Fix double slash in ghost text overlay when input ends with `/`
- Dropdown padding, gap matched to other form dropdowns
- Prevent iOS zoom on input focus via viewport `maximum-scale=1.0`

## Test plan
- [x] Type check passes (`npm run check`)
- [x] Production build passes (`npm run finalize:web`)
- [x] All 56 E2E tests pass (`npm run test:e2e`)
- [x] Manual browser validation of all fixes with screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)