### PR TITLE
Fix Slack notifications suppressed for all agents, not just focused one

### DIFF
--- a/src/focus-tracker.ts
+++ b/src/focus-tracker.ts
@@ -20,6 +20,11 @@ export class FocusTracker {
     this.focusedAgents.delete(agentId);
   }
 
+  /** Clear all focus entries (e.g. user switched away from all agents). */
+  clearAll(): void {
+    this.focusedAgents.clear();
+  }
+
   /** Returns true if the agent was focused within the last TTL window. */
   isFocused(agentId: string): boolean {
     const ts = this.focusedAgents.get(agentId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1353,7 +1353,9 @@ async function registerRoutes() {
     const agentId = body?.agentId;
 
     if (agentId === null || agentId === undefined) {
-      // No specific agent focused — let existing focus entries expire via TTL
+      // User is no longer focused on any agent — clear all focus immediately
+      // so notifications resume without waiting for TTL expiry.
+      focusTracker.clearAll();
       return reply.code(204).send();
     }
 

--- a/test/focus-tracker.test.ts
+++ b/test/focus-tracker.test.ts
@@ -60,6 +60,18 @@ describe("FocusTracker", () => {
     expect(tracker.isFocused("agent-2")).toBe(true);
   });
 
+  it("clearAll removes all focus entries immediately", () => {
+    const tracker = new FocusTracker();
+    tracker.setFocused("agent-1");
+    tracker.setFocused("agent-2");
+    tracker.setFocused("agent-3");
+
+    tracker.clearAll();
+    expect(tracker.isFocused("agent-1")).toBe(false);
+    expect(tracker.isFocused("agent-2")).toBe(false);
+    expect(tracker.isFocused("agent-3")).toBe(false);
+  });
+
   it("refreshes TTL on repeated setFocused calls", () => {
     const tracker = new FocusTracker();
     tracker.setFocused("agent-1");

--- a/web/src/hooks/use-agent-focus.ts
+++ b/web/src/hooks/use-agent-focus.ts
@@ -41,6 +41,8 @@ export function useAgentFocus(
     const tick = () => {
       if (isPageActive() && selectedAgentId) {
         sendFocus(selectedAgentId);
+      } else if (lastReportedRef.current) {
+        sendFocus(null);
       }
     };
 


### PR DESCRIPTION
## Summary
- The focus tracking system (added in #131) never cleared focus entries when the client sent a null signal — it relied on a 30s TTL that was too long relative to the 15s heartbeat interval
- As users clicked through agents in the sidebar, multiple agents accumulated as "focused" and had their Slack notifications silently dropped
- Added `FocusTracker.clearAll()` called on null focus signal, and fixed the client heartbeat to actively clear stale focus when the page is inactive

## Test plan
- [x] Unit tests pass (including new `clearAll` test)
- [x] E2E tests pass (65/65)
- [x] Type check and web build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)