### PR TITLE
Comprehensive documentation update

### DIFF
--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -1,11 +1,22 @@
 import { useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ArrowLeft, ChevronRight, GitBranch, Monitor, PlugZap, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Bell,
+  ChevronRight,
+  GitBranch,
+  Image,
+  Monitor,
+  PlugZap,
+  Signal,
+  Users,
+  X,
+} from "lucide-react";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
-type DocsSection = "agents" | "tools" | "worktrees";
+type DocsSection = "agents" | "tools" | "worktrees" | "personas" | "events" | "media" | "notifications";
 
 type DocsPaneProps = {
   open: boolean;
@@ -59,23 +70,48 @@ const SECTIONS: SectionDef[] = [
         <Section>
           <H3>Creating an agent</H3>
           <P>
-            Click <strong>Create</strong> in the sidebar. Pick a name, choose
-            the CLI (<Code>claude</Code>, <Code>codex</Code>,
-            or <Code>opencode</Code>), and set the working directory to your
-            repo. The working directory determines which repo tools and
-            instruction files the agent loads.
+            Click <strong>Create</strong> in the sidebar (or use the dropdown
+            arrow to pick a specific agent type). Fill in the create form:
+          </P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li><strong>Type</strong> — choose the CLI: <Code>claude</Code>, <Code>codex</Code>, or <Code>opencode</Code>. Disabled types can be enabled in Settings.</li>
+            <li><strong>Name</strong> — optional display name for the agent.</li>
+            <li><strong>Working directory</strong> — path to the repo. Autocompletes as you type and validates that the directory exists. Recent directories are saved for quick selection.</li>
+            <li><strong>Create git worktree</strong> — checked by default. Creates an isolated worktree so the agent works on its own branch without touching your primary checkout. When enabled, you can pick a base branch and optionally set a custom branch name.</li>
+            <li><strong>Full access mode</strong> — starts the CLI in its most permissive execution mode, so the agent can run commands and edit files without confirmation prompts.</li>
+          </ul>
+        </Section>
+
+        <Section>
+          <H3>Setup phases</H3>
+          <P>
+            After creating an agent, the sidebar shows a progress indicator
+            as it moves through setup: creating the worktree, copying
+            environment files, installing dependencies, and starting the
+            session. Once setup completes the agent transitions
+            to <strong>running</strong>.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Status indicators</H3>
+          <P>
+            Each agent in the sidebar shows a color-coded status from its
+            latest event: blue for <strong>working</strong>, red
+            for <strong>blocked</strong>, yellow
+            for <strong>waiting</strong>, and green
+            for <strong>done</strong>. The sidebar also shows the event
+            message and how long ago it was reported.
           </P>
         </Section>
 
         <Section>
           <H3>Starting and stopping</H3>
           <P>
-            Press <strong>Start</strong> to launch the agent in
-            a <Code>tmux</Code> session on the server.
-            Press <strong>Stop</strong> to terminate it. You can also
-            use <strong>Attach</strong> to reconnect to a session that's
-            already running, or <strong>Detach</strong> to disconnect your
-            terminal without stopping the agent.
+            Press the play button to resume a stopped agent. Press the
+            stop button to terminate it. Click an agent's name to attach
+            your terminal to its session, or click again to detach without
+            stopping.
           </P>
         </Section>
 
@@ -84,18 +120,28 @@ const SECTIONS: SectionDef[] = [
           <P>
             The agent runs inside <Code>tmux</Code>, independent of your
             browser. Closing the tab just detaches your terminal view — the
-            agent keeps working. Open Dispatch again and attach to pick up
-            where you left off.
+            agent keeps working. Open Dispatch again and click the agent to
+            pick up where you left off.
           </P>
         </Section>
 
         <Section>
-          <H3>Full access mode</H3>
+          <H3>Agent details</H3>
           <P>
-            When creating an agent, you can enable <strong>full access
-            mode</strong>. This starts the CLI in its most permissive
-            execution mode, so the agent can run commands and edit files
-            without confirmation prompts.
+            Expand an agent card to see its metadata: working directory or
+            worktree path, git branch, agent type, and whether it's running
+            in full access or sandboxed mode. Persona agents show their
+            role and link to their parent agent.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Archiving agents</H3>
+          <P>
+            Click the archive button to remove an agent. If the agent has a
+            worktree with unmerged commits or uncommitted changes, you'll be
+            asked whether to keep or remove the worktree. Archived agents
+            are preserved in the History section of the Activity page.
           </P>
         </Section>
       </>
@@ -201,15 +247,39 @@ const SECTIONS: SectionDef[] = [
             <li><Code>enable_pr_automerge</Code> — auto-merge a PR when checks pass</li>
             <li><Code>dispatch_event</Code> — report agent status (working, blocked, done)</li>
             <li><Code>dispatch_share</Code> — publish a screenshot or image to the session's media stream</li>
+            <li><Code>dispatch_feedback</Code> — submit a structured finding with severity, file reference, and suggestion</li>
+            <li><Code>dispatch_get_feedback</Code> — retrieve feedback findings for the current session</li>
+            <li><Code>dispatch_launch_persona</Code> — launch a persona agent as a child of the current session</li>
           </ul>
+        </Section>
+
+        <Section>
+          <H3>Lifecycle hooks</H3>
+          <P>
+            Repos can define lifecycle hooks
+            in <Code>.dispatch/tools.json</Code> that run automatically at key
+            moments. Currently the <Code>stop</Code> hook is supported — it runs
+            when an agent is stopped or terminated, useful for teardown tasks
+            like shutting down dev servers.
+          </P>
+          <CodeBlock>{`
+{
+  "hooks": {
+    "stop": {
+      "command": ["./bin/cleanup.sh"],
+      "description": "Tear down the agent's dev environment on stop."
+    }
+  }
+}`}</CodeBlock>
         </Section>
 
         <Section>
           <H3>Environment</H3>
           <P>
-            Repo tool commands receive <Code>DISPATCH_AGENT_ID</Code> in their
-            environment, so scripts can scope resources (databases, temp
-            directories, ports) per agent.
+            Repo tool commands and hooks
+            receive <Code>DISPATCH_AGENT_ID</Code> in their environment, so
+            scripts can scope resources (databases, temp directories, ports) per
+            agent.
           </P>
         </Section>
       </>
@@ -223,44 +293,289 @@ const SECTIONS: SectionDef[] = [
     content: (
       <>
         <P>
-          Agents can use git worktrees to work on changes in isolation without
-          affecting the main checkout. This is useful for parallel tasks or
-          keeping exploratory work separate.
+          Git worktrees let agents work on changes in isolation without
+          touching the main checkout. Each agent gets its own branch and
+          directory — ideal for parallel tasks or keeping exploratory work
+          separate.
         </P>
 
         <Section>
-          <H3>Creating a worktree</H3>
+          <H3>Automatic worktree creation</H3>
           <P>
-            Agents call the built-in <Code>create_worktree</Code> tool. It
-            creates a new branch and a linked worktree directory, then the
-            agent <Code>cd</Code>s into it.
+            When creating an agent, the <strong>Create git worktree</strong>{" "}
+            checkbox is enabled by default. Dispatch creates a new branch
+            and linked worktree directory, copies environment files
+            (like <Code>.env</Code>), and starts the agent inside it. You
+            can choose a base branch and optionally set a custom branch name
+            in the create dialog.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>On-demand worktrees</H3>
+          <P>
+            Agents can also create worktrees during a session by calling
+            the <Code>create_worktree</Code> tool. This is useful when an
+            agent decides mid-task that it needs isolation.
           </P>
           <CodeBlock>{`
-# What the agent does behind the scenes:
+# What happens behind the scenes:
 git worktree add -b fix-auth ../project-fix-auth main
 cd ../project-fix-auth`}</CodeBlock>
+        </Section>
+
+        <Section>
+          <H3>Worktree location</H3>
           <P>
-            The worktree is a full copy of the repo on its own branch. The
-            agent can make commits, run tests, and open PRs from there without
-            touching the primary checkout.
+            By default, worktrees are created inside the repo
+            at <Code>.dispatch/worktrees/</Code>. You can change this
+            in <strong>Settings</strong> to place them next to the repo
+            instead (as siblings). This is useful if your tooling doesn't
+            work well with nested worktrees.
           </P>
         </Section>
 
         <Section>
           <H3>Cleaning up</H3>
           <P>
-            When the work is done, the agent
-            calls <Code>cleanup_worktree</Code> to remove the linked directory
-            and optionally delete the branch.
+            When archiving an agent with a worktree, Dispatch checks for
+            unmerged commits and uncommitted changes. If the worktree is
+            clean, it's removed automatically. If there are outstanding
+            changes, you're asked whether to keep the worktree for manual
+            review or remove it. Agents can also
+            call <Code>cleanup_worktree</Code> directly to remove a
+            worktree during a session.
           </P>
         </Section>
 
         <Section>
           <H3>Parallel agents</H3>
           <P>
-            Multiple agents can work in the same repo simultaneously by using
-            separate worktrees. Each agent operates on its own branch and
-            directory, so there are no conflicts between concurrent sessions.
+            Multiple agents can work in the same repo simultaneously. Each
+            uses its own worktree with a separate branch and directory, so
+            there are no conflicts between concurrent sessions.
+          </P>
+        </Section>
+      </>
+    ),
+  },
+  {
+    id: "personas",
+    label: "Personas",
+    icon: Users,
+    title: "Personas",
+    content: (
+      <>
+        <P>
+          Personas are reusable agent roles defined per repository. Each
+          persona reviews work from a specific perspective — for example,
+          security, UX, or architecture. A persona agent runs as a child of
+          the agent that launched it and submits structured feedback.
+        </P>
+
+        <Section>
+          <H3>How personas work</H3>
+          <P>
+            An agent calls the built-in <Code>dispatch_launch_persona</Code>{" "}
+            tool, passing the persona name and a context briefing. Dispatch
+            loads the persona definition from the repo, spawns a new child
+            agent with the persona's instructions and a diff of the current
+            branch, and the child reviews the work and submits findings
+            via <Code>dispatch_feedback</Code>.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Defining personas</H3>
+          <P>
+            Each repo defines its own personas as markdown files
+            in <Code>.dispatch/personas/</Code>. The filename (without
+            extension) becomes the persona slug used when launching. Files
+            use YAML frontmatter for metadata and the body contains
+            instructions with <Code>{"{{context}}"}</Code>{" "}
+            and <Code>{"{{diff}}"}</Code> placeholders that Dispatch fills
+            in at launch time.
+          </P>
+          <CodeBlock>{`
+# .dispatch/personas/security-review.md
+---
+name: Security Review
+description: Reviews code for security vulnerabilities
+feedbackFormat: findings
+---
+
+You are a security reviewer. Analyze the following changes
+for vulnerabilities, injection risks, and auth issues.
+
+## Context
+{{context}}
+
+## Diff
+{{diff}}`}</CodeBlock>
+          <P>
+            The <Code>name</Code> and <Code>description</Code> fields are
+            shown in the persona picker UI. The <Code>feedbackFormat</Code>{" "}
+            field is optional and defaults to <Code>findings</Code>.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Feedback findings</H3>
+          <P>
+            Persona agents submit findings with
+            the <Code>dispatch_feedback</Code> tool. Each finding includes a
+            severity (<Code>critical</Code>, <Code>high</Code>,{" "}
+            <Code>medium</Code>, <Code>low</Code>, <Code>info</Code>),
+            a description, and optionally a file path, line number, and
+            suggested fix. Findings appear in the Feedback panel where you can
+            review and resolve them.
+          </P>
+        </Section>
+      </>
+    ),
+  },
+  {
+    id: "events",
+    label: "Status Events",
+    icon: Signal,
+    title: "Status Events",
+    content: (
+      <>
+        <P>
+          Agents report their status throughout a task using
+          the <Code>dispatch_event</Code> tool. These events drive the status
+          indicators in the sidebar and enable Slack notifications.
+        </P>
+
+        <Section>
+          <H3>Event types</H3>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li><Code>working</Code> — actively making progress (reading files, writing code, running tests)</li>
+            <li><Code>blocked</Code> — hit an error or obstacle that needs resolution</li>
+            <li><Code>waiting_user</Code> — needs a decision or approval before continuing</li>
+            <li><Code>done</Code> — task is complete</li>
+            <li><Code>idle</Code> — no meaningful action was taken (e.g. answered an informational question)</li>
+          </ul>
+        </Section>
+
+        <Section>
+          <H3>How events are used</H3>
+          <P>
+            The agent sidebar shows the latest event message and a color-coded
+            status indicator for each agent. Events are also stored in the
+            database for activity tracking — the Activity page uses them
+            to build heatmaps, working-time breakdowns, and daily status charts.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Configuring agent instructions</H3>
+          <P>
+            To get agents to report events, add instructions to your
+            repo's <Code>CLAUDE.md</Code> (or equivalent config) telling the
+            agent to call <Code>dispatch_event</Code> at key checkpoints:
+            start of turn, phase transitions, errors, and before the final
+            response.
+          </P>
+        </Section>
+      </>
+    ),
+  },
+  {
+    id: "media",
+    label: "Media",
+    icon: Image,
+    title: "Media & Sharing",
+    content: (
+      <>
+        <P>
+          Agents can capture and share screenshots, images, and text files
+          during a session. Shared media appears in the Media sidebar for
+          review.
+        </P>
+
+        <Section>
+          <H3>Sharing media</H3>
+          <P>
+            Agents call the <Code>dispatch_share</Code> tool to publish media.
+            It accepts a file path or raw text content, along with a
+            description. Supported formats include PNG, JPG, GIF, WebP
+            images, MP4 video, and text files.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Simulator screenshots</H3>
+          <P>
+            When <Code>dispatch_share</Code> is called
+            with <Code>source: "simulator"</Code>, it automatically captures
+            a screenshot from the iOS Simulator using <Code>xcrun simctl</Code>.
+            This is useful for agents validating mobile UI changes.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Screen streaming</H3>
+          <P>
+            Agents running Playwright can stream their browser session live.
+            The stream appears in the media sidebar as a real-time MJPEG feed
+            via Chrome DevTools Protocol. When the stream ends, the last frame
+            is saved as a screenshot.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Media sidebar</H3>
+          <P>
+            Click any agent's media count badge to open the sidebar. Media
+            items are shown in reverse chronological order. Click an item
+            to open the full-screen lightbox. New items since your last
+            visit are marked with a badge.
+          </P>
+        </Section>
+      </>
+    ),
+  },
+  {
+    id: "notifications",
+    label: "Notifications",
+    icon: Bell,
+    title: "Notifications",
+    content: (
+      <>
+        <P>
+          Dispatch can send Slack notifications when agents need attention or
+          finish their work, so you don't have to watch the dashboard.
+        </P>
+
+        <Section>
+          <H3>Setting up Slack</H3>
+          <P>
+            Go to <strong>Settings → Notifications</strong> and paste a Slack
+            incoming webhook URL. Use the <strong>Send test</strong> button to
+            verify the integration works.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Configurable events</H3>
+          <P>
+            You can choose which agent events trigger a notification:
+          </P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li><Code>done</Code> — agent finished its task</li>
+            <li><Code>waiting_user</Code> — agent needs your input</li>
+            <li><Code>blocked</Code> — agent hit an error it can't resolve</li>
+          </ul>
+        </Section>
+
+        <Section>
+          <H3>Focus-aware suppression</H3>
+          <P>
+            Dispatch tracks whether you're actively viewing an agent. If you
+            have the agent's terminal open, notifications for that agent are
+            suppressed — you'll only get notified for agents you're not
+            watching.
           </P>
         </Section>
       </>

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -1,134 +1,301 @@
-# API Specification (MVP)
+# API Specification
 
 ## Conventions
 
-- Base path: `/api/v1`
-- Auth: bearer token header (MVP) or Tailscale IP allowlist + token
-- Response: JSON unless binary image endpoint
+- Base path: `/api/v1` (except MCP endpoints which use `/api/mcp`)
+- Auth: cookie-based session after password login
+- Response format: JSON unless noted otherwise
+- Real-time: Server-Sent Events (SSE) for live updates
 
 ## Agent Model
 
 ```json
 {
-  "id": "agt_01J...",
-  "name": "ios-fix-1",
+  "id": "agt_01abc2def345",
+  "name": "fix-auth-bug",
   "status": "running",
-  "cwd": "/Users/bharris/dev/apps/foo",
-  "tmuxSession": "dispatch_agt_01J...",
-  "pid": 12345,
-  "simulatorUdid": "A1B2C3...",
+  "type": "claude",
+  "cwd": "/Users/brad/dev/apps/myproject",
+  "effectiveCwd": "/Users/brad/dev/apps/myproject/.dispatch/worktrees/fix-auth-bug",
+  "tmuxSession": "dispatch_agt_01abc2def345",
+  "fullAccess": true,
+  "setupPhase": null,
+  "latestEvent": { "type": "working", "message": "Running tests" },
+  "parentAgentId": null,
+  "persona": null,
+  "worktreePath": "/Users/brad/dev/apps/myproject/.dispatch/worktrees/fix-auth-bug",
+  "worktreeBranch": "fix-auth-bug",
   "createdAt": "2026-03-07T19:20:00Z",
   "updatedAt": "2026-03-07T19:22:00Z"
 }
 ```
 
-## Endpoints
+## Authentication
 
-### `POST /agents`
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auth/status` | Check auth state and whether password is configured |
+| POST | `/auth/setup` | Set initial password (first-run only) |
+| POST | `/auth/login` | Authenticate and create session cookie |
+| POST | `/auth/logout` | Invalidate session |
+| POST | `/auth/change-password` | Change password (requires valid session) |
 
-Create a new agent.
+## Agent Lifecycle
 
-Request body:
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/agents` | List all active agents |
+| GET | `/agents/:id` | Get agent details |
+| POST | `/agents` | Create new agent |
+| POST | `/agents/:id/start` | Start a stopped agent |
+| POST | `/agents/:id/stop` | Stop a running agent |
+| DELETE | `/agents/:id` | Delete agent (soft delete) |
 
-```json
-{
-  "name": "ios-fix-1",
-  "cwd": "/Users/bharris/dev/apps/foo",
-  "codexArgs": [],
-  "allocateSimulator": true
-}
-```
-
-Response `201`:
-
-```json
-{
-  "agent": { "...": "..." }
-}
-```
-
-### `GET /agents`
-
-List all agents.
-
-Response `200`:
+### `POST /agents` — Create Agent
 
 ```json
 {
-  "agents": []
+  "cwd": "/path/to/repo",
+  "name": "fix-auth-bug",
+  "type": "claude",
+  "fullAccess": true,
+  "agentArgs": ["--model", "opus"],
+  "useWorktree": true,
+  "worktreeBranch": "fix-auth-bug",
+  "baseBranch": "main"
 }
 ```
 
-### `GET /agents/:id`
+For persona agents (launched via `dispatch_launch_persona`):
 
-Get one agent.
-
-### `POST /agents/:id/start`
-
-Start stopped agent (recreate tmux session and process if absent).
+```json
+{
+  "cwd": "/path/to/repo",
+  "type": "claude",
+  "persona": "backend-security-review",
+  "parentAgentId": "agt_01abc2def345",
+  "personaContext": "Review the auth middleware changes..."
+}
+```
 
 ### `POST /agents/:id/stop`
 
-Stop running agent.
-
-Request body:
-
 ```json
-{
-  "force": false,
-  "releaseSimulator": true
-}
+{ "force": false }
 ```
 
 ### `DELETE /agents/:id`
 
-Delete agent metadata (only when stopped unless `force=true`).
+Query params: `force=true`, `cleanupWorktree=true`
 
-### `POST /agents/:id/terminal/token`
+## Agent Setup
 
-Issue short-lived token for terminal websocket session.
+Used during agent initialization to track setup progress.
 
-Response:
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agents/:id/setup/phase` | Report setup phase (`worktree` → `env` → `deps` → `session`) |
+| POST | `/agents/:id/setup/complete` | Mark setup complete with resolved paths |
+
+### `POST /agents/:id/setup/complete`
 
 ```json
 {
-  "wsUrl": "/api/v1/agents/agt_01J/terminal/ws?token=..."
+  "effectiveCwd": "/resolved/working/directory",
+  "worktreePath": "/path/to/worktree",
+  "worktreeBranch": "branch-name"
 }
 ```
 
-### `GET /agents/:id/screenshot`
+## Agent Events & State
 
-Return latest screenshot as `image/png`.
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agents/:id/latest-event` | Update agent's latest status event |
+| POST | `/focus` | Track which agent the user is viewing |
+| GET | `/events` | SSE stream of real-time UI events |
+| GET | `/agents/git-context` | Get git context for agents (filtered by `ids` query param) |
+| GET | `/agents/:id/worktree-status` | Check worktree for unmerged commits and uncommitted changes |
 
-Query params:
+### `POST /agents/:id/latest-event`
 
-- `fresh=true|false` (if true, capture now; else return cached last screenshot if available)
+```json
+{
+  "type": "working",
+  "message": "Running E2E tests",
+  "metadata": {}
+}
+```
 
-### `GET /simulators`
+Event types: `working`, `blocked`, `waiting_user`, `done`, `idle`
 
-List available simulators and reservation status.
+### `GET /events` (SSE)
 
-### `POST /agents/:id/simulator/reassign`
+Server-Sent Events stream. Events include agent state changes, media uploads, and stream updates. Used by the frontend for real-time UI updates.
 
-Reassign simulator.
+## Terminal
 
-## WebSocket
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agents/:id/terminal/token` | Issue short-lived terminal access token |
+| WS | `/agents/:id/terminal/ws?token=...` | WebSocket for interactive terminal I/O |
 
-### `WS /agents/:id/terminal/ws?token=...`
+The WebSocket provides bidirectional terminal I/O with resize support, bridging to the agent's tmux session.
 
-- Bi-directional terminal I/O stream.
-- Server handles tmux attach bridge.
-- Heartbeat/ping every 20s.
+## Media
 
-### `WS /agents/:id/media/ws` (optional in phase 2)
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/agents/:id/media` | List media files with seen/unseen status |
+| GET | `/agents/:id/media/:file` | Download a media file |
+| POST | `/agents/:id/media` | Upload media (multipart form: file + description) |
+| POST | `/agents/:id/media/seen` | Mark media files as seen |
 
-- Push screenshot update metadata or stream frames.
+## Streaming
+
+Live Playwright browser streaming via Chrome DevTools Protocol.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agents/:id/stream` | Start or stop a screen stream |
+| GET | `/agents/:id/stream` | MJPEG stream (`multipart/x-mixed-replace`) |
+| GET | `/agents/:id/stream/viewer` | HTML viewer page for the live stream |
+
+## Personas
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/personas` | List available personas (reads from `.dispatch/personas/` in the repo at `cwd`) |
+
+Query params: `cwd=/path/to/repo`
+
+## Feedback
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/agents/:id/feedback` | Get feedback findings for an agent |
+| PATCH | `/agents/:id/feedback/:feedbackId` | Update feedback status |
+
+### `GET /agents/:id/feedback`
+
+Query params: `scope=children` to include feedback from child persona agents.
+
+### `PATCH /agents/:id/feedback/:feedbackId`
+
+```json
+{ "status": "fixed" }
+```
+
+Status values: `open`, `dismissed`, `forwarded`, `fixed`, `ignored`
+
+## Activity & Analytics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/activity/heatmap` | Activity heatmap data (configurable `days`, `timezone`) |
+| GET | `/activity/stats` | Aggregate stats (working/blocked/waiting time, busiest day) |
+| GET | `/activity/daily-status` | Daily status breakdown |
+| GET | `/activity/active-hours` | Events marked as working/blocked/waiting_user |
+| GET | `/activity/agents-created` | Agent creation counts over time |
+| GET | `/activity/working-time-by-project` | Working time by project directory |
+
+## Token Usage
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/activity/token-stats` | Total token usage (input, output, cache creation, cache reads) |
+| GET | `/activity/token-daily` | Daily token usage breakdown |
+| GET | `/activity/token-by-project` | Token usage by project (top 20) |
+| GET | `/activity/token-by-model` | Token usage by model |
+| POST | `/agents/:id/harvest-tokens` | Harvest token usage from an agent's session |
+
+All token endpoints accept `days` and `timezone` query params.
+
+## History
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/history/projects` | List all projects where agents have worked |
+| GET | `/history/agents` | Paginated agent history with filtering and sorting |
+| GET | `/history/agents/:id` | Detailed agent history including events, tokens, and media |
+
+### `GET /history/agents`
+
+Query params: `project`, `type`, `sort` (`recent` | `oldest`), `limit`, `offset`
+
+## Notifications
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/notifications/settings` | Get Slack webhook URL and enabled event types |
+| POST | `/notifications/settings` | Update webhook URL and event configuration |
+| POST | `/notifications/test` | Send a test message to the configured webhook |
+
+### `POST /notifications/settings`
+
+```json
+{
+  "slackWebhookUrl": "https://hooks.slack.com/services/...",
+  "events": {
+    "done": true,
+    "waiting_user": true,
+    "blocked": false
+  }
+}
+```
+
+## Settings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/agents/settings` | Get agent settings (worktree location) |
+| POST | `/agents/settings` | Update agent settings |
+| GET | `/app/settings/agent-types` | Get enabled agent types |
+| POST | `/app/settings/agent-types` | Set enabled agent types (`claude`, `codex`, `opencode`) |
+
+## System
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Database connectivity check |
+| GET | `/app/version` | Current app version |
+| GET | `/system/defaults` | System defaults (home directory) |
+| GET | `/system/path-info` | Path validation (exists, isDirectory, isGitRepo) |
+| GET | `/system/path-completions` | Directory path autocomplete |
+| GET | `/git/branches` | List remote branches for a repo |
+| POST | `/clipboard/image` | Write browser clipboard image to macOS pasteboard |
+| POST | `/energy-report` | Report PWA energy metrics |
+| GET | `/diagnostics/git-context` | Git context refresh diagnostics |
+
+## Release Management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/release/status` | Current deployed release tag and timestamp |
+| GET | `/release/info` | Latest available version and unreleased commits |
+| POST | `/release` | Trigger new release (`versionType`: major/minor/patch) |
+| POST | `/release/update` | Update to a specific release tag |
+| GET | `/release/stream` | SSE stream for release operation progress |
+| GET | `/app/version` | Current app version info |
+
+## MCP (Model Context Protocol)
+
+These endpoints use the `/api/mcp` base path (not `/api/v1`).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/mcp` | Handle global MCP requests |
+| POST | `/api/mcp/:agentId` | Handle agent-scoped MCP requests with repo context |
+
+Agent-scoped MCP loads repo tools from `.dispatch/tools.json` in the agent's working directory.
 
 ## Error Codes
 
-- `400` invalid request/body
-- `401` unauthenticated
-- `403` unauthorized
-- `404` agent/simulator not found
-- `409` lifecycle conflict (e.g., start running agent)
-- `500` internal runtime failure
+| Code | Meaning |
+|------|---------|
+| 400 | Invalid request body or parameters |
+| 401 | Not authenticated |
+| 403 | Unauthorized |
+| 404 | Agent or resource not found |
+| 409 | Lifecycle conflict (e.g., starting an already-running agent) |
+| 500 | Internal server error |

--- a/docs/08-current-state-handoff.md
+++ b/docs/08-current-state-handoff.md
@@ -1,162 +1,213 @@
-# Current State Handoff (March 2026)
+# Current State Handoff (April 2026)
 
-This doc is for a new agent picking up work on Dispatch. It describes what the tool currently is, how it runs, what is implemented vs planned, and where to make changes.
+This doc is for a new agent or contributor picking up work on Dispatch. It describes what the tool is, how it runs, what's implemented, and where to make changes.
 
 ## What Dispatch Is
 
-Dispatch is a local-first control plane for managing long-running coding agents on a Mac host.
+Dispatch is a local-first control plane for managing long-running coding agents on a Mac host. It provides a browser-based UI for agent control, terminal interaction, media sharing, activity analytics, and automated code review via personas.
 
-Core value today:
-- Start and manage multiple Codex agents backed by `tmux`.
-- Open a browser UI for agent control and terminal interaction.
-- Keep agent sessions alive when browser clients disconnect.
-- Let agents share high-quality screenshots into a media stream via `dispatch-share`.
+Core capabilities:
+- Start and manage multiple coding agents (Claude, Codex, OpenCode) backed by `tmux`.
+- Browser UI with real-time terminal access, media sharing, and activity dashboards.
+- Agent sessions persist across browser disconnects.
+- Git worktree isolation for parallel agent work.
+- MCP-based tooling with repo-specific custom tools.
+- Persona agents for automated code review with structured feedback.
+- Slack notifications with focus-aware suppression.
+- Token usage tracking and activity analytics.
 
-## Implementation Snapshot
+## Project Structure
 
-### Backend
-- Runtime: Node.js + TypeScript + Fastify.
-- Entry point: `/Users/brad/dev/apps/dispatch/src/server.ts`.
-- DB: PostgreSQL (Docker Compose), migrations in `/Users/brad/dev/apps/dispatch/src/db/migrate.ts`.
-- Process/runtime manager: `/Users/brad/dev/apps/dispatch/src/agents/manager.ts`.
-- Terminal bridge: WebSocket + `node-pty` attaching to `tmux`.
+```
+dispatch/                        # pnpm monorepo
+├── apps/
+│   ├── server/                  # Fastify API server (@dispatch/server)
+│   │   └── src/
+│   │       ├── server.ts        # All route registrations (71+ endpoints)
+│   │       ├── agents/          # Agent manager, lifecycle, token harvesting
+│   │       ├── db/              # PostgreSQL migrations and queries
+│   │       ├── notifications/   # Slack notifier
+│   │       ├── personas/        # Persona loader
+│   │       ├── streaming/       # CDP-based screen streaming
+│   │       └── terminal/        # tmux terminal bridge
+│   └── web/                     # Vite React frontend (@dispatch/web)
+│       └── src/
+│           ├── App.tsx          # Main app layout
+│           └── components/      # UI components (shadcn-based)
+├── packages/
+│   └── shared/                  # Shared code (@dispatch/shared)
+│       └── src/
+│           ├── git/             # Worktree operations
+│           ├── github/          # PR operations
+│           ├── mcp/             # MCP server, repo tools, built-in tools
+│           └── lib/             # run-command utility
+├── e2e/                         # Playwright E2E tests (15 spec files)
+├── bin/                         # CLI tools
+└── docs/                        # Documentation
+```
 
-### Frontend
-- React + Vite + Tailwind + shadcn-style components.
-- Source: `/Users/brad/dev/apps/dispatch/web`.
-- Main screen: collapsible left agent rail, center terminal, right media drawer (`Sheet`).
-- Terminal rendering: xterm.js.
+## Tech Stack
 
-### Static serving
-- Backend serves `web/dist` if built.
-- Falls back to legacy `public/` only if `web/dist` is missing.
+- **Runtime**: Node.js + TypeScript
+- **Backend**: Fastify
+- **Frontend**: React + Vite + Tailwind + shadcn/ui
+- **Database**: PostgreSQL (Docker Compose)
+- **Package manager**: pnpm (monorepo workspaces)
+- **Terminal**: xterm.js → WebSocket → tmux
+- **Testing**: Vitest (unit), Playwright (E2E)
 
-## Data and Services
+## Database Schema
 
-### Database schema in use
-`agents` table stores:
-- lifecycle status
-- `cwd`
-- `tmux_session`
-- `media_dir`
-- `codex_args`
-- `last_error`
-- optional `simulator_udid` (not fully wired yet)
+| Table | Purpose |
+|-------|---------|
+| `agents` | Agent records with status, paths, git context, setup phases, persona references |
+| `agent_events` | Status event log (working, blocked, waiting_user, done, idle) |
+| `agent_token_usage` | Token consumption per agent/session/model (input, output, cache) |
+| `agent_feedback` | Structured feedback findings with severity and file references |
+| `media` | Media file metadata (screenshots, videos, descriptions, source) |
+| `media_seen` | Tracks which media items have been viewed |
+| `sessions` | Authentication sessions with expiration |
+| `settings` | Key-value store for app settings |
 
-`simulator_reservations` table exists from migration, but simulator allocation service is not fully implemented.
+Migrations run automatically on API server start.
 
-### Docker-backed persistence
-- File: `/Users/brad/dev/apps/dispatch/docker-compose.yml`
-- Service: `postgres` (`postgres:17-alpine`)
-- Persistent volume: `dispatch_pgdata`
+## Agent Types
 
-## Current User Flow
+Three agent CLIs are supported, each configurable via Settings:
 
-1. Create agent from modal (`name`, absolute `cwd`).
-2. Dispatch creates DB record, starts `tmux` session, launches `codex`.
-3. UI selects agent and can attach terminal (or auto-attach after create/open).
-4. Terminal disconnect/reconnect does not kill agent because `tmux` persists.
-5. Agent shares media with:
-   - `dispatch-share <image-path> [name]`
-   - `dispatch-share --sim [udid] [name]`
-6. Media drawer shows files from that selected agent’s media directory.
-7. Stop sends Ctrl-C then kills tmux session if needed.
-8. Delete removes agent record (and can force-stop running session first).
+| Type | CLI | Description |
+|------|-----|-------------|
+| `claude` | Claude Code | Anthropic's coding agent |
+| `codex` | Codex | OpenAI's coding agent |
+| `opencode` | OpenCode | Open-source coding agent |
 
 ## Agent Runtime Contract
 
-- Session name format: `dispatch_<agent-id>`.
-- Agent ID format: `agt_<12 hex>`.
-- Each agent gets:
-  - `DISPATCH_AGENT_ID`
-  - `DISPATCH_MEDIA_DIR`
-  - typo-compat alias `DISPATCH_MDEIA_DIR`
-  - `PATH` including `DISPATCH_BIN_DIR` for `dispatch-share`.
-- Codex launch includes startup instructions telling agents:
-  - use `dispatch-share` for Playwright and iOS screenshots
-  - default Playwright to headless unless user asks for headed.
+- Session name format: `dispatch_<agent-id>`
+- Agent ID format: `agt_<12 hex>`
+- Each agent receives these environment variables:
+  - `DISPATCH_AGENT_ID` — unique agent identifier
+  - `DISPATCH_MEDIA_DIR` — directory for media files
+  - `PATH` — includes `DISPATCH_BIN_DIR` for CLI tools
+- Agents access MCP tools at `/api/mcp/:agentId`
 
-## API Surface Implemented
+## MCP Tools
 
-Implemented in `src/server.ts`:
-- `GET /api/v1/health`
-- `GET /api/v1/agents`
-- `GET /api/v1/agents/:id`
-- `POST /api/v1/agents`
-- `POST /api/v1/agents/:id/start`
-- `POST /api/v1/agents/:id/stop`
-- `DELETE /api/v1/agents/:id`
-- `GET /api/v1/agents/:id/media`
-- `GET /api/v1/agents/:id/media/:file`
-- `POST /api/v1/agents/:id/terminal/token`
-- `WS /api/v1/agents/:id/terminal/ws?token=...`
+### Built-in Tools (always available)
 
-Not yet implemented from older planning docs:
-- full simulator reservation/allocation workflow
-- dedicated screenshot endpoint like `/agents/:id/screenshot`
-- media websocket push stream (media is currently polled by UI)
+| Tool | Description |
+|------|-------------|
+| `create_worktree` | Create isolated git worktree |
+| `cleanup_worktree` | Remove worktree and optionally delete branch |
+| `create_pr` | Open GitHub pull request |
+| `get_pr_status` | Check PR CI status and reviews |
+| `merge_pr_now` | Merge a pull request |
+| `enable_pr_automerge` | Auto-merge when checks pass |
+| `dispatch_event` | Report agent status |
+| `dispatch_share` | Upload media to session |
+| `dispatch_feedback` | Submit structured finding |
+| `dispatch_get_feedback` | Retrieve feedback findings |
+| `dispatch_launch_persona` | Launch persona child agent |
 
-## Frontend Behavior Today
+### Repo Tools
 
-Main app: `/Users/brad/dev/apps/dispatch/web/src/App.tsx`
+Custom tools defined in `.dispatch/tools.json` at the repo root. Exposed to agents with `repo.` prefix. See `13-agent-scoped-mcp-and-dev-stack-plan.md` for details.
 
-- Left panel:
-  - collapsible rail, not fully hidden
-  - list agents
-  - attention indicator for agents in backend-reported error state
-  - open/start, stop, delete actions per agent
-- Center:
-  - selected agent context
-  - attach/detach terminal controls
-  - auto reconnect when tab regains focus/visibility
-- Right:
-  - media drawer opened by `Media` button
-  - refresh button and per-agent media list
-  - image lightbox for full-size preview
+### Lifecycle Hooks
 
-## Known Friction / Gaps
+The `stop` hook in `.dispatch/tools.json` runs when an agent is stopped (e.g., teardown dev environments).
 
-- No auth enforcement is wired into request handlers yet (`AUTH_TOKEN` exists in config only).
-- Media polling is interval-based (4s), not event-driven.
-- Agent attention is currently narrow: it only reflects backend-reported agent error state, not detached tmux activity or richer app-level response events.
-- Simulator orchestration is partially scaffolded but not end-to-end.
-- Some planned docs still describe endpoints/features not shipped yet.
-- Existing running agents may have old state from previous UI/runtime iterations.
+## Key Features
 
-## Operations Quickstart
+### Activity & Analytics
+- Heatmaps, daily status charts, active-hours analysis
+- Working time by project breakdown
+- Token usage tracking by day, project, and model
+- Agent creation trends
 
-From `/Users/brad/dev/apps/dispatch`:
+### Personas & Feedback
+- Repo-defined personas via `.dispatch/personas/*.md`
+- Structured findings with severity, file refs, suggestions
+- See `15-personas-and-feedback.md`
 
-1. `nvm use default`
-2. `docker compose up -d postgres`
-3. `npm install`
-4. `npm run build`
-5. `npm run start`
-6. Open `http://127.0.0.1:6767`
+### Notifications
+- Slack webhook integration
+- Configurable event triggers (done, waiting_user, blocked)
+- Focus-aware suppression
+- See `16-notifications.md`
 
-For development:
-- `npm run dev` (backend watch mode)
-- `npm --prefix web run dev` (if iterating frontend separately)
+### Media & Streaming
+- Screenshot/image/video sharing via `dispatch_share`
+- iOS Simulator screenshot capture
+- Live Playwright browser streaming via CDP/MJPEG
+- Media sidebar with lightbox and seen/unseen tracking
 
-## Validation Checklist for New Work
+### History
+- Soft-deleted agents preserved for history
+- Paginated agent history with project/type filtering
+- Per-agent detail view with events, tokens, and media
 
-- Run `npm run check`.
-- Run `npm run build`.
-- Verify UI can:
-  - create agent
-  - attach terminal and send input
-  - detach and reattach without killing tmux session
-  - show media from `dispatch-share`
-  - stop and delete agent
-- Stop any throwaway test agents you create.
+## CLI Tools
 
-## Most Relevant Files
+| Binary | Purpose |
+|--------|---------|
+| `dispatch-dev` | Manage isolated dev environments (DB + API + Vite) |
+| `dispatch-server` | Launch the production server |
+| `dispatch-deploy` | Deployment automation |
+| `dispatch-release` | Release management |
+| `dispatch-share` | CLI for sharing media to agent sessions |
+| `dispatch-event` | CLI for reporting agent status events |
+| `dispatch-stream` | CLI for managing screen streams |
+| `dispatch-launchd-wrapper` | macOS launchd service wrapper |
+| `install-launchd` / `uninstall-launchd` | Register/unregister as macOS service |
+| `preflight` | Pre-launch validation |
 
-- Backend API: `/Users/brad/dev/apps/dispatch/src/server.ts`
-- Agent lifecycle/runtime: `/Users/brad/dev/apps/dispatch/src/agents/manager.ts`
-- Terminal attach bridge: `/Users/brad/dev/apps/dispatch/src/terminal/tmux-terminal.ts`
-- Media helper CLI: `/Users/brad/dev/apps/dispatch/bin/dispatch-share`
-- React app: `/Users/brad/dev/apps/dispatch/web/src/App.tsx`
-- UI primitives: `/Users/brad/dev/apps/dispatch/web/src/components/ui`
-- Main README: `/Users/brad/dev/apps/dispatch/README.md`
-- Attention follow-up plan: `/Users/brad/dev/apps/dispatch/docs/09-agent-attention-phase-2.md`
+## API Surface
+
+71+ endpoints across these families: authentication, agent lifecycle, agent setup, events, terminal, media, streaming, personas, feedback, activity/analytics, token usage, history, notifications, settings, system, release management, MCP, and diagnostics. See `03-api-spec.md` for the complete specification.
+
+## Frontend
+
+- Responsive layout with mobile support (slide panels, mobile terminal toolbar)
+- Agent sidebar with real-time status indicators
+- Inline terminal via xterm.js
+- Media sidebar with lightbox viewer
+- Activity dashboard with charts and heatmaps
+- Settings pane (agent types, notifications, security)
+- Feedback panel for reviewing persona findings
+- Documentation pane (in-app)
+- Release manager for self-updates
+- Theming (dark/light mode, CSS custom properties)
+
+## Development
+
+### Commands
+
+```bash
+pnpm install                  # install dependencies
+pnpm run dev                  # backend + frontend dev mode (don't use in agent sessions)
+pnpm run check                # type check backend + web
+pnpm run finalize:web         # type check + production build for web
+pnpm run test                 # unit tests (vitest)
+pnpm run test:e2e             # E2E tests (playwright, spins up isolated DB)
+```
+
+### dispatch-dev (for agents)
+
+Agents should use `dispatch-dev` instead of `pnpm run dev`:
+
+```bash
+dispatch-dev up               # start isolated DB + API + Vite
+dispatch-dev restart           # pick up code changes (reuses ports/DB)
+dispatch-dev status            # check what's running
+dispatch-dev logs              # API server logs
+dispatch-dev down              # full teardown
+```
+
+### Validation Checklist
+
+Before considering work complete:
+1. `pnpm run check` passes
+2. `pnpm run finalize:web` passes (if web files changed)
+3. `pnpm run test:e2e` passes
+4. `pnpm run test` passes (if backend logic changed)

--- a/docs/15-personas-and-feedback.md
+++ b/docs/15-personas-and-feedback.md
@@ -1,0 +1,112 @@
+# Personas and Feedback
+
+## Overview
+
+Personas are reusable agent roles that review work from a specific perspective. When launched, a persona runs as a child agent that analyzes the current branch's changes and submits structured feedback findings. This enables automated code review, security audits, UX reviews, and testing without manual setup.
+
+## How Personas Work
+
+1. A parent agent (or the user via the UI) calls `dispatch_launch_persona` with a persona slug and context briefing.
+2. Dispatch loads the persona definition from `.dispatch/personas/{slug}.md` in the repo.
+3. A new child agent is spawned with:
+   - The persona's instructions as its system prompt
+   - A git diff of the current branch vs main injected via `{{diff}}` placeholder
+   - The caller's context briefing injected via `{{context}}` placeholder
+   - The same agent type and full-access setting as the parent
+4. The child agent reviews the work and submits findings via `dispatch_feedback`.
+5. Findings appear in the parent agent's Feedback panel in the UI.
+
+## Defining Personas
+
+Each repo defines its own personas as markdown files in `.dispatch/personas/`. There are no built-in personas — every repo creates the roles that make sense for its workflow (e.g., security review, UX review, architecture review, testing).
+
+Persona files use markdown with YAML frontmatter:
+
+```yaml
+---
+name: Security Review
+description: Reviews code for security vulnerabilities
+feedbackFormat: findings
+---
+
+You are a security reviewer. Analyze the following changes
+for vulnerabilities, injection risks, and auth issues.
+
+## Context
+{{context}}
+
+## Diff
+{{diff}}
+
+For each issue found, use the dispatch_feedback tool to submit
+a finding with appropriate severity, file path, and suggestion.
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Display name shown in the UI |
+| `description` | Yes | Short description of the persona's purpose |
+| `feedbackFormat` | No | Hint for feedback structure (default: `findings`) |
+
+### Template Placeholders
+
+| Placeholder | Replaced With |
+|-------------|---------------|
+| `{{context}}` | The context briefing provided by the caller |
+| `{{diff}}` | Git diff of the current branch vs the base branch |
+
+## Feedback System
+
+### Submitting Feedback
+
+Agents submit findings via the `dispatch_feedback` MCP tool:
+
+```json
+{
+  "severity": "high",
+  "filePath": "src/auth/middleware.ts",
+  "lineNumber": 42,
+  "description": "Session token is stored in localStorage, vulnerable to XSS",
+  "suggestion": "Use httpOnly cookies for session storage",
+  "mediaRef": "screenshot-xss-demo.png"
+}
+```
+
+### Feedback Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `severity` | No | `critical`, `high`, `medium`, `low`, or `info` (default: `info`) |
+| `filePath` | No | File path relative to repo root |
+| `lineNumber` | No | Line number in the file |
+| `description` | Yes | What was found — the issue or observation |
+| `suggestion` | No | Suggested fix or action |
+| `mediaRef` | No | Filename of previously shared media to attach |
+
+### Feedback Status
+
+Each finding has a status that can be updated from the UI:
+
+| Status | Meaning |
+|--------|---------|
+| `open` | New finding, not yet reviewed |
+| `fixed` | Issue has been addressed |
+| `dismissed` | Finding was reviewed and dismissed |
+| `forwarded` | Sent to another agent or process |
+| `ignored` | Intentionally not addressing |
+
+### Viewing Feedback
+
+- Open an agent's Feedback panel from the sidebar to see findings from its persona children.
+- Findings are grouped by severity and show file references as clickable links.
+- Use `scope=children` on the API to aggregate feedback from all child persona agents.
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/personas` | List available personas (requires `cwd` query param) |
+| GET | `/api/v1/agents/:id/feedback` | Get feedback for an agent (`scope=children` for child feedback) |
+| PATCH | `/api/v1/agents/:id/feedback/:feedbackId` | Update feedback status |

--- a/docs/16-notifications.md
+++ b/docs/16-notifications.md
@@ -1,0 +1,56 @@
+# Notifications
+
+## Overview
+
+Dispatch sends Slack notifications when agents need attention, so you don't have to watch the dashboard. Notifications are event-driven and focus-aware — you only get notified about agents you're not actively viewing.
+
+## Slack Setup
+
+1. Create a Slack incoming webhook for your target channel (see [Slack docs](https://api.slack.com/messaging/webhooks)).
+2. In Dispatch, go to **Settings → Notifications**.
+3. Paste the webhook URL.
+4. Use **Send test** to verify the integration.
+
+## Configurable Events
+
+You can enable or disable notifications for each event type:
+
+| Event | Default | Description |
+|-------|---------|-------------|
+| `done` | Enabled | Agent finished its task |
+| `waiting_user` | Enabled | Agent needs your input or a decision |
+| `blocked` | Disabled | Agent hit an error it can't resolve |
+
+## Focus-Aware Suppression
+
+Dispatch tracks whether you're actively viewing an agent's terminal. When you have an agent's terminal open in the browser, notifications for that agent are suppressed — the assumption is you already know what's happening.
+
+Focus tracking uses a 30-second TTL. If you switch away from an agent for more than 30 seconds, notifications resume for that agent.
+
+## Message Format
+
+Slack messages include:
+- Agent name and status emoji (green for done, yellow for waiting, red for blocked)
+- The event message from the agent
+- Color-coded attachment matching the event type
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/notifications/settings` | Get webhook URL and enabled events |
+| POST | `/api/v1/notifications/settings` | Update webhook URL and event config |
+| POST | `/api/v1/notifications/test` | Send test message to configured webhook |
+
+### `POST /api/v1/notifications/settings`
+
+```json
+{
+  "slackWebhookUrl": "https://hooks.slack.com/services/T.../B.../xxx",
+  "events": {
+    "done": true,
+    "waiting_user": true,
+    "blocked": false
+  }
+}
+```


### PR DESCRIPTION
## Summary
- **Webapp docs pane**: Expanded existing sections (Agents, Worktrees, Repo Tools) to reflect current UI and added 4 new sections: Personas, Status Events, Media & Sharing, Notifications
- **API spec** (`03-api-spec.md`): Full rewrite covering all 71+ endpoints (was 14 MVP-only)
- **Current state handoff** (`08-current-state-handoff.md`): Rewritten for April 2026 with monorepo structure, all features, DB schema, CLI tools
- **New docs**: `15-personas-and-feedback.md`, `16-notifications.md`

## Test plan
- [x] `pnpm run finalize:web` passes
- [x] `pnpm run test:e2e` — 77 passed, 6 skipped (pre-existing terminal-live)
- [ ] Visual review of all 7 docs pane sections in webapp

🤖 Generated with [Claude Code](https://claude.com/claude-code)