### PR TITLE
Fix UI deploy flow to use pnpm instead of npm

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -565,11 +565,10 @@ async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
   await runCommand("git", ["-C", serverDir, "checkout", tag]);
 
   appendReleaseLog(job, "==> installing dependencies");
-  await streamProcess("npm", ["ci", "--silent"], { cwd: serverDir }, job);
-  await streamProcess("npm", ["--prefix", "web", "ci", "--silent"], { cwd: serverDir }, job);
+  await streamProcess("pnpm", ["install", "--frozen-lockfile"], { cwd: serverDir }, job);
 
   appendReleaseLog(job, "==> building");
-  await streamProcess("npm", ["run", "build"], { cwd: serverDir }, job);
+  await streamProcess("pnpm", ["run", "build"], { cwd: serverDir }, job);
 
   // Write release record BEFORE the restart — after the restart our
   // process is dead and can't write anything.


### PR DESCRIPTION
## Summary

- The in-app update/deploy endpoint (`deployTag`) still used `npm ci` and `npm run build`
- After the monorepo migration there's no `package-lock.json`, so `npm ci` hangs indefinitely
- Switch to `pnpm install --frozen-lockfile` and `pnpm run build`

This is the `deployTag()` function in `server.ts` that the Release Manager UI calls — separate from the `dispatch-server update` CLI which was already fixed in #160.

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run test` — 87/87 pass
- After merge + release, test the UI update button

🤖 Generated with [Claude Code](https://claude.com/claude-code)