### PR TITLE
Fix archive modal overflow and terminal reset after archive

### DIFF
--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -150,4 +150,27 @@ test.describe("Agent CRUD", () => {
     // Agent should disappear from sidebar
     await expect(sidebar.getByText(agent.name)).not.toBeVisible({ timeout: 5_000 });
   });
+
+  test("archiving the selected attached agent resets the terminal to empty state", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await expect(agentCard).toBeVisible({ timeout: 5_000 });
+
+    await agentCard.getByText(agent.name).click();
+    await page.getByTestId("attach-button").click();
+    await expect(page.getByTestId("terminal-inert-state")).toBeVisible({ timeout: 5_000 });
+
+    await agentCard.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId("delete-agent-confirm").click();
+
+    await expect(agentCard).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("terminal-empty-state")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("terminal-empty-state")).toContainText("Select an agent");
+    await expect(page.getByTestId("terminal-inert-state")).not.toBeVisible();
+  });
 });

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -161,16 +161,15 @@ test.describe("Agent CRUD", () => {
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await expect(agentCard).toBeVisible({ timeout: 5_000 });
 
-    await agentCard.getByText(agent.name).click();
-    await page.getByTestId("attach-button").click();
-    await expect(page.getByTestId("terminal-inert-state")).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await expect(page.getByTestId("detach-button")).toBeVisible({ timeout: 5_000 });
 
-    await agentCard.locator('[data-agent-control="true"]').last().click();
+    await page.getByTestId(`agent-archive-${agent.id}`).click();
     await page.getByTestId("delete-agent-confirm").click();
 
     await expect(agentCard).not.toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("terminal-empty-state")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("terminal-empty-state")).toContainText("Select an agent");
+    await expect(page.getByTestId("terminal-empty-state")).toContainText("Tap an agent row to focus it.");
     await expect(page.getByTestId("terminal-inert-state")).not.toBeVisible();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -440,6 +440,13 @@ export function App(): JSX.Element {
 
   const deleteAgent = useCallback(
     async (agent: Agent, cleanupWorktree?: string) => {
+      if (connectedAgentId === agent.id) {
+        detachTerminal();
+      }
+      if (selectedAgentId === agent.id) {
+        setSelectedAgentId(null);
+        refreshMedia(null);
+      }
       if (agent.status === "running") {
         await api(`/api/v1/agents/${agent.id}/stop`, {
           method: "POST",
@@ -453,7 +460,7 @@ export function App(): JSX.Element {
       const qs = params.toString();
       await api(`/api/v1/agents/${agent.id}${qs ? `?${qs}` : ""}`, { method: "DELETE" });
     },
-    []
+    [connectedAgentId, detachTerminal, refreshMedia, selectedAgentId, setSelectedAgentId]
   );
 
   const handleRemoveCwdHistory = useCallback((cwd: string) => {

--- a/web/src/components/app/delete-agent-dialog.tsx
+++ b/web/src/components/app/delete-agent-dialog.tsx
@@ -161,8 +161,8 @@ export function DeleteAgentDialog({
             <p className="text-sm text-muted-foreground">The agent will be archived either way.</p>
           </div>
 
-          <div className="flex justify-end gap-2 pt-1">
-            <Button variant="ghost" onClick={close} disabled={deleting}>
+          <div className="grid gap-2 pt-1 sm:grid-cols-[auto,minmax(0,1fr),minmax(0,1fr)]">
+            <Button variant="ghost" onClick={close} disabled={deleting} className="w-full sm:w-auto">
               Cancel
             </Button>
             <Button
@@ -170,6 +170,7 @@ export function DeleteAgentDialog({
               disabled={deleting}
               onClick={() => void handleWorktreeChoice("keep")}
               data-testid="delete-agent-keep-worktree"
+              className="h-auto w-full min-w-0 whitespace-normal py-2 text-center"
             >
               <GitBranch className="mr-1.5 h-4 w-4" />
               Archive, keep worktree
@@ -179,6 +180,7 @@ export function DeleteAgentDialog({
               disabled={deleting}
               onClick={() => void handleWorktreeChoice("force")}
               data-testid="delete-agent-force-worktree"
+              className="h-auto w-full min-w-0 whitespace-normal py-2 text-center"
             >
               {deleting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
               Archive and remove worktree

--- a/web/src/hooks/use-terminal.ts
+++ b/web/src/hooks/use-terminal.ts
@@ -228,6 +228,13 @@ export function useTerminal(args: {
     attachNonceRef.current += 1;
   }, []);
 
+  const resetTerminalSurface = useCallback(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+    term.reset();
+    term.clear();
+  }, []);
+
   const closeSocketTransport = useCallback(() => {
     if (wsRef.current) {
       try { wsRef.current.close(); } catch {}
@@ -319,6 +326,7 @@ export function useTerminal(args: {
           shouldKeepAttachedRef.current = false;
           clearReconnectTimer();
           closeSocket(false);
+          resetTerminalSurface();
           setConnState("disconnected");
           setStatusMessage("Session ended.");
           return;
@@ -443,6 +451,7 @@ export function useTerminal(args: {
               shouldKeepAttachedRef.current = false;
               setConnectedAgentId(null);
               setTerminalMode(null);
+              resetTerminalSurface();
               setConnState("disconnected");
               return;
             }
@@ -464,6 +473,7 @@ export function useTerminal(args: {
             shouldKeepAttachedRef.current = false;
             clearReconnectTimer();
             closeSocket(false);
+            resetTerminalSurface();
             setConnState("disconnected");
             setStatusMessage(message);
             return;
@@ -495,6 +505,7 @@ export function useTerminal(args: {
       markSocketHealthy,
       noteTerminalError,
       probeSocket,
+      resetTerminalSurface,
       restoreConnectedState,
       selectedAgentId,
       sendResize,
@@ -508,9 +519,10 @@ export function useTerminal(args: {
     setRestoreShellAgentId(null);
     clearReconnectTimer();
     closeSocket(false);
+    resetTerminalSurface();
     setConnState("disconnected");
     setStatusMessage("Detached from session.");
-  }, [clearReconnectTimer, closeSocket, invalidateAttachAttempt]);
+  }, [clearReconnectTimer, closeSocket, invalidateAttachAttempt, resetTerminalSurface]);
 
   const sendTerminalInput = useCallback((data: string) => {
     const ws = wsRef.current;


### PR DESCRIPTION
## Summary
- make the worktree archive dialog actions reflow cleanly instead of overflowing on narrow or constrained widths
- reset terminal selection and xterm surface when archiving the currently attached agent so the pane returns to the empty state
- add an end-to-end regression test for archiving an attached agent

## Testing
- npm run check
- npm run finalize:web
- npm run test:e2e