### PR TITLE
Tone down sidebar create button

### DIFF
--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -150,20 +150,20 @@ export function AgentSidebarContent({
         <div className="ml-auto flex items-center">
             <Button
               size="sm"
-              variant="primary"
-              className="rounded-r-none"
+              variant="default"
+              className="rounded-r-none border-r-0 bg-muted/35 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
               onClick={() => onOpenCreateDialog(defaultCreateType)}
               data-testid="create-agent-button"
             >
-              <AgentTypeIcon type={defaultCreateType} className="mr-1 h-4 w-4 border-none bg-transparent p-0 text-primary-foreground" />
+              <AgentTypeIcon type={defaultCreateType} className="mr-1 h-4 w-4 border-none bg-transparent p-0 text-foreground/80" />
               Create
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   size="sm"
-                  variant="primary"
-                  className="rounded-l-none border-l border-primary-foreground/20 px-1"
+                  variant="default"
+                  className="rounded-l-none border-l border-border/80 bg-muted/35 px-1 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
                   data-testid="create-agent-type-dropdown"
                 >
                   <ChevronDown className="h-3.5 w-3.5" />

--- a/web/src/components/app/create-agent-dialog.tsx
+++ b/web/src/components/app/create-agent-dialog.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, BotMessageSquare, Check, CheckCircle2, ChevronDown, GitBranch, Loader2, X } from "lucide-react";
+import { AlertCircle, Check, CheckCircle2, ChevronDown, GitBranch, Loader2, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandLoading } from "@/components/ui/command";
@@ -540,7 +540,7 @@ export function CreateAgentDialog({
               Cancel
             </Button>
             <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-submit">
-              {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <BotMessageSquare className="mr-1.5 h-4 w-4" />}
+              {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
               Create
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- demote the sidebar create split-button from the primary CTA treatment to a muted utility style
- keep the icon and dropdown legible while reducing visual competition with the rest of the app chrome
- validate the updated sidebar interaction in Playwright and keep the isolated dev stack available for inspection

## Verification
- npm run check
- npm run finalize:web
- npm run test:e2e

## Validation stack
- Web: http://127.0.0.1:56747
- API: http://127.0.0.1:56742