### PR TITLE
Fix media stream sidebar: lightbox UX, download/copy, mobile layout

### DIFF
--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -168,46 +168,47 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
 
   const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
 
-  const handleCopy = useCallback(async () => {
-    try {
-      const res = await fetch(src);
-      const ct = res.headers.get("content-type") ?? "";
+  const markCopied = useCallback(() => {
+    setCopied(true);
+    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+    copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
+  }, []);
 
-      if (ct.startsWith("image/png") && typeof ClipboardItem !== "undefined") {
-        const blob = await res.blob();
-        await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
-      } else if (ct.startsWith("text/") || isTextFile(fileName)) {
-        const text = await res.text();
-        await navigator.clipboard.writeText(text);
-      } else {
-        await navigator.clipboard.writeText(window.location.origin + src);
-      }
+  const handleCopy = useCallback(() => {
+    // Safari/iOS requires ClipboardItem to be created synchronously within
+    // the click handler to preserve the user-gesture chain. The blob data
+    // can be a Promise — this lets us fetch content without losing the
+    // gesture context.
+    if (typeof ClipboardItem !== "undefined") {
+      const blobPromise = fetch(src)
+        .then((res) => res.blob())
+        .then((blob) => {
+          if (blob.type.startsWith("image/png")) return blob;
+          // Convert everything else to text/plain for clipboard
+          return blob.text().then((t) => new Blob([t], { type: "text/plain" }));
+        });
 
-      setCopied(true);
-      if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
-      copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API may not be available (e.g. non-HTTPS on mobile).
-      // Fall back to legacy execCommand for text content.
-      try {
-        const res = await fetch(src);
-        const text = await res.text();
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-        setCopied(true);
-        if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
-        copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
-      } catch {
-        // Silent fail — nothing more we can do
-      }
+      void navigator.clipboard
+        .write([new ClipboardItem({ [isTextFile(fileName) ? "text/plain" : "image/png"]: blobPromise })])
+        .then(markCopied)
+        .catch(() => {
+          // If image/png write fails (e.g. non-PNG), retry as text
+          const textBlob = fetch(src)
+            .then((r) => r.text())
+            .then((t) => new Blob([t], { type: "text/plain" }));
+          return navigator.clipboard.write([new ClipboardItem({ "text/plain": textBlob })]);
+        })
+        .then(markCopied)
+        .catch(() => {});
+    } else {
+      // Fallback for browsers without ClipboardItem
+      void fetch(src)
+        .then((res) => res.text())
+        .then((text) => navigator.clipboard.writeText(text))
+        .then(markCopied)
+        .catch(() => {});
     }
-  }, [src, fileName]);
+  }, [src, fileName, markCopied]);
 
   return (
     <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -195,8 +195,19 @@ function copyViaExecCommand(text: string): boolean {
 function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<number | null>(null);
+  const cachedTextRef = useRef<string | null>(null);
 
   const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+
+  // Pre-fetch text content so it's available synchronously on click.
+  // iOS Safari's execCommand fallback requires content in the gesture handler.
+  useEffect(() => {
+    cachedTextRef.current = null;
+    void fetch(src)
+      .then((r) => r.text())
+      .then((t) => { cachedTextRef.current = t; })
+      .catch(() => {});
+  }, [src]);
 
   const markCopied = useCallback(() => {
     setCopied(true);
@@ -205,52 +216,39 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
   }, []);
 
   const handleCopy = useCallback(() => {
-    // iOS Safari requires ClipboardItem to be created synchronously in the
-    // click handler. The blob value can be a Promise — the browser resolves
-    // it internally without losing the user-gesture context.
+    // Strategy 1: ClipboardItem with Promise blob (preserves iOS Safari gesture chain)
     if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
-      const textBlob = fetch(src)
-        .then((r) => r.text())
-        .then((t) => new Blob([t], { type: "text/plain" }));
+      const textBlob = cachedTextRef.current
+        ? Promise.resolve(new Blob([cachedTextRef.current], { type: "text/plain" }))
+        : fetch(src).then((r) => r.text()).then((t) => new Blob([t], { type: "text/plain" }));
 
       void navigator.clipboard
         .write([new ClipboardItem({ "text/plain": textBlob })])
         .then(markCopied)
-        .catch((err) => {
-          console.warn("[copy] ClipboardItem write failed:", err);
-          // Fallback: fetch then try execCommand (works on iOS non-secure contexts)
-          void fetch(src)
-            .then((r) => r.text())
-            .then((t) => {
-              copyViaExecCommand(t);
-              markCopied();
-            })
-            .catch((e) => console.warn("[copy] execCommand fallback failed:", e));
+        .catch(() => {
+          // Strategy 2: execCommand with pre-fetched content (synchronous, no gesture issue)
+          if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
+            markCopied();
+          }
         });
-    } else if (navigator.clipboard?.writeText) {
-      void fetch(src)
-        .then((r) => r.text())
-        .then((t) => navigator.clipboard.writeText(t))
+      return;
+    }
+
+    // Strategy 2: writeText (may fail on iOS if not secure context)
+    if (navigator.clipboard?.writeText && cachedTextRef.current) {
+      void navigator.clipboard.writeText(cachedTextRef.current)
         .then(markCopied)
-        .catch((err) => {
-          console.warn("[copy] writeText failed:", err);
-          void fetch(src)
-            .then((r) => r.text())
-            .then((t) => {
-              copyViaExecCommand(t);
-              markCopied();
-            })
-            .catch((e) => console.warn("[copy] execCommand fallback failed:", e));
+        .catch(() => {
+          if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
+            markCopied();
+          }
         });
-    } else {
-      // No clipboard API at all — use execCommand directly
-      void fetch(src)
-        .then((r) => r.text())
-        .then((t) => {
-          copyViaExecCommand(t);
-          markCopied();
-        })
-        .catch((e) => console.warn("[copy] all methods failed:", e));
+      return;
+    }
+
+    // Strategy 3: execCommand with cached content (synchronous, works everywhere)
+    if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
+      markCopied();
     }
   }, [src, markCopied]);
 

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -175,40 +175,26 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
   }, []);
 
   const handleCopy = useCallback(() => {
-    // Safari/iOS requires ClipboardItem to be created synchronously within
-    // the click handler to preserve the user-gesture chain. The blob data
-    // can be a Promise — this lets us fetch content without losing the
-    // gesture context.
-    if (typeof ClipboardItem !== "undefined") {
-      const blobPromise = fetch(src)
-        .then((res) => res.blob())
-        .then((blob) => {
-          if (blob.type.startsWith("image/png")) return blob;
-          // Convert everything else to text/plain for clipboard
-          return blob.text().then((t) => new Blob([t], { type: "text/plain" }));
-        });
+    // iOS Safari requires ClipboardItem to be created synchronously in the
+    // click handler. The blob value can be a Promise — the browser resolves
+    // it internally without losing the user-gesture context.
+    if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+      const textBlob = fetch(src)
+        .then((r) => r.text())
+        .then((t) => new Blob([t], { type: "text/plain" }));
 
       void navigator.clipboard
-        .write([new ClipboardItem({ [isTextFile(fileName) ? "text/plain" : "image/png"]: blobPromise })])
-        .then(markCopied)
-        .catch(() => {
-          // If image/png write fails (e.g. non-PNG), retry as text
-          const textBlob = fetch(src)
-            .then((r) => r.text())
-            .then((t) => new Blob([t], { type: "text/plain" }));
-          return navigator.clipboard.write([new ClipboardItem({ "text/plain": textBlob })]);
-        })
+        .write([new ClipboardItem({ "text/plain": textBlob })])
         .then(markCopied)
         .catch(() => {});
-    } else {
-      // Fallback for browsers without ClipboardItem
+    } else if (navigator.clipboard?.writeText) {
       void fetch(src)
-        .then((res) => res.text())
-        .then((text) => navigator.clipboard.writeText(text))
+        .then((r) => r.text())
+        .then((t) => navigator.clipboard.writeText(t))
         .then(markCopied)
         .catch(() => {});
     }
-  }, [src, fileName, markCopied]);
+  }, [src, markCopied]);
 
   return (
     <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -162,7 +162,7 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   );
 }
 
