### PR TITLE
Add dispatch_get_feedback MCP tool

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1312,6 +1312,40 @@ export class AgentManager {
     return result.rows;
   }
 
+  async listFeedbackByParentGrouped(
+    parentAgentId: string,
+    persona?: string
+  ): Promise<{ personas: Array<{ persona: string; agentId: string; feedback: FeedbackRecord[] }> }> {
+    const params: unknown[] = [parentAgentId];
+    let whereClause = "WHERE a.parent_agent_id = $1";
+    if (persona) {
+      params.push(persona);
+      whereClause += ` AND a.persona = $${params.length}`;
+    }
+
+    const result = await this.pool.query<FeedbackRecord & { persona: string }>(
+      `SELECT f.id, f.agent_id AS "agentId", a.persona, f.severity, f.file_path AS "filePath", f.line_number AS "lineNumber",
+              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status, f.created_at AS "createdAt"
+       FROM agent_feedback f
+       JOIN agents a ON a.id = f.agent_id
+       ${whereClause}
+       ORDER BY a.persona, f.created_at ASC`,
+      params
+    );
+
+    const grouped = new Map<string, { persona: string; agentId: string; feedback: FeedbackRecord[] }>();
+    for (const row of result.rows) {
+      const key = row.agentId;
+      if (!grouped.has(key)) {
+        grouped.set(key, { persona: row.persona, agentId: row.agentId, feedback: [] });
+      }
+      const { persona: _p, ...feedbackRecord } = row;
+      grouped.get(key)!.feedback.push(feedbackRecord);
+    }
+
+    return { personas: Array.from(grouped.values()) };
+  }
+
   async updateFeedbackStatus(
     feedbackId: number,
     agentId: string,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1314,7 +1314,8 @@ export class AgentManager {
 
   async listFeedbackByParentGrouped(
     parentAgentId: string,
-    persona?: string
+    persona?: string,
+    limit = 100
   ): Promise<{ personas: Array<{ persona: string; agentId: string; feedback: FeedbackRecord[] }> }> {
     const params: unknown[] = [parentAgentId];
     let whereClause = "WHERE a.parent_agent_id = $1";
@@ -1322,6 +1323,7 @@ export class AgentManager {
       params.push(persona);
       whereClause += ` AND a.persona = $${params.length}`;
     }
+    params.push(limit);
 
     const result = await this.pool.query<FeedbackRecord & { persona: string }>(
       `SELECT f.id, f.agent_id AS "agentId", a.persona, f.severity, f.file_path AS "filePath", f.line_number AS "lineNumber",
@@ -1329,7 +1331,8 @@ export class AgentManager {
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
        ${whereClause}
-       ORDER BY a.persona, f.created_at ASC`,
+       ORDER BY a.persona, f.created_at ASC
+       LIMIT $${params.length}`,
       params
     );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -907,6 +907,7 @@ async function registerRoutes() {
       shareMedia: mcpShareMedia,
       submitFeedback: mcpSubmitFeedback,
       launchPersona: mcpLaunchPersona,
+      getFeedback: mcpGetFeedback,
     });
   });
 
@@ -3325,6 +3326,13 @@ async function mcpSubmitFeedback(
   const record = await agentManager.submitFeedback(agentId, feedback);
   uiEventBroker.publish({ type: "feedback.created", agentId, feedback: record });
   return record;
+}
+
+async function mcpGetFeedback(
+  agentId: string,
+  opts: { persona?: string }
+) {
+  return agentManager.listFeedbackByParentGrouped(agentId, opts.persona);
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3330,9 +3330,9 @@ async function mcpSubmitFeedback(
 
 async function mcpGetFeedback(
   agentId: string,
-  opts: { persona?: string }
+  opts: { persona?: string; limit?: number }
 ) {
-  return agentManager.listFeedbackByParentGrouped(agentId, opts.persona);
+  return agentManager.listFeedbackByParentGrouped(agentId, opts.persona, opts.limit);
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -506,4 +506,111 @@ describe("AgentManager", () => {
       }
     });
   });
+
+  describe("listFeedbackByParentGrouped", () => {
+    it("should only return feedback from the requested parent's children", async () => {
+      // Create two parent agents
+      const parentA = await manager.createAgent({ name: "parent-a", cwd: "/tmp", useWorktree: false });
+      const parentB = await manager.createAgent({ name: "parent-b", cwd: "/tmp", useWorktree: false });
+
+      // Create persona children for each parent
+      const childA = await manager.createAgent({
+        name: "child-a",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parentA.id,
+      });
+      const childB = await manager.createAgent({
+        name: "child-b",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "ux-review",
+        parentAgentId: parentB.id,
+      });
+
+      // Submit feedback from both children
+      await manager.submitFeedback(childA.id, {
+        severity: "high",
+        description: "SQL injection in login handler",
+        filePath: "src/auth.ts",
+        lineNumber: 42,
+      });
+      await manager.submitFeedback(childB.id, {
+        severity: "low",
+        description: "Button color contrast",
+        filePath: "src/button.tsx",
+      });
+
+      // Parent A should only see child A's feedback
+      const resultA = await manager.listFeedbackByParentGrouped(parentA.id);
+      expect(resultA.personas).toHaveLength(1);
+      expect(resultA.personas[0].persona).toBe("security-review");
+      expect(resultA.personas[0].agentId).toBe(childA.id);
+      expect(resultA.personas[0].feedback).toHaveLength(1);
+      expect(resultA.personas[0].feedback[0].description).toBe("SQL injection in login handler");
+
+      // Parent B should only see child B's feedback
+      const resultB = await manager.listFeedbackByParentGrouped(parentB.id);
+      expect(resultB.personas).toHaveLength(1);
+      expect(resultB.personas[0].persona).toBe("ux-review");
+      expect(resultB.personas[0].agentId).toBe(childB.id);
+      expect(resultB.personas[0].feedback).toHaveLength(1);
+      expect(resultB.personas[0].feedback[0].description).toBe("Button color contrast");
+    });
+
+    it("should return empty personas array when agent has no children", async () => {
+      const parent = await manager.createAgent({ name: "lonely-parent", cwd: "/tmp", useWorktree: false });
+
+      const result = await manager.listFeedbackByParentGrouped(parent.id);
+      expect(result.personas).toHaveLength(0);
+    });
+
+    it("should filter by persona name", async () => {
+      const parent = await manager.createAgent({ name: "multi-parent", cwd: "/tmp", useWorktree: false });
+
+      const secChild = await manager.createAgent({
+        name: "sec-child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parent.id,
+      });
+      const uxChild = await manager.createAgent({
+        name: "ux-child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "ux-review",
+        parentAgentId: parent.id,
+      });
+
+      await manager.submitFeedback(secChild.id, { description: "sec finding" });
+      await manager.submitFeedback(uxChild.id, { description: "ux finding" });
+
+      const filtered = await manager.listFeedbackByParentGrouped(parent.id, "security-review");
+      expect(filtered.personas).toHaveLength(1);
+      expect(filtered.personas[0].persona).toBe("security-review");
+      expect(filtered.personas[0].feedback[0].description).toBe("sec finding");
+    });
+
+    it("should group multiple feedback items under the same persona", async () => {
+      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const child = await manager.createAgent({
+        name: "child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parent.id,
+      });
+
+      await manager.submitFeedback(child.id, { severity: "critical", description: "finding 1" });
+      await manager.submitFeedback(child.id, { severity: "low", description: "finding 2" });
+
+      const result = await manager.listFeedbackByParentGrouped(parent.id);
+      expect(result.personas).toHaveLength(1);
+      expect(result.personas[0].feedback).toHaveLength(2);
+      expect(result.personas[0].feedback[0].description).toBe("finding 1");
+      expect(result.personas[0].feedback[1].description).toBe("finding 2");
+    });
+  });
 });

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -81,7 +81,7 @@ export type McpRequestContext = {
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
   getFeedback?: (
     agentId: string,
-    opts: { persona?: string }
+    opts: { persona?: string; limit?: number }
   ) => Promise<GetFeedbackResult>;
 };
 
@@ -518,12 +518,19 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           persona: z
             .string()
             .optional()
-            .describe("Filter to a specific persona by name. If omitted, returns feedback from all child personas.")
+            .describe("Filter to a specific persona by name. If omitted, returns feedback from all child personas."),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(100)
+            .default(100)
+            .describe("Maximum number of feedback items to return. Defaults and caps at 100.")
         }
       },
       async (args) => {
         try {
-          const result = await getFeedback(agentId, { persona: args.persona });
+          const result = await getFeedback(agentId, { persona: args.persona, limit: args.limit });
           const totalItems = result.personas.reduce((sum, p) => sum + p.feedback.length, 0);
           const summary = result.personas.length === 0
             ? "No persona feedback found."

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -37,6 +37,28 @@ export type FeedbackInput = {
   mediaRef?: string;
 };
 
+export type FeedbackItem = {
+  id: number;
+  severity: string;
+  description: string;
+  filePath: string | null;
+  lineNumber: number | null;
+  suggestion: string | null;
+  mediaRef: string | null;
+  status: string;
+  createdAt: string;
+};
+
+export type PersonaFeedbackGroup = {
+  persona: string;
+  agentId: string;
+  feedback: FeedbackItem[];
+};
+
+export type GetFeedbackResult = {
+  personas: PersonaFeedbackGroup[];
+};
+
 export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
@@ -57,6 +79,10 @@ export type McpRequestContext = {
     agentId: string,
     opts: { persona: string; context: string }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
+  getFeedback?: (
+    agentId: string,
+    opts: { persona?: string }
+  ) => Promise<GetFeedbackResult>;
 };
 
 export async function handleMcpRequest(
@@ -471,6 +497,40 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
                 text: `Launched persona "${result.persona}" as agent ${result.agentId}.`
               }
             ]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.getFeedback) {
+    const agentId = context.agent.id;
+    const getFeedback = context.getFeedback;
+
+    server.registerTool(
+      "dispatch_get_feedback",
+      {
+        description:
+          "Retrieve structured feedback submitted by persona agents you launched. Returns feedback grouped by persona. Only returns feedback from your direct child persona agents.",
+        inputSchema: {
+          persona: z
+            .string()
+            .optional()
+            .describe("Filter to a specific persona by name. If omitted, returns feedback from all child personas.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await getFeedback(agentId, { persona: args.persona });
+          const totalItems = result.personas.reduce((sum, p) => sum + p.feedback.length, 0);
+          const summary = result.personas.length === 0
+            ? "No persona feedback found."
+            : `Found ${totalItems} feedback item(s) from ${result.personas.length} persona(s).`;
+          return {
+            content: [{ type: "text", text: summary }],
+            structuredContent: result
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary
- Adds `dispatch_get_feedback` MCP tool that lets parent agents retrieve structured feedback submitted by their child persona agents
- Feedback is returned grouped by persona, with optional filtering by persona name
- Scoped to only return feedback from direct children of the calling agent (enforced via `parent_agent_id` join)

## Changes
- `packages/shared/src/mcp/server.ts` — New types (`FeedbackItem`, `PersonaFeedbackGroup`, `GetFeedbackResult`), `getFeedback` context callback, and `dispatch_get_feedback` tool registration
- `apps/server/src/agents/manager.ts` — New `listFeedbackByParentGrouped()` method that queries feedback joined with agents table, groups by persona
- `apps/server/src/server.ts` — `mcpGetFeedback` callback wired into MCP context

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Unit tests pass (87/87)
- [x] E2E tests pass (77/77, 6 pre-existing skips)

Closes CRU-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)