### PR TITLE
Suppress Slack notifications when user is focused on agent

### DIFF
--- a/e2e/focus-tracking.spec.ts
+++ b/e2e/focus-tracking.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect, type Page } from "@playwright/test";
+import { createAgentViaAPI, loadApp } from "./helpers";
+
+const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
+test.describe("Focus tracking API", () => {
+  test("POST /api/v1/focus accepts a valid agentId", async ({ request }) => {
+    const agent = await createAgentViaAPI(request);
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: agent.id },
+    });
+    expect(res.status()).toBe(204);
+  });
+
+  test("POST /api/v1/focus accepts null agentId", async ({ request }) => {
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: null },
+    });
+    expect(res.status()).toBe(204);
+  });
+
+  test("POST /api/v1/focus rejects empty string agentId", async ({ request }) => {
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: "" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST /api/v1/focus accepts missing agentId (treated as null)", async ({ request }) => {
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: {},
+    });
+    expect(res.status()).toBe(204);
+  });
+});
+
+async function simulatePageActive(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    // Override hasFocus to return true (headless browsers return false)
+    document.hasFocus = () => true;
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+  });
+}
+
+async function simulatePageHidden(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    document.hasFocus = () => false;
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+test.describe("Focus tracking frontend", () => {
+  test("sends focus heartbeat when agent is selected and page is active", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request);
+
+    // Set up route intercept BEFORE loading the app
+    const focusRequests: Array<{ agentId: string | null }> = [];
+    await page.route("**/api/v1/focus", async (route) => {
+      const postData = route.request().postDataJSON() as { agentId: string | null };
+      focusRequests.push(postData);
+      await route.fulfill({ status: 204 });
+    });
+
+    await loadApp(page);
+
+    // Override hasFocus before selecting agent (headless = false by default)
+    await page.evaluate(() => {
+      document.hasFocus = () => true;
+    });
+
+    // Select the agent — this triggers the useAgentFocus hook
+    await page.getByText(agent.name).click();
+
+    // The hook fires immediately on effect run when page is active
+    await page.waitForTimeout(1500);
+
+    expect(focusRequests.length).toBeGreaterThanOrEqual(1);
+    const focusRequest = focusRequests.find((r) => r.agentId === agent.id);
+    expect(focusRequest).toBeDefined();
+  });
+
+  test("sends null focus when page becomes hidden", async ({ page, request }) => {
+    const agent = await createAgentViaAPI(request);
+
+    const focusRequests: Array<{ agentId: string | null }> = [];
+    await page.route("**/api/v1/focus", async (route) => {
+      const postData = route.request().postDataJSON() as { agentId: string | null };
+      focusRequests.push(postData);
+      await route.fulfill({ status: 204 });
+    });
+
+    await loadApp(page);
+    await page.evaluate(() => { document.hasFocus = () => true; });
+
+    // Select the agent to start focus tracking
+    await page.getByText(agent.name).click();
+    await page.waitForTimeout(1000);
+
+    // Verify we got an initial focus report
+    expect(focusRequests.some((r) => r.agentId === agent.id)).toBe(true);
+
+    // Clear to isolate the hidden event
+    focusRequests.length = 0;
+
+    // Simulate page going hidden
+    await simulatePageHidden(page);
+    await page.waitForTimeout(500);
+
+    const nullRequest = focusRequests.find((r) => r.agentId === null);
+    expect(nullRequest).toBeDefined();
+  });
+
+  test("resumes focus heartbeat when page becomes visible again", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request);
+
+    const focusRequests: Array<{ agentId: string | null }> = [];
+    await page.route("**/api/v1/focus", async (route) => {
+      const postData = route.request().postDataJSON() as { agentId: string | null };
+      focusRequests.push(postData);
+      await route.fulfill({ status: 204 });
+    });
+
+    await loadApp(page);
+    await page.evaluate(() => { document.hasFocus = () => true; });
+    await page.getByText(agent.name).click();
+    await page.waitForTimeout(1000);
+
+    // Go hidden
+    await simulatePageHidden(page);
+    await page.waitForTimeout(500);
+
+    // Clear to isolate the visible event
+    focusRequests.length = 0;
+
+    // Come back
+    await simulatePageActive(page);
+    await page.waitForTimeout(500);
+
+    const resumedRequest = focusRequests.find((r) => r.agentId === agent.id);
+    expect(resumedRequest).toBeDefined();
+  });
+});