-/** iOS Safari compatible copy via execCommand. Uses Range/getSelection instead of textarea.select(). */
+/** Copy text via hidden textarea + execCommand. Works on iOS Safari non-secure contexts. */
 function copyViaExecCommand(text: string): boolean {
   const textarea = document.createElement("textarea");
   textarea.value = text;
@@ -171,16 +171,8 @@ function copyViaExecCommand(text: string): boolean {
   textarea.style.top = "0";
   textarea.style.opacity = "0";
   document.body.appendChild(textarea);
-
-  // iOS Safari requires Range-based selection, not textarea.select()
-  const range = document.createRange();
-  range.selectNodeContents(textarea);
-  const selection = window.getSelection();
-  if (selection) {
-    selection.removeAllRanges();
-    selection.addRange(range);
-  }
-  textarea.setSelectionRange(0, text.length);
+  textarea.focus();
+  textarea.select();
 
   let ok = false;
   try {
@@ -216,7 +208,16 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
   }, []);
 
   const handleCopy = useCallback(() => {
-    // Strategy 1: ClipboardItem with Promise blob (preserves iOS Safari gesture chain)
+    // If content is pre-fetched, use execCommand (works everywhere including
+    // iOS Safari on non-secure contexts — the only reliable method there).
+    if (cachedTextRef.current) {
+      if (copyViaExecCommand(cachedTextRef.current)) {
+        markCopied();
+        return;
+      }
+    }
+
+    // Secure context: try Clipboard API with ClipboardItem + Promise blob
     if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
       const textBlob = cachedTextRef.current
         ? Promise.resolve(new Blob([cachedTextRef.current], { type: "text/plain" }))
@@ -225,30 +226,7 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
       void navigator.clipboard
         .write([new ClipboardItem({ "text/plain": textBlob })])
         .then(markCopied)
-        .catch(() => {
-          // Strategy 2: execCommand with pre-fetched content (synchronous, no gesture issue)
-          if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
-            markCopied();
-          }
-        });
-      return;
-    }
-
-    // Strategy 2: writeText (may fail on iOS if not secure context)
-    if (navigator.clipboard?.writeText && cachedTextRef.current) {
-      void navigator.clipboard.writeText(cachedTextRef.current)
-        .then(markCopied)
-        .catch(() => {
-          if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
-            markCopied();
-          }
-        });
-      return;
-    }
-
-    // Strategy 3: execCommand with cached content (synchronous, works everywhere)
-    if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
-      markCopied();
+        .catch(() => {});
     }
   }, [src, markCopied]);
 

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -82,11 +82,20 @@ const TEXT_EXTENSIONS = new Set([
   ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
 ]);
 
