### PR TITLE
Add pnpm install to dispatch-server build step

### DIFF
--- a/bin/dispatch-server
+++ b/bin/dispatch-server
@@ -143,6 +143,7 @@ cmd_build() {
   load_nvm
   cd "$ROOT_DIR"
   nvm use >/dev/null
+  pnpm install --frozen-lockfile
   pnpm run build
 }
 


### PR DESCRIPTION
## Summary

- `dispatch-server update` (git pull → build → restart) was missing `pnpm install` before the build step, causing `node_modules missing` errors after pulling new code

Found during the v0.6.15 production deploy — the monorepo migration removed npm's `postinstall` hook that previously installed web deps automatically.

## Test plan

- [x] Tested on production: `dispatch-server update` now runs `pnpm install --frozen-lockfile` → `pnpm run build` → restart → health check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)