### PR TITLE
Fix auth enforcement on fresh installs with no password

### DIFF
--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -14,7 +14,9 @@ export function useAuth(): {
       try {
         const res = await fetch("/api/v1/auth/status", { credentials: "include" });
         if (!res.ok) {
-          setAuthState("needs-login");
+          // Can't determine auth state — let the user through; the backend
+          // enforces auth on every API call anyway.
+          setAuthState("authenticated");
           return;
         }
         const data = (await res.json()) as { passwordSet: boolean; authenticated: boolean };


### PR DESCRIPTION
## Summary
- When `/api/v1/auth/status` returns a non-200 response (e.g. server still starting), the frontend was defaulting to `needs-login`, redirecting to the login page even when no password is set
- Changed the fallback to `authenticated` — the backend enforces auth on every API call anyway, so the frontend doesn't need to be the gatekeeper
- This matches the existing `catch` block behavior for network errors

## Test plan
- [x] `pnpm run finalize:web` — type check + production build passes
- [x] `pnpm run test:e2e` — 79/79 passing
- [x] Playwright validation: fresh dev instance with no password loads dashboard correctly