--- a/src/focus-tracker.ts
+++ b/src/focus-tracker.ts
@@ -1,0 +1,33 @@
+/**
+ * In-memory tracker for which agents the user is actively viewing in the UI.
+ * Used to suppress redundant Slack notifications when the user is already
+ * looking at the agent. State is ephemeral — server restart clears all focus,
+ * which is the safe default (notifications resume).
+ */
+
+const FOCUS_TTL_MS = 30_000;
+
+export class FocusTracker {
+  private focusedAgents = new Map<string, number>();
+
+  /** Mark an agent as focused (user is actively viewing it). */
+  setFocused(agentId: string): void {
+    this.focusedAgents.set(agentId, Date.now());
+  }
+
+  /** Clear focus for an agent (user navigated away or tab hidden). */
+  clearFocused(agentId: string): void {
+    this.focusedAgents.delete(agentId);
+  }
+
+  /** Returns true if the agent was focused within the last TTL window. */
+  isFocused(agentId: string): boolean {
+    const ts = this.focusedAgents.get(agentId);
+    if (ts === undefined) return false;
+    if (Date.now() - ts > FOCUS_TTL_MS) {
+      this.focusedAgents.delete(agentId);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/notifications/slack.ts
+++ b/src/notifications/slack.ts
@@ -31,11 +31,17 @@ type CachedSettings = {
 
 export class SlackNotifier {
   private cachedSettings: CachedSettings | null = null;
+  private isFocused: ((agentId: string) => boolean) | null = null;
 
   constructor(
     private pool: Pool,
     private log: FastifyBaseLogger
   ) {}
+
+  /** Register a callback to check if the user is actively viewing an agent. */
+  setFocusCheck(fn: (agentId: string) => boolean): void {
+    this.isFocused = fn;
+  }
 
   async getWebhookUrl(): Promise<string | null> {
     return getSetting(this.pool, SETTING_WEBHOOK_URL);
@@ -93,6 +99,11 @@ export class SlackNotifier {
     if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return;
 
     try {
+      if (this.isFocused?.(agent.id)) {
+        this.log.debug({ agentId: agent.id }, "Skipping notification — user is focused on agent");
+        return;
+      }
+
       const settings = await this.getCachedSettings();
       if (!settings.webhookUrl) return;
       if (!settings.notifyEvents.includes(event.type as NotifyEventType)) return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import { handleMcpRequest } from "./mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
 import { SlackNotifier } from "./notifications/slack.js";
+import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 
@@ -46,7 +47,9 @@ const app = Fastify({
 });
 const pool = createPool(config);
 const agentManager = new AgentManager(pool, app.log, config);
+const focusTracker = new FocusTracker();
 const slackNotifier = new SlackNotifier(pool, app.log);
+slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 agentManager.onLatestEvent((agent) => void slackNotifier.onAgentEvent(agent));
 const terminalTokenStore = new TerminalTokenStore(60_000);
 
@@ -1343,6 +1346,23 @@ async function registerRoutes() {
       clearInterval(heartbeat);
       unsubscribe();
     });
+  });
+
+  app.post("/api/v1/focus", async (request, reply) => {
+    const body = request.body as { agentId?: unknown };
+    const agentId = body?.agentId;
+
+    if (agentId === null || agentId === undefined) {
+      // No specific agent focused — let existing focus entries expire via TTL
+      return reply.code(204).send();
+    }
+
+    if (typeof agentId !== "string" || !agentId.trim()) {
+      return reply.code(400).send({ error: "agentId must be a non-empty string or null." });
+    }
+
+    focusTracker.setFocused(agentId.trim());
+    return reply.code(204).send();
   });
 
   app.get("/api/v1/agents/:id", async (request, reply) => {

--- a/test/focus-tracker.test.ts
+++ b/test/focus-tracker.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { FocusTracker } from "../src/focus-tracker.js";
+
+describe("FocusTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false for an agent that was never focused", () => {
+    const tracker = new FocusTracker();
+    expect(tracker.isFocused("agent-1")).toBe(false);
+  });
+
+  it("returns true immediately after setFocused", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+    expect(tracker.isFocused("agent-1")).toBe(true);
+  });
+
+  it("returns false after the TTL expires", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+
+    vi.advanceTimersByTime(30_001);
+    expect(tracker.isFocused("agent-1")).toBe(false);
+  });
+
+  it("returns true just before the TTL expires", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+
+    vi.advanceTimersByTime(29_999);
+    expect(tracker.isFocused("agent-1")).toBe(true);
+  });
+
+  it("clearFocused removes focus immediately", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+    expect(tracker.isFocused("agent-1")).toBe(true);
+
+    tracker.clearFocused("agent-1");
+    expect(tracker.isFocused("agent-1")).toBe(false);
+  });
+
+  it("tracks multiple agents independently", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+    tracker.setFocused("agent-2");
+
+    expect(tracker.isFocused("agent-1")).toBe(true);
+    expect(tracker.isFocused("agent-2")).toBe(true);
+
+    tracker.clearFocused("agent-1");
+    expect(tracker.isFocused("agent-1")).toBe(false);
+    expect(tracker.isFocused("agent-2")).toBe(true);
+  });
+
+  it("refreshes TTL on repeated setFocused calls", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+
+    vi.advanceTimersByTime(20_000);
+    tracker.setFocused("agent-1"); // refresh
+
+    vi.advanceTimersByTime(20_000); // 40s total, but only 20s since refresh
+    expect(tracker.isFocused("agent-1")).toBe(true);
+
+    vi.advanceTimersByTime(11_000); // 31s since last refresh
+    expect(tracker.isFocused("agent-1")).toBe(false);
+  });
+});

