### PR TITLE
Fix feedback panel not shrinking terminal on open

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -579,12 +579,12 @@ export function DashboardLayout(): JSX.Element {
         >
           <div
             className={cn(
-              "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",
+              "grid h-full min-h-0 min-w-0",
               isMobile
                 ? "grid-rows-[auto_1fr_auto_auto]"
                 : feedbackDetail
                   ? "grid-rows-[auto_1fr_1fr_auto]"
-                  : "grid-rows-[auto_1fr_0fr_auto]"
+                  : "grid-rows-[auto_1fr_auto]"
             )}
           >
             <AppHeader
@@ -610,19 +610,17 @@ export function DashboardLayout(): JSX.Element {
               terminalHostRef={terminalHostRef}
             />
 
-            {!isMobile ? (
-              <div className={cn("min-h-0 overflow-hidden transition-opacity duration-300", feedbackDetail ? "opacity-100" : "opacity-0")}>
-                {feedbackDetail ? (
-                  <FeedbackDetailPanel
-                    key={feedbackDetail.parentAgentId}
-                    parentAgentId={feedbackDetail.parentAgentId}
-                    itemId={feedbackDetail.itemId}
-                    isConnected={connectedAgentId === feedbackDetail.parentAgentId}
-                    sendTerminalInput={sendTerminalInput}
-                    onClose={() => setFeedbackDetail(null)}
-                    onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
-                  />
-                ) : null}
+            {!isMobile && feedbackDetail ? (
+              <div className="min-h-0 overflow-hidden animate-in slide-in-from-bottom fade-in duration-200">
+                <FeedbackDetailPanel
+                  key={feedbackDetail.parentAgentId}
+                  parentAgentId={feedbackDetail.parentAgentId}
+                  itemId={feedbackDetail.itemId}
+                  isConnected={connectedAgentId === feedbackDetail.parentAgentId}
+                  sendTerminalInput={sendTerminalInput}
+                  onClose={() => setFeedbackDetail(null)}
+                  onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
+                />
               </div>
             ) : null}
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -579,12 +579,12 @@ export function DashboardLayout(): JSX.Element {
         >
           <div
             className={cn(
-              "grid h-full min-h-0 min-w-0",
+              "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",
               isMobile
                 ? "grid-rows-[auto_1fr_auto_auto]"
                 : feedbackDetail
                   ? "grid-rows-[auto_1fr_1fr_auto]"
-                  : "grid-rows-[auto_1fr_auto]"
+                  : "grid-rows-[auto_1fr_0fr_auto]"
             )}
           >
             <AppHeader
@@ -610,17 +610,19 @@ export function DashboardLayout(): JSX.Element {
               terminalHostRef={terminalHostRef}
             />
 
-            {!isMobile && feedbackDetail ? (
-              <div className="min-h-0 overflow-hidden animate-in slide-in-from-bottom fade-in duration-200">
-                <FeedbackDetailPanel
-                  key={feedbackDetail.parentAgentId}
-                  parentAgentId={feedbackDetail.parentAgentId}
-                  itemId={feedbackDetail.itemId}
-                  isConnected={connectedAgentId === feedbackDetail.parentAgentId}
-                  sendTerminalInput={sendTerminalInput}
-                  onClose={() => setFeedbackDetail(null)}
-                  onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
-                />
+            {!isMobile ? (
+              <div className="min-h-0 overflow-hidden">
+                {feedbackDetail ? (
+                  <FeedbackDetailPanel
+                    key={feedbackDetail.parentAgentId}
+                    parentAgentId={feedbackDetail.parentAgentId}
+                    itemId={feedbackDetail.itemId}
+                    isConnected={connectedAgentId === feedbackDetail.parentAgentId}
+                    sendTerminalInput={sendTerminalInput}
+                    onClose={() => setFeedbackDetail(null)}
+                    onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
+                  />
+                ) : null}
               </div>
             ) : null}
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -165,6 +165,10 @@ export function DashboardLayout(): JSX.Element {
 
   // ── Misc UI state ────────────────────────────────────────────────────
   const [feedbackDetail, setFeedbackDetail] = useState<FeedbackDetailState>(null);
+  // Keep last feedback detail alive during close transition so content fades out.
+  const feedbackDetailStaleRef = useRef<NonNullable<FeedbackDetailState> | null>(null);
+  if (feedbackDetail) feedbackDetailStaleRef.current = feedbackDetail;
+  const feedbackDetailRendered = feedbackDetail ?? feedbackDetailStaleRef.current;
   const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
 
   // ── Agent selection ────────────────────────────────────────────────────
@@ -586,6 +590,11 @@ export function DashboardLayout(): JSX.Element {
                   ? "grid-rows-[auto_1fr_1fr_auto]"
                   : "grid-rows-[auto_1fr_0fr_auto]"
             )}
+            onTransitionEnd={(e) => {
+              if (e.propertyName === "grid-template-rows" && !feedbackDetail) {
+                feedbackDetailStaleRef.current = null;
+              }
+            }}
           >
             <AppHeader
               leftOpen={leftPanelOpen}
@@ -611,13 +620,13 @@ export function DashboardLayout(): JSX.Element {
             />
 
             {!isMobile ? (
-              <div className="min-h-0 overflow-hidden">
-                {feedbackDetail ? (
+              <div className={cn("min-h-0 overflow-hidden transition-opacity duration-300", feedbackDetail ? "opacity-100" : "opacity-0")}>
+                {feedbackDetailRendered ? (
                   <FeedbackDetailPanel
-                    key={feedbackDetail.parentAgentId}
-                    parentAgentId={feedbackDetail.parentAgentId}
-                    itemId={feedbackDetail.itemId}
-                    isConnected={connectedAgentId === feedbackDetail.parentAgentId}
+                    key={feedbackDetailRendered.parentAgentId}
+                    parentAgentId={feedbackDetailRendered.parentAgentId}
+                    itemId={feedbackDetailRendered.itemId}
+                    isConnected={connectedAgentId === feedbackDetailRendered.parentAgentId}
                     sendTerminalInput={sendTerminalInput}
                     onClose={() => setFeedbackDetail(null)}
                     onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}


### PR DESCRIPTION
## Summary
- The CSS `grid-template-rows` transition (`0fr` ↔ `1fr`) didn't reliably cause the terminal to re-layout — it kept its old size while the panel grew underneath.
- Fix: remove the grid transition, go back to conditionally switching between 3-row and 4-row grids (instant layout). Panel content gets `slide-in-from-bottom` + `fade-in` animation instead.

## Test plan
- [x] Type check
- [x] Production build
- [x] E2E tests (79/79 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)