### PR TITLE
Add pin examples to agent launch guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,14 @@ dispatch/
 - You MUST call the `dispatch_event` MCP tool throughout every task turn. These events drive the agent status indicator in the Dispatch UI — the more frequently and accurately you report, the more useful the dashboard becomes.
 - **Event types and when to use them:**
   - `working` — You are actively making progress: reading files, writing code, running commands, researching. Use a short message describing the current activity (e.g., "Reading agent-sidebar.tsx", "Running E2E tests", "Refactoring auth middleware").
-  - `blocked` — You hit an error, a failing test, a missing dependency, or any obstacle you are actively trying to resolve. Message should describe the blocker (e.g., "Type error in agent-type-icon.tsx", "E2E test 'sidebar toggle' failing").
+  - `blocked` — You are stuck and unable to make progress without help or a change in approach. Do not use blocked for errors you are actively investigating or fixing — stay in `working` for those. Message should describe why you are stuck (e.g., "Cannot resolve missing API key", "Repeated test failure after 3 different approaches").
   - `waiting_user` — You need a decision, clarification, or approval before continuing. Message should describe what you need (e.g., "Should I delete the legacy endpoint?", "Need confirmation on color palette").
   - `done` — The task is complete and all checks pass. Message should summarize what was accomplished.
   - `idle` — No meaningful action was taken this turn (e.g., an informational question was answered).
 - **Required checkpoints (minimum):**
   1. **Start of turn**: `working` with what you are about to do.
   2. **Phase transitions**: Call `working` again with an updated message whenever your activity shifts to a distinct phase (e.g., moving from research → implementation → testing → validation). This keeps the UI status current.
-  3. **On error or obstacle**: Switch to `blocked` immediately. When you unblock yourself, switch back to `working`.
+  3. **When truly stuck**: Switch to `blocked` only when you cannot make further progress on your own.
   4. **Before final response**: Emit a terminal event — `done`, `idle`, `waiting_user`, or `blocked`.
 - **Hard requirements:**
   - Do not send a final response unless `done`, `waiting_user`, `blocked`, or `idle` has been emitted in the same turn.

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1461,9 +1461,9 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale pins when services are torn down. " +
-      "Pin types: url (dev server URLs, docs links), port (server ports), pr (pull request links), filename (key files changed), code (migration names, commands), string (status summaries, decisions). " +
-      "For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale ones. " +
+      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (migrations, commands), string (status, decisions). " +
+      "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1461,7 +1461,7 @@ export class AgentManager {
       "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
       "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
       "Use dispatch_pin to surface key info in the sidebar. Update pins when values change; delete stale ones. " +
-      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (migrations, commands), string (status, decisions). " +
+      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions). " +
       "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1461,8 +1461,9 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it. " +
-      "Pin examples — url: label='Dev Server' value='http://localhost:3000'; port: label='API Port' value='8080'; pr: label='PR' value='https://github.com/org/repo/pull/42'; filename: label='Key Files' value='src/auth.ts, src/middleware.ts'; code: label='Migration' value='0042_add_users_table'; string: label='Status' value='All 12 tests passing'.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale pins when services are torn down. " +
+      "Pin types: url (dev server URLs, docs links), port (server ports), pr (pull request links), filename (key files changed), code (migration names, commands), string (status summaries, decisions). " +
+      "For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1458,8 +1458,8 @@ export class AgentManager {
       `[dispatch:${agentId}] ` +
       "Dispatch startup rules: Playwright default is headless unless the user explicitly asks for headed mode. " +
       "Capture at least one screenshot per UI validation flow; publish every screenshot with the dispatch_share MCP tool — never leave screenshots local-only. " +
-      "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
-      "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
+      "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (stuck and unable to make progress without help or a change in approach), waiting_user (need user input), done (task complete), idle (no-op turn). " +
+      "Emit working at the start of each turn and when your activity shifts phases. Only use blocked when you are truly stuck — not when you encounter an error you are actively investigating or fixing. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
       "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale ones. " +
       "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (migrations, commands), string (status, decisions). " +

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1461,7 +1461,8 @@ export class AgentManager {
       "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (hit an error or obstacle), waiting_user (need user input), done (task complete), idle (no-op turn). " +
       "Emit working at the start of each turn and when your activity shifts phases. Switch to blocked on errors. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
       "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it.";
+      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Use the appropriate type (url, port, code, string, pr, filename). Update pins when values change; delete stale pins when services are torn down. For longer artifacts like handoff notes, write them to a shared file via dispatch_share and pin a reference to it. " +
+      "Pin examples — url: label='Dev Server' value='http://localhost:3000'; port: label='API Port' value='8080'; pr: label='PR' value='https://github.com/org/repo/pull/42'; filename: label='Key Files' value='src/auth.ts, src/middleware.ts'; code: label='Migration' value='0042_add_users_table'; string: label='Status' value='All 12 tests passing'.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1456,12 +1456,11 @@ export class AgentManager {
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
     const launchGuidance =
       `[dispatch:${agentId}] ` +
-      "Dispatch startup rules: Playwright default is headless unless the user explicitly asks for headed mode. " +
-      "Capture at least one screenshot per UI validation flow; publish every screenshot with the dispatch_share MCP tool — never leave screenshots local-only. " +
-      "Call the dispatch_event MCP tool to report status. Valid types: working (actively making progress), blocked (stuck and unable to make progress without help or a change in approach), waiting_user (need user input), done (task complete), idle (no-op turn). " +
-      "Emit working at the start of each turn and when your activity shifts phases. Only use blocked when you are truly stuck — not when you encounter an error you are actively investigating or fixing. Emit a terminal event (done/idle/waiting_user/blocked) before your final response. " +
-      "When done with Playwright validation, call browser_close to shut down the browser. " +
-      "Use the dispatch_pin MCP tool to pin important info so users can find it in the sidebar. Update pins when values change; delete stale ones. " +
+      "Dispatch startup rules: " +
+      "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
+      "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
+      "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
+      "Use dispatch_pin to surface key info in the sidebar. Update pins when values change; delete stale ones. " +
       "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (migrations, commands), string (status, decisions). " +
       "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -313,7 +313,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       "dispatch_event",
       {
         description:
-          "Report agent status to Dispatch. Must be called at the start of each turn (working), when blocked (blocked), waiting for user input (waiting_user), and before the final response (done or idle).",
+          "Report agent status to Dispatch. Must be called at the start of each turn (working), when stuck and unable to proceed (blocked), waiting for user input (waiting_user), and before the final response (done or idle).",
         inputSchema: {
           type: z.enum(["working", "blocked", "waiting_user", "done", "idle"]).describe("The status event type."),
           message: z.string().describe("A short description of what is happening."),


### PR DESCRIPTION
## Summary
- Re-adds concrete examples for each pin type (`url`, `port`, `pr`, `filename`, `code`, `string`) to the agent launch system prompt
- Agents stopped using pins as much after the examples were removed — this gives them a clear reference for what good pins look like

## Test plan
- [x] `pnpm run check` passes
- [x] E2E tests pass (79 passed, 6 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)