### PR TITLE
Bridge browser clipboard images to host pasteboard for remote sessions

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
-import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
@@ -1017,6 +1017,43 @@ async function registerRoutes() {
       db: "ok",
       now: result.rows[0]?.now
     };
+  });
+
+  // Write an image from the browser clipboard to the host's macOS pasteboard.
+  // This bridges remote browser sessions to the local system clipboard so that
+  // CLI tools (e.g. Claude CLI) can read pasted images via native APIs.
+  app.post("/api/v1/clipboard/image", async (request, reply) => {
+    const data = await request.file();
+    if (!data) {
+      return reply.code(400).send({ error: "An image file field is required." });
+    }
+    const mime = data.mimetype;
+    if (!mime.startsWith("image/")) {
+      return reply.code(400).send({ error: "Only image files are accepted." });
+    }
+
+    const buffer = await data.toBuffer();
+    const ext = mime === "image/png" ? "png" : mime === "image/jpeg" ? "jpg" : "png";
+    const tmpPath = `/tmp/dispatch-clipboard-${Date.now()}.${ext}`;
+    await writeFile(tmpPath, buffer);
+
+    try {
+      const pasteboardClass = ext === "jpg" ? "JPEG" : "PNGf";
+      await new Promise<void>((resolve, reject) => {
+        const proc = spawn("osascript", [
+          "-e",
+          `set the clipboard to (read (POSIX file "${tmpPath}") as «class ${pasteboardClass}»)`
+        ]);
+        proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`osascript exited ${code}`)));
+        proc.on("error", reject);
+      });
+      return reply.code(200).send({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return reply.code(500).send({ error: `Failed to write to pasteboard: ${message}` });
+    } finally {
+      await unlink(tmpPath).catch(() => {});
+    }
   });
 
   app.get("/api/v1/system/defaults", async () => {

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -562,6 +562,36 @@ export function useTerminal(args: {
     };
     host.addEventListener("copy", handleCopy, true);
 
+    // Upload a clipboard image to the host pasteboard, then send Ctrl+V so CLI
+    // tools read it natively. This bridges the browser clipboard to the server.
+    const syncClipboardImage = (blob: File): void => {
+      const form = new FormData();
+      form.append("file", blob, `clipboard.${blob.type === "image/png" ? "png" : "jpg"}`);
+      fetch("/api/v1/clipboard/image", { method: "POST", body: form, credentials: "include" })
+        .then((res) => {
+          if (!res.ok) throw new Error(`clipboard upload: ${res.status}`);
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: "input", data: "\x16" }));
+          }
+        })
+        .catch((err) => console.warn("Clipboard image paste failed:", err));
+    };
+
+    // Intercept paste events (Cmd+V) — clipboard data is available directly.
+    const handlePaste = (e: ClipboardEvent) => {
+      const imageItem = Array.from(e.clipboardData?.items ?? []).find(
+        (item) => item.type.startsWith("image/"),
+      );
+      if (!imageItem) return; // no image — let xterm handle text paste normally
+      const blob = imageItem.getAsFile();
+      if (!blob) return;
+      e.preventDefault();
+      e.stopPropagation();
+      syncClipboardImage(blob);
+    };
+    host.addEventListener("paste", handlePaste, true);
+
     const screenEl = host.querySelector(".xterm-screen") as HTMLElement | null;
     let touchY = 0;
     let touchAccum = 0;
@@ -646,6 +676,7 @@ export function useTerminal(args: {
       invalidateAttachAttempt();
       disposable.dispose();
       host.removeEventListener("copy", handleCopy, true);
+      host.removeEventListener("paste", handlePaste, true);
       host.removeEventListener("touchstart", onTouchStart);
       host.removeEventListener("touchmove", onTouchMove);
       if (screenEl) screenEl.removeEventListener("mousedown", onMouseDown, true);


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/clipboard/image` endpoint that writes uploaded images to the macOS pasteboard via `osascript`
- Intercepts Cmd+V paste events in the browser terminal — when the clipboard contains an image, uploads it to the server and sends Ctrl+V to trigger CLI clipboard read
- Fixes image paste for remote browser sessions where the browser clipboard and server pasteboard are on different machines

## Context
When accessing Dispatch remotely, CLI tools (e.g. Claude CLI) read the server's macOS pasteboard, not the browser's clipboard. Previously, image paste only worked when Universal Clipboard (Handoff) happened to sync between devices. This makes it reliable regardless of proximity.

## Test plan
- [x] `npm run check` passes (backend + web)
- [x] `npm run finalize:web` passes (type check + production build)
- [x] `npm run test:e2e` — 65 passed, 6 skipped (pre-existing terminal-live skips)
- [x] Manual test: Cmd+V with image in remote browser session → image appears in Claude CLI
- [x] API endpoint tested via curl — image written to pasteboard confirmed via Swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)