### PR TITLE
Redesign persona agents in sidebar with UI polish

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,13 +27,14 @@
     "cmdk": "^1.1.1",
     "framer-motion": "^12.35.2",
     "highlight.js": "^11.11.1",
+    "jotai": "^2.19.0",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.14.0",
     "recharts": "^3.8.1",
     "simple-icons": "^16.11.0",
-    "react-router-dom": "^7.14.0",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -458,6 +458,8 @@ export function DashboardLayout(): JSX.Element {
       if (connectedAgentId === agent.id) {
         detachTerminal();
       }
+      setExpandedAgentId((current) => current === agent.id ? null : current);
+      setFeedbackDetail((prev) => prev?.parentAgentId === agent.id ? null : prev);
       const params = new URLSearchParams();
       if (cleanupWorktree) {
         params.set("cleanupWorktree", cleanupWorktree);
@@ -466,7 +468,7 @@ export function DashboardLayout(): JSX.Element {
       // Backend handles stopping + cleanup asynchronously; returns 202 immediately
       await api(`/api/v1/agents/${agent.id}${qs ? `?${qs}` : ""}`, { method: "DELETE" });
     },
-    [connectedAgentId, detachTerminal]
+    [connectedAgentId, detachTerminal, setExpandedAgentId, setFeedbackDetail]
   );
 
   const handleRemoveCwdHistory = useCallback((cwd: string) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -573,6 +573,7 @@ export function DashboardLayout(): JSX.Element {
               sendTerminalInput={sendTerminalInput}
               connectedAgentId={connectedAgentId}
               onOpenFeedbackDetail={setFeedbackDetail}
+              feedbackDetailState={feedbackDetail}
             />
           </div>
         ) : null}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -233,7 +233,7 @@ export function DashboardLayout(): JSX.Element {
       }
       return current;
     });
