### PR TITLE
Rename HOST env var to DISPATCH_HOST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Production server settings. For local development, use bin/dispatch-dev
 # which auto-selects free ports and creates an isolated database.
 
-HOST=0.0.0.0
+DISPATCH_HOST=0.0.0.0
 DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 MEDIA_ROOT=~/.dispatch/media

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -62,7 +62,7 @@ function resolveAgentRuntime(): "tmux" | "inert" {
 
 export function loadConfig(): AppConfig {
   const config: AppConfig = {
-    host: process.env.HOST ?? "127.0.0.1",
+    host: process.env.DISPATCH_HOST ?? process.env.HOST ?? "127.0.0.1",
     port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 6767),
     databaseUrl:
       process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
@@ -95,7 +95,7 @@ function validateConfig(config: AppConfig): void {
   if (config.host === "0.0.0.0") {
     console.warn(
       `${WARN_PREFIX} Server is binding to 0.0.0.0 (all interfaces). ` +
-        `Ensure a password is set or use HOST=127.0.0.1 to restrict to localhost.`,
+        `Ensure a password is set or use DISPATCH_HOST=127.0.0.1 to restrict to localhost.`,
     );
   }
 

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -119,7 +119,7 @@ cp .env.example .env
 Edit `.env` — the only value you must change is `AUTH_TOKEN`:
 
 ```
-HOST=0.0.0.0
+DISPATCH_HOST=0.0.0.0
 DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=<generate-a-real-token>


### PR DESCRIPTION
## Summary
- Renames `HOST` to `DISPATCH_HOST` to avoid conflicts with the generic `HOST` variable used by other tools
- Falls back to `HOST` for backwards compatibility, matching the existing `DISPATCH_PORT ?? PORT` pattern
- Updates `.env.example` and docs to reference the new variable name

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Unit tests pass (101/101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)