### PR TITLE
[codex] Improve pin formatting and validation

### DIFF
--- a/apps/server/src/pins.ts
+++ b/apps/server/src/pins.ts
@@ -1,0 +1,38 @@
+const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename"] as const;
+
+export type PinType = (typeof VALID_PIN_TYPES)[number];
+
+export function isPinType(value: string): value is PinType {
+  return VALID_PIN_TYPES.includes(value as PinType);
+}
+
+export function validatePinValue(type: PinType, value: string): void {
+  if (type === "url") {
+    try {
+      const url = new URL(value);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error("URL pins must use http or https.");
+      }
+    } catch {
+      throw new Error("URL pins must be valid http or https URLs.");
+    }
+  }
+
+  if (type === "port") {
+    const parts = value.split(/[\s,]+/).map((part) => part.trim()).filter(Boolean);
+    if (parts.length === 0) {
+      throw new Error("Port pins must include at least one integer.");
+    }
+
+    for (const part of parts) {
+      if (!/^\d+$/.test(part)) {
+        throw new Error("Port pins must be integers.");
+      }
+
+      const port = Number.parseInt(part, 10);
+      if (!Number.isSafeInteger(port) || port < 0 || port > 65535) {
+        throw new Error("Port pins must be integers between 0 and 65535.");
+      }
+    }
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -63,6 +63,7 @@ import { SlackNotifier } from "./notifications/slack.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
+import { isPinType, validatePinValue } from "./pins.js";
 import { randomUUID } from "node:crypto";
 import {
   computeActivityStats,
@@ -3651,19 +3652,18 @@ async function mcpResolveFeedback(
   return record;
 }
 
-const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename"] as const;
-
 async function mcpUpsertPin(
   agentId: string,
   pin: { label: string; value: string; type: string }
 ): Promise<void> {
-  if (!VALID_PIN_TYPES.includes(pin.type as (typeof VALID_PIN_TYPES)[number])) {
+  if (!isPinType(pin.type)) {
     throw new Error(`Invalid pin type: ${pin.type}`);
   }
+  validatePinValue(pin.type, pin.value);
   const agent = await agentManager.upsertPin(agentId, {
     label: pin.label,
     value: pin.value,
-    type: pin.type as (typeof VALID_PIN_TYPES)[number]
+    type: pin.type
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }

--- a/apps/server/test/pin-values.test.ts
+++ b/apps/server/test/pin-values.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { splitPinValues } from "../../web/src/lib/pins.ts";
+
+describe("splitPinValues", () => {
+  it("splits filename pins on commas and newlines", () => {
+    expect(splitPinValues("filename", "one.ts,\ntwo.ts\nthree.ts")).toEqual([
+      "one.ts",
+      "two.ts",
+      "three.ts",
+    ]);
+  });
+
+  it("splits port pins on commas and whitespace", () => {
+    expect(splitPinValues("port", "3000 4000,\n5000")).toEqual([
+      "3000",
+      "4000",
+      "5000",
+    ]);
+  });
+
+  it("does not split string pins", () => {
+    expect(splitPinValues("string", "line 1\n\n  line 2")).toEqual([
+      "line 1\n\n  line 2",
+    ]);
+  });
+
+  it("does not split code pins", () => {
+    expect(splitPinValues("code", "DISPATCH_AGENT_ID=agt_123")).toEqual([
+      "DISPATCH_AGENT_ID=agt_123",
+    ]);
+  });
+
+  it("does not split pr pins", () => {
+    expect(splitPinValues("pr", "Review queue")).toEqual([
+      "Review queue",
+    ]);
+  });
+
+  it("does not split url pins", () => {
+    expect(splitPinValues("url", "http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins")).toEqual([
+      "http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins",
+    ]);
+  });
+
+  it("preserves the original value when split delimiters produce no tokens", () => {
+    expect(splitPinValues("filename", ",\n")).toEqual([",\n"]);
+    expect(splitPinValues("port", " , \n ")).toEqual([" , \n "]);
+  });
+});

--- a/apps/server/test/pins.test.ts
+++ b/apps/server/test/pins.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { isPinType, validatePinValue } from "../src/pins.js";
+
+describe("pin validation", () => {
+  it("recognizes valid pin types", () => {
+    expect(isPinType("string")).toBe(true);
+    expect(isPinType("url")).toBe(true);
+    expect(isPinType("port")).toBe(true);
+    expect(isPinType("bogus")).toBe(false);
+  });
+
+  it("accepts valid http and https urls", () => {
+    expect(() => validatePinValue("url", "http://localhost:3000")).not.toThrow();
+    expect(() => validatePinValue("url", "https://example.com/path")).not.toThrow();
+  });
+
+  it("rejects invalid urls", () => {
+    expect(() => validatePinValue("url", "localhost:3000")).toThrow(/valid http or https URLs/i);
+    expect(() => validatePinValue("url", "ftp://example.com")).toThrow(/valid http or https URLs/i);
+  });
+
+  it("accepts integer ports in range", () => {
+    expect(() => validatePinValue("port", "0")).not.toThrow();
+    expect(() => validatePinValue("port", "3000")).not.toThrow();
+    expect(() => validatePinValue("port", "65535")).not.toThrow();
+    expect(() => validatePinValue("port", "3000 4000")).not.toThrow();
+    expect(() => validatePinValue("port", "3000,\n4000")).not.toThrow();
+  });
+
+  it("rejects non-integer or out-of-range ports", () => {
+    expect(() => validatePinValue("port", "3000.5")).toThrow(/integers/i);
+    expect(() => validatePinValue("port", "abc")).toThrow(/integers/i);
+    expect(() => validatePinValue("port", "localhost:3000")).toThrow(/integers/i);
+    expect(() => validatePinValue("port", "-1")).toThrow(/integers/i);
+    expect(() => validatePinValue("port", "65536")).toThrow(/0 and 65535/i);
+  });
+
+  it("does not validate other pin types specially", () => {
+    expect(() => validatePinValue("string", "line 1\nline 2")).not.toThrow();
+    expect(() => validatePinValue("filename", "a.ts,\nb.ts")).not.toThrow();
+  });
+});

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -9,9 +9,13 @@ const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
 
 /** Split a pin value into individual items if the type supports it. */
 function splitValues(pin: AgentPin): string[] {
-  // Filenames split on commas (e.g. "file1.ts, file2.ts").
+  // Filenames support comma- or newline-delimited lists.
   if (pin.type === "filename") {
-    const parts = pin.value.split(",").map((s) => s.trim()).filter(Boolean);
+    const parts = pin.value.split(/[,\n]+/).map((s) => s.trim()).filter(Boolean);
+    return parts.length > 0 ? parts : [pin.value];
+  }
+  if (pin.type === "port") {
+    const parts = pin.value.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
     return parts.length > 0 ? parts : [pin.value];
   }
   return [pin.value];
@@ -96,9 +100,15 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
         </span>
       ) : (
         <ScrollArea className="min-w-0 max-h-32">
-          <span className="break-words text-xs text-foreground">
-            {display}
-          </span>
+          {type === "string" ? (
+            <pre className="m-0 whitespace-pre-wrap break-words font-sans text-xs text-foreground">
+              {display}
+            </pre>
+          ) : (
+            <span className="break-words text-xs text-foreground">
+              {display}
+            </span>
+          )}
         </ScrollArea>
       )}
       {href && (

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -2,24 +2,11 @@ import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-reac
 import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
+import { splitPinValues } from "@/lib/pins";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 const SAFE_URL_RE = /^https?:\/\//i;
 const GH_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i;
-
-/** Split a pin value into individual items if the type supports it. */
-function splitValues(pin: AgentPin): string[] {
-  // Filenames support comma- or newline-delimited lists.
-  if (pin.type === "filename") {
-    const parts = pin.value.split(/[,\n]+/).map((s) => s.trim()).filter(Boolean);
-    return parts.length > 0 ? parts : [pin.value];
-  }
-  if (pin.type === "port") {
-    const parts = pin.value.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
-    return parts.length > 0 ? parts : [pin.value];
-  }
-  return [pin.value];
-}
 
 /** Turn a GitHub PR URL into "owner/repo#123"; fall back to the raw value. */
 function formatPrDisplay(value: string): string {
@@ -127,7 +114,7 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
 }
 
 function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
-  const values = splitValues(pin);
+  const values = splitPinValues(pin.type, pin.value);
   const isMulti = values.length > 1;
 
   return (

--- a/apps/web/src/lib/pins.ts
+++ b/apps/web/src/lib/pins.ts
@@ -1,0 +1,15 @@
+import type { AgentPin } from "../components/app/types";
+
+export function splitPinValues(type: AgentPin["type"], value: string): string[] {
+  if (type === "filename") {
+    const parts = value.split(/[,\n]+/).map((s) => s.trim()).filter(Boolean);
+    return parts.length > 0 ? parts : [value];
+  }
+
+  if (type === "port") {
+    const parts = value.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+    return parts.length > 0 ? parts : [value];
+  }
+
+  return [value];
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -18,6 +18,12 @@ type AgentResult = {
   worktreeBranch: string | null;
 };
 
+type AgentPinRecord = {
+  label: string;
+  value: string;
+  type: "string" | "url" | "port" | "code" | "pr" | "filename";
+};
+
 /**
  * Create an agent via the REST API (faster than going through the UI every time).
  * When useWorktree is true, polls until the setup script completes (status transitions
@@ -121,6 +127,23 @@ export async function uploadMediaViaAPI(
 
   if (!res.ok()) {
     throw new Error(`Media upload failed with ${res.status()}`);
+  }
+}
+
+export async function setAgentPinsViaDB(agentId: string, pins: AgentPinRecord[]): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required to seed agent pins.");
+  }
+
+  const pool = new Pool({ connectionString, max: 1 });
+  try {
+    await pool.query(
+      "UPDATE agents SET pins = $2::jsonb, updated_at = NOW() WHERE id = $1",
+      [agentId, JSON.stringify(pins)]
+    );
+  } finally {
+    await pool.end();
   }
 }
 

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { cleanupE2EAgents, createAgentViaAPI, loadApp, uploadMediaViaAPI } from "./helpers";
+import { cleanupE2EAgents, createAgentViaAPI, loadApp, setAgentPinsViaDB, uploadMediaViaAPI } from "./helpers";
 
 test.describe("Media sidebar", () => {
   test.afterAll(async ({ request }) => {
@@ -94,5 +94,40 @@ test.describe("Media sidebar", () => {
     });
     const body = (await res.json()) as { files: Array<{ seen?: boolean }> };
     expect(body.files[0].seen).toBe(true);
+  });
+
+  test("preserves string pin whitespace and splits filename pins", async ({ page, request }) => {
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-pins-${Date.now()}` });
+    await setAgentPinsViaDB(agent.id, [
+      { label: "Notes", type: "string", value: "line 1\n\n  line 2" },
+      { label: "Files", type: "filename", value: "one.ts,\ntwo.ts\nthree.ts" },
+      { label: "Ports", type: "port", value: "3000 4000,\n5000" },
+      { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
+      { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
+      { label: "Review", type: "pr", value: "Review queue" },
+      { label: "Agent ID", type: "code", value: "DISPATCH_AGENT_ID=agt_123" },
+    ]);
+
+    await loadApp(page);
+
+    await page.getByText(agent.name, { exact: true }).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await expect(mediaSidebar).toBeVisible();
+
+    const notesText = await mediaSidebar.locator("pre").textContent();
+    expect(notesText).toBe("line 1\n\n  line 2");
+
+    await expect(mediaSidebar.getByText("one.ts", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("two.ts", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("three.ts", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("3000", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("4000", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
+    await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();
+    await expect(mediaSidebar.getByText("Review queue", { exact: true })).toBeVisible();
+    await expect(mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- preserve whitespace in `string` pins and render them with `pre-wrap`
- split `filename` pins on commas/newlines and `port` pins on commas/whitespace
- validate `url` and `port` pin values on the server before storing them
- expand E2E mock coverage for `string`, `filename`, `port`, `url`, `pr`, and `code` pin rendering

## Why
Agents were using multiline `string` pins for their own formatting, but the sidebar collapsed that whitespace. The pin panel also only split `filename` values on commas and did not validate `url` or `port` values at write time.

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- Playwright validation screenshot: `/api/v1/agents/agt_e82e74b9693b/media/pin-format-expanded-2026-04-05-17-11-45-837.png`

## User Impact
Pins now render closer to what agents provide, invalid `url`/`port` pins are rejected earlier, and the sidebar regression coverage now exercises the remaining formatted pin types.
