### PR TITLE
Add rate limiting to auth endpoints (CRU-38)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,6 +16,7 @@
     "@dispatch/shared": "workspace:*",
     "@fastify/cookie": "^9.4.0",
     "@fastify/multipart": "^8.3.1",
+    "@fastify/rate-limit": "9",
     "@fastify/static": "^6.12.0",
     "@fastify/websocket": "^8.3.1",
     "bcryptjs": "^3.0.3",

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 import fastifyCookie from "@fastify/cookie";
 import fastifyMultipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
+import fastifyRateLimit from "@fastify/rate-limit";
 import fastifyWebsocket from "@fastify/websocket";
 import Fastify from "fastify";
 import type { FastifyReply } from "fastify";
@@ -769,6 +770,7 @@ async function registerRoutes() {
   await app.register(fastifyCookie, { secret: cookieSecret });
   await app.register(fastifyMultipart, { limits: { fileSize: 20 * 1024 * 1024 } });
   await app.register(fastifyWebsocket);
+  await app.register(fastifyRateLimit, { global: false });
 
   // Initialize icon color from DB before serving any requests
   const storedIconColor = await getSetting(pool, ICON_COLOR_KEY);
@@ -871,7 +873,7 @@ async function registerRoutes() {
     return { passwordSet: hasPassword, authenticated };
   });
 
-  app.post("/api/v1/auth/setup", async (request, reply) => {
+  app.post("/api/v1/auth/setup", { config: { rateLimit: { max: 3, timeWindow: "1 minute" } } }, async (request, reply) => {
     if (await isPasswordSetCached()) {
       return reply.code(400).send({ error: "Password is already set." });
     }
@@ -894,7 +896,7 @@ async function registerRoutes() {
     return { ok: true };
   });
 
-  app.post("/api/v1/auth/login", async (request, reply) => {
+  app.post("/api/v1/auth/login", { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } }, async (request, reply) => {
     const body = request.body as { password?: string } | null;
     const password = body?.password;
     if (!password || typeof password !== "string") {

--- a/apps/server/test/rate-limit.test.ts
+++ b/apps/server/test/rate-limit.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import fastifyRateLimit from "@fastify/rate-limit";
+
+/**
+ * Integration tests for rate limiting configuration.
+ *
+ * These verify the @fastify/rate-limit config applied to auth endpoints
+ * in server.ts. Each test group gets a fresh Fastify instance so rate
+ * limit counters don't bleed between tests.
+ */
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(fastifyRateLimit, { global: false });
+
+  // Mirror the rate-limit config from server.ts
+  app.post(
+    "/api/v1/auth/login",
+    { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } },
+    async () => ({ ok: true }),
+  );
+
+  app.post(
+    "/api/v1/auth/setup",
+    { config: { rateLimit: { max: 3, timeWindow: "1 minute" } } },
+    async () => ({ ok: true }),
+  );
+
+  app.get("/api/v1/auth/status", async () => ({ ok: true }));
+
+  await app.ready();
+  return app;
+}
+
+describe("rate limiting", () => {
+  describe("login endpoint", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => { app = await buildApp(); });
+    afterAll(async () => { await app.close(); });
+
+    it("allows 5 attempts then returns 429", async () => {
+      for (let i = 0; i < 5; i++) {
+        const res = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+        expect(res.statusCode).toBe(200);
+      }
+      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+      expect(blocked.statusCode).toBe(429);
+    });
+
+    it("includes rate limit headers", async () => {
+      // First request already consumed above, but headers are present on every response.
+      // The 429 response from the previous test still counts — just verify headers exist.
+      const res = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+      expect(res.headers["x-ratelimit-limit"]).toBe("5");
+    });
+  });
+
+  describe("setup endpoint", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => { app = await buildApp(); });
+    afterAll(async () => { await app.close(); });
+
+    it("allows 3 attempts then returns 429", async () => {
+      for (let i = 0; i < 3; i++) {
+        const res = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+        expect(res.statusCode).toBe(200);
+      }
+      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+      expect(blocked.statusCode).toBe(429);
+    });
+
+    it("429 response includes retry-after header", async () => {
+      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+      expect(blocked.statusCode).toBe(429);
+      expect(blocked.headers["retry-after"]).toBeDefined();
+    });
+  });
+
+  describe("status endpoint", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => { app = await buildApp(); });
+    afterAll(async () => { await app.close(); });
+
+    it("is not rate limited", async () => {
+      for (let i = 0; i < 10; i++) {
+        const res = await app.inject({ method: "GET", url: "/api/v1/auth/status" });
+        expect(res.statusCode).toBe(200);
+      }
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fastify/multipart':
         specifier: ^8.3.1
         version: 8.3.1
+      '@fastify/rate-limit':
+        specifier: '9'
+        version: 9.1.0
       '@fastify/static':
         specifier: ^6.12.0
         version: 6.12.0
@@ -1256,6 +1259,9 @@ packages:
 
   '@fastify/multipart@8.3.1':
     resolution: {integrity: sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==}
+
+  '@fastify/rate-limit@9.1.0':
+    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -5855,6 +5861,12 @@ snapshots:
       fastify-plugin: 4.5.1
       secure-json-parse: 2.7.0
       stream-wormhole: 1.1.0
+
+  '@fastify/rate-limit@9.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 4.5.1
+      toad-cache: 3.7.0
 
   '@fastify/send@2.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `@fastify/rate-limit` (v9, Fastify 4-compatible) with `global: false` — no default limits on any route
- Rate limits `POST /api/v1/auth/login` to **5 requests/minute** per IP
- Rate limits `POST /api/v1/auth/setup` to **3 requests/minute** per IP
- Returns standard 429 Too Many Requests when exceeded

## Test plan
- [x] `pnpm run check` — TypeScript passes
- [x] `pnpm run test` — 96 unit tests pass
- [x] `pnpm run test:e2e` — 79 E2E tests pass (6 pre-existing skips)
- [x] Manual verification: login endpoint returns 429 after 5 rapid attempts

Closes CRU-38