### PR TITLE
Add accent colors to persona launcher dropdown

### DIFF
--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -50,16 +50,25 @@ export function PersonaLauncher({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {personas.map((p) => (
-          <DropdownMenuItem key={p.slug} onClick={() => launchPersona(p.slug)}>
-            <div>
-              <div className="text-sm">{p.name}</div>
-              {p.description ? (
-                <div className="text-xs text-muted-foreground">{p.description}</div>
-              ) : null}
-            </div>
-          </DropdownMenuItem>
-        ))}
+        {personas.map((p, i) => {
+          const colorVar = `var(--chart-${(i % 4) + 1})`;
+          return (
+            <DropdownMenuItem key={p.slug} onClick={() => launchPersona(p.slug)}>
+              <div className="flex items-start gap-2.5">
+                <div
+                  className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: `hsl(${colorVar})` }}
+                />
+                <div>
+                  <div className="text-sm font-medium" style={{ color: `hsl(${colorVar})` }}>{p.name}</div>
+                  {p.description ? (
+                    <div className="text-xs text-muted-foreground">{p.description}</div>
+                  ) : null}
+                </div>
+              </div>
+            </DropdownMenuItem>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Summary
- Each persona in the Launch Persona dropdown now gets a colored dot and tinted name using the theme's `chart-1` through `chart-4` CSS variables
- Colors cycle through teal, amber, sky, and purple (adapts to active theme)
- Makes the persona list more visually distinct and less bland

## Test plan
- [x] `pnpm run finalize:web` passes
- [x] `pnpm run test:e2e` — 77/77 passed
- [x] Validated visually via Playwright on live dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)