### PR TITLE
Add 'pr' pin type for pull request links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Before marking any task as done, run the following checks and fix any failures:
   - `url` — for full URLs (rendered as clickable links)
   - `port` — for port numbers (rendered as a monospace badge)
   - `code` — for commands or config values (rendered as a monospace badge)
+  - `pr` — for pull request URLs (rendered as a link with a PR icon)
   - `string` — for plain text (default)
 
 ## Personas

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -16,7 +16,7 @@ type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "
 type AgentType = "codex" | "claude" | "opencode";
 type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
-type PinType = "string" | "url" | "port" | "code";
+type PinType = "string" | "url" | "port" | "code" | "pr";
 
 export type AgentPin = {
   label: string;
@@ -1155,7 +1155,7 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info (dev server URLs, ports, commands) so users can find them in the sidebar. Use the appropriate type (url, port, code, string). Update pins when values change; delete stale pins when services are torn down.";
+      "Use the dispatch_pin MCP tool to pin important info (dev server URLs, ports, commands) so users can find them in the sidebar. Use the appropriate type (url, port, code, string, pr). Use type 'pr' when pinning a pull request URL. Update pins when values change; delete stale pins when services are torn down.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3477,7 +3477,7 @@ async function mcpUpsertPin(
   const agent = await agentManager.upsertPin(agentId, {
     label: pin.label,
     value: pin.value,
-    type: pin.type as "string" | "url" | "port" | "code"
+    type: pin.type as "string" | "url" | "port" | "code" | "pr"
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3470,14 +3470,19 @@ async function mcpResolveFeedback(
   return record;
 }
 
+const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr"] as const;
+
 async function mcpUpsertPin(
   agentId: string,
   pin: { label: string; value: string; type: string }
 ): Promise<void> {
+  if (!VALID_PIN_TYPES.includes(pin.type as (typeof VALID_PIN_TYPES)[number])) {
+    throw new Error(`Invalid pin type: ${pin.type}`);
+  }
   const agent = await agentManager.upsertPin(agentId, {
     label: pin.label,
     value: pin.value,
-    type: pin.type as "string" | "url" | "port" | "code" | "pr"
+    type: pin.type as (typeof VALID_PIN_TYPES)[number]
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, ExternalLink } from "lucide-react";
+import { Check, Copy, ExternalLink, GitPullRequest } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
@@ -28,22 +28,28 @@ function CopyButton({ value }: { value: string }): JSX.Element {
   );
 }
 
-function resolveDisplayValue(pin: AgentPin): { display: string; href: string | null; badge: boolean } {
+function resolveDisplayValue(pin: AgentPin): { display: string; href: string | null; badge: boolean; icon: "pr" | null } {
+  if (pin.type === "pr" && SAFE_URL_RE.test(pin.value)) {
+    return { display: pin.value, href: pin.value, badge: false, icon: "pr" };
+  }
+  if (pin.type === "pr") {
+    return { display: pin.value, href: null, badge: false, icon: "pr" };
+  }
   if (pin.type === "url" && SAFE_URL_RE.test(pin.value)) {
-    return { display: pin.value, href: pin.value, badge: false };
+    return { display: pin.value, href: pin.value, badge: false, icon: null };
   }
   if (pin.type === "url") {
     // Unsafe scheme (e.g. javascript:) — render as plain text, not a link
-    return { display: pin.value, href: null, badge: false };
+    return { display: pin.value, href: null, badge: false, icon: null };
   }
   if (pin.type === "port" || pin.type === "code") {
-    return { display: pin.value, href: null, badge: true };
+    return { display: pin.value, href: null, badge: true, icon: null };
   }
-  return { display: pin.value, href: null, badge: false };
+  return { display: pin.value, href: null, badge: false, icon: null };
 }
 
 function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
-  const { display, href, badge } = resolveDisplayValue(pin);
+  const { display, href, badge, icon } = resolveDisplayValue(pin);
 
   return (
     <div className="px-4 py-2.5 border-b border-border last:border-b-0">
@@ -51,6 +57,7 @@ function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
         {pin.label}
       </div>
       <div className="flex items-center gap-1.5">
+        {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
         {href ? (
           <a
             href={href}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -3,7 +3,7 @@ export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "err
 export type AgentPin = {
   label: string;
   value: string;
-  type: "string" | "url" | "port" | "code";
+  type: "string" | "url" | "port" | "code" | "pr";
 };
 
 export type Agent = {

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -62,7 +62,7 @@ export type GetFeedbackResult = {
 export type PinInput = {
   label: string;
   value?: string;
-  type?: "string" | "url" | "port" | "code";
+  type?: "string" | "url" | "port" | "code" | "pr";
   delete?: boolean;
 };
 
@@ -358,9 +358,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             .optional()
             .describe("The value to display. Required unless delete is true."),
           type: z
-            .enum(["string", "url", "port", "code"])
+            .enum(["string", "url", "port", "code", "pr"])
             .default("string")
-            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge."),
+            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon."),
           delete: z
             .boolean()
             .default(false)


### PR DESCRIPTION
## Summary
- Adds a new `pr` pin type that renders with a `GitPullRequest` icon and clickable link in the pins sidebar
- Updated across the full stack: MCP tool schema, backend types, frontend rendering, agent launch guidance, and CLAUDE.md docs

## Test plan
- [x] Type checks pass (`pnpm run check`)
- [x] Web build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (79 passed, 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)