### PR TITLE
Harden auth endpoints (CRU-42, CRU-43, CRU-58, CRU-71)

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -44,6 +44,10 @@ export async function deleteSession(pool: Pool, token: string): Promise<void> {
   await pool.query("DELETE FROM sessions WHERE token = $1", [token]);
 }
 
+export async function deleteAllSessions(pool: Pool): Promise<void> {
+  await pool.query("DELETE FROM sessions");
+}
+
 export async function changePassword(
   pool: Pool,
   currentPassword: string,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -14,6 +14,7 @@ import Fastify from "fastify";
 import type { FastifyReply } from "fastify";
 import type WebSocket from "ws";
 import type nodePty from "node-pty";
+import * as z from "zod/v4";
 
 let pty: typeof nodePty;
 try {
@@ -44,6 +45,7 @@ import {
   createSession,
   validateSession,
   deleteSession,
+  deleteAllSessions,
   changePassword,
   cleanExpiredSessions,
   getOrCreateAuthToken,
@@ -776,6 +778,17 @@ function invalidatePasswordSetCache(): void {
 const SESSION_COOKIE = "dispatch_session";
 const SESSION_MAX_AGE_S = 30 * 24 * 60 * 60; // 30 days
 
+const SetupBodySchema = z.object({
+  password: z.string().min(8, "Password must be at least 8 characters."),
+});
+const LoginBodySchema = z.object({
+  password: z.string().min(1, "Password is required."),
+});
+const ChangePasswordBodySchema = z.object({
+  currentPassword: z.string().min(1, "Current password is required."),
+  newPassword: z.string().min(8, "New password must be at least 8 characters."),
+});
+
 async function registerRoutes() {
   const cookieSecret = await getOrCreateCookieSecret(pool);
   await app.register(fastifyCookie, { secret: cookieSecret });
@@ -836,7 +849,7 @@ async function registerRoutes() {
     if (url.startsWith("/api/v1/auth/")) return;
     if (url === "/api/v1/health") return;
     if (url === "/api/v1/app/branding") return;
-    if (url.endsWith("/terminal/ws")) return;
+    if (/^\/api\/v1\/agents\/[^/]+\/terminal\/ws$/.test(url)) return;
 
     // If no password is set, all routes are open (first-run mode).
     if (!(await isPasswordSetCached())) return;
@@ -888,11 +901,11 @@ async function registerRoutes() {
     if (await isPasswordSetCached()) {
       return reply.code(400).send({ error: "Password is already set." });
     }
-    const body = request.body as { password?: string } | null;
-    const password = body?.password;
-    if (!password || typeof password !== "string" || password.length < 4) {
-      return reply.code(400).send({ error: "Password must be at least 4 characters." });
+    const parsed = SetupBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
+    const { password } = parsed.data;
     await setPassword(pool, password);
     invalidatePasswordSetCache();
     const token = await createSession(pool);
@@ -908,11 +921,11 @@ async function registerRoutes() {
   });
 
   app.post("/api/v1/auth/login", { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } }, async (request, reply) => {
-    const body = request.body as { password?: string } | null;
-    const password = body?.password;
-    if (!password || typeof password !== "string") {
-      return reply.code(400).send({ error: "Password is required." });
+    const parsed = LoginBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
+    const { password } = parsed.data;
     if (!(await verifyPassword(pool, password))) {
       return reply.code(401).send({ error: "Invalid password." });
     }
@@ -941,20 +954,25 @@ async function registerRoutes() {
   });
 
   app.post("/api/v1/auth/change-password", async (request, reply) => {
-    // Requires valid session (enforced by hook).
-    const body = request.body as { currentPassword?: string; newPassword?: string } | null;
-    const currentPassword = body?.currentPassword;
-    const newPassword = body?.newPassword;
-    if (!currentPassword || !newPassword || typeof currentPassword !== "string" || typeof newPassword !== "string") {
-      return reply.code(400).send({ error: "currentPassword and newPassword are required." });
+    const parsed = ChangePasswordBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
-    if (newPassword.length < 4) {
-      return reply.code(400).send({ error: "New password must be at least 4 characters." });
-    }
+    const { currentPassword, newPassword } = parsed.data;
     const changed = await changePassword(pool, currentPassword, newPassword);
     if (!changed) {
       return reply.code(401).send({ error: "Current password is incorrect." });
     }
+    await deleteAllSessions(pool);
+    const token = await createSession(pool);
+    reply.setCookie(SESSION_COOKIE, token, {
+      path: "/",
+      httpOnly: true,
+      signed: true,
+      sameSite: "lax",
+      secure: config.tls !== null,
+      maxAge: SESSION_MAX_AGE_S,
+    });
     invalidatePasswordSetCache();
     return { ok: true };
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -953,7 +953,7 @@ async function registerRoutes() {
     return { ok: true };
   });
 
-  app.post("/api/v1/auth/change-password", async (request, reply) => {
+  app.post("/api/v1/auth/change-password", { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } }, async (request, reply) => {
     const parsed = ChangePasswordBodySchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
@@ -2370,7 +2370,7 @@ async function registerRoutes() {
   .gone{display:flex;align-items:center;justify-content:center;height:100vh;color:#666;font-family:system-ui;font-size:14px}
 </style>
 </head><body>
-<img id="feed" src="/api/v1/agents/${id}/stream" alt="Live stream">
+<img id="feed" src="/api/v1/agents/${escapeHtml(id)}/stream" alt="Live stream">
 <script>
   const img = document.getElementById('feed');
   img.onerror = () => {

--- a/apps/web/src/components/app/security-settings.tsx
+++ b/apps/web/src/components/app/security-settings.tsx
@@ -39,7 +39,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
 
   const handleSetPassword = async (e: FormEvent) => {
     e.preventDefault();
-    if (newPassword.length < 4 || newPassword !== confirmPassword) return;
+    if (newPassword.length < 8 || newPassword !== confirmPassword) return;
     setError("");
     setMessage("");
     setLoading(true);
@@ -67,7 +67,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
 
   const handleChangePassword = async (e: FormEvent) => {
     e.preventDefault();
-    if (!currentPassword || newPassword.length < 4 || newPassword !== confirmPassword) return;
+    if (!currentPassword || newPassword.length < 8 || newPassword !== confirmPassword) return;
     setError("");
     setMessage("");
     setLoading(true);
@@ -123,7 +123,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
           )}
           <Input
             type="password"
-            placeholder={passwordSet ? "New password (min 4 characters)" : "Password (min 4 characters)"}
+            placeholder={passwordSet ? "New password (min 8 characters)" : "Password (min 8 characters)"}
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
             data-testid="security-new-password"
@@ -141,7 +141,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
           <Button
             type="submit"
             variant="primary"
-            disabled={loading || newPassword.length < 4 || newPassword !== confirmPassword || (passwordSet && !currentPassword)}
+            disabled={loading || newPassword.length < 8 || newPassword !== confirmPassword || (passwordSet && !currentPassword)}
           >
             {loading ? (passwordSet ? "Changing..." : "Setting up...") : (passwordSet ? "Change password" : "Set password")}
           </Button>


### PR DESCRIPTION
## Summary
- **CRU-43**: Replace unsafe `as` type casts with Zod schema validation on `/auth/setup`, `/auth/login`, and `/auth/change-password` endpoints
- **CRU-42**: Increase minimum password length from 4 to 8 characters (server schemas + frontend validation/placeholder text)
- **CRU-58**: Invalidate all existing sessions on password change, then issue a fresh session for the current user
- **CRU-71**: Tighten WebSocket auth bypass from broad `endsWith("/terminal/ws")` to exact route regex matching `/api/v1/agents/:id/terminal/ws`

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — unit tests pass
- [x] `pnpm run test:e2e` — E2E tests pass
- [x] `pnpm run finalize:web` — web build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)