### PR TITLE
Add deploy log line for pnpm migration verification

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -560,6 +560,7 @@ async function fetchLatestReleaseMetadata(tag: string): Promise<GitHubReleaseMet
 /** Shared deploy logic: checkout tag, install, build, write record, restart */
 async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
   setReleasePhase(job, "deploying");
+  appendReleaseLog(job, `==> deploying ${tag} via pnpm`);
 
   appendReleaseLog(job, `==> checking out ${tag}`);
   await runCommand("git", ["-C", serverDir, "checkout", tag]);


### PR DESCRIPTION
## Summary

- Adds a log line to `deployTag()` confirming pnpm deploy path
- Benign change to verify the UI deploy flow works end-to-end after the monorepo migration

## Test plan

- Merge, cut a patch release, deploy via UI update button

🤖 Generated with [Claude Code](https://claude.com/claude-code)