### PR TITLE
Add active hours analytics heatmap

### DIFF
--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loadApp, seedActivityDemoViaAPI } from "./helpers";
+import { loadApp, seedActivityDemoViaDB } from "./helpers";
 
 const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
 
@@ -45,24 +45,22 @@ test.describe("Activity range API", () => {
   });
 
   test("active-hours endpoint returns a full 7x24 grid", async ({ request }) => {
-    await seedActivityDemoViaAPI(request);
+    await seedActivityDemoViaDB();
 
     const res = await request.get("/api/v1/activity/active-hours?range=30d", {
       headers: authHeader,
     });
     expect(res.ok()).toBeTruthy();
 
-    const body = (await res.json()) as {
-      cells: Array<{ dayOfWeek: number; hour: number; count: number; avgPerWeek: number }>;
-    };
-    expect(body.cells).toHaveLength(7 * 24);
-    expect(body.cells.some((cell) => cell.avgPerWeek > 0)).toBe(true);
+    const body = (await res.json()) as { events: Array<{ created_at: string }> };
+    expect(body.events.length).toBeGreaterThan(0);
+    expect(body.events.every((event) => typeof event.created_at === "string")).toBe(true);
   });
 });
 
 test.describe("Active hours UI", () => {
-  test("activity pane renders the active-hours heatmap with seeded data", async ({ page, request }) => {
-    await seedActivityDemoViaAPI(request);
+  test("activity pane renders the active-hours heatmap with seeded data", async ({ page }) => {
+    await seedActivityDemoViaDB();
     await loadApp(page);
 
     await page.getByTestId("activity-button").click();

--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { loadApp, seedActivityDemoViaAPI } from "./helpers";
 
 const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
 
@@ -41,5 +42,36 @@ test.describe("Activity range API", () => {
       expect(Array.isArray(body.days)).toBe(true);
       expect(body.granularity).toBe(granularity);
     }
+  });
+
+  test("active-hours endpoint returns a full 7x24 grid", async ({ request }) => {
+    await seedActivityDemoViaAPI(request);
+
+    const res = await request.get("/api/v1/activity/active-hours?range=30d", {
+      headers: authHeader,
+    });
+    expect(res.ok()).toBeTruthy();
+
+    const body = (await res.json()) as {
+      cells: Array<{ dayOfWeek: number; hour: number; count: number; avgPerWeek: number }>;
+    };
+    expect(body.cells).toHaveLength(7 * 24);
+    expect(body.cells.some((cell) => cell.avgPerWeek > 0)).toBe(true);
+  });
+});
+
+test.describe("Active hours UI", () => {
+  test("activity pane renders the active-hours heatmap with seeded data", async ({ page, request }) => {
+    await seedActivityDemoViaAPI(request);
+    await loadApp(page);
+
+    await page.getByTestId("activity-button").click();
+    await expect(page.getByRole("dialog", { name: "Activity" })).toBeVisible();
+    await expect(page.getByText("Active hours")).toBeVisible();
+    await expect(page.getByTestId("active-hours-cell-sample")).toBeVisible();
+
+    await page.getByTestId("activity-range-select").click();
+    await page.getByRole("option", { name: "Last 30 days" }).click();
+    await expect(page.getByText("Average active-state events per week by weekday and hour for last 30 days.")).toBeVisible();
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,3 +1,4 @@
+import { Pool } from "pg";
 import { type Page, type APIRequestContext } from "@playwright/test";
 
 const API = "/api/v1";
@@ -154,13 +155,174 @@ export async function cleanupE2EAgents(request: APIRequestContext): Promise<void
   }
 }
 
-export async function seedActivityDemoViaAPI(request: APIRequestContext): Promise<void> {
-  const res = await request.post(`${API}/activity/demo-seed`, {
-    headers: authHeaders(),
-  });
+function mulberry32(seed: number): () => number {
+  return () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
-  if (!res.ok()) {
-    throw new Error(`Activity demo seed failed with ${res.status()}`);
+type DemoSeedRow = {
+  agent_id: string;
+  event_type: "working" | "blocked" | "waiting_user" | "done";
+  message: string;
+  metadata: string;
+  created_at: Date;
+  agent_type: string;
+  agent_name: string;
+  project_dir: string;
+};
+
+function buildDemoActivitySeed(now = new Date()): DemoSeedRow[] {
+  const projects = [
+    { dir: "/tmp/dispatch-demo", agentType: "codex" },
+    { dir: "/tmp/ios-client-demo", agentType: "claude" },
+    { dir: "/tmp/marketing-site-demo", agentType: "opencode" },
+  ];
+  const dayCount = 420;
+  const rows: DemoSeedRow[] = [];
+  const start = new Date(now.getTime() - dayCount * 24 * 60 * 60 * 1000);
+
+  for (let dayOffset = 0; dayOffset < dayCount; dayOffset += 1) {
+    const day = new Date(start.getTime() + dayOffset * 24 * 60 * 60 * 1000);
+    const weekday = day.getUTCDay();
+    const weekend = weekday === 0 || weekday === 6;
+    const projectIndex = weekend ? dayOffset % 2 : dayOffset % projects.length;
+    const project = projects[projectIndex];
+    const random = mulberry32(dayOffset * 97 + projectIndex * 131 + 17);
+
+    const activeAgents = weekend ? (random() > 0.58 ? 1 : 0) : (random() > 0.82 ? 3 : 2);
+    for (let agentIndex = 0; agentIndex < activeAgents; agentIndex += 1) {
+      const startHour =
+        weekend
+          ? 9 + Math.floor(random() * 6)
+          : 8 + Math.floor(random() * 3) + (agentIndex === 2 ? 1 : 0);
+      const startMinute = Math.floor(random() * 40);
+      const workingBlockMinutes = weekend
+        ? 70 + Math.floor(random() * 80)
+        : 105 + Math.floor(random() * 85);
+      const blockedMinutes = random() > (weekend ? 0.78 : 0.55) ? 0 : 10 + Math.floor(random() * 35);
+      const waitingMinutes = random() > (weekend ? 0.88 : 0.68) ? 0 : 8 + Math.floor(random() * 28);
+      const reviewBlockMinutes = weekend ? 20 + Math.floor(random() * 40) : 45 + Math.floor(random() * 55);
+      const agentId = `seed-active-hours-${projectIndex}-${agentIndex}`;
+      const agentName = weekend ? `Weekend ${agentIndex + 1}` : `Builder ${projectIndex + 1}-${agentIndex + 1}`;
+
+      const workingAt = new Date(Date.UTC(
+        day.getUTCFullYear(),
+        day.getUTCMonth(),
+        day.getUTCDate(),
+        startHour,
+        startMinute,
+      ));
+      rows.push({
+        agent_id: agentId,
+        event_type: "working",
+        message: "Deep work block",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "working" }),
+        created_at: workingAt,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+
+      let cursor = new Date(workingAt.getTime() + workingBlockMinutes * 60 * 1000);
+      if (blockedMinutes > 0) {
+        rows.push({
+          agent_id: agentId,
+          event_type: "blocked",
+          message: "Waiting on review feedback",
+          metadata: JSON.stringify({ seed: "activity-demo", phase: "blocked" }),
+          created_at: cursor,
+          agent_type: project.agentType,
+          agent_name: agentName,
+          project_dir: project.dir,
+        });
+        cursor = new Date(cursor.getTime() + blockedMinutes * 60 * 1000);
+      }
+
+      if (waitingMinutes > 0) {
+        rows.push({
+          agent_id: agentId,
+          event_type: "waiting_user",
+          message: "Need a product call",
+          metadata: JSON.stringify({ seed: "activity-demo", phase: "waiting" }),
+          created_at: cursor,
+          agent_type: project.agentType,
+          agent_name: agentName,
+          project_dir: project.dir,
+        });
+        cursor = new Date(cursor.getTime() + waitingMinutes * 60 * 1000);
+      }
+
+      rows.push({
+        agent_id: agentId,
+        event_type: "working",
+        message: "Afternoon execution",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "wrap-up" }),
+        created_at: cursor,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+      cursor = new Date(cursor.getTime() + reviewBlockMinutes * 60 * 1000);
+
+      rows.push({
+        agent_id: agentId,
+        event_type: "done",
+        message: "Shipped for the day",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "done" }),
+        created_at: cursor,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+    }
+  }
+
+  return rows.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+}
+
+export async function seedActivityDemoViaDB(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required to seed activity demo data.");
+  }
+
+  const pool = new Pool({ connectionString, max: 1 });
+  const rows = buildDemoActivitySeed();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `DELETE FROM agent_events
+       WHERE metadata::text LIKE '%"seed":"activity-demo"%'`
+    );
+    const insertSql = `INSERT INTO agent_events
+      (agent_id, event_type, message, metadata, created_at, agent_type, agent_name, project_dir)
+      VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8)`;
+
+    for (const row of rows) {
+      await client.query(insertSql, [
+        row.agent_id,
+        row.event_type,
+        row.message,
+        row.metadata,
+        row.created_at,
+        row.agent_type,
+        row.agent_name,
+        row.project_dir,
+      ]);
+    }
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+    await pool.end();
   }
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -154,6 +154,16 @@ export async function cleanupE2EAgents(request: APIRequestContext): Promise<void
   }
 }
 
+export async function seedActivityDemoViaAPI(request: APIRequestContext): Promise<void> {
+  const res = await request.post(`${API}/activity/demo-seed`, {
+    headers: authHeaders(),
+  });
+
+  if (!res.ok()) {
+    throw new Error(`Activity demo seed failed with ${res.status()}`);
+  }
+}
+
 /**
  * Navigate to the app root and wait for the shell to be ready
  * (sidebar rendered + health polling started).

--- a/src/activity-metrics.ts
+++ b/src/activity-metrics.ts
@@ -13,6 +13,15 @@ export type ActivityStatsResult = {
   stateDurations: Record<string, number>;
 };
 
+export type ActiveHoursCell = {
+  dayOfWeek: number;
+  hour: number;
+  count: number;
+  avgPerWeek: number;
+};
+
+const ACTIVE_HOURS_EVENT_TYPES = new Set(["working", "blocked", "waiting_user"]);
+
 function bucketStart(timeMs: number, granularity: ActivityGranularity): string {
   const bucket = new Date(timeMs);
   if (granularity === "week") {
@@ -157,4 +166,46 @@ export function computeDailyStatus(
   return Array.from(dailyMap.entries())
     .map(([day, durations]) => ({ day, ...durations }))
     .sort((a, b) => String(a.day).localeCompare(String(b.day)));
+}
+
+export function computeActiveHours(
+  rows: Array<Pick<ActivityEventRow, "event_type" | "created_at">>,
+  rangeStart: Date | null,
+  now = new Date()
+): ActiveHoursCell[] {
+  const counts = new Map<string, number>();
+  const rangeStartMs = rangeStart?.getTime() ?? null;
+  let firstTimestamp = Number.POSITIVE_INFINITY;
+  let lastTimestamp = Number.NEGATIVE_INFINITY;
+
+  for (const row of rows) {
+    const timestamp = row.created_at.getTime();
+    if (rangeStartMs !== null && timestamp < rangeStartMs) continue;
+    if (!ACTIVE_HOURS_EVENT_TYPES.has(row.event_type)) continue;
+
+    firstTimestamp = Math.min(firstTimestamp, timestamp);
+    lastTimestamp = Math.max(lastTimestamp, timestamp);
+
+    const key = `${row.created_at.getUTCDay()}:${row.created_at.getUTCHours()}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const effectiveStartMs = rangeStartMs ?? (Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime());
+  const effectiveEndMs = Number.isFinite(lastTimestamp) ? Math.max(lastTimestamp, now.getTime()) : now.getTime();
+  const spanWeeks = Math.max(1, (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000));
+
+  const cells: ActiveHoursCell[] = [];
+  for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {
+    for (let hour = 0; hour < 24; hour += 1) {
+      const count = counts.get(`${dayOfWeek}:${hour}`) ?? 0;
+      cells.push({
+        dayOfWeek,
+        hour,
+        count,
+        avgPerWeek: Number((count / spanWeeks).toFixed(2)),
+      });
+    }
+  }
+
+  return cells;
 }

--- a/src/activity-metrics.ts
+++ b/src/activity-metrics.ts
@@ -13,15 +13,6 @@ export type ActivityStatsResult = {
   stateDurations: Record<string, number>;
 };
 
-export type ActiveHoursCell = {
-  dayOfWeek: number;
-  hour: number;
-  count: number;
-  avgPerWeek: number;
-};
-
-const ACTIVE_HOURS_EVENT_TYPES = new Set(["working", "blocked", "waiting_user"]);
-
 function bucketStart(timeMs: number, granularity: ActivityGranularity): string {
   const bucket = new Date(timeMs);
   if (granularity === "week") {
@@ -166,46 +157,4 @@ export function computeDailyStatus(
   return Array.from(dailyMap.entries())
     .map(([day, durations]) => ({ day, ...durations }))
     .sort((a, b) => String(a.day).localeCompare(String(b.day)));
-}
-
-export function computeActiveHours(
-  rows: Array<Pick<ActivityEventRow, "event_type" | "created_at">>,
-  rangeStart: Date | null,
-  now = new Date()
-): ActiveHoursCell[] {
-  const counts = new Map<string, number>();
-  const rangeStartMs = rangeStart?.getTime() ?? null;
-  let firstTimestamp = Number.POSITIVE_INFINITY;
-  let lastTimestamp = Number.NEGATIVE_INFINITY;
-
-  for (const row of rows) {
-    const timestamp = row.created_at.getTime();
-    if (rangeStartMs !== null && timestamp < rangeStartMs) continue;
-    if (!ACTIVE_HOURS_EVENT_TYPES.has(row.event_type)) continue;
-
-    firstTimestamp = Math.min(firstTimestamp, timestamp);
-    lastTimestamp = Math.max(lastTimestamp, timestamp);
-
-    const key = `${row.created_at.getUTCDay()}:${row.created_at.getUTCHours()}`;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-
-  const effectiveStartMs = rangeStartMs ?? (Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime());
-  const effectiveEndMs = Number.isFinite(lastTimestamp) ? Math.max(lastTimestamp, now.getTime()) : now.getTime();
-  const spanWeeks = Math.max(1, (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000));
-
-  const cells: ActiveHoursCell[] = [];
-  for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {
-    for (let hour = 0; hour < 24; hour += 1) {
-      const count = counts.get(`${dayOfWeek}:${hour}`) ?? 0;
-      cells.push({
-        dayOfWeek,
-        hour,
-        count,
-        avgPerWeek: Number((count / spanWeeks).toFixed(2)),
-      });
-    }
-  }
-
-  return cells;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,7 +41,6 @@ import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { harvestTokenUsage } from "./agents/token-harvester.js";
 import {
-  computeActiveHours,
   computeActivityStats,
   computeDailyStatus,
   type ActivityEventRow,
@@ -185,140 +184,6 @@ function getBucketGranularity(range: ActivityRange): "day" | "week" | "month" {
 function bucketExpression(range: ActivityRange, column: string): string {
   const granularity = getBucketGranularity(range);
   return `date_trunc('${granularity}', ${column})::date::text`;
-}
-
-function isDemoSeedEnabled(): boolean {
-  return process.env.NODE_ENV !== "production";
-}
-
-function mulberry32(seed: number): () => number {
-  return () => {
-    let t = (seed += 0x6d2b79f5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-type DemoSeedRow = {
-  agent_id: string;
-  event_type: AgentLatestEventType;
-  message: string;
-  metadata: string;
-  created_at: Date;
-  agent_type: string;
-  agent_name: string;
-  project_dir: string;
-};
-
-function buildDemoActivitySeed(now = new Date()): DemoSeedRow[] {
-  const projects = [
-    { dir: "/Users/brad/dev/apps/dispatch", agentType: "codex" },
-    { dir: "/Users/brad/dev/apps/ios-client", agentType: "claude" },
-    { dir: "/Users/brad/dev/apps/marketing-site", agentType: "opencode" },
-  ];
-  const dayCount = 420;
-  const rows: DemoSeedRow[] = [];
-  const start = new Date(now.getTime() - dayCount * 24 * 60 * 60 * 1000);
-
-  for (let dayOffset = 0; dayOffset < dayCount; dayOffset += 1) {
-    const day = new Date(start.getTime() + dayOffset * 24 * 60 * 60 * 1000);
-    const weekday = day.getUTCDay();
-    const weekend = weekday === 0 || weekday === 6;
-    const projectIndex = weekend ? dayOffset % 2 : dayOffset % projects.length;
-    const project = projects[projectIndex];
-    const seed = dayOffset * 97 + projectIndex * 131 + 17;
-    const random = mulberry32(seed);
-
-    const activeAgents = weekend ? (random() > 0.58 ? 1 : 0) : (random() > 0.82 ? 3 : 2);
-    for (let agentIndex = 0; agentIndex < activeAgents; agentIndex += 1) {
-      const startHour =
-        weekend
-          ? 9 + Math.floor(random() * 6)
-          : 8 + Math.floor(random() * 3) + (agentIndex === 2 ? 1 : 0);
-      const startMinute = Math.floor(random() * 40);
-      const workingBlockMinutes = weekend
-        ? 70 + Math.floor(random() * 80)
-        : 105 + Math.floor(random() * 85);
-      const blockedMinutes = random() > (weekend ? 0.78 : 0.55) ? 0 : 10 + Math.floor(random() * 35);
-      const waitingMinutes = random() > (weekend ? 0.88 : 0.68) ? 0 : 8 + Math.floor(random() * 28);
-      const reviewBlockMinutes = weekend ? 20 + Math.floor(random() * 40) : 45 + Math.floor(random() * 55);
-      const agentId = `seed-active-hours-${projectIndex}-${agentIndex}`;
-      const agentName = weekend ? `Weekend ${agentIndex + 1}` : `Builder ${projectIndex + 1}-${agentIndex + 1}`;
-
-      const workingAt = new Date(Date.UTC(
-        day.getUTCFullYear(),
-        day.getUTCMonth(),
-        day.getUTCDate(),
-        startHour,
-        startMinute,
-      ));
-      rows.push({
-        agent_id: agentId,
-        event_type: "working",
-        message: "Deep work block",
-        metadata: JSON.stringify({ seed: "activity-demo", phase: "working" }),
-        created_at: workingAt,
-        agent_type: project.agentType,
-        agent_name: agentName,
-        project_dir: project.dir,
-      });
-
-      let cursor = new Date(workingAt.getTime() + workingBlockMinutes * 60 * 1000);
-      if (blockedMinutes > 0) {
-        rows.push({
-          agent_id: agentId,
-          event_type: "blocked",
-          message: "Waiting on review feedback",
-          metadata: JSON.stringify({ seed: "activity-demo", phase: "blocked" }),
-          created_at: cursor,
-          agent_type: project.agentType,
-          agent_name: agentName,
-          project_dir: project.dir,
-        });
-        cursor = new Date(cursor.getTime() + blockedMinutes * 60 * 1000);
-      }
-
-      if (waitingMinutes > 0) {
-        rows.push({
-          agent_id: agentId,
-          event_type: "waiting_user",
-          message: "Need a product call",
-          metadata: JSON.stringify({ seed: "activity-demo", phase: "waiting" }),
-          created_at: cursor,
-          agent_type: project.agentType,
-          agent_name: agentName,
-          project_dir: project.dir,
-        });
-        cursor = new Date(cursor.getTime() + waitingMinutes * 60 * 1000);
-      }
-
-      rows.push({
-        agent_id: agentId,
-        event_type: "working",
-        message: "Afternoon execution",
-        metadata: JSON.stringify({ seed: "activity-demo", phase: "wrap-up" }),
-        created_at: cursor,
-        agent_type: project.agentType,
-        agent_name: agentName,
-        project_dir: project.dir,
-      });
-      cursor = new Date(cursor.getTime() + reviewBlockMinutes * 60 * 1000);
-
-      rows.push({
-        agent_id: agentId,
-        event_type: "done",
-        message: "Shipped for the day",
-        metadata: JSON.stringify({ seed: "activity-demo", phase: "done" }),
-        created_at: cursor,
-        agent_type: project.agentType,
-        agent_name: agentName,
-        project_dir: project.dir,
-      });
-    }
-  }
-
-  return rows.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
 }
 
 async function loadScopedActivityEvents(
@@ -1604,63 +1469,16 @@ async function registerRoutes() {
   app.get("/api/v1/activity/active-hours", async (request) => {
     const query = request.query as { range?: string };
     const range = parseActivityRange(query.range);
-    const { rows, rangeStart } = await loadScopedActivityEvents(range);
-    const cells = computeActiveHours(rows, rangeStart);
-
-    return { cells };
-  });
-
-  app.post("/api/v1/activity/demo-seed", async (_request, reply) => {
-    if (!isDemoSeedEnabled()) {
-      return reply.code(404).send({ error: "Not found" });
-    }
-
-    const rows = buildDemoActivitySeed();
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
-      await client.query(
-        `DELETE FROM agent_events
-         WHERE metadata::text LIKE '%"seed":"activity-demo"%'`
-      );
-
-      const insertSql = `INSERT INTO agent_events
-        (agent_id, event_type, message, metadata, created_at, agent_type, agent_name, project_dir)
-        VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8)`;
-
-      for (const row of rows) {
-        await client.query(insertSql, [
-          row.agent_id,
-          row.event_type,
-          row.message,
-          row.metadata,
-          row.created_at,
-          row.agent_type,
-          row.agent_name,
-          row.project_dir,
-        ]);
-      }
-
-      await client.query("COMMIT");
-    } catch (error) {
-      await client.query("ROLLBACK");
-      throw error;
-    } finally {
-      client.release();
-    }
-
-    const seeded = computeActiveHours(
-      rows.map((row) => ({ event_type: row.event_type, created_at: row.created_at })),
-      getRangeLowerBound("all")
+    const eventFilter = rangeWhereClause(range, "created_at");
+    const result = await pool.query<{ created_at: string }>(
+      `SELECT created_at::text AS created_at
+       FROM agent_events
+       ${eventFilter.clause ? `${eventFilter.clause} AND` : "WHERE"} event_type IN ('working', 'blocked', 'waiting_user')
+       ORDER BY created_at`,
+      eventFilter.params
     );
-    const maxAvgPerWeek = Math.max(...seeded.map((cell) => cell.avgPerWeek), 0);
 
-    return {
-      insertedEvents: rows.length,
-      activeHourCells: seeded.filter((cell) => cell.count > 0).length,
-      maxAvgPerWeek,
-      seededThrough: rows.at(-1)?.created_at.toISOString() ?? null,
-    };
+    return { events: result.rows };
   });
 
   // ── Token usage ──────────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,7 @@ import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { harvestTokenUsage } from "./agents/token-harvester.js";
 import {
+  computeActiveHours,
   computeActivityStats,
   computeDailyStatus,
   type ActivityEventRow,
@@ -184,6 +185,140 @@ function getBucketGranularity(range: ActivityRange): "day" | "week" | "month" {
 function bucketExpression(range: ActivityRange, column: string): string {
   const granularity = getBucketGranularity(range);
   return `date_trunc('${granularity}', ${column})::date::text`;
+}
+
+function isDemoSeedEnabled(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type DemoSeedRow = {
+  agent_id: string;
+  event_type: AgentLatestEventType;
+  message: string;
+  metadata: string;
+  created_at: Date;
+  agent_type: string;
+  agent_name: string;
+  project_dir: string;
+};
+
+function buildDemoActivitySeed(now = new Date()): DemoSeedRow[] {
+  const projects = [
+    { dir: "/Users/brad/dev/apps/dispatch", agentType: "codex" },
+    { dir: "/Users/brad/dev/apps/ios-client", agentType: "claude" },
+    { dir: "/Users/brad/dev/apps/marketing-site", agentType: "opencode" },
+  ];
+  const dayCount = 420;
+  const rows: DemoSeedRow[] = [];
+  const start = new Date(now.getTime() - dayCount * 24 * 60 * 60 * 1000);
+
+  for (let dayOffset = 0; dayOffset < dayCount; dayOffset += 1) {
+    const day = new Date(start.getTime() + dayOffset * 24 * 60 * 60 * 1000);
+    const weekday = day.getUTCDay();
+    const weekend = weekday === 0 || weekday === 6;
+    const projectIndex = weekend ? dayOffset % 2 : dayOffset % projects.length;
+    const project = projects[projectIndex];
+    const seed = dayOffset * 97 + projectIndex * 131 + 17;
+    const random = mulberry32(seed);
+
+    const activeAgents = weekend ? (random() > 0.58 ? 1 : 0) : (random() > 0.82 ? 3 : 2);
+    for (let agentIndex = 0; agentIndex < activeAgents; agentIndex += 1) {
+      const startHour =
+        weekend
+          ? 9 + Math.floor(random() * 6)
+          : 8 + Math.floor(random() * 3) + (agentIndex === 2 ? 1 : 0);
+      const startMinute = Math.floor(random() * 40);
+      const workingBlockMinutes = weekend
+        ? 70 + Math.floor(random() * 80)
+        : 105 + Math.floor(random() * 85);
+      const blockedMinutes = random() > (weekend ? 0.78 : 0.55) ? 0 : 10 + Math.floor(random() * 35);
+      const waitingMinutes = random() > (weekend ? 0.88 : 0.68) ? 0 : 8 + Math.floor(random() * 28);
+      const reviewBlockMinutes = weekend ? 20 + Math.floor(random() * 40) : 45 + Math.floor(random() * 55);
+      const agentId = `seed-active-hours-${projectIndex}-${agentIndex}`;
+      const agentName = weekend ? `Weekend ${agentIndex + 1}` : `Builder ${projectIndex + 1}-${agentIndex + 1}`;
+
+      const workingAt = new Date(Date.UTC(
+        day.getUTCFullYear(),
+        day.getUTCMonth(),
+        day.getUTCDate(),
+        startHour,
+        startMinute,
+      ));
+      rows.push({
+        agent_id: agentId,
+        event_type: "working",
+        message: "Deep work block",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "working" }),
+        created_at: workingAt,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+
+      let cursor = new Date(workingAt.getTime() + workingBlockMinutes * 60 * 1000);
+      if (blockedMinutes > 0) {
+        rows.push({
+          agent_id: agentId,
+          event_type: "blocked",
+          message: "Waiting on review feedback",
+          metadata: JSON.stringify({ seed: "activity-demo", phase: "blocked" }),
+          created_at: cursor,
+          agent_type: project.agentType,
+          agent_name: agentName,
+          project_dir: project.dir,
+        });
+        cursor = new Date(cursor.getTime() + blockedMinutes * 60 * 1000);
+      }
+
+      if (waitingMinutes > 0) {
+        rows.push({
+          agent_id: agentId,
+          event_type: "waiting_user",
+          message: "Need a product call",
+          metadata: JSON.stringify({ seed: "activity-demo", phase: "waiting" }),
+          created_at: cursor,
+          agent_type: project.agentType,
+          agent_name: agentName,
+          project_dir: project.dir,
+        });
+        cursor = new Date(cursor.getTime() + waitingMinutes * 60 * 1000);
+      }
+
+      rows.push({
+        agent_id: agentId,
+        event_type: "working",
+        message: "Afternoon execution",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "wrap-up" }),
+        created_at: cursor,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+      cursor = new Date(cursor.getTime() + reviewBlockMinutes * 60 * 1000);
+
+      rows.push({
+        agent_id: agentId,
+        event_type: "done",
+        message: "Shipped for the day",
+        metadata: JSON.stringify({ seed: "activity-demo", phase: "done" }),
+        created_at: cursor,
+        agent_type: project.agentType,
+        agent_name: agentName,
+        project_dir: project.dir,
+      });
+    }
+  }
+
+  return rows.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
 }
 
 async function loadScopedActivityEvents(
@@ -1464,6 +1599,68 @@ async function registerRoutes() {
     const dailyStatus = computeDailyStatus(rows, rangeStart, granularity);
 
     return { days: dailyStatus, granularity };
+  });
+
+  app.get("/api/v1/activity/active-hours", async (request) => {
+    const query = request.query as { range?: string };
+    const range = parseActivityRange(query.range);
+    const { rows, rangeStart } = await loadScopedActivityEvents(range);
+    const cells = computeActiveHours(rows, rangeStart);
+
+    return { cells };
+  });
+
+  app.post("/api/v1/activity/demo-seed", async (_request, reply) => {
+    if (!isDemoSeedEnabled()) {
+      return reply.code(404).send({ error: "Not found" });
+    }
+
+    const rows = buildDemoActivitySeed();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `DELETE FROM agent_events
+         WHERE metadata::text LIKE '%"seed":"activity-demo"%'`
+      );
+
+      const insertSql = `INSERT INTO agent_events
+        (agent_id, event_type, message, metadata, created_at, agent_type, agent_name, project_dir)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8)`;
+
+      for (const row of rows) {
+        await client.query(insertSql, [
+          row.agent_id,
+          row.event_type,
+          row.message,
+          row.metadata,
+          row.created_at,
+          row.agent_type,
+          row.agent_name,
+          row.project_dir,
+        ]);
+      }
+
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    const seeded = computeActiveHours(
+      rows.map((row) => ({ event_type: row.event_type, created_at: row.created_at })),
+      getRangeLowerBound("all")
+    );
+    const maxAvgPerWeek = Math.max(...seeded.map((cell) => cell.avgPerWeek), 0);
+
+    return {
+      insertedEvents: rows.length,
+      activeHourCells: seeded.filter((cell) => cell.count > 0).length,
+      maxAvgPerWeek,
+      seededThrough: rows.at(-1)?.created_at.toISOString() ?? null,
+    };
   });
 
   // ── Token usage ──────────────────────────────────────────────────

--- a/test/activity-metrics.test.ts
+++ b/test/activity-metrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeActiveHours,
   computeActivityStats,
   computeDailyStatus,
   type ActivityEventRow,
@@ -44,5 +45,44 @@ describe("activity metrics boundary carry-in", () => {
     const days = computeDailyStatus(rows, new Date("2026-03-21T00:00:00Z"), "day");
 
     expect(days).toEqual([{ day: "2026-03-21", working: 20 * 60 * 1000 }]);
+  });
+
+  it("groups active hours by weekday and hour using active-state events only", () => {
+    const rows = [
+      row("a1", "working", "2026-03-23T09:10:00Z"),
+      row("a1", "blocked", "2026-03-23T09:45:00Z"),
+      row("a1", "done", "2026-03-23T09:55:00Z"),
+    ];
+
+    const cells = computeActiveHours(
+      rows,
+      new Date("2026-03-20T00:00:00Z"),
+      new Date("2026-03-27T00:00:00Z")
+    );
+
+    expect(cells.find((cell) => cell.dayOfWeek === 1 && cell.hour === 9)).toMatchObject({
+      count: 2,
+      avgPerWeek: 2,
+    });
+  });
+
+  it("normalizes active hours for longer ranges as average events per week", () => {
+    const rows = [
+      row("a1", "working", "2026-03-03T09:00:00Z"),
+      row("a1", "working", "2026-03-10T09:00:00Z"),
+      row("a1", "working", "2026-03-17T09:00:00Z"),
+      row("a1", "working", "2026-03-24T09:00:00Z"),
+    ];
+
+    const cells = computeActiveHours(
+      rows,
+      new Date("2026-03-01T00:00:00Z"),
+      new Date("2026-03-29T00:00:00Z")
+    );
+
+    expect(cells.find((cell) => cell.dayOfWeek === 2 && cell.hour === 9)).toMatchObject({
+      count: 4,
+      avgPerWeek: 1,
+    });
   });
 });

--- a/test/activity-metrics.test.ts
+++ b/test/activity-metrics.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  computeActiveHours,
-  computeActivityStats,
-  computeDailyStatus,
-  type ActivityEventRow,
-} from "../src/activity-metrics.js";
+import { computeActivityStats, computeDailyStatus, type ActivityEventRow } from "../src/activity-metrics.js";
 
 function row(agent_id: string, event_type: string, created_at: string): ActivityEventRow {
   return { agent_id, event_type, created_at: new Date(created_at) };
@@ -45,44 +40,5 @@ describe("activity metrics boundary carry-in", () => {
     const days = computeDailyStatus(rows, new Date("2026-03-21T00:00:00Z"), "day");
 
     expect(days).toEqual([{ day: "2026-03-21", working: 20 * 60 * 1000 }]);
-  });
-
-  it("groups active hours by weekday and hour using active-state events only", () => {
-    const rows = [
-      row("a1", "working", "2026-03-23T09:10:00Z"),
-      row("a1", "blocked", "2026-03-23T09:45:00Z"),
-      row("a1", "done", "2026-03-23T09:55:00Z"),
-    ];
-
-    const cells = computeActiveHours(
-      rows,
-      new Date("2026-03-20T00:00:00Z"),
-      new Date("2026-03-27T00:00:00Z")
-    );
-
-    expect(cells.find((cell) => cell.dayOfWeek === 1 && cell.hour === 9)).toMatchObject({
-      count: 2,
-      avgPerWeek: 2,
-    });
-  });
-
-  it("normalizes active hours for longer ranges as average events per week", () => {
-    const rows = [
-      row("a1", "working", "2026-03-03T09:00:00Z"),
-      row("a1", "working", "2026-03-10T09:00:00Z"),
-      row("a1", "working", "2026-03-17T09:00:00Z"),
-      row("a1", "working", "2026-03-24T09:00:00Z"),
-    ];
-
-    const cells = computeActiveHours(
-      rows,
-      new Date("2026-03-01T00:00:00Z"),
-      new Date("2026-03-29T00:00:00Z")
-    );
-
-    expect(cells.find((cell) => cell.dayOfWeek === 2 && cell.hour === 9)).toMatchObject({
-      count: 4,
-      avgPerWeek: 1,
-    });
   });
 });

--- a/web/src/components/app/activity-pane.tsx
+++ b/web/src/components/app/activity-pane.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import {
@@ -27,6 +27,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   ACTIVITY_RANGES,
+  useActiveHours,
   useActivityHeatmap,
   useActivityStats,
   useDailyStatus,
@@ -36,6 +37,7 @@ import {
   useTokenByProject,
   rangeLabel,
   type ActivityGranularity,
+  type ActiveHoursCell,
   type ActivityRange,
   type DailyStatusEntry,
   type TokenDailyEntry,
@@ -252,6 +254,103 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
         <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-500/70" />
         <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-400" />
         <span>More</span>
+      </div>
+    </div>
+  );
+}
+
+const ACTIVE_HOURS_DAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
+const ACTIVE_HOURS_DAY_LABELS: Record<number, string> = {
+  0: "Sun",
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+};
+
+function activeHoursIntensity(value: number, max: number): string {
+  if (value <= 0) return "bg-muted/40";
+  const ratio = value / max;
+  if (ratio <= 0.2) return "bg-sky-100/80";
+  if (ratio <= 0.4) return "bg-cyan-200/80";
+  if (ratio <= 0.6) return "bg-sky-300/80";
+  if (ratio <= 0.8) return "bg-cyan-500/80";
+  return "bg-sky-700/85";
+}
+
+function formatHour(hour: number): string {
+  const suffix = hour >= 12 ? "p" : "a";
+  const normalized = hour % 12 === 0 ? 12 : hour % 12;
+  return `${normalized}${suffix}`;
+}
+
+function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: ActivityRange }) {
+  const cellMap = useMemo(
+    () => new Map(data.map((cell) => [`${cell.dayOfWeek}:${cell.hour}`, cell])),
+    [data]
+  );
+  const max = Math.max(...data.map((cell) => cell.avgPerWeek), 0.01);
+  const cadenceLabel = range === "7d" ? "events" : "avg events / week";
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <div className="grid min-w-[760px] grid-cols-[56px_repeat(24,minmax(0,1fr))] gap-x-1.5 gap-y-2">
+          <div />
+          {Array.from({ length: 24 }, (_, hour) => (
+            <div
+              key={`label-${hour}`}
+              className="text-center text-[10px] font-medium text-muted-foreground"
+            >
+              {hour % 2 === 0 ? formatHour(hour) : ""}
+            </div>
+          ))}
+
+          {ACTIVE_HOURS_DAY_ORDER.map((dayOfWeek) => (
+            <Fragment key={`row-${dayOfWeek}`}>
+              <div className="flex items-center text-xs font-medium text-muted-foreground">
+                {ACTIVE_HOURS_DAY_LABELS[dayOfWeek]}
+              </div>
+              {Array.from({ length: 24 }, (_, hour) => {
+                const cell = cellMap.get(`${dayOfWeek}:${hour}`) ?? {
+                  dayOfWeek,
+                  hour,
+                  count: 0,
+                  avgPerWeek: 0,
+                };
+                const title =
+                  range === "7d"
+                    ? `${ACTIVE_HOURS_DAY_LABELS[dayOfWeek]} ${formatHour(hour)}: ${cell.count} active events`
+                    : `${ACTIVE_HOURS_DAY_LABELS[dayOfWeek]} ${formatHour(hour)}: ${cell.avgPerWeek} avg events/week (${cell.count} total)`;
+                return (
+                  <div
+                    key={`${dayOfWeek}-${hour}`}
+                    title={title}
+                    data-testid={dayOfWeek === 1 && hour === 9 ? "active-hours-cell-sample" : undefined}
+                    className={cn(
+                      "h-5 rounded-[6px] border border-border/40 transition-colors",
+                      activeHoursIntensity(cell.avgPerWeek, max)
+                    )}
+                  />
+                );
+              })}
+            </Fragment>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+        <span>Less</span>
+        <div className="h-2.5 w-5 rounded-full bg-muted/40" />
+        <div className="h-2.5 w-5 rounded-full bg-sky-100/80" />
+        <div className="h-2.5 w-5 rounded-full bg-cyan-200/80" />
+        <div className="h-2.5 w-5 rounded-full bg-sky-300/80" />
+        <div className="h-2.5 w-5 rounded-full bg-cyan-500/80" />
+        <div className="h-2.5 w-5 rounded-full bg-sky-700/85" />
+        <span>More</span>
+        <span className="ml-2">{cadenceLabel}</span>
       </div>
     </div>
   );
@@ -562,6 +661,7 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
   const { data: heatmapData } = useActivityHeatmap();
   const { data: stats } = useActivityStats(range);
   const { data: dailyStatus } = useDailyStatus(range);
+  const { data: activeHours } = useActiveHours(range);
   const { data: tokenStats } = useTokenStats(range);
   const { data: tokenDaily } = useTokenDaily(range);
   const { data: tokenByModel } = useTokenByModel(range);
@@ -572,6 +672,7 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
     ? tokenStats.total_input + tokenStats.total_cache_creation + tokenStats.total_cache_read + tokenStats.total_output
     : 0;
   const hasTokenData = totalTokens > 0;
+  const hasActiveHourData = activeHours?.some((cell) => cell.count > 0) ?? false;
 
   return (
     <DialogPrimitive.Root
@@ -619,7 +720,7 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
 
           {/* Body */}
           <ScrollArea className="flex-1">
-            <div className="mx-auto max-w-3xl min-w-0 overflow-hidden space-y-6 sm:space-y-8 px-3 py-4 sm:px-5 sm:py-6 md:px-8">
+            <div className="mx-auto max-w-3xl min-w-0 overflow-hidden space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
               {/* Stats row */}
               {stats && hasData && (
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -665,6 +766,20 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
                     data={dailyStatus.days}
                     granularity={dailyStatus.granularity}
                   />
+                </div>
+              )}
+
+              {activeHours && activeHours.length > 0 && hasActiveHourData && (
+                <div>
+                  <h2 className="mb-1 text-sm font-medium text-foreground">
+                    Active hours
+                  </h2>
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    {range === "7d"
+                      ? "Active-state events by weekday and hour for the last 7 days."
+                      : `Average active-state events per week by weekday and hour for ${rangeLabel(range).toLowerCase()}.`}
+                  </p>
+                  <ActiveHoursGrid data={activeHours} range={range} />
                 </div>
               )}
 

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -7,6 +7,12 @@ const ACTIVITY_QUERY_OPTIONS = {
 };
 
 type HeatmapDay = { day: string; count: number };
+export type ActiveHoursCell = {
+  dayOfWeek: number;
+  hour: number;
+  count: number;
+  avgPerWeek: number;
+};
 
 export const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
 export type ActivityRange = (typeof ACTIVITY_RANGES)[number];
@@ -80,6 +86,19 @@ export function useDailyStatus(range: ActivityRange) {
       return api<BucketedActivityResponse<DailyStatusEntry>>(
         scopedActivityPath("/api/v1/activity/daily-status", range)
       );
+    },
+    ...ACTIVITY_QUERY_OPTIONS,
+  });
+}
+
+export function useActiveHours(range: ActivityRange) {
+  return useQuery<ActiveHoursCell[]>({
+    queryKey: ["activity", "active-hours", range],
+    queryFn: async () => {
+      const payload = await api<{ cells: ActiveHoursCell[] }>(
+        scopedActivityPath("/api/v1/activity/active-hours", range)
+      );
+      return payload.cells;
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { buildActiveHours, type ActiveHourEvent, type ActiveHoursCell } from "@/lib/active-hours";
+
+export type { ActiveHoursCell } from "@/lib/active-hours";
 
 const ACTIVITY_QUERY_OPTIONS = {
   staleTime: 60_000,
@@ -7,12 +10,6 @@ const ACTIVITY_QUERY_OPTIONS = {
 };
 
 type HeatmapDay = { day: string; count: number };
-export type ActiveHoursCell = {
-  dayOfWeek: number;
-  hour: number;
-  count: number;
-  avgPerWeek: number;
-};
 
 export const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
 export type ActivityRange = (typeof ACTIVITY_RANGES)[number];
@@ -95,10 +92,10 @@ export function useActiveHours(range: ActivityRange) {
   return useQuery<ActiveHoursCell[]>({
     queryKey: ["activity", "active-hours", range],
     queryFn: async () => {
-      const payload = await api<{ cells: ActiveHoursCell[] }>(
+      const payload = await api<{ events: ActiveHourEvent[] }>(
         scopedActivityPath("/api/v1/activity/active-hours", range)
       );
-      return payload.cells;
+      return buildActiveHours(payload.events, range);
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });

--- a/web/src/lib/active-hours.ts
+++ b/web/src/lib/active-hours.ts
@@ -1,0 +1,63 @@
+import type { ActivityRange } from "@/hooks/use-activity";
+
+export type ActiveHourEvent = {
+  created_at: string;
+};
+
+export type ActiveHoursCell = {
+  dayOfWeek: number;
+  hour: number;
+  count: number;
+  avgPerWeek: number;
+};
+
+function rangeStart(range: ActivityRange, now: Date): Date | null {
+  if (range === "all") return null;
+  if (range === "year") return new Date(now.getFullYear(), 0, 1, 0, 0, 0, 0);
+  if (range === "7d") return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+}
+
+export function buildActiveHours(
+  events: ActiveHourEvent[],
+  range: ActivityRange,
+  now = new Date()
+): ActiveHoursCell[] {
+  const counts = new Map<string, number>();
+  const lowerBound = rangeStart(range, now);
+  const lowerBoundMs = lowerBound?.getTime() ?? null;
+  let firstTimestamp = Number.POSITIVE_INFINITY;
+  let lastTimestamp = Number.NEGATIVE_INFINITY;
+
+  for (const event of events) {
+    const date = new Date(event.created_at);
+    const timestamp = date.getTime();
+    if (Number.isNaN(timestamp)) continue;
+    if (lowerBoundMs !== null && timestamp < lowerBoundMs) continue;
+
+    firstTimestamp = Math.min(firstTimestamp, timestamp);
+    lastTimestamp = Math.max(lastTimestamp, timestamp);
+
+    const key = `${date.getDay()}:${date.getHours()}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const effectiveStartMs = lowerBoundMs ?? (Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime());
+  const effectiveEndMs = Number.isFinite(lastTimestamp) ? Math.max(lastTimestamp, now.getTime()) : now.getTime();
+  const spanWeeks = Math.max(1, (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000));
+
+  const cells: ActiveHoursCell[] = [];
+  for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {
+    for (let hour = 0; hour < 24; hour += 1) {
+      const count = counts.get(`${dayOfWeek}:${hour}`) ?? 0;
+      cells.push({
+        dayOfWeek,
+        hour,
+        count,
+        avgPerWeek: Number((count / spanWeeks).toFixed(2)),
+      });
+    }
+  }
+
+  return cells;
+}


### PR DESCRIPTION
## Summary
- add a range-aware active-hours analytics endpoint and activity-pane heatmap
- normalize longer ranges as average active events per week and add a dev-only long-span demo seed endpoint
- give the active-hours grid its own blue-cyan palette and extra bottom breathing room in the activity pane

## Validation
- npm run check
- npm run finalize:web
- npm test
- npm run test:e2e

## Review notes
- validation stack remains available at http://127.0.0.1:49845
- demo seed endpoint: POST /api/v1/activity/demo-seed