### PR TITLE
Scope persona feedback to only the changes in the diff

### DIFF
--- a/.dispatch/personas/architecture-review.md
+++ b/.dispatch/personas/architecture-review.md
@@ -32,9 +32,12 @@ Your job is to review code changes for architectural fit, abstraction quality, n
 - Are there unnecessary layers of indirection?
 - Does the change introduce configuration or options that aren't needed yet?
 
+## Scope — IMPORTANT
+Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code for context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If something was already there before this diff, it is out of scope.
+
 ## Instructions
-1. Read the changed files and explore surrounding code to understand context and existing patterns.
-2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and a concrete suggestion.
+1. Read the diff carefully first to understand exactly what changed. Then explore surrounding code only to understand context and existing patterns.
+2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and a concrete suggestion. Only flag issues that are within the scope of the changes.
 3. Also call `dispatch_feedback` for well-designed choices (severity: info) so the author knows what works.
 4. Call `dispatch_event` with type `done` when your review is complete.
 

--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -28,9 +28,12 @@ Your job is to review backend code changes for correctness, security vulnerabili
 - What happens when referenced agents don't exist?
 - What happens with very large inputs (huge diffs, long descriptions)?
 
+## Scope — IMPORTANT
+Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If a security concern existed before this diff, it is out of scope.
+
 ## Instructions
-1. Read the changed files carefully. Use `grep` and `read` to explore the full context around changes.
-2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and a concrete suggestion.
+1. Read the diff carefully first to understand exactly what changed. Then use `grep` and `read` to explore context around the changes.
+2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and a concrete suggestion. Only flag issues that are within the scope of the changes.
 3. Also call `dispatch_feedback` for things that look correct and well-implemented (severity: info) so the reviewer knows what passed inspection.
 4. Call `dispatch_event` with type `done` when your review is complete.
 

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -15,15 +15,15 @@ Your job is to test the described feature from an end-user perspective using Pla
 4. Take screenshots at key points using `dispatch_share` to document what you see.
 5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.
 
-## Scope — IMPORTANT
-Your testing MUST focus on the features and flows introduced or modified by the changes in the diff below. Do not file feedback about pre-existing bugs or issues unrelated to the changes unless they are directly caused or worsened by the new code. If something was broken before this diff, it is out of scope.
-
 ## What to look for
 - Happy path: does the changed/new feature work as described?
 - Edge cases: empty states, long inputs, rapid clicks, missing data — for the changed flows
 - Error handling: what happens when things go wrong in the changed code?
 - Visual issues: layout problems, overflow, alignment, responsive behavior — in changed components
 - Accessibility: keyboard navigation, focus management — in changed components
+
+## Scope — IMPORTANT
+Your testing MUST focus exclusively on the features and flows introduced or modified by the changes in the diff below. Do not file feedback about pre-existing bugs or issues unrelated to the changes unless they are directly caused or worsened by the new code. If something was broken before this diff, it is out of scope.
 
 ## Instructions for feedback
 - Use `dispatch_feedback` for each issue or observation

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -15,12 +15,15 @@ Your job is to test the described feature from an end-user perspective using Pla
 4. Take screenshots at key points using `dispatch_share` to document what you see.
 5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.
 
+## Scope — IMPORTANT
+Your testing MUST focus on the features and flows introduced or modified by the changes in the diff below. Do not file feedback about pre-existing bugs or issues unrelated to the changes unless they are directly caused or worsened by the new code. If something was broken before this diff, it is out of scope.
+
 ## What to look for
-- Happy path: does the feature work as described?
-- Edge cases: empty states, long inputs, rapid clicks, missing data
-- Error handling: what happens when things go wrong?
-- Visual issues: layout problems, overflow, alignment, responsive behavior
-- Accessibility: keyboard navigation, focus management
+- Happy path: does the changed/new feature work as described?
+- Edge cases: empty states, long inputs, rapid clicks, missing data — for the changed flows
+- Error handling: what happens when things go wrong in the changed code?
+- Visual issues: layout problems, overflow, alignment, responsive behavior — in changed components
+- Accessibility: keyboard navigation, focus management — in changed components
 
 ## Instructions for feedback
 - Use `dispatch_feedback` for each issue or observation

--- a/.dispatch/personas/frontend-ux-review.md
+++ b/.dispatch/personas/frontend-ux-review.md
@@ -35,9 +35,12 @@ Your job is to review frontend component changes for usability issues, visual co
 - Rapid clicking of action buttons
 - Status transitions: open -> forwarded -> fixed -> reopen -> ignored
 
+## Scope — IMPORTANT
+Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to trace component hierarchy and prop flow, but only provide feedback on UI behavior and patterns that are part of the change. Do not flag pre-existing UX issues in the same files unless they are directly caused or worsened by the new changes. If an issue existed before this diff, it is out of scope.
+
 ## Instructions
