### PR TITLE
Add log rotation for diagnostics and server logs

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { appendFile, copyFile, mkdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { appendFile, copyFile, mkdir, open, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -150,12 +150,17 @@ export type AgentEventListener = (agent: AgentRecord) => void;
 
 export class AgentManager {
   private static readonly TMUX_INVENTORY_INTERVAL_MS = 60_000;
+  private static readonly LOG_MAINTENANCE_INTERVAL_MS = 5 * 60_000;
+  private static readonly MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+  private static readonly DIAGNOSTICS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+  private static readonly SERVER_LOG_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
   private readonly runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
   private readonly eventListeners: AgentEventListener[] = [];
   private lastTmuxInventoryAt = 0;
+  private lastLogMaintenanceAt = 0;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
@@ -710,6 +715,7 @@ export class AgentManager {
 
   async reconcileAgentStatuses(): Promise<AgentRecord[]> {
     await this.maybeCaptureTmuxInventory();
+    await this.maybeMaintenanceLogs();
 
     const result = await this.pool.query(
       "SELECT id, tmux_session AS \"tmuxSession\", status, updated_at AS \"updatedAt\" FROM agents WHERE deleted_at IS NULL AND status IN ('running', 'stopping', 'creating')"
@@ -914,6 +920,89 @@ export class AgentManager {
       await writeFile(path.join(this.diagnosticsRoot(), fileName), JSON.stringify(payload, null, 2), "utf-8");
     } catch (error) {
       this.logger.warn({ err: error, agentId: input.agentId }, "Failed to capture missing tmux session incident.");
+    }
+  }
+
+  private async maybeMaintenanceLogs(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastLogMaintenanceAt < AgentManager.LOG_MAINTENANCE_INTERVAL_MS) {
+      return;
+    }
+    this.lastLogMaintenanceAt = now;
+
+    try {
+      // Rotate tmux-inventory.jsonl (keep 1 backup)
+      const inventoryPath = path.join(this.diagnosticsRoot(), "tmux-inventory.jsonl");
+      await this.rotateFile(inventoryPath, 1);
+
+      // Rotate dispatch.log via copytruncate (keep 3 backups)
+      const serverLogPath = path.join(os.homedir(), ".dispatch", "logs", "dispatch.log");
+      await this.copyTruncateFile(serverLogPath, 3);
+
+      // Delete old diagnostics JSON files (> 7 days)
+      await this.deleteOldFiles(this.diagnosticsRoot(), /\.json$/, AgentManager.DIAGNOSTICS_MAX_AGE_MS);
+
+      // Delete old rotated logs (inventory backups > 7 days, server log backups > 14 days)
+      await this.deleteOldFiles(this.diagnosticsRoot(), /tmux-inventory\.jsonl\.\d+$/, AgentManager.DIAGNOSTICS_MAX_AGE_MS);
+      await this.deleteOldFiles(path.join(os.homedir(), ".dispatch", "logs"), /dispatch\.log\.\d+$/, AgentManager.SERVER_LOG_MAX_AGE_MS);
+    } catch (error) {
+      this.logger.warn({ err: error }, "Log maintenance failed.");
+    }
+  }
+
+  /** Rotate by renaming: file -> file.1, file.1 -> file.2, etc. */
+  private async rotateFile(filePath: string, maxBackups: number): Promise<void> {
+    try {
+      const s = await stat(filePath);
+      if (s.size < AgentManager.MAX_LOG_SIZE_BYTES) return;
+    } catch { return; } // file doesn't exist
+
+    // Shift existing backups
+    for (let i = maxBackups; i >= 1; i--) {
+      const src = i === 1 ? filePath : `${filePath}.${i - 1}`;
+      const dst = `${filePath}.${i}`;
+      try { await rename(src, dst); } catch { /* missing, skip */ }
+    }
+  }
+
+  /** Copy then truncate in-place (preserves open file descriptors like launchd's). */
+  private async copyTruncateFile(filePath: string, maxBackups: number): Promise<void> {
+    try {
+      const s = await stat(filePath);
+      if (s.size < AgentManager.MAX_LOG_SIZE_BYTES) return;
+    } catch { return; }
+
+    // Shift existing backups
+    for (let i = maxBackups; i >= 2; i--) {
+      try { await rename(`${filePath}.${i - 1}`, `${filePath}.${i}`); } catch { /* missing */ }
+    }
+
+    // Copy current to .1, then truncate in place.
+    // Small data-loss window between copy and truncate (same as logrotate copytruncate). Acceptable for diagnostic logs.
+    await copyFile(filePath, `${filePath}.1`);
+    const fh = await open(filePath, "r+");
+    try {
+      await fh.truncate(0);
+    } finally {
+      await fh.close();
+    }
+  }
+
+  /** Delete files matching a pattern that are older than maxAgeMs. */
+  private async deleteOldFiles(dir: string, pattern: RegExp, maxAgeMs: number): Promise<void> {
+    let entries: string[];
+    try { entries = await readdir(dir); } catch { return; }
+
+    const now = Date.now();
+    for (const entry of entries) {
+      if (!pattern.test(entry)) continue;
+      const filePath = path.join(dir, entry);
+      try {
+        const s = await stat(filePath);
+        if (now - s.mtimeMs > maxAgeMs) {
+          await unlink(filePath);
+        }
+      } catch { /* already gone or inaccessible */ }
     }
   }
 


### PR DESCRIPTION
## Summary
- Prevents unbounded growth of `~/.dispatch/diagnostics/tmux-inventory.jsonl` (had grown to 387 MB) and `~/.dispatch/logs/dispatch.log` (79 MB)
- Adds `maybeMaintenanceLogs()` to the existing reconcile loop, running every 5 minutes
- Rotates `tmux-inventory.jsonl` at 10 MB (rename, 1 backup, 7-day retention)
- Rotates `dispatch.log` at 10 MB via copytruncate to preserve launchd/systemd file descriptors (3 backups, 14-day retention)
- Deletes missing-session diagnostic JSON files older than 7 days

## Test plan
- [x] `pnpm run check` — types pass
- [x] `pnpm run test` — 87 unit tests pass
- [x] `pnpm run test:e2e` — 77 E2E tests pass (6 pre-existing skips)
- [x] Dev instance started, health check and logging verified working
- [x] Infra review persona launched — feedback triaged, one comment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)