--- a/test/slack-notifier.test.ts
+++ b/test/slack-notifier.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { SlackNotifier } from "../src/notifications/slack.js";
+import type { AgentRecord } from "../src/agents/manager.js";
+
+// Stub the DB settings module so SlackNotifier never hits a real DB.
+vi.mock("../src/db/settings.js", () => ({
+  getSetting: vi.fn((_pool: unknown, key: string) => {
+    if (key === "slack_webhook_url") return Promise.resolve("https://hooks.slack.com/test");
+    if (key === "slack_notify_events") return Promise.resolve(JSON.stringify(["done", "waiting_user", "blocked"]));
+    return Promise.resolve(null);
+  }),
+  setSetting: vi.fn(() => Promise.resolve()),
+  deleteSetting: vi.fn(() => Promise.resolve()),
+}));
+
+// Capture fetch calls instead of hitting the network.
+const fetchSpy = vi.fn(() =>
+  Promise.resolve(new Response("ok", { status: 200 }))
+);
+vi.stubGlobal("fetch", fetchSpy);
+
+function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id: "agent-1",
+    name: "test-agent",
+    type: "claude",
+    status: "running",
+    cwd: "/tmp",
+    worktreePath: null,
+    worktreeBranch: null,
+    tmuxSession: null,
+    simulatorUdid: null,
+    mediaDir: null,
+    agentArgs: [],
+    fullAccess: false,
+    setupPhase: null,
+    lastError: null,
+    latestEvent: {
+      type: "done",
+      message: "Task complete",
+      updatedAt: new Date().toISOString(),
+      metadata: null,
+    },
+    gitContext: null,
+    gitContextStale: false,
+    gitContextUpdatedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const mockLog = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+  silent: vi.fn(),
+  level: "debug",
+} as unknown as import("fastify").FastifyBaseLogger;
+
+describe("SlackNotifier focus suppression", () => {
+  beforeEach(() => {
+    fetchSpy.mockClear();
+    vi.mocked(mockLog.debug).mockClear();
+  });
+
+  it("sends notification when no focus check is registered", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await notifier.onAgentEvent(makeAgent());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url] = fetchSpy.mock.calls[0] as [string, ...unknown[]];
+    expect(url).toBe("https://hooks.slack.com/test");
+  });
+
+  it("sends notification when agent is NOT focused", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck(() => false);
+
+    await notifier.onAgentEvent(makeAgent());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses notification when agent IS focused", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck(() => true);
+
+    await notifier.onAgentEvent(makeAgent());
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockLog.debug).toHaveBeenCalledWith(
+      { agentId: "agent-1" },
+      "Skipping notification — user is focused on agent"
+    );
+  });
+
+  it("suppresses only the focused agent, not others", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck((id) => id === "agent-1");
+
+    // Focused agent — should be suppressed
+    await notifier.onAgentEvent(makeAgent({ id: "agent-1" }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Different agent — should send
+    await notifier.onAgentEvent(makeAgent({ id: "agent-2" }));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends notification for non-notify event types regardless of focus", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck(() => true);
+
+    // "working" is not in the notify list, so it exits early before the focus check
+    await notifier.onAgentEvent(
+      makeAgent({
+        latestEvent: { type: "working", message: "doing stuff", updatedAt: new Date().toISOString(), metadata: null },
+      })
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Should NOT have logged the focus skip message (exited before that check)
+    expect(mockLog.debug).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { useSSE } from "@/hooks/use-sse";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useTheme } from "@/hooks/use-theme";
+import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { AGENT_TYPES, type AgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -228,6 +229,9 @@ export function App(): JSX.Element {
 
   const connectedAgentIdRef = useRef<string | null>(null);
   connectedAgentIdRef.current = connectedAgentId;
+
+  // ── Focus tracking (notification suppression) ─────────────────────────
+  useAgentFocus(selectedAgentId, authState);
 
   // ── SSE ───────────────────────────────────────────────────────────────
   useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, markSeenInCache);

--- a/web/src/hooks/use-agent-focus.ts
+++ b/web/src/hooks/use-agent-focus.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+import type { AuthState } from "@/components/app/types";
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Sends periodic focus heartbeats to the server so it knows the user is
+ * actively viewing a specific agent. The server uses this to suppress
+ * redundant Slack notifications.
+ *
+ * Heartbeats are only sent when:
+ * - The user is authenticated
+ * - The browser tab is visible and focused
+ * - An agent is selected
+ *
+ * When any condition becomes false, a null-focus signal is sent so the
+ * server can let the TTL expire naturally.
+ */
+export function useAgentFocus(
+  selectedAgentId: string | null,
+  authState: AuthState,
+): void {
+  const lastReportedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (authState !== "authenticated") return;
+
+    const sendFocus = (agentId: string | null) => {
+      lastReportedRef.current = agentId;
+      void fetch("/api/v1/focus", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId }),
+        keepalive: true,
+      }).catch(() => {});
+    };
+
+    const isPageActive = () => document.hasFocus() && !document.hidden;
+
+    const tick = () => {
+      if (isPageActive() && selectedAgentId) {
+        sendFocus(selectedAgentId);
+      }
+    };
+
+    // Send immediately if conditions are met
+    tick();
+
+    const interval = setInterval(tick, HEARTBEAT_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (!isPageActive() && lastReportedRef.current) {
+        sendFocus(null);
+      } else if (isPageActive() && selectedAgentId) {
+        sendFocus(selectedAgentId);
+      }
+    };
+
+    const onBlur = () => {
+      if (lastReportedRef.current) {
+        sendFocus(null);
+      }
+    };
+
+    const onFocus = () => {
+      if (selectedAgentId && !document.hidden) {
+        sendFocus(selectedAgentId);
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("blur", onBlur);
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("blur", onBlur);
+      window.removeEventListener("focus", onFocus);
+      if (lastReportedRef.current) {
+        sendFocus(null);
+      }
+    };
+  }, [authState, selectedAgentId]);
+}


