### PR TITLE
Clean up internal references for open-source readiness

### DIFF
--- a/.dispatch/config.json
+++ b/.dispatch/config.json
@@ -1,9 +1,3 @@
 {
-  "linear": {
-    "team": "CrumbStream",
-    "teamKey": "CRU",
-    "project": "Dispatch",
-    "projectId": "42ebddeb-57b8-467b-a484-fe0e3dc46d46",
-    "projectUrl": "https://linear.app/crumbstream/project/dispatch-ad9a26f53856"
-  }
+  "linear": {}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ artifacts/
 .playwright-mcp/
 test-results/
 playwright-report/
+.dispatch/config.json
+.dispatch/worktrees/

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ cd dispatch
 # 2. Use the correct Node version
 nvm install && nvm use
 
-# 3. Install dependencies (backend + frontend)
-npm install && npm --prefix web install
+# 3. Install dependencies
+pnpm install
 
 # 4. Copy the example env file
 cp .env.example .env
@@ -158,5 +158,4 @@ These tools only work inside running agent sessions (they require agent-scoped M
 
 ## Issue Tracking
 
-- Linear project: [Dispatch](https://linear.app/crumbstream/project/dispatch-ad9a26f53856)
-- Routing config: `.dispatch/config.json` under the `linear` key
+- [GitHub Issues](https://github.com/selfcontained/dispatch/issues)

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1110,8 +1110,6 @@ export class AgentManager {
     const envPrefixParts = [
       `DISPATCH_AGENT_ID=${this.shellEscape(agentId)}`,
       `DISPATCH_MEDIA_DIR=${this.shellEscape(mediaDir)}`,
-      // Compatibility alias for common typo to keep screenshot sharing reliable.
-      `DISPATCH_MDEIA_DIR=${this.shellEscape(mediaDir)}`,
       `DISPATCH_PORT=${this.shellEscape(String(this.config.port))}`,
       `DISPATCH_SCHEME=${this.config.tls ? "https" : "http"}`,
       `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`,

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "crumbstream" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight";
+export type ThemeId = "default" | "cool-navy" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -168,7 +168,7 @@ const MATRIX: TerminalPalette = {
 
 export const THEMES: ThemeDefinition[] = [
   {
-    id: "crumbstream",
+    id: "cool-navy",
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -41,7 +41,7 @@
   --terminal-bg: 0 0% 8%;
 }
 
-[data-theme="crumbstream"] {
+[data-theme="cool-navy"] {
   --background: 222 18% 7%;
   --foreground: 224 13% 95%;
   --card: 222 16% 9%;

--- a/bin/hostess-share
+++ b/bin/hostess-share
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Backward-compatible wrapper for older agent instructions/scripts.
-exec "$(dirname "$0")/dispatch-share" "$@"

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -38,8 +38,8 @@ Set up Dispatch on this machine. The repo is at https://github.com/selfcontained
 4. Start Postgres: brew services start postgresql@17
 5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
 6. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
-7. Run: nvm use && npm ci && npm --prefix web ci && npm run build
-8. Verify locally: npm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
+7. Run: nvm use && pnpm install && pnpm run build
+8. Verify locally: pnpm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
 9. Install the launchd service: bin/install-launchd --port 6767
 10. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
 11. Configure enabled agent types: check which agent CLIs are already installed (claude --version, codex --version, opencode --version), then use the API to enable only those types: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to match installed CLIs).
@@ -132,12 +132,11 @@ Generate a token with `openssl rand -hex 32`.
 
 ```bash
 nvm use
-npm ci
-npm --prefix web ci
-npm run build
+pnpm install
+pnpm run build
 
 # Quick smoke test
-npm run start
+pnpm run start
 # In another terminal:
 curl -s http://127.0.0.1:6767/api/v1/health | jq
 # Ctrl-C to stop

--- a/docs/14-theming.md
+++ b/docs/14-theming.md
@@ -131,7 +131,7 @@ Add a new `[data-theme="your-theme-id"]` block in `web/src/index.css`. You must 
 1. Add the new ID to the `ThemeId` union type:
 
 ```ts
-export type ThemeId = "default" | "crumbstream" | "midnight";
+export type ThemeId = "default" | "cool-navy" | "midnight";
 ```
 
 2. Add an entry to the `THEMES` array with a label, description, 4 representative hex swatches (shown in the picker UI), and a `terminal` palette:
@@ -154,9 +154,9 @@ That's it — the theme picker, localStorage persistence, flash-free loading, an
 
 ### Step 3: Validate
 
-1. Run `npm run finalize:web` to verify the build compiles.
+1. Run `pnpm run finalize:web` to verify the build compiles.
 2. Start a dev server and visually check: sidebar, status footer, badges, buttons, terminal pane, settings pane, and the create-agent dialog.
-3. Run `npm run test:e2e` to confirm no regressions.
+3. Run `pnpm run test:e2e` to confirm no regressions.
 
 ## Color design tips
 


### PR DESCRIPTION
## Summary
- Remove `DISPATCH_MDEIA_DIR` typo alias from agent manager (CRU-48)
- Replace internal Linear project URL with GitHub Issues link in README (CRU-59)
- Strip internal Linear config from `.dispatch/config.json` and gitignore it (CRU-60)
- Rename `"crumbstream"` theme ID to `"cool-navy"` across CSS, TypeScript, and docs (CRU-61)
- Remove legacy `bin/hostess-share` script from old project name (CRU-63)
- Fix `npm` → `pnpm` references in README and setup docs (CRU-65)

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — web build succeeds
- [x] `pnpm run test` — 91 unit tests pass
- [x] `pnpm run test:e2e` — 79 E2E tests pass (6 pre-existing skips)
- [ ] Verify theme picker still works (stored "crumbstream" preference gracefully falls back to default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)