### PR TITLE
Add dispatch_resolve_feedback MCP tool

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1370,6 +1370,23 @@ export class AgentManager {
     return result.rows[0] ?? null;
   }
 
+  async updateFeedbackStatusByParent(
+    feedbackId: number,
+    parentAgentId: string,
+    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
+  ): Promise<FeedbackRecord | null> {
+    const result = await this.pool.query<FeedbackRecord>(
+      `UPDATE agent_feedback af SET status = $2
+       FROM agents a
+       WHERE af.id = $1 AND af.agent_id = a.id AND a.parent_agent_id = $3
+       RETURNING af.id, af.agent_id AS "agentId", af.severity, af.file_path AS "filePath",
+                 af.line_number AS "lineNumber", af.description, af.suggestion,
+                 af.media_ref AS "mediaRef", af.status, af.created_at AS "createdAt"`,
+      [feedbackId, status, parentAgentId]
+    );
+    return result.rows[0] ?? null;
+  }
+
   private baseAgentSelectSql(): string {
     return `
       SELECT

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -87,7 +87,8 @@ type UiEvent =
   | { type: "media.seen"; agentId: string; keys: string[] }
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string }
-  | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord };
+  | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
+  | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -972,6 +973,7 @@ async function registerRoutes() {
       submitFeedback: mcpSubmitFeedback,
       launchPersona: mcpLaunchPersona,
       getFeedback: mcpGetFeedback,
+      resolveFeedback: mcpResolveFeedback,
     });
   });
 
@@ -3442,6 +3444,17 @@ async function mcpGetFeedback(
   opts: { persona?: string; limit?: number }
 ) {
   return agentManager.listFeedbackByParentGrouped(agentId, opts.persona, opts.limit);
+}
+
+async function mcpResolveFeedback(
+  agentId: string,
+  feedbackId: number,
+  status: "fixed" | "ignored"
+): Promise<import("./agents/manager.js").FeedbackRecord> {
+  const record = await agentManager.updateFeedbackStatusByParent(feedbackId, agentId, status);
+  if (!record) throw new Error(`Feedback #${feedbackId} not found or not owned by a child of this agent.`);
+  uiEventBroker.publish({ type: "feedback.updated", agentId: record.agentId, feedback: record });
+  return record;
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -613,4 +613,51 @@ describe("AgentManager", () => {
       expect(result.personas[0].feedback[1].description).toBe("finding 2");
     });
   });
+
+  describe("updateFeedbackStatusByParent", () => {
+    it("should allow a parent to resolve its child's feedback", async () => {
+      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const child = await manager.createAgent({
+        name: "child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parent.id,
+      });
+
+      const feedback = await manager.submitFeedback(child.id, {
+        severity: "high",
+        description: "XSS vulnerability",
+      });
+
+      const updated = await manager.updateFeedbackStatusByParent(feedback.id, parent.id, "fixed");
+      expect(updated).not.toBeNull();
+      expect(updated!.id).toBe(feedback.id);
+      expect(updated!.status).toBe("fixed");
+    });
+
+    it("should return null when parent does not own the child", async () => {
+      const parentA = await manager.createAgent({ name: "parent-a", cwd: "/tmp", useWorktree: false });
+      const parentB = await manager.createAgent({ name: "parent-b", cwd: "/tmp", useWorktree: false });
+      const child = await manager.createAgent({
+        name: "child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parentA.id,
+      });
+
+      const feedback = await manager.submitFeedback(child.id, { description: "finding" });
+
+      const result = await manager.updateFeedbackStatusByParent(feedback.id, parentB.id, "ignored");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for non-existent feedback id", async () => {
+      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+
+      const result = await manager.updateFeedbackStatusByParent(99999, parent.id, "fixed");
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -12,7 +12,8 @@ type UiEvent =
   | { type: "media.seen"; agentId: string; keys: string[] }
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string }
-  | { type: "feedback.created"; agentId: string };
+  | { type: "feedback.created"; agentId: string }
+  | { type: "feedback.updated"; agentId: string };
 
 export function useSSE(
   authState: AuthState,
@@ -93,7 +94,7 @@ export function useSSE(
           return;
         }
 
-        if (payload.type === "feedback.created") {
+        if (payload.type === "feedback.created" || payload.type === "feedback.updated") {
           void queryClient.invalidateQueries({ queryKey: ["feedback"] });
         }
       } catch {}

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -83,6 +83,11 @@ export type McpRequestContext = {
     agentId: string,
     opts: { persona?: string; limit?: number }
   ) => Promise<GetFeedbackResult>;
+  resolveFeedback?: (
+    agentId: string,
+    feedbackId: number,
+    status: "fixed" | "ignored"
+  ) => Promise<FeedbackItem>;
 };
 
 export async function handleMcpRequest(
@@ -538,6 +543,39 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           return {
             content: [{ type: "text", text: summary }],
             structuredContent: result
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.resolveFeedback) {
+    const agentId = context.agent.id;
+    const resolveFeedback = context.resolveFeedback;
+
+    server.registerTool(
+      "dispatch_resolve_feedback",
+      {
+        description:
+          "Resolve a persona feedback item by marking it as fixed or ignored. Use after retrieving feedback with dispatch_get_feedback to update the status of individual items.",
+        inputSchema: {
+          feedbackId: z
+            .number()
+            .int()
+            .positive()
+            .describe("The ID of the feedback item to resolve."),
+          status: z
+            .enum(["fixed", "ignored"])
+            .describe("Resolution status: 'fixed' if addressed, 'ignored' if not applicable.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await resolveFeedback(agentId, args.feedbackId, args.status);
+          return {
+            content: [{ type: "text", text: `Feedback #${result.id} marked as ${result.status}.` }]
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary
- Adds a new `dispatch_resolve_feedback` MCP tool that lets agents mark persona feedback items as "fixed" or "ignored"
- Completes the feedback lifecycle alongside `dispatch_feedback` (submit) and `dispatch_get_feedback` (retrieve)
- Authorization enforced via parent-child JOIN — only the parent agent that launched a persona can resolve its feedback
- Adds `feedback.updated` SSE event so the UI refreshes in real-time
- Includes 3 unit tests covering happy path, authorization guard, and non-existent ID

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 94 unit tests pass (3 new)
- [x] `pnpm run test:e2e` — 79 E2E tests pass
- [x] Backend security review persona — no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)