### PR TITLE
Fix worktree archival check to use tracking branch

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1435,6 +1435,7 @@ export class AgentManager {
         ``,
         `  if git -C "$REPO_ROOT" worktree add -b "${worktreeBranchName}" "$WT_PATH" "$BASE_REF" 2>&1; then`,
         `    ok "Worktree created at $WT_PATH"`,
+        `    git -C "$WT_PATH" branch --set-upstream-to "$BASE_REF" "${worktreeBranchName}" 2>/dev/null || true`,
         `    EFFECTIVE_CWD="$WT_PATH"`,
         `    WORKTREE_PATH="\\"$WT_PATH\\""`,
         `    WORKTREE_BRANCH="\\"${worktreeBranchName}\\""`,
@@ -1560,14 +1561,35 @@ export class AgentManager {
 
   private async getUnmergedChanges(worktreePath: string): Promise<{ hasUnmergedCommits: boolean; changedFiles: string[] }> {
     try {
-      // Fetch origin/main so we detect commits that were merged via PR
+      // Discover the upstream tracking branch (set at worktree creation time).
+      // Falls back to origin/main for older worktrees that don't have one.
+      let upstreamRef: string | null = null;
+      try {
+        const upstream = await runCommand(
+          "git", ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+          { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
+        );
+        if (upstream.exitCode === 0 && upstream.stdout) {
+          upstreamRef = upstream.stdout;
+        }
+      } catch {
+        // No upstream set — will fall back below
+      }
+
+      // Determine which remote branch to fetch
+      const remoteBranch = upstreamRef?.startsWith("origin/")
+        ? upstreamRef.slice("origin/".length)
+        : "main";
+
       await runCommand(
-        "git", ["-C", worktreePath, "fetch", "origin", "main", "--quiet"],
+        "git", ["-C", worktreePath, "fetch", "origin", remoteBranch, "--quiet"],
         { allowedExitCodes: [0, 1, 128], timeoutMs: 15_000 }
       );
 
-      // Compare against origin/main (falls back to local main if fetch failed)
-      const baseRef = await this.resolveRef(worktreePath, "origin/main") ?? await this.resolveRef(worktreePath, "main");
+      // Resolve the base ref: prefer upstream, fall back to origin/main → main
+      const baseRef = (upstreamRef ? await this.resolveRef(worktreePath, upstreamRef) : null)
+        ?? await this.resolveRef(worktreePath, "origin/main")
+        ?? await this.resolveRef(worktreePath, "main");
       if (!baseRef) {
         return { hasUnmergedCommits: false, changedFiles: [] };
       }

--- a/apps/server/test/git-worktree.test.ts
+++ b/apps/server/test/git-worktree.test.ts
@@ -42,6 +42,7 @@ describe("git worktree services", () => {
         case `-C ${repoRoot} show-ref --verify --quiet refs/remotes/origin/feature-auth-flow`:
           return { exitCode: 1, stdout: "", stderr: "" };
         case `-C ${repoRoot} worktree add -b feature-auth-flow ${expectedWorktreePath} origin/main`:
+        case `-C ${expectedWorktreePath} branch --set-upstream-to origin/main feature-auth-flow`:
           return { exitCode: 0, stdout: "", stderr: "" };
         default:
           throw new Error(`Unexpected command: ${key}`);

--- a/packages/shared/src/git/worktree.ts
+++ b/packages/shared/src/git/worktree.ts
@@ -105,6 +105,12 @@ export async function createGitWorktree(
     baseRef
   ]);
 
+  // Set upstream tracking so archival checks know which branch to compare against
+  await commandRunner("git", [
+    "-C", worktreePath,
+    "branch", "--set-upstream-to", baseRef, branchName
+  ], { allowedExitCodes: [0, 1, 128] });
+
   return {
     repoRoot,
     worktreePath,


### PR DESCRIPTION
## Summary
- The unmerged-change check during agent archival always compared against `origin/main`, causing false "unmerged commits" warnings for agents whose worktrees were based on non-main branches
- Now sets git upstream tracking (`--set-upstream-to`) at worktree creation time and resolves it dynamically during archival checks
- Falls back to `origin/main` for backward compatibility with existing worktrees

## Test plan
- [x] Unit tests pass (`pnpm run test`)
- [x] E2E tests pass (`pnpm run test:e2e`) — 77 passed
- [x] Type checks pass (`pnpm run check`)
- [x] Live-tested on dev instance: created agent with non-main base branch, verified correct unmerged detection, verified warning clears after merge to base

🤖 Generated with [Claude Code](https://claude.com/claude-code)