### PR TITLE
Widen metrics/history panes and fix active hours touch scrolling

### DIFF
--- a/apps/web/src/components/app/activity-pane.tsx
+++ b/apps/web/src/components/app/activity-pane.tsx
@@ -278,7 +278,7 @@ function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: Acti
   return (
     <div className="space-y-3">
       <ScrollArea style={{ maxWidth: "calc(100vw - 24px)" }} className="max-w-full">
-        <div className="grid min-w-[760px] w-max grid-cols-[56px_repeat(24,minmax(0,1fr))] gap-x-1.5 gap-y-2 pb-2">
+        <div className="grid w-max grid-cols-[56px_repeat(24,28px)] gap-x-1.5 gap-y-2 pb-2">
           <div />
           {Array.from({ length: 24 }, (_, hour) => (
             <div
@@ -785,7 +785,7 @@ export function ActivityPane({ open, onClose, initialTab, onTabChange }: Activit
 
           {/* Metrics tab body */}
           {tab === "metrics" && <ScrollArea className="flex-1">
-            <div className="mx-auto max-w-3xl min-w-0 overflow-hidden space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
+            <div className="mx-auto max-w-5xl min-w-0 overflow-hidden space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
               {/* Token usage stats */}
               {hasTokenData && tokenStats && (
                 <div className="flex flex-wrap gap-2 sm:gap-3">

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -116,7 +116,7 @@ function AgentHistoryList({
   const hasActiveFilters = debouncedSearch || type || project || range !== "all";
 
   return (
-    <div className="mx-auto flex h-full max-w-3xl flex-col px-3 sm:px-5 md:px-8">
+    <div className="mx-auto flex h-full max-w-5xl flex-col px-3 sm:px-5 md:px-8">
       {/* Search + filters */}
       <div className="space-y-2 pt-4 pb-2">
         <div className="relative">
@@ -746,7 +746,7 @@ function AgentHistoryDetail({
     tokenUsage.total_output;
 
   return (
-    <div className="mx-auto max-w-3xl min-w-0 space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
+    <div className="mx-auto max-w-5xl min-w-0 space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
       {/* Header */}
       <div>
         <button


### PR DESCRIPTION
## Summary
- Bumped max-width from `max-w-3xl` (768px) to `max-w-5xl` (1024px) for Metrics and History tab content so they use more available space on wider screens (e.g. iPad)
- Fixed Active Hours heatmap touch scrolling by switching from `1fr` grid columns to fixed `28px` columns — the content now naturally overflows the container, enabling drag-to-scroll on touch devices (matching how the Activity heatmap already works)

## Test plan
- [x] `pnpm run finalize:web` passes
- [x] `pnpm run test:e2e` — 79 passed
- [x] Playwright UI validation of both Metrics and History tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)