### PR TITLE
Separate release creation from local deploy

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -725,9 +725,10 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
 
     job.tag = tag;
     broadcastReleaseEvent({ type: "tag", tag });
-    appendReleaseLog(job, `==> release workflow produced tag: ${tag}`);
+    appendReleaseLog(job, `==> release ${tag} created successfully`);
 
-    await deployTag(job, tag);
+    // Release creation is done — the user can update separately.
+    setReleasePhase(job, "done");
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     if (activeReleaseJob) {
@@ -1036,9 +1037,13 @@ async function registerRoutes() {
       let commits: Array<{ sha: string; subject: string }> = [];
       let refMissing = false;
 
-      if (isAdmin && currentTag) {
+      // Compare latest release tag to main to find truly unreleased commits.
+      // Using latestTag (not currentTag) ensures that instances running an
+      // older version don't show already-released commits as "unreleased".
+      const compareTag = latestTag ?? currentTag;
+      if (isAdmin && compareTag) {
         const refCheck = await runCommand(
-          "git", ["-C", serverDir, "rev-parse", "--verify", currentTag],
+          "git", ["-C", serverDir, "rev-parse", "--verify", compareTag],
           { allowedExitCodes: [0, 128] }
         );
         if (refCheck.exitCode !== 0) {
@@ -1046,14 +1051,14 @@ async function registerRoutes() {
         } else {
           const countResult = await runCommand("git", [
             "-C", serverDir,
-            "rev-list", `${currentTag}..origin/main`, "--count"
+            "rev-list", `${compareTag}..origin/main`, "--count"
           ]);
           unreleasedCount = Number(countResult.stdout) || 0;
 
           if (unreleasedCount > 0) {
             const logResult = await runCommand("git", [
               "-C", serverDir,
-              "log", `${currentTag}..origin/main`,
+              "log", `${compareTag}..origin/main`,
               "--no-merges",
               "--format=%H\t%s",
               "--max-count=20"

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -85,7 +85,7 @@ const PHASE_LABELS: Record<ReleasePhase, string> = {
   failed: "Failed"
 };
 
-const CREATE_PHASES: ReleasePhase[] = ["preflight", "triggering", "watching", "deploying", "restarting", "done"];
+const CREATE_PHASES: ReleasePhase[] = ["preflight", "triggering", "watching", "done"];
 const UPDATE_PHASES: ReleasePhase[] = ["fetching", "deploying", "restarting", "done"];
 
 function formatDate(iso: string): string {
@@ -197,7 +197,10 @@ export function ReleaseManager(): JSX.Element {
 
     es.onerror = () => {
       setJob((prev) => {
-        if (prev?.phase === "restarting" || prev?.phase === "deploying") {
+        // Only start health polling for update jobs (which restart the server).
+        // Release creation no longer restarts, so SSE errors during create
+        // are just normal disconnects.
+        if (prev?.jobType === "update" && (prev.phase === "restarting" || prev.phase === "deploying")) {
           startHealthPoll(prev.tag);
           return { ...prev, phase: "restarting" };
         }
@@ -489,12 +492,32 @@ export function ReleaseManager(): JSX.Element {
             )}
 
             {isDone && (
-              <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
-                <CheckCircle2 className="h-4 w-4 shrink-0" />
-                <span>
-                  {job.jobType === "update" ? "Updated to" : "Deployed"}{" "}
-                  <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
-                </span>
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
+                  <CheckCircle2 className="h-4 w-4 shrink-0" />
+                  <span>
+                    {job.jobType === "update" ? "Updated to" : "Released"}{" "}
+                    <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
+                  </span>
+                </div>
+
+                {/* After a release creation, offer to update or dismiss */}
+                {job.jobType === "create" && job.tag && (
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => void handleUpdate(job.tag!)}
+                      className="rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
+                    >
+                      Update to {job.tag}
+                    </button>
+                    <button
+                      onClick={() => { setJob(null); setInfo(null); }}
+                      className="rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                )}
               </div>
             )}
 

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -503,20 +503,27 @@ export function ReleaseManager(): JSX.Element {
 
                 {/* After a release creation, offer to update or dismiss */}
                 {job.jobType === "create" && job.tag && (
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => void handleUpdate(job.tag!)}
-                      className="rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
-                    >
-                      Update to {job.tag}
-                    </button>
-                    <button
-                      onClick={() => { setJob(null); setInfo(null); }}
-                      className="rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
-                    >
-                      Dismiss
-                    </button>
-                  </div>
+                  <>
+                    {releaseError && (
+                      <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        {releaseError}
+                      </div>
+                    )}
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => void handleUpdate(job.tag!)}
+                        className="rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
+                      >
+                        Update to {job.tag}
+                      </button>
+                      <button
+                        onClick={() => { setJob(null); setInfo(null); setReleaseError(null); }}
+                        className="rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- **Release no longer auto-deploys**: `runReleaseJob()` now stops after the GitHub Actions workflow produces a tag instead of automatically checking out, building, and restarting the local instance. After completion, the UI shows a success banner with an "Update to {tag}" button and a "Dismiss" option.
- **Fix unreleased commits comparison**: The "Create release" section now compares `latestTag..origin/main` instead of `currentTag..origin/main`, so instances running older versions only see truly unreleased commits — not ones that were already included in newer releases.
- **Fix post-release UI state**: Since release creation no longer restarts the server, there's no SSE disconnect/reconnect cycle or confusing intermediate state. The completion screen is stable and offers clear next actions.

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — web build passes
- [x] `pnpm run test` — 91 unit tests pass
- [x] `pnpm run test:e2e` — 79 E2E tests pass (6 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)