### PR TITLE
Add esbuild to pnpm onlyBuiltDependencies whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "esbuild",
       "node-pty",
       "sharp"
     ]


### PR DESCRIPTION
## Summary
- Adds `esbuild` to `pnpm.onlyBuiltDependencies` in the root `package.json`
- esbuild's postinstall script needs to run to install platform-specific binaries, particularly on Linux where it prompts for permission without this

## Test plan
- [ ] Verify `pnpm install` completes without esbuild permission prompts on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)