### PR TITLE
Fix node-pty import for tsx/esbuild CJS interop

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -16,7 +16,13 @@ import type nodePty from "node-pty";
 
 let pty: typeof nodePty;
 try {
-  pty = (await import("node-pty")).default;
+  // node-pty is CJS with __esModule: true. Under Node.js native ESM
+  // (production), .default === module.exports. Under tsx/esbuild (dev),
+  // .default is undefined because esbuild respects __esModule and looks
+  // for exports.default which doesn't exist. Fall back to the module
+  // namespace itself which always has the named exports.
+  const m = await import("node-pty");
+  pty = (m.default ?? m) as typeof nodePty;
 } catch {
   console.error(
     "\n✗ Failed to load node-pty native module.\n" +


### PR DESCRIPTION
## Summary
- Fix `pty.spawn` crash (`TypeError: Cannot read properties of undefined`) when running `dispatch-dev --live` in worktrees
- node-pty sets `__esModule: true` in its CJS exports, causing `.default` to be `undefined` under tsx/esbuild while working fine under Node.js native ESM (production)
- Use `m.default ?? m` fallback so the import works in both runtimes

## Context
The bug was latent since the monorepo migration but only surfaced when a live terminal WebSocket was opened via `dispatch-dev` (which uses tsx). Production (`node dist/server.js`) was unaffected because Node.js native ESM handles CJS `.default` differently.

## Test plan
- [x] `pnpm run check` — type check passes
- [x] `pnpm run test` — 94 unit tests pass
- [x] `pnpm run test:e2e` — 79 E2E tests pass
- [x] Verified `pty.spawn` works under both tsx and native Node.js ESM