### PR TITLE
Fix false unmerged-changes warning and add uncommitted changes detection

### DIFF
--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -23,6 +23,7 @@ function createTestRepo(suffix: string): string {
     stdio: "ignore",
   });
   writeFileSync(`${repoPath}/README.md`, "# test\n");
+  writeFileSync(`${repoPath}/.gitignore`, ".env\n");
   execSync("git add -A && git commit -m 'initial' && git push origin main", {
     cwd: repoPath,
     stdio: "ignore",
@@ -121,6 +122,7 @@ test.describe("Worktree", () => {
     const status = await getWorktreeStatusViaAPI(request, agent.id);
     expect(status.hasWorktree).toBe(false);
     expect(status.hasUnmergedCommits).toBe(false);
+    expect(status.hasUncommittedChanges).toBe(false);
     expect(status.worktreePath).toBeNull();
     expect(status.branchName).toBeNull();
   });
@@ -289,6 +291,7 @@ test.describe("Worktree filesystem", () => {
     const status = await getWorktreeStatusViaAPI(request, agent.id);
     expect(status.hasWorktree).toBe(true);
     expect(status.hasUnmergedCommits).toBe(false);
+    expect(status.hasUncommittedChanges).toBe(false);
     expect(status.branchName).toBeTruthy();
     expect(status.worktreePath).toBe(agent.worktreePath);
   });
@@ -327,6 +330,42 @@ test.describe("Worktree filesystem", () => {
     expect(status.hasWorktree).toBe(true);
     expect(status.hasUnmergedCommits).toBe(true);
     expect(status.changedFiles).toContain("new-file.txt");
+  });
+
+  test("worktree-status reports uncommitted changes for modified files", async ({ request }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-uncommitted-${Date.now()}`,
+      cwd: repoPath,
+      useWorktree: true,
+    });
+
+    // Create an unstaged file in the worktree (no commit)
+    writeFileSync(`${agent.worktreePath}/uncommitted-file.txt`, "uncommitted work\n");
+
+    const status = await getWorktreeStatusViaAPI(request, agent.id);
+    expect(status.hasWorktree).toBe(true);
+    expect(status.hasUnmergedCommits).toBe(false);
+    expect(status.hasUncommittedChanges).toBe(true);
+    expect(status.uncommittedFiles).toContain("uncommitted-file.txt");
+  });
+
+  test("deleting agent with uncommitted changes and cleanupWorktree=auto preserves worktree", async ({ request }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-keepuncommitted-${Date.now()}`,
+      cwd: repoPath,
+      useWorktree: true,
+    });
+
+    writeFileSync(`${agent.worktreePath}/uncommitted-keep.txt`, "keep this\n");
+
+    const wtPath = agent.worktreePath!;
+    await deleteAgentViaAPI(request, agent.id, "auto");
+
+    // Worktree should be preserved because it has uncommitted changes
+    expect(existsSync(wtPath)).toBe(true);
+
+    // Clean up manually
+    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, { stdio: "ignore" });
   });
 
   test("deleting agent with unmerged commits and cleanupWorktree=auto preserves worktree", async ({ request }) => {
@@ -406,7 +445,7 @@ test.describe("Worktree filesystem", () => {
     await page.getByTestId("delete-agent-confirm").click();
 
     // Second step: worktree choice dialog should appear
-    await expect(page.getByText("Worktree Has Unmerged Changes")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Worktree Has Outstanding Changes")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("delete-agent-keep-worktree")).toBeVisible();
     await expect(page.getByTestId("delete-agent-force-worktree")).toBeVisible();
 
@@ -455,7 +494,7 @@ test.describe("Worktree filesystem", () => {
     await page.getByTestId("delete-agent-confirm").click();
 
     // Second step: worktree choice dialog
-    await expect(page.getByText("Worktree Has Unmerged Changes")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Worktree Has Outstanding Changes")).toBeVisible({ timeout: 5_000 });
 
     // Choose "Delete worktree"
     const wtPath = agent.worktreePath!;

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -78,9 +78,11 @@ type WorktreeCleanupMode = "auto" | "keep" | "force";
 export type WorktreeStatus = {
   hasWorktree: boolean;
   hasUnmergedCommits: boolean;
+  hasUncommittedChanges: boolean;
   worktreePath: string | null;
   branchName: string | null;
   changedFiles: string[];
+  uncommittedFiles: string[];
 };
 
 type StopAgentInput = {
@@ -438,7 +440,7 @@ export class AgentManager {
       try {
         const shouldCleanup =
           cleanupWorktree === "force" ||
-          (cleanupWorktree === "auto" && !(await this.hasUnmergedCommits(agent.worktreePath)));
+          (cleanupWorktree === "auto" && !(await this.hasOutstandingChanges(agent.worktreePath)));
 
         if (shouldCleanup) {
           await cleanupGitWorktree({
@@ -465,12 +467,14 @@ export class AgentManager {
     const agent = await this.getRequiredAgent(id);
 
     if (!agent.worktreePath) {
-      return { hasWorktree: false, hasUnmergedCommits: false, worktreePath: null, branchName: null, changedFiles: [] };
+      return { hasWorktree: false, hasUnmergedCommits: false, hasUncommittedChanges: false, worktreePath: null, branchName: null, changedFiles: [], uncommittedFiles: [] };
     }
 
     let branchName: string | null = null;
     let hasUnmergedCommits = false;
+    let hasUncommittedChanges = false;
     let changedFiles: string[] = [];
+    let uncommittedFiles: string[] = [];
 
     try {
       const branchResult = await runCommand(
@@ -478,9 +482,14 @@ export class AgentManager {
         { allowedExitCodes: [0, 1] }
       );
       branchName = branchResult.exitCode === 0 && branchResult.stdout ? branchResult.stdout : null;
-      const result = await this.getUnmergedChanges(agent.worktreePath);
-      hasUnmergedCommits = result.hasUnmergedCommits;
-      changedFiles = result.changedFiles;
+      const [unmerged, uncommitted] = await Promise.all([
+        this.getUnmergedChanges(agent.worktreePath),
+        this.getUncommittedChanges(agent.worktreePath),
+      ]);
+      hasUnmergedCommits = unmerged.hasUnmergedCommits;
+      changedFiles = unmerged.changedFiles;
+      hasUncommittedChanges = uncommitted.hasUncommittedChanges;
+      uncommittedFiles = uncommitted.uncommittedFiles;
     } catch {
       // Worktree may have been manually removed
     }
@@ -488,9 +497,11 @@ export class AgentManager {
     return {
       hasWorktree: true,
       hasUnmergedCommits,
+      hasUncommittedChanges,
       worktreePath: agent.worktreePath,
       branchName,
-      changedFiles
+      changedFiles,
+      uncommittedFiles
     };
   }
 
@@ -1477,9 +1488,12 @@ export class AgentManager {
     }
   }
 
-  private async hasUnmergedCommits(worktreePath: string): Promise<boolean> {
-    const result = await this.getUnmergedChanges(worktreePath);
-    return result.hasUnmergedCommits;
+  private async hasOutstandingChanges(worktreePath: string): Promise<boolean> {
+    const [unmerged, uncommitted] = await Promise.all([
+      this.getUnmergedChanges(worktreePath),
+      this.getUncommittedChanges(worktreePath),
+    ]);
+    return unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
   }
 
   private async getUnmergedChanges(worktreePath: string): Promise<{ hasUnmergedCommits: boolean; changedFiles: string[] }> {
@@ -1496,24 +1510,49 @@ export class AgentManager {
         return { hasUnmergedCommits: false, changedFiles: [] };
       }
 
-      // Direct content diff between HEAD and the base ref.
-      // This handles squash-merged PRs: even though commit SHAs differ,
-      // if the tree content is identical the diff will be empty.
-      const contentDiff = await runCommand(
-        "git", ["-C", worktreePath, "diff", "--name-only", baseRef, "HEAD"],
-        { allowedExitCodes: [0, 128], timeoutMs: 10_000 }
+      // Simulate merging this branch into main. If the resulting tree is
+      // identical to main's tree, everything on this branch is already in main
+      // (handles squash-merges, rebases, and main moving forward with releases).
+      const mergeTree = await runCommand(
+        "git", ["-C", worktreePath, "merge-tree", "--write-tree", baseRef, "HEAD"],
+        { allowedExitCodes: [0, 1], timeoutMs: 10_000 }
       );
-      const changedFiles = contentDiff.exitCode === 0
-        ? contentDiff.stdout.trim().split("\n").filter(Boolean)
-        : [];
+      // merge-tree outputs the tree hash on the first line (exit 1 = conflicts)
+      const resultTree = mergeTree.stdout.trim().split("\n")[0];
+      const mainTree = await runCommand(
+        "git", ["-C", worktreePath, "rev-parse", `${baseRef}^{tree}`],
+        { allowedExitCodes: [0], timeoutMs: 5_000 }
+      );
 
-      if (changedFiles.length === 0) {
+      if (resultTree === mainTree.stdout.trim()) {
         return { hasUnmergedCommits: false, changedFiles: [] };
       }
 
-      return { hasUnmergedCommits: true, changedFiles };
+      // Trees differ — find which files the branch would actually change
+      const fileDiff = await runCommand(
+        "git", ["-C", worktreePath, "diff", "--name-only", mainTree.stdout.trim(), resultTree],
+        { allowedExitCodes: [0], timeoutMs: 10_000 }
+      );
+      const changedFiles = fileDiff.stdout.trim().split("\n").filter(Boolean);
+
+      return { hasUnmergedCommits: changedFiles.length > 0, changedFiles };
     } catch {
       return { hasUnmergedCommits: false, changedFiles: [] };
+    }
+  }
+
+  private async getUncommittedChanges(worktreePath: string): Promise<{ hasUncommittedChanges: boolean; uncommittedFiles: string[] }> {
+    try {
+      // Detect staged + unstaged modifications and untracked files
+      const status = await runCommand(
+        "git", ["-C", worktreePath, "status", "--porcelain"],
+        { allowedExitCodes: [0], timeoutMs: 10_000 }
+      );
+      const uncommittedFiles = status.stdout.trim().split("\n").filter(Boolean).map((line) => line.slice(3));
+
+      return { hasUncommittedChanges: uncommittedFiles.length > 0, uncommittedFiles };
+    } catch {
+      return { hasUncommittedChanges: false, uncommittedFiles: [] };
     }
   }
 

--- a/web/src/components/app/delete-agent-dialog.tsx
+++ b/web/src/components/app/delete-agent-dialog.tsx
@@ -9,9 +9,11 @@ import { api } from "@/lib/api";
 type WorktreeStatus = {
   hasWorktree: boolean;
   hasUnmergedCommits: boolean;
+  hasUncommittedChanges: boolean;
   worktreePath: string | null;
   branchName: string | null;
   changedFiles: string[];
+  uncommittedFiles: string[];
 };
 
 type DeleteStep = "confirm" | "worktree-choice";
@@ -75,8 +77,8 @@ export function DeleteAgentDialog({
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return;
 
-    // If there's a worktree with unmerged commits, transition to choice step
-    if (worktreeStatus?.hasWorktree && worktreeStatus.hasUnmergedCommits) {
+    // If there's a worktree with unmerged commits or uncommitted changes, transition to choice step
+    if (worktreeStatus?.hasWorktree && (worktreeStatus.hasUnmergedCommits || worktreeStatus.hasUncommittedChanges)) {
       setStep("worktree-choice");
       return;
     }
@@ -114,28 +116,49 @@ export function DeleteAgentDialog({
   }, [setOpen, setDeleteTarget]);
 
   if (step === "worktree-choice" && worktreeStatus) {
+    const hasUnmerged = worktreeStatus.hasUnmergedCommits && worktreeStatus.changedFiles.length > 0;
+    const hasUncommitted = worktreeStatus.hasUncommittedChanges && worktreeStatus.uncommittedFiles.length > 0;
+
     return (
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Worktree Has Unmerged Changes</DialogTitle>
+            <DialogTitle>Worktree Has Outstanding Changes</DialogTitle>
           </DialogHeader>
 
-          <div className="flex flex-col gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-foreground">
-            <div className="flex items-start gap-2">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-              <span>
-                Branch <code className="rounded bg-muted px-1 py-0.5 text-xs">{worktreeStatus.branchName}</code> has
-                commits not merged to origin. The agent will be deleted either way.
-              </span>
-            </div>
-            {worktreeStatus.changedFiles.length > 0 && (
-              <div className="ml-6 max-h-40 overflow-y-auto rounded bg-muted/50 px-2 py-1.5 text-xs font-mono leading-relaxed text-muted-foreground">
-                {worktreeStatus.changedFiles.map((file) => (
-                  <div key={file}>{file}</div>
-                ))}
+          <div className="flex flex-col gap-3">
+            {hasUnmerged && (
+              <div className="flex flex-col gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-foreground">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                  <span>
+                    Branch <code className="rounded bg-muted px-1 py-0.5 text-xs">{worktreeStatus.branchName}</code> has
+                    commits not merged to origin.
+                  </span>
+                </div>
+                <div className="ml-6 max-h-40 overflow-y-auto rounded bg-muted/50 px-2 py-1.5 text-xs font-mono leading-relaxed text-muted-foreground">
+                  {worktreeStatus.changedFiles.map((file) => (
+                    <div key={file}>{file}</div>
+                  ))}
+                </div>
               </div>
             )}
+
+            {hasUncommitted && (
+              <div className="flex flex-col gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-foreground">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                  <span>Worktree has uncommitted changes.</span>
+                </div>
+                <div className="ml-6 max-h-40 overflow-y-auto rounded bg-muted/50 px-2 py-1.5 text-xs font-mono leading-relaxed text-muted-foreground">
+                  {worktreeStatus.uncommittedFiles.map((file) => (
+                    <div key={file}>{file}</div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <p className="text-sm text-muted-foreground">The agent will be deleted either way.</p>
           </div>
 
           <div className="flex justify-end gap-2 pt-1">


### PR DESCRIPTION
## Summary
- Replace `git diff --name-only origin/main HEAD` with `git merge-tree --write-tree` to detect unmerged changes — eliminates false positives when main moves forward (e.g. version bumps after a release)
- Add separate uncommitted changes detection via `git status --porcelain`, surfaced as a distinct section in the delete dialog
- Both checks run in parallel for faster dialog load

## Test plan
- [x] Existing worktree e2e tests updated and passing
- [x] New tests for uncommitted changes detection and auto-cleanup preservation
- [x] Test repo now includes `.gitignore` to prevent `.env` leaking between tests
- [x] Full suite: 58 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)