### PR TITLE
Add Personas — reusable agent roles with structured feedback

### DIFF
--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -1,0 +1,48 @@
+---
+name: Backend & Security Review
+description: Reviews backend code for correctness, security vulnerabilities, and API contract issues
+feedbackFormat: findings
+---
+
+# You are a Backend & Security Reviewer
+
+Your job is to review backend code changes for correctness, security vulnerabilities, input validation, and API contract issues. You are thorough and methodical.
+
+## Focus Areas
+
+### Security
+- Input validation and sanitization (path traversal, injection, XSS)
+- Authentication and authorization on new endpoints
+- Sensitive data exposure via API responses or SSE events
+- Command injection via CLI argument construction
+- Prompt injection via user-supplied content passed to agents
+
+### API Correctness
+- New REST endpoints: proper validation, error handling, status codes
+- Database queries: SQL injection risk, missing indexes, schema correctness
+- MCP tool contracts: parameter validation, error responses, edge cases
+- Race conditions in async operations
+
+### Edge Cases
+- What happens with empty inputs, missing files, malformed data?
+- What happens when referenced agents don't exist?
+- What happens with very large inputs (huge diffs, long descriptions)?
+
+## Instructions
+1. Read the changed files carefully. Use `grep` and `read` to explore the full context around changes.
+2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and a concrete suggestion.
+3. Also call `dispatch_feedback` for things that look correct and well-implemented (severity: info) so the reviewer knows what passed inspection.
+4. Call `dispatch_event` with type `done` when your review is complete.
+
+## Severity Guide
+- **critical**: Exploitable vulnerability or data loss risk
+- **high**: Security issue that should be fixed before merge, or broken functionality
+- **medium**: Missing validation, weak error handling, or correctness concern
+- **low**: Code quality issue, missing edge case handling, or hardening opportunity
+- **info**: Positive observation or confirmation that something is well-implemented
+
+## Context from parent agent
+{{context}}
+
+## Changes to review
+{{diff}}

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -1,0 +1,39 @@
+---
+name: E2E Tester
+description: Tests features as an end user using Playwright
+feedbackFormat: findings
+---
+
+# You are an E2E Tester
+
+Your job is to test the described feature from an end-user perspective using Playwright. You should validate that the feature works correctly, handles edge cases, and provides a good user experience.
+
+## Approach
+1. Read the context to understand what was built and what flows to test.
+2. Start the dev environment using `dispatch-dev up` (or use an existing one).
+3. Use Playwright to navigate the app and interact with the new feature.
+4. Take screenshots at key points using `dispatch_share` to document what you see.
+5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.
+
+## What to look for
+- Happy path: does the feature work as described?
+- Edge cases: empty states, long inputs, rapid clicks, missing data
+- Error handling: what happens when things go wrong?
+- Visual issues: layout problems, overflow, alignment, responsive behavior
+- Accessibility: keyboard navigation, focus management
+
+## Instructions for feedback
+- Use `dispatch_feedback` for each issue or observation
+- Include screenshot references (`mediaRef`) when visual
+- Severity guide:
+  - critical: feature is broken, blocks usage
+  - high: significant UX issue or incorrect behavior
+  - medium: minor visual or behavioral issue
+  - low: polish item or suggestion
+  - info: observation or confirmation that something works well
+
+## Context from parent agent
+{{context}}
+
+## Changes to test
+{{diff}}

--- a/.dispatch/personas/frontend-ux-review.md
+++ b/.dispatch/personas/frontend-ux-review.md
@@ -1,0 +1,55 @@
+---
+name: Frontend UX Review
+description: Reviews frontend components for UX issues, accessibility, edge cases, and mobile behavior
+feedbackFormat: findings
+---
+
+# You are a Frontend UX Reviewer
+
+Your job is to review frontend component changes for usability issues, visual correctness, accessibility, edge cases, and mobile behavior. You read the code carefully and reason about how it will behave in different states.
+
+## Focus Areas
+
+### Component Behavior
+- State management: does the UI handle all states correctly (loading, empty, error, populated)?
+- Conditional rendering: are there cases where elements show/hide incorrectly?
+- Event handling: click propagation, focus management, keyboard accessibility
+- Data flow: are props threaded correctly? Are there stale closures or missing dependencies?
+
+### UX Patterns
+- Is the interaction model intuitive? Does the user know what to do?
+- Are disabled states clear about why something is disabled and what to do about it?
+- Do action buttons behave consistently across different contexts (sidebar card vs sheet)?
+- Is feedback visible when the user needs it? Does it get in the way when they don't?
+
+### Mobile & Responsive
+- Does the sidebar content fit in 320px without overflow or truncation issues?
+- Do touch targets meet minimum size (44px recommended)?
+- Does the bottom sheet work well on small viewports?
+- Does the mobile close-on-action behavior make sense for each action type?
+
+### Edge Cases
+- 0 feedback items, 1 item, 20+ items
+- Very long description or suggestion text
+- Multiple persona children on one parent
+- Rapid clicking of action buttons
+- Status transitions: open -> forwarded -> fixed -> reopen -> ignored
+
+## Instructions
+1. Read the changed frontend files carefully. Trace the component hierarchy and prop flow.
+2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and suggestion.
+3. Think about what a user would experience, not just whether the code is correct.
+4. Call `dispatch_event` with type `done` when your review is complete.
+
+## Severity Guide
+- **critical**: Broken UI that prevents core functionality
+- **high**: Significant UX issue that would confuse users or prevent them from completing a task
+- **medium**: Inconsistent behavior, missing state handling, or accessibility gap
+- **low**: Polish item, minor visual issue, or improvement opportunity
+- **info**: Well-implemented pattern worth noting
+
+## Context from parent agent
+{{context}}
+
+## Changes to review
+{{diff}}

