### PR TITLE
Add analytics time range selector

### DIFF
--- a/docs/activity-metrics-roadmap.md
+++ b/docs/activity-metrics-roadmap.md
@@ -2,47 +2,68 @@
 
 High-level plan for expanding Dispatch's activity tracking and usage metrics.
 
-## Current State (PR #140)
+## Shipped
+
+The following work is already in the product and should be treated as baseline, not future roadmap:
 
 - `agent_events` history table with `agent_type`, `agent_name`, `project_dir`
-- Stat cards: total working time, avg blocked time, avg waiting time, busiest day
-- Yearly activity heatmap (Jan–Dec)
-- Daily stacked bar chart (last 30 days, recharts)
+- Stat cards for total working time, avg blocked time, avg waiting time, busiest day
+- Yearly activity heatmap
+- Daily status stacked bar chart for the last 30 days
 - Delete/stop events captured in history
+- Soft delete via `agents.deleted_at`, with active-agent queries filtering deleted rows
+- Token harvesting into `agent_token_usage`
+- Token dashboards for totals, daily usage, by model, and by project
 
-## Phase 1: Low-Hanging Fruit from Existing Data
+## Next Up: Event-Derived Metrics
 
-Derive new metrics from `agent_events` without schema changes.
+Derive more value from existing `agent_events` data before adding new ingestion paths.
 
-- **Agent count over time** — agents created per day/week (first event per agent_id)
-- **Success rate** — ratio of agents reaching `done` vs `idle`/stopped
+- **Time period selector** — scope activity queries and charts to last 30d / this year / all time
+- **Agent count over time** — agents created per day/week using the first event per `agent_id`
 - **Per-project breakdown** — group by `project_dir`, show working time per project
-- **Active hours heatmap** — hour-of-day × day-of-week grid from event timestamps
-- **Time period selector** — scope all metrics to last 30d / this year / all time
+- **Active hours heatmap** — hour-of-day x day-of-week grid from event timestamps
 
-## Phase 2: Soft Delete
+Why this phase goes first:
 
-Add `deleted_at` column to `agents` table, filter from list/UI queries.
+- no schema changes required
+- no new background harvesting required
+- unlocks a better information architecture for the activity pane
 
-Unlocks:
-- Agent session history (see past agents, what they worked on)
-- Total agents ever created (not just currently existing)
+## Follow-On: History Views Enabled By Soft Delete
+
+Soft delete is already implemented, but the analytics surface does not yet expose the richer history it enables.
+
+Potential additions:
+
+- Agent session history for deleted agents
+- Total agents ever created
 - Per-agent timelines and lifetime metrics
-- Richer stats: avg agent lifetime, most productive agents
+- Richer stats such as avg agent lifetime and most productive agents
 
-## Phase 3: Token Tracking
+## Follow-On: Token Analytics Expansion
 
-Parse Claude Code JSONL session logs at agent stop/delete.
+Token tracking is already implemented. Remaining work here is higher-order analytics rather than ingestion.
 
-- New `agent_token_usage` table (agent_id, session, input_tokens, output_tokens, model, timestamp)
-- Harvest from `~/.claude/sessions/` JSONL files
-- Display: total tokens used, tokens per day, tokens per project
-- Cost estimation: tokens × model pricing (configurable rates)
+Potential additions:
 
-## Phase 4: Tool & PR Tracking
+- Cost estimation using configurable model pricing
+- Per-agent token history and lifetime rollups
+- Better attribution for multi-project or worktree-heavy usage patterns
 
-Log MCP tool calls and PR events for workflow insights.
+## Later: Tool And PR Tracking
 
-- Record MCP tool calls in event history or separate table (tool name, agent_id, timestamp)
-- Track PR creation events (already flows through MCP `create_pr` tool)
-- Display: PRs created per week, most-used tools, tool call volume over time
+Add workflow analytics once the event-derived dashboards are in place.
+
+- Record MCP tool calls in `agent_events` or a dedicated table
+- Track PR creation events from the GitHub MCP tools
+- Display PRs created per week, most-used tools, and tool-call volume over time
+
+## Recommended Build Order
+
+1. Add a shared time period selector and thread it through existing activity queries.
+2. Ship event-derived metrics from `agent_events`: agent-count-over-time and per-project working time.
+3. Add the active-hours heatmap.
+4. Expose deleted-agent history views now that soft delete exists.
+5. Add token cost estimation and deeper token analysis.
+6. Add MCP tool and PR tracking.

