### PR TITLE
Fix activity date bucketing and use theme-aware chart colors

### DIFF
--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -3,10 +3,26 @@ import { loadApp, seedActivityDemoViaDB } from "./helpers";
 
 const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
 
+function activityParams(opts: { daysBack?: number; granularity?: string } = {}): string {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const now = new Date();
+  const params = new URLSearchParams({ tz, granularity: opts.granularity ?? "day" });
+  if (opts.daysBack !== undefined) {
+    params.set("start", new Date(now.getTime() - opts.daysBack * 86400000).toISOString());
+    params.set("end", now.toISOString());
+  }
+  return params.toString();
+}
+
 test.describe("Activity range API", () => {
-  test("stats endpoint accepts the shared range values", async ({ request }) => {
-    for (const range of ["7d", "30d", "year", "all"]) {
-      const res = await request.get(`/api/v1/activity/stats?range=${range}`, {
+  test("stats endpoint accepts start/end/tz params", async ({ request }) => {
+    const testCases = [
+      { daysBack: 7, granularity: "day" },
+      { daysBack: 30, granularity: "day" },
+      { granularity: "month" }, // no start = all time
+    ];
+    for (const tc of testCases) {
+      const res = await request.get(`/api/v1/activity/stats?${activityParams(tc)}`, {
         headers: authHeader,
       });
       expect(res.ok()).toBeTruthy();
@@ -24,32 +40,33 @@ test.describe("Activity range API", () => {
     }
   });
 
-  test("daily-status endpoint returns matching granularity for each range", async ({ request }) => {
-    const expected = {
-      "7d": "day",
-      "30d": "day",
-      year: "month",
-      all: "month",
-    } as const;
+  test("daily-status endpoint returns matching granularity", async ({ request }) => {
+    const testCases = [
+      { daysBack: 7, granularity: "day" },
+      { daysBack: 30, granularity: "day" },
+      { granularity: "month" },
+    ] as const;
 
-    for (const [range, granularity] of Object.entries(expected)) {
-      const res = await request.get(`/api/v1/activity/daily-status?range=${range}`, {
-        headers: authHeader,
-      });
+    for (const tc of testCases) {
+      const res = await request.get(
+        `/api/v1/activity/daily-status?${activityParams(tc)}`,
+        { headers: authHeader }
+      );
       expect(res.ok()).toBeTruthy();
 
       const body = (await res.json()) as { days: unknown[]; granularity: string };
       expect(Array.isArray(body.days)).toBe(true);
-      expect(body.granularity).toBe(granularity);
+      expect(body.granularity).toBe(tc.granularity);
     }
   });
 
-  test("active-hours endpoint returns a full 7x24 grid", async ({ request }) => {
+  test("active-hours endpoint returns events", async ({ request }) => {
     await seedActivityDemoViaDB();
 
-    const res = await request.get("/api/v1/activity/active-hours?range=30d", {
-      headers: authHeader,
-    });
+    const res = await request.get(
+      `/api/v1/activity/active-hours?${activityParams({ daysBack: 30 })}`,
+      { headers: authHeader }
+    );
     expect(res.ok()).toBeTruthy();
 
     const body = (await res.json()) as { events: Array<{ created_at: string }> };

--- a/e2e/token-usage.spec.ts
+++ b/e2e/token-usage.spec.ts
@@ -3,6 +3,17 @@ import { loadApp } from "./helpers";
 
 const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
 
+function activityParams(opts: { daysBack?: number; granularity?: string } = {}): string {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const now = new Date();
+  const params = new URLSearchParams({ tz, granularity: opts.granularity ?? "day" });
+  if (opts.daysBack !== undefined) {
+    params.set("start", new Date(now.getTime() - opts.daysBack * 86400000).toISOString());
+    params.set("end", now.toISOString());
+  }
+  return params.toString();
+}
+
 test.describe("Token usage API", () => {
   test("GET /api/v1/activity/token-stats returns zeroes when empty", async ({ request }) => {
     const res = await request.get("/api/v1/activity/token-stats", { headers: authHeader });
@@ -22,7 +33,10 @@ test.describe("Token usage API", () => {
   });
 
   test("GET /api/v1/activity/token-daily returns empty days array when no data", async ({ request }) => {
-    const res = await request.get("/api/v1/activity/token-daily?range=30d", { headers: authHeader });
+    const res = await request.get(
+      `/api/v1/activity/token-daily?${activityParams({ daysBack: 30, granularity: "day" })}`,
+      { headers: authHeader }
+    );
     expect(res.ok()).toBeTruthy();
 
     const body = (await res.json()) as { days: unknown[]; granularity: string };
@@ -47,30 +61,44 @@ test.describe("Token usage API", () => {
     expect(res.status()).toBe(404);
   });
 
-  test("token endpoints accept shared range values", async ({ request }) => {
-    const daily7 = await request.get("/api/v1/activity/token-daily?range=7d", { headers: authHeader });
+  test("token endpoints accept start/end/tz params", async ({ request }) => {
+    const daily7 = await request.get(
+      `/api/v1/activity/token-daily?${activityParams({ daysBack: 7, granularity: "day" })}`,
+      { headers: authHeader }
+    );
     expect(daily7.ok()).toBeTruthy();
     expect(((await daily7.json()) as { granularity: string }).granularity).toBe("day");
 
-    const daily30 = await request.get("/api/v1/activity/token-daily?range=30d", { headers: authHeader });
+    const daily30 = await request.get(
+      `/api/v1/activity/token-daily?${activityParams({ daysBack: 30, granularity: "day" })}`,
+      { headers: authHeader }
+    );
     expect(daily30.ok()).toBeTruthy();
     expect(((await daily30.json()) as { granularity: string }).granularity).toBe("day");
 
-    const dailyYear = await request.get("/api/v1/activity/token-daily?range=year", { headers: authHeader });
-    expect(dailyYear.ok()).toBeTruthy();
-    expect(((await dailyYear.json()) as { granularity: string }).granularity).toBe("month");
+    const dailyMonth = await request.get(
+      `/api/v1/activity/token-daily?${activityParams({ granularity: "month" })}`,
+      { headers: authHeader }
+    );
+    expect(dailyMonth.ok()).toBeTruthy();
+    expect(((await dailyMonth.json()) as { granularity: string }).granularity).toBe("month");
 
-    const dailyAll = await request.get("/api/v1/activity/token-daily?range=all", { headers: authHeader });
-    expect(dailyAll.ok()).toBeTruthy();
-    expect(((await dailyAll.json()) as { granularity: string }).granularity).toBe("month");
-
-    const totals = await request.get("/api/v1/activity/token-stats?range=year", { headers: authHeader });
+    const totals = await request.get(
+      `/api/v1/activity/token-stats?${activityParams({ granularity: "month" })}`,
+      { headers: authHeader }
+    );
     expect(totals.ok()).toBeTruthy();
 
-    const byProject = await request.get("/api/v1/activity/token-by-project?range=all", { headers: authHeader });
+    const byProject = await request.get(
+      `/api/v1/activity/token-by-project?${activityParams()}`,
+      { headers: authHeader }
+    );
     expect(byProject.ok()).toBeTruthy();
 
-    const byModel = await request.get("/api/v1/activity/token-by-model?range=30d", { headers: authHeader });
+    const byModel = await request.get(
+      `/api/v1/activity/token-by-model?${activityParams({ daysBack: 30 })}`,
+      { headers: authHeader }
+    );
     expect(byModel.ok()).toBeTruthy();
   });
 });
@@ -97,8 +125,9 @@ test.describe("Token usage UI", () => {
 
     await expect(page.getByTestId("activity-range-select")).toContainText("This year");
 
+    // After switching to "This year", requests should include tz and granularity params
     await expect.poll(
-      () => requests.filter((url) => url.includes("range=year")).length
+      () => requests.filter((url) => url.includes("tz=") && url.includes("granularity=")).length
     ).toBeGreaterThanOrEqual(6);
 
     // Close dialog

--- a/src/activity-metrics.ts
+++ b/src/activity-metrics.ts
@@ -13,16 +13,23 @@ export type ActivityStatsResult = {
   stateDurations: Record<string, number>;
 };
 
+function localDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 function bucketStart(timeMs: number, granularity: ActivityGranularity): string {
   const bucket = new Date(timeMs);
   if (granularity === "week") {
-    const day = bucket.getUTCDay();
+    const day = bucket.getDay();
     const diff = day === 0 ? -6 : 1 - day;
-    bucket.setUTCDate(bucket.getUTCDate() + diff);
+    bucket.setDate(bucket.getDate() + diff);
   } else if (granularity === "month") {
-    bucket.setUTCDate(1);
+    bucket.setDate(1);
   }
-  return bucket.toISOString().slice(0, 10);
+  return localDateString(bucket);
 }
 
 export function computeActivityStats(

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,8 +63,7 @@ const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
-const ACTIVITY_RANGES = ["7d", "30d", "year", "all"] as const;
-type ActivityRange = (typeof ACTIVITY_RANGES)[number];
+type ActivityGranularity = "day" | "week" | "month";
 type UiEvent =
   | { type: "snapshot"; agents: AgentRecord[] }
   | { type: "agent.upsert"; agent: AgentRecord }
@@ -146,51 +145,65 @@ const GIT_CONTEXT_MIN_REQUEUE_MS = 60_000;
 const GIT_DIAGNOSTICS_HISTORY_LIMIT = 200;
 const pendingGitRefreshAgentIds = new Set<string>();
 
-function parseActivityRange(input: unknown): ActivityRange {
-  return typeof input === "string" && (ACTIVITY_RANGES as readonly string[]).includes(input)
-    ? (input as ActivityRange)
-    : "7d";
+type ActivityQuery = {
+  start: Date | null;
+  end: Date | null;
+  tz: string;
+  granularity: ActivityGranularity;
+};
+
+const VALID_GRANULARITIES = new Set<ActivityGranularity>(["day", "week", "month"]);
+const FALLBACK_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+function parseActivityQuery(query: Record<string, unknown>): ActivityQuery {
+  const startStr = typeof query.start === "string" ? query.start : "";
+  const endStr = typeof query.end === "string" ? query.end : "";
+  const tz = typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
+  const gran = typeof query.granularity === "string" ? query.granularity : "day";
+
+  const start = startStr ? new Date(startStr) : null;
+  const end = endStr ? new Date(endStr) : null;
+
+  return {
+    start: start && !Number.isNaN(start.getTime()) ? start : null,
+    end: end && !Number.isNaN(end.getTime()) ? end : null,
+    tz,
+    granularity: VALID_GRANULARITIES.has(gran as ActivityGranularity)
+      ? (gran as ActivityGranularity)
+      : "day",
+  };
 }
 
-function currentYearStart(): Date {
-  const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), 0, 1, 0, 0, 0, 0));
-}
-
-function getRangeLowerBound(range: ActivityRange): Date | null {
-  if (range === "all") return null;
-  if (range === "year") return currentYearStart();
-  if (range === "7d") return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-}
-
-function rangeWhereClause(range: ActivityRange, column: string): {
-  clause: string;
-  params: unknown[];
-} {
-  const lowerBound = getRangeLowerBound(range);
-  if (!lowerBound) {
-    return { clause: "", params: [] };
+function timeRangeClause(
+  aq: ActivityQuery,
+  column: string,
+  paramOffset = 0
+): { clause: string; params: unknown[] } {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  if (aq.start) {
+    params.push(aq.start);
+    conditions.push(`${column} >= $${paramOffset + params.length}`);
   }
-  return { clause: `WHERE ${column} >= $1`, params: [lowerBound] };
+  if (aq.end) {
+    params.push(aq.end);
+    conditions.push(`${column} <= $${paramOffset + params.length}`);
+  }
+  return {
+    clause: conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "",
+    params,
+  };
 }
 
-function getBucketGranularity(range: ActivityRange): "day" | "week" | "month" {
-  if (range === "7d" || range === "30d") return "day";
-  if (range === "year") return "month";
-  return "month";
-}
-
-function bucketExpression(range: ActivityRange, column: string): string {
-  const granularity = getBucketGranularity(range);
-  return `date_trunc('${granularity}', ${column})::date::text`;
+function dateTruncTz(granularity: ActivityGranularity, column: string, tz: string): string {
+  return `date_trunc('${granularity}', ${column} AT TIME ZONE '${tz.replace(/'/g, "''")}')::date::text`;
 }
 
 async function loadScopedActivityEvents(
-  range: ActivityRange
+  aq: ActivityQuery
 ): Promise<{ rows: ActivityEventRow[]; rangeStart: Date | null }> {
-  const rangeStart = getRangeLowerBound(range);
-  const eventFilter = rangeWhereClause(range, "created_at");
+  const rangeStart = aq.start;
+  const eventFilter = timeRangeClause(aq, "created_at");
 
   const inRangeResult = await pool.query<ActivityEventRow>(
     `SELECT agent_id, event_type, created_at
@@ -1417,11 +1430,12 @@ async function registerRoutes() {
   // ── Activity tracking ──────────────────────────────────────────────
 
   app.get("/api/v1/activity/heatmap", async (request) => {
-    const query = request.query as { days?: string };
-    const days = Math.min(Math.max(parseInt(query.days ?? "365", 10) || 365, 1), 730);
+    const query = request.query as Record<string, unknown>;
+    const days = Math.min(Math.max(parseInt((query.days as string) ?? "365", 10) || 365, 1), 730);
+    const tz = typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
 
     const result = await pool.query<{ day: string; count: number }>(
-      `SELECT date_trunc('day', created_at)::date::text AS day, COUNT(*)::int AS count
+      `SELECT ${dateTruncTz("day", "created_at", tz)} AS day, COUNT(*)::int AS count
        FROM agent_events
        WHERE created_at >= NOW() - make_interval(days => $1)
        GROUP BY day ORDER BY day`,
@@ -1432,13 +1446,12 @@ async function registerRoutes() {
   });
 
   app.get("/api/v1/activity/stats", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const { rows, rangeStart } = await loadScopedActivityEvents(range);
-    const eventFilter = rangeWhereClause(range, "created_at");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const { rows, rangeStart } = await loadScopedActivityEvents(aq);
+    const eventFilter = timeRangeClause(aq, "created_at");
 
     const busiestDayResult = await pool.query<{ day: string; count: number }>(
-      `SELECT date_trunc('day', created_at)::date::text AS day, COUNT(*)::int AS count
+      `SELECT ${dateTruncTz("day", "created_at", aq.tz)} AS day, COUNT(*)::int AS count
        FROM agent_events
        ${eventFilter.clause}
       GROUP BY day ORDER BY count DESC LIMIT 1`,
@@ -1457,19 +1470,16 @@ async function registerRoutes() {
   });
 
   app.get("/api/v1/activity/daily-status", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const granularity = getBucketGranularity(range);
-    const { rows, rangeStart } = await loadScopedActivityEvents(range);
-    const dailyStatus = computeDailyStatus(rows, rangeStart, granularity);
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const { rows, rangeStart } = await loadScopedActivityEvents(aq);
+    const dailyStatus = computeDailyStatus(rows, rangeStart, aq.granularity);
 
-    return { days: dailyStatus, granularity };
+    return { days: dailyStatus, granularity: aq.granularity };
   });
 
   app.get("/api/v1/activity/active-hours", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const eventFilter = rangeWhereClause(range, "created_at");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const eventFilter = timeRangeClause(aq, "created_at");
     const result = await pool.query<{ created_at: string }>(
       `SELECT created_at::text AS created_at
        FROM agent_events
@@ -1484,9 +1494,8 @@ async function registerRoutes() {
   // ── Token usage ──────────────────────────────────────────────────
 
   app.get("/api/v1/activity/token-stats", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
     const result = await pool.query<{
       total_input: number;
       total_cache_creation: number;
@@ -1510,10 +1519,8 @@ async function registerRoutes() {
   });
 
   app.get("/api/v1/activity/token-daily", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const granularity = getBucketGranularity(range);
-    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
 
     const result = await pool.query<{
       day: string;
@@ -1524,7 +1531,7 @@ async function registerRoutes() {
       messages: number;
     }>(
       `SELECT
-        ${bucketExpression(range, "COALESCE(session_start, harvested_at)")} AS day,
+        ${dateTruncTz(aq.granularity, "COALESCE(session_start, harvested_at)", aq.tz)} AS day,
         SUM(input_tokens)::int AS input_tokens,
         SUM(cache_creation_tokens)::int AS cache_creation_tokens,
         SUM(cache_read_tokens)::int AS cache_read_tokens,
@@ -1535,13 +1542,12 @@ async function registerRoutes() {
        GROUP BY day ORDER BY day`,
       tokenFilter.params
     );
-    return { days: result.rows, granularity };
+    return { days: result.rows, granularity: aq.granularity };
   });
 
   app.get("/api/v1/activity/token-by-project", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const tokenFilter = rangeWhereClause(range, "COALESCE(t.session_start, t.harvested_at)");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const tokenFilter = timeRangeClause(aq, "COALESCE(t.session_start, t.harvested_at)");
     const result = await pool.query<{
       project_dir: string;
       total_input: number;
@@ -1565,9 +1571,8 @@ async function registerRoutes() {
   });
 
   app.get("/api/v1/activity/token-by-model", async (request) => {
-    const query = request.query as { range?: string };
-    const range = parseActivityRange(query.range);
-    const tokenFilter = rangeWhereClause(range, "COALESCE(session_start, harvested_at)");
+    const aq = parseActivityQuery(request.query as Record<string, unknown>);
+    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
     const result = await pool.query<{
       model: string;
       total_input: number;

--- a/test/activity-metrics.test.ts
+++ b/test/activity-metrics.test.ts
@@ -32,13 +32,17 @@ describe("activity metrics boundary carry-in", () => {
   });
 
   it("attributes carried-in status time to the in-range daily bucket", () => {
+    // Use midday timestamps so the local-date bucket is the same across timezones
     const rows = [
-      row("a1", "working", "2026-03-20T23:50:00Z"),
-      row("a1", "done", "2026-03-21T00:20:00Z"),
+      row("a1", "working", "2026-03-20T12:00:00Z"),
+      row("a1", "done", "2026-03-21T12:20:00Z"),
     ];
 
-    const days = computeDailyStatus(rows, new Date("2026-03-21T00:00:00Z"), "day");
+    const rangeStart = new Date("2026-03-21T12:00:00Z");
+    const days = computeDailyStatus(rows, rangeStart, "day");
 
-    expect(days).toEqual([{ day: "2026-03-21", working: 20 * 60 * 1000 }]);
+    // The segment starts at rangeStart (Mar 21 local) and lasts 20 minutes
+    const expectedDay = new Date(rangeStart).toLocaleDateString("en-CA"); // YYYY-MM-DD
+    expect(days).toEqual([{ day: expectedDay, working: 20 * 60 * 1000 }]);
   });
 });

--- a/web/src/components/app/activity-pane.tsx
+++ b/web/src/components/app/activity-pane.tsx
@@ -128,10 +128,10 @@ const MONTH_NAMES = [
 function intensityClass(count: number, max: number): string {
   if (count === 0) return "bg-muted/60";
   const ratio = count / max;
-  if (ratio <= 0.25) return "bg-emerald-900/50";
-  if (ratio <= 0.5) return "bg-emerald-700/60";
-  if (ratio <= 0.75) return "bg-emerald-500/70";
-  return "bg-emerald-400";
+  if (ratio <= 0.25) return "bg-status-working/25";
+  if (ratio <= 0.5) return "bg-status-working/45";
+  if (ratio <= 0.75) return "bg-status-working/65";
+  return "bg-status-working/90";
 }
 
 type HeatmapCell = { date: string; count: number; label: string };
@@ -249,10 +249,10 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
       <div className="mt-2 flex items-center gap-1.5 pl-8 text-[10px] text-muted-foreground">
         <span>Less</span>
         <div className="h-[11px] w-[11px] rounded-[2px] bg-muted/60" />
-        <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-900/50" />
-        <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-700/60" />
-        <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-500/70" />
-        <div className="h-[11px] w-[11px] rounded-[2px] bg-emerald-400" />
+        <div className="h-[11px] w-[11px] rounded-[2px] bg-status-working/25" />
+        <div className="h-[11px] w-[11px] rounded-[2px] bg-status-working/45" />
+        <div className="h-[11px] w-[11px] rounded-[2px] bg-status-working/65" />
+        <div className="h-[11px] w-[11px] rounded-[2px] bg-status-working/90" />
         <span>More</span>
       </div>
     </div>
@@ -273,11 +273,11 @@ const ACTIVE_HOURS_DAY_LABELS: Record<number, string> = {
 function activeHoursIntensity(value: number, max: number): string {
   if (value <= 0) return "bg-muted/40";
   const ratio = value / max;
-  if (ratio <= 0.2) return "bg-sky-100/80";
-  if (ratio <= 0.4) return "bg-cyan-200/80";
-  if (ratio <= 0.6) return "bg-sky-300/80";
-  if (ratio <= 0.8) return "bg-cyan-500/80";
-  return "bg-sky-700/85";
+  if (ratio <= 0.2) return "bg-chart-3/20";
+  if (ratio <= 0.4) return "bg-chart-3/40";
+  if (ratio <= 0.6) return "bg-chart-3/55";
+  if (ratio <= 0.8) return "bg-chart-3/70";
+  return "bg-chart-3/90";
 }
 
 function formatHour(hour: number): string {
@@ -344,11 +344,11 @@ function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: Acti
       <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
         <span>Less</span>
         <div className="h-2.5 w-5 rounded-full bg-muted/40" />
-        <div className="h-2.5 w-5 rounded-full bg-sky-100/80" />
-        <div className="h-2.5 w-5 rounded-full bg-cyan-200/80" />
-        <div className="h-2.5 w-5 rounded-full bg-sky-300/80" />
-        <div className="h-2.5 w-5 rounded-full bg-cyan-500/80" />
-        <div className="h-2.5 w-5 rounded-full bg-sky-700/85" />
+        <div className="h-2.5 w-5 rounded-full bg-chart-3/20" />
+        <div className="h-2.5 w-5 rounded-full bg-chart-3/40" />
+        <div className="h-2.5 w-5 rounded-full bg-chart-3/55" />
+        <div className="h-2.5 w-5 rounded-full bg-chart-3/70" />
+        <div className="h-2.5 w-5 rounded-full bg-chart-3/90" />
         <span>More</span>
         <span className="ml-2">{cadenceLabel}</span>
       </div>
@@ -487,10 +487,10 @@ function shortProjectName(projectDir: string): string {
 const TOKEN_ORDER = ["input_tokens", "cache_read_tokens", "cache_creation_tokens", "output_tokens"];
 
 const tokenChartConfig: ChartConfig = {
-  input_tokens: { label: "Input", color: "hsl(217, 91%, 60%)" },
-  cache_read_tokens: { label: "Cache read", color: "hsl(172, 66%, 50%)" },
-  cache_creation_tokens: { label: "Cache write", color: "hsl(189, 94%, 43%)" },
-  output_tokens: { label: "Output", color: "hsl(38, 92%, 50%)" },
+  input_tokens: { label: "Input", color: "hsl(var(--chart-1))" },
+  cache_read_tokens: { label: "Cache read", color: "hsl(var(--chart-3))" },
+  cache_creation_tokens: { label: "Cache write", color: "hsl(var(--chart-4))" },
+  output_tokens: { label: "Output", color: "hsl(var(--chart-2))" },
 };
 
 const EMPTY_TOKEN_ENTRY = (day: string): TokenDailyEntry => ({
@@ -624,7 +624,7 @@ function ModelBreakdown({ data }: { data: TokenByModel[] }) {
             label={shortModelName(m.model)}
             value={total}
             maxValue={max}
-            color="bg-blue-500/70"
+            color="bg-chart-5"
             sub={`· ${m.sessions} session${m.sessions !== 1 ? "s" : ""}`}
           />
         );
@@ -647,7 +647,7 @@ function ProjectBreakdown({ data }: { data: TokenByProject[] }) {
           label={shortProjectName(p.project_dir)}
           value={p.total_input + p.total_output}
           maxValue={max}
-          color="bg-emerald-500/70"
+          color="bg-chart-6"
         />
       ))}
     </div>

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -28,8 +28,38 @@ export function rangeLabel(range: ActivityRange): string {
   }
 }
 
-function scopedActivityPath(path: string, range: ActivityRange): string {
-  return `${path}?range=${range}`;
+const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+function getGranularity(range: ActivityRange): ActivityGranularity {
+  if (range === "7d" || range === "30d") return "day";
+  return "month";
+}
+
+function getRangeBounds(range: ActivityRange): { start: string; end: string } {
+  const now = new Date();
+  const end = now.toISOString();
+
+  if (range === "year") {
+    const yearStart = new Date(now.getFullYear(), 0, 1, 0, 0, 0, 0);
+    return { start: yearStart.toISOString(), end };
+  }
+  if (range === "7d") {
+    return { start: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(), end };
+  }
+  if (range === "30d") {
+    return { start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(), end };
+  }
+  // "all" — no bounds
+  return { start: "", end: "" };
+}
+
+function activityParams(range: ActivityRange): string {
+  const { start, end } = getRangeBounds(range);
+  const granularity = getGranularity(range);
+  const params = new URLSearchParams({ tz: LOCAL_TZ, granularity });
+  if (start) params.set("start", start);
+  if (end) params.set("end", end);
+  return params.toString();
 }
 
 export type ActivityStats = {
@@ -59,8 +89,9 @@ export function useActivityHeatmap(days = 365) {
   return useQuery<HeatmapDay[]>({
     queryKey: ["activity", "heatmap", days],
     queryFn: async () => {
+      const params = new URLSearchParams({ days: String(days), tz: LOCAL_TZ });
       const payload = await api<{ days: HeatmapDay[] }>(
-        `/api/v1/activity/heatmap?days=${days}`
+        `/api/v1/activity/heatmap?${params}`
       );
       return payload.days;
     },
@@ -71,7 +102,7 @@ export function useActivityHeatmap(days = 365) {
 export function useActivityStats(range: ActivityRange) {
   return useQuery<ActivityStats>({
     queryKey: ["activity", "stats", range],
-    queryFn: () => api<ActivityStats>(scopedActivityPath("/api/v1/activity/stats", range)),
+    queryFn: () => api<ActivityStats>(`/api/v1/activity/stats?${activityParams(range)}`),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -79,11 +110,10 @@ export function useActivityStats(range: ActivityRange) {
 export function useDailyStatus(range: ActivityRange) {
   return useQuery<BucketedActivityResponse<DailyStatusEntry>>({
     queryKey: ["activity", "daily-status", range],
-    queryFn: async () => {
-      return api<BucketedActivityResponse<DailyStatusEntry>>(
-        scopedActivityPath("/api/v1/activity/daily-status", range)
-      );
-    },
+    queryFn: () =>
+      api<BucketedActivityResponse<DailyStatusEntry>>(
+        `/api/v1/activity/daily-status?${activityParams(range)}`
+      ),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -92,10 +122,14 @@ export function useActiveHours(range: ActivityRange) {
   return useQuery<ActiveHoursCell[]>({
     queryKey: ["activity", "active-hours", range],
     queryFn: async () => {
+      const { start, end } = getRangeBounds(range);
+      const params = new URLSearchParams({ tz: LOCAL_TZ });
+      if (start) params.set("start", start);
+      if (end) params.set("end", end);
       const payload = await api<{ events: ActiveHourEvent[] }>(
-        scopedActivityPath("/api/v1/activity/active-hours", range)
+        `/api/v1/activity/active-hours?${params}`
       );
-      return buildActiveHours(payload.events, range);
+      return buildActiveHours(payload.events);
     },
     ...ACTIVITY_QUERY_OPTIONS,
   });
@@ -124,7 +158,7 @@ export type TokenDailyEntry = {
 export function useTokenStats(range: ActivityRange) {
   return useQuery<TokenStats>({
     queryKey: ["activity", "token-stats", range],
-    queryFn: () => api<TokenStats>(scopedActivityPath("/api/v1/activity/token-stats", range)),
+    queryFn: () => api<TokenStats>(`/api/v1/activity/token-stats?${activityParams(range)}`),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -132,11 +166,10 @@ export function useTokenStats(range: ActivityRange) {
 export function useTokenDaily(range: ActivityRange) {
   return useQuery<BucketedActivityResponse<TokenDailyEntry>>({
     queryKey: ["activity", "token-daily", range],
-    queryFn: async () => {
-      return api<BucketedActivityResponse<TokenDailyEntry>>(
-        scopedActivityPath("/api/v1/activity/token-daily", range)
-      );
-    },
+    queryFn: () =>
+      api<BucketedActivityResponse<TokenDailyEntry>>(
+        `/api/v1/activity/token-daily?${activityParams(range)}`
+      ),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -162,7 +195,7 @@ export function useTokenByModel(range: ActivityRange) {
     queryKey: ["activity", "token-by-model", range],
     queryFn: async () => {
       const payload = await api<{ models: TokenByModel[] }>(
-        scopedActivityPath("/api/v1/activity/token-by-model", range)
+        `/api/v1/activity/token-by-model?${activityParams(range)}`
       );
       return payload.models;
     },
@@ -175,7 +208,7 @@ export function useTokenByProject(range: ActivityRange) {
     queryKey: ["activity", "token-by-project", range],
     queryFn: async () => {
       const payload = await api<{ projects: TokenByProject[] }>(
-        scopedActivityPath("/api/v1/activity/token-by-project", range)
+        `/api/v1/activity/token-by-project?${activityParams(range)}`
       );
       return payload.projects;
     },

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -28,6 +28,14 @@
   --status-done: 198 93% 60%;
   --status-idle: 240 4% 46%;
 
+  /* Chart colors */
+  --chart-1: 158 64% 52%;   /* teal — input tokens */
+  --chart-2: 45 96% 64%;    /* amber — output tokens */
+  --chart-3: 200 80% 55%;   /* sky — cache read */
+  --chart-4: 280 60% 60%;   /* purple — cache write */
+  --chart-5: 158 64% 42%;   /* deep teal — model bars */
+  --chart-6: 45 96% 54%;    /* deep amber — project bars */
+
   /* Surface & terminal */
   --surface: 50 15% 5%;
   --terminal-bg: 0 0% 8%;
@@ -58,6 +66,13 @@
   --status-done: 207 100% 67%;
   --status-idle: 220 8% 50%;
 
+  --chart-1: 207 100% 67%;
+  --chart-2: 55 87% 63%;
+  --chart-3: 170 60% 50%;
+  --chart-4: 280 70% 65%;
+  --chart-5: 207 80% 55%;
+  --chart-6: 150 57% 49%;
+
   --surface: 225 16% 7%;
   --terminal-bg: 225 16% 7%;
 }
@@ -86,6 +101,13 @@
   --status-waiting: 45 93% 58%;
   --status-done: 198 93% 60%;
   --status-idle: 0 0% 35%;
+
+  --chart-1: 160 72% 52%;
+  --chart-2: 45 93% 58%;
+  --chart-3: 198 93% 60%;
+  --chart-4: 280 60% 58%;
+  --chart-5: 160 60% 42%;
+  --chart-6: 45 80% 48%;
 
   --surface: 0 0% 2%;
   --terminal-bg: 0 0% 0%;
@@ -116,6 +138,13 @@
   --status-done: 205 82% 45%;
   --status-idle: 194 14% 40%;
 
+  --chart-1: 205 82% 45%;
+  --chart-2: 45 100% 35%;
+  --chart-3: 68 100% 30%;
+  --chart-4: 330 60% 45%;
+  --chart-5: 205 70% 40%;
+  --chart-6: 68 80% 25%;
+
   --surface: 192 100% 8%;
   --terminal-bg: 192 100% 11%;
 }
@@ -144,6 +173,13 @@
   --status-waiting: 46 97% 42%;
   --status-done: 217 91% 50%;
   --status-idle: 0 0% 60%;
+
+  --chart-1: 217 91% 50%;
+  --chart-2: 46 97% 42%;
+  --chart-3: 142 71% 35%;
+  --chart-4: 280 60% 50%;
+  --chart-5: 217 80% 45%;
+  --chart-6: 142 60% 30%;
 
   --surface: 40 20% 96%;
   --terminal-bg: 40 10% 96%;
@@ -174,6 +210,13 @@
   --status-done: 191 99% 50%;
   --status-idle: 262 20% 45%;
 
+  --chart-1: 191 99% 50%;
+  --chart-2: 57 100% 79%;
+  --chart-3: 325 100% 62%;
+  --chart-4: 262 70% 65%;
+  --chart-5: 191 80% 40%;
+  --chart-6: 160 100% 40%;
+
   --surface: 262 52% 4%;
   --terminal-bg: 262 52% 6%;
 }
@@ -203,6 +246,13 @@
   --status-done: 207 100% 67%;
   --status-idle: 220 8% 40%;
 
+  --chart-1: 207 100% 67%;
+  --chart-2: 55 87% 63%;
+  --chart-3: 170 60% 50%;
+  --chart-4: 280 70% 65%;
+  --chart-5: 207 80% 55%;
+  --chart-6: 150 57% 49%;
+
   --surface: 0 0% 2%;
   --terminal-bg: 0 0% 0%;
 }
@@ -231,6 +281,13 @@
   --status-waiting: 46 52% 54%;
   --status-done: 153 76% 64%;
   --status-idle: 132 12% 40%;
+
+  --chart-1: 136 100% 71%;
+  --chart-2: 46 52% 54%;
+  --chart-3: 153 76% 64%;
+  --chart-4: 100 50% 45%;
+  --chart-5: 136 80% 50%;
+  --chart-6: 46 40% 44%;
 
   --surface: 145 24% 2%;
   --terminal-bg: 150 20% 1.5%;

--- a/web/src/lib/active-hours.ts
+++ b/web/src/lib/active-hours.ts
@@ -1,5 +1,3 @@
-import type { ActivityRange } from "@/hooks/use-activity";
-
 export type ActiveHourEvent = {
   created_at: string;
 };
@@ -11,21 +9,11 @@ export type ActiveHoursCell = {
   avgPerWeek: number;
 };
 
-function rangeStart(range: ActivityRange, now: Date): Date | null {
-  if (range === "all") return null;
-  if (range === "year") return new Date(now.getFullYear(), 0, 1, 0, 0, 0, 0);
-  if (range === "7d") return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-  return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-}
-
 export function buildActiveHours(
   events: ActiveHourEvent[],
-  range: ActivityRange,
   now = new Date()
 ): ActiveHoursCell[] {
   const counts = new Map<string, number>();
-  const lowerBound = rangeStart(range, now);
-  const lowerBoundMs = lowerBound?.getTime() ?? null;
   let firstTimestamp = Number.POSITIVE_INFINITY;
   let lastTimestamp = Number.NEGATIVE_INFINITY;
 
@@ -33,7 +21,6 @@ export function buildActiveHours(
     const date = new Date(event.created_at);
     const timestamp = date.getTime();
     if (Number.isNaN(timestamp)) continue;
-    if (lowerBoundMs !== null && timestamp < lowerBoundMs) continue;
 
     firstTimestamp = Math.min(firstTimestamp, timestamp);
     lastTimestamp = Math.max(lastTimestamp, timestamp);
@@ -42,7 +29,7 @@ export function buildActiveHours(
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
 
-  const effectiveStartMs = lowerBoundMs ?? (Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime());
+  const effectiveStartMs = Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime();
   const effectiveEndMs = Number.isFinite(lastTimestamp) ? Math.max(lastTimestamp, now.getTime()) : now.getTime();
   const spanWeeks = Math.max(1, (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000));
 

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -35,6 +35,14 @@ export default {
           waiting: "hsl(var(--status-waiting) / <alpha-value>)",
           done: "hsl(var(--status-done) / <alpha-value>)",
           idle: "hsl(var(--status-idle) / <alpha-value>)"
+        },
+        chart: {
+          1: "hsl(var(--chart-1) / <alpha-value>)",
+          2: "hsl(var(--chart-2) / <alpha-value>)",
+          3: "hsl(var(--chart-3) / <alpha-value>)",
+          4: "hsl(var(--chart-4) / <alpha-value>)",
+          5: "hsl(var(--chart-5) / <alpha-value>)",
+          6: "hsl(var(--chart-6) / <alpha-value>)"
         }
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- **Fix UTC date bug**: Activity dates were bucketed in UTC, so evening events appeared on the next day. The client now sends explicit `start`/`end` timestamps with `tz`, making the server timezone-agnostic.
- **Theme-aware chart colors**: Replaced all hardcoded colors (emerald, sky/cyan mix, raw HSL values) with per-theme CSS variables (`--chart-1` through `--chart-6`). Every chart now adapts to the active theme with distinct, readable hues.
- **Cleanup**: Removed duplicate client-side date range resolution from `active-hours.ts` since the server already filters by the client-provided range.

## Test plan
- [x] `npm run check` — types pass
- [x] `npm test` — 82 unit tests pass
- [x] `npm run test:e2e` — 77 E2E tests pass
- [x] `npm run finalize:web` — production build succeeds
- [x] Visual verification of all 8 themes via Playwright screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)