### PR TITLE
Add instance name setting and reorganize settings sections

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -50,7 +50,7 @@ import {
 import { loadConfig } from "./config.js";
 import { createPool } from "./db/client.js";
 import { runMigrations } from "./db/migrate.js";
-import { getSetting, setSetting } from "./db/settings.js";
+import { deleteSetting, getSetting, setSetting } from "./db/settings.js";
 import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { handleMcpRequest } from "@dispatch/shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
@@ -1365,6 +1365,7 @@ async function registerRoutes() {
 
   // --- Agent worktree settings ---
   const WORKTREE_LOCATION_KEY = "worktree_location";
+  const INSTANCE_NAME_KEY = "instance_name";
   type WorktreeLocation = "sibling" | "nested";
   const VALID_WORKTREE_LOCATIONS: WorktreeLocation[] = ["sibling", "nested"];
 
@@ -1372,11 +1373,12 @@ async function registerRoutes() {
     const raw = await getSetting(pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation: WorktreeLocation =
       raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw) ? (raw as WorktreeLocation) : "sibling";
-    return { worktreeLocation, iconColor: cachedIconColor };
+    const instanceName = (await getSetting(pool, INSTANCE_NAME_KEY)) ?? "";
+    return { worktreeLocation, iconColor: cachedIconColor, instanceName };
   });
 
   app.post("/api/v1/agents/settings", async (request, reply) => {
-    const body = request.body as { worktreeLocation?: unknown; iconColor?: unknown };
+    const body = request.body as { worktreeLocation?: unknown; iconColor?: unknown; instanceName?: unknown };
 
     if (body.worktreeLocation !== undefined) {
       if (typeof body.worktreeLocation !== "string" || !(VALID_WORKTREE_LOCATIONS as string[]).includes(body.worktreeLocation)) {
@@ -1393,10 +1395,23 @@ async function registerRoutes() {
       rewriteForColor(body.iconColor as IconColor);
     }
 
+    if (body.instanceName !== undefined) {
+      if (typeof body.instanceName !== "string") {
+        return reply.code(400).send({ error: "instanceName must be a string." });
+      }
+      const trimmed = body.instanceName.trim().slice(0, 100);
+      if (trimmed) {
+        await setSetting(pool, INSTANCE_NAME_KEY, trimmed);
+      } else {
+        await deleteSetting(pool, INSTANCE_NAME_KEY);
+      }
+    }
+
     const raw = await getSetting(pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation: WorktreeLocation =
       raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw) ? (raw as WorktreeLocation) : "sibling";
-    return { worktreeLocation, iconColor: cachedIconColor };
+    const instanceName = (await getSetting(pool, INSTANCE_NAME_KEY)) ?? "";
+    return { worktreeLocation, iconColor: cachedIconColor, instanceName };
   });
 
   // --- Notification settings ---

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,7 @@ import { useSSE } from "@/hooks/use-sse";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useIconColor } from "@/hooks/use-icon-color";
+import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { AGENT_TYPES, type AgentType, isAgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
@@ -115,6 +116,12 @@ export function DashboardLayout(): JSX.Element {
   // ── Theme & Branding ──────────────────────────────────────────────────
   const { theme, setTheme } = useTheme();
   const { iconColor, setIconColor, isLoading: isIconColorSaving, error: iconColorError, clearError: clearIconColorError } = useIconColor();
+  const { instanceName } = useInstanceName();
+
+  // ── Page title ───────────────────────────────────────────────────────
+  useEffect(() => {
+    document.title = instanceName ? `${instanceName} — Dispatch` : "Dispatch";
+  }, [instanceName]);
 
   // ── Auth (from context — AuthLayout guarantees authenticated) ─────────
   const { handleLogout } = useAuthContext();

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   X
 } from "lucide-react";
 import { useIconColor } from "@/hooks/use-icon-color";
+import { useInstanceName } from "@/hooks/use-instance-name";
 
 import { AgentMeta } from "@/components/app/agent-meta";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
@@ -99,6 +100,7 @@ export function AgentSidebarContent({
   className
 }: AgentSidebarContentProps): JSX.Element {
   const { iconColor } = useIconColor();
+  const { instanceName } = useInstanceName();
 
   const defaultCreateType: AgentType = lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
     ? lastUsedAgentType
@@ -150,9 +152,15 @@ export function AgentSidebarContent({
 
   return (
     <aside data-testid="agent-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-r-2 border-border bg-card text-foreground", className)}>
-      <div className="flex h-14 items-center px-3 pt-[env(safe-area-inset-top)]">
-        <div className="flex items-center">
-          <img src={`/icons/${iconColor}/brand-full-logo.svg`} alt="Dispatch" className="h-7 w-auto max-w-[180px] object-contain" />
+      <div className="flex min-h-14 items-center px-3 pt-[env(safe-area-inset-top)]">
+        <div className="flex items-center gap-2.5">
+          <img src={`/icons/${iconColor}/brand-icon.svg`} alt="" className="h-7 w-7 shrink-0 object-contain" />
+          <div className="flex min-w-0 flex-col justify-center">
+            <div className="text-sm font-bold uppercase tracking-widest text-foreground">Dispatch</div>
+            {instanceName ? (
+              <div className="truncate text-[11px] leading-tight text-muted-foreground">{instanceName}</div>
+            ) : null}
+          </div>
         </div>
         {onRequestClose ? (
           <div className="ml-auto">

--- a/apps/web/src/components/app/security-settings.tsx
+++ b/apps/web/src/components/app/security-settings.tsx
@@ -101,7 +101,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
   }
 
   return (
-    <div className="flex flex-col gap-8 overflow-y-auto p-6">
+    <div className="flex flex-col gap-8 p-6">
       <div>
         <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           {passwordSet ? "Change Password" : "Set Password"}

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { Bell, ChevronDown, ChevronRight, ArrowLeft, ArrowDownToLine, ExternalLink, Palette, RefreshCw, Shield, Trash2, Users, X } from "lucide-react";
+import { ArrowDownToLine, ArrowLeft, Bell, ChevronDown, ChevronRight, ExternalLink, Info, RefreshCw, Settings, Trash2, Users, X } from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { NotificationSettings } from "@/components/app/notification-settings";
@@ -8,20 +8,20 @@ import { ReleaseManager } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
+import { useInstanceName } from "@/hooks/use-instance-name";
 import { type ThemeId, THEMES } from "@/hooks/use-theme";
 import { type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "release" | "security" | "notifications" | "appearance" | "agents" | "app";
+type SettingsSection = "general" | "agents" | "notifications" | "updates" | "about";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
-  { id: "release", label: "Updates", icon: ArrowDownToLine },
-  { id: "security", label: "Security", icon: Shield },
-  { id: "notifications", label: "Notifications", icon: Bell },
-  { id: "appearance", label: "Appearance", icon: Palette },
+  { id: "general", label: "General", icon: Settings },
   { id: "agents", label: "Agents", icon: Users },
-  { id: "app", label: "App", icon: RefreshCw }
+  { id: "notifications", label: "Notifications", icon: Bell },
+  { id: "updates", label: "Updates", icon: ArrowDownToLine },
+  { id: "about", label: "About", icon: Info },
 ];
 
 type AppVersionInfo = {
@@ -31,6 +31,90 @@ type AppVersionInfo = {
   releaseNotes: string | null;
   releaseUrl: string | null;
 };
+
+function InstanceNameSettings(): JSX.Element {
+  const { instanceName, setInstanceName, isSaving, saveError, didSave, clearSaveState } = useInstanceName();
+  const [draft, setDraft] = useState(instanceName);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showSaved, setShowSaved] = useState(false);
+
+  // Sync draft when the stored value loads/changes (but not while the user is editing)
+  useEffect(() => {
+    if (document.activeElement !== inputRef.current) {
+      setDraft(instanceName);
+    }
+  }, [instanceName]);
+
+  // Revert draft on save error
+  useEffect(() => {
+    if (saveError) {
+      setDraft(instanceName);
+    }
+  }, [saveError, instanceName]);
+
+  // Show brief "Saved" confirmation
+  useEffect(() => {
+    if (didSave) {
+      setShowSaved(true);
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = setTimeout(() => {
+        setShowSaved(false);
+        clearSaveState();
+      }, 2000);
+    }
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, [didSave, clearSaveState]);
+
+  const save = useCallback(() => {
+    const trimmed = draft.trim();
+    if (trimmed !== instanceName) {
+      setInstanceName(trimmed);
+    }
+    setDraft(trimmed);
+  }, [draft, instanceName, setInstanceName]);
+
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Instance name
+      </div>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Give this Dispatch instance a name to distinguish it from others. Shown in the sidebar and browser tab.
+      </p>
+      <div className="flex items-center gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => { setDraft(e.target.value); if (saveError) clearSaveState(); }}
+          onBlur={save}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              save();
+              inputRef.current?.blur();
+            }
+          }}
+          disabled={isSaving}
+          placeholder="e.g. Production, Staging, Local"
+          maxLength={100}
+          className={cn(
+            "w-full max-w-sm rounded border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none disabled:opacity-50",
+            saveError ? "border-destructive" : "border-border focus:border-primary/50"
+          )}
+        />
+        {showSaved && !saveError ? (
+          <span className="text-xs text-muted-foreground">Saved</span>
+        ) : null}
+      </div>
+      {saveError ? (
+        <p className="mt-1.5 text-xs text-destructive">Failed to save. Please try again.</p>
+      ) : null}
+    </div>
+  );
+}
 
 function AppSettings(): JSX.Element {
   const [reloading, setReloading] = useState(false);
@@ -415,7 +499,7 @@ export function SettingsPane({
   initialSection,
   onSectionChange,
 }: SettingsPaneProps): JSX.Element {
-  const resolvedInitial = isValidSection(initialSection) ? initialSection : "release";
+  const resolvedInitial = isValidSection(initialSection) ? initialSection : "general";
   const [activeSection, setActiveSectionState] = useState<SettingsSection | null>(resolvedInitial);
 
   // Sync from URL when initialSection changes (e.g. navigating directly to /settings/appearance)
@@ -436,7 +520,7 @@ export function SettingsPane({
       onOpenChange={(v) => {
         if (!v) {
           onClose();
-          setActiveSectionState("release");
+          setActiveSectionState("general");
         }
       }}
     >
@@ -509,10 +593,19 @@ export function SettingsPane({
 
             {/* Content */}
             <div className={cn("min-h-0 min-w-0 flex-1", activeSection === null && "hidden md:block")}>
-              {activeSection === "release" && <ReleaseManager />}
-              {activeSection === "security" && <SecuritySettings onLogout={onLogout} />}
-              {activeSection === "notifications" && <NotificationSettings />}
-              {activeSection === "appearance" && <AppearanceSettings theme={theme} setTheme={setTheme} iconColor={iconColor} setIconColor={setIconColor} isIconColorSaving={isIconColorSaving} iconColorError={iconColorError} clearIconColorError={clearIconColorError} />}
+              {activeSection === "general" && (
+                <div className="flex flex-col overflow-y-auto">
+                  <div className="p-4 md:p-6">
+                    <InstanceNameSettings />
+                  </div>
+                  <div className="border-t border-border">
+                    <AppearanceSettings theme={theme} setTheme={setTheme} iconColor={iconColor} setIconColor={setIconColor} isIconColorSaving={isIconColorSaving} iconColorError={iconColorError} clearIconColorError={clearIconColorError} />
+                  </div>
+                  <div className="border-t border-border">
+                    <SecuritySettings onLogout={onLogout} />
+                  </div>
+                </div>
+              )}
               {activeSection === "agents" && (
                 <div className="flex flex-col">
                   <AgentTypeSettings
@@ -524,7 +617,9 @@ export function SettingsPane({
                   </div>
                 </div>
               )}
-              {activeSection === "app" && <AppSettings />}
+              {activeSection === "notifications" && <NotificationSettings />}
+              {activeSection === "updates" && <ReleaseManager />}
+              {activeSection === "about" && <AppSettings />}
             </div>
           </div>
         </DialogPrimitive.Content>

--- a/apps/web/src/hooks/use-instance-name.ts
+++ b/apps/web/src/hooks/use-instance-name.ts
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useInstanceName(): {
+  instanceName: string;
+  setInstanceName: (name: string) => void;
+  isSaving: boolean;
+  saveError: boolean;
+  didSave: boolean;
+  clearSaveState: () => void;
+} {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<{ instanceName: string }>({
+    queryKey: ["agents-settings"],
+    queryFn: async () => {
+      const res = await fetch("/api/v1/agents/settings");
+      if (!res.ok) throw new Error("Failed to fetch settings");
+      return res.json();
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await fetch("/api/v1/agents/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ instanceName: name }),
+      });
+      if (!res.ok) throw new Error("Failed to save instance name");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
+    },
+  });
+
+  const setInstanceName = useCallback(
+    (name: string) => {
+      mutation.mutate(name);
+    },
+    [mutation],
+  );
+
+  const clearSaveState = useCallback(() => {
+    mutation.reset();
+  }, [mutation]);
+
+  return {
+    instanceName: data?.instanceName ?? "",
+    setInstanceName,
+    isSaving: mutation.isPending,
+    saveError: mutation.isError,
+    didSave: mutation.isSuccess,
+    clearSaveState,
+  };
+}

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -43,7 +43,7 @@ test.describe("App shell", () => {
   test("sidebar shows the Dispatch logo", async ({ page }) => {
     await loadApp(page);
 
-    const logo = page.getByTestId("agent-sidebar").locator('img[alt="Dispatch"]');
-    await expect(logo).toBeVisible();
+    const title = page.getByTestId("agent-sidebar").getByText("Dispatch", { exact: true });
+    await expect(title).toBeVisible();
   });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -12,23 +12,23 @@ test.describe("Settings pane", () => {
     // Click the Settings button in the sidebar footer
     await page.getByTestId("settings-button").click();
 
-    // Settings overlay should appear with a "Settings" heading and "Updates" nav item
+    // Settings overlay should appear with a "Settings" heading and "General" nav item
     await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 3_000 });
-    const releaseNav = page.getByRole("navigation").getByText("Updates");
-    await expect(releaseNav).toBeVisible();
+    const generalNav = page.getByRole("navigation").getByText("General");
+    await expect(generalNav).toBeVisible();
 
     // Close it via the X button (sr-only "Close")
     await page.getByRole("button", { name: "Close" }).click();
 
-    // The Updates nav item should no longer be visible (pane is closed)
-    await expect(releaseNav).not.toBeVisible({ timeout: 3_000 });
+    // The General nav item should no longer be visible (pane is closed)
+    await expect(generalNav).not.toBeVisible({ timeout: 3_000 });
   });
 
   test("shows version metadata in the App section", async ({ page }) => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByRole("navigation").getByText("App", { exact: true }).click();
+    await page.getByRole("navigation").getByText("About", { exact: true }).click();
 
     await expect(page.getByTestId("app-version-card")).toBeVisible();
     await expect(page.getByTestId("app-version-semver")).not.toHaveText("");


### PR DESCRIPTION
## Summary
- Add instance name setting so users can label their Dispatch instance — shown in the sidebar below the DISPATCH title and in the browser tab title (`"Name — Dispatch"`)
- Reorganize settings from 6 sections to 5: merge Appearance + Security into **General**, rename App to **About**, keep Updates/Agents/Notifications unchanged
- Sidebar header updated to use icon + text layout (instead of single SVG) so instance name can sit below the title

## Details
- **Backend**: `instanceName` added to `GET/POST /api/v1/agents/settings`, stored in existing settings table
- **Frontend**: new `useInstanceName` hook (shares `agents-settings` react-query key with `useIconColor`), `InstanceNameSettings` component with auto-save on blur/Enter, "Saved" confirmation, error handling with draft revert
- **Sidebar**: `brand-icon.svg` + text "DISPATCH" in flex row with `items-center gap-2.5`, instance name below in muted text, `min-h-14` to accommodate safe area insets
- **Page title**: `useEffect` in App.tsx sets `document.title` dynamically

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — production build passes
- [x] `pnpm run test:e2e` — 79/79 tests pass (6 pre-existing skips)
- [x] Playwright validation: set instance name in settings, verified sidebar + page title update
- [x] Playwright validation: cleared instance name, verified clean layout
- [x] Frontend UX review persona feedback addressed (8 items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)