### PR TITLE
Fix media serving for historical agents in agent history

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1982,8 +1982,9 @@ async function registerRoutes() {
   app.get("/api/v1/agents/:id/media", async (request, reply) => {
     const params = request.params as { id?: string };
     const id = params.id ?? "";
-    const agent = await agentManager.getAgent(id);
-    if (!agent) {
+    // Include deleted agents so historical media lists still work
+    const agentExists = await pool.query("SELECT 1 FROM agents WHERE id = $1", [id]);
+    if (agentExists.rows.length === 0) {
       return reply.code(404).send({ error: "Agent not found." });
     }
 
@@ -2000,8 +2001,13 @@ async function registerRoutes() {
   app.get("/api/v1/agents/:id/media/:file", async (request, reply) => {
     const params = request.params as { id?: string; file?: string };
     const id = params.id ?? "";
-    const agent = await agentManager.getAgent(id);
-    if (!agent) {
+
+    // Look up agent including deleted ones so historical media still loads
+    const agentRow = await pool.query<{ id: string; media_dir: string | null }>(
+      "SELECT id, media_dir FROM agents WHERE id = $1",
+      [id]
+    );
+    if (agentRow.rows.length === 0) {
       return reply.code(404).send({ error: "Agent not found." });
     }
 
@@ -2010,7 +2016,7 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "Invalid media file name." });
     }
 
-    const filePath = path.join(resolveMediaDir(agent.id, agent.mediaDir), file);
+    const filePath = path.join(resolveMediaDir(agentRow.rows[0].id, agentRow.rows[0].media_dir), file);
     const fileStat = await stat(filePath).catch(() => null);
     if (!fileStat || !fileStat.isFile()) {
       return reply.code(404).send({ error: "Media file not found." });

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -410,7 +410,7 @@ function DetailTabs({
   const lightboxItems = useMemo(
     () =>
       media.map((m) => ({
-        src: `/api/v1/agents/${agentId}/media/${m.file_name}`,
+        src: `/api/v1/agents/${agentId}/media/${encodeURIComponent(m.file_name)}`,
         caption: m.description ?? stripTimestamp(m.file_name),
         file: {
           name: m.file_name,
@@ -482,7 +482,7 @@ function DetailTabs({
                 >
                   {m.source === "screenshot" || m.source === "simulator" ? (
                     <img
-                      src={`/api/v1/agents/${agentId}/media/${m.file_name}`}
+                      src={`/api/v1/agents/${agentId}/media/${encodeURIComponent(m.file_name)}`}
                       alt={m.description ?? m.file_name}
                       className="aspect-video w-full object-cover"
                       loading="lazy"


### PR DESCRIPTION
## Summary
- Media images in the History tab were broken (404) because the media serving endpoints used `agentManager.getAgent()` which filters out soft-deleted agents (`WHERE deleted_at IS NULL`)
- Changed both `/api/v1/agents/:id/media` and `/api/v1/agents/:id/media/:file` to query agents directly without the `deleted_at` filter
- Added `encodeURIComponent()` to frontend media URLs in the history detail view

## Test plan
- [x] Type checks pass (`pnpm run check`)
- [x] Web build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (77 passed)
- [x] Manual validation: created agent with media, deleted it, verified media still serves with HTTP 200
- [x] Playwright UI validation: history detail Media tab shows image correctly for deleted agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)