### PR TITLE
Fix Claude token harvest and activity refresh

### DIFF
--- a/src/agents/token-harvester.ts
+++ b/src/agents/token-harvester.ts
@@ -44,10 +44,14 @@ const UPSERT_SQL = `INSERT INTO agent_token_usage
 
 // ── Claude Code harvesting ────────────────────────────────────────
 
-/** Map an agent's working directory to the corresponding Claude projects directory. */
+function claudeProjectRoot(): string {
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+/** Map an agent's working directory to the current Claude projects directory encoding. */
 export function cwdToClaudeProjectDir(cwd: string): string {
-  const encoded = cwd.replaceAll("/", "-");
-  return path.join(os.homedir(), ".claude", "projects", encoded);
+  const encoded = cwd.replaceAll(/[^a-zA-Z0-9_-]/g, "-");
+  return path.join(claudeProjectRoot(), encoded);
 }
 
 async function discoverSessionFiles(dir: string): Promise<string[]> {
@@ -118,7 +122,6 @@ async function harvestClaudeTokenUsage(
 ): Promise<void> {
   const effectiveCwd = agent.worktreePath ?? agent.cwd;
   const projectDir = cwdToClaudeProjectDir(effectiveCwd);
-
   const files = await discoverSessionFiles(projectDir);
   if (files.length === 0) return;
 

--- a/test/token-harvester.test.ts
+++ b/test/token-harvester.test.ts
@@ -7,7 +7,7 @@ import { cwdToClaudeProjectDir } from "../src/agents/token-harvester.js";
 
 describe("token-harvester", () => {
   describe("cwdToClaudeProjectDir", () => {
-    it("encodes a simple path by replacing / with -", () => {
+    it("encodes a simple path by sanitizing non-alphanumeric path chars", () => {
       const result = cwdToClaudeProjectDir("/Users/brad/dev/apps/dispatch");
       expect(result).toBe(
         path.join(os.homedir(), ".claude", "projects", "-Users-brad-dev-apps-dispatch")
@@ -23,7 +23,7 @@ describe("token-harvester", () => {
           os.homedir(),
           ".claude",
           "projects",
-          "-Users-brad-dev-apps-dispatch-.dispatch-worktrees-agt-abc123"
+          "-Users-brad-dev-apps-dispatch--dispatch-worktrees-agt-abc123"
         )
       );
     });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -715,7 +715,9 @@ export function App(): JSX.Element {
       />
 
       <DocsPane open={docsPaneOpen} onClose={() => setDocsPaneOpen(false)} />
-      <ActivityPane open={activityPaneOpen} onClose={() => setActivityPaneOpen(false)} />
+      {activityPaneOpen ? (
+        <ActivityPane open={activityPaneOpen} onClose={() => setActivityPaneOpen(false)} />
+      ) : null}
       <SettingsPane
         open={settingsPaneOpen}
         onClose={() => setSettingsPaneOpen(false)}

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -1,6 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
+const ACTIVITY_QUERY_OPTIONS = {
+  staleTime: 60_000,
+  refetchOnMount: "always" as const,
+};
+
 type HeatmapDay = { day: string; count: number };
 
 export type ActivityStats = {
@@ -31,7 +36,7 @@ export function useActivityHeatmap(days = 365) {
       );
       return payload.days;
     },
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -39,7 +44,7 @@ export function useActivityStats() {
   return useQuery<ActivityStats>({
     queryKey: ["activity", "stats"],
     queryFn: () => api<ActivityStats>("/api/v1/activity/stats"),
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -52,7 +57,7 @@ export function useDailyStatus(days = 30) {
       );
       return payload.days;
     },
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -80,7 +85,7 @@ export function useTokenStats() {
   return useQuery<TokenStats>({
     queryKey: ["activity", "token-stats"],
     queryFn: () => api<TokenStats>("/api/v1/activity/token-stats"),
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -93,7 +98,7 @@ export function useTokenDaily(days = 30) {
       );
       return payload.days;
     },
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -120,7 +125,7 @@ export function useTokenByModel() {
       const payload = await api<{ models: TokenByModel[] }>("/api/v1/activity/token-by-model");
       return payload.models;
     },
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
@@ -131,7 +136,6 @@ export function useTokenByProject() {
       const payload = await api<{ projects: TokenByProject[] }>("/api/v1/activity/token-by-project");
       return payload.projects;
     },
-    staleTime: 60_000,
+    ...ACTIVITY_QUERY_OPTIONS,
   });
 }
-


### PR DESCRIPTION
## Summary
- fix Claude token harvesting to use the actual sanitized project directory format found on disk
- add coverage for the corrected Claude project-dir mapping
- mount the Activity pane only when opened and refetch activity queries on mount while still using cached data

## Validation
- npm run check
- npm test
- npm run finalize:web
- npm run test:e2e