### PR TITLE
Fix working directory default using worktree path instead of project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "check": "tsc --noEmit && npm run check:web",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "bash scripts/e2e-isolated.sh"
+    "test:e2e": "bash scripts/e2e-isolated.sh",
+    "postinstall": "npm --prefix web install"
   },
   "dependencies": {
     "@fastify/cookie": "^9.4.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,11 @@ const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
 const CWD_HISTORY_KEY = "dispatch:cwdHistory";
 const CWD_HISTORY_MAX = 20;
 
+/** Return the project root for an agent, preferring gitContext.repoRoot over cwd (which may be a worktree path). */
+function agentProjectRoot(agent: Agent | undefined | null): string | undefined {
+  return agent?.gitContext?.repoRoot?.trim() || agent?.cwd?.trim() || undefined;
+}
+
 function readLastUsedCwd(): string {
   if (typeof window === "undefined") return "";
   const stored = window.localStorage.getItem(LAST_USED_CWD_KEY)?.trim();
@@ -246,7 +251,7 @@ export function App(): JSX.Element {
 
   // ── Persist last-used CWD ─────────────────────────────────────────────
   useEffect(() => {
-    const lastUsedCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
+    const lastUsedCwd = agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
     if (lastUsedCwd) {
       window.localStorage.setItem(LAST_USED_CWD_KEY, lastUsedCwd);
     }
@@ -314,9 +319,9 @@ export function App(): JSX.Element {
 
   // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
-    const activeCwd = selectedAgent?.cwd?.trim() || connectedAgent?.cwd?.trim();
+    const activeCwd = agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
     if (activeCwd) return activeCwd;
-    const latestAgentCwd = agents[0]?.cwd?.trim();
+    const latestAgentCwd = agentProjectRoot(agents[0]);
     if (latestAgentCwd) return latestAgentCwd;
     return readLastUsedCwd();
   }, [agents, connectedAgent, selectedAgent]);


### PR DESCRIPTION
## Summary
- When an agent was created with a worktree, its worktree path (e.g. `.dispatch/worktrees/agt-xxx`) became the default working directory for the next agent. Now resolves `gitContext.repoRoot` to use the actual project root instead.
- Adds a `postinstall` script so `npm install` at the root automatically installs `web/` dependencies — fixes missing deps in worktrees.

## Test plan
- [x] Created a worktree agent in dev instance, verified the create dialog pre-fills the project root (`/Users/brad/dev/apps/dispatch`) not the worktree path
- [x] Verified localStorage persists the project root when selecting a worktree agent
- [x] Screenshot shared via dispatch_share

🤖 Generated with [Claude Code](https://claude.com/claude-code)