### PR TITLE
Fix dispatch-deploy and install-launchd to use pnpm

### DIFF
--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -126,9 +126,8 @@ build_tag() {
   load_nvm
   cd "$SERVER_DIR"
   nvm use >/dev/null
-  npm ci --silent
-  npm --prefix web ci --silent
-  npm run build
+  pnpm install --frozen-lockfile
+  pnpm run build
 }
 
 write_release_record() {

--- a/bin/install-launchd
+++ b/bin/install-launchd
@@ -80,11 +80,10 @@ export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"
 cd "$SERVER_DIR"
 nvm use >/dev/null
-npm ci --silent
-npm --prefix web ci --silent
+pnpm install --frozen-lockfile
 
 echo "==> building"
-npm run build
+pnpm run build
 
 mkdir -p "$LOG_DIR"
 


### PR DESCRIPTION
## Summary
- `bin/dispatch-deploy` and `bin/install-launchd` still used `npm ci` / `npm run build` from before the monorepo migration
- Since `package-lock.json` no longer exists, `npm ci` hangs and builds fail
- Switch both to `pnpm install --frozen-lockfile` and `pnpm run build`, matching the server and in-app deploy code

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Unit tests pass (`pnpm run test` — 87 passed)
- [x] E2E tests pass (`pnpm run test:e2e` — 77 passed, 6 skipped)
- [x] Both scripts pass `bash -n` syntax check
- [ ] Manual: run `bin/dispatch-deploy --latest` on a server with the monorepo layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)