### PR TITLE
Allow string pins to wrap instead of truncating

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3651,7 +3651,7 @@ async function mcpResolveFeedback(
   return record;
 }
 
-const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr"] as const;
+const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename"] as const;
 
 async function mcpUpsertPin(
   agentId: string,

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
 import { cn } from "@/lib/utils";
@@ -77,49 +77,70 @@ function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedVal
 
 function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string }): JSX.Element {
   const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
+  const isPlainString = !href && !badge;
+  const [expanded, setExpanded] = useState(false);
+  const [clamped, setClamped] = useState(false);
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+    setClamped(el.scrollHeight > el.clientHeight);
+  }, [display]);
 
   return (
-    <div className={cn("flex gap-1.5", href || badge ? "items-center" : "items-start")}>
-      {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
-      {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
-      {href ? (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
-          title={tooltip}
-        >
-          {display}
-        </a>
-      ) : badge ? (
-        <span
-          className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
-          title={tooltip}
-        >
-          {display}
-        </span>
-      ) : (
-        <span
-          className="min-w-0 break-words text-xs text-foreground"
-        >
-          {display}
-        </span>
-      )}
-      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+    <div>
+      <div className={cn("flex gap-1.5", isPlainString ? "items-start" : "items-center")}>
+        {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
+        {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
         {href ? (
           <a
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-            title="Open in browser"
+            className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+            title={tooltip}
           >
-            <ExternalLink className="h-3 w-3" />
+            {display}
           </a>
-        ) : null}
-        <CopyButton value={value} />
+        ) : badge ? (
+          <span
+            className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+            title={tooltip}
+          >
+            {display}
+          </span>
+        ) : (
+          <span
+            ref={textRef}
+            className={cn("min-w-0 break-words text-xs text-foreground", !expanded && "line-clamp-6")}
+          >
+            {display}
+          </span>
+        )}
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          {href ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              title="Open in browser"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          ) : null}
+          <CopyButton value={value} />
+        </div>
       </div>
+      {isPlainString && (clamped || expanded) && (
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,8 +1,8 @@
 import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
-import { cn } from "@/lib/utils";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 const SAFE_URL_RE = /^https?:\/\//i;
 const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
@@ -72,66 +72,45 @@ function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedVal
 
 function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string }): JSX.Element {
   const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
-  const isPlainString = !href && !badge;
-  const [expanded, setExpanded] = useState(false);
-  const [clamped, setClamped] = useState(false);
-  const textRef = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    const el = textRef.current;
-    if (!el) return;
-    setClamped(el.scrollHeight > el.clientHeight);
-  }, [display]);
 
   return (
-    <div>
-      <div className={cn("flex gap-1.5", isPlainString ? "items-start" : "items-center")}>
-        {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
-        {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
-        {href ? (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
-            title={tooltip}
-          >
-            {display}
-          </a>
-        ) : badge ? (
-          <span
-            className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
-            title={tooltip}
-          >
-            {display}
-          </span>
-        ) : (
-          <span
-            ref={textRef}
-            className={cn("min-w-0 break-words text-xs text-foreground", !expanded && "line-clamp-6")}
-          >
-            {display}
-          </span>
-        )}
-        {href && (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-            title="Open in browser"
-          >
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        )}
-      </div>
-      {isPlainString && (clamped || expanded) && (
-        <button
-          onClick={() => setExpanded((v) => !v)}
-          className="mt-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+    <div className="flex items-center gap-1.5">
+      {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
+      {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="min-w-0 truncate text-xs text-blue-400 hover:text-blue-300 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+          title={tooltip}
         >
-          {expanded ? "Show less" : "Show more"}
-        </button>
+          {display}
+        </a>
+      ) : badge ? (
+        <span
+          className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+          title={tooltip}
+        >
+          {display}
+        </span>
+      ) : (
+        <ScrollArea className="min-w-0 max-h-32">
+          <span className="break-words text-xs text-foreground">
+            {display}
+          </span>
+        </ScrollArea>
+      )}
+      {href && (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+          title="Open in browser"
+        >
+          <ExternalLink className="h-3 w-3" />
+        </a>
       )}
     </div>
   );

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-reac
 import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
+import { cn } from "@/lib/utils";
 
 const SAFE_URL_RE = /^https?:\/\//i;
 const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
@@ -78,7 +79,7 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
   const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className={cn("flex gap-1.5", href || badge ? "items-center" : "items-start")}>
       {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
       {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
       {href ? (

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -101,7 +101,7 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
         </span>
       ) : (
         <span
-          className="min-w-0 text-xs text-foreground"
+          className="min-w-0 break-words text-xs text-foreground"
         >
           {display}
         </span>

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -9,14 +9,9 @@ const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
 
 /** Split a pin value into individual items if the type supports it. */
 function splitValues(pin: AgentPin): string[] {
-  // URLs split on newline only — commas appear legitimately in query strings.
-  if (pin.type === "url") {
-    const parts = pin.value.split(/\n/).map((s) => s.trim()).filter(Boolean);
-    return parts.length > 0 ? parts : [pin.value];
-  }
-  // Other list-like types split on commas or newlines.
-  if (pin.type === "string" || pin.type === "port" || pin.type === "filename") {
-    const parts = pin.value.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+  // Filenames split on commas (e.g. "file1.ts, file2.ts").
+  if (pin.type === "filename") {
+    const parts = pin.value.split(",").map((s) => s.trim()).filter(Boolean);
     return parts.length > 0 ? parts : [pin.value];
   }
   return [pin.value];
@@ -118,20 +113,17 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
             {display}
           </span>
         )}
-        <div className="ml-auto flex shrink-0 items-center gap-0.5">
-          {href ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-              title="Open in browser"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          ) : null}
-          <CopyButton value={value} />
-        </div>
+        {href && (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            title="Open in browser"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
       </div>
       {isPlainString && (clamped || expanded) && (
         <button
@@ -155,11 +147,9 @@ function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
           {pin.label}
         </div>
-        {isMulti && (
-          <div className="ml-auto">
-            <CopyButton value={values.join("\n")} title="Copy all" />
-          </div>
-        )}
+        <div className="ml-auto">
+          <CopyButton value={pin.value} title={isMulti ? "Copy all" : "Copy to clipboard"} />
+        </div>
       </div>
       <div className="flex flex-col gap-1 mt-1">
         {values.map((v, i) => (

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -100,8 +100,7 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
         </span>
       ) : (
         <span
-          className="min-w-0 truncate text-xs text-foreground"
-          title={tooltip}
+          className="min-w-0 text-xs text-foreground"
         >
           {display}
         </span>


### PR DESCRIPTION
## Summary
- Remove `truncate` from string-type pin values so agent findings and status messages display fully instead of clipping to one line

## Test plan
- [x] Type check passes (`pnpm run finalize:web`)
- [x] E2E tests pass (79/79)
- [x] Visual validation: compared wrapping vs truncated rendering at narrow width