### PR TITLE
Fix truncated file names in uncommitted changes display

### DIFF
--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -346,7 +346,7 @@ test.describe("Worktree filesystem", () => {
     expect(status.hasWorktree).toBe(true);
     expect(status.hasUnmergedCommits).toBe(false);
     expect(status.hasUncommittedChanges).toBe(true);
-    expect(status.uncommittedFiles).toContain("uncommitted-file.txt");
+    expect(status.uncommittedFiles).toContain("?? uncommitted-file.txt");
   });
 
   test("deleting agent with uncommitted changes and cleanupWorktree=auto preserves worktree", async ({ request }) => {

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1548,7 +1548,7 @@ export class AgentManager {
         "git", ["-C", worktreePath, "status", "--porcelain"],
         { allowedExitCodes: [0], timeoutMs: 10_000 }
       );
-      const uncommittedFiles = status.stdout.trim().split("\n").filter(Boolean).map((line) => line.slice(3));
+      const uncommittedFiles = status.stdout.trim().split("\n").filter(Boolean);
 
       return { hasUncommittedChanges: uncommittedFiles.length > 0, uncommittedFiles };
     } catch {


### PR DESCRIPTION
## Summary
- `runCommand` trims stdout, which shifted the `slice(3)` offset on `git status --porcelain` output, cutting the first character of filenames (e.g. `ackage-lock.json` instead of `package-lock.json`)
- Fixed by passing raw porcelain lines through unmodified — the status prefix (`M`, `??`, etc.) provides useful context in the UI anyway

## Test plan
- [x] Unit tests pass (`npm test`)
- [x] E2E tests pass (`npm run test:e2e`)
- [x] Validated locally via dev stack — delete dialog shows correct file names with status prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)