### PR TITLE
Fix feedback sheet hidden behind mobile slide panel

### DIFF
--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -407,7 +407,7 @@ export function ParentFeedbackPanel({
 
       {/* Full feedback detail sheet */}
       <Sheet open={!!sheetItem} onOpenChange={(open) => { if (!open) setSheetItemId(null); }}>
-        <SheetContent side="bottom" hideCloseButton className="relative flex min-h-[40vh] max-h-[80vh] flex-col overflow-hidden px-6 py-5">
+        <SheetContent side="bottom" hideCloseButton overlayClassName="z-[70]" className="z-[70] flex min-h-[40vh] max-h-[80vh] flex-col overflow-hidden px-6 py-5">
           {sheetItem ? (
             <>
               {/* Nav + close in one container so they share alignment */}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -45,14 +45,15 @@ interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
     VariantProps<typeof sheetVariants> {
   hideCloseButton?: boolean;
+  overlayClassName?: string;
 }
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, hideCloseButton = false, ...props }, ref) => (
+>(({ side = "right", className, children, hideCloseButton = false, overlayClassName, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    <SheetOverlay className={overlayClassName} />
     <DialogPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
       {!hideCloseButton ? (


### PR DESCRIPTION
## Summary
- PR #177 added `relative` to the feedback `SheetContent` className, which via tailwind-merge overrode the `fixed` positioning from `sheetVariants` — causing the sheet to render in normal flow instead of fixed to the viewport
- The sheet's `z-50` was also below the `MobileSlidePanel`'s `z-[60]`, so even when positioned correctly, it rendered behind the mobile sidebar
- Fix: remove `relative` (unnecessary since `fixed` already creates a containing block for absolute children) and bump overlay + content to `z-[70]` via a new `overlayClassName` prop on `SheetContent`

## Test plan
- [x] Verified feedback sheet renders correctly on mobile (390x844) inside MobileSlidePanel
- [x] Verified feedback sheet renders correctly on desktop (1280x800) 
- [x] `pnpm run finalize:web` passes (type check + production build)
- [x] All 77 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)