--- a/.dispatch/personas/security-review.md
+++ b/.dispatch/personas/security-review.md
@@ -1,0 +1,34 @@
+---
+name: Security Reviewer
+description: Reviews code changes for security vulnerabilities and best practices
+feedbackFormat: findings
+---
+
+# You are a Security Reviewer
+
+Your job is to review code changes for security vulnerabilities, unsafe patterns, and best practices violations.
+
+## Focus Areas
+- Authentication and authorization flaws
+- Input validation and injection (SQL, command, XSS)
+- Secrets, credentials, and sensitive data exposure
+- Insecure dependencies or configurations
+- OWASP Top 10 categories
+- Race conditions and TOCTOU issues
+
+## Instructions
+1. Read through the changes described below carefully.
+2. For each issue you find, call the `dispatch_feedback` MCP tool with:
+   - `severity`: critical, high, medium, low, or info
+   - `filePath`: path to the affected file (relative to repo root)
+   - `lineNumber`: approximate line number if applicable
+   - `description`: clear explanation of the vulnerability or concern
+   - `suggestion`: concrete fix or mitigation
+3. If you find no issues, submit a single `info` severity feedback confirming the changes look secure.
+4. Call `dispatch_event` with type `done` when your review is complete.
+
+## Context from parent agent
+{{context}}
+
+## Changes to review
+{{diff}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,9 @@ Before marking any task as done, run the following checks and fix any failures:
 - Production uses the `dispatch` database. Never connect to it from dev servers.
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.
+
+## Personas
+- When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.
+- Provide a thorough context briefing in the `context` parameter: what was built, key files changed, areas of concern, and any specific instructions from the user.
+- Available personas are defined in `.dispatch/personas/` as markdown files.
+- When acting as a persona agent, use the `dispatch_feedback` MCP tool to submit structured findings instead of just reporting in prose.

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -515,6 +515,19 @@ export class AgentManager {
       .catch((err) => this.logger.warn({ err }, "Failed to insert delete event"));
 
     await this.pool.query("UPDATE agents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1", [id]);
+
+    // Cascade: archive child agents (persona agents spawned by this parent)
+    const children = await this.pool.query<{ id: string }>(
+      "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
+      [id]
+    );
+    for (const child of children.rows) {
+      try {
+        await this.deleteAgent(child.id, true, cleanupWorktree);
+      } catch (err) {
+        this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
+      }
+    }
   }
 
   async checkWorktreeStatus(id: string): Promise<WorktreeStatus> {
@@ -1282,6 +1295,19 @@ export class AgentManager {
               description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"
        FROM agent_feedback WHERE agent_id = $1 ORDER BY created_at ASC`,
       [agentId]
+    );
+    return result.rows;
+  }
+
+  async listFeedbackByParent(parentAgentId: string): Promise<FeedbackRecord[]> {
+    const result = await this.pool.query<FeedbackRecord>(
+      `SELECT f.id, f.agent_id AS "agentId", f.severity, f.file_path AS "filePath", f.line_number AS "lineNumber",
+              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status, f.created_at AS "createdAt"
+       FROM agent_feedback f
+       JOIN agents a ON a.id = f.agent_id
+       WHERE a.parent_agent_id = $1
+       ORDER BY f.created_at ASC`,
+      [parentAgentId]
     );
     return result.rows;
   }

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1288,14 +1288,15 @@ export class AgentManager {
 
   async updateFeedbackStatus(
     feedbackId: number,
-    status: "open" | "dismissed" | "forwarded"
+    agentId: string,
+    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
   ): Promise<FeedbackRecord | null> {
     const result = await this.pool.query<FeedbackRecord>(
       `UPDATE agent_feedback SET status = $2
-       WHERE id = $1
+       WHERE id = $1 AND agent_id = $3
        RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
                  description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"`,
-      [feedbackId, status]
+      [feedbackId, status, agentId]
     );
     return result.rows[0] ?? null;
   }

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -51,6 +51,9 @@ export type AgentRecord = {
   gitContext: AgentGitContext | null;
   gitContextStale: boolean;
   gitContextUpdatedAt: string | null;
+  persona: string | null;
+  parentAgentId: string | null;
+  personaContext: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -73,6 +76,9 @@ type CreateAgentInput = {
   worktreeBranch?: string;
   baseBranch?: string;
   worktreeLocation?: WorktreeLocation;
+  persona?: string;
+  parentAgentId?: string;
+  personaContext?: string;
 };
 
 type WorktreeCleanupMode = "auto" | "keep" | "force";
@@ -89,6 +95,28 @@ export type WorktreeStatus = {
 
 type StopAgentInput = {
   force?: boolean;
+};
+
+export type FeedbackInput = {
+  severity?: "critical" | "high" | "medium" | "low" | "info";
+  filePath?: string;
+  lineNumber?: number;
+  description: string;
+  suggestion?: string;
+  mediaRef?: string;
+};
+
+export type FeedbackRecord = {
+  id: number;
+  agentId: string;
+  severity: string;
+  filePath: string | null;
+  lineNumber: number | null;
+  description: string;
+  suggestion: string | null;
+  mediaRef: string | null;
+  status: string;
+  createdAt: string;
 };
 
 type AgentLatestEventInput = {
@@ -176,10 +204,11 @@ export class AgentManager {
     const initialSetupPhase: SetupPhase = useWorktree ? "worktree" : "session";
     await this.pool.query(
       `
-      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, updated_at)
-      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, NOW())
+      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, updated_at)
+      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, NOW())
       `,
-      [id, name, type, originalCwd, tmuxSession, mediaDir, JSON.stringify(agentArgs), fullAccess, initialSetupPhase]
+      [id, name, type, originalCwd, tmuxSession, mediaDir, JSON.stringify(agentArgs), fullAccess, initialSetupPhase,
+        input.persona ?? null, input.parentAgentId ?? null, input.personaContext ?? null]
     );
 
     if (this.config.agentRuntime === "inert") {
@@ -1223,6 +1252,54 @@ export class AgentManager {
     }
   }
 
+  // --- Feedback ---
+
+  async submitFeedback(
+    agentId: string,
+    feedback: FeedbackInput
+  ): Promise<FeedbackRecord> {
+    const result = await this.pool.query<FeedbackRecord>(
+      `INSERT INTO agent_feedback (agent_id, severity, file_path, line_number, description, suggestion, media_ref)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
+                 description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"`,
+      [
+        agentId,
+        feedback.severity ?? "info",
+        feedback.filePath ?? null,
+        feedback.lineNumber ?? null,
+        feedback.description,
+        feedback.suggestion ?? null,
+        feedback.mediaRef ?? null,
+      ]
+    );
+    return result.rows[0]!;
+  }
+
+  async listFeedback(agentId: string): Promise<FeedbackRecord[]> {
+    const result = await this.pool.query<FeedbackRecord>(
+      `SELECT id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
+              description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"
+       FROM agent_feedback WHERE agent_id = $1 ORDER BY created_at ASC`,
+      [agentId]
+    );
+    return result.rows;
+  }
+
+  async updateFeedbackStatus(
+    feedbackId: number,
+    status: "open" | "dismissed" | "forwarded"
+  ): Promise<FeedbackRecord | null> {
+    const result = await this.pool.query<FeedbackRecord>(
+      `UPDATE agent_feedback SET status = $2
+       WHERE id = $1
+       RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
+                 description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"`,
+      [feedbackId, status]
+    );
+    return result.rows[0] ?? null;
+  }
+
   private baseAgentSelectSql(): string {
     return `
       SELECT
@@ -1256,6 +1333,9 @@ export class AgentManager {
         git_context AS "gitContext",
         git_context_stale AS "gitContextStale",
         git_context_updated_at AS "gitContextUpdatedAt",
+        persona,
+        parent_agent_id AS "parentAgentId",
+        persona_context AS "personaContext",
         created_at AS "createdAt",
         updated_at AS "updatedAt"
       FROM agents

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -153,6 +153,26 @@ export async function runMigrations(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_atu_agent_id ON agent_token_usage(agent_id);
     CREATE INDEX IF NOT EXISTS idx_atu_session_start ON agent_token_usage(session_start);
+
+    -- Persona support
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS persona TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS parent_agent_id TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS persona_context TEXT;
+
+    CREATE TABLE IF NOT EXISTS agent_feedback (
+      id SERIAL PRIMARY KEY,
+      agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      severity TEXT NOT NULL DEFAULT 'info',
+      file_path TEXT,
+      line_number INTEGER,
+      description TEXT NOT NULL,
+      suggestion TEXT,
+      media_ref TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_agent_feedback_agent_id ON agent_feedback(agent_id);
   `;
 
   try {

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -84,6 +84,9 @@ export async function loadPersonaBySlug(
   repoRoot: string,
   slug: string
 ): Promise<PersonaDefinition | null> {
+  if (slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
+    throw new Error("Invalid persona slug.");
+  }
   const filePath = path.join(repoRoot, PERSONAS_DIR, `${slug}.md`);
   let content: string;
   try {

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -1,0 +1,121 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type PersonaDefinition = {
+  /** Filename without extension (used as persona ID) */
+  slug: string;
+  /** Display name from frontmatter */
+  name: string;
+  /** Short description from frontmatter */
+  description: string;
+  /** Feedback format hint (default: "findings") */
+  feedbackFormat: string;
+  /** Raw markdown body (after frontmatter) */
+  body: string;
+};
+
+type PersonaFrontmatter = {
+  name?: string;
+  description?: string;
+  feedbackFormat?: string;
+};
+
+const PERSONAS_DIR = ".dispatch/personas";
+const MAX_DIFF_BYTES = 50 * 1024;
+
+function parseFrontmatter(content: string): { frontmatter: PersonaFrontmatter; body: string } {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const endIndex = trimmed.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const fmBlock = trimmed.slice(3, endIndex).trim();
+  const body = trimmed.slice(endIndex + 4).trim();
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of fmBlock.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    if (key && value) {
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter: frontmatter as PersonaFrontmatter, body };
+}
+
+export async function loadPersonas(repoRoot: string): Promise<PersonaDefinition[]> {
+  const dir = path.join(repoRoot, PERSONAS_DIR);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const mdFiles = entries.filter((f) => f.endsWith(".md")).sort();
+  const personas: PersonaDefinition[] = [];
+
+  for (const file of mdFiles) {
+    const content = await readFile(path.join(dir, file), "utf-8");
+    const { frontmatter, body } = parseFrontmatter(content);
+    const slug = file.replace(/\.md$/, "");
+
+    personas.push({
+      slug,
+      name: frontmatter.name ?? slug,
+      description: frontmatter.description ?? "",
+      feedbackFormat: frontmatter.feedbackFormat ?? "findings",
+      body,
+    });
+  }
+
+  return personas;
+}
+
+export async function loadPersonaBySlug(
+  repoRoot: string,
+  slug: string
+): Promise<PersonaDefinition | null> {
+  const filePath = path.join(repoRoot, PERSONAS_DIR, `${slug}.md`);
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const { frontmatter, body } = parseFrontmatter(content);
+  return {
+    slug,
+    name: frontmatter.name ?? slug,
+    description: frontmatter.description ?? "",
+    feedbackFormat: frontmatter.feedbackFormat ?? "findings",
+    body,
+  };
+}
+
+export function assemblePersonaPrompt(
+  persona: PersonaDefinition,
+  context: string,
+  diff: string
+): string {
+  let truncatedDiff = diff;
+  if (Buffer.byteLength(diff, "utf-8") > MAX_DIFF_BYTES) {
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    truncatedDiff =
+      decoder.decode(Buffer.from(diff, "utf-8").subarray(0, MAX_DIFF_BYTES)) +
+      "\n\n[... diff truncated at 50KB ...]";
+  }
+
+  return persona.body
+    .replace("{{context}}", context)
+    .replace("{{diff}}", truncatedDiff);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2293,15 +2293,17 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "Invalid feedback id." });
     }
 
-    const validStatuses = ["open", "dismissed", "forwarded"] as const;
+    const validStatuses = ["open", "dismissed", "forwarded", "fixed", "ignored"] as const;
     if (typeof body?.status !== "string" || !(validStatuses as readonly string[]).includes(body.status)) {
-      return reply.code(400).send({ error: "status must be one of: open, dismissed, forwarded" });
+      return reply.code(400).send({ error: "status must be one of: open, dismissed, forwarded, fixed, ignored" });
     }
 
     try {
+      const agentId = params.id ?? "";
       const updated = await agentManager.updateFeedbackStatus(
         feedbackId,
-        body.status as "open" | "dismissed" | "forwarded"
+        agentId,
+        body.status as "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
       );
       if (!updated) return reply.code(404).send({ error: "Feedback not found." });
       return { feedback: updated };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -15,7 +15,8 @@ import type WebSocket from "ws";
 import pty from "node-pty";
 
 import { AgentError, AgentManager } from "./agents/manager.js";
-import type { AgentGitContext, AgentRecord } from "./agents/manager.js";
+import type { AgentGitContext, AgentRecord, FeedbackRecord } from "./agents/manager.js";
+import { loadPersonas, loadPersonaBySlug, assemblePersonaPrompt } from "./personas/loader.js";
 import {
   isPasswordSet,
   setPassword,
@@ -72,7 +73,8 @@ type UiEvent =
   | { type: "media.changed"; agentId: string }
   | { type: "media.seen"; agentId: string; keys: string[] }
   | { type: "stream.started"; agentId: string }
-  | { type: "stream.stopped"; agentId: string };
+  | { type: "stream.stopped"; agentId: string }
+  | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -902,7 +904,9 @@ async function registerRoutes() {
       repoRoot,
       worktreeRoot,
       upsertEvent: mcpUpsertEvent,
-      shareMedia: mcpShareMedia
+      shareMedia: mcpShareMedia,
+      submitFeedback: mcpSubmitFeedback,
+      launchPersona: mcpLaunchPersona,
     });
   });
 
@@ -2027,6 +2031,9 @@ async function registerRoutes() {
       useWorktree?: unknown;
       worktreeBranch?: unknown;
       baseBranch?: unknown;
+      persona?: unknown;
+      parentAgentId?: unknown;
+      personaContext?: unknown;
     };
 
     if (typeof body?.cwd !== "string") {
@@ -2096,7 +2103,10 @@ async function registerRoutes() {
         useWorktree: typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
         worktreeBranch: typeof body.worktreeBranch === "string" ? body.worktreeBranch : undefined,
         baseBranch: typeof body.baseBranch === "string" ? body.baseBranch : undefined,
-        worktreeLocation
+        worktreeLocation,
+        persona: typeof body.persona === "string" ? body.persona : undefined,
+        parentAgentId: typeof body.parentAgentId === "string" ? body.parentAgentId : undefined,
+        personaContext: typeof body.personaContext === "string" ? body.personaContext : undefined,
       });
       queueGitContextRefresh([agent.id]);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
@@ -2235,6 +2245,66 @@ async function registerRoutes() {
         uiEventBroker.publish({ type: "agent.deleted", agentId: existing.id });
       }
       return reply.code(204).send();
+    } catch (error) {
+      return handleAgentError(reply, error);
+    }
+  });
+
+  // --- Personas ---
+
+  app.get("/api/v1/personas", async (request, reply) => {
+    const query = request.query as { cwd?: unknown };
+    if (typeof query.cwd !== "string") {
+      return reply.code(400).send({ error: "cwd query parameter is required." });
+    }
+    try {
+      // Try worktree root first (uncommitted persona files live here), then repo root
+      let personas = await loadPersonas(await resolveWorktreeRoot(query.cwd));
+      if (personas.length === 0) {
+        personas = await loadPersonas(await resolveRepoRoot(query.cwd));
+      }
+      return { personas };
+    } catch {
+      return { personas: [] };
+    }
+  });
+
+  // --- Feedback ---
+
+  app.get("/api/v1/agents/:id/feedback", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    try {
+      const agent = await agentManager.getAgent(id);
+      if (!agent) return reply.code(404).send({ error: "Agent not found." });
+      const feedback = await agentManager.listFeedback(id);
+      return { feedback };
+    } catch (error) {
+      return handleAgentError(reply, error);
+    }
+  });
+
+  app.patch("/api/v1/agents/:id/feedback/:feedbackId", async (request, reply) => {
+    const params = request.params as { id?: string; feedbackId?: string };
+    const body = request.body as { status?: unknown };
+    const feedbackId = parseInt(params.feedbackId ?? "", 10);
+
+    if (isNaN(feedbackId)) {
+      return reply.code(400).send({ error: "Invalid feedback id." });
+    }
+
+    const validStatuses = ["open", "dismissed", "forwarded"] as const;
+    if (typeof body?.status !== "string" || !(validStatuses as readonly string[]).includes(body.status)) {
+      return reply.code(400).send({ error: "status must be one of: open, dismissed, forwarded" });
+    }
+
+    try {
+      const updated = await agentManager.updateFeedbackStatus(
+        feedbackId,
+        body.status as "open" | "dismissed" | "forwarded"
+      );
+      if (!updated) return reply.code(404).send({ error: "Feedback not found." });
+      return { feedback: updated };
     } catch (error) {
       return handleAgentError(reply, error);
     }
@@ -3046,6 +3116,102 @@ async function mcpUpsertEvent(
     metadata: event.metadata
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+}
+
+async function mcpSubmitFeedback(
+  agentId: string,
+  feedback: import("./agents/manager.js").FeedbackInput
+): Promise<FeedbackRecord> {
+  const record = await agentManager.submitFeedback(agentId, feedback);
+  uiEventBroker.publish({ type: "feedback.created", agentId, feedback: record });
+  return record;
+}
+
+async function mcpLaunchPersona(
+  agentId: string,
+  opts: { persona: string; context: string }
+): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
+  const parent = await agentManager.getAgent(agentId);
+  if (!parent) throw new Error("Parent agent not found.");
+
+  const parentCwd = parent.worktreePath ?? parent.cwd;
+  // Try worktree root first (persona files may be uncommitted), then repo root
+  let personaRoot: string;
+  try {
+    personaRoot = await resolveWorktreeRoot(parentCwd);
+  } catch {
+    try {
+      personaRoot = await resolveRepoRoot(parentCwd);
+    } catch {
+      throw new Error("Parent agent is not in a git repository.");
+    }
+  }
+
+  let persona = await loadPersonaBySlug(personaRoot, opts.persona);
+  if (!persona) {
+    // Fall back to repo root if worktree root didn't have it
+    try {
+      const repoRoot = await resolveRepoRoot(parentCwd);
+      if (repoRoot !== personaRoot) {
+        persona = await loadPersonaBySlug(repoRoot, opts.persona);
+      }
+    } catch {}
+  }
+  if (!persona) {
+    throw new Error(`Persona "${opts.persona}" not found in .dispatch/personas/.`);
+  }
+
+  // Generate git diff for context
+  let diff = "";
+  try {
+    const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
+    const diffResult = await runCommand("git", ["diff", "main...HEAD"], { cwd: parentCwd });
+    diff = diffResult.stdout;
+  } catch {
+    diff = "(unable to generate diff)";
+  }
+
+  const prompt = assemblePersonaPrompt(persona, opts.context, diff);
+
+  // Build agent args — include full access flag if parent has it
+  const personaArgs: string[] = [`--append-system-prompt`, prompt];
+  if (parent.fullAccess) {
+    const fullAccessArg =
+      parent.type === "claude" ? CLAUDE_FULL_ACCESS_ARG
+      : parent.type === "codex" ? CODEX_FULL_ACCESS_ARG
+      : null;
+    if (fullAccessArg) personaArgs.push(fullAccessArg);
+  }
+
+  const agent = await agentManager.createAgent({
+    name: `${opts.persona}-${agentId.slice(-6)}`,
+    type: parent.type,
+    cwd: parentCwd,
+    agentArgs: personaArgs,
+    fullAccess: parent.fullAccess,
+    useWorktree: false,
+    persona: opts.persona,
+    parentAgentId: agentId,
+    personaContext: opts.context,
+  });
+
+  queueGitContextRefresh([agent.id]);
+  uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+
+  // Send initial prompt to the persona agent after it starts up
+  if (agent.tmuxSession) {
+    const tmuxSession = agent.tmuxSession;
+    const initialMessage = "Begin your review now. Follow your system prompt instructions.";
+    setTimeout(async () => {
+      try {
+        const { runCommand: run } = await import("@dispatch/shared/lib/run-command.js");
+        await run("tmux", ["send-keys", "-t", tmuxSession, "-l", initialMessage]);
+        await run("tmux", ["send-keys", "-t", tmuxSession, "Enter"]);
+      } catch {}
+    }, 10_000);
+  }
+
+  return { agentId: agent.id, persona: opts.persona, parentAgentId: agentId };
 }
 
 async function mcpShareMedia(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2235,14 +2235,23 @@ async function registerRoutes() {
 
     try {
       const existing = await agentManager.getAgent(params.id);
+      // Collect child agent IDs before deletion so we can clean up their resources
+      const childRows = await pool.query<{ id: string }>(
+        "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
+        [params.id]
+      );
       await agentManager.deleteAgent(params.id, force, cleanupWorktree);
-      if (existing) {
-        streamManager.stopStream(existing.id);
-        pendingGitRefreshAgentIds.delete(existing.id);
-        pendingGitRefreshEnqueuedAt.delete(existing.id);
-        activeGitRefreshAgentIds.delete(existing.id);
-        gitRefreshAgentDiagnostics.delete(existing.id);
-        uiEventBroker.publish({ type: "agent.deleted", agentId: existing.id });
+      const deletedIds = [
+        ...(existing ? [existing.id] : []),
+        ...childRows.rows.map((r) => r.id),
+      ];
+      for (const deletedId of deletedIds) {
+        streamManager.stopStream(deletedId);
+        pendingGitRefreshAgentIds.delete(deletedId);
+        pendingGitRefreshEnqueuedAt.delete(deletedId);
+        activeGitRefreshAgentIds.delete(deletedId);
+        gitRefreshAgentDiagnostics.delete(deletedId);
+        uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
       }
       return reply.code(204).send();
     } catch (error) {
@@ -2273,8 +2282,13 @@ async function registerRoutes() {
 
   app.get("/api/v1/agents/:id/feedback", async (request, reply) => {
     const params = request.params as { id?: string };
+    const query = request.query as { scope?: unknown };
     const id = params.id ?? "";
     try {
+      if (query.scope === "children") {
+        const feedback = await agentManager.listFeedbackByParent(id);
+        return { feedback };
+      }
       const agent = await agentManager.getAgent(id);
       if (!agent) return reply.code(404).send({ error: "Agent not found." });
       const feedback = await agentManager.listFeedback(id);

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -69,6 +69,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // Clean up agents between tests
+  await pool.query("DELETE FROM agent_feedback");
   await pool.query("DELETE FROM media_seen");
   await pool.query("DELETE FROM media");
   await pool.query("DELETE FROM agents");

--- a/apps/server/test/db/setup.ts
+++ b/apps/server/test/db/setup.ts
@@ -132,6 +132,26 @@ export async function runTestMigrations(pool: Pool): Promise<void> {
     ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS agent_type TEXT;
     ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS agent_name TEXT;
     ALTER TABLE agent_events ADD COLUMN IF NOT EXISTS project_dir TEXT;
+
+    -- Persona support
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS persona TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS parent_agent_id TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS persona_context TEXT;
+
+    CREATE TABLE IF NOT EXISTS agent_feedback (
+      id SERIAL PRIMARY KEY,
+      agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      severity TEXT NOT NULL DEFAULT 'info',
+      file_path TEXT,
+      line_number INTEGER,
+      description TEXT NOT NULL,
+      suggestion TEXT,
+      media_ref TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_agent_feedback_agent_id ON agent_feedback(agent_id);
   `;
 
   await pool.query(sql);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -567,6 +567,8 @@ export function App(): JSX.Element {
               detachTerminal={detachTerminal}
               attachToAgent={attachToAgent}
               startAgent={startAgent}
+              sendTerminalInput={sendTerminalInput}
+              connectedAgentId={connectedAgentId}
             />
           </div>
         ) : null}
@@ -663,6 +665,8 @@ export function App(): JSX.Element {
             detachTerminal={detachAndClearSelection}
             attachToAgent={attachToAgent}
             startAgent={startAgent}
+            sendTerminalInput={sendTerminalInput}
+            connectedAgentId={connectedAgentId}
             closeOnSessionAction={true}
             onRequestClose={() => setMobileLeftOpen(false)}
           />

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -440,23 +440,19 @@ export function AgentSidebarContent({
                           ) : null}
                         </div>
                       </div>
+                      {!agent.persona ? (
+                        <div className="px-3 pb-2">
+                          <ParentFeedbackPanel
+                            parentAgentId={agent.id}
+                            sendTerminalInput={sendTerminalInput}
+                            isConnected={connectedAgentId === agent.id}
+                            onRequestClose={onRequestClose}
+                            closeOnSessionAction={closeOnSessionAction}
+                          />
+                        </div>
+                      ) : null}
                     </div>
                   </div>
-                  {/* Feedback from child personas — always visible, outside expandable area */}
-                  {!agent.persona && childAgents.length > 0 ? (
-                    <div className="px-3 pb-2">
-                      {childAgents.map((child) => (
-                        <ParentFeedbackPanel
-                          key={`feedback-${child.id}`}
-                          personaAgent={child}
-                          sendTerminalInput={sendTerminalInput}
-                          isConnected={connectedAgentId === agent.id}
-                          onRequestClose={onRequestClose}
-                          closeOnSessionAction={closeOnSessionAction}
-                        />
-                      ))}
-                    </div>
-                  ) : null}
                 </motion.div>
                 {childAgents.map((child) => {
                   const childState = agentVisualState(child);
@@ -498,11 +494,11 @@ export function AgentSidebarContent({
                           ) : null}
                         </div>
                         {childIsStopped ? (
-                          <button data-agent-control="true" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => startAgent(child)}><Play className="h-3.5 w-3.5" /></button>
+                          <button data-agent-control="true" aria-label="Resume agent" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => startAgent(child)}><Play className="h-3.5 w-3.5" /></button>
                         ) : (
-                          <button data-agent-control="true" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setStopTarget(child); setStopConfirmOpen(true); }}><Square className="h-3.5 w-3.5" /></button>
+                          <button data-agent-control="true" aria-label="Stop agent" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setStopTarget(child); setStopConfirmOpen(true); }}><Square className="h-3.5 w-3.5" /></button>
                         )}
-                        <button data-agent-control="true" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
+                        <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
                       </div>
                       {child.latestEvent ? (
                         childIsExpanded ? (

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -14,6 +14,8 @@ import {
 
 import { AgentMeta } from "@/components/app/agent-meta";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
+import { FeedbackPanel } from "@/components/app/feedback-panel";
+import { PersonaLauncher } from "@/components/app/persona-launcher";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -46,6 +48,8 @@ type AgentSidebarSharedProps = {
   detachTerminal: () => void;
   attachToAgent: (agent: Agent) => Promise<void>;
   startAgent: (agent: Agent) => Promise<void>;
+  sendTerminalInput?: (data: string) => void;
+  connectedAgentId?: string | null;
 };
 
 type AgentSidebarProps = AgentSidebarSharedProps & {
@@ -83,6 +87,8 @@ export function AgentSidebarContent({
   detachTerminal,
   attachToAgent,
   startAgent,
+  sendTerminalInput,
+  connectedAgentId,
   onRequestClose,
   closeOnSessionAction = false,
   closeButtonIcon = "x",
@@ -413,7 +419,32 @@ export function AgentSidebarContent({
                             </div>
                           </div>
                           {agent.lastError ? <AgentMeta label="Last error" value={agent.lastError} /> : null}
+                          {agent.persona ? (
+                            <div className="flex items-center gap-1.5">
+                              <span className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Persona</span>
+                              <Badge variant="running">{agent.persona}</Badge>
+                              {agent.parentAgentId ? (
+                                <span className="text-[10px] text-muted-foreground">
+                                  from {agents.find((a) => a.id === agent.parentAgentId)?.name ?? agent.parentAgentId.slice(-6)}
+                                </span>
+                              ) : null}
+                            </div>
+                          ) : null}
+                          {!isStopped && !agent.persona && sendTerminalInput && connectedAgentId === agent.id ? (
+                            <PersonaLauncher
+                              agent={agent}
+                              sendTerminalInput={sendTerminalInput}
+                            />
+                          ) : null}
                         </div>
+                        {agent.persona ? (
+                          <FeedbackPanel
+                            agent={agent}
+                            agents={agents}
+                            sendTerminalInput={sendTerminalInput}
+                            connectedAgentId={connectedAgentId}
+                          />
+                        ) : null}
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   AlertTriangle,
   Activity,
@@ -14,7 +15,7 @@ import {
 
 import { AgentMeta } from "@/components/app/agent-meta";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
-import { FeedbackPanel } from "@/components/app/feedback-panel";
+import { ParentFeedbackPanel } from "@/components/app/feedback-panel";
 import { PersonaLauncher } from "@/components/app/persona-launcher";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
@@ -203,7 +204,8 @@ export function AgentSidebarContent({
             <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
           ) : (
             <LayoutGroup>
-            {agents.map((agent) => {
+            {agents.filter((a) => !a.parentAgentId).map((agent) => {
+              const childAgents = agents.filter((a) => a.parentAgentId === agent.id);
               const state = agentVisualState(agent);
               const isSelected = selectedAgentId === agent.id;
               const isStopped = state === "stopped";
@@ -213,15 +215,15 @@ export function AgentSidebarContent({
               const needsAttention = agent.status === "error";
 
               return (
+                <React.Fragment key={agent.id}>
                 <motion.div
-                  key={agent.id}
                   layout
                   transition={{ duration: 0.3, ease: "easeInOut" }}
                   data-testid={`agent-card-${agent.id}`}
                   className={cn(
                     "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
                     borderForAgentState(state),
-                    isActive ? "bg-status-done/10" : isSelected && "bg-muted/60",
+                    isSelected && "bg-muted/60",
                     isStopped && "opacity-60"
                   )}
                 >
@@ -437,18 +439,84 @@ export function AgentSidebarContent({
                             />
                           ) : null}
                         </div>
-                        {agent.persona ? (
-                          <FeedbackPanel
-                            agent={agent}
-                            agents={agents}
-                            sendTerminalInput={sendTerminalInput}
-                            connectedAgentId={connectedAgentId}
-                          />
-                        ) : null}
                       </div>
                     </div>
                   </div>
+                  {/* Feedback from child personas — always visible, outside expandable area */}
+                  {!agent.persona && childAgents.length > 0 ? (
+                    <div className="px-3 pb-2">
+                      {childAgents.map((child) => (
+                        <ParentFeedbackPanel
+                          key={`feedback-${child.id}`}
+                          personaAgent={child}
+                          sendTerminalInput={sendTerminalInput}
+                          isConnected={connectedAgentId === agent.id}
+                          onRequestClose={onRequestClose}
+                          closeOnSessionAction={closeOnSessionAction}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
                 </motion.div>
+                {childAgents.map((child) => {
+                  const childState = agentVisualState(child);
+                  const childIsSelected = selectedAgentId === child.id;
+                  const childIsStopped = childState === "stopped";
+                  const childIsActive = childState === "active";
+                  const childIsExpanded = childIsActive || expandedAgentId === child.id;
+
+                  return (
+                    <motion.div
+                      key={child.id}
+                      layout
+                      transition={{ duration: 0.3, ease: "easeInOut" }}
+                      data-testid={`agent-card-${child.id}`}
+                      className={cn(
+                        "border-b border-r-4 border-border pl-5 pr-2 py-2 transition-colors duration-300",
+                        borderForAgentState(childState),
+                        childIsSelected && "bg-muted/60",
+                        childIsStopped && "opacity-60"
+                      )}
+                    >
+                      <div
+                        className={cn("flex items-center gap-1.5", !childIsStopped && "cursor-pointer")}
+                        data-testid={`agent-row-${child.id}`}
+                        onClick={(event) => {
+                          const target = event.target as HTMLElement;
+                          if (target.closest("[data-agent-control='true']")) return;
+                          if (childIsStopped) return;
+                          if (childIsActive) { detachTerminal(); return; }
+                          if (closeOnSessionAction) onRequestClose?.();
+                          void attachToAgent(child);
+                        }}
+                      >
+                        <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
+                          <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} />
+                          <span className="truncate">{child.name}</span>
+                          {child.persona ? (
+                            <Badge variant="running" className="text-[9px] shrink-0">{child.persona}</Badge>
+                          ) : null}
+                        </div>
+                        {childIsStopped ? (
+                          <button data-agent-control="true" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => startAgent(child)}><Play className="h-3.5 w-3.5" /></button>
+                        ) : (
+                          <button data-agent-control="true" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setStopTarget(child); setStopConfirmOpen(true); }}><Square className="h-3.5 w-3.5" /></button>
+                        )}
+                        <button data-agent-control="true" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
+                      </div>
+                      {child.latestEvent ? (
+                        childIsExpanded ? (
+                          <div className="mt-1 flex flex-wrap items-center gap-x-0 text-xs text-muted-foreground">
+                            <span className={cn("font-medium", child.latestEvent.type === "working" ? "text-status-working" : child.latestEvent.type === "blocked" ? "text-status-blocked" : child.latestEvent.type === "waiting_user" ? "text-status-waiting" : child.latestEvent.type === "done" ? "text-status-done" : "text-status-idle")}>{child.latestEvent.type === "working" ? "Working" : child.latestEvent.type === "blocked" ? "Blocked" : child.latestEvent.type === "waiting_user" ? "Waiting" : child.latestEvent.type === "done" ? "Done" : "Idle"}</span>
+                            <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+                            <span className="min-w-0 truncate">{child.latestEvent.message}</span>
+                          </div>
+                        ) : null
+                      ) : null}
+                    </motion.div>
+                  );
+                })}
+              </React.Fragment>
               );
             })}
             </LayoutGroup>

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Ban, Check, CheckCircle2, ChevronRight, Copy, Expand, Info, MessageCircleQuestion, RotateCcw, Wrench } from "lucide-react";
+import { Ban, Check, CheckCircle2, ChevronRight, Copy, Expand, MessageCircleQuestion, RotateCcw, Wrench } from "lucide-react";
 
 import { type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
@@ -43,7 +43,7 @@ function formatFeedbackText(item: FeedbackItem): string {
 }
 
 function FeedbackActions({
-  item,
+  item: _item,
   isConnected,
   onForward,
   onCopy,

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,162 +1,356 @@
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ArrowRight, CheckCircle2, Info, X } from "lucide-react";
+import { AlertTriangle, Ban, Check, CheckCircle2, ChevronRight, Clipboard, Expand, Info, MessageCircleQuestion, RotateCcw, Wrench } from "lucide-react";
 
 import { type Agent, type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyText } from "@/hooks/use-copy";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-const SEVERITY_CONFIG: Record<string, { color: string; icon: typeof AlertTriangle }> = {
-  critical: { color: "text-red-500", icon: AlertTriangle },
-  high: { color: "text-orange-500", icon: AlertTriangle },
-  medium: { color: "text-yellow-500", icon: AlertTriangle },
-  low: { color: "text-blue-400", icon: Info },
-  info: { color: "text-muted-foreground", icon: Info },
+const SEVERITY_DOT: Record<string, string> = {
+  critical: "bg-red-500",
+  high: "bg-orange-500",
+  medium: "bg-yellow-500",
+  low: "bg-blue-400",
+  info: "bg-muted-foreground",
 };
 
-export function FeedbackPanel({
-  agent,
-  agents,
-  sendTerminalInput,
-  connectedAgentId,
+const SEVERITY_LABELS: Record<string, { label: string; variant: "error" | "default" }> = {
+  critical: { label: "Critical", variant: "error" },
+  high: { label: "High", variant: "error" },
+  medium: { label: "Medium", variant: "default" },
+  low: { label: "Low", variant: "default" },
+  info: { label: "Info", variant: "default" },
+};
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  forwarded: { label: "Sent", color: "text-blue-400" },
+  fixed: { label: "Fixed", color: "text-green-500" },
+  ignored: { label: "Ignored", color: "text-muted-foreground/60" },
+};
+
+function formatFeedbackText(item: FeedbackItem): string {
+  const parts: string[] = [];
+  if (item.filePath) parts.push(`File: ${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`);
+  parts.push(`Severity: ${item.severity}`);
+  parts.push(item.description);
+  if (item.suggestion) parts.push(`Suggestion: ${item.suggestion}`);
+  return parts.join("\n");
+}
+
+function FeedbackActions({
+  item,
+  isConnected,
+  onForward,
+  onCopy,
+  copied,
+  onUpdateStatus,
+  isActionable,
+  statusLabel,
+  size = "sm",
 }: {
-  agent: Agent;
-  agents: Agent[];
+  item: FeedbackItem;
+  isConnected: boolean;
+  onForward: (mode: "wdyt" | "fix") => void;
+  onCopy: () => void;
+  copied: boolean;
+  onUpdateStatus: (status: string) => void;
+  isActionable: boolean;
+  statusLabel: { label: string; color: string } | undefined;
+  size?: "sm" | "default";
+}): JSX.Element {
+  const btnClass = size === "sm" ? "h-5 gap-1 px-1.5 text-[10px]" : "h-7 gap-1.5 px-2.5 text-xs";
+  const iconClass = size === "sm" ? "h-2.5 w-2.5" : "h-3.5 w-3.5";
+  const resolveIconClass = size === "sm" ? "h-3 w-3" : "h-4 w-4";
+  const resolveBtnClass = size === "sm" ? "h-5 px-1 text-[10px]" : "h-7 px-2 text-xs gap-1.5";
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-1">
+        {isActionable ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost" size="sm"
+                  className={cn(btnClass, !isConnected && "opacity-40")}
+                  disabled={!isConnected}
+                  onClick={() => onForward("wdyt")}
+                >
+                  <MessageCircleQuestion className={iconClass} /> WDYT
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{isConnected ? "Ask what it thinks about this" : "Attach to agent to use"}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost" size="sm"
+                  className={cn(btnClass, !isConnected && "opacity-40")}
+                  disabled={!isConnected}
+                  onClick={() => onForward("fix")}
+                >
+                  <Wrench className={iconClass} /> Fix
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{isConnected ? "Tell agent to fix this" : "Attach to agent to use"}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="sm" className={btnClass + " text-muted-foreground"} onClick={onCopy}>
+                {copied ? <Check className={iconClass + " text-green-500"} /> : <Clipboard className={iconClass} />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Copy to clipboard</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="flex items-center gap-px">
+        {isActionable ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="sm" className={resolveBtnClass + " text-green-500/70 hover:text-green-500"} onClick={() => onUpdateStatus("fixed")}>
+                  <CheckCircle2 className={resolveIconClass} />
+                  {size === "default" ? "Fixed" : null}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Mark as fixed</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="sm" className={resolveBtnClass + " text-muted-foreground/50 hover:text-muted-foreground"} onClick={() => onUpdateStatus("ignored")}>
+                  <Ban className={resolveIconClass} />
+                  {size === "default" ? "Ignore" : null}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Ignore this finding</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <div className="flex items-center gap-1">
+            {statusLabel ? (
+              <span className={cn("text-[10px]", size === "default" && "text-sm", statusLabel.color)}>{statusLabel.label}</span>
+            ) : null}
+            <Button variant="ghost" size="sm" className={btnClass} onClick={() => onUpdateStatus("open")}>
+              <RotateCcw className={iconClass} /> Reopen
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact feedback panel shown on the PARENT agent.
+ */
+export function ParentFeedbackPanel({
+  personaAgent,
+  sendTerminalInput,
+  isConnected,
+  onRequestClose,
+  closeOnSessionAction,
+}: {
+  personaAgent: Agent;
   sendTerminalInput?: (data: string) => void;
-  connectedAgentId?: string | null;
+  isConnected: boolean;
+  onRequestClose?: () => void;
+  closeOnSessionAction?: boolean;
 }): JSX.Element | null {
   const queryClient = useQueryClient();
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [sheetItem, setSheetItem] = useState<FeedbackItem | null>(null);
+  const [copied, copyText] = useCopyText();
 
   const { data: feedback = [] } = useQuery<FeedbackItem[]>({
-    queryKey: ["feedback", agent.id],
+    queryKey: ["feedback", personaAgent.id],
     queryFn: async () => {
-      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${agent.id}/feedback`);
+      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${personaAgent.id}/feedback`);
       return result.feedback;
     },
   });
 
-  const openItems = feedback.filter((f) => f.status === "open");
-
   if (feedback.length === 0) return null;
 
-  const parentAgent = agent.parentAgentId
-    ? agents.find((a) => a.id === agent.parentAgentId)
-    : null;
+  const activeCount = feedback.filter((f) => f.status === "open" || f.status === "forwarded").length;
 
-  const updateStatus = async (id: number, status: "dismissed" | "forwarded") => {
-    await api(`/api/v1/agents/${agent.id}/feedback/${id}`, {
+  const updateStatus = async (item: FeedbackItem, status: string) => {
+    await api(`/api/v1/agents/${personaAgent.id}/feedback/${item.id}`, {
       method: "PATCH",
       body: JSON.stringify({ status }),
     });
-    queryClient.setQueryData<FeedbackItem[]>(["feedback", agent.id], (old) =>
-      old?.map((f) => (f.id === id ? { ...f, status } : f))
-    );
+    const update = (f: FeedbackItem) => f.id === item.id ? { ...f, status: status as FeedbackItem["status"] } : f;
+    queryClient.setQueryData<FeedbackItem[]>(["feedback", personaAgent.id], (old) => old?.map(update));
   };
 
-  const forwardToParent = async (item: FeedbackItem) => {
-    if (!parentAgent || !sendTerminalInput || connectedAgentId !== parentAgent.id) return;
-
-    const parts = [`[Feedback from ${agent.persona ?? "persona"}]`];
-    if (item.filePath) parts.push(`File: ${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`);
-    parts.push(`Severity: ${item.severity}`);
-    parts.push(item.description);
-    if (item.suggestion) parts.push(`Suggestion: ${item.suggestion}`);
-
-    sendTerminalInput(parts.join("\n") + "\n");
-    await updateStatus(item.id, "forwarded");
+  const dismissUI = () => {
+    setSheetItem(null);
+    if (closeOnSessionAction) onRequestClose?.();
   };
+
+  const forward = (item: FeedbackItem, mode: "wdyt" | "fix") => {
+    if (sendTerminalInput && isConnected) {
+      const prefix = mode === "fix"
+        ? `Fix the following issue found by the ${personaAgent.persona ?? "persona"} reviewer:`
+        : `A ${personaAgent.persona ?? "persona"} reviewer flagged the following. What do you think — is this a real concern?`;
+      const text = prefix + "\n" + formatFeedbackText(item) + "\r";
+      sendTerminalInput(text);
+      void updateStatus(item, "forwarded");
+    }
+    dismissUI();
+  };
+
+  const handleCopy = (item: FeedbackItem) => {
+    copyText(formatFeedbackText(item));
+    dismissUI();
+  };
+
+  const handleResolve = (item: FeedbackItem, status: string) => {
+    void updateStatus(item, status);
+    setSheetItem(null);
+  };
+
+  const severityInfo = (sev: string) => SEVERITY_LABELS[sev] ?? SEVERITY_LABELS.info;
 
   return (
-    <div className="mt-2 space-y-1.5">
-      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground/80">
-        <span>Feedback ({openItems.length} open)</span>
-      </div>
-      {feedback.map((item) => {
-        const config = SEVERITY_CONFIG[item.severity] ?? SEVERITY_CONFIG.info;
-        const Icon = config.icon;
-        const isOpen = item.status === "open";
-
-        return (
-          <div
-            key={item.id}
-            className={cn(
-              "rounded border px-2 py-1.5 text-xs",
-              isOpen ? "border-border bg-muted/30" : "border-transparent opacity-50"
-            )}
-          >
-            <div className="flex items-start gap-1.5">
-              <Icon className={cn("mt-0.5 h-3 w-3 shrink-0", config.color)} />
-              <div className="min-w-0 flex-1">
-                {item.filePath ? (
-                  <div className="truncate font-mono text-[10px] text-muted-foreground">
-                    {item.filePath}{item.lineNumber ? `:${item.lineNumber}` : ""}
-                  </div>
-                ) : null}
-                <div className="text-foreground">{item.description}</div>
-                {item.suggestion ? (
-                  <div className="mt-0.5 text-muted-foreground">
-                    {item.suggestion}
-                  </div>
-                ) : null}
-              </div>
-              <Badge
-                className="shrink-0 text-[9px]"
-                variant={item.severity === "critical" || item.severity === "high" ? "error" : "default"}
-              >
-                {item.severity}
-              </Badge>
-            </div>
-            {isOpen ? (
-              <div className="mt-1.5 flex items-center gap-1">
-                {parentAgent && sendTerminalInput && connectedAgentId === parentAgent.id ? (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-5 gap-1 px-1.5 text-[10px]"
-                          onClick={() => forwardToParent(item)}
-                        >
-                          <ArrowRight className="h-2.5 w-2.5" />
-                          Forward
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Send to {parentAgent.name}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : null}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-5 gap-1 px-1.5 text-[10px] text-muted-foreground"
-                  onClick={() => updateStatus(item.id, "dismissed")}
-                >
-                  <X className="h-2.5 w-2.5" />
-                  Dismiss
-                </Button>
-                {item.status === "forwarded" ? (
-                  <span className="flex items-center gap-0.5 text-[10px] text-green-500">
-                    <CheckCircle2 className="h-2.5 w-2.5" /> Forwarded
-                  </span>
-                ) : null}
-              </div>
-            ) : (
-              <div className="mt-1 text-[10px] text-muted-foreground">
-                {item.status === "forwarded" ? (
-                  <span className="flex items-center gap-0.5 text-green-500">
-                    <CheckCircle2 className="h-2.5 w-2.5" /> Forwarded
-                  </span>
-                ) : (
-                  "Dismissed"
-                )}
-              </div>
-            )}
+    <>
+      <div className="mt-1.5">
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+          {personaAgent.persona ?? "Persona"} feedback ({activeCount} active)
+        </div>
+        {!isConnected && activeCount > 0 ? (
+          <div className="text-[10px] text-muted-foreground/60 italic mb-1">
+            Attach to this agent to forward feedback
           </div>
-        );
-      })}
-    </div>
+        ) : null}
+        <div className="space-y-px">
+          {feedback.map((item) => {
+            const isActionable = item.status === "open" || item.status === "forwarded";
+            const isExpanded = expandedId === item.id;
+            const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
+            const statusLabel = STATUS_LABELS[item.status];
+
+            return (
+              <div key={item.id} className={cn(!isActionable && "opacity-40")}>
+                {/* Compact row */}
+                <button
+                  className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-[11px] hover:bg-muted/40 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); setExpandedId(isExpanded ? null : item.id); }}
+                >
+                  <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", isExpanded && "rotate-90")} />
+                  <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
+                  <span className="min-w-0 truncate font-mono text-muted-foreground">
+                    {item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-foreground">
+                    {item.description}
+                  </span>
+                  {statusLabel && !isActionable ? (
+                    <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
+                  ) : null}
+                </button>
+
+                {/* Expanded inline card — clamped */}
+                {isExpanded ? (
+                  <div className="ml-4 mr-1 mb-1.5 rounded-md border border-border bg-background px-2.5 py-2 text-xs shadow-sm" onClick={(e) => e.stopPropagation()}>
+                    {item.filePath ? (
+                      <div className="font-mono text-[10px] text-muted-foreground mb-1">
+                        {item.filePath}{item.lineNumber ? `:${item.lineNumber}` : ""}
+                      </div>
+                    ) : null}
+                    <div className="text-foreground leading-relaxed line-clamp-3">{item.description}</div>
+                    {item.suggestion ? (
+                      <div className="mt-1 text-muted-foreground leading-relaxed line-clamp-2">{item.suggestion}</div>
+                    ) : null}
+
+                    <div className="mt-2">
+                      <FeedbackActions
+                        item={item}
+                        isConnected={isConnected}
+                        onForward={(mode) => forward(item, mode)}
+                        onCopy={() => handleCopy(item)}
+                        copied={copied}
+                        onUpdateStatus={(s) => handleResolve(item, s)}
+                        isActionable={isActionable}
+                        statusLabel={statusLabel}
+                      />
+                    </div>
+
+                    <button
+                      className="mt-1.5 flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                      onClick={() => setSheetItem(item)}
+                    >
+                      <Expand className="h-2.5 w-2.5" /> View full
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Full feedback detail sheet */}
+      <Sheet open={!!sheetItem} onOpenChange={(open) => { if (!open) setSheetItem(null); }}>
+        <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto">
+          {sheetItem ? (
+            <>
+              <SheetHeader>
+                <div className="flex items-center gap-2">
+                  <Badge variant={severityInfo(sheetItem.severity).variant}>
+                    {severityInfo(sheetItem.severity).label}
+                  </Badge>
+                  <SheetTitle className="text-base">
+                    {sheetItem.filePath
+                      ? `${sheetItem.filePath}${sheetItem.lineNumber ? `:${sheetItem.lineNumber}` : ""}`
+                      : "Feedback"}
+                  </SheetTitle>
+                </div>
+                <SheetDescription className="text-xs text-muted-foreground">
+                  From {personaAgent.persona ?? "persona"} review
+                </SheetDescription>
+              </SheetHeader>
+
+              <div className="mt-4 space-y-3">
+                <div>
+                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Description</div>
+                  <div className="text-sm text-foreground leading-relaxed whitespace-pre-wrap">{sheetItem.description}</div>
+                </div>
+
+                {sheetItem.suggestion ? (
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Suggestion</div>
+                    <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">{sheetItem.suggestion}</div>
+                  </div>
+                ) : null}
+
+                <div className="pt-2 border-t border-border">
+                  <FeedbackActions
+                    item={sheetItem}
+                    isConnected={isConnected}
+                    onForward={(mode) => forward(sheetItem, mode)}
+                    onCopy={() => handleCopy(sheetItem)}
+                    copied={copied}
+                    onUpdateStatus={(s) => handleResolve(sheetItem, s)}
+                    isActionable={sheetItem.status === "open" || sheetItem.status === "forwarded"}
+                    statusLabel={STATUS_LABELS[sheetItem.status]}
+                    size="default"
+                  />
+                </div>
+              </div>
+            </>
+          ) : null}
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,0 +1,162 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, ArrowRight, CheckCircle2, Info, X } from "lucide-react";
+
+import { type Agent, type FeedbackItem } from "@/components/app/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const SEVERITY_CONFIG: Record<string, { color: string; icon: typeof AlertTriangle }> = {
+  critical: { color: "text-red-500", icon: AlertTriangle },
+  high: { color: "text-orange-500", icon: AlertTriangle },
+  medium: { color: "text-yellow-500", icon: AlertTriangle },
+  low: { color: "text-blue-400", icon: Info },
+  info: { color: "text-muted-foreground", icon: Info },
+};
+
+export function FeedbackPanel({
+  agent,
+  agents,
+  sendTerminalInput,
+  connectedAgentId,
+}: {
+  agent: Agent;
+  agents: Agent[];
+  sendTerminalInput?: (data: string) => void;
+  connectedAgentId?: string | null;
+}): JSX.Element | null {
+  const queryClient = useQueryClient();
+
+  const { data: feedback = [] } = useQuery<FeedbackItem[]>({
+    queryKey: ["feedback", agent.id],
+    queryFn: async () => {
+      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${agent.id}/feedback`);
+      return result.feedback;
+    },
+  });
+
+  const openItems = feedback.filter((f) => f.status === "open");
+
+  if (feedback.length === 0) return null;
+
+  const parentAgent = agent.parentAgentId
+    ? agents.find((a) => a.id === agent.parentAgentId)
+    : null;
+
+  const updateStatus = async (id: number, status: "dismissed" | "forwarded") => {
+    await api(`/api/v1/agents/${agent.id}/feedback/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ status }),
+    });
+    queryClient.setQueryData<FeedbackItem[]>(["feedback", agent.id], (old) =>
+      old?.map((f) => (f.id === id ? { ...f, status } : f))
+    );
+  };
+
+  const forwardToParent = async (item: FeedbackItem) => {
+    if (!parentAgent || !sendTerminalInput || connectedAgentId !== parentAgent.id) return;
+
+    const parts = [`[Feedback from ${agent.persona ?? "persona"}]`];
+    if (item.filePath) parts.push(`File: ${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`);
+    parts.push(`Severity: ${item.severity}`);
+    parts.push(item.description);
+    if (item.suggestion) parts.push(`Suggestion: ${item.suggestion}`);
+
+    sendTerminalInput(parts.join("\n") + "\n");
+    await updateStatus(item.id, "forwarded");
+  };
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground/80">
+        <span>Feedback ({openItems.length} open)</span>
+      </div>
+      {feedback.map((item) => {
+        const config = SEVERITY_CONFIG[item.severity] ?? SEVERITY_CONFIG.info;
+        const Icon = config.icon;
+        const isOpen = item.status === "open";
+
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              "rounded border px-2 py-1.5 text-xs",
+              isOpen ? "border-border bg-muted/30" : "border-transparent opacity-50"
+            )}
+          >
+            <div className="flex items-start gap-1.5">
+              <Icon className={cn("mt-0.5 h-3 w-3 shrink-0", config.color)} />
+              <div className="min-w-0 flex-1">
+                {item.filePath ? (
+                  <div className="truncate font-mono text-[10px] text-muted-foreground">
+                    {item.filePath}{item.lineNumber ? `:${item.lineNumber}` : ""}
+                  </div>
+                ) : null}
+                <div className="text-foreground">{item.description}</div>
+                {item.suggestion ? (
+                  <div className="mt-0.5 text-muted-foreground">
+                    {item.suggestion}
+                  </div>
+                ) : null}
+              </div>
+              <Badge
+                className="shrink-0 text-[9px]"
+                variant={item.severity === "critical" || item.severity === "high" ? "error" : "default"}
+              >
+                {item.severity}
+              </Badge>
+            </div>
+            {isOpen ? (
+              <div className="mt-1.5 flex items-center gap-1">
+                {parentAgent && sendTerminalInput && connectedAgentId === parentAgent.id ? (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-5 gap-1 px-1.5 text-[10px]"
+                          onClick={() => forwardToParent(item)}
+                        >
+                          <ArrowRight className="h-2.5 w-2.5" />
+                          Forward
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Send to {parentAgent.name}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 gap-1 px-1.5 text-[10px] text-muted-foreground"
+                  onClick={() => updateStatus(item.id, "dismissed")}
+                >
+                  <X className="h-2.5 w-2.5" />
+                  Dismiss
+                </Button>
+                {item.status === "forwarded" ? (
+                  <span className="flex items-center gap-0.5 text-[10px] text-green-500">
+                    <CheckCircle2 className="h-2.5 w-2.5" /> Forwarded
+                  </span>
+                ) : null}
+              </div>
+            ) : (
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                {item.status === "forwarded" ? (
+                  <span className="flex items-center gap-0.5 text-green-500">
+                    <CheckCircle2 className="h-2.5 w-2.5" /> Forwarded
+                  </span>
+                ) : (
+                  "Dismissed"
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Ban, Check, CheckCircle2, ChevronRight, Clipboard, Expand, Info, MessageCircleQuestion, RotateCcw, Wrench } from "lucide-react";
+import { AlertTriangle, Ban, Check, CheckCircle2, ChevronRight, Copy, Expand, Info, MessageCircleQuestion, RotateCcw, Wrench } from "lucide-react";
 
-import { type Agent, type FeedbackItem } from "@/components/app/types";
+import { type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
@@ -63,10 +63,10 @@ function FeedbackActions({
   statusLabel: { label: string; color: string } | undefined;
   size?: "sm" | "default";
 }): JSX.Element {
-  const btnClass = size === "sm" ? "h-5 gap-1 px-1.5 text-[10px]" : "h-7 gap-1.5 px-2.5 text-xs";
-  const iconClass = size === "sm" ? "h-2.5 w-2.5" : "h-3.5 w-3.5";
-  const resolveIconClass = size === "sm" ? "h-3 w-3" : "h-4 w-4";
-  const resolveBtnClass = size === "sm" ? "h-5 px-1 text-[10px]" : "h-7 px-2 text-xs gap-1.5";
+  const btnClass = size === "sm" ? "h-6 gap-1 px-1.5 text-[10px]" : "h-7 gap-1.5 px-2.5 text-xs";
+  const iconClass = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
+  const resolveIconClass = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
+  const resolveBtnClass = size === "sm" ? "h-6 px-1.5 text-[10px]" : "h-7 px-2 text-xs gap-1.5";
 
   return (
     <div className="flex items-center justify-between">
@@ -104,16 +104,15 @@ function FeedbackActions({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className={btnClass + " text-muted-foreground"} onClick={onCopy}>
-                {copied ? <Check className={iconClass + " text-green-500"} /> : <Clipboard className={iconClass} />}
-                {copied ? "Copied" : "Copy"}
+              <Button variant="ghost" size="sm" className={btnClass} onClick={onCopy}>
+                {copied ? <Check className={iconClass + " text-green-500"} /> : <Copy className={iconClass} />}
               </Button>
             </TooltipTrigger>
             <TooltipContent>Copy to clipboard</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>
-      <div className="flex items-center gap-px">
+      <div className="flex items-center gap-1">
         {isActionable ? (
           <TooltipProvider>
             <Tooltip>
@@ -154,13 +153,13 @@ function FeedbackActions({
  * Compact feedback panel shown on the PARENT agent.
  */
 export function ParentFeedbackPanel({
-  personaAgent,
+  parentAgentId,
   sendTerminalInput,
   isConnected,
   onRequestClose,
   closeOnSessionAction,
 }: {
-  personaAgent: Agent;
+  parentAgentId: string;
   sendTerminalInput?: (data: string) => void;
   isConnected: boolean;
   onRequestClose?: () => void;
@@ -168,40 +167,48 @@ export function ParentFeedbackPanel({
 }): JSX.Element | null {
   const queryClient = useQueryClient();
   const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [sheetItem, setSheetItem] = useState<FeedbackItem | null>(null);
-  const [copied, copyText] = useCopyText();
+  const [sheetItemId, setSheetItemId] = useState<number | null>(null);
+  const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
+  const [showResolved, setShowResolved] = useState(false);
+  const [, copyText] = useCopyText();
+  const copiedTimerRef = useRef<number | null>(null);
 
   const { data: feedback = [] } = useQuery<FeedbackItem[]>({
-    queryKey: ["feedback", personaAgent.id],
+    queryKey: ["feedback", parentAgentId, "children"],
     queryFn: async () => {
-      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${personaAgent.id}/feedback`);
+      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${parentAgentId}/feedback?scope=children`);
       return result.feedback;
     },
   });
 
+  const sheetItem = sheetItemId != null ? feedback.find((f) => f.id === sheetItemId) ?? null : null;
+
   if (feedback.length === 0) return null;
 
-  const activeCount = feedback.filter((f) => f.status === "open" || f.status === "forwarded").length;
+  const activeItems = feedback.filter((f) => f.status === "open" || f.status === "forwarded");
+  const resolvedItems = feedback.filter((f) => f.status !== "open" && f.status !== "forwarded");
+  const activeCount = activeItems.length;
+  const visibleItems = showResolved ? feedback : activeItems;
 
   const updateStatus = async (item: FeedbackItem, status: string) => {
-    await api(`/api/v1/agents/${personaAgent.id}/feedback/${item.id}`, {
+    await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
       method: "PATCH",
       body: JSON.stringify({ status }),
     });
     const update = (f: FeedbackItem) => f.id === item.id ? { ...f, status: status as FeedbackItem["status"] } : f;
-    queryClient.setQueryData<FeedbackItem[]>(["feedback", personaAgent.id], (old) => old?.map(update));
+    queryClient.setQueryData<FeedbackItem[]>(["feedback", parentAgentId, "children"], (old) => old?.map(update));
   };
 
   const dismissUI = () => {
-    setSheetItem(null);
+    setSheetItemId(null);
     if (closeOnSessionAction) onRequestClose?.();
   };
 
   const forward = (item: FeedbackItem, mode: "wdyt" | "fix") => {
     if (sendTerminalInput && isConnected) {
       const prefix = mode === "fix"
-        ? `Fix the following issue found by the ${personaAgent.persona ?? "persona"} reviewer:`
-        : `A ${personaAgent.persona ?? "persona"} reviewer flagged the following. What do you think — is this a real concern?`;
+        ? "Fix the following issue found by the persona reviewer:"
+        : "A persona reviewer flagged the following. What do you think — is this a real concern?";
       const text = prefix + "\n" + formatFeedbackText(item) + "\r";
       sendTerminalInput(text);
       void updateStatus(item, "forwarded");
@@ -211,12 +218,18 @@ export function ParentFeedbackPanel({
 
   const handleCopy = (item: FeedbackItem) => {
     copyText(formatFeedbackText(item));
+    setCopiedItemId(item.id);
+    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+    copiedTimerRef.current = window.setTimeout(() => setCopiedItemId(null), 2000);
     dismissUI();
   };
 
   const handleResolve = (item: FeedbackItem, status: string) => {
     void updateStatus(item, status);
-    setSheetItem(null);
+    setSheetItemId(null);
+    // Auto-expand the next unresolved item
+    const remaining = activeItems.filter((f) => f.id !== item.id);
+    setExpandedId(remaining.length > 0 ? remaining[0]!.id : null);
   };
 
   const severityInfo = (sev: string) => SEVERITY_LABELS[sev] ?? SEVERITY_LABELS.info;
@@ -225,7 +238,7 @@ export function ParentFeedbackPanel({
     <>
       <div className="mt-1.5">
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
-          {personaAgent.persona ?? "Persona"} feedback ({activeCount} active)
+          Persona feedback ({activeCount} active)
         </div>
         {!isConnected && activeCount > 0 ? (
           <div className="text-[10px] text-muted-foreground/60 italic mb-1">
@@ -233,7 +246,7 @@ export function ParentFeedbackPanel({
           </div>
         ) : null}
         <div className="space-y-px">
-          {feedback.map((item) => {
+          {visibleItems.map((item) => {
             const isActionable = item.status === "open" || item.status === "forwarded";
             const isExpanded = expandedId === item.id;
             const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
@@ -243,7 +256,7 @@ export function ParentFeedbackPanel({
               <div key={item.id} className={cn(!isActionable && "opacity-40")}>
                 {/* Compact row */}
                 <button
-                  className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-[11px] hover:bg-muted/40 transition-colors"
+                  className="flex w-full items-center gap-1.5 rounded px-1 py-2 md:py-1 text-left text-[11px] hover:bg-muted/40 transition-colors"
                   onClick={(e) => { e.stopPropagation(); setExpandedId(isExpanded ? null : item.id); }}
                 >
                   <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", isExpanded && "rotate-90")} />
@@ -261,13 +274,19 @@ export function ParentFeedbackPanel({
 
                 {/* Expanded inline card — clamped */}
                 {isExpanded ? (
-                  <div className="ml-4 mr-1 mb-1.5 rounded-md border border-border bg-background px-2.5 py-2 text-xs shadow-sm" onClick={(e) => e.stopPropagation()}>
+                  <div className="relative ml-4 mr-1 mb-1.5 rounded-md border border-border bg-background px-2.5 py-2 text-xs shadow-sm" onClick={(e) => e.stopPropagation()}>
+                    <button
+                      className="absolute -top-1.5 -right-1.5 p-1 rounded text-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+                      onClick={() => setSheetItemId(item.id)}
+                    >
+                      <Expand className="h-3.5 w-3.5" />
+                    </button>
                     {item.filePath ? (
-                      <div className="font-mono text-[10px] text-muted-foreground mb-1">
+                      <div className="font-mono text-[10px] text-muted-foreground mb-1 pr-6">
                         {item.filePath}{item.lineNumber ? `:${item.lineNumber}` : ""}
                       </div>
                     ) : null}
-                    <div className="text-foreground leading-relaxed line-clamp-3">{item.description}</div>
+                    <div className="text-foreground leading-relaxed line-clamp-3 pr-6">{item.description}</div>
                     {item.suggestion ? (
                       <div className="mt-1 text-muted-foreground leading-relaxed line-clamp-2">{item.suggestion}</div>
                     ) : null}
@@ -278,30 +297,31 @@ export function ParentFeedbackPanel({
                         isConnected={isConnected}
                         onForward={(mode) => forward(item, mode)}
                         onCopy={() => handleCopy(item)}
-                        copied={copied}
+                        copied={copiedItemId === item.id}
                         onUpdateStatus={(s) => handleResolve(item, s)}
                         isActionable={isActionable}
                         statusLabel={statusLabel}
                       />
                     </div>
-
-                    <button
-                      className="mt-1.5 flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => setSheetItem(item)}
-                    >
-                      <Expand className="h-2.5 w-2.5" /> View full
-                    </button>
                   </div>
                 ) : null}
               </div>
             );
           })}
         </div>
+        {resolvedItems.length > 0 ? (
+          <button
+            className="mt-1 text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+            onClick={(e) => { e.stopPropagation(); setShowResolved(!showResolved); }}
+          >
+            {showResolved ? "Hide" : "Show"} {resolvedItems.length} resolved
+          </button>
+        ) : null}
       </div>
 
       {/* Full feedback detail sheet */}
-      <Sheet open={!!sheetItem} onOpenChange={(open) => { if (!open) setSheetItem(null); }}>
-        <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto">
+      <Sheet open={!!sheetItem} onOpenChange={(open) => { if (!open) setSheetItemId(null); }}>
+        <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto px-6 py-5">
           {sheetItem ? (
             <>
               <SheetHeader>
@@ -316,7 +336,7 @@ export function ParentFeedbackPanel({
                   </SheetTitle>
                 </div>
                 <SheetDescription className="text-xs text-muted-foreground">
-                  From {personaAgent.persona ?? "persona"} review
+                  From persona review
                 </SheetDescription>
               </SheetHeader>
 
@@ -339,7 +359,7 @@ export function ParentFeedbackPanel({
                     isConnected={isConnected}
                     onForward={(mode) => forward(sheetItem, mode)}
                     onCopy={() => handleCopy(sheetItem)}
-                    copied={copied}
+                    copied={copiedItemId === sheetItem.id}
                     onUpdateStatus={(s) => handleResolve(sheetItem, s)}
                     isActionable={sheetItem.status === "open" || sheetItem.status === "forwarded"}
                     statusLabel={STATUS_LABELS[sheetItem.status]}

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import { Sparkles } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
@@ -24,20 +24,17 @@ export function PersonaLauncher({
   agent: Agent;
   sendTerminalInput: (data: string) => void;
 }): JSX.Element | null {
-  const [personas, setPersonas] = useState<PersonaSummary[]>([]);
-  const [loaded, setLoaded] = useState(false);
+  const cwd = agent.worktreePath ?? agent.cwd;
 
-  useEffect(() => {
-    const cwd = agent.worktreePath ?? agent.cwd;
-    api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(cwd)}`)
-      .then((data) => {
-        setPersonas(data.personas);
-        setLoaded(true);
-      })
-      .catch(() => setLoaded(true));
-  }, [agent.cwd, agent.worktreePath]);
+  const { data: personas = [] } = useQuery<PersonaSummary[]>({
+    queryKey: ["personas", cwd],
+    queryFn: async () => {
+      const result = await api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(cwd)}`);
+      return result.personas;
+    },
+  });
 
-  if (!loaded || personas.length === 0) return null;
+  if (personas.length === 0) return null;
 
   const launchPersona = (slug: string) => {
     const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
@@ -47,7 +44,7 @@ export function PersonaLauncher({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-6 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground">
+        <Button variant="ghost" className="gap-1.5 border border-border/60 bg-background/50 text-muted-foreground hover:text-foreground hover:bg-muted/60">
           <Sparkles className="h-3 w-3" />
           Launch Persona
         </Button>

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -41,9 +41,7 @@ export function PersonaLauncher({
 
   const launchPersona = (slug: string) => {
     const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
-    sendTerminalInput(message);
-    // Send Enter as carriage return to submit in the terminal
-    setTimeout(() => sendTerminalInput("\r"), 50);
+    sendTerminalInput(message + "\r");
   };
 
   return (

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { type Agent } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { api } from "@/lib/api";
+
+type PersonaSummary = {
+  slug: string;
+  name: string;
+  description: string;
+};
+
+export function PersonaLauncher({
+  agent,
+  sendTerminalInput,
+}: {
+  agent: Agent;
+  sendTerminalInput: (data: string) => void;
+}): JSX.Element | null {
+  const [personas, setPersonas] = useState<PersonaSummary[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const cwd = agent.worktreePath ?? agent.cwd;
+    api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(cwd)}`)
+      .then((data) => {
+        setPersonas(data.personas);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, [agent.cwd, agent.worktreePath]);
+
+  if (!loaded || personas.length === 0) return null;
+
+  const launchPersona = (slug: string) => {
+    const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
+    sendTerminalInput(message);
+    // Send Enter as carriage return to submit in the terminal
+    setTimeout(() => sendTerminalInput("\r"), 50);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-6 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground">
+          <Sparkles className="h-3 w-3" />
+          Launch Persona
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {personas.map((p) => (
+          <DropdownMenuItem key={p.slug} onClick={() => launchPersona(p.slug)}>
+            <div>
+              <div className="text-sm">{p.name}</div>
+              {p.description ? (
+                <div className="text-xs text-muted-foreground">{p.description}</div>
+              ) : null}
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -27,9 +27,25 @@ export type Agent = {
     worktreeName: string;
     isWorktree: boolean;
   } | null;
+  persona?: string | null;
+  parentAgentId?: string | null;
+  personaContext?: string | null;
   hasStream?: boolean;
   createdAt: string;
   updatedAt: string;
+};
+
+export type FeedbackItem = {
+  id: number;
+  agentId: string;
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  filePath: string | null;
+  lineNumber: number | null;
+  description: string;
+  suggestion: string | null;
+  mediaRef: string | null;
+  status: "open" | "dismissed" | "forwarded";
+  createdAt: string;
 };
 
 export type MediaFile = {

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -44,7 +44,7 @@ export type FeedbackItem = {
   description: string;
   suggestion: string | null;
   mediaRef: string | null;
-  status: "open" | "dismissed" | "forwarded";
+  status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored";
   createdAt: string;
 };
 

--- a/apps/web/src/hooks/use-copy.ts
+++ b/apps/web/src/hooks/use-copy.ts
@@ -1,0 +1,52 @@
+import { useCallback, useRef, useState } from "react";
+
+/** Copy text via hidden textarea + execCommand. Works on iOS Safari non-secure contexts. */
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "0";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
+/**
+ * Hook for copying text to clipboard with iOS Safari support.
+ * Returns [copied, copyText] — `copied` is true for 2s after a successful copy.
+ */
+export function useCopyText(): [boolean, (text: string) => void] {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const copyText = useCallback((text: string) => {
+    // Try execCommand first (works on iOS Safari non-secure contexts)
+    if (copyViaExecCommand(text)) {
+      setCopied(true);
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setCopied(false), 2000);
+      return;
+    }
+    // Fall back to Clipboard API
+    if (navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        if (timerRef.current) window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => setCopied(false), 2000);
+      }).catch(() => {});
+    }
+  }, []);
+
+  return [copied, copyText];
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -11,7 +11,8 @@ type UiEvent =
   | { type: "media.changed"; agentId: string }
   | { type: "media.seen"; agentId: string; keys: string[] }
   | { type: "stream.started"; agentId: string }
-  | { type: "stream.stopped"; agentId: string };
+  | { type: "stream.stopped"; agentId: string }
+  | { type: "feedback.created"; agentId: string };
 
 export function useSSE(
   authState: AuthState,
@@ -89,6 +90,11 @@ export function useSSE(
 
         if (payload.type === "media.seen") {
           markSeenInCache(payload.agentId, new Set(payload.keys));
+          return;
+        }
+
+        if (payload.type === "feedback.created") {
+          void queryClient.invalidateQueries({ queryKey: ["feedback", payload.agentId], exact: true });
         }
       } catch {}
     };

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -94,7 +94,7 @@ export function useSSE(
         }
 
         if (payload.type === "feedback.created") {
-          void queryClient.invalidateQueries({ queryKey: ["feedback", payload.agentId], exact: true });
+          void queryClient.invalidateQueries({ queryKey: ["feedback"] });
         }
       } catch {}
     };

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -455,7 +455,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files.",
         inputSchema: {
           persona: z.string().describe("Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."),
-          context: z.string().describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention.")
+          context: z.string().max(100_000).describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention.")
         }
       },
       async (args) => {

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -28,6 +28,15 @@ export type MediaResult = {
   description: string;
 };
 
+export type FeedbackInput = {
+  severity?: "critical" | "high" | "medium" | "low" | "info";
+  filePath?: string;
+  lineNumber?: number;
+  description: string;
+  suggestion?: string;
+  mediaRef?: string;
+};
+
 export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
@@ -40,6 +49,14 @@ export type McpRequestContext = {
     agentId: string,
     opts: { filePath: string; description: string; source?: string; name?: string }
   ) => Promise<MediaResult>;
+  submitFeedback?: (
+    agentId: string,
+    feedback: FeedbackInput
+  ) => Promise<{ id: number }>;
+  launchPersona?: (
+    agentId: string,
+    opts: { persona: string; context: string }
+  ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
 };
 
 export async function handleMcpRequest(
@@ -366,6 +383,94 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
               }
             ],
             structuredContent: result
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.submitFeedback) {
+    const agentId = context.agent.id;
+    const submitFeedback = context.submitFeedback;
+
+    server.registerTool(
+      "dispatch_feedback",
+      {
+        description:
+          "Submit a structured feedback finding to Dispatch. Use this to report issues, suggestions, or observations about the code being reviewed. Each call creates one feedback item.",
+        inputSchema: {
+          severity: z
+            .enum(["critical", "high", "medium", "low", "info"])
+            .default("info")
+            .describe("Severity level of the finding."),
+          filePath: z
+            .string()
+            .optional()
+            .describe("File path relative to repo root where the issue was found."),
+          lineNumber: z
+            .number()
+            .optional()
+            .describe("Line number in the file."),
+          description: z.string().describe("What was found — the issue or observation."),
+          suggestion: z
+            .string()
+            .optional()
+            .describe("Suggested fix or action to take."),
+          mediaRef: z
+            .string()
+            .optional()
+            .describe("Filename of a previously shared media file (from dispatch_share) to attach.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await submitFeedback(agentId, {
+            severity: args.severity,
+            filePath: args.filePath,
+            lineNumber: args.lineNumber,
+            description: args.description,
+            suggestion: args.suggestion,
+            mediaRef: args.mediaRef
+          });
+          return {
+            content: [{ type: "text", text: `Feedback #${result.id} submitted.` }]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.launchPersona) {
+    const agentId = context.agent.id;
+    const launchPersona = context.launchPersona;
+
+    server.registerTool(
+      "dispatch_launch_persona",
+      {
+        description:
+          "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files.",
+        inputSchema: {
+          persona: z.string().describe("Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."),
+          context: z.string().describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await launchPersona(agentId, {
+            persona: args.persona,
+            context: args.context
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Launched persona "${result.persona}" as agent ${result.agentId}.`
+              }
+            ]
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary

Adds a Personas feature that lets users define reusable agent roles (security reviewer, e2e tester, etc.) that can be launched against another agent's work. Persona agents produce structured feedback via a new `dispatch_feedback` MCP tool, which surfaces in the Dispatch UI for the user to review, forward to the parent agent, or resolve.

**Key additions:**
- Persona definitions in `.dispatch/personas/*.md` with frontmatter (name, description, feedbackFormat) and `{{context}}`/`{{diff}}` template placeholders
- `dispatch_launch_persona` and `dispatch_feedback` MCP tools
- Persona loader module (`apps/server/src/personas/loader.ts`)
- Database: `persona`, `parent_agent_id`, `persona_context` columns on agents + `agent_feedback` table
- REST API: `GET /api/v1/personas`, `GET /api/v1/agents/:id/feedback`, `PATCH /api/v1/agents/:id/feedback/:feedbackId`
- Web UI: Launch Persona dropdown, parent/child hierarchy nesting in sidebar, compact feedback list with expandable cards, bottom sheet detail view, WDYT/Fix/Copy/Fixed/Ignore actions, `useCopyText` hook
- 4 example personas: security-review, e2e-tester, backend-security-review, frontend-ux-review

**Dogfooded:** The feature was used to review itself — persona agents found and fixed real issues (IDOR on feedback endpoint, path traversal in loader, aria-labels, input validation, consolidated feedback panel).

## Test plan
- [x] `pnpm run check` — types pass
- [x] `pnpm run test` — 87 unit tests pass
- [x] `pnpm run test:e2e` — 77 E2E tests pass
- [x] `pnpm run finalize:web` — production build succeeds
- [x] Live tested with real Claude agents on dev instance (full flow: parent launches persona, persona submits feedback, user reviews/forwards, parent fixes)
- [ ] Manual mobile testing of bottom sheet and sidebar feedback UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)