### PR TITLE
Add text file sharing with syntax-highlighted viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dispatch",
       "version": "0.5.13",
+      "hasInstallScript": true,
       "dependencies": {
         "@fastify/cookie": "^9.4.0",
         "@fastify/multipart": "^8.3.1",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -284,21 +284,25 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       "dispatch_share",
       {
         description:
-          "Upload a media file to Dispatch for sharing. Supports png, jpg, jpeg, gif, webp, and mp4. Use source 'simulator' with a simulator UDID to capture a screenshot directly from an iOS Simulator.",
+          "Upload a media file or text snippet to Dispatch for sharing. Supports images (png/jpg/jpeg/gif/webp), video (mp4), and text files (txt/md/json/yaml/ts/py/go/rs/sh/sql/etc). Use source 'simulator' to capture from an iOS Simulator. For text snippets, pass content directly with a name (e.g. name='config.yaml') instead of writing to a file first.",
         inputSchema: {
           filePath: z
             .string()
             .optional()
-            .describe("Absolute path to the media file to upload. Not required when source is 'simulator'."),
+            .describe("Absolute path to the file to upload. Not required when source is 'simulator' or when content is provided."),
+          content: z
+            .string()
+            .optional()
+            .describe("Text content to share directly (max 32KB). Requires name param with a file extension (e.g. 'snippet.ts'). Use this for text snippets instead of writing to a temp file."),
           description: z.string().describe("A short description of the shared media."),
           source: z
-            .enum(["screenshot", "simulator"])
+            .enum(["screenshot", "simulator", "text"])
             .default("screenshot")
-            .describe("The source type of the media."),
+            .describe("The source type of the media. Automatically set to 'text' when sharing text files."),
           name: z
             .string()
             .optional()
-            .describe("Preferred file name for the upload. Derived from the file path if omitted."),
+            .describe("Preferred file name for the upload. Required when using content param. Derived from the file path if omitted."),
           simulatorUdid: z
             .string()
             .optional()
@@ -309,7 +313,25 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         try {
           let filePath = args.filePath;
 
-          if (args.source === "simulator") {
+          if (args.content !== undefined) {
+            const MAX_CONTENT_BYTES = 32 * 1024;
+            if (Buffer.byteLength(args.content, "utf-8") > MAX_CONTENT_BYTES) {
+              return toToolError(new Error("content exceeds 32KB limit. Write to a file and use filePath instead."));
+            }
+            if (!args.name) {
+              return toToolError(new Error("name is required when using content param (e.g. 'snippet.ts')."));
+            }
+            const { writeFile: writeFileTmp } = await import("node:fs/promises");
+            const tmpDir = process.env.TMPDIR ?? "/tmp";
+            const timestamp = new Date()
+              .toISOString()
+              .replace(/[:.]/g, "-")
+              .replace("T", "-")
+              .replace("Z", "");
+            const tmpPath = `${tmpDir}/dispatch-text-${timestamp}-${args.name}`;
+            await writeFileTmp(tmpPath, args.content, "utf-8");
+            filePath = tmpPath;
+          } else if (args.source === "simulator") {
             const { execFile } = await import("node:child_process");
             const { promisify } = await import("node:util");
             const execFileAsync = promisify(execFile);
@@ -325,7 +347,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           }
 
           if (!filePath) {
-            return toToolError(new Error("filePath is required when source is not 'simulator'."));
+            return toToolError(new Error("filePath is required when source is not 'simulator' and content is not provided."));
           }
 
           const result = await shareMedia(agentId, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1470,12 +1470,13 @@ async function registerRoutes() {
 
     const fileName = data.filename;
     if (!isMediaFile(fileName)) {
-      return reply.code(400).send({ error: "Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4." });
+      return reply.code(400).send({ error: "Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4 or text files (txt/md/json/yaml/ts/py/etc)." });
     }
 
-    const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? "screenshot";
-    const validSources = ["screenshot", "stream", "simulator"];
-    const source = validSources.includes(sourceField) ? sourceField : "screenshot";
+    const isText = isTextFile(fileName);
+    const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? (isText ? "text" : "screenshot");
+    const validSources = ["screenshot", "stream", "simulator", "text"];
+    const source = validSources.includes(sourceField) ? sourceField : (isText ? "text" : "screenshot");
     const description = (data.fields.description as { value?: string } | undefined)?.value ?? null;
     if (!description) {
       return reply.code(400).send({ error: "A description field is required." });
@@ -2549,8 +2550,21 @@ async function markSeenMediaKeys(agentId: string, keys: string[]): Promise<void>
   );
 }
 
+const TEXT_EXTENSIONS = new Set([
+  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
+  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
+  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
+  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
+  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
+]);
+
+function isTextFile(name: string): boolean {
+  const ext = path.extname(name).toLowerCase();
+  return TEXT_EXTENSIONS.has(ext);
+}
+
 function isMediaFile(name: string): boolean {
-  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name);
+  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name) || isTextFile(name);
 }
 
 function mimeType(name: string): string {
@@ -2572,6 +2586,42 @@ function mimeType(name: string): string {
 
   if (/\.mp4$/i.test(name)) {
     return "video/mp4";
+  }
+
+  if (/\.json$/i.test(name)) {
+    return "application/json";
+  }
+
+  if (/\.xml$/i.test(name)) {
+    return "application/xml";
+  }
+
+  if (/\.html$/i.test(name)) {
+    return "text/html";
+  }
+
+  if (/\.css$/i.test(name)) {
+    return "text/css";
+  }
+
+  if (/\.(js|jsx|mjs)$/i.test(name)) {
+    return "text/javascript";
+  }
+
+  if (/\.csv$/i.test(name)) {
+    return "text/csv";
+  }
+
+  if (/\.md$/i.test(name)) {
+    return "text/markdown";
+  }
+
+  if (/\.ya?ml$/i.test(name)) {
+    return "text/yaml";
+  }
+
+  if (isTextFile(name)) {
+    return "text/plain";
   }
 
   return "application/octet-stream";
@@ -2624,17 +2674,18 @@ async function mcpShareMedia(
   if (!agent) throw new Error("Agent not found.");
 
   if (!isMediaFile(opts.filePath)) {
-    throw new Error("Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4.");
+    throw new Error("Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4 or text files (txt/md/json/yaml/ts/py/etc).");
   }
 
-  const validSources = ["screenshot", "stream", "simulator"];
-  const source = opts.source && validSources.includes(opts.source) ? opts.source : "screenshot";
+  const isText = isTextFile(opts.filePath);
+  const validSources = ["screenshot", "stream", "simulator", "text"];
+  const source = isText ? "text" : (opts.source && validSources.includes(opts.source) ? opts.source : "screenshot");
 
   const buffer = await readFile(opts.filePath);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
   const baseName = opts.name ?? path.basename(opts.filePath);
   const ext0 = path.extname(baseName).toLowerCase();
-  const fallbackExt = ext0 === ".mp4" ? ".mp4" : ".png";
+  const fallbackExt = ext0 === ".mp4" ? ".mp4" : isText ? (ext0 || ".txt") : ".png";
   const safeName = baseName.replace(/ /g, "-").replace(/[^A-Za-z0-9._-]/g, "") || `shared-${timestamp}${fallbackExt}`;
   const ext = path.extname(safeName);
   const base = path.basename(safeName, ext);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "framer-motion": "^12.35.2",
+        "highlight.js": "^11.11.1",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6019,6 +6020,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/idb": {
@@ -13147,6 +13157,11 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
     },
     "idb": {
       "version": "7.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "framer-motion": "^12.35.2",
+    "highlight.js": "^11.11.1",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/src/components/app/media-lightbox.tsx
+++ b/web/src/components/app/media-lightbox.tsx
@@ -1,14 +1,99 @@
-import { type TouchEvent, useEffect, useRef } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { type TouchEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronLeft, ChevronRight, Copy, Download } from "lucide-react";
+import hljs from "highlight.js/lib/core";
+import typescript from "highlight.js/lib/languages/typescript";
+import javascript from "highlight.js/lib/languages/javascript";
+import python from "highlight.js/lib/languages/python";
+import go from "highlight.js/lib/languages/go";
+import rust from "highlight.js/lib/languages/rust";
+import bash from "highlight.js/lib/languages/bash";
+import json from "highlight.js/lib/languages/json";
+import yaml from "highlight.js/lib/languages/yaml";
+import xml from "highlight.js/lib/languages/xml";
+import css from "highlight.js/lib/languages/css";
+import sql from "highlight.js/lib/languages/sql";
+import markdown from "highlight.js/lib/languages/markdown";
+import swift from "highlight.js/lib/languages/swift";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import java from "highlight.js/lib/languages/java";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import ruby from "highlight.js/lib/languages/ruby";
+import php from "highlight.js/lib/languages/php";
+import lua from "highlight.js/lib/languages/lua";
+import r from "highlight.js/lib/languages/r";
+import elixir from "highlight.js/lib/languages/elixir";
+import erlang from "highlight.js/lib/languages/erlang";
+import haskell from "highlight.js/lib/languages/haskell";
+import diff from "highlight.js/lib/languages/diff";
+import ini from "highlight.js/lib/languages/ini";
+import objectivec from "highlight.js/lib/languages/objectivec";
+import nim from "highlight.js/lib/languages/nim";
+
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("go", go);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("swift", swift);
+hljs.registerLanguage("kotlin", kotlin);
+hljs.registerLanguage("java", java);
+hljs.registerLanguage("c", c);
+hljs.registerLanguage("cpp", cpp);
+hljs.registerLanguage("ruby", ruby);
+hljs.registerLanguage("php", php);
+hljs.registerLanguage("lua", lua);
+hljs.registerLanguage("r", r);
+hljs.registerLanguage("elixir", elixir);
+hljs.registerLanguage("erlang", erlang);
+hljs.registerLanguage("haskell", haskell);
+hljs.registerLanguage("diff", diff);
+hljs.registerLanguage("ini", ini);
+hljs.registerLanguage("objectivec", objectivec);
+hljs.registerLanguage("nim", nim);
 
 import { Button } from "@/components/ui/button";
+
+const EXT_TO_LANG: Record<string, string> = {
+  ".ts": "typescript", ".tsx": "typescript", ".js": "javascript", ".jsx": "javascript",
+  ".py": "python", ".go": "go", ".rs": "rust", ".sh": "bash", ".bash": "bash",
+  ".json": "json", ".yaml": "yaml", ".yml": "yaml", ".toml": "ini",
+  ".html": "xml", ".xml": "xml", ".css": "css", ".sql": "sql",
+  ".md": "markdown", ".swift": "swift", ".kt": "kotlin", ".java": "java",
+  ".c": "c", ".cpp": "cpp", ".h": "c", ".hpp": "cpp",
+  ".rb": "ruby", ".php": "php", ".lua": "lua", ".r": "r",
+  ".ex": "elixir", ".exs": "elixir", ".erl": "erlang", ".hs": "haskell",
+  ".diff": "diff", ".patch": "diff", ".ini": "ini", ".cfg": "ini", ".conf": "ini",
+  ".zig": "zig", ".nim": "nim", ".m": "objectivec",
+};
+
+const TEXT_EXTENSIONS = new Set([
+  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
+  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
+  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
+  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
+  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
+]);
+
+function isTextFile(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot === -1) return false;
+  return TEXT_EXTENSIONS.has(name.slice(dot).toLowerCase());
+}
 
 type MediaLightboxItem = {
   src: string;
   caption: string;
   file: {
     name: string;
-    source?: "screenshot" | "stream" | "simulator";
+    source?: "screenshot" | "stream" | "simulator" | "text";
   };
 };
 
@@ -18,6 +103,111 @@ type MediaLightboxProps = {
   totalItems: number;
   setLightboxIndex: (nextIndex: number | null) => void;
 };
+
+function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.Element {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    setContent(null);
+    setError(null);
+    let cancelled = false;
+    fetch(src)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+        return res.text();
+      })
+      .then((text) => { if (!cancelled) setContent(text); })
+      .catch((err) => { if (!cancelled) setError(String(err)); });
+    return () => { cancelled = true; };
+  }, [src]);
+
+  const handleCopy = useCallback(() => {
+    if (!content) return;
+    void navigator.clipboard.writeText(content).then(() => {
+      setCopied(true);
+      if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
+    });
+  }, [content]);
+
+  const handleDownload = useCallback(() => {
+    if (!content) return;
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [content, fileName]);
+
+  const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+
+  const highlightedHtml = useMemo(() => {
+    if (!content) return null;
+    const dot = fileName.lastIndexOf(".");
+    const ext = dot !== -1 ? fileName.slice(dot).toLowerCase() : "";
+    const lang = EXT_TO_LANG[ext];
+    if (lang) {
+      try {
+        return hljs.highlight(content, { language: lang }).value;
+      } catch {
+        // fall through to auto-detect
+      }
+    }
+    try {
+      return hljs.highlightAuto(content).value;
+    } catch {
+      return null;
+    }
+  }, [content, fileName]);
+
+  if (error) {
+    return <div className="grid h-full place-items-center text-sm text-destructive">{error}</div>;
+  }
+
+  if (content === null) {
+    return <div className="grid h-full place-items-center text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+        <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={handleDownload}
+          >
+            <Download className="h-3.5 w-3.5" />
+            Download
+          </Button>
+          <Button
+            size="sm"
+            variant={copied ? "default" : "ghost"}
+            className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
+            onClick={handleCopy}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied!" : "Copy"}
+          </Button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        {highlightedHtml ? (
+          <pre className="p-4 text-sm leading-relaxed"><code className="hljs" dangerouslySetInnerHTML={{ __html: highlightedHtml }} /></pre>
+        ) : (
+          <pre className="p-4 text-sm leading-relaxed text-foreground"><code>{content}</code></pre>
+        )}
+      </div>
+    </div>
+  );
+}
 
 const SWIPE_THRESHOLD_PX = 48;
 
@@ -145,7 +335,11 @@ export function MediaLightbox({
           <ChevronLeft className="h-8 w-8" />
         </button>
 
-        {/\.mp4/i.test(item.src) ? (
+        {item.file.source === "text" || isTextFile(item.file.name) ? (
+          <div className="h-full w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-surface">
+            <TextViewer src={item.src} fileName={item.file.name} />
+          </div>
+        ) : /\.mp4/i.test(item.src) ? (
           <video
             src={item.src}
             controls

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -1,9 +1,28 @@
 import { type RefObject, useCallback, useEffect } from "react";
-import { ChevronRight, ExternalLink, MonitorPlay, X } from "lucide-react";
+import { ChevronRight, ExternalLink, FileText, MonitorPlay, X } from "lucide-react";
 
 import { type MediaFile } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+
+const TEXT_EXTENSIONS = new Set([
+  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
+  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
+  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
+  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
+  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
+]);
+
+function isTextFileName(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot === -1) return false;
+  return TEXT_EXTENSIONS.has(name.slice(dot).toLowerCase());
+}
+
+function fileExtension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot === -1 ? "" : name.slice(dot + 1).toLowerCase();
+}
 
 type MediaSidebarSharedProps = {
   mediaFiles: MediaFile[];
@@ -110,6 +129,7 @@ export function MediaSidebarContent({
             const unseen = !file.seen;
 
             const isStream = file.source === "stream";
+            const isText = file.source === "text" || isTextFileName(file.name);
 
             return (
               <article
@@ -130,7 +150,21 @@ export function MediaSidebarContent({
                 ) : (
                   <div className="mb-2 text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</div>
                 )}
-                {/\.mp4$/i.test(file.name) ? (
+                {isText ? (
+                  <button
+                    className={cn(
+                      "block w-full overflow-hidden rounded border-2 bg-muted/50 p-3 text-left",
+                      unseen ? "media-thumb-unseen" : "media-thumb-seen"
+                    )}
+                    onClick={() => openLightbox(file)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <FileText className="h-4 w-4 flex-none text-muted-foreground" />
+                      <span className="truncate text-xs font-medium text-foreground">{file.name.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "")}</span>
+                      <span className="ml-auto flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{fileExtension(file.name)}</span>
+                    </div>
+                  </button>
+                ) : /\.mp4$/i.test(file.name) ? (
                   <div className={cn(
                     "block w-full overflow-hidden border-2 bg-black/60",
                     unseen ? "media-thumb-unseen" : "media-thumb-seen"

--- a/web/src/components/app/types.ts
+++ b/web/src/components/app/types.ts
@@ -38,7 +38,7 @@ export type MediaFile = {
   updatedAt: string;
   url: string;
   seen?: boolean;
-  source?: "screenshot" | "stream" | "simulator";
+  source?: "screenshot" | "stream" | "simulator" | "text";
   description?: string | null;
 };
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -391,6 +391,146 @@ html[data-theme="matrix"] [role="button"] {
   }
 }
 
+/* ── Syntax highlighting (highlight.js) ─────────────────────────────
+   Uses Dispatch theme variables so colors adapt to every theme. */
+.hljs {
+  background: hsl(var(--surface));
+  color: hsl(var(--foreground));
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-deletion {
+  color: hsl(var(--primary));
+}
+.hljs-string,
+.hljs-doctag,
+.hljs-regexp,
+.hljs-addition {
+  color: hsl(var(--status-working));
+}
+.hljs-number,
+.hljs-literal {
+  color: hsl(var(--status-done));
+}
+.hljs-comment,
+.hljs-quote {
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+.hljs-type,
+.hljs-built_in {
+  color: hsl(var(--status-waiting));
+}
+.hljs-title,
+.hljs-title\.class_,
+.hljs-title\.function_ {
+  color: hsl(var(--ring));
+}
+.hljs-attr,
+.hljs-attribute {
+  color: hsl(var(--primary));
+  opacity: 0.85;
+}
+.hljs-variable,
+.hljs-template-variable {
+  color: hsl(var(--foreground));
+}
+.hljs-meta,
+.hljs-meta .hljs-keyword {
+  color: hsl(var(--destructive));
+}
+.hljs-symbol,
+.hljs-bullet {
+  color: hsl(var(--status-done));
+}
+.hljs-section {
+  color: hsl(var(--ring));
+  font-weight: bold;
+}
+.hljs-name,
+.hljs-tag {
+  color: hsl(var(--primary));
+}
+.hljs-params {
+  color: hsl(var(--foreground));
+  opacity: 0.8;
+}
+.hljs-punctuation {
+  color: hsl(var(--muted-foreground));
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+
+/* Midnight: blue primary, pink destructive — lean into blues and pinks */
+[data-theme="midnight"] .hljs-keyword,
+[data-theme="midnight"] .hljs-selector-tag,
+[data-theme="midnight"] .hljs-deletion {
+  color: hsl(var(--primary));             /* blue */
+}
+[data-theme="midnight"] .hljs-string,
+[data-theme="midnight"] .hljs-doctag,
+[data-theme="midnight"] .hljs-regexp,
+[data-theme="midnight"] .hljs-addition {
+  color: hsl(var(--destructive));         /* pink */
+}
+[data-theme="midnight"] .hljs-title,
+[data-theme="midnight"] .hljs-title\.class_,
+[data-theme="midnight"] .hljs-title\.function_ {
+  color: hsl(var(--status-waiting));      /* yellow */
+}
+[data-theme="midnight"] .hljs-attr,
+[data-theme="midnight"] .hljs-attribute {
+  color: hsl(var(--primary));
+  opacity: 0.75;
+}
+[data-theme="midnight"] .hljs-name,
+[data-theme="midnight"] .hljs-tag {
+  color: hsl(var(--destructive));         /* pink for tags */
+}
+[data-theme="midnight"] .hljs-meta,
+[data-theme="midnight"] .hljs-meta .hljs-keyword {
+  color: hsl(var(--status-working));      /* green for meta only */
+}
+
+/* OLED Black: green primary is too monochrome — use blue/yellow/red accents */
+[data-theme="oled-black"] .hljs-keyword,
+[data-theme="oled-black"] .hljs-selector-tag,
+[data-theme="oled-black"] .hljs-deletion {
+  color: hsl(var(--status-done));         /* blue */
+}
+[data-theme="oled-black"] .hljs-string,
+[data-theme="oled-black"] .hljs-doctag,
+[data-theme="oled-black"] .hljs-regexp,
+[data-theme="oled-black"] .hljs-addition {
+  color: hsl(var(--destructive));         /* red */
+}
+[data-theme="oled-black"] .hljs-title,
+[data-theme="oled-black"] .hljs-title\.class_,
+[data-theme="oled-black"] .hljs-title\.function_ {
+  color: hsl(var(--status-waiting));      /* yellow */
+}
+[data-theme="oled-black"] .hljs-type,
+[data-theme="oled-black"] .hljs-built_in {
+  color: hsl(var(--primary));             /* green — just for types */
+}
+[data-theme="oled-black"] .hljs-attr,
+[data-theme="oled-black"] .hljs-attribute {
+  color: hsl(var(--status-done));         /* blue */
+  opacity: 0.8;
+}
+[data-theme="oled-black"] .hljs-name,
+[data-theme="oled-black"] .hljs-tag {
+  color: hsl(var(--status-done));         /* blue */
+}
+[data-theme="oled-black"] .hljs-meta,
+[data-theme="oled-black"] .hljs-meta .hljs-keyword {
+  color: hsl(var(--status-waiting));      /* yellow for meta */
+}
+
 /* Pause GPU-composited animations when the page is hidden to reduce energy */
 html[data-hidden] .dispatch-reconnect-scan {
   animation-play-state: paused;


### PR DESCRIPTION
## Summary
- Agents can now share text files and code snippets through the media sharing system, solving the tmux line-wrap copy/paste problem
- Text files render as compact cards (file icon + name + extension badge) in the media sidebar, and open in a full-screen viewer with syntax highlighting, copy-to-clipboard, and download
- The `dispatch_share` MCP tool gains an inline `content` param (max 32KB) so agents can share snippets directly without writing temp files
- Syntax highlighting uses highlight.js with 28 languages, and custom CSS that adapts to all 8 Dispatch themes via CSS variables (with per-theme overrides for midnight and OLED)

## Test plan
- [x] Type check passes (`npm run check`)
- [x] Production build passes (`npm run finalize:web`)
- [x] All 65 E2E tests pass (`npm run test:e2e`)
- [x] UI validated in Playwright: text file cards in sidebar, text viewer lightbox with copy/download
- [x] Syntax highlighting validated across all 8 themes (default, solarized, vaporwave, matrix, light, crumbstream, midnight, OLED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)