### PR TITLE
Pin agent Bash tool cwd to worktree root to prevent drift

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1014,7 +1014,10 @@ export class AgentManager {
       `HOSTESS_PORT=${this.shellEscape(String(this.config.port))}`,
       // Compatibility alias for common typo to keep screenshot sharing reliable.
       `HOSTESS_MDEIA_DIR=${this.shellEscape(mediaDir)}`,
-      `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`
+      `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`,
+      // Pin the Bash tool's cwd to the project root (worktree) after every command.
+      // Prevents cwd drift back to the original repo root during long conversations.
+      `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`
     ];
 
     // When TLS is enabled with a CA cert, tell agent CLI tools to trust it


### PR DESCRIPTION
## Summary
- Sets `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1` in the agent launch environment
- This tells Claude Code's Bash tool to reset cwd to the project root (the worktree) after every command
- Prevents long conversations from drifting back to the original repo root and accidentally committing on main

## Context
An agent launched in a worktree started committing to main after a long conversation. The root cause is that Claude Code's Bash tool cwd tracking can drift during context compression. This env var is a documented Claude Code feature that pins the Bash tool's working directory to the project root.

## Test plan
- [ ] Verify type checks pass (`npm run check`)
- [ ] Verify E2E tests pass (`npm run test:e2e`)
- [ ] Validate with a live dev instance agent in a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)