### PR TITLE
Add ResizeObserver to terminal for container size changes

### DIFF
--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -684,9 +684,15 @@ export function useTerminal(args: {
 
     window.addEventListener("resize", onResize);
 
+    // ResizeObserver so the terminal reflows when its container changes size
+    // (e.g. feedback panel opening/closing via CSS grid transition).
+    const resizeObserver = new ResizeObserver(onResize);
+    resizeObserver.observe(host);
+
     return () => {
       invalidateAttachAttempt();
       disposable.dispose();
+      resizeObserver.disconnect();
       host.removeEventListener("copy", handleCopy, true);
       host.removeEventListener("paste", handlePaste, true);
       host.removeEventListener("touchstart", onTouchStart);


### PR DESCRIPTION
## Summary
- The terminal only resized on `window.resize` events, not when its container changed size via CSS grid transitions (feedback panel open/close).
- Adds a `ResizeObserver` on the terminal host element that calls `fit()` + `sendResize()`, so xterm reflows whenever its container changes size.

## Root cause
The feedback panel uses a CSS grid-template-rows transition to smoothly shrink the terminal. But xterm.js doesn't know its container changed size unless told — it was only listening for `window.resize`. A `ResizeObserver` fires during any container size change, including CSS transitions.

## Test plan
- [x] Type check
- [x] Production build
- [x] E2E tests (79/79 passing)
- [ ] Manual: open feedback panel with a live terminal and verify it reflows smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)