### PR TITLE
Enable refetchOnWindowFocus and always refetch feedback on mount

### DIFF
--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -186,6 +186,7 @@ export function ParentFeedbackPanel({
       const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${parentAgentId}/feedback?scope=children`);
       return result.feedback;
     },
+    staleTime: 0,
   });
 
   const sheetItem = sheetItemId != null ? feedback.find((f) => f.id === sheetItemId) ?? null : null;
@@ -526,6 +527,7 @@ function useFeedbackData(parentAgentId: string) {
       const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${parentAgentId}/feedback?scope=children`);
       return result.feedback;
     },
+    staleTime: 0,
   });
 
   const { data: allAgents = [] } = useQuery<Agent[]>({ queryKey: ["agents"], enabled: false });

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -29,6 +29,7 @@ export function useAgents(
     },
     select: (data) => sortAgentsByCreatedAtDesc(data),
     enabled,
+    refetchOnWindowFocus: false,
   });
 
   // Re-sort agents in query cache.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -24,7 +24,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 30_000,
       retry: 1,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   },
 });


### PR DESCRIPTION
## Summary

- Enable `refetchOnWindowFocus` globally in the QueryClient defaults (was `false`, now `true`). This lets React Query's built-in SWR behavior refetch stale queries when the user returns to the tab — covering the gap where SSE disconnects on tab hide and `feedback.created` events are lost.
- Set `staleTime: 0` on both feedback queries (`ParentFeedbackPanel` and `useFeedbackData`) so they always refetch when the component mounts (agent expanded in sidebar), ensuring fresh data without requiring a page reload.
- Auth query already has its own `refetchOnWindowFocus: false` so it's unaffected.

## Test plan

- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — 79/79 pass (6 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)