### PR TITLE
Fix copy action in feedback sheet and consolidate clipboard logic

### DIFF
--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Ban, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, Maximize, MessageCircleQuestion, RotateCcw, Wrench, X } from "lucide-react";
 
@@ -173,8 +173,7 @@ export function ParentFeedbackPanel({
   const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
   const [showResolved, setShowResolved] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
-  const [, copyText] = useCopyText();
-  const copiedTimerRef = useRef<number | null>(null);
+  const [copied, copyText] = useCopyText();
 
   const { data: feedback = [] } = useQuery<FeedbackItem[]>({
     queryKey: ["feedback", parentAgentId, "children"],
@@ -259,8 +258,6 @@ export function ParentFeedbackPanel({
   const handleCopy = (item: FeedbackItem) => {
     copyText(formatFeedbackText(item));
     setCopiedItemId(item.id);
-    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
-    copiedTimerRef.current = window.setTimeout(() => setCopiedItemId(null), 2000);
   };
 
   const handleResolve = (item: FeedbackItem, status: string) => {
@@ -377,7 +374,7 @@ export function ParentFeedbackPanel({
                                   isConnected={isConnected}
                                   onForward={(mode) => forward(item, mode)}
                                   onCopy={() => handleCopy(item)}
-                                  copied={copiedItemId === item.id}
+                                  copied={copied && copiedItemId === item.id}
                                   onUpdateStatus={(s) => handleResolve(item, s)}
                                   isActionable={isActionable}
                                   statusLabel={statusLabel}
@@ -490,7 +487,7 @@ export function ParentFeedbackPanel({
                   isConnected={isConnected}
                   onForward={(mode) => forward(sheetItem, mode)}
                   onCopy={() => handleCopy(sheetItem)}
-                  copied={copiedItemId === sheetItem.id}
+                  copied={copied && copiedItemId === sheetItem.id}
                   onUpdateStatus={(s) => handleResolve(sheetItem, s)}
                   isActionable={sheetItem.status === "open" || sheetItem.status === "forwarded"}
                   statusLabel={STATUS_LABELS[sheetItem.status]}

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -261,7 +261,6 @@ export function ParentFeedbackPanel({
     setCopiedItemId(item.id);
     if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
     copiedTimerRef.current = window.setTimeout(() => setCopiedItemId(null), 2000);
-    dismissUI();
   };
 
   const handleResolve = (item: FeedbackItem, status: string) => {

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -60,6 +60,7 @@ hljs.registerLanguage("objectivec", objectivec);
 hljs.registerLanguage("nim", nim);
 
 import { Button } from "@/components/ui/button";
+import { useCopyText } from "@/hooks/use-copy";
 
 const EXT_TO_LANG: Record<string, string> = {
   ".ts": "typescript", ".tsx": "typescript", ".js": "javascript", ".jsx": "javascript",
@@ -171,31 +172,10 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   );
 }
 
-/** Copy text via hidden textarea + execCommand. Works on iOS Safari non-secure contexts. */
-function copyViaExecCommand(text: string): boolean {
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.left = "0";
-  textarea.style.top = "0";
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.focus();
-  textarea.select();
-
-  let ok = false;
-  try {
-    ok = document.execCommand("copy");
-  } catch {
-    ok = false;
-  }
-  document.body.removeChild(textarea);
-  return ok;
-}
-
 function MediaActions({ src, fileName, isText }: { src: string; fileName: string; isText?: boolean }): JSX.Element {
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<number | null>(null);
+  const [copied, copyText] = useCopyText();
+  const [imageCopied, setImageCopied] = useState(false);
+  const imageCopiedTimerRef = useRef<number | null>(null);
   const cachedTextRef = useRef<string | null>(null);
 
   const displayName = stripTimestamp(fileName);
@@ -212,28 +192,20 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
     return () => controller.abort();
   }, [src, isText]);
 
-  // Clean up the "Copied!" timer on unmount.
+  // Clean up the image-copied timer on unmount.
   useEffect(() => () => {
-    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
+    if (imageCopiedTimerRef.current) window.clearTimeout(imageCopiedTimerRef.current);
   }, []);
 
-  const markCopied = useCallback(() => {
-    setCopied(true);
-    if (copiedTimerRef.current) window.clearTimeout(copiedTimerRef.current);
-    copiedTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
+  const markImageCopied = useCallback(() => {
+    setImageCopied(true);
+    if (imageCopiedTimerRef.current) window.clearTimeout(imageCopiedTimerRef.current);
+    imageCopiedTimerRef.current = window.setTimeout(() => setImageCopied(false), 2000);
   }, []);
 
   const handleCopy = useCallback(() => {
     if (isText) {
-      // Text files: use execCommand with pre-fetched content (works on iOS Safari
-      // non-secure contexts). Fall back to Clipboard API on secure contexts.
-      if (cachedTextRef.current && copyViaExecCommand(cachedTextRef.current)) {
-        markCopied();
-        return;
-      }
-      if (navigator.clipboard?.writeText && cachedTextRef.current) {
-        void navigator.clipboard.writeText(cachedTextRef.current).then(markCopied).catch(() => {});
-      }
+      if (cachedTextRef.current) copyText(cachedTextRef.current);
     } else {
       // Images: use Clipboard API (only works on secure contexts / desktop).
       // On mobile non-secure contexts, users can long-press to copy images.
@@ -241,11 +213,13 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
         const blobPromise = fetch(src).then((r) => r.blob());
         void navigator.clipboard
           .write([new ClipboardItem({ "image/png": blobPromise })])
-          .then(markCopied)
+          .then(markImageCopied)
           .catch(() => {});
       }
     }
-  }, [src, isText, markCopied]);
+  }, [src, isText, copyText, markImageCopied]);
+
+  const showCopied = isText ? copied : imageCopied;
 
   const showCopy = isText || HAS_CLIPBOARD_WRITE;
 
@@ -263,13 +237,13 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
       {showCopy && (
         <Button
           size="sm"
-          variant={copied ? "default" : "ghost"}
-          className={copied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
+          variant={showCopied ? "default" : "ghost"}
+          className={showCopied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
           onClick={handleCopy}
           title="Copy"
         >
-          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          <span className="hidden sm:inline">{copied ? "Copied!" : "Copy"}</span>
+          {showCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          <span className="hidden sm:inline">{showCopied ? "Copied!" : "Copy"}</span>
         </Button>
       )}
     </div>

--- a/apps/web/src/hooks/use-copy.ts
+++ b/apps/web/src/hooks/use-copy.ts
@@ -23,30 +23,34 @@ function copyViaExecCommand(text: string): boolean {
 }
 
 /**
- * Hook for copying text to clipboard with iOS Safari support.
+ * Hook for copying text to clipboard.
+ * Prefers the Clipboard API (works inside dialogs/sheets with focus traps),
+ * falls back to execCommand for iOS Safari non-secure contexts.
  * Returns [copied, copyText] — `copied` is true for 2s after a successful copy.
  */
 export function useCopyText(): [boolean, (text: string) => void] {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<number | null>(null);
 
+  const markCopied = useCallback(() => {
+    setCopied(true);
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setCopied(false), 2000);
+  }, []);
+
   const copyText = useCallback((text: string) => {
-    // Try execCommand first (works on iOS Safari non-secure contexts)
-    if (copyViaExecCommand(text)) {
-      setCopied(true);
-      if (timerRef.current) window.clearTimeout(timerRef.current);
-      timerRef.current = window.setTimeout(() => setCopied(false), 2000);
+    // Prefer Clipboard API — it works inside focus-trapped dialogs (sheets, modals)
+    // where execCommand fails because the hidden textarea can't receive focus.
+    if (navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(text).then(markCopied).catch(() => {
+        // Clipboard API rejected (e.g. non-secure context) — try execCommand
+        if (copyViaExecCommand(text)) markCopied();
+      });
       return;
     }
-    // Fall back to Clipboard API
-    if (navigator.clipboard?.writeText) {
-      void navigator.clipboard.writeText(text).then(() => {
-        setCopied(true);
-        if (timerRef.current) window.clearTimeout(timerRef.current);
-        timerRef.current = window.setTimeout(() => setCopied(false), 2000);
-      }).catch(() => {});
-    }
-  }, []);
+    // No Clipboard API — fall back to execCommand (iOS Safari non-secure contexts)
+    if (copyViaExecCommand(text)) markCopied();
+  }, [markCopied]);
 
   return [copied, copyText];
 }


### PR DESCRIPTION
## Summary
- Fix broken copy button in the persona feedback sheet's bottom drawer — the Radix Dialog focus trap prevented `execCommand("copy")` from working inside the sheet
- Reverse clipboard strategy: prefer `navigator.clipboard.writeText` (works inside focus-trapped dialogs), fall back to `execCommand` only when the API is unavailable
- Consolidate duplicated `copyViaExecCommand` from media-lightbox into the shared `useCopyText` hook so all copy actions use the same path
- Remove `dismissUI()` from `handleCopy` so the sheet stays open after copying

## Test plan
- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — 79 passed, 6 skipped (pre-existing terminal-live skips)
- [ ] Manual: open feedback sheet, click copy button, verify text lands in clipboard
- [ ] Manual: copy from media lightbox (text file + image) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)