### PR TITLE
Focus terminal when sidebar closes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,6 +196,7 @@ export function App(): JSX.Element {
     statusMessage,
     terminalHostRef,
     ctrlPendingRef,
+    focusTerminal,
     ensureTerminalConnected,
     detachTerminal,
     sendTerminalInput,
@@ -231,6 +232,21 @@ export function App(): JSX.Element {
 
   // ── SSE ───────────────────────────────────────────────────────────────
   useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, markSeenInCache);
+
+  // Return focus to the terminal when either sidebar closes.
+  const prevLeftOpenRef = useRef(leftPanelOpen);
+  const prevMediaOpenRef = useRef(mediaPanelOpen);
+  useEffect(() => {
+    const leftClosed = prevLeftOpenRef.current && !leftPanelOpen;
+    const mediaClosed = prevMediaOpenRef.current && !mediaPanelOpen;
+    prevLeftOpenRef.current = leftPanelOpen;
+    prevMediaOpenRef.current = mediaPanelOpen;
+    if (leftClosed || mediaClosed) {
+      // Delay slightly so the sidebar close animation doesn't steal focus.
+      const timer = window.setTimeout(focusTerminal, 50);
+      return () => window.clearTimeout(timer);
+    }
+  }, [leftPanelOpen, mediaPanelOpen, focusTerminal]);
 
   // ── Energy metrics ────────────────────────────────────────────────────
   useEffect(() => {

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -80,6 +80,7 @@ export function useTerminal(args: {
   statusMessage: string;
   terminalHostRef: RefObject<HTMLDivElement>;
   ctrlPendingRef: MutableRefObject<boolean>;
+  focusTerminal: () => void;
   ensureTerminalConnected: (clearScreen?: boolean, userInitiated?: boolean, targetAgentId?: string) => Promise<void>;
   detachTerminal: () => void;
   sendTerminalInput: (data: string) => void;
@@ -762,6 +763,10 @@ export function useTerminal(args: {
     return () => window.clearTimeout(timer);
   }, [theme, connState, connectedAgentId, detachTerminal, ensureTerminalConnected]);
 
+  const focusTerminal = useCallback(() => {
+    terminalRef.current?.focus();
+  }, []);
+
   return useMemo(() => ({
     connState,
     connectedAgentId,
@@ -770,6 +775,7 @@ export function useTerminal(args: {
     statusMessage,
     terminalHostRef: terminalHostRef as RefObject<HTMLDivElement>,
     ctrlPendingRef,
+    focusTerminal,
     ensureTerminalConnected,
     detachTerminal,
     sendTerminalInput,
@@ -779,6 +785,7 @@ export function useTerminal(args: {
     terminalMode,
     terminalPlaceholderMessage,
     statusMessage,
+    focusTerminal,
     ensureTerminalConnected,
     detachTerminal,
     sendTerminalInput,


### PR DESCRIPTION
## Summary
- Exposes a `focusTerminal` callback from `useTerminal` that calls `terminalRef.current?.focus()`
- Adds an effect in `App.tsx` that detects when either sidebar (agent or media) transitions from open to closed, and refocuses the terminal after a brief delay
- When no terminal session is active, the focus call is a safe no-op (xterm is `visibility: hidden`)

## Test plan
- [x] Type check passes (`npm run check`)
- [x] Production build passes (`npm run finalize:web`)
- [x] E2E tests pass (58 passed, 6 skipped)
- [x] Verified sidebar open/close in Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)