### PR TITLE
Refine sidebar focus and expansion flow

### DIFF
--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -1,24 +1,25 @@
 import { test, expect } from "@playwright/test";
 import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
 
+const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
 test.describe("Agent CRUD", () => {
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);
   });
 
   test("displays 'No agents yet' when the list is empty", async ({ page, request }) => {
-    const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
     // Stop and delete only e2e-prefixed agents (never touch real agents)
-    const listRes = await request.get("/api/v1/agents", { headers: authHeader });
+    const listRes = await request.get("/api/v1/agents", { headers: AUTH_HEADER });
     const { agents } = (await listRes.json()) as { agents: Array<{ id: string; name: string; status: string }> };
     const e2eAgents = agents.filter((a) => a.name.startsWith("e2e-agent-"));
     for (const agent of e2eAgents) {
       if (agent.status !== "stopped") {
-        await request.post(`/api/v1/agents/${agent.id}/stop`, { headers: authHeader });
+        await request.post(`/api/v1/agents/${agent.id}/stop`, { headers: AUTH_HEADER });
       }
     }
     for (const agent of e2eAgents) {
-      await request.delete(`/api/v1/agents/${agent.id}`, { headers: authHeader });
+      await request.delete(`/api/v1/agents/${agent.id}`, { headers: AUTH_HEADER });
     }
 
     // Skip empty-state assertion if non-e2e agents remain
@@ -88,20 +89,45 @@ test.describe("Agent CRUD", () => {
     await expect(sidebar.getByText(agent.name)).toBeVisible({ timeout: 5_000 });
   });
 
-  test("selecting an agent expands its details in the sidebar", async ({
+  test("caret expands an agent without focusing it", async ({
     page,
     request,
   }) => {
     const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
     await loadApp(page);
 
-    // Click the agent name to select it
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
-    await agentCard.getByText(agent.name).click();
+    await page.getByTestId(`agent-expand-toggle-${agent.id}`).click();
 
-    // The expanded card should show "Working dir" metadata
     await expect(agentCard.getByText("Working dir")).toBeVisible({ timeout: 3_000 });
     await expect(agentCard.getByText("/tmp")).toBeVisible();
+    await expect(page.getByTestId("terminal-empty-state")).toBeVisible();
+  });
+
+  test("attached agent stays expanded while another agent is toggled open", async ({
+    page,
+    request,
+  }) => {
+    const attachedAgent = await createAgentViaAPI(request, { name: `e2e-agent-attached-${Date.now()}` });
+    const peekAgent = await createAgentViaAPI(request, { name: `e2e-agent-peek-${Date.now()}` });
+
+    await request.post(`/api/v1/agents/${attachedAgent.id}/start`, { headers: AUTH_HEADER });
+    await request.post(`/api/v1/agents/${peekAgent.id}/start`, { headers: AUTH_HEADER });
+
+    await loadApp(page);
+
+    const attachedCard = page.getByTestId(`agent-card-${attachedAgent.id}`);
+    const peekCard = page.getByTestId(`agent-card-${peekAgent.id}`);
+
+    await page.getByTestId(`agent-row-${attachedAgent.id}`).click();
+    await expect(page.getByTestId("detach-button")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId(`agent-expand-toggle-${attachedAgent.id}`)).toBeDisabled();
+    await expect(attachedCard.getByText("Working dir")).toBeVisible({ timeout: 3_000 });
+
+    await page.getByTestId(`agent-expand-toggle-${peekAgent.id}`).click();
+
+    await expect(attachedCard.getByText("Working dir")).toBeVisible();
+    await expect(peekCard.getByText("Working dir")).toBeVisible();
   });
 
   test("delete agent via overflow menu removes it from sidebar", async ({
@@ -116,7 +142,7 @@ test.describe("Agent CRUD", () => {
 
     // Click the Archive button on the agent card
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
-    await agentCard.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // Confirm the archive
     await page.getByTestId("delete-agent-confirm").click();

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -22,7 +22,7 @@ test.describe("App shell", () => {
 
     await expect(page.getByTestId("terminal-empty-state")).toBeVisible();
     await expect(page.getByTestId("terminal-empty-state")).toContainText(
-      "Select an agent"
+      "Tap an agent row to focus it."
     );
   });
 

--- a/e2e/header-overflow.spec.ts
+++ b/e2e/header-overflow.spec.ts
@@ -18,13 +18,11 @@ test.describe("Header overflow", () => {
     await loadApp(page);
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
-    await agentCard.getByText(agent.name).click();
-
-    const attachButton = page.getByTestId("attach-button");
-    await expect(attachButton).toBeVisible({ timeout: 10_000 });
-    await attachButton.click();
+    await agentCard.waitFor({ state: "visible", timeout: 10_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
 
     const status = page.getByTestId("app-header-status");
+    await expect(status).toBeVisible({ timeout: 10_000 });
     await expect(status).toHaveAttribute("title", longMessage);
     await expect(status).toContainText("This is a deliberately long agent description");
 

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -79,14 +79,9 @@ test.describe("Terminal live connection", () => {
     const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
     await loadApp(page);
 
-    // Select the agent and click play/attach
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await agentCard.waitFor({ state: "visible", timeout: 5_000 });
-    await agentCard.getByText(agent.name).click();
-
-    // The agent is already running, so we should see "Attach to session" button
-    const attachBtn = agentCard.locator('[data-agent-control="true"]').first();
-    await attachBtn.click();
+    await page.getByTestId(`agent-row-${agent.id}`).click();
 
     // Terminal should connect within 3 seconds
     await waitForTerminalConnected(page, 3_000);
@@ -101,9 +96,7 @@ test.describe("Terminal live connection", () => {
     // Attach to the agent's terminal
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await agentCard.waitFor({ state: "visible", timeout: 5_000 });
-    await agentCard.getByText(agent.name).click();
-    const attachBtn = agentCard.locator('[data-agent-control="true"]').first();
-    await attachBtn.click();
+    await page.getByTestId(`agent-row-${agent.id}`).click();
     await waitForTerminalConnected(page, 5_000);
 
     // Now create 3 agents rapidly to trigger SSE agent.upsert events
@@ -130,9 +123,7 @@ test.describe("Terminal live connection", () => {
     // Attach to terminal
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await agentCard.waitFor({ state: "visible", timeout: 5_000 });
-    await agentCard.getByText(agent.name).click();
-    const attachBtn = agentCard.locator('[data-agent-control="true"]').first();
-    await attachBtn.click();
+    await page.getByTestId(`agent-row-${agent.id}`).click();
     await waitForTerminalConnected(page, 5_000);
 
     // Stop the agent
@@ -146,12 +137,9 @@ test.describe("Terminal live connection", () => {
       headers: authHeaders(),
     });
 
-    // Re-attach — click the agent card again and attach
-    await agentCard.getByText(agent.name).click();
-    // Wait for the play/attach button to appear after status update
+    // Re-attach by tapping the row again after the status update.
     await page.waitForTimeout(500);
-    const reattachBtn = agentCard.locator('[data-agent-control="true"]').first();
-    await reattachBtn.click();
+    await page.getByTestId(`agent-row-${agent.id}`).click();
 
     // Should reconnect within a reasonable time
     await waitForTerminalConnected(page, 5_000);
@@ -171,11 +159,8 @@ test.describe("Terminal live connection", () => {
 
     // Switch back and forth 5 times
     for (let i = 0; i < 5; i++) {
-      const card = i % 2 === 0 ? cardA : cardB;
-      const name = i % 2 === 0 ? agentA.name : agentB.name;
-      await card.getByText(name).click();
-      const btn = card.locator('[data-agent-control="true"]').first();
-      await btn.click();
+      const targetAgentId = i % 2 === 0 ? agentA.id : agentB.id;
+      await page.getByTestId(`agent-row-${targetAgentId}`).click();
       await page.waitForTimeout(300);
     }
 
@@ -198,9 +183,7 @@ test.describe("Terminal live connection", () => {
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await agentCard.waitFor({ state: "visible", timeout: 5_000 });
-    await agentCard.getByText(agent.name).click();
-    const attachBtn = agentCard.locator('[data-agent-control="true"]').first();
-    await attachBtn.click();
+    await page.getByTestId(`agent-row-${agent.id}`).click();
     await waitForTerminalConnected(page, 5_000);
     await expect.poll(() => tokenRequests).toBe(1);
 

--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -161,7 +161,7 @@ test.describe("Worktree", () => {
 
     // Click the Archive button on the agent card
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
-    await agentCard.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // Should show standard archive confirmation (not worktree choice)
     await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });
@@ -434,7 +434,7 @@ test.describe("Worktree filesystem", () => {
     await expect(agentCard).toBeVisible({ timeout: 5_000 });
 
     // Click the Archive button
-    await agentCard.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // First step: standard archive confirmation
     await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });
@@ -482,7 +482,7 @@ test.describe("Worktree filesystem", () => {
     await expect(agentCard2).toBeVisible({ timeout: 5_000 });
 
     // Click the Archive button
-    await agentCard2.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // First step: standard archive confirmation
     await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -150,6 +150,7 @@ export function App(): JSX.Element {
   const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
   const [docsPaneOpen, setDocsPaneOpen] = useState(false);
   const [activityPaneOpen, setActivityPaneOpen] = useState(false);
+  const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
 
   // ── Agents (placeholder connectedAgentId — filled by terminal hook) ──
   // We use a temporary variable; useAgents only needs connectedAgentId for
@@ -175,6 +176,13 @@ export function App(): JSX.Element {
 
   selectedAgentIdRef.current = selectedAgentId;
 
+  const focusedAgentId = sharedConnState === "connected" || sharedConnState === "reconnecting"
+    ? (sharedConnectedAgentId ?? selectedAgentId)
+    : null;
+  const focusedAgent = focusedAgentId
+    ? agents.find((agent) => agent.id === focusedAgentId) ?? null
+    : null;
+
   const {
     mediaFiles,
     animatingMediaKeys,
@@ -186,17 +194,27 @@ export function App(): JSX.Element {
     mediaViewportRef,
     refreshMedia,
     markSeenInCache,
-  } = useMedia(selectedAgentId, mediaPanelOpen);
+  } = useMedia(focusedAgentId, mediaPanelOpen);
 
-  const selectedAgentHasStream = selectedAgentId ? streamingAgentIds.has(selectedAgentId) : false;
-  const selectedAgentStreamUrl = selectedAgentId ? `/api/v1/agents/${selectedAgentId}/stream` : null;
+  const focusedAgentHasStream = focusedAgentId ? streamingAgentIds.has(focusedAgentId) : false;
+  const focusedAgentStreamUrl = focusedAgentId ? `/api/v1/agents/${focusedAgentId}/stream` : null;
+
+  const ensureAuxExpanded = useCallback((agentId: string) => {
+    setExpandedAgentId((current) => {
+      if (current === null || current === agentId) {
+        return agentId;
+      }
+      return current;
+    });
+  }, []);
 
   // ── Terminal ──────────────────────────────────────────────────────────
   const onAgentSelected = useCallback(
     (agentId: string) => {
       setSelectedAgentId(agentId);
+      ensureAuxExpanded(agentId);
     },
-    [setSelectedAgentId]
+    [ensureAuxExpanded, setSelectedAgentId]
   );
 
   const {
@@ -233,6 +251,13 @@ export function App(): JSX.Element {
     setSharedConnState(connState);
   }, [connState]);
 
+  useEffect(() => {
+    if (expandedAgentId && agents.some((agent) => agent.id === expandedAgentId)) {
+      return;
+    }
+    setExpandedAgentId(null);
+  }, [agents, expandedAgentId]);
+
   // Re-sort agents when connected agent changes.
   useEffect(() => {
     resortAgents();
@@ -242,7 +267,7 @@ export function App(): JSX.Element {
   connectedAgentIdRef.current = connectedAgentId;
 
   // ── Focus tracking (notification suppression) ─────────────────────────
-  useAgentFocus(selectedAgentId, authState);
+  useAgentFocus(focusedAgentId, authState);
 
   // ── SSE ───────────────────────────────────────────────────────────────
   useSSE(authState, connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, markSeenInCache);
@@ -281,7 +306,7 @@ export function App(): JSX.Element {
 
   // ── Persist last-used CWD ─────────────────────────────────────────────
   useEffect(() => {
-    const lastUsedCwd = agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
+    const lastUsedCwd = agentProjectRoot(connectedAgent) || agentProjectRoot(selectedAgent);
     if (lastUsedCwd) {
       window.localStorage.setItem(LAST_USED_CWD_KEY, lastUsedCwd);
     }
@@ -330,7 +355,6 @@ export function App(): JSX.Element {
 
   // ── Derived values ────────────────────────────────────────────────────
   const isAttached = connState === "connected" && Boolean(connectedAgentId);
-  const canAttachSelected = Boolean(selectedAgent && selectedAgent.status === "running" && !isAttached);
   const showHeaderStatus = connState !== "disconnected";
 
   const statusText = useMemo(() => {
@@ -343,9 +367,8 @@ export function App(): JSX.Element {
       return `Connected to session ${connectedAgent.name}`;
     }
     if (apiState === "down") return "Unable to reach API service.";
-    if (selectedAgent) return `Ready to attach to session ${selectedAgent.name}`;
-    return "Select an agent to open a session.";
-  }, [apiState, connectedAgent, connState, selectedAgent]);
+    return "Tap an agent row to focus it.";
+  }, [apiState, connectedAgent, connState]);
 
   // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
@@ -368,25 +391,25 @@ export function App(): JSX.Element {
 
   const toggleAgentDetails = useCallback(
     (agentId: string) => {
-      const nextId = selectedAgentId === agentId ? null : agentId;
-      setSelectedAgentId(nextId);
-      refreshMedia(nextId);
+      setExpandedAgentId((current) => (current === agentId ? null : agentId));
     },
-    [refreshMedia, selectedAgentId, setSelectedAgentId]
+    []
   );
 
   const attachToAgent = useCallback(
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
+      ensureAuxExpanded(agent.id);
       refreshMedia(agent.id);
       await ensureTerminalConnected(true, true, agent.id);
     },
-    [ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [ensureAuxExpanded, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
 
   const startAgent = useCallback(
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
+      ensureAuxExpanded(agent.id);
       await api(`/api/v1/agents/${agent.id}/start`, {
         method: "POST",
         body: JSON.stringify({}),
@@ -394,20 +417,25 @@ export function App(): JSX.Element {
       refreshMedia(agent.id);
       await ensureTerminalConnected(true, true, agent.id);
     },
-    [ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [ensureAuxExpanded, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
+
+  const detachAndClearSelection = useCallback(() => {
+    detachTerminal();
+    setSelectedAgentId(null);
+  }, [detachTerminal, setSelectedAgentId]);
 
   const stopAgent = useCallback(
     async (agent: Agent) => {
       if (connectedAgentId === agent.id) {
-        detachTerminal();
+        detachAndClearSelection();
       }
       await api(`/api/v1/agents/${agent.id}/stop`, {
         method: "POST",
         body: JSON.stringify({ force: true }),
       });
     },
-    [connectedAgentId, detachTerminal]
+    [connectedAgentId, detachAndClearSelection]
   );
 
   const deleteAgent = useCallback(
@@ -464,6 +492,7 @@ export function App(): JSX.Element {
         setLastUsedAgentType(createType);
         setCwdHistory(addToCwdHistory(createCwd.trim()));
         setSelectedAgentId(payload.agent.id);
+        ensureAuxExpanded(payload.agent.id);
         refreshMedia(payload.agent.id);
         // Small delay to let tmux session start before connecting
         setTimeout(() => void ensureTerminalConnected(true, true, payload.agent.id), 300);
@@ -471,13 +500,8 @@ export function App(): JSX.Element {
         setCreating(false);
       }
     },
-    [createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
+    [createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia, setSelectedAgentId]
   );
-
-  const attachSelectedAgent = useCallback(() => {
-    if (!selectedAgent || (selectedAgent.status !== "running" && selectedAgent.status !== "creating")) return;
-    void attachToAgent(selectedAgent);
-  }, [attachToAgent, selectedAgent]);
 
   const borderForAgentState = (state: AgentVisualState): string => {
     if (state === "active") return "border-r-status-done";
@@ -512,6 +536,7 @@ export function App(): JSX.Element {
               leftOpen={leftOpen}
               agents={agents}
               selectedAgentId={selectedAgentId}
+              expandedAgentId={expandedAgentId}
               overflowAgentId={overflowAgentId}
               setLeftOpen={setLeftOpen}
               onOpenCreateDialog={openCreateDialog}
@@ -552,17 +577,14 @@ export function App(): JSX.Element {
               statusText={statusText}
               showReconnectIndicator={connState === "reconnecting"}
               isAttached={isAttached}
-              canAttachSelected={canAttachSelected}
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}
               setMediaOpen={handleSetMediaPanelOpen}
-              attachSelectedAgent={attachSelectedAgent}
-              detachTerminal={detachTerminal}
+              detachTerminal={detachAndClearSelection}
             />
 
             <TerminalPane
               isAttached={isAttached}
-              hasSelectedAgent={Boolean(selectedAgentId)}
               connState={connState}
               statusMessage={statusMessage}
               terminalMode={terminalMode}
@@ -584,14 +606,14 @@ export function App(): JSX.Element {
           <MediaSidebar
             mediaOpen={mediaOpen}
             mediaFiles={mediaFiles}
-            selectedAgentId={selectedAgentId}
-            selectedAgentName={selectedAgent?.name ?? null}
+            selectedAgentId={focusedAgentId}
+            selectedAgentName={focusedAgent?.name ?? null}
             animatingMediaKeys={animatingMediaKeys}
 
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
-            hasStream={selectedAgentHasStream}
-            streamUrl={selectedAgentStreamUrl}
+            hasStream={focusedAgentHasStream}
+            streamUrl={focusedAgentStreamUrl}
             openLightbox={openLightbox}
           />
         </div>
@@ -610,6 +632,7 @@ export function App(): JSX.Element {
           <AgentSidebarContent
             agents={agents}
             selectedAgentId={selectedAgentId}
+            expandedAgentId={expandedAgentId}
             overflowAgentId={overflowAgentId}
             onOpenCreateDialog={(type?: AgentType) => { setMobileLeftOpen(false); openCreateDialog(type); }}
             enabledAgentTypes={enabledAgentTypes}
@@ -624,7 +647,7 @@ export function App(): JSX.Element {
             borderForAgentState={borderForAgentState}
             toggleAgentDetails={toggleAgentDetails}
             isFullAccessEnabled={isFullAccessEnabled}
-            detachTerminal={detachTerminal}
+            detachTerminal={detachAndClearSelection}
             attachToAgent={attachToAgent}
             stopAgent={stopAgent}
             startAgent={startAgent}
@@ -646,13 +669,13 @@ export function App(): JSX.Element {
         >
             <MediaSidebarContent
               mediaFiles={mediaFiles}
-              selectedAgentId={selectedAgentId}
-              selectedAgentName={selectedAgent?.name ?? null}
+              selectedAgentId={focusedAgentId}
+              selectedAgentName={focusedAgent?.name ?? null}
               animatingMediaKeys={animatingMediaKeys}
   
               mediaViewportRef={mediaViewportRef}
-              hasStream={selectedAgentHasStream}
-              streamUrl={selectedAgentStreamUrl}
+              hasStream={focusedAgentHasStream}
+              streamUrl={focusedAgentStreamUrl}
               openLightbox={openLightbox}
               onRequestClose={() => setMobileMediaOpen(false)}
             />

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -5,8 +5,6 @@ import {
   BookOpenText,
   ChevronDown,
   ChevronLeft,
-  Eye,
-  EyeOff,
   Loader2,
   Play,
   Square,
@@ -28,6 +26,7 @@ import { cn } from "@/lib/utils";
 type AgentSidebarSharedProps = {
   agents: Agent[];
   selectedAgentId: string | null;
+  expandedAgentId: string | null;
   overflowAgentId: string | null;
   onOpenCreateDialog: (type?: AgentType) => void;
   enabledAgentTypes: AgentType[];
@@ -63,6 +62,7 @@ type AgentSidebarContentProps = AgentSidebarSharedProps & {
 export function AgentSidebarContent({
   agents,
   selectedAgentId,
+  expandedAgentId,
   overflowAgentId: _overflowAgentId,
   onOpenCreateDialog,
   enabledAgentTypes,
@@ -200,7 +200,7 @@ export function AgentSidebarContent({
               const isSelected = selectedAgentId === agent.id;
               const isStopped = state === "stopped";
               const isActive = state === "active";
-              const isExpanded = isSelected;
+              const isExpanded = isActive || expandedAgentId === agent.id;
               const fullAccessEnabled = isFullAccessEnabled(agent);
               const needsAttention = agent.status === "error";
 
@@ -218,25 +218,32 @@ export function AgentSidebarContent({
                   )}
                 >
                   <div
-                    className="flex cursor-pointer items-center gap-1.5"
+                    className={cn("flex items-center gap-1.5", !isStopped && "cursor-pointer")}
+                    data-testid={`agent-row-${agent.id}`}
                     onClick={(event) => {
                       const target = event.target as HTMLElement;
                       if (target.closest("[data-agent-control='true']")) {
                         return;
                       }
-                      toggleAgentDetails(agent.id);
+                      if (isStopped) {
+                        return;
+                      }
+                      if (isActive) {
+                        detachTerminal();
+                        return;
+                      }
+                      if (closeOnSessionAction) {
+                        onRequestClose?.();
+                      }
+                      void attachToAgent(agent);
                     }}
                   >
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
-                          data-agent-control="true"
-                          className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold"
-                          onClick={() => toggleAgentDetails(agent.id)}
-                        >
+                        <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
                           <AgentTypeIcon type={agent.type} eventType={agent.status === "running" ? agent.latestEvent?.type : null} />
                           <span className="truncate">{agent.name}</span>
-                        </button>
+                        </div>
                       </TooltipTrigger>
                       <TooltipContent>{agent.cwd}</TooltipContent>
                     </Tooltip>
@@ -270,56 +277,19 @@ export function AgentSidebarContent({
                         <TooltipContent>Resume<br /><span className="text-muted-foreground">Start agent session</span></TooltipContent>
                       </Tooltip>
                     ) : (
-                      <>
-                        {isActive ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                size="icon"
-                                variant="ghost-info"
-                                data-agent-control="true"
-                                onClick={detachTerminal}
-                              >
-                                <Eye className="h-3.5 w-3.5" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Unfocus<br /><span className="text-muted-foreground">Agent keeps running</span></TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                size="icon"
-                                variant="ghost"
-                                data-agent-control="true"
-                                onClick={() => {
-                                  if (closeOnSessionAction) {
-                                    onRequestClose?.();
-                                  }
-                                  void attachToAgent(agent);
-                                }}
-                              >
-                                <EyeOff className="h-3.5 w-3.5 opacity-40" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Focus<br /><span className="text-muted-foreground">Watch this agent</span></TooltipContent>
-                          </Tooltip>
-                        )}
-
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              size="icon"
-                              variant="ghost-warning"
-                              data-agent-control="true"
-                              onClick={() => void stopAgent(agent)}
-                            >
-                              <Square className="h-3.5 w-3.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>Stop<br /><span className="text-muted-foreground">End agent session</span></TooltipContent>
-                        </Tooltip>
-                      </>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            size="icon"
+                            variant="ghost-warning"
+                            data-agent-control="true"
+                            onClick={() => void stopAgent(agent)}
+                          >
+                            <Square className="h-3.5 w-3.5" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Stop<br /><span className="text-muted-foreground">End agent session</span></TooltipContent>
+                      </Tooltip>
                     )}
 
                     <Tooltip>
@@ -328,6 +298,7 @@ export function AgentSidebarContent({
                           size="icon"
                           variant="ghost-destructive"
                           data-agent-control="true"
+                          data-testid={`agent-archive-${agent.id}`}
                           className="ml-auto"
                           onClick={() => {
                             setDeleteTarget(agent);
@@ -338,6 +309,27 @@ export function AgentSidebarContent({
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>Archive<br /><span className="text-muted-foreground">Remove agent</span></TooltipContent>
+                    </Tooltip>
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          data-agent-control="true"
+                          data-testid={`agent-expand-toggle-${agent.id}`}
+                          disabled={isActive}
+                          onClick={() => {
+                            if (isActive) {
+                              return;
+                            }
+                            toggleAgentDetails(agent.id);
+                          }}
+                        >
+                          <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180", isActive && "opacity-40")} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{isActive ? "Attached agent stays open" : isExpanded ? "Hide details" : "Show details"}</TooltipContent>
                     </Tooltip>
                   </div>
 

--- a/web/src/components/app/app-header.tsx
+++ b/web/src/components/app/app-header.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, PanelLeftOpen, PanelRightOpen } from "lucide-react";
+import { Eye, PanelLeftOpen, PanelRightOpen } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -11,11 +11,9 @@ type AppHeaderProps = {
   statusText: string;
   showReconnectIndicator: boolean;
   isAttached: boolean;
-  canAttachSelected: boolean;
   unseenMediaCount: number;
   setLeftOpen: (open: boolean) => void;
   setMediaOpen: (open: boolean) => void;
-  attachSelectedAgent: () => void;
   detachTerminal: () => void;
 };
 
@@ -27,11 +25,9 @@ export function AppHeader({
   statusText,
   showReconnectIndicator,
   isAttached,
-  canAttachSelected,
   unseenMediaCount,
   setLeftOpen,
   setMediaOpen,
-  attachSelectedAgent,
   detachTerminal
 }: AppHeaderProps): JSX.Element {
   const compactSessionAction = mediaOpen && !isMobile;
@@ -107,17 +103,6 @@ export function AppHeader({
           >
             <Eye className="mr-1 h-3.5 w-3.5" />
             <span className={cn(compactSessionAction ? "hidden" : "hidden sm:inline")}>Unfocus</span>
-          </Button>
-        ) : canAttachSelected ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={attachSelectedAgent}
-            title="Focus on this agent"
-            data-testid="attach-button"
-          >
-            <EyeOff className="mr-1 h-3.5 w-3.5" />
-            <span className={cn(compactSessionAction ? "hidden" : "hidden sm:inline")}>Focus</span>
           </Button>
         ) : null}
 

--- a/web/src/components/app/media-sidebar.tsx
+++ b/web/src/components/app/media-sidebar.tsx
@@ -119,7 +119,7 @@ export function MediaSidebarContent({
       <div ref={mediaViewportRef} className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
         {mediaFiles.length === 0 && !hasStream ? (
           <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
-            {selectedAgentId ? "No media yet." : "Select an agent to view media."}
+            {selectedAgentId ? "No media yet." : "Focus an agent to view media."}
           </div>
         ) : mediaFiles.length === 0 ? null : (
           mediaFiles.map((file) => {

--- a/web/src/components/app/terminal-pane.tsx
+++ b/web/src/components/app/terminal-pane.tsx
@@ -6,7 +6,6 @@ import { cn } from "@/lib/utils";
 
 type TerminalPaneProps = {
   isAttached: boolean;
-  hasSelectedAgent: boolean;
   connState: ConnState;
   statusMessage: string;
   terminalMode: "tmux" | "inert" | null;
@@ -16,7 +15,6 @@ type TerminalPaneProps = {
 
 export const TerminalPane = memo(function TerminalPane({
   isAttached,
-  hasSelectedAgent,
   connState,
   statusMessage,
   terminalMode,
@@ -38,7 +36,7 @@ export const TerminalPane = memo(function TerminalPane({
     return () => window.clearTimeout(timer);
   }, [connState]);
 
-  const showEmptyState = connState === "disconnected" && !isAttached && !hasSelectedAgent;
+  const showEmptyState = connState === "disconnected" && !isAttached;
   const showInertState = terminalMode === "inert" && isAttached;
 
   return (
@@ -57,7 +55,7 @@ export const TerminalPane = memo(function TerminalPane({
         <div data-testid="terminal-empty-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
-            <p className="text-sm">Select an agent and press Resume to start.</p>
+            <p className="text-sm">Tap an agent row to focus it.</p>
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- make agent row taps drive attach and detach while moving details inspection to a dedicated caret
- keep the attached agent pinned open and remove the detached selection model from header/media state
- update Playwright coverage for the revised sidebar, terminal, and archive interactions

## Testing
- npm run check
- npm run finalize:web
- npm run test:e2e