### PR TITLE
Make agent archival async with progress tracking

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -55,6 +55,7 @@ export type AgentRecord = {
   fullAccess: boolean;
   setupPhase: SetupPhase;
   archivePhase: ArchivePhase;
+  archiveCleanupMode: WorktreeCleanupMode | null;
   lastError: string | null;
   latestEvent: AgentLatestEvent | null;
   pins: AgentPin[];
@@ -485,15 +486,25 @@ export class AgentManager {
    * Fast, synchronous first phase of archival: validates state and marks agent as archiving.
    * Returns the updated agent record for SSE broadcast.
    */
-  async beginArchive(id: string): Promise<AgentRecord> {
-    const agent = await this.getRequiredAgent(id);
+  async beginArchive(id: string, cleanupWorktree: WorktreeCleanupMode = "auto"): Promise<AgentRecord> {
+    // Atomic transition: only one caller can move out of non-archiving state.
+    // This prevents TOCTOU races when concurrent DELETE requests hit the same agent.
+    const result = await this.pool.query(
+      `UPDATE agents
+       SET status = 'archiving', archive_phase = 'stopping', archive_cleanup_mode = $2, updated_at = NOW()
+       WHERE id = $1 AND deleted_at IS NULL AND status != 'archiving'
+       RETURNING id`,
+      [id, cleanupWorktree]
+    );
 
-    if (agent.status === "archiving") {
+    if (result.rowCount === 0) {
+      // Either the agent doesn't exist, is already deleted, or is already archiving
+      const existing = await this.getAgent(id);
+      if (!existing) {
+        throw new AgentError("Agent not found.", 404);
+      }
       throw new AgentError("Agent is already being archived.", 409);
     }
-
-    await this.setAgentStatus(id, "archiving", null, agent.tmuxSession ?? undefined);
-    await this.setArchivePhase(id, "stopping");
 
     return await this.getRequiredAgent(id);
   }
@@ -504,7 +515,6 @@ export class AgentManager {
    */
   async executeArchive(
     id: string,
-    cleanupWorktree: WorktreeCleanupMode,
     callbacks: {
       onPhaseChange: (agent: AgentRecord) => void;
       onComplete: (deletedIds: string[]) => void;
@@ -516,6 +526,7 @@ export class AgentManager {
 
     try {
       const agent = await this.getRequiredAgent(id);
+      const cleanupWorktree = agent.archiveCleanupMode ?? "auto";
 
       // Phase: stopping — tear down session without changing agent status
       const t = Date.now();
@@ -608,7 +619,7 @@ export class AgentManager {
         )
         .catch((err) => this.logger.warn({ err }, "Failed to insert delete event"));
 
-      await this.pool.query("UPDATE agents SET deleted_at = NOW(), archive_phase = NULL, updated_at = NOW() WHERE id = $1", [id]);
+      await this.pool.query("UPDATE agents SET deleted_at = NOW(), archive_phase = NULL, archive_cleanup_mode = NULL, updated_at = NOW() WHERE id = $1", [id]);
       durations.db = Date.now() - tDb;
 
       // Cascade: archive child agents (persona agents spawned by this parent)
@@ -680,6 +691,19 @@ export class AgentManager {
     await this.pool.query("UPDATE agents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1", [id]);
     durations.db = Date.now() - tDb;
 
+    // Cascade to any children (recursive to handle multi-level nesting)
+    const children = await this.pool.query<{ id: string }>(
+      "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
+      [id]
+    );
+    for (const child of children.rows) {
+      try {
+        await this.deleteAgentDirect(child.id, true, cleanupWorktree);
+      } catch (err) {
+        this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
+      }
+    }
+
     durations.total = Date.now() - deleteStart;
     const parts = Object.entries(durations).map(([k, v]) => `${k}=${v}ms`).join(", ");
     this.logger.info({ agentId: id, durations }, `Archive durations: ${parts}`);
@@ -741,7 +765,7 @@ export class AgentManager {
           latest_event_metadata = $4::jsonb,
           latest_event_updated_at = NOW(),
           updated_at = NOW()
-      WHERE id = $1
+      WHERE id = $1 AND deleted_at IS NULL
       `,
       [id, input.type, message, JSON.stringify(input.metadata ?? {})]
     );
@@ -760,14 +784,17 @@ export class AgentManager {
       )
       .catch((err) => this.logger.warn({ err }, "Failed to insert agent event history"));
 
-    const agent = (await this.getAgent(id)) as AgentRecord;
-    if (agent) {
-      for (const listener of this.eventListeners) {
-        try {
-          listener(agent);
-        } catch (err) {
-          this.logger.warn({ err }, "Agent event listener threw");
-        }
+    // Agent could be soft-deleted between the UPDATE and this SELECT in rare races.
+    // Guard against null to prevent downstream crashes (e.g. in event listeners).
+    const agent = await this.getAgent(id);
+    if (!agent) {
+      throw new AgentError("Agent not found.", 404);
+    }
+    for (const listener of this.eventListeners) {
+      try {
+        listener(agent);
+      } catch (err) {
+        this.logger.warn({ err }, "Agent event listener threw");
       }
     }
     return agent;
@@ -1696,6 +1723,7 @@ export class AgentManager {
         full_access AS "fullAccess",
         setup_phase AS "setupPhase",
         archive_phase AS "archivePhase",
+        archive_cleanup_mode AS "archiveCleanupMode",
         last_error AS "lastError",
         CASE
           WHEN latest_event_type IS NULL OR latest_event_message IS NULL OR latest_event_updated_at IS NULL THEN NULL

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -12,10 +12,11 @@ import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { loadRepoHooks } from "@dispatch/shared/mcp/repo-tools.js";
 import { harvestTokenUsage } from "./token-harvester.js";
 
-type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "unknown";
+type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "archiving" | "error" | "unknown";
 type AgentType = "codex" | "claude" | "opencode";
 type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
+type ArchivePhase = "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
 type PinType = "string" | "url" | "port" | "code" | "pr";
 
 export type AgentPin = {
@@ -53,6 +54,7 @@ export type AgentRecord = {
   agentArgs: string[];
   fullAccess: boolean;
   setupPhase: SetupPhase;
+  archivePhase: ArchivePhase;
   lastError: string | null;
   latestEvent: AgentLatestEvent | null;
   pins: AgentPin[];
@@ -479,18 +481,182 @@ export class AgentManager {
     return (await this.getAgent(id)) as AgentRecord;
   }
 
-  async deleteAgent(id: string, force = false, cleanupWorktree: WorktreeCleanupMode = "auto"): Promise<void> {
+  /**
+   * Fast, synchronous first phase of archival: validates state and marks agent as archiving.
+   * Returns the updated agent record for SSE broadcast.
+   */
+  async beginArchive(id: string): Promise<AgentRecord> {
+    const agent = await this.getRequiredAgent(id);
+
+    if (agent.status === "archiving") {
+      throw new AgentError("Agent is already being archived.", 409);
+    }
+
+    await this.setAgentStatus(id, "archiving", null, agent.tmuxSession ?? undefined);
+    await this.setArchivePhase(id, "stopping");
+
+    return await this.getRequiredAgent(id);
+  }
+
+  /**
+   * Long-running second phase of archival: stops agent, cleans up worktree, soft-deletes.
+   * Designed to run fire-and-forget after beginArchive returns.
+   */
+  async executeArchive(
+    id: string,
+    cleanupWorktree: WorktreeCleanupMode,
+    callbacks: {
+      onPhaseChange: (agent: AgentRecord) => void;
+      onComplete: (deletedIds: string[]) => void;
+      onError: (error: unknown) => void;
+    }
+  ): Promise<void> {
+    const deleteStart = Date.now();
+    const durations: Record<string, number> = {};
+
+    try {
+      const agent = await this.getRequiredAgent(id);
+
+      // Phase: stopping — tear down session without changing agent status
+      const t = Date.now();
+      try {
+        await this.runLifecycleHook("stop", agent).catch((err) =>
+          this.logger.warn({ err, agentId: id }, "Stop hook failed during archive; continuing")
+        );
+        if (agent.tmuxSession && (await this.hasAgentSession(agent.tmuxSession))) {
+          await this.stopAgentSession(agent.tmuxSession, true);
+        }
+        harvestTokenUsage(this.pool, {
+          id: agent.id,
+          type: agent.type,
+          cwd: agent.cwd,
+          worktreePath: agent.worktreePath,
+        }, this.logger).catch((err) =>
+          this.logger.warn({ err, agentId: id }, "Token harvest failed during archive")
+        );
+      } catch (err) {
+        this.logger.warn({ err, agentId: id }, "Stop during archive failed; continuing");
+      }
+      durations.stop = Date.now() - t;
+
+      const publishPhase = async (phase: ArchivePhase) => {
+        await this.setArchivePhase(id, phase);
+        const updated = await this.getAgent(id);
+        if (updated) callbacks.onPhaseChange(updated);
+      };
+
+      // Phase: worktree-check
+      await publishPhase("worktree-check");
+
+      if (agent.worktreePath) {
+        try {
+          const tCheck = Date.now();
+          let shouldCleanup = cleanupWorktree === "force";
+          let preserveReason: string | undefined;
+
+          if (!shouldCleanup && cleanupWorktree === "auto") {
+            const [unmerged, uncommitted] = await Promise.all([
+              this.getUnmergedChanges(agent.worktreePath),
+              this.getUncommittedChanges(agent.worktreePath),
+            ]);
+            const hasChanges = unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
+            shouldCleanup = !hasChanges;
+            if (hasChanges) {
+              const reasons: string[] = [];
+              if (unmerged.hasUnmergedCommits) reasons.push(`${unmerged.changedFiles.length} unmerged file(s)`);
+              if (uncommitted.hasUncommittedChanges) reasons.push(`${uncommitted.uncommittedFiles.length} uncommitted file(s)`);
+              preserveReason = reasons.join(", ");
+            }
+          } else if (!shouldCleanup && cleanupWorktree === "keep") {
+            preserveReason = "user chose keep";
+          }
+          durations.outstandingChangesCheck = Date.now() - tCheck;
+
+          if (shouldCleanup) {
+            // Phase: worktree-cleanup
+            await publishPhase("worktree-cleanup");
+
+            const tCleanup = Date.now();
+            await cleanupGitWorktree({
+              cwd: agent.worktreePath,
+              deleteBranch: true,
+              force: true
+            });
+            durations.worktreeCleanup = Date.now() - tCleanup;
+            this.logger.info({ agentId: id, worktreePath: agent.worktreePath }, "Cleaned up agent worktree.");
+          } else {
+            this.logger.info(
+              { agentId: id, worktreePath: agent.worktreePath, cleanupWorktree, preserveReason },
+              `Preserved agent worktree: ${preserveReason}.`
+            );
+          }
+        } catch (error) {
+          this.logger.warn({ err: error, agentId: id }, "Worktree cleanup failed; leaving on disk.");
+        }
+      }
+
+      // Phase: finalizing
+      await publishPhase("finalizing");
+
+      const tDb = Date.now();
+      await this.pool
+        .query(
+          `INSERT INTO agent_events (agent_id, event_type, message, metadata, agent_type, agent_name, project_dir)
+           SELECT $1, 'idle', 'Agent deleted.', '{"source":"system"}'::jsonb, type, name, COALESCE(git_context->>'repoRoot', cwd)
+           FROM agents WHERE id = $1`,
+          [id]
+        )
+        .catch((err) => this.logger.warn({ err }, "Failed to insert delete event"));
+
+      await this.pool.query("UPDATE agents SET deleted_at = NOW(), archive_phase = NULL, updated_at = NOW() WHERE id = $1", [id]);
+      durations.db = Date.now() - tDb;
+
+      // Cascade: archive child agents (persona agents spawned by this parent)
+      const tCascade = Date.now();
+      const children = await this.pool.query<{ id: string }>(
+        "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
+        [id]
+      );
+      for (const child of children.rows) {
+        try {
+          await this.deleteAgentDirect(child.id, true, cleanupWorktree);
+        } catch (err) {
+          this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
+        }
+      }
+      if (children.rows.length > 0) {
+        durations.cascadeChildren = Date.now() - tCascade;
+      }
+
+      durations.total = Date.now() - deleteStart;
+      const parts = Object.entries(durations).map(([k, v]) => `${k}=${v}ms`).join(", ");
+      this.logger.info({ agentId: id, durations }, `Archive durations: ${parts}`);
+
+      const deletedIds = [id, ...children.rows.map((r) => r.id)];
+      callbacks.onComplete(deletedIds);
+    } catch (error) {
+      this.logger.error({ err: error, agentId: id }, "Archive failed");
+      try {
+        await this.setAgentStatus(id, "error", error instanceof Error ? error.message : "Archive failed");
+        await this.setArchivePhase(id, null);
+      } catch { /* best effort */ }
+      callbacks.onError(error);
+    }
+  }
+
+  /**
+   * Synchronous delete for child/cascade agents (no worktree, fast).
+   */
+  private async deleteAgentDirect(id: string, force = false, cleanupWorktree: WorktreeCleanupMode = "auto"): Promise<void> {
     const deleteStart = Date.now();
     const durations: Record<string, number> = {};
     const agent = await this.getRequiredAgent(id);
     const sessionExists = agent.tmuxSession ? await this.hasAgentSession(agent.tmuxSession) : false;
 
-    // If tmux is already gone, treat the agent as effectively stopped even if status is stale.
     if (agent.status === "running" && sessionExists && !force) {
       throw new AgentError("Agent is running. Stop it first or use force delete.", 409);
     }
 
-    // Run full stop lifecycle (hooks, graceful shutdown, token harvest) for non-stopped agents.
     if (agent.status !== "stopped") {
       const t = Date.now();
       try {
@@ -501,52 +667,6 @@ export class AgentManager {
       durations.stop = Date.now() - t;
     }
 
-    // Worktree cleanup
-    if (agent.worktreePath) {
-      try {
-        const tCheck = Date.now();
-        let shouldCleanup = cleanupWorktree === "force";
-        let preserveReason: string | undefined;
-
-        if (!shouldCleanup && cleanupWorktree === "auto") {
-          const [unmerged, uncommitted] = await Promise.all([
-            this.getUnmergedChanges(agent.worktreePath),
-            this.getUncommittedChanges(agent.worktreePath),
-          ]);
-          const hasChanges = unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
-          shouldCleanup = !hasChanges;
-          if (hasChanges) {
-            const reasons: string[] = [];
-            if (unmerged.hasUnmergedCommits) reasons.push(`${unmerged.changedFiles.length} unmerged file(s)`);
-            if (uncommitted.hasUncommittedChanges) reasons.push(`${uncommitted.uncommittedFiles.length} uncommitted file(s)`);
-            preserveReason = reasons.join(", ");
-          }
-        } else if (!shouldCleanup && cleanupWorktree === "keep") {
-          preserveReason = "user chose keep";
-        }
-        durations.outstandingChangesCheck = Date.now() - tCheck;
-
-        if (shouldCleanup) {
-          const tCleanup = Date.now();
-          await cleanupGitWorktree({
-            cwd: agent.worktreePath,
-            deleteBranch: true,
-            force: true
-          });
-          durations.worktreeCleanup = Date.now() - tCleanup;
-          this.logger.info({ agentId: id, worktreePath: agent.worktreePath }, "Cleaned up agent worktree.");
-        } else {
-          this.logger.info(
-            { agentId: id, worktreePath: agent.worktreePath, cleanupWorktree, preserveReason },
-            `Preserved agent worktree: ${preserveReason}.`
-          );
-        }
-      } catch (error) {
-        this.logger.warn({ err: error, agentId: id }, "Worktree cleanup failed; leaving on disk.");
-      }
-    }
-
-    // Record a final stopped event in history before deleting the agent row
     const tDb = Date.now();
     await this.pool
       .query(
@@ -559,23 +679,6 @@ export class AgentManager {
 
     await this.pool.query("UPDATE agents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1", [id]);
     durations.db = Date.now() - tDb;
-
-    // Cascade: archive child agents (persona agents spawned by this parent)
-    const tCascade = Date.now();
-    const children = await this.pool.query<{ id: string }>(
-      "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
-      [id]
-    );
-    for (const child of children.rows) {
-      try {
-        await this.deleteAgent(child.id, true, cleanupWorktree);
-      } catch (err) {
-        this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
-      }
-    }
-    if (children.rows.length > 0) {
-      durations.cascadeChildren = Date.now() - tCascade;
-    }
 
     durations.total = Date.now() - deleteStart;
     const parts = Object.entries(durations).map(([k, v]) => `${k}=${v}ms`).join(", ");
@@ -658,11 +761,13 @@ export class AgentManager {
       .catch((err) => this.logger.warn({ err }, "Failed to insert agent event history"));
 
     const agent = (await this.getAgent(id)) as AgentRecord;
-    for (const listener of this.eventListeners) {
-      try {
-        listener(agent);
-      } catch (err) {
-        this.logger.warn({ err }, "Agent event listener threw");
+    if (agent) {
+      for (const listener of this.eventListeners) {
+        try {
+          listener(agent);
+        } catch (err) {
+          this.logger.warn({ err }, "Agent event listener threw");
+        }
       }
     }
     return agent;
@@ -718,12 +823,25 @@ export class AgentManager {
     await this.maybeMaintenanceLogs();
 
     const result = await this.pool.query(
-      "SELECT id, tmux_session AS \"tmuxSession\", status, updated_at AS \"updatedAt\" FROM agents WHERE deleted_at IS NULL AND status IN ('running', 'stopping', 'creating')"
+      "SELECT id, tmux_session AS \"tmuxSession\", status, updated_at AS \"updatedAt\" FROM agents WHERE deleted_at IS NULL AND status IN ('running', 'stopping', 'creating', 'archiving')"
     );
 
     const reconciled: AgentRecord[] = [];
 
     for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string; updatedAt: string }>) {
+      // Archiving agents are handled separately — only resume if stuck for > 30s
+      if (row.status === "archiving") {
+        const stuckSeconds = (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
+        if (stuckSeconds > 30) {
+          this.logger.info({ id: row.id, stuckSeconds }, "Found agent stuck in archiving state — will be resumed");
+          const agent = await this.getAgent(row.id);
+          if (agent) {
+            reconciled.push(agent);
+          }
+        }
+        continue;
+      }
+
       const exists = row.tmuxSession ? await this.hasAgentSession(row.tmuxSession) : false;
 
       if (!exists) {
@@ -1577,6 +1695,7 @@ export class AgentManager {
         codex_args AS "agentArgs",
         full_access AS "fullAccess",
         setup_phase AS "setupPhase",
+        archive_phase AS "archivePhase",
         last_error AS "lastError",
         CASE
           WHEN latest_event_type IS NULL OR latest_event_message IS NULL OR latest_event_updated_at IS NULL THEN NULL
@@ -1668,6 +1787,13 @@ export class AgentManager {
   private async setSetupPhase(id: string, phase: SetupPhase): Promise<void> {
     await this.pool.query(
       `UPDATE agents SET setup_phase = $2, updated_at = NOW() WHERE id = $1`,
+      [id, phase]
+    );
+  }
+
+  private async setArchivePhase(id: string, phase: ArchivePhase): Promise<void> {
+    await this.pool.query(
+      `UPDATE agents SET archive_phase = $2, updated_at = NOW() WHERE id = $1`,
       [id, phase]
     );
   }

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -182,6 +182,7 @@ export async function runMigrations(): Promise<void> {
 
     -- Async archival phase tracking
     ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_phase TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_cleanup_mode TEXT;
   `;
 
   try {

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -179,6 +179,9 @@ export async function runMigrations(): Promise<void> {
 
     -- Agent pins (key-value info surfaced in UI)
     ALTER TABLE agents ADD COLUMN IF NOT EXISTS pins JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+    -- Async archival phase tracking
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_phase TEXT;
   `;
 
   try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -79,6 +79,7 @@ const slackNotifier = new SlackNotifier(pool, app.log);
 slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 agentManager.onLatestEvent((agent) => void slackNotifier.onAgentEvent(agent));
 const terminalTokenStore = new TerminalTokenStore(60_000);
+const activeArchives = new Set<Promise<void>>();
 
 const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", "idle"] as const;
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -2558,8 +2559,8 @@ async function registerRoutes() {
       const agent = await agentManager.beginArchive(params.id, cleanupWorktree);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 
-      // Fire-and-forget: run cleanup in background
-      void agentManager.executeArchive(params.id, {
+      // Fire-and-forget: run cleanup in background (tracked for graceful shutdown)
+      const archivePromise = agentManager.executeArchive(params.id, {
         onPhaseChange: (updated) => {
           uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
         },
@@ -2577,6 +2578,8 @@ async function registerRoutes() {
           app.log.error({ err: error, agentId: params.id }, "Background archive failed");
         }
       });
+      activeArchives.add(archivePromise);
+      archivePromise.finally(() => activeArchives.delete(archivePromise));
 
       return reply.code(202).send({ status: "archiving" });
     } catch (error) {
@@ -2990,7 +2993,7 @@ async function runAgentStatusReconciliation(): Promise<void> {
         console.log(`[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`);
         uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
         // Cleanup mode is persisted on the agent record by beginArchive
-        void agentManager.executeArchive(agent.id, {
+        const archivePromise = agentManager.executeArchive(agent.id, {
           onPhaseChange: (updated) => {
             uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
           },
@@ -3008,6 +3011,8 @@ async function runAgentStatusReconciliation(): Promise<void> {
             app.log.error({ err: error, agentId: agent.id }, "Resumed archive failed");
           }
         });
+        activeArchives.add(archivePromise);
+        archivePromise.finally(() => activeArchives.delete(archivePromise));
       } else {
         console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
         uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
@@ -3462,6 +3467,17 @@ async function shutdown(code: number): Promise<void> {
   stopGitContextRefreshLoop();
   stopAgentStatusReconcileLoop();
   stopSessionCleanupTimer();
+
+  // Wait for in-flight archives to finish so clean shutdowns don't leave agents stuck in "archiving"
+  if (activeArchives.size > 0) {
+    app.log.info({ count: activeArchives.size }, "Waiting for in-flight archives to complete…");
+    const ARCHIVE_DRAIN_TIMEOUT_MS = 10_000;
+    await Promise.race([
+      Promise.allSettled(activeArchives),
+      new Promise((resolve) => setTimeout(resolve, ARCHIVE_DRAIN_TIMEOUT_MS)),
+    ]);
+  }
+
   await pool.end().catch(() => null);
   await app.close().catch(() => null);
   process.exit(code);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2558,26 +2558,31 @@ async function registerRoutes() {
         : "auto";
 
     try {
-      const existing = await agentManager.getAgent(params.id);
-      // Collect child agent IDs before deletion so we can clean up their resources
-      const childRows = await pool.query<{ id: string }>(
-        "SELECT id FROM agents WHERE parent_agent_id = $1 AND deleted_at IS NULL",
-        [params.id]
-      );
-      await agentManager.deleteAgent(params.id, force, cleanupWorktree);
-      const deletedIds = [
-        ...(existing ? [existing.id] : []),
-        ...childRows.rows.map((r) => r.id),
-      ];
-      for (const deletedId of deletedIds) {
-        streamManager.stopStream(deletedId);
-        pendingGitRefreshAgentIds.delete(deletedId);
-        pendingGitRefreshEnqueuedAt.delete(deletedId);
-        activeGitRefreshAgentIds.delete(deletedId);
-        gitRefreshAgentDiagnostics.delete(deletedId);
-        uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
-      }
-      return reply.code(204).send();
+      // Fast synchronous phase: mark agent as archiving and return immediately
+      const agent = await agentManager.beginArchive(params.id);
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+
+      // Fire-and-forget: run cleanup in background
+      void agentManager.executeArchive(params.id, cleanupWorktree, {
+        onPhaseChange: (updated) => {
+          uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
+        },
+        onComplete: (deletedIds) => {
+          for (const deletedId of deletedIds) {
+            streamManager.stopStream(deletedId);
+            pendingGitRefreshAgentIds.delete(deletedId);
+            pendingGitRefreshEnqueuedAt.delete(deletedId);
+            activeGitRefreshAgentIds.delete(deletedId);
+            gitRefreshAgentDiagnostics.delete(deletedId);
+            uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
+          }
+        },
+        onError: (error) => {
+          app.log.error({ err: error, agentId: params.id }, "Background archive failed");
+        }
+      });
+
+      return reply.code(202).send({ status: "archiving" });
     } catch (error) {
       return handleAgentError(reply, error);
     }
@@ -2984,8 +2989,32 @@ async function runAgentStatusReconciliation(): Promise<void> {
   try {
     const reconciled = await agentManager.reconcileAgentStatuses();
     for (const agent of reconciled) {
-      console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      if (agent.status === "archiving") {
+        // Resume interrupted archive
+        console.log(`[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`);
+        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+        void agentManager.executeArchive(agent.id, "auto", {
+          onPhaseChange: (updated) => {
+            uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
+          },
+          onComplete: (deletedIds) => {
+            for (const deletedId of deletedIds) {
+              streamManager.stopStream(deletedId);
+              pendingGitRefreshAgentIds.delete(deletedId);
+              pendingGitRefreshEnqueuedAt.delete(deletedId);
+              activeGitRefreshAgentIds.delete(deletedId);
+              gitRefreshAgentDiagnostics.delete(deletedId);
+              uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
+            }
+          },
+          onError: (error) => {
+            app.log.error({ err: error, agentId: agent.id }, "Resumed archive failed");
+          }
+        });
+      } else {
+        console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
+        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      }
     }
   } catch (error) {
     app.log.warn({ err: error }, "Agent status reconciliation failed.");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -80,6 +80,7 @@ slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 agentManager.onLatestEvent((agent) => void slackNotifier.onAgentEvent(agent));
 const terminalTokenStore = new TerminalTokenStore(60_000);
 const activeArchives = new Set<Promise<void>>();
+const archivingAgentIds = new Set<string>();
 
 const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", "idle"] as const;
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -2559,8 +2560,10 @@ async function registerRoutes() {
       const agent = await agentManager.beginArchive(params.id, cleanupWorktree);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 
-      // Fire-and-forget: run cleanup in background (tracked for graceful shutdown)
-      const archivePromise = agentManager.executeArchive(params.id, {
+      // Fire-and-forget: run cleanup in background (tracked for graceful shutdown + dedup)
+      const agentId = params.id;
+      archivingAgentIds.add(agentId);
+      const archivePromise = agentManager.executeArchive(agentId, {
         onPhaseChange: (updated) => {
           uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
         },
@@ -2575,11 +2578,14 @@ async function registerRoutes() {
           }
         },
         onError: (error) => {
-          app.log.error({ err: error, agentId: params.id }, "Background archive failed");
+          app.log.error({ err: error, agentId }, "Background archive failed");
         }
       });
       activeArchives.add(archivePromise);
-      archivePromise.finally(() => activeArchives.delete(archivePromise));
+      archivePromise.finally(() => {
+        activeArchives.delete(archivePromise);
+        archivingAgentIds.delete(agentId);
+      });
 
       return reply.code(202).send({ status: "archiving" });
     } catch (error) {
@@ -2989,10 +2995,15 @@ async function runAgentStatusReconciliation(): Promise<void> {
     const reconciled = await agentManager.reconcileAgentStatuses();
     for (const agent of reconciled) {
       if (agent.status === "archiving") {
+        // Skip if this agent already has an active archive in progress
+        if (archivingAgentIds.has(agent.id)) {
+          continue;
+        }
         // Resume interrupted archive
         console.log(`[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`);
         uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
         // Cleanup mode is persisted on the agent record by beginArchive
+        archivingAgentIds.add(agent.id);
         const archivePromise = agentManager.executeArchive(agent.id, {
           onPhaseChange: (updated) => {
             uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
@@ -3012,7 +3023,10 @@ async function runAgentStatusReconciliation(): Promise<void> {
           }
         });
         activeArchives.add(archivePromise);
-        archivePromise.finally(() => activeArchives.delete(archivePromise));
+        archivePromise.finally(() => {
+          activeArchives.delete(archivePromise);
+          archivingAgentIds.delete(agent.id);
+        });
       } else {
         console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
         uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2539,15 +2539,10 @@ async function registerRoutes() {
 
   app.delete("/api/v1/agents/:id", async (request, reply) => {
     const params = request.params as { id?: unknown };
-    const query = request.query as { force?: unknown; cleanupWorktree?: unknown };
+    const query = request.query as { cleanupWorktree?: unknown };
 
     if (typeof params.id !== "string") {
       return reply.code(400).send({ error: "Missing agent id." });
-    }
-
-    const force = query.force === "true" || query.force === true;
-    if (query.force !== undefined && typeof query.force !== "string" && typeof query.force !== "boolean") {
-      return reply.code(400).send({ error: "force must be true or false." });
     }
 
     const validCleanupModes = ["auto", "keep", "force"] as const;
@@ -2558,12 +2553,13 @@ async function registerRoutes() {
         : "auto";
 
     try {
-      // Fast synchronous phase: mark agent as archiving and return immediately
-      const agent = await agentManager.beginArchive(params.id);
+      // Fast synchronous phase: mark agent as archiving and return immediately.
+      // cleanupWorktree is persisted so reconciliation can honor it if the server restarts.
+      const agent = await agentManager.beginArchive(params.id, cleanupWorktree);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 
       // Fire-and-forget: run cleanup in background
-      void agentManager.executeArchive(params.id, cleanupWorktree, {
+      void agentManager.executeArchive(params.id, {
         onPhaseChange: (updated) => {
           uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
         },
@@ -2993,7 +2989,8 @@ async function runAgentStatusReconciliation(): Promise<void> {
         // Resume interrupted archive
         console.log(`[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`);
         uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
-        void agentManager.executeArchive(agent.id, "auto", {
+        // Cleanup mode is persisted on the agent record by beginArchive
+        void agentManager.executeArchive(agent.id, {
           onPhaseChange: (updated) => {
             uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
           },

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -330,9 +330,9 @@ describe("AgentManager", () => {
   describe("archiveAgent", () => {
     /** Helper: run the full beginArchive + executeArchive flow and wait for completion. */
     async function archiveAgent(id: string, cleanupWorktree: "auto" | "keep" | "force" = "auto"): Promise<void> {
-      await manager.beginArchive(id);
+      await manager.beginArchive(id, cleanupWorktree);
       await new Promise<void>((resolve, reject) => {
-        void manager.executeArchive(id, cleanupWorktree, {
+        void manager.executeArchive(id, {
           onPhaseChange: () => {},
           onComplete: () => resolve(),
           onError: (err) => reject(err),

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -327,13 +327,25 @@ describe("AgentManager", () => {
     });
   });
 
-  describe("deleteAgent", () => {
+  describe("archiveAgent", () => {
+    /** Helper: run the full beginArchive + executeArchive flow and wait for completion. */
+    async function archiveAgent(id: string, cleanupWorktree: "auto" | "keep" | "force" = "auto"): Promise<void> {
+      await manager.beginArchive(id);
+      await new Promise<void>((resolve, reject) => {
+        void manager.executeArchive(id, cleanupWorktree, {
+          onPhaseChange: () => {},
+          onComplete: () => resolve(),
+          onError: (err) => reject(err),
+        });
+      });
+    }
+
     it("should soft-delete an agent", async () => {
       const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
 
-      // Stop first so delete doesn't need force
+      // Stop first so beginArchive doesn't need force
       await manager.stopAgent(agent.id, { force: true });
-      await manager.deleteAgent(agent.id);
+      await archiveAgent(agent.id);
 
       // getAgent filters out soft-deleted agents
       const fetched = await manager.getAgent(agent.id);
@@ -348,7 +360,7 @@ describe("AgentManager", () => {
     it("should exclude soft-deleted agents from listAgents", async () => {
       const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
       await manager.stopAgent(agent.id, { force: true });
-      await manager.deleteAgent(agent.id);
+      await archiveAgent(agent.id);
 
       const agents = await manager.listAgents();
       expect(agents.find((a) => a.id === agent.id)).toBeUndefined();
@@ -367,7 +379,7 @@ describe("AgentManager", () => {
         [agent.id]
       );
 
-      await manager.deleteAgent(agent.id, true);
+      await archiveAgent(agent.id);
 
       // Media rows are preserved since soft delete doesn't trigger CASCADE
       const media = await pool.query("SELECT * FROM media WHERE agent_id = $1", [agent.id]);
@@ -378,11 +390,34 @@ describe("AgentManager", () => {
 
     it("should throw 404 for non-existent agent", async () => {
       try {
-        await manager.deleteAgent("agt_nonexistent");
+        await manager.beginArchive("agt_nonexistent");
         expect.unreachable("should have thrown");
       } catch (err) {
         expect(err).toBeInstanceOf(AgentError);
         expect((err as InstanceType<typeof AgentError>).statusCode).toBe(404);
+      }
+    });
+
+    it("should set status to archiving during beginArchive", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      await manager.stopAgent(agent.id, { force: true });
+
+      const archiving = await manager.beginArchive(agent.id);
+      expect(archiving.status).toBe("archiving");
+      expect(archiving.archivePhase).toBe("stopping");
+    });
+
+    it("should reject archiving an already-archiving agent", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      await manager.stopAgent(agent.id, { force: true });
+      await manager.beginArchive(agent.id);
+
+      try {
+        await manager.beginArchive(agent.id);
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(AgentError);
+        expect((err as InstanceType<typeof AgentError>).statusCode).toBe(409);
       }
     });
   });

--- a/apps/server/test/db/setup.ts
+++ b/apps/server/test/db/setup.ts
@@ -155,6 +155,9 @@ export async function runTestMigrations(pool: Pool): Promise<void> {
 
     -- Agent pins
     ALTER TABLE agents ADD COLUMN IF NOT EXISTS pins JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+    -- Async archival phase tracking
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_phase TEXT;
   `;
 
   await pool.query(sql);

--- a/apps/server/test/db/setup.ts
+++ b/apps/server/test/db/setup.ts
@@ -158,6 +158,7 @@ export async function runTestMigrations(pool: Pool): Promise<void> {
 
     -- Async archival phase tracking
     ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_phase TEXT;
+    ALTER TABLE agents ADD COLUMN IF NOT EXISTS archive_cleanup_mode TEXT;
   `;
 
   await pool.query(sql);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -465,24 +465,15 @@ export function DashboardLayout(): JSX.Element {
       if (connectedAgentId === agent.id) {
         detachTerminal();
       }
-      if (validatedSelectedAgentId === agent.id) {
-        setSelectedAgentId(null);
-        refreshMedia(null);
-      }
-      if (agent.status === "running") {
-        await api(`/api/v1/agents/${agent.id}/stop`, {
-          method: "POST",
-          body: JSON.stringify({ force: true }),
-        });
-      }
       const params = new URLSearchParams();
       if (cleanupWorktree) {
         params.set("cleanupWorktree", cleanupWorktree);
       }
       const qs = params.toString();
+      // Backend handles stopping + cleanup asynchronously; returns 202 immediately
       await api(`/api/v1/agents/${agent.id}${qs ? `?${qs}` : ""}`, { method: "DELETE" });
     },
-    [connectedAgentId, detachTerminal, refreshMedia, validatedSelectedAgentId]
+    [connectedAgentId, detachTerminal]
   );
 
   const handleRemoveCwdHistory = useCallback((cwd: string) => {
@@ -625,6 +616,7 @@ export function DashboardLayout(): JSX.Element {
               terminalMode={terminalMode}
               terminalPlaceholderMessage={terminalPlaceholderMessage}
               terminalHostRef={terminalHostRef}
+              archivePhase={selectedAgent?.status === "archiving" ? selectedAgent.archivePhase : null}
             />
 
             {!isMobile ? (

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -280,7 +280,7 @@ export function AgentSidebarContent({
                       </Badge>
                     ) : null}
 
-                    {isStopped ? (
+                    {isStopped && agent.status !== "archiving" ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
@@ -299,7 +299,7 @@ export function AgentSidebarContent({
                         </TooltipTrigger>
                         <TooltipContent>Resume<br /><span className="text-muted-foreground">Start agent session</span></TooltipContent>
                       </Tooltip>
-                    ) : (
+                    ) : agent.status === "archiving" ? null : (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
@@ -326,6 +326,7 @@ export function AgentSidebarContent({
                           data-agent-control="true"
                           data-testid={`agent-archive-${agent.id}`}
                           className="ml-auto"
+                          disabled={agent.status === "archiving" || agent.status === "creating"}
                           onClick={() => {
                             setDeleteTarget(agent);
                             setDeleteConfirmOpen(true);
@@ -367,6 +368,18 @@ export function AgentSidebarContent({
                          agent.setupPhase === "env" ? "Copying environment…" :
                          agent.setupPhase === "deps" ? "Installing dependencies…" :
                          agent.setupPhase === "session" ? "Starting session…" : "Setting up…"}
+                      </span>
+                    </div>
+                  ) : null}
+
+                  {agent.status === "archiving" ? (
+                    <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-orange-400">
+                      <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                      <span className="truncate font-medium">
+                        {agent.archivePhase === "stopping" ? "Stopping agent…" :
+                         agent.archivePhase === "worktree-check" ? "Checking worktree…" :
+                         agent.archivePhase === "worktree-cleanup" ? "Removing worktree…" :
+                         agent.archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
                       </span>
                     </div>
                   ) : null}
@@ -515,7 +528,7 @@ export function AgentSidebarContent({
                         ) : (
                           <button data-agent-control="true" aria-label="Stop agent" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setStopTarget(child); setStopConfirmOpen(true); }}><Square className="h-3.5 w-3.5" /></button>
                         )}
-                        <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
+                        <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors disabled:opacity-30" disabled={child.status === "archiving"} onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
                       </div>
                       {child.latestEvent ? (
                         childIsExpanded ? (

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -1,7 +1,7 @@
 import { memo, type RefObject, useEffect, useState } from "react";
-import { Loader2, TerminalSquare } from "lucide-react";
+import { Archive, Loader2, TerminalSquare } from "lucide-react";
 
-import { type ConnState } from "@/components/app/types";
+import { type Agent, type ConnState } from "@/components/app/types";
 import { cn } from "@/lib/utils";
 
 type TerminalPaneProps = {
@@ -11,6 +11,7 @@ type TerminalPaneProps = {
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
   terminalHostRef: RefObject<HTMLDivElement>;
+  archivePhase: Agent["archivePhase"];
 };
 
 export const TerminalPane = memo(function TerminalPane({
@@ -19,7 +20,8 @@ export const TerminalPane = memo(function TerminalPane({
   statusMessage,
   terminalMode,
   terminalPlaceholderMessage,
-  terminalHostRef
+  terminalHostRef,
+  archivePhase
 }: TerminalPaneProps): JSX.Element {
   const [showReconnectOverlay, setShowReconnectOverlay] = useState(false);
 
@@ -69,6 +71,25 @@ export const TerminalPane = memo(function TerminalPane({
               {terminalPlaceholderMessage ??
                 "This environment does not launch a real tmux session or CLI process. Agent lifecycle flows are simulated for UI validation."}
             </p>
+          </div>
+        </div>
+      ) : null}
+
+      {archivePhase ? (
+        <div data-testid="terminal-archive-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
+          <div className="flex max-w-md flex-col items-center gap-3 px-6 text-center text-muted-foreground">
+            <Archive className="h-9 w-9 text-orange-400" />
+            <p className="text-base font-medium text-foreground">Archiving agent</p>
+            <div className="flex items-center gap-2 text-sm text-orange-400">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>
+                {archivePhase === "stopping" ? "Stopping agent…" :
+                 archivePhase === "worktree-check" ? "Checking worktree…" :
+                 archivePhase === "worktree-cleanup" ? "Removing worktree…" :
+                 archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground/70">You can switch to another agent while this completes.</p>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -1,4 +1,4 @@
-export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "error" | "unknown";
+export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "archiving" | "error" | "unknown";
 
 export type AgentPin = {
   label: string;
@@ -18,6 +18,7 @@ export type Agent = {
   agentArgs: string[];
   fullAccess: boolean;
   setupPhase?: "worktree" | "env" | "deps" | "session" | null;
+  archivePhase?: "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
   lastError?: string | null;
   latestEvent?: {
     type: "working" | "blocked" | "waiting_user" | "done" | "idle";

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -139,6 +139,12 @@ export async function deleteAgentViaAPI(
   await request.delete(`${API}/agents/${agentId}?force=true&cleanupWorktree=${cleanupWorktree}`, {
     headers: authHeaders(),
   });
+  // Archive is async — poll until the agent is actually gone
+  for (let i = 0; i < 50; i++) {
+    const res = await request.get(`${API}/agents/${agentId}`, { headers: authHeaders() });
+    if (res.status() === 404) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
 }
 
 /**

--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -143,7 +143,7 @@ test.describe("Worktree", () => {
     const res = await request.delete(`/api/v1/agents/${agent.id}?cleanupWorktree=keep`, {
       headers: authHeader,
     });
-    expect(res.status()).toBe(204);
+    expect(res.status()).toBe(202);
   });
 
   test("delete dialog shows standard confirmation for agent without worktree", async ({


### PR DESCRIPTION
## Summary
- Convert synchronous `DELETE /api/v1/agents/:id` into async flow — endpoint returns 202 immediately, cleanup runs in background
- Add `"archiving"` agent status and `archive_phase` column to track progress phases (stopping → worktree-check → worktree-cleanup → finalizing)
- SSE `agent.upsert` events stream phase changes; `agent.deleted` fires on completion
- Sidebar shows archive phase spinner (mirroring the setup phase pattern during creation)
- Terminal pane shows archive overlay when viewing an archiving agent
- Reconciliation resumes archives interrupted by server restart (with 30s guard)
- Fix null-safety bug in `upsertLatestEvent` that could crash the server when an agent is soft-deleted between the DB update and the listener notification

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — production build passes
- [x] `pnpm run test` — 96 unit tests pass (including new beginArchive/executeArchive tests)
- [x] `pnpm run test:e2e` — 79 E2E tests pass (6 skipped, same as baseline)
- [ ] Manual: archive an agent, verify sidebar shows progress phases, switch to another agent during archival, verify agent disappears when done

🤖 Generated with [Claude Code](https://claude.com/claude-code)