### PR TITLE
Add agent pins feature with tabbed sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,17 @@ Before marking any task as done, run the following checks and fix any failures:
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.
 
+## Agent Pins
+- When you start a dev server, database, or any service with dynamic ports, **pin the URLs immediately** using the `dispatch_pin` MCP tool so the user can find them without asking.
+- Pin cleanup commands (e.g. `dispatch-dev down`) so the user doesn't have to ask.
+- Update pins when ports/URLs change (e.g. after a `dispatch-dev restart`).
+- Remove stale pins with `dispatch_pin` using `delete: true` when a service is torn down.
+- Use the appropriate `type` for each pin:
+  - `url` — for full URLs (rendered as clickable links)
+  - `port` — for port numbers (rendered as a monospace badge)
+  - `code` — for commands or config values (rendered as a monospace badge)
+  - `string` — for plain text (default)
+
 ## Personas
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.
 - Provide a thorough context briefing in the `context` parameter: what was built, key files changed, areas of concern, and any specific instructions from the user.

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -16,6 +16,13 @@ type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "
 type AgentType = "codex" | "claude" | "opencode";
 type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
+type PinType = "string" | "url" | "port" | "code";
+
+export type AgentPin = {
+  label: string;
+  value: string;
+  type: PinType;
+};
 
 type AgentLatestEvent = {
   type: AgentLatestEventType;
@@ -48,6 +55,7 @@ export type AgentRecord = {
   setupPhase: SetupPhase;
   lastError: string | null;
   latestEvent: AgentLatestEvent | null;
+  pins: AgentPin[];
   gitContext: AgentGitContext | null;
   gitContextStale: boolean;
   gitContextUpdatedAt: string | null;
@@ -616,6 +624,44 @@ export class AgentManager {
       }
     }
     return agent;
+  }
+
+  async upsertPin(id: string, pin: AgentPin): Promise<AgentRecord> {
+    const MAX_PINS = 50;
+    const current = await this.getAgent(id);
+    if (!current) throw new AgentError("Agent not found.", 404);
+
+    const pins = (current.pins ?? []).filter(
+      (p) => p.label.toLowerCase() !== pin.label.toLowerCase()
+    );
+    if (pins.length >= MAX_PINS) {
+      throw new AgentError(`Maximum of ${MAX_PINS} pins reached.`, 400);
+    }
+    pins.push(pin);
+
+    await this.pool.query(
+      `UPDATE agents SET pins = $2::jsonb, updated_at = NOW() WHERE id = $1`,
+      [id, JSON.stringify(pins)]
+    );
+
+    return (await this.getAgent(id)) as AgentRecord;
+  }
+
+  async deletePin(id: string, label: string): Promise<AgentRecord> {
+    const current = await this.getAgent(id);
+    if (!current) throw new AgentError("Agent not found.", 404);
+
+    const lowerLabel = label.toLowerCase();
+    const pins = (current.pins ?? []).filter(
+      (p) => p.label.toLowerCase() !== lowerLabel
+    );
+
+    await this.pool.query(
+      `UPDATE agents SET pins = $2::jsonb, updated_at = NOW() WHERE id = $1`,
+      [id, JSON.stringify(pins)]
+    );
+
+    return (await this.getAgent(id)) as AgentRecord;
   }
 
   async reconcileAgents(): Promise<void> {
@@ -1417,6 +1463,7 @@ export class AgentManager {
             COALESCE(latest_event_metadata, '{}'::jsonb)
           )
         END AS "latestEvent",
+        COALESCE(pins, '[]'::jsonb) AS "pins",
         git_context AS "gitContext",
         git_context_stale AS "gitContextStale",
         git_context_updated_at AS "gitContextUpdatedAt",

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -173,6 +173,9 @@ export async function runMigrations(): Promise<void> {
     );
 
     CREATE INDEX IF NOT EXISTS idx_agent_feedback_agent_id ON agent_feedback(agent_id);
+
+    -- Agent pins (key-value info surfaced in UI)
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS pins JSONB NOT NULL DEFAULT '[]'::jsonb;
   `;
 
   try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -981,6 +981,8 @@ async function registerRoutes() {
       launchPersona: mcpLaunchPersona,
       getFeedback: mcpGetFeedback,
       resolveFeedback: mcpResolveFeedback,
+      upsertPin: mcpUpsertPin,
+      deletePin: mcpDeletePin,
     });
   });
 
@@ -3466,6 +3468,26 @@ async function mcpResolveFeedback(
   if (!record) throw new Error(`Feedback #${feedbackId} not found or not owned by a child of this agent.`);
   uiEventBroker.publish({ type: "feedback.updated", agentId: record.agentId, feedback: record });
   return record;
+}
+
+async function mcpUpsertPin(
+  agentId: string,
+  pin: { label: string; value: string; type: string }
+): Promise<void> {
+  const agent = await agentManager.upsertPin(agentId, {
+    label: pin.label,
+    value: pin.value,
+    type: pin.type as "string" | "url" | "port" | "code"
+  });
+  uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+}
+
+async function mcpDeletePin(
+  agentId: string,
+  label: string
+): Promise<void> {
+  const agent = await agentManager.deletePin(agentId, label);
+  uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/test/db/setup.ts
+++ b/apps/server/test/db/setup.ts
@@ -152,6 +152,9 @@ export async function runTestMigrations(pool: Pool): Promise<void> {
     );
 
     CREATE INDEX IF NOT EXISTS idx_agent_feedback_agent_id ON agent_feedback(agent_id);
+
+    -- Agent pins
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS pins JSONB NOT NULL DEFAULT '[]'::jsonb;
   `;
 
   await pool.query(sql);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -642,8 +642,9 @@ export function DashboardLayout(): JSX.Element {
             mediaFiles={mediaFiles}
             selectedAgentId={focusedAgentId}
             selectedAgentName={focusedAgent?.name ?? null}
+            selectedAgentPins={focusedAgent?.pins ?? []}
             animatingMediaKeys={animatingMediaKeys}
-
+            unseenMediaCount={unseenMediaCount}
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
             hasStream={focusedAgentHasStream}
@@ -708,8 +709,9 @@ export function DashboardLayout(): JSX.Element {
               mediaFiles={mediaFiles}
               selectedAgentId={focusedAgentId}
               selectedAgentName={focusedAgent?.name ?? null}
+              selectedAgentPins={focusedAgent?.pins ?? []}
               animatingMediaKeys={animatingMediaKeys}
-
+              unseenMediaCount={unseenMediaCount}
               mediaViewportRef={mediaViewportRef}
               hasStream={focusedAgentHasStream}
               streamUrl={focusedAgentStreamUrl}

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,8 +1,9 @@
-import { type RefObject, useCallback, useEffect } from "react";
+import { type RefObject, useCallback, useEffect, useState, useRef } from "react";
 import { ChevronRight, ExternalLink, FileText, MonitorPlay, X } from "lucide-react";
 
-import { type MediaFile } from "@/components/app/types";
+import { type AgentPin, type MediaFile } from "@/components/app/types";
 import { MediaActions, isTextFile, stripTimestamp } from "@/components/app/media-lightbox";
+import { PinsPanel } from "@/components/app/pins-panel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -16,11 +17,13 @@ type MediaSidebarSharedProps = {
   mediaFiles: MediaFile[];
   selectedAgentId: string | null;
   selectedAgentName: string | null;
+  selectedAgentPins: AgentPin[];
   animatingMediaKeys: Set<string>;
   mediaViewportRef: RefObject<HTMLDivElement>;
   openLightbox: (file: MediaFile) => void;
   hasStream: boolean;
   streamUrl: string | null;
+  unseenMediaCount: number;
 };
 
 type MediaSidebarProps = MediaSidebarSharedProps & {
@@ -33,6 +36,8 @@ type MediaSidebarContentProps = MediaSidebarSharedProps & {
   closeButtonIcon?: "chevron" | "x";
   className?: string;
 };
+
+type SidebarTab = "pins" | "media";
 
 function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; selectedAgentId: string }): JSX.Element {
   const popOut = useCallback(() => {
@@ -68,38 +73,17 @@ function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; 
   );
 }
 
-export function MediaSidebarContent({
+function MediaContent({
   mediaFiles,
   selectedAgentId,
-  selectedAgentName,
   animatingMediaKeys,
   mediaViewportRef,
   openLightbox,
   hasStream,
   streamUrl,
-  onRequestClose,
-  closeButtonIcon = "x",
-  className
-}: MediaSidebarContentProps): JSX.Element {
+}: Pick<MediaSidebarSharedProps, "mediaFiles" | "selectedAgentId" | "animatingMediaKeys" | "mediaViewportRef" | "openLightbox" | "hasStream" | "streamUrl">): JSX.Element {
   return (
-    <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
-      <div className="flex items-center px-3 py-2 pt-[env(safe-area-inset-top)]">
-        <div>
-          <div className="text-sm font-semibold uppercase tracking-wide">Media Stream</div>
-          <div className="text-xs text-muted-foreground">
-            Viewing: {selectedAgentName ?? "none"}
-          </div>
-        </div>
-        <div className="ml-auto flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">{mediaFiles.length} items</span>
-          {onRequestClose ? (
-            <Button size="icon" variant="ghost" onClick={onRequestClose} title="Close media sidebar">
-              {closeButtonIcon === "chevron" ? <ChevronRight className="h-4 w-4" /> : <X className="h-4 w-4" />}
-            </Button>
-          ) : null}
-        </div>
-      </div>
-
+    <>
       {hasStream && streamUrl && selectedAgentId ? (
         <LiveStreamSection streamUrl={streamUrl} selectedAgentId={selectedAgentId} />
       ) : null}
@@ -181,6 +165,106 @@ export function MediaSidebarContent({
             );
           })
         )}
+      </div>
+    </>
+  );
+}
+
+export function MediaSidebarContent({
+  mediaFiles,
+  selectedAgentId,
+  selectedAgentName,
+  selectedAgentPins,
+  animatingMediaKeys,
+  mediaViewportRef,
+  openLightbox,
+  hasStream,
+  streamUrl,
+  unseenMediaCount,
+  onRequestClose,
+  closeButtonIcon = "x",
+  className
+}: MediaSidebarContentProps): JSX.Element {
+  const [activeTab, setActiveTab] = useState<SidebarTab>("pins");
+  const prevAgentIdRef = useRef(selectedAgentId);
+
+  // Reset to pins tab when agent changes
+  if (prevAgentIdRef.current !== selectedAgentId) {
+    prevAgentIdRef.current = selectedAgentId;
+    if (activeTab !== "pins") {
+      setActiveTab("pins");
+    }
+  }
+
+  const pinCount = selectedAgentPins.length;
+
+  return (
+    <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
+      {/* Tab header */}
+      <div className="flex items-center border-b border-border pt-[env(safe-area-inset-top)]">
+        <div className="flex flex-1">
+          <button
+            onClick={() => setActiveTab("pins")}
+            className={cn(
+              "relative flex items-center gap-1.5 px-4 py-2.5 text-xs font-semibold uppercase tracking-wide transition-colors",
+              activeTab === "pins"
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground/80"
+            )}
+          >
+            Pins
+            {pinCount > 0 && activeTab !== "pins" ? (
+              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-semibold text-muted-foreground">
+                {pinCount}
+              </span>
+            ) : null}
+            {activeTab === "pins" ? (
+              <span className="absolute bottom-0 left-4 right-4 h-0.5 bg-foreground" />
+            ) : null}
+          </button>
+          <button
+            onClick={() => setActiveTab("media")}
+            className={cn(
+              "relative flex items-center gap-1.5 px-4 py-2.5 text-xs font-semibold uppercase tracking-wide transition-colors",
+              activeTab === "media"
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground/80"
+            )}
+          >
+            Media
+            {unseenMediaCount > 0 && activeTab !== "media" ? (
+              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500/20 px-1 text-[10px] font-semibold text-blue-400">
+                {unseenMediaCount}
+              </span>
+            ) : null}
+            {activeTab === "media" ? (
+              <span className="absolute bottom-0 left-4 right-4 h-0.5 bg-foreground" />
+            ) : null}
+          </button>
+        </div>
+        {onRequestClose ? (
+          <div className="px-2">
+            <Button size="icon" variant="ghost" onClick={onRequestClose} title="Close sidebar" className="h-7 w-7">
+              {closeButtonIcon === "chevron" ? <ChevronRight className="h-4 w-4" /> : <X className="h-4 w-4" />}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Tab content — both panels stay mounted so refs (e.g. IntersectionObserver) remain attached */}
+      <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "pins" && "hidden")}>
+        <PinsPanel pins={selectedAgentPins} selectedAgentName={selectedAgentName} />
+      </div>
+      <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "media" && "hidden")}>
+        <MediaContent
+          mediaFiles={mediaFiles}
+          selectedAgentId={selectedAgentId}
+          animatingMediaKeys={animatingMediaKeys}
+          mediaViewportRef={mediaViewportRef}
+          openLightbox={openLightbox}
+          hasStream={hasStream}
+          streamUrl={streamUrl}
+        />
       </div>
     </aside>
   );

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,0 +1,121 @@
+import { Check, Copy, ExternalLink } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+import { type AgentPin } from "@/components/app/types";
+
+const SAFE_URL_RE = /^https?:\/\//i;
+
+function CopyButton({ value }: { value: string }): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    }).catch(() => {});
+  }, [value]);
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+    </button>
+  );
+}
+
+function resolveDisplayValue(pin: AgentPin): { display: string; href: string | null; badge: boolean } {
+  if (pin.type === "url" && SAFE_URL_RE.test(pin.value)) {
+    return { display: pin.value, href: pin.value, badge: false };
+  }
+  if (pin.type === "url") {
+    // Unsafe scheme (e.g. javascript:) — render as plain text, not a link
+    return { display: pin.value, href: null, badge: false };
+  }
+  if (pin.type === "port" || pin.type === "code") {
+    return { display: pin.value, href: null, badge: true };
+  }
+  return { display: pin.value, href: null, badge: false };
+}
+
+function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
+  const { display, href, badge } = resolveDisplayValue(pin);
+
+  return (
+    <div className="px-4 py-2.5 border-b border-border last:border-b-0">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+        {pin.label}
+      </div>
+      <div className="flex items-center gap-1.5">
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+            title={display}
+          >
+            {display}
+          </a>
+        ) : badge ? (
+          <span
+            className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+            title={display}
+          >
+            {display}
+          </span>
+        ) : (
+          <span
+            className="min-w-0 truncate text-xs text-foreground"
+            title={display}
+          >
+            {display}
+          </span>
+        )}
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          {href ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              title="Open in browser"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          ) : null}
+          <CopyButton value={pin.value} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type PinsPanelProps = {
+  pins: AgentPin[];
+  selectedAgentName: string | null;
+};
+
+export function PinsPanel({ pins, selectedAgentName }: PinsPanelProps): JSX.Element {
+  if (pins.length === 0) {
+    return (
+      <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
+        {selectedAgentName
+          ? "No pins yet. Agents can pin URLs, ports, and other info here."
+          : "Focus an agent to view pins."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+      {pins.map((pin) => (
+        <PinItem key={pin.label.toLowerCase()} pin={pin} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -1,5 +1,11 @@
 export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "unknown";
 
+export type AgentPin = {
+  label: string;
+  value: string;
+  type: "string" | "url" | "port" | "code";
+};
+
 export type Agent = {
   id: string;
   name: string;
@@ -19,6 +25,7 @@ export type Agent = {
     updatedAt: string;
     metadata?: Record<string, unknown> | null;
   } | null;
+  pins?: AgentPin[];
   mediaDir: string | null;
   gitContext?: {
     repoRoot: string;

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -20,18 +20,20 @@ test.describe("Media sidebar", () => {
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
-    await expect(mediaSidebar).toContainText(firstAgent.name);
-    await expect(mediaSidebar).toContainText("1 items");
+
+    // Switch to Media tab (sidebar defaults to Pins tab)
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
     await expect(mediaSidebar.getByText("First image")).toBeVisible();
 
     await page.getByText(secondAgent.name, { exact: true }).click();
-    await expect(mediaSidebar).toContainText(secondAgent.name);
+    // Agent switch resets to Pins tab — switch back to Media
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
     await uploadMediaViaAPI(request, firstAgent.id, "Second image", "second-image.png");
     await page.getByText(firstAgent.name, { exact: true }).click();
-    await expect(mediaSidebar).toContainText(firstAgent.name);
+    // Agent switch resets to Pins tab again
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
 
-    await expect(mediaSidebar).toContainText("2 items", { timeout: 10_000 });
-    await expect(mediaSidebar.getByText("Second image")).toBeVisible();
+    await expect(mediaSidebar.getByText("Second image")).toBeVisible({ timeout: 10_000 });
   });
 
   test("navigates between fullscreen media items", async ({ page, request }) => {
@@ -46,7 +48,7 @@ test.describe("Media sidebar", () => {
     await page.getByTestId("toggle-media-sidebar").click();
 
     const mediaSidebar = page.getByTestId("media-sidebar");
-    await expect(mediaSidebar).toContainText("2 items");
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
 
     await mediaSidebar.getByRole("button", { name: "Second image" }).click();
 
@@ -80,7 +82,7 @@ test.describe("Media sidebar", () => {
     await page.getByTestId("toggle-media-sidebar").click();
 
     const mediaSidebar = page.getByTestId("media-sidebar");
-    await expect(mediaSidebar).toContainText("1 items");
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
 
     // The item should flip to "seen" once visible (IntersectionObserver fires).
     const thumb = mediaSidebar.locator(".media-thumb-seen");

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -59,6 +59,13 @@ export type GetFeedbackResult = {
   personas: PersonaFeedbackGroup[];
 };
 
+export type PinInput = {
+  label: string;
+  value?: string;
+  type?: "string" | "url" | "port" | "code";
+  delete?: boolean;
+};
+
 export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
@@ -88,6 +95,14 @@ export type McpRequestContext = {
     feedbackId: number,
     status: "fixed" | "ignored"
   ) => Promise<FeedbackItem>;
+  upsertPin?: (
+    agentId: string,
+    pin: { label: string; value: string; type: string }
+  ) => Promise<void>;
+  deletePin?: (
+    agentId: string,
+    label: string
+  ) => Promise<void>;
 };
 
 export async function handleMcpRequest(
@@ -317,6 +332,59 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           });
           return {
             content: [{ type: "text", text: `Updated ${agentId}: ${args.type} - ${args.message}` }]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.upsertPin && context.deletePin) {
+    const agentId = context.agent.id;
+    const upsertPin = context.upsertPin;
+    const deletePin = context.deletePin;
+
+    server.registerTool(
+      "dispatch_pin",
+      {
+        description:
+          "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info like dev server URLs, ports, and commands. To update a pin, set it again with the same label. To remove a pin, pass delete: true.",
+        inputSchema: {
+          label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
+          value: z
+            .string()
+            .max(2000)
+            .optional()
+            .describe("The value to display. Required unless delete is true."),
+          type: z
+            .enum(["string", "url", "port", "code"])
+            .default("string")
+            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge."),
+          delete: z
+            .boolean()
+            .default(false)
+            .describe("Set to true to remove the pin with this label.")
+        }
+      },
+      async (args) => {
+        try {
+          if (args.delete) {
+            await deletePin(agentId, args.label);
+            return {
+              content: [{ type: "text", text: `Removed pin "${args.label}".` }]
+            };
+          }
+          if (!args.value) {
+            return toToolError(new Error("value is required when not deleting a pin."));
+          }
+          await upsertPin(agentId, {
+            label: args.label,
+            value: args.value,
+            type: args.type ?? "string"
+          });
+          return {
+            content: [{ type: "text", text: `Pinned "${args.label}": ${args.value}` }]
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary

- Adds `dispatch_pin` MCP tool so agents can pin key-value pairs (URLs, ports, commands) to the UI
- Converts the right sidebar from media-only to a tabbed layout with **Pins** (default) and **Media** tabs
- Pins update in real-time via SSE and persist as JSONB on the agents table
- Includes XSS protection (http/https-only URLs), input limits (100 char labels, 2000 char values, 50 pins max), touch-friendly targets, and keyboard focus indicators

## Pin types

| Type | Renders as | Example |
|------|-----------|---------|
| `url` | Clickable blue link | `http://localhost:4821` |
| `port` | Monospace badge | `5432` |
| `code` | Monospace badge | `dispatch-dev down` |
| `string` | Plain text | `feature/my-branch` |

## Test plan

- [x] Type check passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] 79/79 E2E tests pass (media sidebar tests updated for tab navigation)
- [x] Live agent validated: Claude agent called `dispatch_pin` via MCP, pins appeared in UI in real-time
- [x] Frontend UX review persona — addressed touch targets, focus indicators, copy reliability
- [x] Backend security review persona — addressed XSS via URL scheme validation, input length limits, pin count cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)