### PR TITLE
Update analytics roadmap status

### DIFF
--- a/docs/activity-metrics-roadmap.md
+++ b/docs/activity-metrics-roadmap.md
@@ -7,9 +7,11 @@ High-level plan for expanding Dispatch's activity tracking and usage metrics.
 The following work is already in the product and should be treated as baseline, not future roadmap:
 
 - `agent_events` history table with `agent_type`, `agent_name`, `project_dir`
+- Shared activity time period selector for `7d` / `30d` / `year` / `all`
 - Stat cards for total working time, avg blocked time, avg waiting time, busiest day
 - Yearly activity heatmap
 - Daily status stacked bar chart for the last 30 days
+- Active-hours heatmap with client-local weekday/hour bucketing
 - Delete/stop events captured in history
 - Soft delete via `agents.deleted_at`, with active-agent queries filtering deleted rows
 - Token harvesting into `agent_token_usage`
@@ -19,10 +21,8 @@ The following work is already in the product and should be treated as baseline, 
 
 Derive more value from existing `agent_events` data before adding new ingestion paths.
 
-- **Time period selector** — scope activity queries and charts to last 30d / this year / all time
 - **Agent count over time** — agents created per day/week using the first event per `agent_id`
 - **Per-project breakdown** — group by `project_dir`, show working time per project
-- **Active hours heatmap** — hour-of-day x day-of-week grid from event timestamps
 
 Why this phase goes first:
 
@@ -61,9 +61,7 @@ Add workflow analytics once the event-derived dashboards are in place.
 
 ## Recommended Build Order
 
-1. Add a shared time period selector and thread it through existing activity queries.
-2. Ship event-derived metrics from `agent_events`: agent-count-over-time and per-project working time.
-3. Add the active-hours heatmap.
-4. Expose deleted-agent history views now that soft delete exists.
-5. Add token cost estimation and deeper token analysis.
-6. Add MCP tool and PR tracking.
+1. Ship the remaining event-derived metrics from `agent_events`: agent-count-over-time and per-project working time.
+2. Expose deleted-agent history views now that soft delete exists.
+3. Add token cost estimation and deeper token analysis.
+4. Add MCP tool and PR tracking.

--- a/web/src/components/app/activity-pane.tsx
+++ b/web/src/components/app/activity-pane.tsx
@@ -296,8 +296,8 @@ function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: Acti
 
   return (
     <div className="space-y-3">
-      <div className="overflow-x-auto">
-        <div className="grid min-w-[760px] grid-cols-[56px_repeat(24,minmax(0,1fr))] gap-x-1.5 gap-y-2">
+      <div style={{ maxWidth: "calc(100vw - 24px)" }} className="max-w-full overflow-x-auto">
+        <div className="grid min-w-[760px] w-max grid-cols-[56px_repeat(24,minmax(0,1fr))] gap-x-1.5 gap-y-2">
           <div />
           {Array.from({ length: 24 }, (_, hour) => (
             <div
@@ -770,7 +770,7 @@ export function ActivityPane({ open, onClose }: ActivityPaneProps): JSX.Element 
               )}
 
               {activeHours && activeHours.length > 0 && hasActiveHourData && (
-                <div>
+                <div className="min-w-0">
                   <h2 className="mb-1 text-sm font-medium text-foreground">
                     Active hours
                   </h2>


### PR DESCRIPTION
## Summary
- move the shared activity range selector into the shipped baseline
- mark the active-hours heatmap as shipped and note client-local time bucketing
- tighten the remaining roadmap to the still-open analytics work

## Testing
- not run (documentation-only change)