-  }, []);
+  }, [setExpandedAgentId]);
 
   // ── Terminal ──────────────────────────────────────────────────────────
   const {
@@ -408,7 +408,7 @@ export function DashboardLayout(): JSX.Element {
     (agentId: string) => {
       setExpandedAgentId((current) => (current === agentId ? null : agentId));
     },
-    []
+    [setExpandedAgentId]
   );
 
   const attachToAgent = useCallback(
@@ -598,7 +598,6 @@ export function DashboardLayout(): JSX.Element {
               showHeaderStatus={showHeaderStatus}
               statusText={statusText}
               showReconnectIndicator={connState === "reconnecting"}
-              isAttached={isAttached}
               hasActiveAgent={hasActiveAgent}
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";
+import { feedbackDetailAtom, expandedAgentIdAtom } from "@/lib/store";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
 import { ActivityPane } from "@/components/app/activity-pane";
@@ -171,12 +173,12 @@ export function DashboardLayout(): JSX.Element {
   const [stopTarget, setStopTarget] = useState<Agent | null>(null);
 
   // ── Misc UI state ────────────────────────────────────────────────────
-  const [feedbackDetail, setFeedbackDetail] = useState<FeedbackDetailState>(null);
+  const [feedbackDetail, setFeedbackDetail] = useAtom(feedbackDetailAtom);
   // Keep last feedback detail alive during close transition so content fades out.
   const feedbackDetailStaleRef = useRef<NonNullable<FeedbackDetailState> | null>(null);
   if (feedbackDetail) feedbackDetailStaleRef.current = feedbackDetail;
   const feedbackDetailRendered = feedbackDetail ?? feedbackDetailStaleRef.current;
-  const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
+  const [expandedAgentId, setExpandedAgentId] = useAtom(expandedAgentIdAtom);
 
   // ── Agent selection ────────────────────────────────────────────────────
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
@@ -269,22 +271,10 @@ export function DashboardLayout(): JSX.Element {
     setSharedConnState(connState);
   }, [connState]);
 
-  useEffect(() => {
-    if (expandedAgentId && agents.some((agent) => agent.id === expandedAgentId)) {
-      return;
-    }
-    setExpandedAgentId(null);
-  }, [agents, expandedAgentId]);
-
   // Re-sort agents when connected agent changes.
   useEffect(() => {
     resortAgents();
   }, [connectedAgentId, resortAgents]);
-
-  // Close feedback detail panel when the connected agent changes.
-  useEffect(() => {
-    setFeedbackDetail((prev) => prev && connectedAgentId !== prev.parentAgentId ? null : prev);
-  }, [connectedAgentId]);
 
   const connectedAgentIdRef = useRef<string | null>(null);
   connectedAgentIdRef.current = connectedAgentId;
@@ -377,15 +367,10 @@ export function DashboardLayout(): JSX.Element {
 
   // ── Derived values ────────────────────────────────────────────────────
   const isAttached = connState === "connected" && Boolean(connectedAgentId);
+  const hasActiveAgent = Boolean(validatedSelectedAgentId);
   const showHeaderStatus = connState !== "disconnected";
 
-  // Close media/pins sidebar when fully disconnected (not during agent switches).
-  useEffect(() => {
-    if (connState === "disconnected" && !connectedAgentId) {
-      setMediaOpen(false);
-      setMobileMediaOpen(false);
-    }
-  }, [connState, connectedAgentId, setMediaOpen, setMobileMediaOpen]);
+
 
   const statusText = useMemo(() => {
     if (connState === "reconnecting") {
@@ -612,6 +597,7 @@ export function DashboardLayout(): JSX.Element {
               statusText={statusText}
               showReconnectIndicator={connState === "reconnecting"}
               isAttached={isAttached}
+              hasActiveAgent={hasActiveAgent}
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}
               setMediaOpen={handleSetMediaPanelOpen}
@@ -655,7 +641,7 @@ export function DashboardLayout(): JSX.Element {
 
         <div className="hidden shrink-0 md:block">
           <MediaSidebar
-            mediaOpen={mediaOpen}
+            mediaOpen={mediaOpen && hasActiveAgent}
             mediaFiles={mediaFiles}
             selectedAgentId={focusedAgentId}
             selectedAgentName={focusedAgent?.name ?? null}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -379,6 +379,14 @@ export function DashboardLayout(): JSX.Element {
   const isAttached = connState === "connected" && Boolean(connectedAgentId);
   const showHeaderStatus = connState !== "disconnected";
 
+  // Close media/pins sidebar when fully disconnected (not during agent switches).
+  useEffect(() => {
+    if (connState === "disconnected" && !connectedAgentId) {
+      setMediaOpen(false);
+      setMobileMediaOpen(false);
+    }
+  }, [connState, connectedAgentId, setMediaOpen, setMobileMediaOpen]);
+
   const statusText = useMemo(() => {
     if (connState === "reconnecting") {
       if (connectedAgent) return `Reconnecting to session ${connectedAgent.name}...`;
@@ -607,7 +615,6 @@ export function DashboardLayout(): JSX.Element {
               unseenMediaCount={unseenMediaCount}
               setLeftOpen={handleSetLeftPanelOpen}
               setMediaOpen={handleSetMediaPanelOpen}
-              detachTerminal={detachAndClearSelection}
             />
 
             <TerminalPane

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -73,7 +73,6 @@ export function AgentCard({
   const state = getVisualState(agent);
   const isSelected = selectedAgentId === agent.id;
   const isStopped = state === "stopped";
-  const isActive = state === "active";
   const isExpanded = expandedAgentId === agent.id;
   const fullAccessEnabled = isFullAccessEnabled(agent);
   const needsAttention = agent.status === "error";

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -1,0 +1,334 @@
+import React from "react";
+import {
+  AlertTriangle,
+  Archive,
+  ChevronDown,
+  Loader2,
+  Play,
+  Square,
+} from "lucide-react";
+
+import { AgentMeta } from "@/components/app/agent-meta";
+import { AgentTypeIcon } from "@/components/app/agent-type-icon";
+import { latestEventLabel, latestEventColor, formatRelativeTime } from "@/components/app/agent-event-utils";
+import { type FeedbackDetailState, ParentFeedbackPanel } from "@/components/app/feedback-panel";
+import { PersonaLauncher } from "@/components/app/persona-launcher";
+import { type Agent, type AgentVisualState } from "@/components/app/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { AnimatePresence, motion } from "framer-motion";
+import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import { cn } from "@/lib/utils";
+
+export type AgentCardProps = {
+  agent: Agent;
+  agents: Agent[];
+  childAgents: Agent[];
+  selectedAgentId: string | null;
+  expandedAgentId: string | null;
+  agentVisualState: (agent: Agent) => AgentVisualState;
+  borderForAgentState: (state: AgentVisualState) => string;
+  toggleAgentDetails: (agentId: string) => void;
+  isFullAccessEnabled: (agent: Pick<Agent, "agentArgs" | "fullAccess">) => boolean;
+  detachTerminal: () => void;
+  attachToAgent: (agent: Agent) => Promise<void>;
+  startAgent: (agent: Agent) => Promise<void>;
+  setDeleteTarget: (agent: Agent | null) => void;
+  setDeleteConfirmOpen: (open: boolean) => void;
+  setStopTarget: (agent: Agent | null) => void;
+  setStopConfirmOpen: (open: boolean) => void;
+  sendTerminalInput?: (data: string) => void;
+  connectedAgentId?: string | null;
+  onOpenFeedbackDetail?: (state: FeedbackDetailState) => void;
+  feedbackDetailState?: FeedbackDetailState;
+  onRequestClose?: () => void;
+  closeOnSessionAction?: boolean;
+};
+
+export function AgentCard({
+  agent,
+  agents,
+  childAgents,
+  selectedAgentId,
+  expandedAgentId,
+  agentVisualState: getVisualState,
+  borderForAgentState,
+  toggleAgentDetails,
+  isFullAccessEnabled,
+  detachTerminal,
+  attachToAgent,
+  startAgent,
+  setDeleteTarget,
+  setDeleteConfirmOpen,
+  setStopTarget,
+  setStopConfirmOpen,
+  sendTerminalInput,
+  connectedAgentId,
+  onOpenFeedbackDetail,
+  feedbackDetailState,
+  onRequestClose,
+  closeOnSessionAction = false,
+}: AgentCardProps): JSX.Element {
+  const state = getVisualState(agent);
+  const isSelected = selectedAgentId === agent.id;
+  const isStopped = state === "stopped";
+  const isActive = state === "active";
+  const isExpanded = isActive || expandedAgentId === agent.id;
+  const fullAccessEnabled = isFullAccessEnabled(agent);
+  const needsAttention = agent.status === "error";
+
+  return (
+    <React.Fragment>
+      <div
+        data-testid={`agent-card-${agent.id}`}
+        className={cn(
+          "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
+          borderForAgentState(state),
+          isSelected && "bg-muted/60",
+          isStopped && "opacity-60"
+        )}
+      >
+        <div
+          className={cn("flex items-center gap-1.5", !isStopped && "cursor-pointer")}
+          data-testid={`agent-row-${agent.id}`}
+          onClick={(event) => {
+            const target = event.target as HTMLElement;
+            if (target.closest("[data-agent-control='true']")) return;
+            if (isStopped) return;
+            if (isActive) { detachTerminal(); return; }
+            if (closeOnSessionAction) onRequestClose?.();
+            void attachToAgent(agent);
+          }}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
+                <AgentTypeIcon type={agent.type} eventType={agent.status === "running" ? agent.latestEvent?.type : null} />
+                <span className="truncate">{agent.name}</span>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>{agent.cwd}</TooltipContent>
+          </Tooltip>
+
+          {needsAttention ? (
+            <Badge
+              className="border-status-blocked/45 bg-status-blocked/15 text-status-blocked"
+              title={agent.lastError ?? "Agent entered an error state and may need attention."}
+            >
+              Attention
+            </Badge>
+          ) : null}
+
+          {isStopped && agent.status !== "archiving" ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost-primary"
+                  data-agent-control="true"
+                  onClick={() => {
+                    if (closeOnSessionAction) onRequestClose?.();
+                    void startAgent(agent);
+                  }}
+                >
+                  <Play className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Resume<br /><span className="text-muted-foreground">Start agent session</span></TooltipContent>
+            </Tooltip>
+          ) : agent.status === "archiving" ? null : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost-warning"
+                  data-agent-control="true"
+                  onClick={() => {
+                    setStopTarget(agent);
+                    setStopConfirmOpen(true);
+                  }}
+                >
+                  <Square className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Stop<br /><span className="text-muted-foreground">End agent session</span></TooltipContent>
+            </Tooltip>
+          )}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost-destructive"
+                data-agent-control="true"
+                data-testid={`agent-archive-${agent.id}`}
+                className="ml-auto"
+                disabled={agent.status === "archiving" || agent.status === "creating"}
+                onClick={() => {
+                  setDeleteTarget(agent);
+                  setDeleteConfirmOpen(true);
+                }}
+              >
+                <Archive className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Archive<br /><span className="text-muted-foreground">Remove agent</span></TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                data-agent-control="true"
+                data-testid={`agent-expand-toggle-${agent.id}`}
+                disabled={isActive}
+                onClick={() => {
+                  if (isActive) return;
+                  toggleAgentDetails(agent.id);
+                }}
+              >
+                <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180", isActive && "opacity-40")} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{isActive ? "Attached agent stays open" : isExpanded ? "Hide details" : "Show details"}</TooltipContent>
+          </Tooltip>
+        </div>
+
+        {agent.status === "creating" && agent.setupPhase ? (
+          <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-status-working">
+            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+            <span className="truncate font-medium">
+              {agent.setupPhase === "worktree" ? "Creating worktree…" :
+               agent.setupPhase === "env" ? "Copying environment…" :
+               agent.setupPhase === "deps" ? "Installing dependencies…" :
+               agent.setupPhase === "session" ? "Starting session…" : "Setting up…"}
+            </span>
+          </div>
+        ) : null}
+
+        {agent.status === "archiving" ? (
+          <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-orange-400">
+            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+            <span className="truncate font-medium">
+              {agent.archivePhase === "stopping" ? "Stopping agent…" :
+               agent.archivePhase === "worktree-check" ? "Checking worktree…" :
+               agent.archivePhase === "worktree-cleanup" ? "Removing worktree…" :
+               agent.archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
+            </span>
+          </div>
+        ) : null}
+
+        {agent.latestEvent ? (
+          isExpanded ? (
+            <div className="mt-1 text-xs text-muted-foreground">
+              <div className="flex items-baseline">
+                <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
+                <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+                <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
+              </div>
+              <div className="mt-0.5 leading-relaxed text-muted-foreground">{agent.latestEvent.message}</div>
+            </div>
+          ) : (
+            <div className="mt-1 flex min-w-0 items-baseline text-xs text-muted-foreground">
+              <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
+              <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+              <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
+              <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
+              <span className="min-w-0 truncate">{agent.latestEvent.message}</span>
+            </div>
+          )
+        ) : null}
+
+        <AnimatePresence initial={false}>
+          {isExpanded ? (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="mt-2 overflow-hidden"
+            >
+              <div className="px-3 pb-2 pt-1">
+                <div className="grid gap-2 text-xs text-muted-foreground">
+                  {agent.gitContext?.isWorktree ? (
+                    <>
+                      <AgentMeta label="Repo" value={agent.gitContext.repoRoot.split("/").pop() ?? agent.gitContext.repoRoot} />
+                      <AgentMeta label="Branch" value={agent.gitContext.branch} mono truncateStart />
+                      <AgentMeta label="Worktree" value={agent.cwd} mono truncateStart />
+                    </>
+                  ) : (
+                    <>
+                      <AgentMeta label="Working dir" value={agent.cwd} mono truncateStart />
+                      {agent.gitContext ? (
+                        <AgentMeta label="Branch" value={agent.gitContext.branch} mono truncateStart />
+                      ) : (
+                        <div className="grid gap-1">
+                          <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Git</div>
+                          <div className="text-foreground text-xs">Not a git repository</div>
+                        </div>
+                      )}
+                    </>
+                  )}
+                  <div className="flex items-center justify-between">
+                    <div className="text-foreground">{AGENT_TYPE_LABELS[agent.type as AgentType] ?? agent.type ?? "Codex"}</div>
+                    <div
+                      className={cn(
+                        "inline-flex items-center gap-1 px-1.5 py-0.5 text-foreground text-[11px]",
+                        fullAccessEnabled &&
+                          "border border-status-waiting/45 bg-status-waiting/15 text-status-waiting"
+                      )}
+                    >
+                      {fullAccessEnabled ? <AlertTriangle className="h-3 w-3" /> : null}
+                      <span>{fullAccessEnabled ? "Full access" : "Sandboxed"}</span>
+                    </div>
+                  </div>
+                  {agent.lastError ? <AgentMeta label="Last error" value={agent.lastError} /> : null}
+                  {agent.persona ? (
+                    <div className="flex items-center gap-1.5">
+                      <span className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Persona</span>
+                      <Badge variant="running">{agent.persona}</Badge>
+                      {agent.parentAgentId ? (
+                        <span className="text-[10px] text-muted-foreground">
+                          from {agents.find((a) => a.id === agent.parentAgentId)?.name ?? agent.parentAgentId.slice(-6)}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
+                  {!isStopped && !agent.persona ? (
+                    <PersonaLauncher
+                      agent={agent}
+                      sendTerminalInput={sendTerminalInput}
+                      disabled={connectedAgentId !== agent.id}
+                    />
+                  ) : null}
+                </div>
+              </div>
+              {!agent.persona ? (
+                <div className="px-3 pb-2">
+                  <ParentFeedbackPanel
+                    parentAgentId={agent.id}
+                    sendTerminalInput={sendTerminalInput}
+                    isConnected={connectedAgentId === agent.id}
+                    onRequestClose={onRequestClose}
+                    closeOnSessionAction={closeOnSessionAction}
+                    onOpenDetail={onOpenFeedbackDetail}
+                    activeDetailItemId={feedbackDetailState?.parentAgentId === agent.id ? feedbackDetailState.itemId : null}
+                    childAgents={childAgents}
+                    selectedAgentId={selectedAgentId}
+                    agentVisualState={getVisualState}
+                    detachTerminal={detachTerminal}
+                    attachToAgent={attachToAgent}
+                    setDeleteTarget={setDeleteTarget}
+                    setDeleteConfirmOpen={setDeleteConfirmOpen}
+                  />
+                </div>
+              ) : null}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -74,7 +74,7 @@ export function AgentCard({
   const isSelected = selectedAgentId === agent.id;
   const isStopped = state === "stopped";
   const isActive = state === "active";
-  const isExpanded = isActive || expandedAgentId === agent.id;
+  const isExpanded = expandedAgentId === agent.id;
   const fullAccessEnabled = isFullAccessEnabled(agent);
   const needsAttention = agent.status === "error";
 
@@ -96,7 +96,7 @@ export function AgentCard({
             const target = event.target as HTMLElement;
             if (target.closest("[data-agent-control='true']")) return;
             if (isStopped) return;
-            if (isActive) { detachTerminal(); return; }
+            if (connectedAgentId === agent.id) { detachTerminal(); if (isExpanded) toggleAgentDetails(agent.id); return; }
             if (closeOnSessionAction) onRequestClose?.();
             void attachToAgent(agent);
           }}
@@ -183,16 +183,18 @@ export function AgentCard({
                 variant="ghost"
                 data-agent-control="true"
                 data-testid={`agent-expand-toggle-${agent.id}`}
-                disabled={isActive}
                 onClick={() => {
-                  if (isActive) return;
+                  // If collapsing while a child persona is connected, detach it
+                  if (isExpanded && connectedAgentId && childAgents.some((c) => c.id === connectedAgentId)) {
+                    detachTerminal();
+                  }
                   toggleAgentDetails(agent.id);
                 }}
               >
-                <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180", isActive && "opacity-40")} />
+                <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180")} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isActive ? "Attached agent stays open" : isExpanded ? "Hide details" : "Show details"}</TooltipContent>
+            <TooltipContent>{isExpanded ? "Hide details" : "Show details"}</TooltipContent>
           </Tooltip>
         </div>
 

--- a/apps/web/src/components/app/agent-event-utils.ts
+++ b/apps/web/src/components/app/agent-event-utils.ts
@@ -1,0 +1,31 @@
+import type { Agent } from "@/components/app/types";
+
+type EventType = NonNullable<Agent["latestEvent"]>["type"];
+
+export function latestEventLabel(type: EventType): string {
+  if (type === "waiting_user") return "Waiting";
+  if (type === "working") return "Working";
+  if (type === "blocked") return "Blocked";
+  if (type === "done") return "Done";
+  return "Idle";
+}
+
+export function latestEventColor(type: EventType): string {
+  if (type === "working") return "text-status-working";
+  if (type === "blocked") return "text-status-blocked";
+  if (type === "waiting_user") return "text-status-waiting";
+  if (type === "done") return "text-status-done";
+  return "text-foreground/80";
+}
+
+export function formatRelativeTime(value: string): string {
+  const date = new Date(value);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) return "";
+
+  const deltaSeconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
+  if (deltaSeconds < 60) return "just now";
+  if (deltaSeconds < 3600) return `${Math.floor(deltaSeconds / 60)}m ago`;
+  if (deltaSeconds < 86_400) return `${Math.floor(deltaSeconds / 3600)}h ago`;
+  return `${Math.floor(deltaSeconds / 86_400)}d ago`;
+}

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -1,30 +1,22 @@
-import React from "react";
 import {
-  AlertTriangle,
   Activity,
-  Archive,
   BookOpenText,
   ChevronDown,
   ChevronLeft,
-  Loader2,
-  Play,
-  Square,
   Settings,
   X
 } from "lucide-react";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 
-import { AgentMeta } from "@/components/app/agent-meta";
+import { AgentCard } from "@/components/app/agent-card";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
-import { type FeedbackDetailState, ParentFeedbackPanel } from "@/components/app/feedback-panel";
-import { PersonaLauncher } from "@/components/app/persona-launcher";
+import { type FeedbackDetailState } from "@/components/app/feedback-panel";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
+import React from "react";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { cn } from "@/lib/utils";
 
@@ -54,6 +46,7 @@ type AgentSidebarSharedProps = {
   sendTerminalInput?: (data: string) => void;
   connectedAgentId?: string | null;
   onOpenFeedbackDetail?: (state: FeedbackDetailState) => void;
+  feedbackDetailState?: FeedbackDetailState;
 };
 
 type AgentSidebarProps = AgentSidebarSharedProps & {
@@ -94,6 +87,7 @@ export function AgentSidebarContent({
   sendTerminalInput,
   connectedAgentId,
   onOpenFeedbackDetail,
+  feedbackDetailState,
   onRequestClose,
   closeOnSessionAction = false,
   closeButtonIcon = "x",
@@ -105,50 +99,6 @@ export function AgentSidebarContent({
   const defaultCreateType: AgentType = lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
     ? lastUsedAgentType
     : enabledAgentTypes[0] ?? "codex";
-
-  const latestEventLabel = (type: NonNullable<Agent["latestEvent"]>["type"]): string => {
-    if (type === "waiting_user") {
-      return "Waiting";
-    }
-    if (type === "working") {
-      return "Working";
-    }
-    if (type === "blocked") {
-      return "Blocked";
-    }
-    if (type === "done") {
-      return "Done";
-    }
-    return "Idle";
-  };
-
-  const latestEventColor = (type: NonNullable<Agent["latestEvent"]>["type"]): string => {
-    if (type === "working") return "text-status-working";
-    if (type === "blocked") return "text-status-blocked";
-    if (type === "waiting_user") return "text-status-waiting";
-    if (type === "done") return "text-status-done";
-    return "text-foreground/80";
-  };
-
-  const formatRelativeTime = (value: string): string => {
-    const date = new Date(value);
-    const time = date.getTime();
-    if (!Number.isFinite(time)) {
-      return "";
-    }
-
-    const deltaSeconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
-    if (deltaSeconds < 60) {
-      return "just now";
-    }
-    if (deltaSeconds < 3600) {
-      return `${Math.floor(deltaSeconds / 60)}m ago`;
-    }
-    if (deltaSeconds < 86_400) {
-      return `${Math.floor(deltaSeconds / 3600)}h ago`;
-    }
-    return `${Math.floor(deltaSeconds / 86_400)}d ago`;
-  };
 
   return (
     <aside data-testid="agent-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-r-2 border-border bg-card text-foreground", className)}>
@@ -216,336 +166,35 @@ export function AgentSidebarContent({
           {agents.length === 0 ? (
             <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
           ) : (
-            <LayoutGroup>
-            {agents.filter((a) => !a.parentAgentId).map((agent) => {
-              const childAgents = agents.filter((a) => a.parentAgentId === agent.id);
-              const state = agentVisualState(agent);
-              const isSelected = selectedAgentId === agent.id;
-              const isStopped = state === "stopped";
-              const isActive = state === "active";
-              const isExpanded = isActive || expandedAgentId === agent.id;
-              const fullAccessEnabled = isFullAccessEnabled(agent);
-              const needsAttention = agent.status === "error";
-
-              return (
-                <React.Fragment key={agent.id}>
-                <motion.div
-                  layout
-                  transition={{ duration: 0.3, ease: "easeInOut" }}
-                  data-testid={`agent-card-${agent.id}`}
-                  className={cn(
-                    "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
-                    borderForAgentState(state),
-                    isSelected && "bg-muted/60",
-                    isStopped && "opacity-60"
-                  )}
-                >
-                  <div
-                    className={cn("flex items-center gap-1.5", !isStopped && "cursor-pointer")}
-                    data-testid={`agent-row-${agent.id}`}
-                    onClick={(event) => {
-                      const target = event.target as HTMLElement;
-                      if (target.closest("[data-agent-control='true']")) {
-                        return;
-                      }
-                      if (isStopped) {
-                        return;
-                      }
-                      if (isActive) {
-                        detachTerminal();
-                        return;
-                      }
-                      if (closeOnSessionAction) {
-                        onRequestClose?.();
-                      }
-                      void attachToAgent(agent);
-                    }}
-                  >
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
-                          <AgentTypeIcon type={agent.type} eventType={agent.status === "running" ? agent.latestEvent?.type : null} />
-                          <span className="truncate">{agent.name}</span>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent>{agent.cwd}</TooltipContent>
-                    </Tooltip>
-
-                    {needsAttention ? (
-                      <Badge
-                        className="border-status-blocked/45 bg-status-blocked/15 text-status-blocked"
-                        title={agent.lastError ?? "Agent entered an error state and may need attention."}
-                      >
-                        Attention
-                      </Badge>
-                    ) : null}
-
-                    {isStopped && agent.status !== "archiving" ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            size="icon"
-                            variant="ghost-primary"
-                            data-agent-control="true"
-                            onClick={() => {
-                              if (closeOnSessionAction) {
-                                onRequestClose?.();
-                              }
-                              void startAgent(agent);
-                            }}
-                          >
-                            <Play className="h-3.5 w-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Resume<br /><span className="text-muted-foreground">Start agent session</span></TooltipContent>
-                      </Tooltip>
-                    ) : agent.status === "archiving" ? null : (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            size="icon"
-                            variant="ghost-warning"
-                            data-agent-control="true"
-                            onClick={() => {
-                              setStopTarget(agent);
-                              setStopConfirmOpen(true);
-                            }}
-                          >
-                            <Square className="h-3.5 w-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Stop<br /><span className="text-muted-foreground">End agent session</span></TooltipContent>
-                      </Tooltip>
-                    )}
-
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          size="icon"
-                          variant="ghost-destructive"
-                          data-agent-control="true"
-                          data-testid={`agent-archive-${agent.id}`}
-                          className="ml-auto"
-                          disabled={agent.status === "archiving" || agent.status === "creating"}
-                          onClick={() => {
-                            setDeleteTarget(agent);
-                            setDeleteConfirmOpen(true);
-                          }}
-                        >
-                          <Archive className="h-3.5 w-3.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Archive<br /><span className="text-muted-foreground">Remove agent</span></TooltipContent>
-                    </Tooltip>
-
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          data-agent-control="true"
-                          data-testid={`agent-expand-toggle-${agent.id}`}
-                          disabled={isActive}
-                          onClick={() => {
-                            if (isActive) {
-                              return;
-                            }
-                            toggleAgentDetails(agent.id);
-                          }}
-                        >
-                          <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180", isActive && "opacity-40")} />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>{isActive ? "Attached agent stays open" : isExpanded ? "Hide details" : "Show details"}</TooltipContent>
-                    </Tooltip>
-                  </div>
-
-                  {agent.status === "creating" && agent.setupPhase ? (
-                    <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-status-working">
-                      <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
-                      <span className="truncate font-medium">
-                        {agent.setupPhase === "worktree" ? "Creating worktree…" :
-                         agent.setupPhase === "env" ? "Copying environment…" :
-                         agent.setupPhase === "deps" ? "Installing dependencies…" :
-                         agent.setupPhase === "session" ? "Starting session…" : "Setting up…"}
-                      </span>
-                    </div>
-                  ) : null}
-
-                  {agent.status === "archiving" ? (
-                    <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-orange-400">
-                      <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
-                      <span className="truncate font-medium">
-                        {agent.archivePhase === "stopping" ? "Stopping agent…" :
-                         agent.archivePhase === "worktree-check" ? "Checking worktree…" :
-                         agent.archivePhase === "worktree-cleanup" ? "Removing worktree…" :
-                         agent.archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
-                      </span>
-                    </div>
-                  ) : null}
-
-                  {agent.latestEvent ? (
-                    isExpanded ? (
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        <div className="flex items-baseline">
-                          <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
-                          <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-                          <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
-                        </div>
-                        <div className="mt-0.5 leading-relaxed text-muted-foreground">{agent.latestEvent.message}</div>
-                      </div>
-                    ) : (
-                      <div className="mt-1 flex min-w-0 items-baseline text-xs text-muted-foreground">
-                        <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
-                        <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-                        <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
-                        <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-                        <span className="min-w-0 truncate">{agent.latestEvent.message}</span>
-                      </div>
-                    )
-                  ) : null}
-
-                  <AnimatePresence initial={false}>
-                    {isExpanded ? (
-                      <motion.div
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: "auto", opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.2, ease: "easeOut" }}
-                        className="mt-2 overflow-hidden"
-                      >
-                        <div className="px-3 pb-2 pt-1">
-                          <div className="grid gap-2 text-xs text-muted-foreground">
-                            {agent.gitContext?.isWorktree ? (
-                              <>
-                                <AgentMeta label="Repo" value={agent.gitContext.repoRoot.split("/").pop() ?? agent.gitContext.repoRoot} />
-                                <AgentMeta label="Branch" value={agent.gitContext.branch} mono truncateStart />
-                                <AgentMeta label="Worktree" value={agent.cwd} mono truncateStart />
-                              </>
-                            ) : (
-                              <>
-                                <AgentMeta label="Working dir" value={agent.cwd} mono truncateStart />
-                                {agent.gitContext ? (
-                                  <AgentMeta label="Branch" value={agent.gitContext.branch} mono truncateStart />
-                                ) : (
-                                  <div className="grid gap-1">
-                                    <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Git</div>
-                                    <div className="text-foreground text-xs">Not a git repository</div>
-                                  </div>
-                                )}
-                              </>
-                            )}
-                            <div className="flex items-center justify-between">
-                              <div className="text-foreground">{AGENT_TYPE_LABELS[agent.type as AgentType] ?? agent.type ?? "Codex"}</div>
-                              <div
-                                className={cn(
-                                  "inline-flex items-center gap-1 px-1.5 py-0.5 text-foreground text-[11px]",
-                                  fullAccessEnabled &&
-                                    "border border-status-waiting/45 bg-status-waiting/15 text-status-waiting"
-                                )}
-                              >
-                                {fullAccessEnabled ? <AlertTriangle className="h-3 w-3" /> : null}
-                                <span>{fullAccessEnabled ? "Full access" : "Sandboxed"}</span>
-                              </div>
-                            </div>
-                            {agent.lastError ? <AgentMeta label="Last error" value={agent.lastError} /> : null}
-                            {agent.persona ? (
-                              <div className="flex items-center gap-1.5">
-                                <span className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Persona</span>
-                                <Badge variant="running">{agent.persona}</Badge>
-                                {agent.parentAgentId ? (
-                                  <span className="text-[10px] text-muted-foreground">
-                                    from {agents.find((a) => a.id === agent.parentAgentId)?.name ?? agent.parentAgentId.slice(-6)}
-                                  </span>
-                                ) : null}
-                              </div>
-                            ) : null}
-                            {!isStopped && !agent.persona && sendTerminalInput && connectedAgentId === agent.id ? (
-                              <PersonaLauncher
-                                agent={agent}
-                                sendTerminalInput={sendTerminalInput}
-                              />
-                            ) : null}
-                          </div>
-                        </div>
-                        {!agent.persona ? (
-                          <div className="px-3 pb-2">
-                            <ParentFeedbackPanel
-                              parentAgentId={agent.id}
-                              sendTerminalInput={sendTerminalInput}
-                              isConnected={connectedAgentId === agent.id}
-                              onRequestClose={onRequestClose}
-                              closeOnSessionAction={closeOnSessionAction}
-                              onOpenDetail={onOpenFeedbackDetail}
-                            />
-                          </div>
-                        ) : null}
-                      </motion.div>
-                    ) : null}
-                  </AnimatePresence>
-                </motion.div>
-                {childAgents.map((child) => {
-                  const childState = agentVisualState(child);
-                  const childIsSelected = selectedAgentId === child.id;
-                  const childIsStopped = childState === "stopped";
-                  const childIsActive = childState === "active";
-                  const childIsExpanded = childIsActive || expandedAgentId === child.id;
-
-                  return (
-                    <motion.div
-                      key={child.id}
-                      layout
-                      transition={{ duration: 0.3, ease: "easeInOut" }}
-                      data-testid={`agent-card-${child.id}`}
-                      className={cn(
-                        "border-b border-r-4 border-border pl-5 pr-2 py-2 transition-colors duration-300",
-                        borderForAgentState(childState),
-                        childIsSelected && "bg-muted/60",
-                        childIsStopped && "opacity-60"
-                      )}
-                    >
-                      <div
-                        className={cn("flex items-center gap-1.5", !childIsStopped && "cursor-pointer")}
-                        data-testid={`agent-row-${child.id}`}
-                        onClick={(event) => {
-                          const target = event.target as HTMLElement;
-                          if (target.closest("[data-agent-control='true']")) return;
-                          if (childIsStopped) return;
-                          if (childIsActive) { detachTerminal(); return; }
-                          if (closeOnSessionAction) onRequestClose?.();
-                          void attachToAgent(child);
-                        }}
-                      >
-                        <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
-                          <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} />
-                          <span className="truncate">{child.name}</span>
-                          {child.persona ? (
-                            <Badge variant="running" className="text-[9px] shrink-0">{child.persona}</Badge>
-                          ) : null}
-                        </div>
-                        {childIsStopped ? (
-                          <button data-agent-control="true" aria-label="Resume agent" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => startAgent(child)}><Play className="h-3.5 w-3.5" /></button>
-                        ) : (
-                          <button data-agent-control="true" aria-label="Stop agent" className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors" onClick={() => { setStopTarget(child); setStopConfirmOpen(true); }}><Square className="h-3.5 w-3.5" /></button>
-                        )}
-                        <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors disabled:opacity-30" disabled={child.status === "archiving"} onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
-                      </div>
-                      {child.latestEvent ? (
-                        childIsExpanded ? (
-                          <div className="mt-1 flex flex-wrap items-center gap-x-0 text-xs text-muted-foreground">
-                            <span className={cn("font-medium", child.latestEvent.type === "working" ? "text-status-working" : child.latestEvent.type === "blocked" ? "text-status-blocked" : child.latestEvent.type === "waiting_user" ? "text-status-waiting" : child.latestEvent.type === "done" ? "text-status-done" : "text-status-idle")}>{child.latestEvent.type === "working" ? "Working" : child.latestEvent.type === "blocked" ? "Blocked" : child.latestEvent.type === "waiting_user" ? "Waiting" : child.latestEvent.type === "done" ? "Done" : "Idle"}</span>
-                            <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-                            <span className="min-w-0 truncate">{child.latestEvent.message}</span>
-                          </div>
-                        ) : null
-                      ) : null}
-                    </motion.div>
-                  );
-                })}
-              </React.Fragment>
-              );
-            })}
-            </LayoutGroup>
+            <React.Fragment>
+            {agents.filter((a) => !a.parentAgentId).map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                agents={agents}
+                childAgents={agents.filter((a) => a.parentAgentId === agent.id)}
+                selectedAgentId={selectedAgentId}
+                expandedAgentId={expandedAgentId}
+                agentVisualState={agentVisualState}
+                borderForAgentState={borderForAgentState}
+                toggleAgentDetails={toggleAgentDetails}
+                isFullAccessEnabled={isFullAccessEnabled}
+                detachTerminal={detachTerminal}
+                attachToAgent={attachToAgent}
+                startAgent={startAgent}
+                setDeleteTarget={setDeleteTarget}
+                setDeleteConfirmOpen={setDeleteConfirmOpen}
+                setStopTarget={setStopTarget}
+                setStopConfirmOpen={setStopConfirmOpen}
+                sendTerminalInput={sendTerminalInput}
+                connectedAgentId={connectedAgentId}
+                onOpenFeedbackDetail={onOpenFeedbackDetail}
+                feedbackDetailState={feedbackDetailState}
+                onRequestClose={onRequestClose}
+                closeOnSessionAction={closeOnSessionAction}
+              />
+            ))}
+            </React.Fragment>
           )}
         </TooltipProvider>
       </div>

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -12,6 +12,7 @@ type AppHeaderProps = {
   statusText: string;
   showReconnectIndicator: boolean;
   isAttached: boolean;
+  hasActiveAgent: boolean;
   unseenMediaCount: number;
   setLeftOpen: (open: boolean) => void;
   setMediaOpen: (open: boolean) => void;
@@ -25,6 +26,7 @@ export function AppHeader({
   statusText,
   showReconnectIndicator,
   isAttached,
+  hasActiveAgent,
   unseenMediaCount,
   setLeftOpen,
   setMediaOpen,
@@ -92,7 +94,7 @@ export function AppHeader({
       )}
 
       <div className="ml-auto flex shrink-0 items-center gap-1">
-        {isAttached && (!mediaOpen || isMobile) ? (
+        {hasActiveAgent && (!mediaOpen || isMobile) ? (
           <Button
             size="icon"
             variant="ghost"

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -11,7 +11,6 @@ type AppHeaderProps = {
   showHeaderStatus: boolean;
   statusText: string;
   showReconnectIndicator: boolean;
-  isAttached: boolean;
   hasActiveAgent: boolean;
   unseenMediaCount: number;
   setLeftOpen: (open: boolean) => void;
@@ -25,7 +24,6 @@ export function AppHeader({
   showHeaderStatus,
   statusText,
   showReconnectIndicator,
-  isAttached,
   hasActiveAgent,
   unseenMediaCount,
   setLeftOpen,

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -1,4 +1,4 @@
-import { Eye, PanelLeftOpen, PanelRightOpen } from "lucide-react";
+import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useIconColor } from "@/hooks/use-icon-color";
@@ -15,7 +15,6 @@ type AppHeaderProps = {
   unseenMediaCount: number;
   setLeftOpen: (open: boolean) => void;
   setMediaOpen: (open: boolean) => void;
-  detachTerminal: () => void;
 };
 
 export function AppHeader({
@@ -29,10 +28,8 @@ export function AppHeader({
   unseenMediaCount,
   setLeftOpen,
   setMediaOpen,
-  detachTerminal
 }: AppHeaderProps): JSX.Element {
   const { iconColor } = useIconColor();
-  const compactSessionAction = mediaOpen && !isMobile;
 
   return (
     <header
@@ -95,20 +92,7 @@ export function AppHeader({
       )}
 
       <div className="ml-auto flex shrink-0 items-center gap-1">
-        {isAttached ? (
-          <Button
-            size="sm"
-            variant="ghost-info"
-            onClick={detachTerminal}
-            title="Unfocus"
-            data-testid="detach-button"
-          >
-            <Eye className="mr-1 h-3.5 w-3.5" />
-            <span className={cn(compactSessionAction ? "hidden" : "hidden sm:inline")}>Unfocus</span>
-          </Button>
-        ) : null}
-
-        {(!mediaOpen || isMobile) ? (
+        {isAttached && (!mediaOpen || isMobile) ? (
           <Button
             size="icon"
             variant="ghost"

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Ban, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, Maximize, MessageCircleQuestion, RotateCcw, Wrench, X } from "lucide-react";
+import { Ban, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, MessageCircleQuestion, RotateCcw, Wrench, X } from "lucide-react";
 
 import { FrontTruncatedValue } from "@/components/app/agent-meta";
-import { type Agent, type FeedbackItem } from "@/components/app/types";
+import { PersonaAgentRow } from "@/components/app/persona-agent-row";
+import { type Agent, type AgentVisualState, type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
@@ -171,6 +172,14 @@ export function ParentFeedbackPanel({
   onRequestClose,
   closeOnSessionAction,
   onOpenDetail,
+  activeDetailItemId,
+  childAgents = [],
+  selectedAgentId,
+  agentVisualState: getVisualState,
+  detachTerminal,
+  attachToAgent,
+  setDeleteTarget,
+  setDeleteConfirmOpen,
 }: {
   parentAgentId: string;
   sendTerminalInput?: (data: string) => void;
@@ -179,9 +188,17 @@ export function ParentFeedbackPanel({
   closeOnSessionAction?: boolean;
   /** When provided, opens the detail in the main grid panel instead of a Sheet (desktop). */
   onOpenDetail?: (state: FeedbackDetailState) => void;
+  /** The currently open detail item id (used to highlight the active row). */
+  activeDetailItemId?: number | null;
+  childAgents?: Agent[];
+  selectedAgentId?: string | null;
+  agentVisualState?: (agent: Agent) => AgentVisualState;
+  detachTerminal?: () => void;
+  attachToAgent?: (agent: Agent) => Promise<void>;
+  setDeleteTarget?: (agent: Agent | null) => void;
+  setDeleteConfirmOpen?: (open: boolean) => void;
 }): JSX.Element | null {
   const queryClient = useQueryClient();
-  const [expandedId, setExpandedId] = useState<number | null>(null);
   const [sheetItemId, setSheetItemId] = useState<number | null>(null);
   const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
   const [showResolved, setShowResolved] = useState(false);
@@ -284,147 +301,138 @@ export function ParentFeedbackPanel({
       ? remaining[Math.min(Math.max(idx, 0), remaining.length - 1)]!.id
       : null;
     setSheetItemId(sheetItemId != null ? nextId : null);
-    setExpandedId(nextId);
   }, [updateStatus, activeItems, sheetItemId]);
 
   const severityInfo = (sev: string) => SEVERITY_LABELS[sev] ?? SEVERITY_LABELS.info;
 
-  if (feedback.length === 0) return null;
+  if (feedback.length === 0 && childAgents.length === 0) return null;
+
+  // Group feedback by agentId
+  const feedbackByAgent = new Map<string, FeedbackItem[]>();
+  for (const item of visibleItems) {
+    const list = feedbackByAgent.get(item.agentId);
+    if (list) list.push(item);
+    else feedbackByAgent.set(item.agentId, [item]);
+  }
+
+  // Count resolved items per agent from the full feedback list
+  const resolvedCountByAgent = new Map<string, number>();
+  for (const item of resolvedItems) {
+    resolvedCountByAgent.set(item.agentId, (resolvedCountByAgent.get(item.agentId) ?? 0) + 1);
+  }
+
+  // Build ordered list: child agents first (preserving order), then any agentIds with feedback but no child agent
+  const agentIds = new Set(childAgents.map((a) => a.id));
+  for (const agentId of feedbackByAgent.keys()) {
+    agentIds.add(agentId);
+  }
 
   return (
     <>
       <div className="mt-1.5">
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
-          Persona feedback ({activeCount} active)
+          Personas{activeCount > 0 ? ` (${activeCount} findings)` : ""}
         </div>
-        {!isConnected && activeCount > 0 ? (
-          <div className="text-[10px] text-muted-foreground/60 italic mb-1">
-            Attach to this agent to forward feedback
-          </div>
-        ) : null}
-        <div className="space-y-2">
-          {(() => {
-            // Group items by agentId to show persona sections
-            const groups = new Map<string, FeedbackItem[]>();
-            for (const item of visibleItems) {
-              const list = groups.get(item.agentId);
-              if (list) list.push(item);
-              else groups.set(item.agentId, [item]);
-            }
-            const needsGrouping = groups.size > 1;
+        <div className="space-y-1.5">
+          {childAgents.map((child, childIndex) => {
+            const items = feedbackByAgent.get(child.id) ?? [];
+            const isGroupCollapsed = collapsedGroups.has(child.id);
+            const childState = getVisualState?.(child);
 
-            return Array.from(groups.entries()).map(([agentId, items]) => {
-              const attr = personaAttribution.get(agentId);
-              const isGroupCollapsed = needsGrouping && collapsedGroups.has(agentId);
-              return (
-                <div key={agentId}>
-                  {needsGrouping ? (
-                    <button
-                      className="flex w-full items-center gap-1.5 mb-0.5 text-left hover:bg-muted/40 rounded transition-colors"
-                      onClick={(e) => {
+            return (
+              <div key={child.id}>
+                {getVisualState && detachTerminal && attachToAgent && setDeleteTarget && setDeleteConfirmOpen ? (
+                  <div
+                    className="cursor-pointer"
+                    onClick={(e) => {
+                      if ((e.target as HTMLElement).closest("[data-agent-control='true']")) return;
+                      if (items.length > 0) {
                         e.stopPropagation();
                         setCollapsedGroups((prev) => {
                           const next = new Set(prev);
-                          if (next.has(agentId)) next.delete(agentId);
-                          else next.add(agentId);
+                          if (next.has(child.id)) next.delete(child.id);
+                          else next.add(child.id);
                           return next;
                         });
-                      }}
-                    >
-                      <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isGroupCollapsed && "rotate-90")} />
-                      <span
-                        className="h-1.5 w-1.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: attr?.color ?? "hsl(var(--muted-foreground))" }}
-                      />
-                      <span
-                        className="text-[10px] font-medium"
-                        style={{ color: attr?.color ?? undefined }}
-                      >
-                        {attr?.name ?? agentId.slice(-6)}
-                      </span>
-                      <span className="text-[9px] text-muted-foreground/50">
-                        {items.filter((f) => f.status === "open" || f.status === "forwarded").length}
-                      </span>
-                    </button>
-                  ) : null}
-                  {!isGroupCollapsed ? <div className={cn("space-y-px", needsGrouping && "ml-2.5")}>
-                    {items.map((item) => {
-                      const isActionable = item.status === "open" || item.status === "forwarded";
-                      const isExpanded = expandedId === item.id;
-                      const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
-                      const statusLabel = STATUS_LABELS[item.status];
+                      }
+                    }}
+                  >
+                    <PersonaAgentRow
+                      child={child}
+                      childIndex={childIndex}
+                      childState={childState!}
+                      isSelected={selectedAgentId === child.id}
+                      detachTerminal={detachTerminal}
+                      attachToAgent={attachToAgent}
+                      setDeleteTarget={setDeleteTarget}
+                      setDeleteConfirmOpen={setDeleteConfirmOpen}
+                      onRequestClose={onRequestClose}
+                      closeOnSessionAction={closeOnSessionAction}
+                      feedbackCount={items.filter((f) => f.status === "open" || f.status === "forwarded").length}
+                      isCollapsed={isGroupCollapsed}
+                      hasFeedback={items.length > 0}
+                    />
+                  </div>
+                ) : null}
+                {!isGroupCollapsed && items.length > 0 ? (() => {
+                  const groupResolvedCount = resolvedCountByAgent.get(child.id) ?? 0;
+                  return (
+                    <div className="space-y-px ml-4 mt-0.5">
+                      {items.map((item) => {
+                        const isActionable = item.status === "open" || item.status === "forwarded";
+                        const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
+                        const statusLabel = STATUS_LABELS[item.status];
+                        const isSelected = item.id === (activeDetailItemId ?? sheetItemId);
 
-                      return (
-                        <div key={item.id} className={cn(!isActionable && "opacity-40")}>
-                          {/* Compact row */}
-                          <button
-                            className="flex w-full items-center gap-1.5 rounded px-1 py-2 md:py-1 text-left text-[11px] hover:bg-muted/40 transition-colors"
-                            onClick={(e) => { e.stopPropagation(); setExpandedId(isExpanded ? null : item.id); }}
-                          >
-                            <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", isExpanded && "rotate-90")} />
-                            <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
-                            <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
-                              <FrontTruncatedValue
-                                value={item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
-                                mono
-                              />
-                            </div>
-                            <span className="min-w-0 flex-1 truncate text-foreground">
-                              {item.description}
-                            </span>
-                            {statusLabel && !isActionable ? (
-                              <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
-                            ) : null}
-                          </button>
-
-                          {/* Expanded inline card — clamped */}
-                          {isExpanded ? (
-                            <div className="relative ml-4 mr-1 mb-1.5 rounded-md border border-border bg-background px-2.5 py-2 text-xs shadow-sm" onClick={(e) => e.stopPropagation()}>
-                              <button
-                                className="absolute top-1 right-1 p-1 rounded text-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
-                                onClick={() => {
-                                  if (onOpenDetail) {
-                                    onOpenDetail({ parentAgentId, itemId: item.id });
-                                  } else {
-                                    setSheetItemId(item.id);
-                                  }
-                                }}
-                              >
-                                <Maximize className="h-3.5 w-3.5" />
-                              </button>
-                              <div className="text-foreground leading-relaxed line-clamp-3 pr-6">{item.description}</div>
-
-                              <div className="mt-2">
-                                <FeedbackActions
-                                  item={item}
-                                  isConnected={isConnected}
-                                  onForward={(mode) => forward(item, mode)}
-                                  onCopy={() => handleCopy(item)}
-                                  copied={copied && copiedItemId === item.id}
-                                  onUpdateStatus={(s) => handleResolve(item, s)}
-                                  isActionable={isActionable}
-                                  statusLabel={statusLabel}
+                        return (
+                          <div key={item.id} className={cn(!isActionable && "opacity-40")}>
+                            <button
+                              className={cn(
+                                "flex w-full items-center gap-1.5 px-1 py-2 md:py-1 text-left text-[11px] transition-colors",
+                                "border-b-2",
+                              isSelected ? "border-primary" : "border-transparent hover:bg-muted/40"
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (onOpenDetail) {
+                                  onOpenDetail({ parentAgentId, itemId: item.id });
+                                } else {
+                                  setSheetItemId(item.id);
+                                }
+                              }}
+                            >
+                              <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
+                              <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
+                                <FrontTruncatedValue
+                                  value={item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
+                                  mono
                                 />
                               </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-                  </div> : null}
-                </div>
-              );
-            });
-          })()}
+                              <span className="min-w-0 flex-1 truncate text-foreground">
+                                {item.description}
+                              </span>
+                              {statusLabel && !isActionable ? (
+                                <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
+                              ) : null}
+                            </button>
+                          </div>
+                        );
+                      })}
+                      {groupResolvedCount > 0 ? (
+                        <button
+                          className="mt-1 rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground/60 hover:bg-muted/40 hover:text-muted-foreground transition-colors"
+                          onClick={(e) => { e.stopPropagation(); setShowResolved(!showResolved); }}
+                        >
+                          {showResolved ? "Hide" : "Show"} {groupResolvedCount} resolved
+                        </button>
+                      ) : null}
+                    </div>
+                  );
+                })() : null}
+              </div>
+            );
+          })}
         </div>
-        {resolvedItems.length > 0 ? (
-          <button
-            className="mt-1 text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-            onClick={(e) => { e.stopPropagation(); setShowResolved(!showResolved); }}
-          >
-            {showResolved ? "Hide" : "Show"} {resolvedItems.length} resolved
-          </button>
-        ) : null}
       </div>
 
       {/* Full feedback detail sheet — only used on mobile (when onOpenDetail is not provided) */}

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -249,7 +249,6 @@ export function ParentFeedbackPanel({
       }
     }
     return map;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allAgents, parentAgentId, personas]);
 
   const activeItems = useMemo(() => feedback.filter((f) => f.status === "open" || f.status === "forwarded").sort(bySeverity), [feedback]);
@@ -607,7 +606,6 @@ function useFeedbackData(parentAgentId: string) {
       }
     }
     return map;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allAgents, parentAgentId, personas]);
 
   const updateStatus = useCallback(async (item: FeedbackItem, status: string) => {

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useCopyText } from "@/hooks/use-copy";
 import { api } from "@/lib/api";
 import { Markdown } from "@/components/ui/markdown";
+import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 export type FeedbackDetailState = { parentAgentId: string; itemId: number } | null;
@@ -374,61 +375,74 @@ export function ParentFeedbackPanel({
                     />
                   </div>
                 ) : null}
-                {!isGroupCollapsed && items.length > 0 ? (() => {
-                  const groupResolvedCount = resolvedCountByAgent.get(child.id) ?? 0;
-                  return (
-                    <div className="space-y-px ml-4 mt-0.5">
-                      {items.map((item) => {
-                        const isActionable = item.status === "open" || item.status === "forwarded";
-                        const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
-                        const statusLabel = STATUS_LABELS[item.status];
-                        const isSelected = item.id === (activeDetailItemId ?? sheetItemId);
+                <AnimatePresence initial={false}>
+                  {!isGroupCollapsed && items.length > 0 ? (() => {
+                    const groupResolvedCount = resolvedCountByAgent.get(child.id) ?? 0;
+                    return (
+                      <motion.div
+                        key={`feedback-${child.id}`}
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: "easeOut" }}
+                        className="overflow-hidden"
+                      >
+                        <div className="space-y-px ml-4 mt-0.5">
+                          {items.map((item) => {
+                            const isActionable = item.status === "open" || item.status === "forwarded";
+                            const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
+                            const statusLabel = STATUS_LABELS[item.status];
+                            const isSelected = item.id === (activeDetailItemId ?? sheetItemId);
 
-                        return (
-                          <div key={item.id} className={cn(!isActionable && "opacity-40")}>
-                            <button
-                              className={cn(
-                                "flex w-full items-center gap-1.5 px-1 py-2 md:py-1 text-left text-[11px] transition-colors",
-                                "border-b-2",
-                              isSelected ? "border-primary" : "border-transparent hover:bg-muted/40"
-                              )}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (onOpenDetail) {
-                                  onOpenDetail({ parentAgentId, itemId: item.id });
-                                } else {
-                                  setSheetItemId(item.id);
-                                }
-                              }}
-                            >
-                              <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
-                              <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
-                                <FrontTruncatedValue
-                                  value={item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
-                                  mono
-                                />
+                            return (
+                              <div key={item.id} className={cn(!isActionable && "opacity-40")}>
+                                <button
+                                  className={cn(
+                                    "flex w-full items-center gap-1.5 px-1 py-2 md:py-1 text-left text-[11px] transition-colors",
+                                    "border-b-2",
+                                    isSelected ? "border-primary" : "border-transparent hover:bg-muted/40"
+                                  )}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    if (isSelected) {
+                                      if (onOpenDetail) onOpenDetail(null);
+                                      else setSheetItemId(null);
+                                    } else {
+                                      if (onOpenDetail) onOpenDetail({ parentAgentId, itemId: item.id });
+                                      else setSheetItemId(item.id);
+                                    }
+                                  }}
+                                >
+                                  <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
+                                  <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
+                                    <FrontTruncatedValue
+                                      value={item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
+                                      mono
+                                    />
+                                  </div>
+                                  <span className="min-w-0 flex-1 truncate text-foreground">
+                                    {item.description}
+                                  </span>
+                                  {statusLabel && !isActionable ? (
+                                    <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
+                                  ) : null}
+                                </button>
                               </div>
-                              <span className="min-w-0 flex-1 truncate text-foreground">
-                                {item.description}
-                              </span>
-                              {statusLabel && !isActionable ? (
-                                <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
-                              ) : null}
+                            );
+                          })}
+                          {groupResolvedCount > 0 ? (
+                            <button
+                              className="mt-1 rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground/60 hover:bg-muted/40 hover:text-muted-foreground transition-colors"
+                              onClick={(e) => { e.stopPropagation(); setShowResolved(!showResolved); }}
+                            >
+                              {showResolved ? "Hide" : "Show"} {groupResolvedCount} resolved
                             </button>
-                          </div>
-                        );
-                      })}
-                      {groupResolvedCount > 0 ? (
-                        <button
-                          className="mt-1 rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground/60 hover:bg-muted/40 hover:text-muted-foreground transition-colors"
-                          onClick={(e) => { e.stopPropagation(); setShowResolved(!showResolved); }}
-                        >
-                          {showResolved ? "Hide" : "Show"} {groupResolvedCount} resolved
-                        </button>
-                      ) : null}
-                    </div>
-                  );
-                })() : null}
+                          ) : null}
+                        </div>
+                      </motion.div>
+                    );
+                  })() : null}
+                </AnimatePresence>
               </div>
             );
           })}

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -89,29 +89,31 @@ function FeedbackActions({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost" size="sm"
-                  className={cn(btnClass, !isConnected && "opacity-40")}
-                  disabled={!isConnected}
-                  onClick={() => onForward("wdyt")}
-                >
-                  <MessageCircleQuestion className={iconClass} /> WDYT
-                </Button>
+                <span className={cn(!isConnected && "cursor-not-allowed")}>
+                  <Button
+                    variant="ghost" size="sm"
+                    className={cn(btnClass, !isConnected && "opacity-40 pointer-events-none")}
+                    onClick={() => onForward("wdyt")}
+                  >
+                    <MessageCircleQuestion className={iconClass} /> WDYT
+                  </Button>
+                </span>
               </TooltipTrigger>
-              <TooltipContent>{isConnected ? "Ask what it thinks about this" : "Attach to agent to use"}</TooltipContent>
+              <TooltipContent>{isConnected ? "Ask what it thinks about this" : "Connect to parent agent to forward feedback"}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost" size="sm"
-                  className={cn(btnClass, !isConnected && "opacity-40")}
-                  disabled={!isConnected}
-                  onClick={() => onForward("fix")}
-                >
-                  <Wrench className={iconClass} /> Fix
-                </Button>
+                <span className={cn(!isConnected && "cursor-not-allowed")}>
+                  <Button
+                    variant="ghost" size="sm"
+                    className={cn(btnClass, !isConnected && "opacity-40 pointer-events-none")}
+                    onClick={() => onForward("fix")}
+                  >
+                    <Wrench className={iconClass} /> Fix
+                  </Button>
+                </span>
               </TooltipTrigger>
-              <TooltipContent>{isConnected ? "Tell agent to fix this" : "Attach to agent to use"}</TooltipContent>
+              <TooltipContent>{isConnected ? "Tell agent to fix this" : "Connect to parent agent to forward feedback"}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
         ) : null}
@@ -339,6 +341,17 @@ export function ParentFeedbackPanel({
             const items = feedbackByAgent.get(child.id) ?? [];
             const isGroupCollapsed = collapsedGroups.has(child.id);
             const childState = getVisualState?.(child);
+            const unresolvedCount = items.filter((f) => f.status === "open" || f.status === "forwarded").length;
+
+            const canTriage = isConnected && !!sendTerminalInput;
+            const handleTriage = unresolvedCount > 0
+              ? () => {
+                  if (!canTriage) return;
+                  const personaName = child.persona ?? child.name;
+                  const message = `Review and triage the pending feedback from the "${personaName}" persona. Use the dispatch_get_feedback MCP tool to fetch the unresolved items, then address each one: fix the ones that should be fixed and resolve them as you go using dispatch_resolve_feedback. When done, provide a summary report explaining what you addressed and what you chose not to address along with why.`;
+                  sendTerminalInput!(message + "\r");
+                }
+              : undefined;
 
             return (
               <div key={child.id}>
@@ -369,9 +382,11 @@ export function ParentFeedbackPanel({
                       setDeleteConfirmOpen={setDeleteConfirmOpen}
                       onRequestClose={onRequestClose}
                       closeOnSessionAction={closeOnSessionAction}
-                      feedbackCount={items.filter((f) => f.status === "open" || f.status === "forwarded").length}
+                      feedbackCount={unresolvedCount}
                       isCollapsed={isGroupCollapsed}
                       hasFeedback={items.length > 0}
+                      onTriage={handleTriage}
+                      triageDisabled={!canTriage}
                     />
                   </div>
                 ) : null}

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,7 +1,9 @@
-import { type RefObject, useCallback, useEffect, useState, useRef } from "react";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
 import { ChevronRight, ExternalLink, FileText, MonitorPlay, X } from "lucide-react";
+import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
+import { mediaSidebarTabAtom } from "@/lib/store";
 import { MediaActions, isTextFile, stripTimestamp } from "@/components/app/media-lightbox";
 import { PinsPanel } from "@/components/app/pins-panel";
 import { Button } from "@/components/ui/button";
@@ -37,7 +39,6 @@ type MediaSidebarContentProps = MediaSidebarSharedProps & {
   className?: string;
 };
 
-type SidebarTab = "pins" | "media";
 
 function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; selectedAgentId: string }): JSX.Element {
   const popOut = useCallback(() => {
@@ -185,7 +186,7 @@ export function MediaSidebarContent({
   closeButtonIcon = "x",
   className
 }: MediaSidebarContentProps): JSX.Element {
-  const [activeTab, setActiveTab] = useState<SidebarTab>("pins");
+  const [activeTab, setActiveTab] = useAtom(mediaSidebarTabAtom);
   const prevAgentIdRef = useRef(selectedAgentId);
 
   // Reset to pins tab when agent changes

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -1,0 +1,121 @@
+import { Archive, ChevronRight, Terminal, X } from "lucide-react";
+
+import { AgentTypeIcon } from "@/components/app/agent-type-icon";
+import { latestEventLabel, latestEventColor } from "@/components/app/agent-event-utils";
+import { type Agent, type AgentVisualState } from "@/components/app/types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+export type PersonaAgentRowProps = {
+  child: Agent;
+  childIndex: number;
+  childState: AgentVisualState;
+  isSelected: boolean;
+  detachTerminal: () => void;
+  attachToAgent: (agent: Agent) => Promise<void>;
+  setDeleteTarget: (agent: Agent | null) => void;
+  setDeleteConfirmOpen: (open: boolean) => void;
+  onRequestClose?: () => void;
+  closeOnSessionAction?: boolean;
+  feedbackCount?: number;
+  isCollapsed?: boolean;
+  hasFeedback?: boolean;
+};
+
+export function PersonaAgentRow({
+  child,
+  childIndex,
+  childState,
+  isSelected,
+  detachTerminal,
+  attachToAgent,
+  setDeleteTarget,
+  setDeleteConfirmOpen,
+  onRequestClose,
+  closeOnSessionAction,
+  feedbackCount,
+  isCollapsed,
+  hasFeedback,
+}: PersonaAgentRowProps): JSX.Element {
+  const childIsStopped = childState === "stopped";
+  const childIsActive = childState === "active";
+  const colorVar = `var(--chart-${(childIndex % 4) + 1})`;
+
+  return (
+    <div
+      data-testid={`agent-card-${child.id}`}
+      className={cn(
+        "flex items-center gap-2 border-r-2 px-2 py-1.5 transition-colors duration-200",
+        hasFeedback && "cursor-pointer hover:bg-muted/50",
+        childIsStopped && "opacity-50",
+        isSelected ? "border-r-status-done" : "border-r-transparent"
+      )}
+    >
+      {hasFeedback ? (
+        <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isCollapsed && "rotate-90")} />
+      ) : null}
+      <div
+        className="mt-0.5 h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: `hsl(${colorVar})` }}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-xs font-medium" style={{ color: `hsl(${colorVar})` }}>
+            {child.persona ?? child.name}
+          </span>
+          <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} className="h-3.5 w-3.5 shrink-0" />
+          {feedbackCount != null && feedbackCount > 0 ? (
+            <span className="text-[9px] text-muted-foreground/50">{feedbackCount}</span>
+          ) : null}
+        </div>
+        {child.latestEvent ? (
+          <div className="mt-0.5 text-[10px]">
+            <span className={cn("font-medium", latestEventColor(child.latestEvent.type))}>{latestEventLabel(child.latestEvent.type)}</span>
+          </div>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        {!childIsStopped ? (
+          childIsActive ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  data-agent-control="true"
+                  aria-label="Disconnect from agent"
+                  className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+                  onClick={() => detachTerminal()}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Disconnect</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  data-agent-control="true"
+                  aria-label="Connect to agent terminal"
+                  className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+                  onClick={() => {
+                    if (closeOnSessionAction) onRequestClose?.();
+                    void attachToAgent(child);
+                  }}
+                >
+                  <Terminal className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>View terminal</TooltipContent>
+            </Tooltip>
+          )
+        ) : null}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors disabled:opacity-30" disabled={child.status === "archiving"} onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
+          </TooltipTrigger>
+          <TooltipContent>Archive</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -74,14 +74,14 @@ export function PersonaAgentRow({
           </div>
         ) : null}
       </div>
-      <div className="flex shrink-0 items-center gap-3">
+      <div className="flex shrink-0 items-center gap-1">
         {onTriage ? (
           <Tooltip>
             <TooltipTrigger asChild>
               <span data-agent-control="true" className={cn(triageDisabled && "cursor-not-allowed")}>
                 <button
                   aria-label="Auto-triage feedback"
-                  className={cn("rounded p-0.5 transition-colors", triageDisabled ? "text-muted-foreground/25 pointer-events-none" : "text-muted-foreground/50 hover:text-foreground")}
+                  className={cn("rounded p-2 transition-colors", triageDisabled ? "text-muted-foreground/25 pointer-events-none" : "text-muted-foreground/50 hover:text-foreground")}
                   onClick={onTriage}
                 >
                   <ListChecks className="h-3.5 w-3.5" />
@@ -98,7 +98,7 @@ export function PersonaAgentRow({
                 <button
                   data-agent-control="true"
                   aria-label="Disconnect from agent"
-                  className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+                  className="rounded p-2 text-muted-foreground/50 hover:text-foreground transition-colors"
                   onClick={() => detachTerminal()}
                 >
                   <X className="h-3.5 w-3.5" />
@@ -112,7 +112,7 @@ export function PersonaAgentRow({
                 <button
                   data-agent-control="true"
                   aria-label="Connect to agent terminal"
-                  className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+                  className="rounded p-2 text-muted-foreground/50 hover:text-foreground transition-colors"
                   onClick={() => {
                     if (closeOnSessionAction) onRequestClose?.();
                     void attachToAgent(child);
@@ -127,7 +127,7 @@ export function PersonaAgentRow({
         ) : null}
         <Tooltip>
           <TooltipTrigger asChild>
-            <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="rounded p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors disabled:opacity-30" disabled={child.status === "archiving"} onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
+            <button data-agent-control="true" aria-label="Archive agent" data-testid={`agent-archive-${child.id}`} className="rounded p-2 text-muted-foreground/50 hover:text-foreground transition-colors disabled:opacity-30" disabled={child.status === "archiving"} onClick={() => { setDeleteTarget(child); setDeleteConfirmOpen(true); }}><Archive className="h-3.5 w-3.5" /></button>
           </TooltipTrigger>
           <TooltipContent>Archive</TooltipContent>
         </Tooltip>

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -1,4 +1,4 @@
-import { Archive, ChevronRight, Terminal, X } from "lucide-react";
+import { Archive, ChevronRight, ListChecks, Terminal, X } from "lucide-react";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { latestEventLabel, latestEventColor } from "@/components/app/agent-event-utils";
@@ -20,6 +20,8 @@ export type PersonaAgentRowProps = {
   feedbackCount?: number;
   isCollapsed?: boolean;
   hasFeedback?: boolean;
+  onTriage?: () => void;
+  triageDisabled?: boolean;
 };
 
 export function PersonaAgentRow({
@@ -36,6 +38,8 @@ export function PersonaAgentRow({
   feedbackCount,
   isCollapsed,
   hasFeedback,
+  onTriage,
+  triageDisabled,
 }: PersonaAgentRowProps): JSX.Element {
   const childIsStopped = childState === "stopped";
   const childIsActive = childState === "active";
@@ -54,18 +58,14 @@ export function PersonaAgentRow({
       {hasFeedback ? (
         <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isCollapsed && "rotate-90")} />
       ) : null}
-      <div
-        className="mt-0.5 h-2 w-2 shrink-0 rounded-full"
-        style={{ backgroundColor: `hsl(${colorVar})` }}
-      />
+      <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} className="h-3.5 w-3.5 shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           <span className="truncate text-xs font-medium" style={{ color: `hsl(${colorVar})` }}>
             {child.persona ?? child.name}
           </span>
-          <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} className="h-3.5 w-3.5 shrink-0" />
           {feedbackCount != null && feedbackCount > 0 ? (
-            <span className="text-[9px] text-muted-foreground/50">{feedbackCount}</span>
+            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/20 px-1 text-[10px] font-semibold text-primary">{feedbackCount}</span>
           ) : null}
         </div>
         {child.latestEvent ? (
@@ -75,6 +75,22 @@ export function PersonaAgentRow({
         ) : null}
       </div>
       <div className="flex shrink-0 items-center gap-3">
+        {onTriage ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span data-agent-control="true" className={cn(triageDisabled && "cursor-not-allowed")}>
+                <button
+                  aria-label="Auto-triage feedback"
+                  className={cn("rounded p-0.5 transition-colors", triageDisabled ? "text-muted-foreground/25 pointer-events-none" : "text-muted-foreground/50 hover:text-foreground")}
+                  onClick={onTriage}
+                >
+                  <ListChecks className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{triageDisabled ? "Connect to parent agent to auto-triage" : "Auto-triage feedback"}</TooltipContent>
+          </Tooltip>
+        ) : null}
         {!childIsStopped ? (
           childIsActive ? (
             <Tooltip>

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -20,9 +20,11 @@ type PersonaSummary = {
 export function PersonaLauncher({
   agent,
   sendTerminalInput,
+  disabled = false,
 }: {
   agent: Agent;
-  sendTerminalInput: (data: string) => void;
+  sendTerminalInput?: (data: string) => void;
+  disabled?: boolean;
 }): JSX.Element | null {
   const cwd = agent.worktreePath ?? agent.cwd;
 
@@ -37,6 +39,7 @@ export function PersonaLauncher({
   if (personas.length === 0) return null;
 
   const launchPersona = (slug: string) => {
+    if (!sendTerminalInput) return;
     const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
     sendTerminalInput(message + "\r");
   };
@@ -44,7 +47,7 @@ export function PersonaLauncher({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="gap-1.5 border border-border/60 bg-background/50 text-muted-foreground hover:text-foreground hover:bg-muted/60">
+        <Button variant="ghost" disabled={disabled} className="gap-1.5 border border-border/60 bg-background/50 text-muted-foreground hover:text-foreground hover:bg-muted/60">
           <Sparkles className="h-3 w-3" />
           Launch Persona
         </Button>

--- a/apps/web/src/hooks/use-layout.ts
+++ b/apps/web/src/hooks/use-layout.ts
@@ -1,18 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtom } from "jotai";
+import { leftSidebarOpenAtom, mediaSidebarOpenAtom } from "@/lib/store";
 
-const LEFT_SIDEBAR_KEY = "dispatch:leftSidebarOpen";
-const MEDIA_SIDEBAR_KEY = "dispatch:mediaSidebarOpen";
 const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px)";
 
-function readBool(key: string, fallback: boolean): boolean {
-  if (typeof window === "undefined") return fallback;
-  const stored = window.localStorage.getItem(key);
-  return stored === null ? fallback : stored === "true";
-}
-
 export function useLayout() {
-  const [leftOpen, setLeftOpen] = useState(() => readBool(LEFT_SIDEBAR_KEY, true));
-  const [mediaOpen, setMediaOpen] = useState(() => readBool(MEDIA_SIDEBAR_KEY, false));
+  const [leftOpen, setLeftOpen] = useAtom(leftSidebarOpenAtom);
+  const [mediaOpen, setMediaOpen] = useAtom(mediaSidebarOpenAtom);
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== "undefined" ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches : false
   );
@@ -31,17 +25,6 @@ export function useLayout() {
     return () => query.removeEventListener("change", onChange);
   }, []);
 
-  // Persist sidebar state to localStorage.
-  useEffect(() => {
-    const value = String(leftOpen);
-    window.localStorage.setItem(LEFT_SIDEBAR_KEY, value);
-  }, [leftOpen]);
-
-  useEffect(() => {
-    const value = String(mediaOpen);
-    window.localStorage.setItem(MEDIA_SIDEBAR_KEY, value);
-  }, [mediaOpen]);
-
   // Reset mobile panels when switching to desktop.
   useEffect(() => {
     if (!isMobile) {
@@ -59,7 +42,7 @@ export function useLayout() {
       }
       setLeftOpen(open);
     },
-    [isMobile]
+    [isMobile, setLeftOpen]
   );
 
   const handleSetMediaPanelOpen = useCallback(
@@ -71,7 +54,7 @@ export function useLayout() {
       }
       setMediaOpen(open);
     },
-    [isMobile]
+    [isMobile, setMediaOpen]
   );
 
   return useMemo(() => ({
@@ -96,6 +79,8 @@ export function useLayout() {
     mediaPanelOpen,
     mobileLeftOpen,
     mobileMediaOpen,
+    setLeftOpen,
+    setMediaOpen,
     handleSetLeftPanelOpen,
     handleSetMediaPanelOpen,
   ]);

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -232,10 +232,10 @@ export function getTerminalPalette(themeId: ThemeId): TerminalPalette {
 const STORAGE_KEY = "dispatch:theme";
 
 function getStoredTheme(): ThemeId {
-  if (typeof window === "undefined") return "default";
+  if (typeof window === "undefined") return "cool-navy";
   const stored = window.localStorage.getItem(STORAGE_KEY);
   if (stored && THEMES.some((t) => t.id === stored)) return stored as ThemeId;
-  return "default";
+  return "cool-navy";
 }
 
 function applyTheme(themeId: ThemeId): void {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -1,0 +1,32 @@
+import { atom } from "jotai";
+import type { FeedbackDetailState } from "@/components/app/feedback-panel";
+
+function atomWithLocalStorage<T>(key: string, initialValue: T) {
+  const baseAtom = atom<T>((() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const stored = window.localStorage.getItem(key);
+      if (stored === null) return initialValue;
+      return JSON.parse(stored) as T;
+    } catch {
+      return initialValue;
+    }
+  })());
+
+  const derivedAtom = atom(
+    (get) => get(baseAtom),
+    (_get, set, update: T | ((prev: T) => T)) => {
+      const nextValue = typeof update === "function" ? (update as (prev: T) => T)(_get(baseAtom)) : update;
+      set(baseAtom, nextValue);
+      window.localStorage.setItem(key, JSON.stringify(nextValue));
+    }
+  );
+
+  return derivedAtom;
+}
+
+export const leftSidebarOpenAtom = atomWithLocalStorage("dispatch:leftSidebarOpen", true);
+export const mediaSidebarOpenAtom = atomWithLocalStorage("dispatch:mediaSidebarOpen", false);
+export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">("dispatch:mediaSidebarTab", "pins");
+export const feedbackDetailAtom = atomWithLocalStorage<FeedbackDetailState>("dispatch:feedbackDetail", null);
+export const expandedAgentIdAtom = atomWithLocalStorage<string | null>("dispatch:expandedAgentId", null);

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -120,9 +120,7 @@ test.describe("Agent CRUD", () => {
     const peekCard = page.getByTestId(`agent-card-${peekAgent.id}`);
 
     await page.getByTestId(`agent-row-${attachedAgent.id}`).click();
-    await expect(page.getByTestId("detach-button")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId(`agent-expand-toggle-${attachedAgent.id}`)).toBeDisabled();
-    await expect(attachedCard.getByText("Working dir")).toBeVisible({ timeout: 3_000 });
+    await expect(attachedCard.getByText("Working dir")).toBeVisible({ timeout: 5_000 });
 
     await page.getByTestId(`agent-expand-toggle-${peekAgent.id}`).click();
 
@@ -162,7 +160,7 @@ test.describe("Agent CRUD", () => {
     await expect(agentCard).toBeVisible({ timeout: 5_000 });
 
     await page.getByTestId(`agent-row-${agent.id}`).click();
-    await expect(page.getByTestId("detach-button")).toBeVisible({ timeout: 5_000 });
+    await expect(agentCard.getByText("Working dir")).toBeVisible({ timeout: 5_000 });
 
     await page.getByTestId(`agent-archive-${agent.id}`).click();
     await page.getByTestId("delete-agent-confirm").click();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      jotai:
+        specifier: ^2.19.0
+        version: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
@@ -3405,6 +3408,24 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  jotai@2.19.0:
+    resolution: {integrity: sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -8203,6 +8224,13 @@ snapshots:
   jiti@1.21.7: {}
 
   jose@6.2.2: {}
+
+  jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@types/react': 18.3.28
+      react: 18.3.1
 
   js-base64@3.7.8: {}
 


### PR DESCRIPTION
## Summary

- Persona sub-agents collapse with parent agent and use launcher-style colored dots/names instead of standard agent rows
- Extract `agent-card`, `persona-agent-row`, and `agent-event-utils` into separate files
- Merge persona agent rows into feedback group headers — click to expand/collapse findings
- Feedback items open directly in sheet/detail panel (skip inline expand), click to deselect
- Auto-triage button on persona rows instructs parent agent to review and resolve feedback via MCP tools
- Fix parent agent expand/collapse and disconnect behavior
- Remove unfocus button from header
- Pins/media sidebar gated on selected agent (not async connection state)
- Default theme changed to cool-navy
- Persist UI state with jotai: sidebar open/closed, media tab, feedback detail, expanded agent

## Test plan
- [x] `pnpm run finalize:web` — type check + production build
- [x] `pnpm run test:e2e` — 79/79 passed (6 skipped pre-existing)
- [ ] Visual validation: expand/collapse parent agents, persona feedback, sidebar toggling
- [ ] Verify state persists across page refresh (expanded agent, feedback detail, sidebar tab)
- [ ] Test auto-triage button injects prompt when parent connected, disabled tooltip when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)