### PR DESCRIPTION
## Summary

- Adds a heartbeat-based focus tracking system so Slack notifications are suppressed when the user is actively viewing the agent that triggered the event
- Frontend sends `POST /api/v1/focus` every 15s while the browser tab is visible and focused, with an agent selected
- Server maintains an in-memory `FocusTracker` map with 30s TTL — if heartbeats stop (tab hidden, app backgrounded, browser closed), focus expires and notifications resume automatically
- `SlackNotifier` checks focus state before sending, skipping notifications for focused agents

## Design decisions

- **In-memory only** — no DB persistence needed; server restart safely resets to "notify everything"
- **Heartbeat + TTL** over event pairs — self-healing if the browser crashes or loses network
- **Browser focus, not WebSocket connection** — being "connected" to a terminal session doesn't suppress; only active `document.hasFocus() && !document.hidden` does

## Test plan

- [x] `npm run check` — type checks pass
- [x] `npm run finalize:web` — production build succeeds
- [x] `npm run test:e2e` — 58 passed, 6 skipped (pre-existing tmux-dependent)
- [ ] Manual: select agent with tab focused → trigger done event → no Slack notification
- [ ] Manual: background tab → trigger done event → Slack notification fires
- [ ] Manual: wait 30s idle → trigger done event → Slack notification fires