### PR TITLE
Add token usage tracking with Claude and Codex support

### DIFF
--- a/e2e/token-usage.spec.ts
+++ b/e2e/token-usage.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
+test.describe("Token usage API", () => {
+  test("GET /api/v1/activity/token-stats returns zeroes when empty", async ({ request }) => {
+    const res = await request.get("/api/v1/activity/token-stats", { headers: authHeader });
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as {
+      total_input: number;
+      total_cache_creation: number;
+      total_cache_read: number;
+      total_output: number;
+      total_messages: number;
+      total_sessions: number;
+    };
+    expect(body.total_input).toBe(0);
+    expect(body.total_output).toBe(0);
+    expect(body.total_sessions).toBe(0);
+  });
+
+  test("GET /api/v1/activity/token-daily returns empty days array when no data", async ({ request }) => {
+    const res = await request.get("/api/v1/activity/token-daily?days=7", { headers: authHeader });
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as { days: unknown[] };
+    expect(Array.isArray(body.days)).toBe(true);
+    expect(body.days.length).toBe(0);
+  });
+
+  test("GET /api/v1/activity/token-by-project returns empty projects array when no data", async ({ request }) => {
+    const res = await request.get("/api/v1/activity/token-by-project", { headers: authHeader });
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as { projects: unknown[] };
+    expect(Array.isArray(body.projects)).toBe(true);
+    expect(body.projects.length).toBe(0);
+  });
+
+  test("POST /api/v1/agents/:id/harvest-tokens returns 404 for unknown agent", async ({ request }) => {
+    const res = await request.post("/api/v1/agents/nonexistent-agent/harvest-tokens", {
+      headers: authHeader,
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test("token-daily respects days parameter and clamps to range", async ({ request }) => {
+    // days=0 should clamp to 1
+    const res = await request.get("/api/v1/activity/token-daily?days=0", { headers: authHeader });
+    expect(res.ok()).toBeTruthy();
+
+    // days=999 should clamp to 90
+    const res2 = await request.get("/api/v1/activity/token-daily?days=999", { headers: authHeader });
+    expect(res2.ok()).toBeTruthy();
+  });
+});
+
+test.describe("Token usage UI", () => {
+  test("Activity pane shows token stats when data exists", async ({ page, request }) => {
+    // Seed token data directly via the database isn't available in E2E,
+    // so we check the pane renders without errors when there's no data
+    await page.goto("/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Open the activity pane
+    await page.getByTestId("activity-button").click();
+    await expect(page.getByRole("dialog", { name: "Activity" })).toBeVisible();
+
+    // Heatmap should render
+    await expect(page.getByText("Activity this year")).toBeVisible();
+
+    // Close dialog
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByRole("dialog", { name: "Activity" })).not.toBeVisible();
+  });
+});

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -9,6 +9,7 @@ import type { Pool } from "pg";
 import type { AppConfig } from "../config.js";
 import { createGitWorktree, cleanupGitWorktree } from "../git/worktree.js";
 import { runCommand } from "../lib/run-command.js";
+import { harvestTokenUsage } from "./token-harvester.js";
 
 type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "unknown";
 type AgentType = "codex" | "claude" | "opencode";
@@ -404,6 +405,16 @@ export class AgentManager {
         type: "idle",
         message: "Session stopped."
       });
+
+      // Harvest token usage from session logs (fire-and-forget)
+      harvestTokenUsage(this.pool, {
+        id: agent.id,
+        type: agent.type,
+        cwd: agent.cwd,
+        worktreePath: agent.worktreePath,
+      }, this.logger).catch((err) =>
+        this.logger.warn({ err, agentId: id }, "Token harvest failed on stop")
+      );
     } catch (error) {
       const message = this.errorMessage(error);
       await this.setAgentStatus(id, "error", message, tmuxSession ?? undefined);
@@ -456,6 +467,16 @@ export class AgentManager {
         this.logger.warn({ err: error, agentId: id }, "Worktree cleanup failed; leaving on disk.");
       }
     }
+
+    // Harvest token usage before soft-deleting
+    await harvestTokenUsage(this.pool, {
+      id: agent.id,
+      type: agent.type,
+      cwd: agent.cwd,
+      worktreePath: agent.worktreePath,
+    }, this.logger).catch((err) =>
+      this.logger.warn({ err, agentId: id }, "Token harvest failed on delete")
+    );
 
     // Record a final stopped event in history before deleting the agent row
     await this.pool
@@ -1008,6 +1029,7 @@ export class AgentManager {
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
     const launchGuidance =
+      `[dispatch:${agentId}] ` +
       "Dispatch startup rules: Playwright default is headless unless the user explicitly asks for headed mode. " +
       "Capture at least one screenshot per UI validation flow; publish every screenshot with the dispatch_share MCP tool (filePath + description for Playwright, or source 'simulator' for iOS Simulator) — never leave screenshots local-only. " +
       "Call the dispatch_event MCP tool at the start of each turn (working), when blocked or waiting for input (blocked/waiting_user), and before your final response (done on success, idle for no-op turns). Never send a final response without a terminal status event. " +

--- a/src/agents/token-harvester.ts
+++ b/src/agents/token-harvester.ts
@@ -1,0 +1,311 @@
+import { createReadStream } from "node:fs";
+import { readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+
+import type { Pool } from "pg";
+
+import type { AgentRecord } from "./manager.js";
+
+type ModelTokenTotals = {
+  inputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  outputTokens: number;
+  messageCount: number;
+};
+
+type SessionTokenSummary = {
+  sessionId: string;
+  totals: Map<string, ModelTokenTotals>;
+  sessionStart: string | null;
+  sessionEnd: string | null;
+};
+
+type HarvestAgent = Pick<AgentRecord, "id" | "type" | "cwd" | "worktreePath">;
+
+type HarvestLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
+
+const UPSERT_SQL = `INSERT INTO agent_token_usage
+  (agent_id, session_id, model, input_tokens, cache_creation_tokens, cache_read_tokens,
+   output_tokens, message_count, session_start, session_end)
+ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ ON CONFLICT (agent_id, session_id, model)
+ DO UPDATE SET
+   input_tokens = EXCLUDED.input_tokens,
+   cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+   cache_read_tokens = EXCLUDED.cache_read_tokens,
+   output_tokens = EXCLUDED.output_tokens,
+   message_count = EXCLUDED.message_count,
+   session_start = EXCLUDED.session_start,
+   session_end = EXCLUDED.session_end,
+   harvested_at = NOW()`;
+
+// ── Claude Code harvesting ────────────────────────────────────────
+
+/** Map an agent's working directory to the corresponding Claude projects directory. */
+export function cwdToClaudeProjectDir(cwd: string): string {
+  const encoded = cwd.replaceAll("/", "-");
+  return path.join(os.homedir(), ".claude", "projects", encoded);
+}
+
+async function discoverSessionFiles(dir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((f) => f.endsWith(".jsonl"))
+    .map((f) => path.join(dir, f));
+}
+
+async function parseClaudeSessionTokenUsage(filePath: string): Promise<SessionTokenSummary> {
+  const sessionId = path.basename(filePath, ".jsonl");
+  const totals = new Map<string, ModelTokenTotals>();
+  let sessionStart: string | null = null;
+  let sessionEnd: string | null = null;
+
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: "utf-8" }),
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (entry.type !== "assistant") continue;
+    const message = entry.message as Record<string, unknown> | undefined;
+    if (!message?.usage) continue;
+
+    const usage = message.usage as Record<string, number>;
+    const model = (message.model as string) ?? "unknown";
+    const ts = entry.timestamp as string | undefined;
+
+    if (ts) {
+      if (!sessionStart) sessionStart = ts;
+      sessionEnd = ts;
+    }
+
+    let bucket = totals.get(model);
+    if (!bucket) {
+      bucket = { inputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, outputTokens: 0, messageCount: 0 };
+      totals.set(model, bucket);
+    }
+
+    bucket.inputTokens += usage.input_tokens ?? 0;
+    bucket.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
+    bucket.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+    bucket.outputTokens += usage.output_tokens ?? 0;
+    bucket.messageCount += 1;
+  }
+
+  return { sessionId, totals, sessionStart, sessionEnd };
+}
+
+async function harvestClaudeTokenUsage(
+  pool: Pool,
+  agent: HarvestAgent,
+  logger?: HarvestLogger
+): Promise<void> {
+  const effectiveCwd = agent.worktreePath ?? agent.cwd;
+  const projectDir = cwdToClaudeProjectDir(effectiveCwd);
+
+  const files = await discoverSessionFiles(projectDir);
+  if (files.length === 0) return;
+
+  for (const file of files) {
+    try {
+      const summary = await parseClaudeSessionTokenUsage(file);
+
+      for (const [model, t] of summary.totals) {
+        if (t.messageCount === 0) continue;
+
+        await pool.query(UPSERT_SQL, [
+          agent.id,
+          summary.sessionId,
+          model,
+          t.inputTokens,
+          t.cacheCreationTokens,
+          t.cacheReadTokens,
+          t.outputTokens,
+          t.messageCount,
+          summary.sessionStart,
+          summary.sessionEnd,
+        ]);
+      }
+    } catch (err) {
+      logger?.warn({ err, file }, "Failed to parse Claude session file for token usage");
+    }
+  }
+}
+
+// ── Codex harvesting ──────────────────────────────────────────────
+
+const CODEX_SESSIONS_DIR = path.join(os.homedir(), ".codex", "sessions");
+const DISPATCH_TAG_RE = /\[dispatch:(agt_[a-z0-9_]+)\]/;
+
+type CodexTokenUsage = {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+
+/**
+ * Recursively discover all rollout JSONL files under ~/.codex/sessions/.
+ * Files are organized as YYYY/MM/DD/rollout-*.jsonl.
+ */
+async function discoverCodexRolloutFiles(): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true }) as import("node:fs").Dirent[];
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.name.endsWith(".jsonl")) {
+        files.push(full);
+      }
+    }
+  }
+
+  await walk(CODEX_SESSIONS_DIR);
+  return files;
+}
+
+/**
+ * Parse a Codex rollout JSONL in a single pass: check for the agent tag
+ * in the first 20 lines, then extract model and cumulative token usage.
+ * Returns null if the file doesn't belong to the given agent or has no token data.
+ */
+async function parseCodexRolloutForAgent(
+  filePath: string,
+  agentId: string
+): Promise<{ usage: CodexTokenUsage; model: string; sessionStart: string | null; sessionEnd: string | null } | null> {
+  let matched = false;
+  let lastUsage: CodexTokenUsage | null = null;
+  let model = "unknown";
+  let sessionStart: string | null = null;
+  let sessionEnd: string | null = null;
+  let linesRead = 0;
+
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: "utf-8" }),
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    linesRead++;
+
+    // Check for agent tag in the first 20 lines
+    if (!matched) {
+      if (linesRead > 20) break;
+      const tagMatch = DISPATCH_TAG_RE.exec(line);
+      if (tagMatch && tagMatch[1] === agentId) matched = true;
+      continue;
+    }
+
+    if (!line.trim()) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const ts = entry.timestamp as string | undefined;
+    if (ts && !sessionStart) sessionStart = ts;
+    if (ts) sessionEnd = ts;
+
+    if (entry.type === "turn_context") {
+      const payload = entry.payload as Record<string, unknown> | undefined;
+      if (payload?.model) model = payload.model as string;
+    }
+
+    if (entry.type === "event_msg") {
+      const payload = entry.payload as Record<string, unknown> | undefined;
+      if (payload?.type === "token_count") {
+        const info = payload.info as Record<string, unknown> | undefined;
+        if (info?.total_token_usage) {
+          lastUsage = info.total_token_usage as CodexTokenUsage;
+        }
+      }
+    }
+  }
+
+  if (!matched || !lastUsage) return null;
+  return { usage: lastUsage, model, sessionStart, sessionEnd };
+}
+
+async function harvestCodexTokenUsage(
+  pool: Pool,
+  agent: HarvestAgent,
+  logger?: HarvestLogger
+): Promise<void> {
+  const rolloutFiles = await discoverCodexRolloutFiles();
+  if (rolloutFiles.length === 0) return;
+
+  for (const file of rolloutFiles) {
+    try {
+      const result = await parseCodexRolloutForAgent(file, agent.id);
+      if (!result) continue;
+
+      const { usage, model, sessionStart, sessionEnd } = result;
+      const sessionId = path.basename(file, ".jsonl");
+
+      // Normalize to additive model: cached_input_tokens is a subset of input_tokens
+      const nonCachedInput = usage.input_tokens - (usage.cached_input_tokens ?? 0);
+      const cachedInput = usage.cached_input_tokens ?? 0;
+
+      await pool.query(UPSERT_SQL, [
+        agent.id,
+        sessionId,
+        model,
+        nonCachedInput,
+        0, // cache_creation_tokens (N/A for Codex)
+        cachedInput,
+        usage.output_tokens,
+        1, // message_count: Codex gives cumulative totals, count as 1 session
+        sessionStart,
+        sessionEnd,
+      ]);
+    } catch (err) {
+      logger?.warn({ err, file }, "Failed to parse Codex rollout for token usage");
+    }
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+/**
+ * Harvest token usage for an agent based on its type.
+ * Claude agents: parse ~/.claude/projects/ JSONL session logs.
+ * Codex agents: find matching rollout files in ~/.codex/sessions/.
+ */
+export async function harvestTokenUsage(
+  pool: Pool,
+  agent: HarvestAgent,
+  logger?: HarvestLogger
+): Promise<void> {
+  if (agent.type === "codex") {
+    await harvestCodexTokenUsage(pool, agent, logger);
+  } else if (agent.type === "claude") {
+    await harvestClaudeTokenUsage(pool, agent, logger);
+  }
+  // opencode: no token tracking support yet
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -134,6 +134,25 @@ export async function runMigrations(): Promise<void> {
 
     ALTER TABLE agents
       ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+    CREATE TABLE IF NOT EXISTS agent_token_usage (
+      id SERIAL PRIMARY KEY,
+      agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      message_count INTEGER NOT NULL DEFAULT 0,
+      harvested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      session_start TIMESTAMPTZ,
+      session_end TIMESTAMPTZ,
+      UNIQUE (agent_id, session_id, model)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_atu_agent_id ON agent_token_usage(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_atu_session_start ON agent_token_usage(session_start);
   `;
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { SlackNotifier } from "./notifications/slack.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
+import { harvestTokenUsage } from "./agents/token-harvester.js";
 
 const config = loadConfig();
 const app = Fastify({
@@ -1510,6 +1511,115 @@ async function registerRoutes() {
       .sort((a, b) => a.day.localeCompare(b.day));
 
     return { days: dailyStatus };
+  });
+
+  // ── Token usage ──────────────────────────────────────────────────
+
+  app.get("/api/v1/activity/token-stats", async () => {
+    const result = await pool.query<{
+      total_input: number;
+      total_cache_creation: number;
+      total_cache_read: number;
+      total_output: number;
+      total_messages: number;
+      total_sessions: number;
+    }>(
+      `SELECT
+        COALESCE(SUM(input_tokens), 0)::int AS total_input,
+        COALESCE(SUM(cache_creation_tokens), 0)::int AS total_cache_creation,
+        COALESCE(SUM(cache_read_tokens), 0)::int AS total_cache_read,
+        COALESCE(SUM(output_tokens), 0)::int AS total_output,
+        COALESCE(SUM(message_count), 0)::int AS total_messages,
+        COUNT(DISTINCT session_id)::int AS total_sessions
+       FROM agent_token_usage`
+    );
+    return result.rows[0];
+  });
+
+  app.get("/api/v1/activity/token-daily", async (request) => {
+    const query = request.query as { days?: string };
+    const days = Math.min(Math.max(parseInt(query.days ?? "30", 10) || 30, 1), 90);
+
+    const result = await pool.query<{
+      day: string;
+      input_tokens: number;
+      cache_creation_tokens: number;
+      cache_read_tokens: number;
+      output_tokens: number;
+      messages: number;
+    }>(
+      `SELECT
+        date_trunc('day', COALESCE(session_start, harvested_at))::date::text AS day,
+        SUM(input_tokens)::int AS input_tokens,
+        SUM(cache_creation_tokens)::int AS cache_creation_tokens,
+        SUM(cache_read_tokens)::int AS cache_read_tokens,
+        SUM(output_tokens)::int AS output_tokens,
+        SUM(message_count)::int AS messages
+       FROM agent_token_usage
+       WHERE COALESCE(session_start, harvested_at) >= NOW() - make_interval(days => $1)
+       GROUP BY day ORDER BY day`,
+      [days]
+    );
+    return { days: result.rows };
+  });
+
+  app.get("/api/v1/activity/token-by-project", async () => {
+    const result = await pool.query<{
+      project_dir: string;
+      total_input: number;
+      total_output: number;
+      messages: number;
+    }>(
+      `SELECT
+        COALESCE(a.git_context->>'repoRoot', a.cwd) AS project_dir,
+        SUM(t.input_tokens + t.cache_creation_tokens + t.cache_read_tokens)::int AS total_input,
+        SUM(t.output_tokens)::int AS total_output,
+        SUM(t.message_count)::int AS messages
+       FROM agent_token_usage t
+       JOIN agents a ON a.id = t.agent_id
+       GROUP BY project_dir
+       ORDER BY total_input DESC
+       LIMIT 20`
+    );
+    return { projects: result.rows };
+  });
+
+  app.get("/api/v1/activity/token-by-model", async () => {
+    const result = await pool.query<{
+      model: string;
+      total_input: number;
+      total_cache_creation: number;
+      total_cache_read: number;
+      total_output: number;
+      sessions: number;
+    }>(
+      `SELECT
+        model,
+        COALESCE(SUM(input_tokens), 0)::int AS total_input,
+        COALESCE(SUM(cache_creation_tokens), 0)::int AS total_cache_creation,
+        COALESCE(SUM(cache_read_tokens), 0)::int AS total_cache_read,
+        COALESCE(SUM(output_tokens), 0)::int AS total_output,
+        COUNT(DISTINCT session_id)::int AS sessions
+       FROM agent_token_usage
+       GROUP BY model
+       ORDER BY (SUM(input_tokens) + SUM(cache_creation_tokens) + SUM(cache_read_tokens) + SUM(output_tokens)) DESC`
+    );
+    return { models: result.rows };
+  });
+
+  app.post("/api/v1/agents/:id/harvest-tokens", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const agent = await agentManager.getAgent(id);
+    if (!agent) return reply.code(404).send({ error: "Agent not found" });
+
+    await harvestTokenUsage(pool, {
+      id: agent.id,
+      type: agent.type,
+      cwd: agent.cwd,
+      worktreePath: agent.worktreePath,
+    }, app.log);
+
+    return { ok: true };
   });
 
   // ── Agents ────────────────────────────────────────────────────────

--- a/test/token-harvester.test.ts
+++ b/test/token-harvester.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { cwdToClaudeProjectDir } from "../src/agents/token-harvester.js";
+
+describe("token-harvester", () => {
+  describe("cwdToClaudeProjectDir", () => {
+    it("encodes a simple path by replacing / with -", () => {
+      const result = cwdToClaudeProjectDir("/Users/brad/dev/apps/dispatch");
+      expect(result).toBe(
+        path.join(os.homedir(), ".claude", "projects", "-Users-brad-dev-apps-dispatch")
+      );
+    });
+
+    it("handles nested worktree paths", () => {
+      const result = cwdToClaudeProjectDir(
+        "/Users/brad/dev/apps/dispatch/.dispatch/worktrees/agt-abc123"
+      );
+      expect(result).toBe(
+        path.join(
+          os.homedir(),
+          ".claude",
+          "projects",
+          "-Users-brad-dev-apps-dispatch-.dispatch-worktrees-agt-abc123"
+        )
+      );
+    });
+  });
+
+  describe("parseSessionTokenUsage (via harvestTokenUsage)", () => {
+    // We test the full harvest flow by creating temp JSONL files and a mock pool
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await mkdtemp(path.join(os.tmpdir(), "token-harvest-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("parses assistant entries and accumulates token usage", async () => {
+      const sessionId = "test-session-abc";
+      const jsonlPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+      const lines = [
+        JSON.stringify({
+          type: "user",
+          message: { content: "Hello" },
+          timestamp: "2026-03-28T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-6",
+            usage: {
+              input_tokens: 100,
+              cache_creation_input_tokens: 50,
+              cache_read_input_tokens: 200,
+              output_tokens: 30,
+            },
+          },
+          timestamp: "2026-03-28T10:00:01.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-6",
+            usage: {
+              input_tokens: 150,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 300,
+              output_tokens: 45,
+            },
+          },
+          timestamp: "2026-03-28T10:00:05.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-sonnet-4-6",
+            usage: {
+              input_tokens: 50,
+              cache_creation_input_tokens: 10,
+              cache_read_input_tokens: 80,
+              output_tokens: 20,
+            },
+          },
+          timestamp: "2026-03-28T10:00:10.000Z",
+        }),
+      ];
+
+      await writeFile(jsonlPath, lines.join("\n") + "\n");
+
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+
+      const upserted: Array<{ params: unknown[] }> = [];
+      const mockPool = {
+        query: vi.fn(async (_sql: string, params: unknown[]) => {
+          upserted.push({ params });
+          return { rows: [], rowCount: 0 };
+        }),
+      };
+
+      // Write JSONL to the claude projects dir that maps to our tmpDir
+      const { mkdir } = await import("node:fs/promises");
+      const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
+      await mkdir(fakeProjectDir, { recursive: true });
+      const realJsonlPath = path.join(fakeProjectDir, `${sessionId}.jsonl`);
+      await writeFile(realJsonlPath, lines.join("\n") + "\n");
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt-test",
+        type: "claude" as const,
+        cwd: tmpDir,
+        worktreePath: null,
+      });
+
+      // Should have 2 upserts: one for claude-opus-4-6, one for claude-sonnet-4-6
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+
+      // Find opus upsert
+      const opusCall = upserted.find((u) => u.params[2] === "claude-opus-4-6");
+      expect(opusCall).toBeDefined();
+      expect(opusCall!.params[0]).toBe("agt-test"); // agent_id
+      expect(opusCall!.params[1]).toBe(sessionId); // session_id
+      expect(opusCall!.params[3]).toBe(250); // input_tokens: 100 + 150
+      expect(opusCall!.params[4]).toBe(50); // cache_creation: 50 + 0
+      expect(opusCall!.params[5]).toBe(500); // cache_read: 200 + 300
+      expect(opusCall!.params[6]).toBe(75); // output_tokens: 30 + 45
+      expect(opusCall!.params[7]).toBe(2); // message_count
+
+      // Find sonnet upsert
+      const sonnetCall = upserted.find((u) => u.params[2] === "claude-sonnet-4-6");
+      expect(sonnetCall).toBeDefined();
+      expect(sonnetCall!.params[3]).toBe(50); // input_tokens
+      expect(sonnetCall!.params[4]).toBe(10); // cache_creation
+      expect(sonnetCall!.params[5]).toBe(80); // cache_read
+      expect(sonnetCall!.params[6]).toBe(20); // output_tokens
+      expect(sonnetCall!.params[7]).toBe(1); // message_count
+
+      // Clean up the fake project dir
+      await rm(fakeProjectDir, { recursive: true, force: true });
+    });
+
+    it("silently returns when project dir does not exist", async () => {
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+
+      const mockPool = {
+        query: vi.fn(),
+      };
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt-nonexistent",
+        type: "claude" as const,
+        cwd: "/nonexistent/path/that/does/not/exist",
+        worktreePath: null,
+      });
+
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it("skips malformed JSON lines", async () => {
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { mkdir } = await import("node:fs/promises");
+
+      const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
+      await mkdir(fakeProjectDir, { recursive: true });
+
+      const sessionId = "malformed-session";
+      const jsonlPath = path.join(fakeProjectDir, `${sessionId}.jsonl`);
+
+      const lines = [
+        "not valid json",
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-6",
+            usage: {
+              input_tokens: 100,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              output_tokens: 50,
+            },
+          },
+          timestamp: "2026-03-28T10:00:00.000Z",
+        }),
+        "", // empty line
+      ];
+
+      await writeFile(jsonlPath, lines.join("\n") + "\n");
+
+      const mockPool = {
+        query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      };
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt-malformed",
+        type: "claude" as const,
+        cwd: tmpDir,
+        worktreePath: null,
+      });
+
+      // Should still have parsed the valid entry
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+
+      await rm(fakeProjectDir, { recursive: true, force: true });
+    });
+
+    it("uses worktreePath when available", async () => {
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { mkdir } = await import("node:fs/promises");
+
+      const worktreeDir = await mkdtemp(path.join(os.tmpdir(), "worktree-test-"));
+      const fakeProjectDir = cwdToClaudeProjectDir(worktreeDir);
+      await mkdir(fakeProjectDir, { recursive: true });
+
+      const sessionId = "worktree-session";
+      const jsonlPath = path.join(fakeProjectDir, `${sessionId}.jsonl`);
+
+      await writeFile(
+        jsonlPath,
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+          timestamp: "2026-03-28T10:00:00.000Z",
+        }) + "\n"
+      );
+
+      const mockPool = {
+        query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      };
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt-wt",
+        type: "claude" as const,
+        cwd: "/original/cwd",
+        worktreePath: worktreeDir,
+      });
+
+      // Should have used worktreePath (not cwd) for session file discovery
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+
+      await rm(fakeProjectDir, { recursive: true, force: true });
+      await rm(worktreeDir, { recursive: true, force: true });
+    });
+
+    it("skips opencode agents gracefully", async () => {
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+
+      const mockPool = { query: vi.fn() };
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt-opencode",
+        type: "opencode" as const,
+        cwd: "/some/path",
+        worktreePath: null,
+      });
+
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Codex token harvesting", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await mkdtemp(path.join(os.tmpdir(), "codex-harvest-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("parses Codex rollout token_count events and normalizes cache tokens", async () => {
+      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { mkdir } = await import("node:fs/promises");
+
+      // Create a fake ~/.codex/sessions/ structure
+      const sessionsDir = path.join(os.homedir(), ".codex", "sessions", "test-harvest");
+      await mkdir(sessionsDir, { recursive: true });
+
+      const rolloutFile = path.join(sessionsDir, "rollout-test-codex.jsonl");
+
+      const lines = [
+        JSON.stringify({
+          timestamp: "2026-03-28T10:00:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "[dispatch:agt_codex_test] Say hello" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-03-28T10:00:01.000Z",
+          type: "turn_context",
+          payload: { model: "gpt-5.4", cwd: "/tmp" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-03-28T10:00:02.000Z",
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: {
+              total_token_usage: {
+                input_tokens: 10000,
+                cached_input_tokens: 3000,
+                output_tokens: 500,
+                total_tokens: 10500,
+              },
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-03-28T10:00:05.000Z",
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: {
+              total_token_usage: {
+                input_tokens: 20000,
+                cached_input_tokens: 8000,
+                output_tokens: 1200,
+                total_tokens: 21200,
+              },
+            },
+          },
+        }),
+      ];
+
+      await writeFile(rolloutFile, lines.join("\n") + "\n");
+
+      const upserted: Array<{ params: unknown[] }> = [];
+      const mockPool = {
+        query: vi.fn(async (_sql: string, params: unknown[]) => {
+          upserted.push({ params });
+          return { rows: [], rowCount: 0 };
+        }),
+      };
+
+      await harvestTokenUsage(mockPool as any, {
+        id: "agt_codex_test",
+        type: "codex" as const,
+        cwd: "/tmp",
+        worktreePath: null,
+      });
+
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+      const params = upserted[0].params;
+      expect(params[0]).toBe("agt_codex_test"); // agent_id
+      expect(params[2]).toBe("gpt-5.4"); // model
+      // Normalized: input_tokens - cached = 20000 - 8000 = 12000
+      expect(params[3]).toBe(12000); // input_tokens (non-cached)
+      expect(params[4]).toBe(0); // cache_creation_tokens (N/A for Codex)
+      expect(params[5]).toBe(8000); // cache_read_tokens (= cached_input_tokens)
+      expect(params[6]).toBe(1200); // output_tokens
+      expect(params[7]).toBe(1); // message_count (session-level)
+
+      // Clean up
+      await rm(sessionsDir, { recursive: true, force: true });
+    });
+  });
+});

--- a/web/src/components/app/activity-pane.tsx
+++ b/web/src/components/app/activity-pane.tsx
@@ -22,7 +22,15 @@ import {
   useActivityHeatmap,
   useActivityStats,
   useDailyStatus,
+  useTokenStats,
+  useTokenDaily,
+  useTokenByModel,
+  useTokenByProject,
   type DailyStatusEntry,
+  type TokenDailyEntry,
+  type TokenStats,
+  type TokenByModel,
+  type TokenByProject,
 } from "@/hooks/use-activity";
 
 type ActivityPaneProps = {
@@ -77,10 +85,10 @@ function StatCard({
   sub?: string;
 }) {
   return (
-    <div className="rounded-md border border-border bg-muted/40 px-4 py-3">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-foreground">{value}</p>
-      {sub && <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p>}
+    <div className="min-w-0 rounded-md border border-border bg-muted/40 px-2.5 py-2 sm:px-4 sm:py-3">
+      <p className="text-[10px] sm:text-xs text-muted-foreground">{label}</p>
+      <p className="mt-0.5 sm:mt-1 text-lg sm:text-2xl font-semibold text-foreground">{value}</p>
+      {sub && <p className="mt-0.5 text-[10px] sm:text-xs text-muted-foreground">{sub}</p>}
     </div>
   );
 }
@@ -167,8 +175,8 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
   const { cells, months, max } = useMemo(() => buildHeatmapGrid(data), [data]);
 
   return (
-    <div className="overflow-hidden">
-      <div className="flex pl-8 mb-1">
+    <div style={{ maxWidth: "calc(100vw - 24px)" }} className="overflow-x-auto">
+      <div className="flex pl-8 mb-1 w-max">
         {months.map((m, i) => {
           const nextCol = months[i + 1]?.col ?? cells.length;
           const span = nextCol - m.col;
@@ -184,7 +192,7 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
         })}
       </div>
 
-      <div className="flex gap-0">
+      <div className="flex gap-0 w-max">
         <div className="flex flex-col gap-[2px] pr-1.5 pt-0">
           {DAY_LABELS.map((label, i) => (
             <span
@@ -229,16 +237,16 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
 
 // ── Daily stacked bar chart (recharts) ──────────────────────────────
 
-function fillGaps(data: DailyStatusEntry[]): DailyStatusEntry[] {
+function fillGaps<T extends { day: string }>(data: T[], defaultEntry: (day: string) => T): T[] {
   if (data.length < 2) return data;
-  const filled: DailyStatusEntry[] = [];
+  const filled: T[] = [];
   const dataMap = new Map(data.map((d) => [d.day, d]));
   const start = new Date(data[0].day + "T00:00:00");
   const end = new Date(data[data.length - 1].day + "T00:00:00");
   const cursor = new Date(start);
   while (cursor <= end) {
     const iso = cursor.toISOString().slice(0, 10);
-    filled.push(dataMap.get(iso) ?? { day: iso });
+    filled.push(dataMap.get(iso) ?? defaultEntry(iso));
     cursor.setDate(cursor.getDate() + 1);
   }
   return filled;
@@ -246,7 +254,7 @@ function fillGaps(data: DailyStatusEntry[]): DailyStatusEntry[] {
 
 function DailyStackedBarChart({ data: rawData }: { data: DailyStatusEntry[] }) {
   const chartData = useMemo(() => {
-    const filled = fillGaps(rawData);
+    const filled = fillGaps<DailyStatusEntry>(rawData, (day) => ({ day }));
     return filled.map((d) => ({
       day: d.day,
       label: formatDate(d.day),
@@ -265,7 +273,7 @@ function DailyStackedBarChart({ data: rawData }: { data: DailyStatusEntry[] }) {
   }
 
   return (
-    <ChartContainer config={chartConfig} className="aspect-[2.5/1] w-full">
+    <ChartContainer config={chartConfig} className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full">
       <BarChart data={chartData} barCategoryGap="20%">
         <CartesianGrid vertical={false} />
         <XAxis
@@ -299,7 +307,7 @@ function DailyStackedBarChart({ data: rawData }: { data: DailyStatusEntry[] }) {
             />
           }
         />
-        <ChartLegend content={<ChartLegendContent />} />
+        <ChartLegend content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />} />
         {STATUS_ORDER.map((key) => (
           <Bar
             key={key}
@@ -314,14 +322,216 @@ function DailyStackedBarChart({ data: rawData }: { data: DailyStatusEntry[] }) {
   );
 }
 
+// ── Token helpers ──────────────────────────────────────────────────
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return String(n);
+}
+
+function cacheHitRate(stats: TokenStats): number {
+  const totalInput = stats.total_input + stats.total_cache_creation + stats.total_cache_read;
+  if (totalInput === 0) return 0;
+  return Math.round((stats.total_cache_read / totalInput) * 100);
+}
+
+function shortModelName(model: string): string {
+  if (model.includes("opus")) return "Opus";
+  if (model.includes("sonnet")) return "Sonnet";
+  if (model.includes("haiku")) return "Haiku";
+  if (model.includes("gpt-5")) return "GPT-5";
+  if (model.includes("gpt-4")) return "GPT-4";
+  return model;
+}
+
+function shortProjectName(projectDir: string): string {
+  const parts = projectDir.split("/").filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : projectDir;
+}
+
+// ── Token daily chart ─────────────────────────────────────────────
+
+const TOKEN_ORDER = ["input_tokens", "cache_read_tokens", "cache_creation_tokens", "output_tokens"];
+
+const tokenChartConfig: ChartConfig = {
+  input_tokens: { label: "Input", color: "hsl(217, 91%, 60%)" },
+  cache_read_tokens: { label: "Cache read", color: "hsl(172, 66%, 50%)" },
+  cache_creation_tokens: { label: "Cache write", color: "hsl(189, 94%, 43%)" },
+  output_tokens: { label: "Output", color: "hsl(38, 92%, 50%)" },
+};
+
+const EMPTY_TOKEN_ENTRY = (day: string): TokenDailyEntry => ({
+  day,
+  input_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_read_tokens: 0,
+  output_tokens: 0,
+  messages: 0,
+});
+
+function DailyTokenChart({ data: rawData }: { data: TokenDailyEntry[] }) {
+  const chartData = useMemo(() => {
+    const filled = fillGaps(rawData, EMPTY_TOKEN_ENTRY);
+    return filled.map((d) => ({ ...d, label: formatDate(d.day) }));
+  }, [rawData]);
+
+  if (chartData.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+        No token data yet
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer config={tokenChartConfig} className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full">
+      <BarChart data={chartData} barCategoryGap="20%">
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          interval="preserveStartEnd"
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              formatter={(value, name) => (
+                <>
+                  <div
+                    className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                    style={{
+                      backgroundColor: tokenChartConfig[name as string]?.color,
+                    }}
+                  />
+                  <div className="flex flex-1 items-center justify-between gap-8">
+                    <span className="text-muted-foreground">
+                      {tokenChartConfig[name as string]?.label ?? name}
+                    </span>
+                    <span className="font-mono font-medium text-foreground tabular-nums">
+                      {formatTokenCount(value as number)}
+                    </span>
+                  </div>
+                </>
+              )}
+              labelFormatter={(label) => label as string}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />} />
+        {TOKEN_ORDER.map((key) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            stackId="tokens"
+            fill={tokenChartConfig[key]?.color}
+            radius={key === "output_tokens" ? [2, 2, 0, 0] : 0}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+// ── Horizontal bar helper ──────────────────────────────────────────
+
+function HorizontalBar({
+  label,
+  value,
+  maxValue,
+  color = "bg-emerald-500/70",
+  sub,
+}: {
+  label: string;
+  value: number;
+  maxValue: number;
+  color?: string;
+  sub?: string;
+}) {
+  const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="truncate text-foreground">{label}</span>
+        <span className="ml-2 shrink-0 font-mono text-muted-foreground tabular-nums">
+          {formatTokenCount(value)}{sub ? ` ${sub}` : ""}
+        </span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-muted/60">
+        <div
+          className={cn("h-2 rounded-full transition-all", color)}
+          style={{ width: `${Math.max(pct, 1)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Per-model breakdown ───────────────────────────────────────────
+
+function ModelBreakdown({ data }: { data: TokenByModel[] }) {
+  if (data.length === 0) return null;
+  const max = Math.max(...data.map((m) => m.total_input + m.total_cache_creation + m.total_cache_read + m.total_output));
+
+  return (
+    <div className="space-y-3">
+      {data.map((m) => {
+        const total = m.total_input + m.total_cache_creation + m.total_cache_read + m.total_output;
+        return (
+          <HorizontalBar
+            key={m.model}
+            label={shortModelName(m.model)}
+            value={total}
+            maxValue={max}
+            color="bg-blue-500/70"
+            sub={`· ${m.sessions} session${m.sessions !== 1 ? "s" : ""}`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Per-project breakdown ─────────────────────────────────────────
+
+function ProjectBreakdown({ data }: { data: TokenByProject[] }) {
+  if (data.length === 0) return null;
+  const max = Math.max(...data.map((p) => p.total_input + p.total_output));
+
+  return (
+    <div className="space-y-3">
+      {data.map((p) => (
+        <HorizontalBar
+          key={p.project_dir}
+          label={shortProjectName(p.project_dir)}
+          value={p.total_input + p.total_output}
+          maxValue={max}
+          color="bg-emerald-500/70"
+        />
+      ))}
+    </div>
+  );
+}
+
 // ── Main pane ───────────────────────────────────────────────────────
 
 export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element {
   const { data: heatmapData } = useActivityHeatmap();
   const { data: stats } = useActivityStats();
   const { data: dailyStatus } = useDailyStatus(30);
+  const { data: tokenStats } = useTokenStats();
+  const { data: tokenDaily } = useTokenDaily(30);
+  const { data: tokenByModel } = useTokenByModel();
+  const { data: tokenByProject } = useTokenByProject();
 
   const hasData = stats && (stats.totalWorkingMs > 0 || stats.avgBlockedMs > 0 || stats.avgWaitingMs > 0);
+  const totalTokens = tokenStats
+    ? tokenStats.total_input + tokenStats.total_cache_creation + tokenStats.total_cache_read + tokenStats.total_output
+    : 0;
+  const hasTokenData = totalTokens > 0;
 
   return (
     <DialogPrimitive.Root
@@ -351,7 +561,7 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
 
           {/* Body */}
           <ScrollArea className="flex-1">
-            <div className="mx-auto max-w-3xl space-y-8 px-5 py-6 md:px-8">
+            <div className="mx-auto max-w-3xl min-w-0 overflow-hidden space-y-6 sm:space-y-8 px-3 py-4 sm:px-5 sm:py-6 md:px-8">
               {/* Stats row */}
               {stats && hasData && (
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -398,8 +608,69 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
                 </div>
               )}
 
+              {/* Token usage stats */}
+              {hasTokenData && tokenStats && (
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
+                  <StatCard
+                    label="Total tokens"
+                    value={formatTokenCount(totalTokens)}
+                    sub={`${formatTokenCount(tokenStats.total_output)} output`}
+                  />
+                  <StatCard
+                    label="Cache hit rate"
+                    value={`${cacheHitRate(tokenStats)}%`}
+                    sub="of input from cache"
+                  />
+                  <StatCard
+                    label="Avg tokens / session"
+                    value={
+                      tokenStats.total_sessions > 0
+                        ? formatTokenCount(Math.round(totalTokens / tokenStats.total_sessions))
+                        : "—"
+                    }
+                  />
+                  <StatCard
+                    label="Sessions"
+                    value={tokenStats.total_sessions}
+                    sub={`${tokenStats.total_messages} messages`}
+                  />
+                </div>
+              )}
+
+              {/* Daily token chart */}
+              {tokenDaily && tokenDaily.length > 0 && (
+                <div>
+                  <h2 className="mb-3 text-sm font-medium text-foreground">
+                    Daily token usage (last 30 days)
+                  </h2>
+                  <DailyTokenChart data={tokenDaily} />
+                </div>
+              )}
+
+              {/* Model & project breakdowns side by side */}
+              {hasTokenData && (tokenByModel?.length || tokenByProject?.length) ? (
+                <div className="grid gap-6 sm:grid-cols-2">
+                  {tokenByModel && tokenByModel.length > 0 && (
+                    <div>
+                      <h2 className="mb-3 text-sm font-medium text-foreground">
+                        Tokens by model
+                      </h2>
+                      <ModelBreakdown data={tokenByModel} />
+                    </div>
+                  )}
+                  {tokenByProject && tokenByProject.length > 0 && (
+                    <div>
+                      <h2 className="mb-3 text-sm font-medium text-foreground">
+                        Tokens by project
+                      </h2>
+                      <ProjectBreakdown data={tokenByProject} />
+                    </div>
+                  )}
+                </div>
+              ) : null}
+
               {/* Empty state */}
-              {stats && !hasData && (!heatmapData || heatmapData.length === 0) && (
+              {stats && !hasData && (!heatmapData || heatmapData.length === 0) && !hasTokenData && (
                 <div className="py-12 text-center text-sm text-muted-foreground">
                   No activity yet. Stats will appear here as agents run.
                 </div>

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -31,6 +31,7 @@ export function useActivityHeatmap(days = 365) {
       );
       return payload.days;
     },
+    staleTime: 60_000,
   });
 }
 
@@ -38,6 +39,7 @@ export function useActivityStats() {
   return useQuery<ActivityStats>({
     queryKey: ["activity", "stats"],
     queryFn: () => api<ActivityStats>("/api/v1/activity/stats"),
+    staleTime: 60_000,
   });
 }
 
@@ -50,5 +52,86 @@ export function useDailyStatus(days = 30) {
       );
       return payload.days;
     },
+    staleTime: 60_000,
   });
 }
+
+// ── Token usage ───────────────────────────────────────────────────
+
+export type TokenStats = {
+  total_input: number;
+  total_cache_creation: number;
+  total_cache_read: number;
+  total_output: number;
+  total_messages: number;
+  total_sessions: number;
+};
+
+export type TokenDailyEntry = {
+  day: string;
+  input_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  output_tokens: number;
+  messages: number;
+};
+
+export function useTokenStats() {
+  return useQuery<TokenStats>({
+    queryKey: ["activity", "token-stats"],
+    queryFn: () => api<TokenStats>("/api/v1/activity/token-stats"),
+    staleTime: 60_000,
+  });
+}
+
+export function useTokenDaily(days = 30) {
+  return useQuery<TokenDailyEntry[]>({
+    queryKey: ["activity", "token-daily", days],
+    queryFn: async () => {
+      const payload = await api<{ days: TokenDailyEntry[] }>(
+        `/api/v1/activity/token-daily?days=${days}`
+      );
+      return payload.days;
+    },
+    staleTime: 60_000,
+  });
+}
+
+export type TokenByModel = {
+  model: string;
+  total_input: number;
+  total_cache_creation: number;
+  total_cache_read: number;
+  total_output: number;
+  sessions: number;
+};
+
+export type TokenByProject = {
+  project_dir: string;
+  total_input: number;
+  total_output: number;
+  messages: number;
+};
+
+export function useTokenByModel() {
+  return useQuery<TokenByModel[]>({
+    queryKey: ["activity", "token-by-model"],
+    queryFn: async () => {
+      const payload = await api<{ models: TokenByModel[] }>("/api/v1/activity/token-by-model");
+      return payload.models;
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useTokenByProject() {
+  return useQuery<TokenByProject[]>({
+    queryKey: ["activity", "token-by-project"],
+    queryFn: async () => {
+      const payload = await api<{ projects: TokenByProject[] }>("/api/v1/activity/token-by-project");
+      return payload.projects;
+    },
+    staleTime: 60_000,
+  });
+}
+


### PR DESCRIPTION
## Summary
- Adds token usage tracking by parsing Claude Code JSONL session logs and Codex rollout files at agent stop/delete
- New `agent_token_usage` table with FK to agents (leverages soft delete — no denormalized agent_name/project_dir)
- Activity pane now shows: stat cards (total tokens, cache hit rate, avg tokens/session, sessions), daily stacked bar chart, tokens by model, tokens by project
- Codex agent correlation via `[dispatch:agent_id]` tag injected into launch guidance
- Normalizes Codex cached tokens (subset model) to Claude's additive model for apples-to-apples comparison
- Mobile-responsive layout: 2x2 stat cards, taller charts, scrollable heatmap, stacked breakdowns

## New files
- `src/agents/token-harvester.ts` — JSONL parsing for Claude + Codex, DB upsert
- `e2e/token-usage.spec.ts` — 6 E2E tests for API endpoints and UI
- `test/token-harvester.test.ts` — 8 unit tests for harvester logic

## Test plan
- [x] `npm run check` — types clean
- [x] `npm run finalize:web` — production build passes
- [x] `npm test` — 8 unit tests pass
- [x] `npm run test:e2e` — 71 E2E tests pass (6 pre-existing skips)
- [x] Visual validation on desktop and mobile (390px) via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)