### PR TITLE
Fix settings content not scrolling on overflow

### DIFF
--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -158,7 +158,7 @@ export function AgentSidebarContent({
           <div className="flex min-w-0 flex-col justify-center">
             <div className="text-sm font-bold uppercase tracking-widest text-foreground">Dispatch</div>
             {instanceName ? (
-              <div className="truncate text-[11px] leading-tight text-muted-foreground">{instanceName}</div>
+              <div title={instanceName} className="truncate text-[11px] leading-tight text-muted-foreground">{instanceName}</div>
             ) : null}
           </div>
         </div>

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -78,14 +78,15 @@ function InstanceNameSettings(): JSX.Element {
 
   return (
     <div>
-      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+      <label htmlFor="instance-name" className="mb-1.5 block text-[10px] uppercase tracking-widest text-muted-foreground">
         Instance name
-      </div>
+      </label>
       <p className="mb-3 text-sm text-muted-foreground">
         Give this Dispatch instance a name to distinguish it from others. Shown in the sidebar and browser tab.
       </p>
       <div className="flex items-center gap-2">
         <input
+          id="instance-name"
           ref={inputRef}
           type="text"
           value={draft}

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -509,12 +509,9 @@ export function SettingsPane({
     }
   }, [open, initialSection]);
 
-  const contentRef = useRef<HTMLDivElement>(null);
-
   const setActiveSection = useCallback((section: SettingsSection | null) => {
     setActiveSectionState(section);
     onSectionChange?.(section);
-    contentRef.current?.scrollTo(0, 0);
   }, [onSectionChange]);
 
   return (
@@ -595,7 +592,7 @@ export function SettingsPane({
             )}
 
             {/* Content */}
-            <div ref={contentRef} className={cn("min-h-0 min-w-0 flex-1 overflow-y-auto", activeSection === null && "hidden md:block")}>
+            <div key={activeSection} className={cn("min-h-0 min-w-0 flex-1 overflow-y-auto", activeSection === null && "hidden md:block")}>
               {activeSection === "general" && (
                 <div className="flex flex-col">
                   <div className="p-4 md:p-6">

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -509,9 +509,12 @@ export function SettingsPane({
     }
   }, [open, initialSection]);
 
+  const contentRef = useRef<HTMLDivElement>(null);
+
   const setActiveSection = useCallback((section: SettingsSection | null) => {
     setActiveSectionState(section);
     onSectionChange?.(section);
+    contentRef.current?.scrollTo(0, 0);
   }, [onSectionChange]);
 
   return (
@@ -592,7 +595,7 @@ export function SettingsPane({
             )}
 
             {/* Content */}
-            <div className={cn("min-h-0 min-w-0 flex-1 overflow-y-auto", activeSection === null && "hidden md:block")}>
+            <div ref={contentRef} className={cn("min-h-0 min-w-0 flex-1 overflow-y-auto", activeSection === null && "hidden md:block")}>
               {activeSection === "general" && (
                 <div className="flex flex-col">
                   <div className="p-4 md:p-6">

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -592,9 +592,9 @@ export function SettingsPane({
             )}
 
             {/* Content */}
-            <div className={cn("min-h-0 min-w-0 flex-1", activeSection === null && "hidden md:block")}>
+            <div className={cn("min-h-0 min-w-0 flex-1 overflow-y-auto", activeSection === null && "hidden md:block")}>
               {activeSection === "general" && (
-                <div className="flex flex-col overflow-y-auto">
+                <div className="flex flex-col">
                   <div className="p-4 md:p-6">
                     <InstanceNameSettings />
                   </div>


### PR DESCRIPTION
## Summary
- Move `overflow-y-auto` from the general section wrapper to the shared content container so all settings sections scroll when content exceeds the viewport height
- Especially apparent on mobile where the settings content would get clipped with no way to scroll to sections below the fold

## Test plan
- [x] Verified on 375×667 mobile viewport — content scrolls to reveal Icon Color and Set Password sections
- [x] `pnpm run finalize:web` passes
- [x] All 79 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)