-function isTextFile(name: string): boolean {
+export function isTextFile(name: string): boolean {
   const dot = name.lastIndexOf(".");
   if (dot === -1) return false;
   return TEXT_EXTENSIONS.has(name.slice(dot).toLowerCase());
 }
+
+const TIMESTAMP_RE = /-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/;
+
+/** Strip the timestamp suffix that the server appends to media filenames. */
+export function stripTimestamp(name: string): string {
+  return name.replace(TIMESTAMP_RE, "");
+}
+
+const HAS_CLIPBOARD_WRITE = typeof ClipboardItem !== "undefined" && !!navigator.clipboard?.write;
 
 type MediaLightboxItem = {
   src: string;
@@ -189,17 +198,24 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
   const copiedTimerRef = useRef<number | null>(null);
   const cachedTextRef = useRef<string | null>(null);
 
-  const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+  const displayName = stripTimestamp(fileName);
 
   // Pre-fetch text content so it's available synchronously for execCommand copy.
   useEffect(() => {
     cachedTextRef.current = null;
     if (!isText) return;
-    void fetch(src)
+    const controller = new AbortController();
+    void fetch(src, { signal: controller.signal })
       .then((r) => r.text())
       .then((t) => { cachedTextRef.current = t; })
       .catch(() => {});
+    return () => controller.abort();
   }, [src, isText]);
+
+  // Clean up the "Copied!" timer on unmount.
+  useEffect(() => () => {
+    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+  }, []);
 
   const markCopied = useCallback(() => {
     setCopied(true);
@@ -221,7 +237,7 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
     } else {
       // Images: use Clipboard API (only works on secure contexts / desktop).
       // On mobile non-secure contexts, users can long-press to copy images.
-      if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+      if (HAS_CLIPBOARD_WRITE) {
         const blobPromise = fetch(src).then((r) => r.blob());
         void navigator.clipboard
           .write([new ClipboardItem({ "image/png": blobPromise })])
@@ -231,8 +247,7 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
     }
   }, [src, isText, markCopied]);
 
-  // Hide copy button for non-text on non-secure contexts (won't work)
-  const showCopy = isText || (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write);
+  const showCopy = isText || HAS_CLIPBOARD_WRITE;
 
   return (
     <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>
@@ -311,7 +326,7 @@ export function MediaLightbox({
 
   const isText = item.file.source === "text" || isTextFile(item.file.name);
   const isVideo = /\.mp4/i.test(item.src);
-  const displayName = item.file.name.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+  const displayName = stripTimestamp(item.file.name);
 
   const sizeLabel = item.file.size >= 1024 * 1024
     ? `${(item.file.size / (1024 * 1024)).toFixed(1)} MB`

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -162,6 +162,36 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   );
 }
 
+/** iOS Safari compatible copy via execCommand. Uses Range/getSelection instead of textarea.select(). */
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "0";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+
+  // iOS Safari requires Range-based selection, not textarea.select()
+  const range = document.createRange();
+  range.selectNodeContents(textarea);
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+  textarea.setSelectionRange(0, text.length);
+
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
 function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<number | null>(null);
@@ -186,13 +216,41 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
       void navigator.clipboard
         .write([new ClipboardItem({ "text/plain": textBlob })])
         .then(markCopied)
-        .catch(() => {});
+        .catch((err) => {
+          console.warn("[copy] ClipboardItem write failed:", err);
+          // Fallback: fetch then try execCommand (works on iOS non-secure contexts)
+          void fetch(src)
+            .then((r) => r.text())
+            .then((t) => {
+              copyViaExecCommand(t);
+              markCopied();
+            })
+            .catch((e) => console.warn("[copy] execCommand fallback failed:", e));
+        });
     } else if (navigator.clipboard?.writeText) {
       void fetch(src)
         .then((r) => r.text())
         .then((t) => navigator.clipboard.writeText(t))
         .then(markCopied)
-        .catch(() => {});
+        .catch((err) => {
+          console.warn("[copy] writeText failed:", err);
+          void fetch(src)
+            .then((r) => r.text())
+            .then((t) => {
+              copyViaExecCommand(t);
+              markCopied();
+            })
+            .catch((e) => console.warn("[copy] execCommand fallback failed:", e));
+        });
+    } else {
+      // No clipboard API at all — use execCommand directly
+      void fetch(src)
+        .then((r) => r.text())
+        .then((t) => {
+          copyViaExecCommand(t);
+          markCopied();
+        })
+        .catch((e) => console.warn("[copy] all methods failed:", e));
     }
   }, [src, markCopied]);
 

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -1,5 +1,5 @@
-import { type TouchEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronLeft, ChevronRight, Copy, Download } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronLeft, ChevronRight, Copy, Download, X } from "lucide-react";
 import hljs from "highlight.js/lib/core";
 import typescript from "highlight.js/lib/languages/typescript";
 import javascript from "highlight.js/lib/languages/javascript";
