### PR TITLE
Add confirmation modal for stopping an agent

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { LoginPage } from "@/components/app/login-page";
 import { SettingsPane } from "@/components/app/settings-pane";
 import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
 import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
+import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
 import { MediaLightbox } from "@/components/app/media-lightbox";
 import { MediaSidebar, MediaSidebarContent } from "@/components/app/media-sidebar";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
@@ -145,6 +146,8 @@ export function App(): JSX.Element {
   // ── Delete dialog state ───────────────────────────────────────────────
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
+  const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
+  const [stopTarget, setStopTarget] = useState<Agent | null>(null);
 
   // ── Panes ─────────────────────────────────────────────────────────────
   const [settingsPaneOpen, setSettingsPaneOpen] = useState(false);
@@ -555,13 +558,14 @@ export function App(): JSX.Element {
               setOverflowAgentId={setOverflowAgentId}
               setDeleteTarget={setDeleteTarget}
               setDeleteConfirmOpen={setDeleteConfirmOpen}
+              setStopTarget={setStopTarget}
+              setStopConfirmOpen={setStopConfirmOpen}
               agentVisualState={agentVisualState}
               borderForAgentState={borderForAgentState}
               toggleAgentDetails={toggleAgentDetails}
               isFullAccessEnabled={isFullAccessEnabled}
               detachTerminal={detachTerminal}
               attachToAgent={attachToAgent}
-              stopAgent={stopAgent}
               startAgent={startAgent}
             />
           </div>
@@ -650,13 +654,14 @@ export function App(): JSX.Element {
             setOverflowAgentId={setOverflowAgentId}
             setDeleteTarget={setDeleteTarget}
             setDeleteConfirmOpen={(open) => { if (open) setMobileLeftOpen(false); setDeleteConfirmOpen(open); }}
+            setStopTarget={setStopTarget}
+            setStopConfirmOpen={(open) => { if (open) setMobileLeftOpen(false); setStopConfirmOpen(open); }}
             agentVisualState={agentVisualState}
             borderForAgentState={borderForAgentState}
             toggleAgentDetails={toggleAgentDetails}
             isFullAccessEnabled={isFullAccessEnabled}
             detachTerminal={detachAndClearSelection}
             attachToAgent={attachToAgent}
-            stopAgent={stopAgent}
             startAgent={startAgent}
             closeOnSessionAction={true}
             onRequestClose={() => setMobileLeftOpen(false)}
@@ -719,6 +724,14 @@ export function App(): JSX.Element {
         setOpen={setDeleteConfirmOpen}
         setDeleteTarget={setDeleteTarget}
         onDelete={deleteAgent}
+      />
+
+      <StopAgentDialog
+        open={stopConfirmOpen}
+        stopTarget={stopTarget}
+        setOpen={setStopConfirmOpen}
+        setStopTarget={setStopTarget}
+        onStop={stopAgent}
       />
 
       <DocsPane open={docsPaneOpen} onClose={() => setDocsPaneOpen(false)} />

--- a/web/src/components/app/agent-sidebar.tsx
+++ b/web/src/components/app/agent-sidebar.tsx
@@ -37,13 +37,14 @@ type AgentSidebarSharedProps = {
   setOverflowAgentId: (value: string | null | ((current: string | null) => string | null)) => void;
   setDeleteTarget: (agent: Agent | null) => void;
   setDeleteConfirmOpen: (open: boolean) => void;
+  setStopTarget: (agent: Agent | null) => void;
+  setStopConfirmOpen: (open: boolean) => void;
   agentVisualState: (agent: Agent) => AgentVisualState;
   borderForAgentState: (state: AgentVisualState) => string;
   toggleAgentDetails: (agentId: string) => void;
   isFullAccessEnabled: (agent: Pick<Agent, "agentArgs" | "fullAccess">) => boolean;
   detachTerminal: () => void;
   attachToAgent: (agent: Agent) => Promise<void>;
-  stopAgent: (agent: Agent) => Promise<void>;
   startAgent: (agent: Agent) => Promise<void>;
 };
 
@@ -73,13 +74,14 @@ export function AgentSidebarContent({
   setOverflowAgentId: _setOverflowAgentId,
   setDeleteTarget,
   setDeleteConfirmOpen,
+  setStopTarget,
+  setStopConfirmOpen,
   agentVisualState,
   borderForAgentState,
   toggleAgentDetails,
   isFullAccessEnabled,
   detachTerminal,
   attachToAgent,
-  stopAgent,
   startAgent,
   onRequestClose,
   closeOnSessionAction = false,
@@ -283,7 +285,10 @@ export function AgentSidebarContent({
                             size="icon"
                             variant="ghost-warning"
                             data-agent-control="true"
-                            onClick={() => void stopAgent(agent)}
+                            onClick={() => {
+                              setStopTarget(agent);
+                              setStopConfirmOpen(true);
+                            }}
                           >
                             <Square className="h-3.5 w-3.5" />
                           </Button>

--- a/web/src/components/app/stop-agent-dialog.tsx
+++ b/web/src/components/app/stop-agent-dialog.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useState } from "react";
+import { Loader2, Square } from "lucide-react";
+
+import { type Agent } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+type StopAgentDialogProps = {
+  open: boolean;
+  stopTarget: Agent | null;
+  setOpen: (open: boolean) => void;
+  setStopTarget: (agent: Agent | null) => void;
+  onStop: (agent: Agent) => Promise<void>;
+};
+
+export function StopAgentDialog({
+  open,
+  stopTarget,
+  setOpen,
+  setStopTarget,
+  onStop
+}: StopAgentDialogProps): JSX.Element {
+  const [stopping, setStopping] = useState(false);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setStopTarget(null);
+  }, [setOpen, setStopTarget]);
+
+  const handleConfirmStop = useCallback(async () => {
+    if (!stopTarget) return;
+
+    setStopping(true);
+    try {
+      await onStop(stopTarget);
+      setOpen(false);
+      setStopTarget(null);
+    } finally {
+      setStopping(false);
+    }
+  }, [stopTarget, onStop, setOpen, setStopTarget]);
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) close(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Stop Agent</DialogTitle>
+          <DialogDescription>
+            {stopTarget
+              ? `Stop "${stopTarget.name}"? The session will end and any in-progress work may be interrupted.`
+              : "Stop this agent?"}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" data-testid="stop-agent-cancel" onClick={close} disabled={stopping}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            data-testid="stop-agent-confirm"
+            disabled={stopping}
+            onClick={() => void handleConfirmStop()}
+          >
+            {stopping ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Square className="mr-1.5 h-4 w-4" />}
+            Stop
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a confirmation dialog when clicking the stop button on an agent, preventing accidental stops
- Follows the same pattern as the existing delete/archive agent dialog (`DeleteAgentDialog`)
- Dialog shows the agent name and warns that in-progress work may be interrupted
- Cancel dismisses the dialog; Stop confirms and stops the agent

## Test plan
- [x] Type check passes (`npm run check`)
- [x] Web build passes (`npm run finalize:web`)
- [x] All 73 E2E tests pass
- [x] Manual Playwright validation: cancel dismisses dialog, confirm stops agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)