### PR TITLE
Fix terminal not resizing when feedback panel opens

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -248,6 +248,7 @@ export function DashboardLayout(): JSX.Element {
     isMobile,
     leftOpen,
     mediaOpen,
+    feedbackOpen: !!feedbackDetail,
     setSelectedAgentId,
     refreshMedia,
   });

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -70,6 +70,7 @@ export function useTerminal(args: {
   isMobile: boolean;
   leftOpen: boolean;
   mediaOpen: boolean;
+  feedbackOpen: boolean;
   setSelectedAgentId: (agentId: string) => void;
   refreshMedia: (agentId?: string | null) => void;
 }): {
@@ -94,6 +95,7 @@ export function useTerminal(args: {
     isMobile,
     leftOpen,
     mediaOpen,
+    feedbackOpen,
     setSelectedAgentId,
     refreshMedia,
   } = args;
@@ -756,7 +758,7 @@ export function useTerminal(args: {
     fitNow();
     const timer = window.setTimeout(fitNow, 340);
     return () => window.clearTimeout(timer);
-  }, [isMobile, leftOpen, mediaOpen, sendResize]);
+  }, [isMobile, leftOpen, mediaOpen, feedbackOpen, sendResize]);
 
   // Persist active shell agent.
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "node-pty"
+      "node-pty",
+      "sharp"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add `feedbackOpen` to the terminal layout-change fit effect deps, matching the existing pattern for `leftOpen` and `mediaOpen`
- Terminal now correctly resizes (48→24 rows) when the feedback detail panel slides up
- Allow `sharp` build scripts in `pnpm.onlyBuiltDependencies`

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (79 passed)
- [x] Live validation: terminal resizes correctly when feedback panel opens/closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)