@@ -93,6 +93,8 @@ type MediaLightboxItem = {
   caption: string;
   file: {
     name: string;
+    size: number;
+    updatedAt: string;
     source?: "screenshot" | "stream" | "simulator" | "text";
   };
 };
@@ -107,8 +109,6 @@ type MediaLightboxProps = {
 function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.Element {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     setContent(null);
@@ -123,28 +123,6 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
       .catch((err) => { if (!cancelled) setError(String(err)); });
     return () => { cancelled = true; };
   }, [src]);
-
-  const handleCopy = useCallback(() => {
-    if (!content) return;
-    void navigator.clipboard.writeText(content).then(() => {
-      setCopied(true);
-      if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
-      copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
-    });
-  }, [content]);
-
-  const handleDownload = useCallback(() => {
-    if (!content) return;
-    const blob = new Blob([content], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
-    a.click();
-    URL.revokeObjectURL(url);
-  }, [content, fileName]);
-
-  const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
 
   const highlightedHtml = useMemo(() => {
     if (!content) return null;
@@ -174,42 +152,89 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-        <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
-        <div className="ml-auto flex items-center gap-1">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
-            onClick={handleDownload}
-          >
-            <Download className="h-3.5 w-3.5" />
-            Download
-          </Button>
-          <Button
-            size="sm"
-            variant={copied ? "default" : "ghost"}
-            className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
-            onClick={handleCopy}
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "Copied!" : "Copy"}
-          </Button>
-        </div>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto">
-        {highlightedHtml ? (
-          <pre className="p-4 text-sm leading-relaxed"><code className="hljs" dangerouslySetInnerHTML={{ __html: highlightedHtml }} /></pre>
-        ) : (
-          <pre className="p-4 text-sm leading-relaxed text-foreground"><code>{content}</code></pre>
-        )}
-      </div>
+    <div className="min-h-0 flex-1 overflow-auto">
+      {highlightedHtml ? (
+        <pre className="p-4 text-sm leading-relaxed"><code className="hljs" dangerouslySetInnerHTML={{ __html: highlightedHtml }} /></pre>
+      ) : (
+        <pre className="p-4 text-sm leading-relaxed text-foreground"><code>{content}</code></pre>
+      )}
     </div>
   );
 }
 
