### PR TITLE
Add filename pin type and multi-value pin support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,17 +105,6 @@ Before marking any task as done, run the following checks and fix any failures:
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.
 
-## Agent Pins
-- When you start a dev server, database, or any service with dynamic ports, **pin the URLs immediately** using the `dispatch_pin` MCP tool so the user can find them without asking.
-- Pin cleanup commands (e.g. `dispatch-dev down`) so the user doesn't have to ask.
-- Update pins when ports/URLs change (e.g. after a `dispatch-dev restart`).
-- Remove stale pins with `dispatch_pin` using `delete: true` when a service is torn down.
-- Use the appropriate `type` for each pin:
-  - `url` — for full URLs (rendered as clickable links)
-  - `port` — for port numbers (rendered as a monospace badge)
-  - `code` — for commands or config values (rendered as a monospace badge)
-  - `pr` — for pull request URLs (rendered as a link with a PR icon)
-  - `string` — for plain text (default)
 
 ## Personas
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ Before marking any task as done, run the following checks and fix any failures:
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.
 
+## Agent Pins
+- Agents use `dispatch_pin` to surface key info (URLs, files, ports, PRs, decisions) in the sidebar. Types: `url`, `port`, `code`, `string`, `pr`, `filename`. List-like types support comma/newline-delimited multi-value.
 
 ## Personas
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1427,9 +1427,7 @@ export class AgentManager {
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
       "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. " +
-      "Pin examples: dev server URLs (url), PR links when created (pr), key files changed (filename, comma-separated), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), non-obvious architecture decisions or assumptions (string), and the specific blocking question when in waiting_user state. " +
-      "For list-like types (filename, url, string, port), separate multiple values with commas or newlines — each will render as its own row. " +
-      "For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
+      "For list-like types (filename, url, string, port), separate multiple values with commas or newlines — each renders as its own row. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1426,7 +1426,7 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -17,7 +17,7 @@ type AgentType = "codex" | "claude" | "opencode";
 type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
 type ArchivePhase = "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
-type PinType = "string" | "url" | "port" | "code" | "pr";
+type PinType = "string" | "url" | "port" | "code" | "pr" | "filename";
 
 export type AgentPin = {
   label: string;
@@ -1426,7 +1426,10 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info (dev server URLs, ports, commands) so users can find them in the sidebar. Use the appropriate type (url, port, code, string, pr). Use type 'pr' when pinning a pull request URL. Update pins when values change; delete stale pins when services are torn down.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. " +
+      "Pin examples: dev server URLs (url), PR links when created (pr), key files changed (filename, comma-separated), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), non-obvious architecture decisions or assumptions (string), and the specific blocking question when in waiting_user state. " +
+      "For list-like types (filename, url, string, port), separate multiple values with commas or newlines — each will render as its own row. " +
+      "For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1426,8 +1426,7 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. " +
-      "For list-like types (filename, url, string, port), separate multiple values with commas or newlines — each renders as its own row. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -6,14 +6,19 @@ import { type AgentPin } from "@/components/app/types";
 const SAFE_URL_RE = /^https?:\/\//i;
 const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
 
-/** Types that support comma/newline-delimited multi-value. */
-const MULTI_VALUE_TYPES = new Set<AgentPin["type"]>(["string", "url", "port", "filename"]);
-
 /** Split a pin value into individual items if the type supports it. */
 function splitValues(pin: AgentPin): string[] {
-  if (!MULTI_VALUE_TYPES.has(pin.type)) return [pin.value];
-  const parts = pin.value.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
-  return parts.length > 0 ? parts : [pin.value];
+  // URLs split on newline only — commas appear legitimately in query strings.
+  if (pin.type === "url") {
+    const parts = pin.value.split(/\n/).map((s) => s.trim()).filter(Boolean);
+    return parts.length > 0 ? parts : [pin.value];
+  }
+  // Other list-like types split on commas or newlines.
+  if (pin.type === "string" || pin.type === "port" || pin.type === "filename") {
+    const parts = pin.value.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+    return parts.length > 0 ? parts : [pin.value];
+  }
+  return [pin.value];
 }
 
 /** Turn a GitHub PR URL into "owner/repo#123"; fall back to the raw value. */
@@ -22,7 +27,7 @@ function formatPrDisplay(value: string): string {
   return m ? `${m[1]}#${m[2]}` : value;
 }
 
-function CopyButton({ value }: { value: string }): JSX.Element {
+function CopyButton({ value, title }: { value: string; title?: string }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -38,7 +43,7 @@ function CopyButton({ value }: { value: string }): JSX.Element {
     <button
       onClick={handleCopy}
       className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-      title="Copy to clipboard"
+      title={title ?? "Copy to clipboard"}
     >
       {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
     </button>
@@ -121,13 +126,21 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
 
 function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
   const values = splitValues(pin);
+  const isMulti = values.length > 1;
 
   return (
     <div className="px-4 py-2.5 border-b border-border last:border-b-0">
-      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
-        {pin.label}
+      <div className="flex items-center gap-1">
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
+          {pin.label}
+        </div>
+        {isMulti && (
+          <div className="ml-auto">
+            <CopyButton value={values.join("\n")} title="Copy all" />
+          </div>
+        )}
       </div>
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-1 mt-1">
         {values.map((v, i) => (
           <PinValueRow key={i} type={pin.type} value={v} />
         ))}
@@ -146,7 +159,7 @@ export function PinsPanel({ pins, selectedAgentName }: PinsPanelProps): JSX.Elem
     return (
       <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
         {selectedAgentName
-          ? "No pins yet. Agents can pin URLs, ports, and other info here."
+          ? "No pins yet. Agents can pin URLs, files, ports, and other info here."
           : "Focus an agent to view pins."}
       </div>
     );

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,10 +1,20 @@
-import { Check, Copy, ExternalLink, GitPullRequest } from "lucide-react";
+import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
 
 const SAFE_URL_RE = /^https?:\/\//i;
 const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
+
+/** Types that support comma/newline-delimited multi-value. */
+const MULTI_VALUE_TYPES = new Set<AgentPin["type"]>(["string", "url", "port", "filename"]);
+
+/** Split a pin value into individual items if the type supports it. */
+function splitValues(pin: AgentPin): string[] {
+  if (!MULTI_VALUE_TYPES.has(pin.type)) return [pin.value];
+  const parts = pin.value.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+  return parts.length > 0 ? parts : [pin.value];
+}
 
 /** Turn a GitHub PR URL into "owner/repo#123"; fall back to the raw value. */
 function formatPrDisplay(value: string): string {
@@ -35,75 +45,92 @@ function CopyButton({ value }: { value: string }): JSX.Element {
   );
 }
 
-function resolveDisplayValue(pin: AgentPin): { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | null } {
-  if (pin.type === "pr" && SAFE_URL_RE.test(pin.value)) {
-    return { display: formatPrDisplay(pin.value), tooltip: pin.value, href: pin.value, badge: false, icon: "pr" };
+type ResolvedValue = { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | "file" | null };
+
+function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedValue {
+  if (type === "pr" && SAFE_URL_RE.test(value)) {
+    return { display: formatPrDisplay(value), tooltip: value, href: value, badge: false, icon: "pr" };
   }
-  if (pin.type === "pr") {
-    return { display: pin.value, tooltip: pin.value, href: null, badge: false, icon: "pr" };
+  if (type === "pr") {
+    return { display: value, tooltip: value, href: null, badge: false, icon: "pr" };
   }
-  if (pin.type === "url" && SAFE_URL_RE.test(pin.value)) {
-    return { display: pin.value, tooltip: pin.value, href: pin.value, badge: false, icon: null };
+  if (type === "url" && SAFE_URL_RE.test(value)) {
+    return { display: value, tooltip: value, href: value, badge: false, icon: null };
   }
-  if (pin.type === "url") {
-    // Unsafe scheme (e.g. javascript:) — render as plain text, not a link
-    return { display: pin.value, tooltip: pin.value, href: null, badge: false, icon: null };
+  if (type === "url") {
+    return { display: value, tooltip: value, href: null, badge: false, icon: null };
   }
-  if (pin.type === "port" || pin.type === "code") {
-    return { display: pin.value, tooltip: pin.value, href: null, badge: true, icon: null };
+  if (type === "filename") {
+    return { display: value, tooltip: value, href: null, badge: true, icon: "file" };
   }
-  return { display: pin.value, tooltip: pin.value, href: null, badge: false, icon: null };
+  if (type === "port" || type === "code") {
+    return { display: value, tooltip: value, href: null, badge: true, icon: null };
+  }
+  return { display: value, tooltip: value, href: null, badge: false, icon: null };
+}
+
+function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string }): JSX.Element {
+  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
+      {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+          title={tooltip}
+        >
+          {display}
+        </a>
+      ) : badge ? (
+        <span
+          className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+          title={tooltip}
+        >
+          {display}
+        </span>
+      ) : (
+        <span
+          className="min-w-0 truncate text-xs text-foreground"
+          title={tooltip}
+        >
+          {display}
+        </span>
+      )}
+      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            title="Open in browser"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        ) : null}
+        <CopyButton value={value} />
+      </div>
+    </div>
+  );
 }
 
 function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
-  const { display, tooltip, href, badge, icon } = resolveDisplayValue(pin);
+  const values = splitValues(pin);
 
   return (
     <div className="px-4 py-2.5 border-b border-border last:border-b-0">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
         {pin.label}
       </div>
-      <div className="flex items-center gap-1.5">
-        {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
-        {href ? (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
-            title={tooltip}
-          >
-            {display}
-          </a>
-        ) : badge ? (
-          <span
-            className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
-            title={tooltip}
-          >
-            {display}
-          </span>
-        ) : (
-          <span
-            className="min-w-0 truncate text-xs text-foreground"
-            title={tooltip}
-          >
-            {display}
-          </span>
-        )}
-        <div className="ml-auto flex shrink-0 items-center gap-0.5">
-          {href ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-              title="Open in browser"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          ) : null}
-          <CopyButton value={pin.value} />
-        </div>
+      <div className="flex flex-col gap-1">
+        {values.map((v, i) => (
+          <PinValueRow key={i} type={pin.type} value={v} />
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -3,7 +3,7 @@ export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "arc
 export type AgentPin = {
   label: string;
   value: string;
-  type: "string" | "url" | "port" | "code" | "pr";
+  type: "string" | "url" | "port" | "code" | "pr" | "filename";
 };
 
 export type Agent = {

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -62,7 +62,7 @@ export type GetFeedbackResult = {
 export type PinInput = {
   label: string;
   value?: string;
-  type?: "string" | "url" | "port" | "code" | "pr";
+  type?: "string" | "url" | "port" | "code" | "pr" | "filename";
   delete?: boolean;
 };
 
@@ -349,7 +349,8 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       "dispatch_pin",
       {
         description:
-          "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info like dev server URLs, ports, and commands. To update a pin, set it again with the same label. To remove a pin, pass delete: true.",
+          "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info. To update a pin, set it again with the same label. To remove a pin, pass delete: true. " +
+          "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), the specific blocking question when in waiting_user state (string).",
         inputSchema: {
           label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
           value: z

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -358,9 +358,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             .optional()
             .describe("The value to display. Required unless delete is true."),
           type: z
-            .enum(["string", "url", "port", "code", "pr"])
+            .enum(["string", "url", "port", "code", "pr", "filename"])
             .default("string")
-            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon."),
+            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
           delete: z
             .boolean()
             .default(false)


### PR DESCRIPTION
## Summary
- Adds a new `filename` pin type rendered with a file icon and monospace badge styling
- Enables multi-value support for list-like pin types (`filename`, `url`, `string`, `port`) — comma or newline-delimited values each render as their own row under a single label
- Broadens agent launch guidance with richer pin usage examples (key files changed, test summaries, architecture decisions, blocking questions, etc.)
- Removes redundant pin guidance from CLAUDE.md (already covered by launch guidance injected into agent system prompts)

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Web finalization passes (`pnpm run finalize:web`)
- [x] E2E tests pass (79 passed, 6 skipped pre-existing)
- [ ] Visual validation: verify filename pins render with file icon and monospace styling
- [ ] Visual validation: verify comma-separated values split into multiple rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)