### PR TITLE
Instruct agents to close Playwright browsers after validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ dispatch/
 - Capture at least one screenshot per validation flow and publish it with the `dispatch_share` MCP tool. Never leave screenshots local-only.
 - For pages with SSE/WebSocket activity, do not use Playwright `waitUntil: "networkidle"` for readiness checks.
 - Use `waitUntil: "domcontentloaded"` (or `"load"`) and wait for concrete UI-ready signals (visible control/text/state) instead.
+- **Browser cleanup**: When you are done with Playwright validation, call `browser_close` to shut down the browser. Do this before your final `dispatch_event` call. Leaving browsers open wastes resources on headless VMs.
 
 ## Component Preference
 - Prefer shadcn/ui components over hand-rolled UI when an equivalent shadcn option exists.


### PR DESCRIPTION
## Summary
- Adds a CLAUDE.md instruction for agents to call `browser_close` when done with Playwright UI validation
- Prevents rogue Chrome instances accumulating on headless VMs

## Test plan
- [ ] Verify agents follow the new instruction and call `browser_close` before their final `dispatch_event`

🤖 Generated with [Claude Code](https://claude.com/claude-code)