-const SWIPE_THRESHOLD_PX = 48;
+function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+
+  const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const res = await fetch(src);
+      const ct = res.headers.get("content-type") ?? "";
+
+      if (ct.startsWith("image/png") && typeof ClipboardItem !== "undefined") {
+        const blob = await res.blob();
+        await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+      } else if (ct.startsWith("text/") || isTextFile(fileName)) {
+        const text = await res.text();
+        await navigator.clipboard.writeText(text);
+      } else {
+        await navigator.clipboard.writeText(window.location.origin + src);
+      }
+
+      setCopied(true);
+      if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API may not be available (e.g. non-HTTPS on mobile).
+      // Fall back to legacy execCommand for text content.
+      try {
+        const res = await fetch(src);
+        const text = await res.text();
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        setCopied(true);
+        if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // Silent fail — nothing more we can do
+      }
+    }
+  }, [src, fileName]);
+
+  return (
+    <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>
+      <a
+        href={src}
+        download={displayName}
+        className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+        title="Download"
+      >
+        <Download className="h-3.5 w-3.5" />
+        <span className="hidden sm:inline">Download</span>
+      </a>
+      <Button
+        size="sm"
+        variant={copied ? "default" : "ghost"}
+        className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
+        onClick={handleCopy}
+        title="Copy"
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        <span className="hidden sm:inline">{copied ? "Copied!" : "Copy"}</span>
+      </Button>
+    </div>
+  );
+}
+
+export { MediaActions };
 
 export function MediaLightbox({
   item,
@@ -217,8 +242,6 @@ export function MediaLightbox({
   totalItems,
   setLightboxIndex
 }: MediaLightboxProps): JSX.Element | null {
-  const touchStartXRef = useRef<number | null>(null);
-
   const canGoPrev = currentIndex > 0;
   const canGoNext = currentIndex >= 0 && currentIndex < totalItems - 1;
 
@@ -259,114 +282,84 @@ export function MediaLightbox({
     return null;
   }
 
-  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
-    touchStartXRef.current = event.changedTouches[0]?.clientX ?? null;
-  };
+  const isText = item.file.source === "text" || isTextFile(item.file.name);
+  const isVideo = /\.mp4/i.test(item.src);
+  const displayName = item.file.name.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
 
-  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
-    if (touchStartXRef.current === null) {
-      return;
-    }
-
-    const endX = event.changedTouches[0]?.clientX ?? touchStartXRef.current;
-    const deltaX = endX - touchStartXRef.current;
-    touchStartXRef.current = null;
-
-    if (deltaX <= -SWIPE_THRESHOLD_PX && canGoNext) {
-      setLightboxIndex(currentIndex + 1);
-      return;
-    }
-
-    if (deltaX >= SWIPE_THRESHOLD_PX && canGoPrev) {
-      setLightboxIndex(currentIndex - 1);
-    }
-  };
+  const sizeLabel = item.file.size >= 1024 * 1024
+    ? `${(item.file.size / (1024 * 1024)).toFixed(1)} MB`
+    : `${Math.max(1, Math.round(item.file.size / 1024))} KB`;
 
   return (
     <div
-      className="fixed inset-0 z-[120] grid grid-rows-[auto_1fr_auto] gap-3 bg-black/90 p-4 sm:p-6"
+      className="fixed inset-0 z-[120] grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_1fr_auto] bg-black/90 p-2 sm:p-6"
       data-testid="media-lightbox"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          setLightboxIndex(null);
-        }
-      }}
     >
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
-          {totalItems > 0 ? `${currentIndex + 1} / ${totalItems}` : ""}
-        </div>
-        <div className="flex items-center gap-2">
+      <div className="mx-auto flex w-full max-w-4xl items-center gap-1 overflow-hidden rounded-t-lg border border-b-0 border-border bg-surface px-2 py-1.5 sm:px-4 sm:py-2">
+        <span className="min-w-0 shrink truncate text-xs font-medium text-foreground sm:text-sm">{displayName}</span>
+        <div className="ml-auto flex shrink-0 items-center">
+          <MediaActions src={item.src} fileName={item.file.name} />
+          <div className="mx-1 hidden h-4 w-px bg-border sm:block" />
           <Button
             aria-label="Previous media item"
             data-testid="media-lightbox-prev"
             disabled={!canGoPrev}
             size="icon"
             variant="ghost"
+            className="h-7 w-7"
             onClick={() => setLightboxIndex(currentIndex - 1)}
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft className="h-3.5 w-3.5" />
           </Button>
