### PR TITLE
Fix launchd wrapper to use monorepo server path

### DIFF
--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -12,4 +12,4 @@
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 cd "$ROOT_DIR"
-exec node "$ROOT_DIR/dist/server.js"
+exec node "$ROOT_DIR/apps/server/dist/server.js"


### PR DESCRIPTION
## Summary

The launchd wrapper (`bin/dispatch-launchd-wrapper`) was pointing to `dist/server.js` — the pre-monorepo location. The server moved to `apps/server/dist/server.js` in PR #158 but this wrapper wasn't updated, causing the launchd-managed production process to run stale pre-migration code with `npm ci` instead of `pnpm install`.

This was the root cause of every UI deploy failure since the monorepo migration.

## Test plan

- [x] Patched production directly — v0.7.4 deployed successfully via UI after fix
- [x] Cleaned up stale pre-monorepo dirs (dist/, web/, test/) from production

🤖 Generated with [Claude Code](https://claude.com/claude-code)