--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -4,7 +4,7 @@ const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-tok
 
 test.describe("Activity range API", () => {
   test("stats endpoint accepts the shared range values", async ({ request }) => {
-    for (const range of ["30d", "year", "all"]) {
+    for (const range of ["7d", "30d", "year", "all"]) {
       const res = await request.get(`/api/v1/activity/stats?range=${range}`, {
         headers: authHeader,
       });

--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
+test.describe("Activity range API", () => {
+  test("stats endpoint accepts the shared range values", async ({ request }) => {
+    for (const range of ["30d", "year", "all"]) {
+      const res = await request.get(`/api/v1/activity/stats?range=${range}`, {
+        headers: authHeader,
+      });
+      expect(res.ok()).toBeTruthy();
+
+      const body = (await res.json()) as {
+        totalWorkingMs: number;
+        avgBlockedMs: number;
+        avgWaitingMs: number;
+        busiestDay: string | null;
+      };
+      expect(typeof body.totalWorkingMs).toBe("number");
+      expect(typeof body.avgBlockedMs).toBe("number");
+      expect(typeof body.avgWaitingMs).toBe("number");
+      expect(body.busiestDay === null || typeof body.busiestDay === "string").toBe(true);
+    }
+  });
+
+  test("daily-status endpoint returns matching granularity for each range", async ({ request }) => {
+    const expected = {
+      "7d": "day",
+      "30d": "day",
+      year: "month",
+      all: "month",
+    } as const;
+
+    for (const [range, granularity] of Object.entries(expected)) {
+      const res = await request.get(`/api/v1/activity/daily-status?range=${range}`, {
+        headers: authHeader,
+      });
+      expect(res.ok()).toBeTruthy();
+
+      const body = (await res.json()) as { days: unknown[]; granularity: string };
+      expect(Array.isArray(body.days)).toBe(true);
+      expect(body.granularity).toBe(granularity);
+    }
+  });
+});

--- a/e2e/token-usage.spec.ts
+++ b/e2e/token-usage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { loadApp } from "./helpers";
 
 const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
 
@@ -21,12 +22,13 @@ test.describe("Token usage API", () => {
   });
 
   test("GET /api/v1/activity/token-daily returns empty days array when no data", async ({ request }) => {
-    const res = await request.get("/api/v1/activity/token-daily?days=7", { headers: authHeader });
+    const res = await request.get("/api/v1/activity/token-daily?range=30d", { headers: authHeader });
     expect(res.ok()).toBeTruthy();
 
-    const body = (await res.json()) as { days: unknown[] };
+    const body = (await res.json()) as { days: unknown[]; granularity: string };
     expect(Array.isArray(body.days)).toBe(true);
     expect(body.days.length).toBe(0);
+    expect(body.granularity).toBe("day");
   });
 
   test("GET /api/v1/activity/token-by-project returns empty projects array when no data", async ({ request }) => {
@@ -45,23 +47,43 @@ test.describe("Token usage API", () => {
     expect(res.status()).toBe(404);
   });
 
-  test("token-daily respects days parameter and clamps to range", async ({ request }) => {
-    // days=0 should clamp to 1
-    const res = await request.get("/api/v1/activity/token-daily?days=0", { headers: authHeader });
-    expect(res.ok()).toBeTruthy();
+  test("token endpoints accept shared range values", async ({ request }) => {
+    const daily7 = await request.get("/api/v1/activity/token-daily?range=7d", { headers: authHeader });
+    expect(daily7.ok()).toBeTruthy();
+    expect(((await daily7.json()) as { granularity: string }).granularity).toBe("day");
 
-    // days=999 should clamp to 90
-    const res2 = await request.get("/api/v1/activity/token-daily?days=999", { headers: authHeader });
-    expect(res2.ok()).toBeTruthy();
+    const daily30 = await request.get("/api/v1/activity/token-daily?range=30d", { headers: authHeader });
+    expect(daily30.ok()).toBeTruthy();
+    expect(((await daily30.json()) as { granularity: string }).granularity).toBe("day");
+
+    const dailyYear = await request.get("/api/v1/activity/token-daily?range=year", { headers: authHeader });
+    expect(dailyYear.ok()).toBeTruthy();
+    expect(((await dailyYear.json()) as { granularity: string }).granularity).toBe("month");
+
+    const dailyAll = await request.get("/api/v1/activity/token-daily?range=all", { headers: authHeader });
+    expect(dailyAll.ok()).toBeTruthy();
+    expect(((await dailyAll.json()) as { granularity: string }).granularity).toBe("month");
+
+    const totals = await request.get("/api/v1/activity/token-stats?range=year", { headers: authHeader });
+    expect(totals.ok()).toBeTruthy();
+
+    const byProject = await request.get("/api/v1/activity/token-by-project?range=all", { headers: authHeader });
+    expect(byProject.ok()).toBeTruthy();
+
+    const byModel = await request.get("/api/v1/activity/token-by-model?range=30d", { headers: authHeader });
+    expect(byModel.ok()).toBeTruthy();
   });
 });
 
 test.describe("Token usage UI", () => {
-  test("Activity pane shows token stats when data exists", async ({ page, request }) => {
-    // Seed token data directly via the database isn't available in E2E,
-    // so we check the pane renders without errors when there's no data
-    await page.goto("/");
-    await page.waitForLoadState("domcontentloaded");
+  test("Activity pane scopes requests when time range changes", async ({ page }) => {
+    const requests: string[] = [];
+    await page.route("**/api/v1/activity/**", async (route) => {
+      requests.push(route.request().url());
+      await route.continue();
+    });
+
+    await loadApp(page);
 
     // Open the activity pane
     await page.getByTestId("activity-button").click();
@@ -69,6 +91,15 @@ test.describe("Token usage UI", () => {
 
     // Heatmap should render
     await expect(page.getByText("Activity this year")).toBeVisible();
+
+    await page.getByTestId("activity-range-select").click();
+    await page.getByRole("option", { name: "This year" }).click();
+
+    await expect(page.getByTestId("activity-range-select")).toContainText("This year");
+
+    await expect.poll(
+      () => requests.filter((url) => url.includes("range=year")).length
+    ).toBeGreaterThanOrEqual(6);
 
     // Close dialog
     await page.getByRole("button", { name: "Close" }).click();

--- a/src/activity-metrics.ts
+++ b/src/activity-metrics.ts
@@ -1,0 +1,160 @@
+export type ActivityGranularity = "day" | "week" | "month";
+
+export type ActivityEventRow = {
+  agent_id: string;
+  event_type: string;
+  created_at: Date;
+};
+
+export type ActivityStatsResult = {
+  totalWorkingMs: number;
+  avgBlockedMs: number;
+  avgWaitingMs: number;
+  stateDurations: Record<string, number>;
+};
+
+function bucketStart(timeMs: number, granularity: ActivityGranularity): string {
+  const bucket = new Date(timeMs);
+  if (granularity === "week") {
+    const day = bucket.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    bucket.setUTCDate(bucket.getUTCDate() + diff);
+  } else if (granularity === "month") {
+    bucket.setUTCDate(1);
+  }
+  return bucket.toISOString().slice(0, 10);
+}
+
+export function computeActivityStats(
+  rows: ActivityEventRow[],
+  rangeStart: Date | null
+): ActivityStatsResult {
+  const rangeStartMs = rangeStart?.getTime() ?? null;
+  const stateDurations: Record<string, number> = {
+    working: 0,
+    blocked: 0,
+    waiting_user: 0,
+  };
+  const sessionBlockedTimes: number[] = [];
+  const sessionWaitingTimes: number[] = [];
+
+  let prevAgentId: string | null = null;
+  let prevType: string | null = null;
+  let prevTime: number | null = null;
+  let sessionBlocked = 0;
+  let sessionWaiting = 0;
+  let sawInRangeEvent = false;
+
+  const flushSession = () => {
+    if (sawInRangeEvent) {
+      sessionBlockedTimes.push(sessionBlocked);
+      sessionWaitingTimes.push(sessionWaiting);
+    }
+    sessionBlocked = 0;
+    sessionWaiting = 0;
+    sawInRangeEvent = false;
+  };
+
+  for (const row of rows) {
+    const t = row.created_at.getTime();
+
+    if (row.agent_id !== prevAgentId) {
+      if (prevAgentId) {
+        flushSession();
+      }
+      prevAgentId = row.agent_id;
+      prevType = row.event_type;
+      prevTime = t;
+      sawInRangeEvent = rangeStartMs === null || t >= rangeStartMs;
+      continue;
+    }
+
+    const currentInRange = rangeStartMs === null || t >= rangeStartMs;
+    sawInRangeEvent ||= currentInRange;
+
+    if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
+      const segmentStart = rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
+      const dur = t - segmentStart;
+      if (dur > 0) {
+        stateDurations[prevType] = (stateDurations[prevType] ?? 0) + dur;
+        if (prevType === "blocked") sessionBlocked += dur;
+        if (prevType === "waiting_user") sessionWaiting += dur;
+      }
+    }
+
+    if (row.event_type === "done" || row.event_type === "idle") {
+      flushSession();
+      prevType = row.event_type;
+      prevTime = t;
+      sawInRangeEvent = false;
+      continue;
+    }
+
+    if (prevType === "done" || prevType === "idle") {
+      sessionBlocked = 0;
+      sessionWaiting = 0;
+      sawInRangeEvent = currentInRange;
+    }
+
+    prevType = row.event_type;
+    prevTime = t;
+  }
+
+  if (prevAgentId) {
+    flushSession();
+  }
+
+  const avg = (arr: number[]) =>
+    arr.length > 0 ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+
+  return {
+    totalWorkingMs: stateDurations.working ?? 0,
+    avgBlockedMs: avg(sessionBlockedTimes),
+    avgWaitingMs: avg(sessionWaitingTimes),
+    stateDurations,
+  };
+}
+
+export function computeDailyStatus(
+  rows: ActivityEventRow[],
+  rangeStart: Date | null,
+  granularity: ActivityGranularity
+): Array<Record<string, number | string>> {
+  const rangeStartMs = rangeStart?.getTime() ?? null;
+  const dailyMap = new Map<string, Record<string, number>>();
+
+  let prevAgentId: string | null = null;
+  let prevType: string | null = null;
+  let prevTime: number | null = null;
+
+  for (const row of rows) {
+    const t = row.created_at.getTime();
+    if (row.agent_id !== prevAgentId) {
+      prevAgentId = row.agent_id;
+      prevType = row.event_type;
+      prevTime = t;
+      continue;
+    }
+
+    if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
+      const segmentStart = rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
+      const dur = t - segmentStart;
+      if (dur > 0) {
+        const dayKey = bucketStart(segmentStart, granularity);
+        let entry = dailyMap.get(dayKey);
+        if (!entry) {
+          entry = {};
+          dailyMap.set(dayKey, entry);
+        }
+        entry[prevType] = (entry[prevType] ?? 0) + dur;
+      }
+    }
+
+    prevType = row.event_type;
+    prevTime = t;
+  }
+
+  return Array.from(dailyMap.entries())
+    .map(([day, durations]) => ({ day, ...durations }))
+    .sort((a, b) => String(a.day).localeCompare(String(b.day)));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,11 @@ import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { harvestTokenUsage } from "./agents/token-harvester.js";
+import {
+  computeActivityStats,
+  computeDailyStatus,
+  type ActivityEventRow,
+} from "./activity-metrics.js";
 
 const config = loadConfig();
 const app = Fastify({
@@ -60,7 +65,6 @@ const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
 const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
 type ActivityRange = (typeof ACTIVITY_RANGES)[number];
-type ActivityGranularity = "day" | "week" | "month";
 type UiEvent =
   | { type: "snapshot"; agents: AgentRecord[] }
   | { type: "agent.upsert"; agent: AgentRecord }
@@ -171,7 +175,7 @@ function rangeWhereClause(range: ActivityRange, column: string): {
   return { clause: `WHERE ${column} >= $1`, params: [lowerBound] };
 }
 
-function getBucketGranularity(range: ActivityRange): ActivityGranularity {
+function getBucketGranularity(range: ActivityRange): "day" | "week" | "month" {
   if (range === "7d" || range === "30d") return "day";
   if (range === "year") return "month";
   return "month";
@@ -180,6 +184,41 @@ function getBucketGranularity(range: ActivityRange): ActivityGranularity {
 function bucketExpression(range: ActivityRange, column: string): string {
   const granularity = getBucketGranularity(range);
   return `date_trunc('${granularity}', ${column})::date::text`;
+}
+
+async function loadScopedActivityEvents(
+  range: ActivityRange
+): Promise<{ rows: ActivityEventRow[]; rangeStart: Date | null }> {
+  const rangeStart = getRangeLowerBound(range);
+  const eventFilter = rangeWhereClause(range, "created_at");
+
+  const inRangeResult = await pool.query<ActivityEventRow>(
+    `SELECT agent_id, event_type, created_at
+     FROM agent_events
+     ${eventFilter.clause}
+     ORDER BY agent_id, created_at`,
+    eventFilter.params
+  );
+
+  if (!rangeStart) {
+    return { rows: inRangeResult.rows, rangeStart: null };
+  }
+
+  const boundaryResult = await pool.query<ActivityEventRow>(
+    `SELECT DISTINCT ON (agent_id) agent_id, event_type, created_at
+     FROM agent_events
+     WHERE created_at < $1
+     ORDER BY agent_id, created_at DESC`,
+    [rangeStart]
+  );
+
+  const rows = [...boundaryResult.rows, ...inRangeResult.rows].sort((a, b) => {
+    const agentCompare = a.agent_id.localeCompare(b.agent_id);
+    if (agentCompare !== 0) return agentCompare;
+    return a.created_at.getTime() - b.created_at.getTime();
+  });
+
+  return { rows, rangeStart };
 }
 const activeGitRefreshAgentIds = new Set<string>();
 const pendingGitRefreshEnqueuedAt = new Map<string, number>();
@@ -1395,179 +1434,34 @@ async function registerRoutes() {
   app.get("/api/v1/activity/stats", async (request) => {
     const query = request.query as { range?: string };
     const range = parseActivityRange(query.range);
+    const { rows, rangeStart } = await loadScopedActivityEvents(range);
     const eventFilter = rangeWhereClause(range, "created_at");
-
-    // Fetch all events ordered by agent then time so we can compute durations
-    const allEvents = await pool.query<{
-      agent_id: string;
-      event_type: string;
-      created_at: Date;
-    }>(
-      `SELECT agent_id, event_type, created_at
-       FROM agent_events
-       ${eventFilter.clause}
-       ORDER BY agent_id, created_at`,
-      eventFilter.params
-    );
 
     const busiestDayResult = await pool.query<{ day: string; count: number }>(
       `SELECT date_trunc('day', created_at)::date::text AS day, COUNT(*)::int AS count
        FROM agent_events
        ${eventFilter.clause}
-       GROUP BY day ORDER BY count DESC LIMIT 1`,
+      GROUP BY day ORDER BY count DESC LIMIT 1`,
       eventFilter.params
     );
-
-    // Compute per-state durations across all agents.
-    // A "session" is a sequence of events for one agent, ending at done/idle.
-    // Time in done/idle states is NOT counted (terminal states).
-    const stateDurations: Record<string, number> = {
-      working: 0,
-      blocked: 0,
-      waiting_user: 0,
-    };
-    const sessionDoneTimes: number[] = [];
-    const sessionBlockedTimes: number[] = [];
-    const sessionWaitingTimes: number[] = [];
-
-    let prevAgentId: string | null = null;
-    let prevType: string | null = null;
-    let prevTime: number | null = null;
-    let sessionStart: number | null = null;
-    let sessionBlocked = 0;
-    let sessionWaiting = 0;
-
-    const flushSession = (isDone: boolean, endTime: number | null) => {
-      if (isDone && sessionStart !== null && endTime !== null) {
-        sessionDoneTimes.push(endTime - sessionStart);
-      }
-      sessionBlockedTimes.push(sessionBlocked);
-      sessionWaitingTimes.push(sessionWaiting);
-      sessionStart = null;
-      sessionBlocked = 0;
-      sessionWaiting = 0;
-    };
-
-    for (const row of allEvents.rows) {
-      const t = row.created_at.getTime();
-
-      // New agent — flush previous session if any
-      if (row.agent_id !== prevAgentId) {
-        if (prevAgentId && sessionStart !== null) {
-          flushSession(prevType === "done", prevTime);
-        }
-        prevAgentId = row.agent_id;
-        prevType = row.event_type;
-        prevTime = t;
-        sessionStart = t;
-        sessionBlocked = 0;
-        sessionWaiting = 0;
-        continue;
-      }
-
-      // Same agent — accumulate duration for previous state
-      if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
-        const dur = t - prevTime;
-        stateDurations[prevType] = (stateDurations[prevType] ?? 0) + dur;
-        if (prevType === "blocked") sessionBlocked += dur;
-        if (prevType === "waiting_user") sessionWaiting += dur;
-      }
-
-      // If this event is done/idle, flush this session
-      if (row.event_type === "done" || row.event_type === "idle") {
-        flushSession(row.event_type === "done", t);
-        prevType = row.event_type;
-        prevTime = t;
-        continue;
-      }
-
-      // If previous was done/idle, this starts a new session
-      if (prevType === "done" || prevType === "idle") {
-        sessionStart = t;
-        sessionBlocked = 0;
-        sessionWaiting = 0;
-      }
-
-      prevType = row.event_type;
-      prevTime = t;
-    }
-    // Flush last session
-    if (prevAgentId && sessionStart !== null) {
-      flushSession(prevType === "done", prevTime);
-    }
-
-    const avg = (arr: number[]) =>
-      arr.length > 0 ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+    const stats = computeActivityStats(rows, rangeStart);
 
     return {
-      totalWorkingMs: stateDurations.working ?? 0,
-      avgBlockedMs: avg(sessionBlockedTimes),
-      avgWaitingMs: avg(sessionWaitingTimes),
+      totalWorkingMs: stats.totalWorkingMs,
+      avgBlockedMs: stats.avgBlockedMs,
+      avgWaitingMs: stats.avgWaitingMs,
       busiestDay: busiestDayResult.rows[0]?.day ?? null,
       busiestDayCount: busiestDayResult.rows[0]?.count ?? 0,
-      stateDurations,
+      stateDurations: stats.stateDurations,
     };
   });
 
   app.get("/api/v1/activity/daily-status", async (request) => {
     const query = request.query as { range?: string };
     const range = parseActivityRange(query.range);
-    const eventFilter = rangeWhereClause(range, "created_at");
     const granularity = getBucketGranularity(range);
-
-    // Get all events in the period, ordered by agent then time
-    const result = await pool.query<{
-      agent_id: string;
-      event_type: string;
-      created_at: Date;
-    }>(
-      `SELECT agent_id, event_type, created_at
-       FROM agent_events
-       ${eventFilter.clause}
-       ORDER BY agent_id, created_at`,
-      eventFilter.params
-    );
-
-    // Build daily duration breakdown
-    const dailyMap = new Map<string, Record<string, number>>();
-
-    let prevAgentId: string | null = null;
-    let prevType: string | null = null;
-    let prevTime: number | null = null;
-
-    for (const row of result.rows) {
-      const t = row.created_at.getTime();
-      if (row.agent_id !== prevAgentId) {
-        prevAgentId = row.agent_id;
-        prevType = row.event_type;
-        prevTime = t;
-        continue;
-      }
-      if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
-        const bucket = new Date(prevTime);
-        if (granularity === "week") {
-          const day = bucket.getUTCDay();
-          const diff = day === 0 ? -6 : 1 - day;
-          bucket.setUTCDate(bucket.getUTCDate() + diff);
-        } else if (granularity === "month") {
-          bucket.setUTCDate(1);
-        }
-        const dayKey = bucket.toISOString().slice(0, 10);
-        const dur = t - prevTime;
-        let entry = dailyMap.get(dayKey);
-        if (!entry) {
-          entry = {};
-          dailyMap.set(dayKey, entry);
-        }
-        entry[prevType] = (entry[prevType] ?? 0) + dur;
-      }
-      prevType = row.event_type;
-      prevTime = t;
-    }
-
-    const dailyStatus = Array.from(dailyMap.entries())
-      .map(([day, durations]) => ({ day, ...durations }))
-      .sort((a, b) => a.day.localeCompare(b.day));
+    const { rows, rangeStart } = await loadScopedActivityEvents(range);
+    const dailyStatus = computeDailyStatus(rows, rangeStart, granularity);
 
     return { days: dailyStatus, granularity };
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,9 @@ const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
+const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
+type ActivityRange = (typeof ACTIVITY_RANGES)[number];
+type ActivityGranularity = "day" | "week" | "month";
 type UiEvent =
   | { type: "snapshot"; agents: AgentRecord[] }
   | { type: "agent.upsert"; agent: AgentRecord }
@@ -138,6 +141,46 @@ const GIT_CONTEXT_REFRESH_CONCURRENCY = 1;
 const GIT_CONTEXT_MIN_REQUEUE_MS = 60_000;
 const GIT_DIAGNOSTICS_HISTORY_LIMIT = 200;
 const pendingGitRefreshAgentIds = new Set<string>();
+
+function parseActivityRange(input: unknown): ActivityRange {
+  return typeof input === "string" && (ACTIVITY_RANGES as readonly string[]).includes(input)
+    ? (input as ActivityRange)
+    : "7d";
+}
+
+function currentYearStart(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), 0, 1, 0, 0, 0, 0));
+}
+
+function getRangeLowerBound(range: ActivityRange): Date | null {
+  if (range === "all") return null;
+  if (range === "year") return currentYearStart();
+  if (range === "7d") return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+}
+
+function rangeWhereClause(range: ActivityRange, column: string): {
+  clause: string;
+  params: unknown[];
+} {
+  const lowerBound = getRangeLowerBound(range);
+  if (!lowerBound) {
+    return { clause: "", params: [] };
+  }
+  return { clause: `WHERE ${column} >= $1`, params: [lowerBound] };
+}
+
+function getBucketGranularity(range: ActivityRange): ActivityGranularity {
+  if (range === "7d" || range === "30d") return "day";
+  if (range === "year") return "month";
+  return "month";
+}
+
+function bucketExpression(range: ActivityRange, column: string): string {
+  const granularity = getBucketGranularity(range);
+  return `date_trunc('${granularity}', ${column})::date::text`;
+}
 const activeGitRefreshAgentIds = new Set<string>();
 const pendingGitRefreshEnqueuedAt = new Map<string, number>();
 const gitRefreshDurationsMs: number[] = [];
@@ -1349,7 +1392,11 @@ async function registerRoutes() {
     return { days: result.rows };
   });
 
-  app.get("/api/v1/activity/stats", async () => {
+  app.get("/api/v1/activity/stats", async (request) => {
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const eventFilter = rangeWhereClause(range, "created_at");
+
     // Fetch all events ordered by agent then time so we can compute durations
     const allEvents = await pool.query<{
       agent_id: string;
@@ -1357,12 +1404,18 @@ async function registerRoutes() {
       created_at: Date;
     }>(
       `SELECT agent_id, event_type, created_at
-       FROM agent_events ORDER BY agent_id, created_at`
+       FROM agent_events
+       ${eventFilter.clause}
+       ORDER BY agent_id, created_at`,
+      eventFilter.params
     );
 
     const busiestDayResult = await pool.query<{ day: string; count: number }>(
       `SELECT date_trunc('day', created_at)::date::text AS day, COUNT(*)::int AS count
-       FROM agent_events GROUP BY day ORDER BY count DESC LIMIT 1`
+       FROM agent_events
+       ${eventFilter.clause}
+       GROUP BY day ORDER BY count DESC LIMIT 1`,
+      eventFilter.params
     );
 
     // Compute per-state durations across all agents.
@@ -1446,13 +1499,10 @@ async function registerRoutes() {
     const avg = (arr: number[]) =>
       arr.length > 0 ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
 
-    const totalTime = Object.values(stateDurations).reduce((a, b) => a + b, 0);
-
     return {
       totalWorkingMs: stateDurations.working ?? 0,
       avgBlockedMs: avg(sessionBlockedTimes),
       avgWaitingMs: avg(sessionWaitingTimes),
-      blockedRatio: totalTime > 0 ? Math.round((stateDurations.blocked / totalTime) * 100) : 0,
       busiestDay: busiestDayResult.rows[0]?.day ?? null,
       busiestDayCount: busiestDayResult.rows[0]?.count ?? 0,
       stateDurations,
@@ -1460,8 +1510,10 @@ async function registerRoutes() {
   });
 
   app.get("/api/v1/activity/daily-status", async (request) => {
-    const query = request.query as { days?: string };
-    const days = Math.min(Math.max(parseInt(query.days ?? "30", 10) || 30, 1), 90);
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const eventFilter = rangeWhereClause(range, "created_at");
+    const granularity = getBucketGranularity(range);
 
     // Get all events in the period, ordered by agent then time
     const result = await pool.query<{
@@ -1471,9 +1523,9 @@ async function registerRoutes() {
     }>(
       `SELECT agent_id, event_type, created_at
        FROM agent_events
-       WHERE created_at >= NOW() - make_interval(days => $1)
+       ${eventFilter.clause}
        ORDER BY agent_id, created_at`,
-      [days]
+      eventFilter.params
     );
 
     // Build daily duration breakdown
@@ -1492,8 +1544,15 @@ async function registerRoutes() {
         continue;
       }
       if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
-        // Attribute duration to the day the segment started
-        const dayKey = new Date(prevTime).toISOString().slice(0, 10);
+        const bucket = new Date(prevTime);
+        if (granularity === "week") {
+          const day = bucket.getUTCDay();
+          const diff = day === 0 ? -6 : 1 - day;
+          bucket.setUTCDate(bucket.getUTCDate() + diff);
+        } else if (granularity === "month") {
+          bucket.setUTCDate(1);
+        }
+        const dayKey = bucket.toISOString().slice(0, 10);
         const dur = t - prevTime;
         let entry = dailyMap.get(dayKey);
         if (!entry) {
@@ -1510,12 +1569,15 @@ async function registerRoutes() {
       .map(([day, durations]) => ({ day, ...durations }))
       .sort((a, b) => a.day.localeCompare(b.day));
 
-    return { days: dailyStatus };
+    return { days: dailyStatus, granularity };
   });
 
   // ── Token usage ──────────────────────────────────────────────────
 
-  app.get("/api/v1/activity/token-stats", async () => {
+  app.get("/api/v1/activity/token-stats", async (request) => {
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
     const result = await pool.query<{
       total_input: number;
       total_cache_creation: number;
@@ -1531,14 +1593,18 @@ async function registerRoutes() {
         COALESCE(SUM(output_tokens), 0)::int AS total_output,
         COALESCE(SUM(message_count), 0)::int AS total_messages,
         COUNT(DISTINCT session_id)::int AS total_sessions
-       FROM agent_token_usage`
+       FROM agent_token_usage
+       ${tokenFilter.clause}`,
+      tokenFilter.params
     );
     return result.rows[0];
   });
 
   app.get("/api/v1/activity/token-daily", async (request) => {
-    const query = request.query as { days?: string };
-    const days = Math.min(Math.max(parseInt(query.days ?? "30", 10) || 30, 1), 90);
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const granularity = getBucketGranularity(range);
+    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
 
     const result = await pool.query<{
       day: string;
@@ -1549,21 +1615,24 @@ async function registerRoutes() {
       messages: number;
     }>(
       `SELECT
-        date_trunc('day', COALESCE(session_start, harvested_at))::date::text AS day,
+        ${bucketExpression(range, "COALESCE(session_start, harvested_at)")} AS day,
         SUM(input_tokens)::int AS input_tokens,
         SUM(cache_creation_tokens)::int AS cache_creation_tokens,
         SUM(cache_read_tokens)::int AS cache_read_tokens,
         SUM(output_tokens)::int AS output_tokens,
         SUM(message_count)::int AS messages
        FROM agent_token_usage
-       WHERE COALESCE(session_start, harvested_at) >= NOW() - make_interval(days => $1)
+       ${tokenFilter.clause}
        GROUP BY day ORDER BY day`,
-      [days]
+      tokenFilter.params
     );
-    return { days: result.rows };
+    return { days: result.rows, granularity };
   });
 
-  app.get("/api/v1/activity/token-by-project", async () => {
+  app.get("/api/v1/activity/token-by-project", async (request) => {
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const tokenFilter = rangeWhereClause(range, "COALESCE(t.session_start, t.harvested_at)");
     const result = await pool.query<{
       project_dir: string;
       total_input: number;
@@ -1577,14 +1646,19 @@ async function registerRoutes() {
         SUM(t.message_count)::int AS messages
        FROM agent_token_usage t
        JOIN agents a ON a.id = t.agent_id
+       ${tokenFilter.clause}
        GROUP BY project_dir
        ORDER BY total_input DESC
-       LIMIT 20`
+       LIMIT 20`,
+      tokenFilter.params
     );
     return { projects: result.rows };
   });
 
-  app.get("/api/v1/activity/token-by-model", async () => {
+  app.get("/api/v1/activity/token-by-model", async (request) => {
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
     const result = await pool.query<{
       model: string;
       total_input: number;
@@ -1599,10 +1673,12 @@ async function registerRoutes() {
         COALESCE(SUM(cache_creation_tokens), 0)::int AS total_cache_creation,
         COALESCE(SUM(cache_read_tokens), 0)::int AS total_cache_read,
         COALESCE(SUM(output_tokens), 0)::int AS total_output,
-        COUNT(DISTINCT session_id)::int AS sessions
+       COUNT(DISTINCT session_id)::int AS sessions
        FROM agent_token_usage
+       ${tokenFilter.clause}
        GROUP BY model
-       ORDER BY (SUM(input_tokens) + SUM(cache_creation_tokens) + SUM(cache_read_tokens) + SUM(output_tokens)) DESC`
+       ORDER BY (SUM(input_tokens) + SUM(cache_creation_tokens) + SUM(cache_read_tokens) + SUM(output_tokens)) DESC`,
+      tokenFilter.params
     );
     return { models: result.rows };
   });

--- a/test/activity-metrics.test.ts
+++ b/test/activity-metrics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeActivityStats,
+  computeDailyStatus,
+  type ActivityEventRow,
+} from "../src/activity-metrics.js";
+
+function row(agent_id: string, event_type: string, created_at: string): ActivityEventRow {
+  return { agent_id, event_type, created_at: new Date(created_at) };
+}
+
+describe("activity metrics boundary carry-in", () => {
+  it("counts time from the range start when a state began before the window", () => {
+    const rows = [
+      row("a1", "working", "2026-03-20T23:50:00Z"),
+      row("a1", "done", "2026-03-21T00:20:00Z"),
+    ];
+
+    const stats = computeActivityStats(rows, new Date("2026-03-21T00:00:00Z"));
+
+    expect(stats.totalWorkingMs).toBe(20 * 60 * 1000);
+  });
+
+  it("counts blocked and waiting averages from clipped boundary segments", () => {
+    const rows = [
+      row("a1", "blocked", "2026-03-20T23:55:00Z"),
+      row("a1", "waiting_user", "2026-03-21T00:10:00Z"),
+      row("a1", "done", "2026-03-21T00:25:00Z"),
+    ];
+
+    const stats = computeActivityStats(rows, new Date("2026-03-21T00:00:00Z"));
+
+    expect(stats.avgBlockedMs).toBe(10 * 60 * 1000);
+    expect(stats.avgWaitingMs).toBe(15 * 60 * 1000);
+  });
+
+  it("attributes carried-in status time to the in-range daily bucket", () => {
+    const rows = [
+      row("a1", "working", "2026-03-20T23:50:00Z"),
+      row("a1", "done", "2026-03-21T00:20:00Z"),
+    ];
+
+    const days = computeDailyStatus(rows, new Date("2026-03-21T00:00:00Z"), "day");
+
+    expect(days).toEqual([{ day: "2026-03-21", working: 20 * 60 * 1000 }]);
+  });
+});

--- a/web/src/components/app/activity-pane.tsx
+++ b/web/src/components/app/activity-pane.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import {
@@ -10,6 +10,13 @@ import {
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
@@ -19,6 +26,7 @@ import {
 } from "@/components/ui/chart";
 import { cn } from "@/lib/utils";
 import {
+  ACTIVITY_RANGES,
   useActivityHeatmap,
   useActivityStats,
   useDailyStatus,
@@ -26,6 +34,9 @@ import {
   useTokenDaily,
   useTokenByModel,
   useTokenByProject,
+  rangeLabel,
+  type ActivityGranularity,
+  type ActivityRange,
   type DailyStatusEntry,
   type TokenDailyEntry,
   type TokenStats,
@@ -57,6 +68,17 @@ function formatDuration(ms: number): string {
 function formatDate(iso: string): string {
   const d = new Date(iso + "T00:00:00");
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatBucketLabel(iso: string, granularity: ActivityGranularity): string {
+  const d = new Date(iso + "T00:00:00");
+  if (granularity === "month") {
+    return d.toLocaleDateString(undefined, { month: "short", year: "2-digit" });
+  }
+  if (granularity === "week") {
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  return formatDate(iso);
 }
 
 function msToMinutes(ms: number): number {
@@ -237,7 +259,12 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
 
 // ── Daily stacked bar chart (recharts) ──────────────────────────────
 
-function fillGaps<T extends { day: string }>(data: T[], defaultEntry: (day: string) => T): T[] {
+function fillGaps<T extends { day: string }>(
+  data: T[],
+  granularity: ActivityGranularity,
+  defaultEntry: (day: string) => T
+): T[] {
+  if (granularity !== "day") return data;
   if (data.length < 2) return data;
   const filled: T[] = [];
   const dataMap = new Map(data.map((d) => [d.day, d]));
@@ -252,17 +279,23 @@ function fillGaps<T extends { day: string }>(data: T[], defaultEntry: (day: stri
   return filled;
 }
 
-function DailyStackedBarChart({ data: rawData }: { data: DailyStatusEntry[] }) {
+function DailyStackedBarChart({
+  data: rawData,
+  granularity,
+}: {
+  data: DailyStatusEntry[];
+  granularity: ActivityGranularity;
+}) {
   const chartData = useMemo(() => {
-    const filled = fillGaps<DailyStatusEntry>(rawData, (day) => ({ day }));
+    const filled = fillGaps<DailyStatusEntry>(rawData, granularity, (day) => ({ day }));
     return filled.map((d) => ({
       day: d.day,
-      label: formatDate(d.day),
+      label: formatBucketLabel(d.day, granularity),
       working: msToMinutes(d.working ?? 0),
       blocked: msToMinutes(d.blocked ?? 0),
       waiting_user: msToMinutes(d.waiting_user ?? 0),
     }));
-  }, [rawData]);
+  }, [granularity, rawData]);
 
   if (chartData.length === 0) {
     return (
@@ -370,11 +403,17 @@ const EMPTY_TOKEN_ENTRY = (day: string): TokenDailyEntry => ({
   messages: 0,
 });
 
-function DailyTokenChart({ data: rawData }: { data: TokenDailyEntry[] }) {
+function DailyTokenChart({
+  data: rawData,
+  granularity,
+}: {
+  data: TokenDailyEntry[];
+  granularity: ActivityGranularity;
+}) {
   const chartData = useMemo(() => {
-    const filled = fillGaps(rawData, EMPTY_TOKEN_ENTRY);
-    return filled.map((d) => ({ ...d, label: formatDate(d.day) }));
-  }, [rawData]);
+    const filled = fillGaps(rawData, granularity, EMPTY_TOKEN_ENTRY);
+    return filled.map((d) => ({ ...d, label: formatBucketLabel(d.day, granularity) }));
+  }, [granularity, rawData]);
 
   if (chartData.length === 0) {
     return (
@@ -519,13 +558,14 @@ function ProjectBreakdown({ data }: { data: TokenByProject[] }) {
 // ── Main pane ───────────────────────────────────────────────────────
 
 export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element {
+  const [range, setRange] = useState<ActivityRange>("7d");
   const { data: heatmapData } = useActivityHeatmap();
-  const { data: stats } = useActivityStats();
-  const { data: dailyStatus } = useDailyStatus(30);
-  const { data: tokenStats } = useTokenStats();
-  const { data: tokenDaily } = useTokenDaily(30);
-  const { data: tokenByModel } = useTokenByModel();
-  const { data: tokenByProject } = useTokenByProject();
+  const { data: stats } = useActivityStats(range);
+  const { data: dailyStatus } = useDailyStatus(range);
+  const { data: tokenStats } = useTokenStats(range);
+  const { data: tokenDaily } = useTokenDaily(range);
+  const { data: tokenByModel } = useTokenByModel(range);
+  const { data: tokenByProject } = useTokenByProject(range);
 
   const hasData = stats && (stats.totalWorkingMs > 0 || stats.avgBlockedMs > 0 || stats.avgWaitingMs > 0);
   const totalTokens = tokenStats
@@ -549,11 +589,29 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
           </DialogPrimitive.Description>
 
           {/* Header */}
-          <div className="flex h-12 shrink-0 items-center border-b border-border px-5">
+          <div className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-5">
             <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               Activity
             </span>
-            <DialogPrimitive.Close className="ml-auto rounded-sm p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+            <div className="ml-auto flex items-center gap-2">
+              <Select value={range} onValueChange={(value) => setRange(value as ActivityRange)}>
+                <SelectTrigger
+                  className="h-8 w-[132px] bg-muted/30 text-xs"
+                  data-testid="activity-range-select"
+                  aria-label="Activity time range"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ACTIVITY_RANGES.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {rangeLabel(option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <DialogPrimitive.Close className="rounded-sm p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
             </DialogPrimitive.Close>
@@ -572,7 +630,6 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
                   <StatCard
                     label="Avg blocked time"
                     value={formatDuration(stats.avgBlockedMs)}
-                    sub={`${stats.blockedRatio}% of total time`}
                   />
                   <StatCard
                     label="Avg waiting time"
@@ -599,12 +656,15 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
               </div>
 
               {/* Daily status bar chart */}
-              {dailyStatus && dailyStatus.length > 0 && (
+              {dailyStatus && dailyStatus.days.length > 0 && (
                 <div>
                   <h2 className="mb-3 text-sm font-medium text-foreground">
-                    Daily status breakdown (last 30 days)
+                    Status breakdown ({rangeLabel(range).toLowerCase()})
                   </h2>
-                  <DailyStackedBarChart data={dailyStatus} />
+                  <DailyStackedBarChart
+                    data={dailyStatus.days}
+                    granularity={dailyStatus.granularity}
+                  />
                 </div>
               )}
 
@@ -638,12 +698,15 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
               )}
 
               {/* Daily token chart */}
-              {tokenDaily && tokenDaily.length > 0 && (
+              {tokenDaily && tokenDaily.days.length > 0 && (
                 <div>
                   <h2 className="mb-3 text-sm font-medium text-foreground">
-                    Daily token usage (last 30 days)
+                    Token usage ({rangeLabel(range).toLowerCase()})
                   </h2>
-                  <DailyTokenChart data={tokenDaily} />
+                  <DailyTokenChart
+                    data={tokenDaily.days}
+                    granularity={tokenDaily.granularity}
+                  />
                 </div>
               )}
 

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -8,11 +8,31 @@ const ACTIVITY_QUERY_OPTIONS = {
 
 type HeatmapDay = { day: string; count: number };
 
+export const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
+export type ActivityRange = (typeof ACTIVITY_RANGES)[number];
+export type ActivityGranularity = "day" | "week" | "month";
+
+export function rangeLabel(range: ActivityRange): string {
+  switch (range) {
+    case "7d":
+      return "Last 7 days";
+    case "30d":
+      return "Last 30 days";
+    case "year":
+      return "This year";
+    case "all":
+      return "All time";
+  }
+}
+
+function scopedActivityPath(path: string, range: ActivityRange): string {
+  return `${path}?range=${range}`;
+}
+
 export type ActivityStats = {
   totalWorkingMs: number;
   avgBlockedMs: number;
   avgWaitingMs: number;
-  blockedRatio: number;
   busiestDay: string | null;
   busiestDayCount: number;
   stateDurations: Record<string, number>;
@@ -25,6 +45,11 @@ export type DailyStatusEntry = {
   waiting_user?: number;
   done?: number;
   idle?: number;
+};
+
+export type BucketedActivityResponse<T> = {
+  days: T[];
+  granularity: ActivityGranularity;
 };
 
 export function useActivityHeatmap(days = 365) {
@@ -40,22 +65,21 @@ export function useActivityHeatmap(days = 365) {
   });
 }
 
-export function useActivityStats() {
+export function useActivityStats(range: ActivityRange) {
   return useQuery<ActivityStats>({
-    queryKey: ["activity", "stats"],
-    queryFn: () => api<ActivityStats>("/api/v1/activity/stats"),
+    queryKey: ["activity", "stats", range],
+    queryFn: () => api<ActivityStats>(scopedActivityPath("/api/v1/activity/stats", range)),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
-export function useDailyStatus(days = 30) {
-  return useQuery<DailyStatusEntry[]>({
-    queryKey: ["activity", "daily-status", days],
+export function useDailyStatus(range: ActivityRange) {
+  return useQuery<BucketedActivityResponse<DailyStatusEntry>>({
+    queryKey: ["activity", "daily-status", range],
     queryFn: async () => {
-      const payload = await api<{ days: DailyStatusEntry[] }>(
-        `/api/v1/activity/daily-status?days=${days}`
+      return api<BucketedActivityResponse<DailyStatusEntry>>(
+        scopedActivityPath("/api/v1/activity/daily-status", range)
       );
-      return payload.days;
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });
@@ -81,22 +105,21 @@ export type TokenDailyEntry = {
   messages: number;
 };
 
-export function useTokenStats() {
+export function useTokenStats(range: ActivityRange) {
   return useQuery<TokenStats>({
-    queryKey: ["activity", "token-stats"],
-    queryFn: () => api<TokenStats>("/api/v1/activity/token-stats"),
+    queryKey: ["activity", "token-stats", range],
+    queryFn: () => api<TokenStats>(scopedActivityPath("/api/v1/activity/token-stats", range)),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
-export function useTokenDaily(days = 30) {
-  return useQuery<TokenDailyEntry[]>({
-    queryKey: ["activity", "token-daily", days],
+export function useTokenDaily(range: ActivityRange) {
+  return useQuery<BucketedActivityResponse<TokenDailyEntry>>({
+    queryKey: ["activity", "token-daily", range],
     queryFn: async () => {
-      const payload = await api<{ days: TokenDailyEntry[] }>(
-        `/api/v1/activity/token-daily?days=${days}`
+      return api<BucketedActivityResponse<TokenDailyEntry>>(
+        scopedActivityPath("/api/v1/activity/token-daily", range)
       );
-      return payload.days;
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });
@@ -118,22 +141,26 @@ export type TokenByProject = {
   messages: number;
 };
 
-export function useTokenByModel() {
+export function useTokenByModel(range: ActivityRange) {
   return useQuery<TokenByModel[]>({
-    queryKey: ["activity", "token-by-model"],
+    queryKey: ["activity", "token-by-model", range],
     queryFn: async () => {
-      const payload = await api<{ models: TokenByModel[] }>("/api/v1/activity/token-by-model");
+      const payload = await api<{ models: TokenByModel[] }>(
+        scopedActivityPath("/api/v1/activity/token-by-model", range)
+      );
       return payload.models;
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
 
-export function useTokenByProject() {
+export function useTokenByProject(range: ActivityRange) {
   return useQuery<TokenByProject[]>({
-    queryKey: ["activity", "token-by-project"],
+    queryKey: ["activity", "token-by-project", range],
     queryFn: async () => {
-      const payload = await api<{ projects: TokenByProject[] }>("/api/v1/activity/token-by-project");
+      const payload = await api<{ projects: TokenByProject[] }>(
+        scopedActivityPath("/api/v1/activity/token-by-project", range)
+      );
       return payload.projects;
     },
     ...ACTIVITY_QUERY_OPTIONS,


### PR DESCRIPTION
## Summary
- add a shared analytics time range selector with `7d`, `30d`, `year`, and `all`
- scope activity and token APIs consistently while keeping the activity heatmap fixed to the current year
- update the activity pane, roadmap, and e2e coverage for the new range behavior

## Testing
- npm run check
- npm test
- npm run finalize:web
- npm run test:e2e