-          <Button onClick={() => setLightboxIndex(null)}>Close</Button>
+          <span className="hidden text-xs tabular-nums text-muted-foreground sm:inline">
+            {totalItems > 0 ? `${currentIndex + 1}/${totalItems}` : ""}
+          </span>
           <Button
             aria-label="Next media item"
             data-testid="media-lightbox-next"
             disabled={!canGoNext}
             size="icon"
             variant="ghost"
+            className="h-7 w-7"
             onClick={() => setLightboxIndex(currentIndex + 1)}
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Button>
+          <div className="mx-1 hidden h-4 w-px bg-border sm:block" />
+          <Button
+            aria-label="Close"
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => setLightboxIndex(null)}
+          >
+            <X className="h-3.5 w-3.5" />
           </Button>
         </div>
       </div>
-      <div
-        className="relative grid min-h-0 grid-cols-[minmax(0,1fr)] place-items-center overflow-hidden"
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
-      >
-        <button
-          aria-label="Previous media item"
-          className="absolute left-0 top-0 z-10 hidden h-full w-1/5 min-w-12 items-center justify-start bg-gradient-to-r from-black/35 to-transparent pl-2 text-white/70 transition hover:text-white disabled:pointer-events-none disabled:opacity-0 sm:flex"
-          disabled={!canGoPrev}
-          onClick={() => setLightboxIndex(currentIndex - 1)}
-          type="button"
-        >
-          <ChevronLeft className="h-8 w-8" />
-        </button>
-
-        {item.file.source === "text" || isTextFile(item.file.name) ? (
-          <div className="h-full w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-surface">
-            <TextViewer src={item.src} fileName={item.file.name} />
-          </div>
-        ) : /\.mp4/i.test(item.src) ? (
+      <div className="mx-auto min-h-0 w-full max-w-4xl overflow-auto border-x border-border bg-black touch-pinch-zoom">
+        {isText ? (
+          <TextViewer src={item.src} fileName={item.file.name} />
+        ) : isVideo ? (
           <video
             src={item.src}
             controls
             playsInline
-            className="max-h-[calc(100vh-10rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain sm:max-h-[calc(100vh-9rem)] sm:max-w-[calc(100vw-6rem)]"
+            className="max-h-[calc(100vh-12rem)] w-full object-contain"
           />
         ) : (
           <img
             src={item.src}
             alt={item.caption}
-            className="max-h-[calc(100vh-10rem)] max-w-[calc(100vw-2rem)] h-auto w-auto object-contain sm:max-h-[calc(100vh-9rem)] sm:max-w-[calc(100vw-6rem)]"
+            className="max-h-[calc(100vh-12rem)] w-full object-contain"
           />
         )}
-
-        <button
-          aria-label="Next media item"
-          className="absolute right-0 top-0 z-10 hidden h-full w-1/5 min-w-12 items-center justify-end bg-gradient-to-l from-black/35 to-transparent pr-2 text-white/70 transition hover:text-white disabled:pointer-events-none disabled:opacity-0 sm:flex"
-          disabled={!canGoNext}
-          onClick={() => setLightboxIndex(currentIndex + 1)}
-          type="button"
-        >
-          <ChevronRight className="h-8 w-8" />
-        </button>
       </div>
-      <div className="flex items-center justify-center gap-2 text-center text-sm text-muted-foreground">
-        <span>{item.caption}</span>
-        {item.file.source ? <span className="text-xs uppercase tracking-wide">{item.file.source}</span> : null}
+      <div className="mx-auto flex w-full max-w-4xl items-center gap-2 rounded-b-lg border border-t-0 border-border bg-surface px-2 py-1.5 text-xs text-muted-foreground sm:gap-3 sm:px-4 sm:py-2">
+        {item.caption ? <span className="min-w-0 truncate">{item.caption}</span> : null}
+        {item.file.source ? <span className="flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">{item.file.source}</span> : null}
+        <span className="ml-auto flex-none">{sizeLabel}</span>
+        <span className="hidden flex-none sm:inline">{new Date(item.file.updatedAt).toLocaleString()}</span>
       </div>
     </div>
   );

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -184,22 +184,22 @@ function copyViaExecCommand(text: string): boolean {
   return ok;
 }
 
-function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX.Element {
+function MediaActions({ src, fileName, isText }: { src: string; fileName: string; isText?: boolean }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<number | null>(null);
   const cachedTextRef = useRef<string | null>(null);
 
   const displayName = fileName.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "");
 
-  // Pre-fetch text content so it's available synchronously on click.
-  // iOS Safari's execCommand fallback requires content in the gesture handler.
+  // Pre-fetch text content so it's available synchronously for execCommand copy.
   useEffect(() => {
     cachedTextRef.current = null;
+    if (!isText) return;
     void fetch(src)
       .then((r) => r.text())
       .then((t) => { cachedTextRef.current = t; })
       .catch(() => {});
-  }, [src]);
+  }, [src, isText]);
 
   const markCopied = useCallback(() => {
     setCopied(true);
@@ -208,27 +208,31 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
   }, []);
 
   const handleCopy = useCallback(() => {
-    // If content is pre-fetched, use execCommand (works everywhere including
-    // iOS Safari on non-secure contexts — the only reliable method there).
-    if (cachedTextRef.current) {
-      if (copyViaExecCommand(cachedTextRef.current)) {
+    if (isText) {
+      // Text files: use execCommand with pre-fetched content (works on iOS Safari
+      // non-secure contexts). Fall back to Clipboard API on secure contexts.
+      if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
         markCopied();
         return;
       }
+      if (navigator.clipboard?.writeText && cachedTextRef.current) {
+        void navigator.clipboard.writeText(cachedTextRef.current).then(markCopied).catch(() => {});
+      }
+    } else {
+      // Images: use Clipboard API (only works on secure contexts / desktop).
+      // On mobile non-secure contexts, users can long-press to copy images.
+      if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+        const blobPromise = fetch(src).then((r) => r.blob());
+        void navigator.clipboard
+          .write([new ClipboardItem({ "image/png": blobPromise })])
+          .then(markCopied)
+          .catch(() => {});
+      }
     }
+  }, [src, isText, markCopied]);
 