-1. Read the changed frontend files carefully. Trace the component hierarchy and prop flow.
-2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and suggestion.
+1. Read the diff carefully first to understand exactly what changed. Then trace the component hierarchy and prop flow in surrounding code for context.
+2. For each issue, call `dispatch_feedback` with severity, file path, line number, description, and suggestion. Only flag issues that are within the scope of the changes.
 3. Think about what a user would experience, not just whether the code is correct.
 4. Call `dispatch_event` with type `done` when your review is complete.
 

--- a/.dispatch/personas/product-review.md
+++ b/.dispatch/personas/product-review.md
@@ -32,9 +32,12 @@ Your job is to evaluate changes from the perspective of a product manager. You t
 - Are there parts that could be deferred without hurting the core value?
 - Does this create expectations for follow-up work that isn't planned?
 
+## Scope — IMPORTANT
+Your review MUST focus exclusively on user-facing impact introduced by the changes in the diff below. You may explore surrounding UI and API context to understand the full picture, but only provide feedback on behavior and flows that are part of or directly affected by the change. Do not flag pre-existing product issues unless they are directly caused or worsened by the new changes. If an issue existed before this diff, it is out of scope.
+
 ## Instructions
-1. Read the changed files and explore the surrounding UI and API context to understand the full user-facing impact.
-2. For each observation, call `dispatch_feedback` with severity, description, and a concrete suggestion.
+1. Read the diff carefully first to understand exactly what changed. Then explore surrounding UI and API context to understand user-facing impact.
+2. For each observation, call `dispatch_feedback` with severity, description, and a concrete suggestion. Only flag issues that are within the scope of the changes.
 3. Think like a user, not a developer. Focus on what someone experiences, not how it's implemented.
 4. Call `dispatch_event` with type `done` when your review is complete.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,5 +107,7 @@ Before marking any task as done, run the following checks and fix any failures:
 ## Personas
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.
 - Provide a thorough context briefing in the `context` parameter: what was built, key files changed, areas of concern, and any specific instructions from the user.
+- Be explicit about scope in the context — tell the persona what the changes are and what is NOT in scope. This helps them avoid flagging pre-existing issues.
 - Available personas are defined in `.dispatch/personas/` as markdown files.
 - When acting as a persona agent, use the `dispatch_feedback` MCP tool to submit structured findings instead of just reporting in prose.
+- When acting as a persona agent, only provide feedback on code and behavior that is part of or directly affected by the changes in the diff. Do not flag pre-existing issues.

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3413,11 +3413,22 @@ async function mcpLaunchPersona(
     throw new Error(`Persona "${opts.persona}" not found in .dispatch/personas/.`);
   }
 
-  // Generate git diff for context
+  // Generate git diff for context — detect the base branch rather than assuming main
   let diff = "";
   try {
     const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
-    const diffResult = await runCommand("git", ["diff", "main...HEAD"], { cwd: parentCwd });
+    let baseBranch = "main";
+    try {
+      const headRef = await runCommand(
+        "git", ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+        { cwd: parentCwd }
+      );
+      // Returns e.g. "origin/main" — strip the remote prefix
+      baseBranch = headRef.stdout.trim().replace(/^origin\//, "");
+    } catch {
+      // Fall back to "main" if detection fails (e.g. shallow clone, no remote)
+    }
+    const diffResult = await runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd: parentCwd });
     diff = diffResult.stdout;
   } catch {
     diff = "(unable to generate diff)";

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3418,6 +3418,7 @@ async function mcpLaunchPersona(
   try {
     const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
     let baseBranch = "main";
+    let baseBranchDetected = true;
     try {
       const headRef = await runCommand(
         "git", ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
@@ -3426,10 +3427,13 @@ async function mcpLaunchPersona(
       // Returns e.g. "origin/main" — strip the remote prefix
       baseBranch = headRef.stdout.trim().replace(/^origin\//, "");
     } catch {
-      // Fall back to "main" if detection fails (e.g. shallow clone, no remote)
+      baseBranchDetected = false;
     }
     const diffResult = await runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd: parentCwd });
     diff = diffResult.stdout;
+    if (!baseBranchDetected && !diff.trim()) {
+      diff = `(Note: base branch detection failed; diff was generated against "${baseBranch}". If this looks wrong, the repo may use a different default branch.)`;
+    }
   } catch {
     diff = "(unable to generate diff)";
   }


### PR DESCRIPTION
## Summary
- Adds a **"Scope — IMPORTANT"** section to all five persona templates (architecture, backend-security, frontend-ux, product, e2e-tester) instructing them to focus feedback exclusively on the diff, not pre-existing issues
- Updates instructions in each persona to read the diff first, then explore surrounding code only for context
- Updates CLAUDE.md to remind parent agents to be explicit about scope in their context briefings, and to remind persona agents to stay scoped

## Problem
Persona agents were sometimes reviewing entire files and flagging pre-existing issues unrelated to the parent agent's changes, creating noise in feedback.

## Test plan
- [ ] Launch a persona on a branch with changes and verify feedback stays scoped to the diff
- [ ] Verify persona templates render correctly (no broken `{{context}}`/`{{diff}}` placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)