### PR TITLE
Harden session tokens and cookie secret in auth layer

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -7,6 +7,10 @@ import { getSetting, setSetting } from "./db/settings.js";
 const BCRYPT_COST = 12;
 const SESSION_TTL_DAYS = 30;
 
+function hashToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
 export async function isPasswordSet(pool: Pool): Promise<boolean> {
   return (await getSetting(pool, "password_hash")) !== null;
 }
@@ -27,21 +31,37 @@ export async function createSession(pool: Pool): Promise<string> {
   const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
   await pool.query(
     "INSERT INTO sessions (token, expires_at) VALUES ($1, $2)",
-    [token, expiresAt]
+    [hashToken(token), expiresAt]
   );
   return token;
 }
 
 export async function validateSession(pool: Pool, token: string): Promise<boolean> {
+  const hashed = hashToken(token);
   const result = await pool.query(
+    "SELECT 1 FROM sessions WHERE token = $1 AND expires_at > NOW()",
+    [hashed]
+  );
+  if ((result.rowCount ?? 0) > 0) return true;
+
+  // Backwards compat: check for legacy plaintext token and upgrade it
+  const legacy = await pool.query(
     "SELECT 1 FROM sessions WHERE token = $1 AND expires_at > NOW()",
     [token]
   );
-  return (result.rowCount ?? 0) > 0;
+  if ((legacy.rowCount ?? 0) > 0) {
+    await pool.query("UPDATE sessions SET token = $1 WHERE token = $2", [hashed, token]);
+    return true;
+  }
+  return false;
 }
 
 export async function deleteSession(pool: Pool, token: string): Promise<void> {
-  await pool.query("DELETE FROM sessions WHERE token = $1", [token]);
+  const result = await pool.query("DELETE FROM sessions WHERE token = $1", [hashToken(token)]);
+  if ((result.rowCount ?? 0) === 0) {
+    // Backwards compat: try legacy plaintext token
+    await pool.query("DELETE FROM sessions WHERE token = $1", [token]);
+  }
 }
 
 export async function deleteAllSessions(pool: Pool): Promise<void> {
@@ -84,7 +104,7 @@ export async function getOrCreateCookieSecret(pool: Pool): Promise<string> {
   const stored = await getSetting(pool, "cookie_secret");
   if (stored) return stored;
 
-  const secret = crypto.randomUUID();
+  const secret = crypto.randomBytes(32).toString("hex");
   await setSetting(pool, "cookie_secret", secret);
   return secret;
 }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -7,6 +7,8 @@ import { getSetting, setSetting } from "./db/settings.js";
 const BCRYPT_COST = 12;
 const SESSION_TTL_DAYS = 30;
 
+// SHA-256 is safe here because session tokens are random UUIDs (122 bits of entropy).
+// Do not reuse this for user-supplied or low-entropy values.
 function hashToken(token: string): string {
   return crypto.createHash("sha256").update(token).digest("hex");
 }
@@ -38,30 +40,23 @@ export async function createSession(pool: Pool): Promise<string> {
 
 export async function validateSession(pool: Pool, token: string): Promise<boolean> {
   const hashed = hashToken(token);
+  // Single query checks both hashed and legacy plaintext tokens to avoid timing side-channel
   const result = await pool.query(
-    "SELECT 1 FROM sessions WHERE token = $1 AND expires_at > NOW()",
-    [hashed]
+    "SELECT token FROM sessions WHERE (token = $1 OR token = $2) AND expires_at > NOW() LIMIT 1",
+    [hashed, token]
   );
-  if ((result.rowCount ?? 0) > 0) return true;
+  if ((result.rowCount ?? 0) === 0) return false;
 
-  // Backwards compat: check for legacy plaintext token and upgrade it
-  const legacy = await pool.query(
-    "SELECT 1 FROM sessions WHERE token = $1 AND expires_at > NOW()",
-    [token]
-  );
-  if ((legacy.rowCount ?? 0) > 0) {
-    await pool.query("UPDATE sessions SET token = $1 WHERE token = $2", [hashed, token]);
-    return true;
+  // Upgrade legacy plaintext token to hashed in-place
+  const matched = result.rows[0].token as string;
+  if (matched !== hashed) {
+    await pool.query("UPDATE sessions SET token = $1 WHERE token = $2", [hashed, matched]);
   }
-  return false;
+  return true;
 }
 
 export async function deleteSession(pool: Pool, token: string): Promise<void> {
-  const result = await pool.query("DELETE FROM sessions WHERE token = $1", [hashToken(token)]);
-  if ((result.rowCount ?? 0) === 0) {
-    // Backwards compat: try legacy plaintext token
-    await pool.query("DELETE FROM sessions WHERE token = $1", [token]);
-  }
+  await pool.query("DELETE FROM sessions WHERE token = $1 OR token = $2", [hashToken(token), token]);
 }
 
 export async function deleteAllSessions(pool: Pool): Promise<void> {


### PR DESCRIPTION
## Summary
- Hash session tokens with SHA-256 before storing in the database, so a DB compromise doesn't expose usable tokens (CRU-45)
- Upgrade cookie secret generation from `crypto.randomUUID()` (122 bits) to `crypto.randomBytes(32)` (256 bits) for new deployments (CRU-72)
- Legacy plaintext session tokens are transparently upgraded to hashed on next validation — no forced re-login

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 150 unit tests pass
- [x] `pnpm run test:e2e` — 79 E2E tests pass (6 skipped are pre-existing terminal-live tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)