-    // Secure context: try Clipboard API with ClipboardItem + Promise blob
-    if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
-      const textBlob = cachedTextRef.current
-        ? Promise.resolve(new Blob([cachedTextRef.current], { type: "text/plain" }))
-        : fetch(src).then((r) => r.text()).then((t) => new Blob([t], { type: "text/plain" }));
-
-      void navigator.clipboard
-        .write([new ClipboardItem({ "text/plain": textBlob })])
-        .then(markCopied)
-        .catch(() => {});
-    }
-  }, [src, markCopied]);
+  // Hide copy button for non-text on non-secure contexts (won't work)
+  const showCopy = isText || (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write);
 
   return (
     <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>
@@ -241,16 +245,18 @@ function MediaActions({ src, fileName }: { src: string; fileName: string }): JSX
         <Download className="h-3.5 w-3.5" />
         <span className="hidden sm:inline">Download</span>
       </a>
-      <Button
-        size="sm"
-        variant={copied ? "default" : "ghost"}
-        className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
-        onClick={handleCopy}
-        title="Copy"
-      >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-        <span className="hidden sm:inline">{copied ? "Copied!" : "Copy"}</span>
-      </Button>
+      {showCopy && (
+        <Button
+          size="sm"
+          variant={copied ? "default" : "ghost"}
+          className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
+          onClick={handleCopy}
+          title="Copy"
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          <span className="hidden sm:inline">{copied ? "Copied!" : "Copy"}</span>
+        </Button>
+      )}
     </div>
   );
 }
