### PR TITLE
Add repo lifecycle hooks (stop hook)

### DIFF
--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -1,7 +1,8 @@
 {
   "hooks": {
     "stop": {
-      "command": ["./bin/dispatch-dev", "down"]
+      "command": ["./bin/dispatch-dev", "down"],
+      "description": "Tear down the agent's isolated dev environment on stop."
     }
   },
   "tools": [

--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -1,4 +1,9 @@
 {
+  "hooks": {
+    "stop": {
+      "command": ["./bin/dispatch-dev", "down"]
+    }
+  },
   "tools": [
     {
       "name": "dev_up",

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -64,8 +64,6 @@ resolve_suffix() {
     echo "$OPT_SUFFIX"
   elif [ -n "${DISPATCH_AGENT_ID:-}" ]; then
     echo "$DISPATCH_AGENT_ID"
-  elif [ -n "${HOSTESS_AGENT_ID:-}" ]; then
-    echo "$HOSTESS_AGENT_ID"
   else
     echo "dev-$$-$(date +%s)"
   fi

--- a/bin/dispatch-event
+++ b/bin/dispatch-event
@@ -35,7 +35,7 @@ if [ -z "$MESSAGE" ]; then
   exit 1
 fi
 
-AGENT_ID="${DISPATCH_AGENT_ID:-${HOSTESS_AGENT_ID:-}}"
+AGENT_ID="${DISPATCH_AGENT_ID:-}"
 if [ -z "$AGENT_ID" ]; then
   echo "DISPATCH_AGENT_ID is not set. Run this command inside a Dispatch agent session." >&2
   exit 1

--- a/bin/dispatch-stream
+++ b/bin/dispatch-stream
@@ -23,7 +23,7 @@ fi
 ACTION="${1:-}"
 shift
 
-AGENT_ID="${DISPATCH_AGENT_ID:-${HOSTESS_AGENT_ID:-}}"
+AGENT_ID="${DISPATCH_AGENT_ID:-}"
 if [ -z "$AGENT_ID" ]; then
   echo "DISPATCH_AGENT_ID is not set. Run this command inside a Dispatch agent session." >&2
   exit 1

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -14,7 +14,7 @@
   "name": "ios-fix-1",
   "status": "running",
   "cwd": "/Users/bharris/dev/apps/foo",
-  "tmuxSession": "hostess_agt_01J...",
+  "tmuxSession": "dispatch_agt_01J...",
   "pid": 12345,
   "simulatorUdid": "A1B2C3...",
   "createdAt": "2026-03-07T19:20:00Z",

--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -25,7 +25,7 @@
 
 ## tmux Session Contract
 
-- Session name: `hostess_<agentId>`
+- Session name: `dispatch_agt_<agentId>_<name>`
 - Window name: `main`
 - Agent process starts in configured `cwd`
 - Closing browser terminal must only detach client, not terminate tmux
@@ -35,13 +35,13 @@
 Example launch command:
 
 ```bash
-tmux new-session -d -s hostess_<agentId> -c "<cwd>" "codex"
+tmux new-session -d -s dispatch_<agentId> -c "<cwd>" "codex"
 ```
 
 Optional with args:
 
 ```bash
-tmux new-session -d -s hostess_<agentId> -c "<cwd>" "codex <args>"
+tmux new-session -d -s dispatch_<agentId> -c "<cwd>" "codex <args>"
 ```
 
 ## Stop Contract
@@ -49,13 +49,13 @@ tmux new-session -d -s hostess_<agentId> -c "<cwd>" "codex <args>"
 Preferred soft stop:
 
 ```bash
-tmux send-keys -t hostess_<agentId> C-c
+tmux send-keys -t dispatch_<agentId> C-c
 ```
 
 Fallback hard stop:
 
 ```bash
-tmux kill-session -t hostess_<agentId>
+tmux kill-session -t dispatch_<agentId>
 ```
 
 ## Reconciliation Routine (on startup)

--- a/docs/08-current-state-handoff.md
+++ b/docs/08-current-state-handoff.md
@@ -1,29 +1,29 @@
 # Current State Handoff (March 2026)
 
-This doc is for a new agent picking up work on Hostess. It describes what the tool currently is, how it runs, what is implemented vs planned, and where to make changes.
+This doc is for a new agent picking up work on Dispatch. It describes what the tool currently is, how it runs, what is implemented vs planned, and where to make changes.
 
-## What Hostess Is
+## What Dispatch Is
 
-Hostess is a local-first control plane for managing long-running Codex CLI agents on a Mac host.
+Dispatch is a local-first control plane for managing long-running coding agents on a Mac host.
 
 Core value today:
 - Start and manage multiple Codex agents backed by `tmux`.
 - Open a browser UI for agent control and terminal interaction.
 - Keep agent sessions alive when browser clients disconnect.
-- Let agents share high-quality screenshots into a media stream via `hostess-share`.
+- Let agents share high-quality screenshots into a media stream via `dispatch-share`.
 
 ## Implementation Snapshot
 
 ### Backend
 - Runtime: Node.js + TypeScript + Fastify.
-- Entry point: `/Users/bharris/dev/apps/hostess/src/server.ts`.
-- DB: PostgreSQL (Docker Compose), migrations in `/Users/bharris/dev/apps/hostess/src/db/migrate.ts`.
-- Process/runtime manager: `/Users/bharris/dev/apps/hostess/src/agents/manager.ts`.
+- Entry point: `/Users/brad/dev/apps/dispatch/src/server.ts`.
+- DB: PostgreSQL (Docker Compose), migrations in `/Users/brad/dev/apps/dispatch/src/db/migrate.ts`.
+- Process/runtime manager: `/Users/brad/dev/apps/dispatch/src/agents/manager.ts`.
 - Terminal bridge: WebSocket + `node-pty` attaching to `tmux`.
 
 ### Frontend
 - React + Vite + Tailwind + shadcn-style components.
-- Source: `/Users/bharris/dev/apps/hostess/web`.
+- Source: `/Users/brad/dev/apps/dispatch/web`.
 - Main screen: collapsible left agent rail, center terminal, right media drawer (`Sheet`).
 - Terminal rendering: xterm.js.
 
@@ -46,34 +46,34 @@ Core value today:
 `simulator_reservations` table exists from migration, but simulator allocation service is not fully implemented.
 
 ### Docker-backed persistence
-- File: `/Users/bharris/dev/apps/hostess/docker-compose.yml`
+- File: `/Users/brad/dev/apps/dispatch/docker-compose.yml`
 - Service: `postgres` (`postgres:17-alpine`)
-- Persistent volume: `hostess_pgdata`
+- Persistent volume: `dispatch_pgdata`
 
 ## Current User Flow
 
 1. Create agent from modal (`name`, absolute `cwd`).
-2. Hostess creates DB record, starts `tmux` session, launches `codex`.
+2. Dispatch creates DB record, starts `tmux` session, launches `codex`.
 3. UI selects agent and can attach terminal (or auto-attach after create/open).
 4. Terminal disconnect/reconnect does not kill agent because `tmux` persists.
 5. Agent shares media with:
-   - `hostess-share <image-path> [name]`
-   - `hostess-share --sim [udid] [name]`
+   - `dispatch-share <image-path> [name]`
+   - `dispatch-share --sim [udid] [name]`
 6. Media drawer shows files from that selected agent’s media directory.
 7. Stop sends Ctrl-C then kills tmux session if needed.
 8. Delete removes agent record (and can force-stop running session first).
 
 ## Agent Runtime Contract
 
-- Session name format: `hostess_<agent-id>`.
+- Session name format: `dispatch_<agent-id>`.
 - Agent ID format: `agt_<12 hex>`.
 - Each agent gets:
-  - `HOSTESS_AGENT_ID`
-  - `HOSTESS_MEDIA_DIR`
-  - typo-compat alias `HOSTESS_MDEIA_DIR`
-  - `PATH` including `HOSTESS_BIN_DIR` for `hostess-share`.
+  - `DISPATCH_AGENT_ID`
+  - `DISPATCH_MEDIA_DIR`
+  - typo-compat alias `DISPATCH_MDEIA_DIR`
+  - `PATH` including `DISPATCH_BIN_DIR` for `dispatch-share`.
 - Codex launch includes startup instructions telling agents:
-  - use `hostess-share` for Playwright and iOS screenshots
+  - use `dispatch-share` for Playwright and iOS screenshots
   - default Playwright to headless unless user asks for headed.
 
 ## API Surface Implemented
@@ -98,7 +98,7 @@ Not yet implemented from older planning docs:
 
 ## Frontend Behavior Today
 
-Main app: `/Users/bharris/dev/apps/hostess/web/src/App.tsx`
+Main app: `/Users/brad/dev/apps/dispatch/web/src/App.tsx`
 
 - Left panel:
   - collapsible rail, not fully hidden
@@ -125,7 +125,7 @@ Main app: `/Users/bharris/dev/apps/hostess/web/src/App.tsx`
 
 ## Operations Quickstart
 
-From `/Users/bharris/dev/apps/hostess`:
+From `/Users/brad/dev/apps/dispatch`:
 
 1. `nvm use default`
 2. `docker compose up -d postgres`
@@ -146,17 +146,17 @@ For development:
   - create agent
   - attach terminal and send input
   - detach and reattach without killing tmux session
-  - show media from `hostess-share`
+  - show media from `dispatch-share`
   - stop and delete agent
 - Stop any throwaway test agents you create.
 
 ## Most Relevant Files
 
-- Backend API: `/Users/bharris/dev/apps/hostess/src/server.ts`
-- Agent lifecycle/runtime: `/Users/bharris/dev/apps/hostess/src/agents/manager.ts`
-- Terminal attach bridge: `/Users/bharris/dev/apps/hostess/src/terminal/tmux-terminal.ts`
-- Media helper CLI: `/Users/bharris/dev/apps/hostess/bin/hostess-share`
-- React app: `/Users/bharris/dev/apps/hostess/web/src/App.tsx`
-- UI primitives: `/Users/bharris/dev/apps/hostess/web/src/components/ui`
-- Main README: `/Users/bharris/dev/apps/hostess/README.md`
-- Attention follow-up plan: `/Users/bharris/dev/apps/hostess/docs/09-agent-attention-phase-2.md`
+- Backend API: `/Users/brad/dev/apps/dispatch/src/server.ts`
+- Agent lifecycle/runtime: `/Users/brad/dev/apps/dispatch/src/agents/manager.ts`
+- Terminal attach bridge: `/Users/brad/dev/apps/dispatch/src/terminal/tmux-terminal.ts`
+- Media helper CLI: `/Users/brad/dev/apps/dispatch/bin/dispatch-share`
+- React app: `/Users/brad/dev/apps/dispatch/web/src/App.tsx`
+- UI primitives: `/Users/brad/dev/apps/dispatch/web/src/components/ui`
+- Main README: `/Users/brad/dev/apps/dispatch/README.md`
+- Attention follow-up plan: `/Users/brad/dev/apps/dispatch/docs/09-agent-attention-phase-2.md`

--- a/docs/09-agent-attention-phase-2.md
+++ b/docs/09-agent-attention-phase-2.md
@@ -1,6 +1,6 @@
 # Agent Attention Phase 2 Plan
 
-This doc describes how to expand Hostess agent attention from the current narrow error-state signal into a backend-backed attention model that can represent detached activity and richer Hostess-owned events without changing the UI contract.
+This doc describes how to expand Dispatch agent attention from the current narrow error-state signal into a backend-backed attention model that can represent detached activity and richer Dispatch-owned events without changing the UI contract.
 
 ## Current Phase 1 Scope
 
@@ -34,13 +34,13 @@ Phase 2 should support multiple backend-owned sources:
 - `error`
   - agent process failed to start, crashed, or hit a lifecycle error
 - `approval_required`
-  - Hostess learns the agent is blocked on approval
+  - Dispatch learns the agent is blocked on approval
 - `input_required`
-  - Hostess learns the agent is waiting for user input
+  - Dispatch learns the agent is waiting for user input
 - `detached_activity`
   - tmux reports meaningful background activity for an unattached agent
 - `response_complete`
-  - a higher-level Hostess conversation/event layer reports the agent finished a response while detached
+  - a higher-level Dispatch conversation/event layer reports the agent finished a response while detached
 
 Not all of these exist in the repo today. This plan defines how to add them without changing the rendered UX.
 
@@ -106,9 +106,9 @@ Candidate mechanisms:
 
 The implementation should prefer explicit tmux metadata over parsing human-readable pane text.
 
-### 3. Accept richer Hostess-owned events
+### 3. Accept richer Dispatch-owned events
 
-If Hostess grows a higher-level conversation/event layer, that layer should emit explicit attention-worthy events instead of forcing the terminal to be the source of truth.
+If Dispatch grows a higher-level conversation/event layer, that layer should emit explicit attention-worthy events instead of forcing the terminal to be the source of truth.
 
 Examples:
 - agent finished a response while detached
@@ -134,7 +134,7 @@ Clearing should be an API mutation so multiple clients remain consistent.
 2. Populate attention from existing backend error state.
 3. Add explicit clear semantics via API mutation.
 4. Add tmux-backed detached activity monitoring.
-5. Add higher-level Hostess attention sources when the product exposes them.
+5. Add higher-level Dispatch attention sources when the product exposes them.
 
 ## Risks
 

--- a/docs/13-agent-scoped-mcp-and-dev-stack-plan.md
+++ b/docs/13-agent-scoped-mcp-and-dev-stack-plan.md
@@ -72,20 +72,72 @@ Current example:
 
 ```json
 {
+  "hooks": {
+    "stop": {
+      "command": ["./bin/dispatch-dev", "down"],
+      "description": "Tear down the agent's isolated dev environment on stop."
+    }
+  },
   "tools": [
     {
-      "name": "project.dev_up",
+      "name": "dev_up",
       "description": "Start the repo's isolated Dispatch development environment.",
-      "command": ["dispatch-dev", "up"]
+      "command": ["./bin/dispatch-dev", "up"]
     },
     {
-      "name": "project.dev_down",
+      "name": "dev_down",
       "description": "Stop the repo's isolated Dispatch development environment.",
-      "command": ["dispatch-dev", "down"]
+      "command": ["./bin/dispatch-dev", "down"]
     }
   ]
 }
 ```
+
+## Lifecycle Hooks
+
+Repos can define lifecycle hooks in `.dispatch/tools.json` under the `hooks` key. Unlike tools (which agents call on demand via MCP), hooks are invoked automatically by Dispatch at specific points in the agent lifecycle.
+
+### Supported hooks
+
+| Hook | When it runs |
+|------|-------------|
+| `stop` | When an agent is stopped (including when deletion triggers a stop) |
+
+### Hook definition
+
+Each hook has:
+
+- `command` (string[], required): The command to execute. First element is the executable, rest are static args.
+- `description` (string, optional): Human-readable description of what the hook does.
+
+### Execution context
+
+- Hooks run in the agent's working directory (`worktreePath` or `cwd`).
+- `DISPATCH_AGENT_ID` is set in the environment, so commands like `dispatch-dev down` can resolve the correct agent-scoped resources.
+- Hooks are best-effort with a 15-second timeout. A failing hook does not block the lifecycle transition.
+- Hook results (including non-zero exit codes) are logged but do not affect agent status.
+- Parsed hooks are cached per manifest path and invalidated by file mtime.
+
+### Example: automatic dev stack cleanup
+
+The Dispatch repo itself uses a stop hook to tear down agent dev stacks:
+
+```json
+{
+  "hooks": {
+    "stop": {
+      "command": ["./bin/dispatch-dev", "down"],
+      "description": "Tear down the agent's isolated dev environment on stop."
+    }
+  }
+}
+```
+
+When an agent stops, Dispatch runs `./bin/dispatch-dev down` with `DISPATCH_AGENT_ID` in the environment. `dispatch-dev` uses that to find the matching state file (`/tmp/dispatch-dev-<agentId>.env`) and tears down the DB container, API server, and Vite server.
+
+### Future hooks
+
+The `hooks` object is extensible. Planned hooks include `start`, `resume`, and `delete`.
 
 ## What We Learned About `dispatch-dev`
 

--- a/docs/13-agent-scoped-mcp-and-dev-stack-plan.md
+++ b/docs/13-agent-scoped-mcp-and-dev-stack-plan.md
@@ -66,7 +66,7 @@ Current design:
 - repo tools must be named under `project.*`
 - handlers are declarative command wrappers, not arbitrary in-process plugins
 - commands run in the resolved repo root
-- commands inherit `DISPATCH_AGENT_ID` and `HOSTESS_AGENT_ID`
+- commands inherit `DISPATCH_AGENT_ID`
 
 Current example:
 

--- a/public/app.js
+++ b/public/app.js
@@ -586,7 +586,7 @@ async function init() {
   setStatus(`API ${health.status}, DB ${health.db}`);
   await refreshAgents();
   await refreshMedia();
-  el.cwdInput.value = "/Users/bharris/dev/apps/hostess";
+  el.cwdInput.value = "";
   setConnectionBadge("disconnected");
 }
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -9,6 +9,7 @@ import type { Pool } from "pg";
 import type { AppConfig } from "../config.js";
 import { createGitWorktree, cleanupGitWorktree } from "../git/worktree.js";
 import { runCommand } from "../lib/run-command.js";
+import { loadRepoHooks } from "../mcp/repo-tools.js";
 import { harvestTokenUsage } from "./token-harvester.js";
 
 type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "unknown";
@@ -394,6 +395,11 @@ export class AgentManager {
     }
 
     await this.setAgentStatus(id, "stopping", null, tmuxSession ?? undefined);
+
+    // Run repo-defined stop hook (best-effort, non-blocking)
+    await this.runLifecycleHook("stop", agent).catch((err) =>
+      this.logger.warn({ err, agentId: id }, "Stop hook failed; continuing shutdown")
+    );
 
     try {
       if (tmuxSession && (await this.hasAgentSession(tmuxSession))) {
@@ -1015,6 +1021,34 @@ export class AgentManager {
 
     if (await this.hasAgentSession(sessionName)) {
       await runCommand("tmux", ["kill-session", "-t", sessionName]);
+    }
+  }
+
+  private async runLifecycleHook(hookName: "stop", agent: AgentRecord): Promise<void> {
+    const repoRoot = agent.worktreePath ?? agent.cwd;
+    if (!repoRoot) return;
+
+    const hooks = await loadRepoHooks(repoRoot);
+    const hook = hooks[hookName];
+    if (!hook) return;
+
+    const [command, ...args] = hook.command;
+    this.logger.info({ agentId: agent.id, hook: hookName, command: hook.command }, "Running lifecycle hook");
+
+    const result = await runCommand(command, args, {
+      cwd: repoRoot,
+      env: {
+        DISPATCH_AGENT_ID: agent.id,
+        HOSTESS_AGENT_ID: agent.id,
+      },
+      timeoutMs: 15_000,
+    });
+
+    if (result.exitCode !== 0) {
+      this.logger.warn(
+        { agentId: agent.id, hook: hookName, exitCode: result.exitCode, stderr: result.stderr },
+        "Lifecycle hook exited with non-zero code"
+      );
     }
   }
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -444,12 +444,13 @@ export class AgentManager {
       throw new AgentError("Agent is running. Stop it first or use force delete.", 409);
     }
 
-    if (agent.status === "running" && !sessionExists) {
-      await this.setAgentStatus(id, "stopped", null, agent.tmuxSession ?? undefined);
-    }
-
-    if (agent.tmuxSession && sessionExists) {
-      await this.stopAgentSession(agent.tmuxSession, true);
+    // Run full stop lifecycle (hooks, graceful shutdown, token harvest) for non-stopped agents.
+    if (agent.status !== "stopped") {
+      try {
+        await this.stopAgent(id, { force: true });
+      } catch (err) {
+        this.logger.warn({ err, agentId: id }, "Stop during delete failed; continuing with deletion");
+      }
     }
 
     // Worktree cleanup
@@ -473,16 +474,6 @@ export class AgentManager {
         this.logger.warn({ err: error, agentId: id }, "Worktree cleanup failed; leaving on disk.");
       }
     }
-
-    // Harvest token usage before soft-deleting
-    await harvestTokenUsage(this.pool, {
-      id: agent.id,
-      type: agent.type,
-      cwd: agent.cwd,
-      worktreePath: agent.worktreePath,
-    }, this.logger).catch((err) =>
-      this.logger.warn({ err, agentId: id }, "Token harvest failed on delete")
-    );
 
     // Record a final stopped event in history before deleting the agent row
     await this.pool

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1039,7 +1039,6 @@ export class AgentManager {
       cwd: repoRoot,
       env: {
         DISPATCH_AGENT_ID: agent.id,
-        HOSTESS_AGENT_ID: agent.id,
       },
       timeoutMs: 15_000,
     });
@@ -1080,13 +1079,8 @@ export class AgentManager {
       `DISPATCH_MEDIA_DIR=${this.shellEscape(mediaDir)}`,
       // Compatibility alias for common typo to keep screenshot sharing reliable.
       `DISPATCH_MDEIA_DIR=${this.shellEscape(mediaDir)}`,
-      `HOSTESS_AGENT_ID=${this.shellEscape(agentId)}`,
-      `HOSTESS_MEDIA_DIR=${this.shellEscape(mediaDir)}`,
       `DISPATCH_PORT=${this.shellEscape(String(this.config.port))}`,
       `DISPATCH_SCHEME=${this.config.tls ? "https" : "http"}`,
-      `HOSTESS_PORT=${this.shellEscape(String(this.config.port))}`,
-      // Compatibility alias for common typo to keep screenshot sharing reliable.
-      `HOSTESS_MDEIA_DIR=${this.shellEscape(mediaDir)}`,
       `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`,
       // Pin the Bash tool's cwd to the project root (worktree) after every command.
       // Prevents cwd drift back to the original repo root during long conversations.
@@ -1284,8 +1278,8 @@ export class AgentManager {
 
   /** Extract agent ID from a session name like "dispatch_agt_abc123_my-task". */
   private agentIdFromSessionName(sessionName: string): string {
-    const match = sessionName.match(/(?:dispatch|hostess)_(agt_[a-f0-9]{12})/);
-    return match?.[1] ?? sessionName.replace(/^(dispatch|hostess)_/, "");
+    const match = sessionName.match(/dispatch_(agt_[a-f0-9]{12})/);
+    return match?.[1] ?? sessionName.replace(/^dispatch_/, "");
   }
 
   private toSessionName(agentId: string, agentName?: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,17 +52,14 @@ export function loadConfig(): AppConfig {
     dispatchBinDir: path.resolve(__dirname, "..", "bin"),
     codexBin:
       process.env.DISPATCH_CODEX_BIN ??
-      process.env.HOSTESS_CODEX_BIN ??
       process.env.CODEX_BIN ??
       "codex",
     claudeBin:
       process.env.DISPATCH_CLAUDE_BIN ??
-      process.env.HOSTESS_CLAUDE_BIN ??
       process.env.CLAUDE_BIN ??
       "claude",
     opencodeBin:
       process.env.DISPATCH_OPENCODE_BIN ??
-      process.env.HOSTESS_OPENCODE_BIN ??
       process.env.OPENCODE_BIN ??
       "opencode",
     agentRuntime: process.env.DISPATCH_AGENT_RUNTIME === "tmux" ? "tmux" : "inert",

--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -1,9 +1,12 @@
 import path from "node:path";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 
 import { runCommand } from "../lib/run-command.js";
 
 const REPO_TOOL_MANIFEST_PATH = path.join(".dispatch", "tools.json");
+
+// Cache parsed hooks keyed by manifest path, invalidated by mtime.
+const hooksCache = new Map<string, { mtime: number; hooks: RepoHooks }>();
 const REPO_TOOL_PREFIX = "repo_";
 const BUILTIN_TOOL_NAMES = new Set([
   "create_worktree",
@@ -23,6 +26,7 @@ type RepoToolFile = {
 
 export type RepoHookDefinition = {
   command: string[];
+  description?: string;
 };
 
 export type RepoHooks = {
@@ -150,9 +154,26 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
 }
 
 export async function loadRepoHooks(repoRoot: string): Promise<RepoHooks> {
-  const config = await readRepoToolFile(path.join(repoRoot, REPO_TOOL_MANIFEST_PATH));
-  if (!config?.hooks || typeof config.hooks !== "object" || Array.isArray(config.hooks)) {
+  const manifestPath = path.join(repoRoot, REPO_TOOL_MANIFEST_PATH);
+
+  // Check mtime for cache invalidation.
+  let mtime: number;
+  try {
+    mtime = (await stat(manifestPath)).mtimeMs;
+  } catch {
     return {};
+  }
+
+  const cached = hooksCache.get(manifestPath);
+  if (cached && cached.mtime === mtime) {
+    return cached.hooks;
+  }
+
+  const config = await readRepoToolFile(manifestPath);
+  if (!config?.hooks || typeof config.hooks !== "object" || Array.isArray(config.hooks)) {
+    const empty = {};
+    hooksCache.set(manifestPath, { mtime, hooks: empty });
+    return empty;
   }
 
   const hooks: RepoHooks = {};
@@ -162,6 +183,7 @@ export async function loadRepoHooks(repoRoot: string): Promise<RepoHooks> {
     hooks.stop = parseHookDefinition(raw.stop, "stop");
   }
 
+  hooksCache.set(manifestPath, { mtime, hooks });
   return hooks;
 }
 
@@ -178,7 +200,9 @@ function parseHookDefinition(value: unknown, name: string): RepoHookDefinition {
     throw new Error(`Hook "${name}" must include a non-empty command array.`);
   }
 
-  return { command };
+  const description = typeof raw.description === "string" ? raw.description.trim() : undefined;
+
+  return { command, ...(description ? { description } : {}) };
 }
 
 function parseRepoToolParams(raw: unknown): RepoToolParam[] | undefined {

--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -18,6 +18,15 @@ const BUILTIN_TOOL_NAMES = new Set([
 
 type RepoToolFile = {
   tools?: unknown;
+  hooks?: unknown;
+};
+
+export type RepoHookDefinition = {
+  command: string[];
+};
+
+export type RepoHooks = {
+  stop?: RepoHookDefinition;
 };
 
 export type RepoToolParam = {
@@ -139,6 +148,38 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
   const params = parseRepoToolParams(rawTool.params);
 
   return { name, description, command, params };
+}
+
+export async function loadRepoHooks(repoRoot: string): Promise<RepoHooks> {
+  const config = await readRepoToolFile(path.join(repoRoot, REPO_TOOL_MANIFEST_PATH));
+  if (!config?.hooks || typeof config.hooks !== "object" || Array.isArray(config.hooks)) {
+    return {};
+  }
+
+  const hooks: RepoHooks = {};
+  const raw = config.hooks as Record<string, unknown>;
+
+  if (raw.stop) {
+    hooks.stop = parseHookDefinition(raw.stop, "stop");
+  }
+
+  return hooks;
+}
+
+function parseHookDefinition(value: unknown, name: string): RepoHookDefinition {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid hook definition for "${name}".`);
+  }
+  const raw = value as Record<string, unknown>;
+  const command = Array.isArray(raw.command) && raw.command.every((part) => typeof part === "string")
+    ? raw.command.map((part) => (part as string).trim()).filter(Boolean)
+    : [];
+
+  if (command.length === 0) {
+    throw new Error(`Hook "${name}" must include a non-empty command array.`);
+  }
+
+  return { command };
 }
 
 function parseRepoToolParams(raw: unknown): RepoToolParam[] | undefined {

--- a/src/mcp/repo-tools.ts
+++ b/src/mcp/repo-tools.ts
@@ -91,7 +91,6 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           cwd: currentRepoRoot,
           env: {
             DISPATCH_AGENT_ID: agentId,
-            HOSTESS_AGENT_ID: agentId
           }
         });
 

--- a/test/dispatch-dev.test.ts
+++ b/test/dispatch-dev.test.ts
@@ -21,7 +21,6 @@ function run(args: string, options?: { expectFail?: boolean }): string {
         ...process.env,
         // Clear agent ID so it doesn't leak into suffix
         DISPATCH_AGENT_ID: "",
-        HOSTESS_AGENT_ID: ""
       }
     }).trim();
   } catch (error) {

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -8,7 +8,7 @@ vi.mock("../src/lib/run-command.js", () => ({
   runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "started", stderr: "" }))
 }));
 
-const { loadRepoTools } = await import("../src/mcp/repo-tools.js");
+const { loadRepoTools, loadRepoHooks } = await import("../src/mcp/repo-tools.js");
 const { runCommand } = await import("../src/lib/run-command.js");
 
 const tempDirs: string[] = [];
@@ -18,11 +18,13 @@ const DEV_PARAMS = [
   { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
 ];
 
-async function createToolsRepo(tools: unknown[]): Promise<string> {
+async function createToolsRepo(tools: unknown[], hooks?: unknown): Promise<string> {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
   tempDirs.push(repoRoot);
   await mkdir(path.join(repoRoot, ".dispatch"));
-  await writeFile(path.join(repoRoot, ".dispatch", "tools.json"), JSON.stringify({ tools }));
+  const config: Record<string, unknown> = { tools };
+  if (hooks !== undefined) config.hooks = hooks;
+  await writeFile(path.join(repoRoot, ".dispatch", "tools.json"), JSON.stringify(config));
   return repoRoot;
 }
 
@@ -90,5 +92,39 @@ describe("loadRepoTools", () => {
 
     const [tool] = await loadRepoTools(repoRoot);
     expect(tool.name).toBe("repo_project_dev_up");
+  });
+});
+
+describe("loadRepoHooks", () => {
+  it("loads a stop hook from tools.json", async () => {
+    const repoRoot = await createToolsRepo([], {
+      stop: { command: ["./bin/dispatch-dev", "down"] }
+    });
+
+    const hooks = await loadRepoHooks(repoRoot);
+    expect(hooks.stop).toEqual({ command: ["./bin/dispatch-dev", "down"] });
+  });
+
+  it("returns empty object when no hooks are defined", async () => {
+    const repoRoot = await createToolsRepo([]);
+
+    const hooks = await loadRepoHooks(repoRoot);
+    expect(hooks).toEqual({});
+  });
+
+  it("returns empty object when tools.json does not exist", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+    tempDirs.push(repoRoot);
+
+    const hooks = await loadRepoHooks(repoRoot);
+    expect(hooks).toEqual({});
+  });
+
+  it("throws on hook with empty command", async () => {
+    const repoRoot = await createToolsRepo([], {
+      stop: { command: [] }
+    });
+
+    await expect(loadRepoHooks(repoRoot)).rejects.toThrow('Hook "stop" must include a non-empty command array');
   });
 });

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -49,7 +49,6 @@ describe("loadRepoTools", () => {
       cwd: repoRoot,
       env: expect.objectContaining({
         DISPATCH_AGENT_ID: "agt_test",
-        HOSTESS_AGENT_ID: "agt_test"
       })
     }));
   });

--- a/test/repo-tools.test.ts
+++ b/test/repo-tools.test.ts
@@ -119,6 +119,15 @@ describe("loadRepoHooks", () => {
     expect(hooks).toEqual({});
   });
 
+  it("parses optional description field", async () => {
+    const repoRoot = await createToolsRepo([], {
+      stop: { command: ["./bin/cleanup"], description: "Clean up resources" }
+    });
+
+    const hooks = await loadRepoHooks(repoRoot);
+    expect(hooks.stop).toEqual({ command: ["./bin/cleanup"], description: "Clean up resources" });
+  });
+
   it("throws on hook with empty command", async () => {
     const repoRoot = await createToolsRepo([], {
       stop: { command: [] }

--- a/web/src/hooks/use-layout.ts
+++ b/web/src/hooks/use-layout.ts
@@ -1,20 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const LEFT_SIDEBAR_KEY = "dispatch:leftSidebarOpen";
-const LEFT_SIDEBAR_LEGACY_KEY = "hostess:leftSidebarOpen";
 const MEDIA_SIDEBAR_KEY = "dispatch:mediaSidebarOpen";
-const MEDIA_SIDEBAR_LEGACY_KEY = "hostess:mediaSidebarOpen";
 const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px)";
 
-function readBool(key: string, legacyKey: string, fallback: boolean): boolean {
+function readBool(key: string, fallback: boolean): boolean {
   if (typeof window === "undefined") return fallback;
-  const stored = window.localStorage.getItem(key) ?? window.localStorage.getItem(legacyKey);
+  const stored = window.localStorage.getItem(key);
   return stored === null ? fallback : stored === "true";
 }
 
 export function useLayout() {
-  const [leftOpen, setLeftOpen] = useState(() => readBool(LEFT_SIDEBAR_KEY, LEFT_SIDEBAR_LEGACY_KEY, true));
-  const [mediaOpen, setMediaOpen] = useState(() => readBool(MEDIA_SIDEBAR_KEY, MEDIA_SIDEBAR_LEGACY_KEY, false));
+  const [leftOpen, setLeftOpen] = useState(() => readBool(LEFT_SIDEBAR_KEY, true));
+  const [mediaOpen, setMediaOpen] = useState(() => readBool(MEDIA_SIDEBAR_KEY, false));
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== "undefined" ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches : false
   );
@@ -37,13 +35,11 @@ export function useLayout() {
   useEffect(() => {
     const value = String(leftOpen);
     window.localStorage.setItem(LEFT_SIDEBAR_KEY, value);
-    window.localStorage.setItem(LEFT_SIDEBAR_LEGACY_KEY, value);
   }, [leftOpen]);
 
   useEffect(() => {
     const value = String(mediaOpen);
     window.localStorage.setItem(MEDIA_SIDEBAR_KEY, value);
-    window.localStorage.setItem(MEDIA_SIDEBAR_LEGACY_KEY, value);
   }, [mediaOpen]);
 
   // Reset mobile panels when switching to desktop.


### PR DESCRIPTION
## Summary
- Extends `.dispatch/tools.json` with a `hooks` object for repo-defined lifecycle callbacks
- Implements `stop` hook: Dispatch runs the configured command when an agent is stopped, with `DISPATCH_AGENT_ID` in the environment
- Adds Dispatch's own stop hook pointing to `dispatch-dev down` for automatic dev stack cleanup
- Best-effort execution with 15s timeout — hook failures don't block agent shutdown

## Details

**Config format:**
```json
{
  "hooks": {
    "stop": {
      "command": ["./bin/dispatch-dev", "down"]
    }
  },
  "tools": [...]
}
```

**How it works:**
1. `stopAgent` sets status to `stopping`
2. Runs the repo's stop hook (if defined) — command receives `DISPATCH_AGENT_ID` env var
3. `dispatch-dev down` uses that env var to resolve the correct suffix and tear down the right stack
4. Normal shutdown continues (kill tmux, update status)

Extensible to `start`, `resume`, `delete` hooks in the future.

## Test plan
- [x] Type check passes (`npm run check`)
- [x] All 86 unit tests pass including 4 new `loadRepoHooks` tests
- [x] Tests cover: loading stop hook, missing hooks, missing file, invalid command validation