### PR TITLE
Align media sidebar header with app header bar

### DIFF
--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -201,7 +201,7 @@ export function MediaSidebarContent({
   return (
     <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
       {/* Tab header */}
-      <div className="flex items-center border-b border-border pt-[env(safe-area-inset-top)]">
+      <div className="flex min-h-14 items-center border-b-2 border-border pt-[env(safe-area-inset-top)]">
         <div className="flex flex-1">
           <button
             onClick={() => setActiveTab("pins")}


### PR DESCRIPTION
## Summary
- Added `min-h-14` to the media sidebar tab header so it matches the 56px height of the app header and left sidebar header
- Changed `border-b` to `border-b-2` so the horizontal border lines up with the main app header's border

## Test plan
- [x] `pnpm run finalize:web` passes
- [x] E2E tests pass (79 passed)
- [x] Visual validation via Playwright — PINS/MEDIA tabs vertically centered and border aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)