@@ -319,7 +325,7 @@ export function MediaLightbox({
       <div className="mx-auto flex w-full max-w-4xl items-center gap-1 overflow-hidden rounded-t-lg border border-b-0 border-border bg-surface px-2 py-1.5 sm:px-4 sm:py-2">
         <span className="min-w-0 shrink truncate text-xs font-medium text-foreground sm:text-sm">{displayName}</span>
         <div className="ml-auto flex shrink-0 items-center">
-          <MediaActions src={item.src} fileName={item.file.name} />
+          <MediaActions src={item.src} fileName={item.file.name} isText={isText} />
           <div className="mx-1 hidden h-4 w-px bg-border sm:block" />
           <Button
             aria-label="Previous media item"

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -2,6 +2,7 @@ import { type RefObject, useCallback, useEffect } from "react";
 import { ChevronRight, ExternalLink, FileText, MonitorPlay, X } from "lucide-react";
 
 import { type MediaFile } from "@/components/app/types";
+import { MediaActions } from "@/components/app/media-lightbox";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -184,7 +185,10 @@ export function MediaSidebarContent({
                 )}
                 <div className="mt-2 text-xs text-muted-foreground">
                   {file.description ? <div>{file.description}</div> : null}
-                  <div className={file.description ? "mt-1" : ""}>{Math.max(1, Math.round(file.size / 1024))} KB</div>
+                  <div className={`flex items-center justify-between gap-2${file.description ? " mt-1" : ""}`}>
+                    <span>{Math.max(1, Math.round(file.size / 1024))} KB</span>
+                    <MediaActions src={cacheBustUrl} fileName={file.name} />
+                  </div>
                 </div>
               </article>
             );

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -187,7 +187,7 @@ export function MediaSidebarContent({
                   {file.description ? <div>{file.description}</div> : null}
                   <div className={`flex items-center justify-between gap-2${file.description ? " mt-1" : ""}`}>
                     <span>{Math.max(1, Math.round(file.size / 1024))} KB</span>
-                    <MediaActions src={cacheBustUrl} fileName={file.name} />
+                    <MediaActions src={cacheBustUrl} fileName={file.name} isText={isText} />
                   </div>
                 </div>
               </article>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -2,23 +2,10 @@ import { type RefObject, useCallback, useEffect } from "react";
 import { ChevronRight, ExternalLink, FileText, MonitorPlay, X } from "lucide-react";
 
 import { type MediaFile } from "@/components/app/types";
-import { MediaActions } from "@/components/app/media-lightbox";
+import { MediaActions, isTextFile, stripTimestamp } from "@/components/app/media-lightbox";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-const TEXT_EXTENSIONS = new Set([
-  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
-  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
-  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
-  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
-  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
-]);
-
-function isTextFileName(name: string): boolean {
-  const dot = name.lastIndexOf(".");
-  if (dot === -1) return false;
-  return TEXT_EXTENSIONS.has(name.slice(dot).toLowerCase());
-}
 
 function fileExtension(name: string): string {
   const dot = name.lastIndexOf(".");
@@ -130,7 +117,7 @@ export function MediaSidebarContent({
             const unseen = !file.seen;
 
             const isStream = file.source === "stream";
-            const isText = file.source === "text" || isTextFileName(file.name);
+            const isText = file.source === "text" || isTextFile(file.name);
 
             return (
               <article
@@ -161,7 +148,7 @@ export function MediaSidebarContent({
                   >
                     <div className="flex items-center gap-2">
                       <FileText className="h-4 w-4 flex-none text-muted-foreground" />
-                      <span className="truncate text-xs font-medium text-foreground">{file.name.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/, "")}</span>
+                      <span className="truncate text-xs font-medium text-foreground">{stripTimestamp(file.name)}</span>
                       <span className="ml-auto flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{fileExtension(file.name)}</span>
                     </div>
                   </button>

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -52,19 +52,19 @@ test.describe("Media sidebar", () => {
 
     const lightbox = page.getByTestId("media-lightbox");
     await expect(lightbox).toBeVisible();
-    await expect(lightbox).toContainText("1 / 2");
+    await expect(lightbox).toContainText("1/2");
     await expect(lightbox).toContainText("Second image");
 
     await page.getByTestId("media-lightbox-next").click();
-    await expect(lightbox).toContainText("2 / 2");
+    await expect(lightbox).toContainText("2/2");
     await expect(lightbox).toContainText("First image");
 
     await page.getByTestId("media-lightbox-prev").click();
-    await expect(lightbox).toContainText("1 / 2");
+    await expect(lightbox).toContainText("1/2");
     await expect(lightbox).toContainText("Second image");
 
     await page.keyboard.press("ArrowRight");
-    await expect(lightbox).toContainText("2 / 2");
+    await expect(lightbox).toContainText("2/2");
 
     await lightbox.getByRole("button", { name: "Close" }).click();
     await expect(lightbox).toBeHidden();


### PR DESCRIPTION
## Summary
- **Fix click interception**: Removed swipe detection and overlay nav buttons that were intercepting clicks on Download/Copy buttons, causing the lightbox to close unexpectedly
- **Download/Copy on all media types**: Added actions to both sidebar and lightbox for images, videos, and text files. Download uses `<a download>` for right-click Save As. Copy handles PNG blobs, text content, and falls back to `execCommand` for mobile
- **Unified lightbox chrome**: Consistent header (filename + actions + nav + close) and footer (description + source badge + size + timestamp) across all media types
- **Mobile layout fix**: Lightbox now constrained to viewport on small screens — icon-only buttons, responsive padding, grid column constraint prevents overflow

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (77/77)
- [x] Validated on dev instance: Download/Copy work without closing lightbox
- [x] Validated at 390x844 mobile viewport: all buttons visible and clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)