### PR TITLE
[codex] Refine terminal header and persona launch handling

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -918,8 +918,7 @@ export class AgentManager {
         }
         const setupLogTail = await this.readSetupLogTail(row.id);
         const errorDetail = setupLogTail || null;
-        const setupLogIndicatesFailure = /\b(error|failed|exception|unexpected)\b/i.test(setupLogTail);
-        const launchFailed = row.status === "creating" || (exitInfo !== null && exitInfo !== 0) || setupLogIndicatesFailure;
+        const launchFailed = row.status === "creating" || (exitInfo !== null && exitInfo !== 0);
         const nextStatus: AgentStatus = launchFailed ? "error" : "stopped";
         const baseMessage = launchFailed
           ? (row.status === "creating"

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -918,12 +918,19 @@ export class AgentManager {
         }
         const setupLogTail = await this.readSetupLogTail(row.id);
         const errorDetail = setupLogTail || null;
-        await this.setAgentStatus(row.id, "stopped", errorDetail, row.tmuxSession ?? undefined);
-        const baseMessage = exitInfo !== null ? `Session exited with code ${exitInfo}.` : "Session ended unexpectedly.";
+        const setupLogIndicatesFailure = /\b(error|failed|exception|unexpected)\b/i.test(setupLogTail);
+        const launchFailed = row.status === "creating" || (exitInfo !== null && exitInfo !== 0) || setupLogIndicatesFailure;
+        const nextStatus: AgentStatus = launchFailed ? "error" : "stopped";
+        const baseMessage = launchFailed
+          ? (row.status === "creating"
+            ? (exitInfo !== null ? `Launch failed with exit code ${exitInfo}.` : "Launch failed before the session became ready.")
+            : (exitInfo !== null ? `Session exited with code ${exitInfo}.` : "Session ended unexpectedly."))
+          : "Session ended normally.";
+        await this.setAgentStatus(row.id, nextStatus, errorDetail, row.tmuxSession ?? undefined);
         await this.setSystemLatestEvent(row.id, {
-          type: "idle",
+          type: launchFailed ? "blocked" : "idle",
           message: setupLogTail ? `${baseMessage}\n${setupLogTail}` : baseMessage,
-          metadata: { source: "system", ...(exitInfo !== null ? { exitCode: exitInfo } : {}) }
+          metadata: { source: "system", ...(exitInfo !== null ? { exitCode: exitInfo } : {}), launchFailed }
         });
         const agent = await this.getAgent(row.id);
         if (agent) {
@@ -1457,6 +1464,7 @@ export class AgentManager {
     const launchGuidance =
       `[dispatch:${agentId}] ` +
       "Dispatch startup rules: " +
+      "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
       "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
       "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
       "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
@@ -1517,6 +1525,7 @@ export class AgentManager {
     const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
     const dispatchMcpUrl = this.dispatchMcpUrl(agentId);
     const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
+    const { passthroughArgs, appendedSystemPrompt } = this.normalizeAgentArgsForType(type, args);
 
     if (type === "claude") {
       const mcpConfig = this.shellEscape(JSON.stringify({
@@ -1549,13 +1558,14 @@ export class AgentManager {
     }
 
     if (type === "opencode") {
-      const promptFlag = `--prompt ${this.shellEscape(launchGuidance)}`;
+      const startupPrompt = appendedSystemPrompt ? `${launchGuidance}\n\n${appendedSystemPrompt}` : launchGuidance;
+      const promptFlag = `--prompt ${this.shellEscape(startupPrompt)}`;
       const sessionFlag = (resume && cliSessionId) ? `--session ${this.shellEscape(cliSessionId)}` : "";
       const flagParts = [promptFlag, sessionFlag].filter(Boolean).join(" ");
-      if (args.length === 0) {
+      if (passthroughArgs.length === 0) {
         return `${envPrefix} ${this.shellEscape(cliBin)} ${flagParts}`;
       }
-      const escaped = args.map((arg) => this.shellEscape(arg)).join(" ");
+      const escaped = passthroughArgs.map((arg) => this.shellEscape(arg)).join(" ");
       return `${envPrefix} ${this.shellEscape(cliBin)} ${escaped} ${flagParts}`;
     }
 
@@ -1571,11 +1581,12 @@ export class AgentManager {
     if (resume && cliSessionId) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} resume ${this.shellEscape(cliSessionId)} ${codexMcpFlags}`;
     }
-    if (args.length === 0) {
-      return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(launchGuidance)}`;
+    const startupPrompt = appendedSystemPrompt ? `${launchGuidance}\n\n${appendedSystemPrompt}` : launchGuidance;
+    if (passthroughArgs.length === 0) {
+      return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(startupPrompt)}`;
     }
-    const escaped = args.map((arg) => this.shellEscape(arg)).join(" ");
-    return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(launchGuidance)}`;
+    const escaped = passthroughArgs.map((arg) => this.shellEscape(arg)).join(" ");
+    return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(startupPrompt)}`;
   }
 
   private dispatchMcpUrl(agentId: string): string {
@@ -1584,6 +1595,30 @@ export class AgentManager {
 
   private shellEscape(value: string): string {
     return `'${value.replaceAll("'", `'\\''`)}'`;
+  }
+
+  private normalizeAgentArgsForType(
+    type: AgentType,
+    args: string[]
+  ): { passthroughArgs: string[]; appendedSystemPrompt: string | null } {
+    if (type === "claude") {
+      return { passthroughArgs: args, appendedSystemPrompt: null };
+    }
+
+    const passthroughArgs: string[] = [];
+    let appendedSystemPrompt: string | null = null;
+
+    for (let index = 0; index < args.length; index += 1) {
+      const arg = args[index];
+      if (arg === "--append-system-prompt" && typeof args[index + 1] === "string") {
+        appendedSystemPrompt = args[index + 1] ?? null;
+        index += 1;
+        continue;
+      }
+      passthroughArgs.push(arg);
+    }
+
+    return { passthroughArgs, appendedSystemPrompt };
   }
 
   private async validateWorkingDirectory(rawCwd: string): Promise<string> {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -169,6 +169,21 @@ describe("AgentManager", () => {
       expect(setupScript).toContain(`/api/mcp/${agent.id}`);
       expect(setupScript).toContain("mcp_servers.dispatch.bearer_token_env_var=");
       expect(setupScript).toContain("DISPATCH_AUTH_TOKEN=");
+      expect(setupScript).toContain("do not start repo work or infer a task from branch/worktree context alone");
+    });
+
+    it("should translate appended system prompts into a single Codex startup prompt", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        useWorktree: false,
+        agentArgs: ["--append-system-prompt", "Persona review instructions", "--model", "gpt-5"],
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).toContain("Persona review instructions");
+      expect(setupScript).toContain("--model");
+      expect(setupScript).not.toContain("--append-system-prompt");
     });
 
     it("should inject an agent-scoped MCP URL into Claude launches", async () => {
@@ -456,6 +471,11 @@ describe("AgentManager", () => {
   describe("reconcileAgents", () => {
     it("should mark agents as stopped when tmux session is gone", async () => {
       const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      await manager.completeSetup(agent.id, {
+        effectiveCwd: "/tmp",
+        worktreePath: null,
+        worktreeBranch: null,
+      });
 
       // Now make tmux report no session
       const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
@@ -480,6 +500,39 @@ describe("AgentManager", () => {
 
       const reconciled = await manager.getAgent(agent.id);
       expect(reconciled!.status).toBe("stopped");
+    });
+
+    it("should surface startup crashes as blocked errors with setup details", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      await writeFile(`/tmp/dispatch_${agent.tmuxSession}.exit`, "EXIT:2");
+      await writeFile(`/tmp/dispatch_setup_${agent.id}.log`, "error: unexpected argument '--append-system-prompt' found\n");
+
+      const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
+      const mockRunCommand = vi.mocked(runCommand);
+      mockRunCommand.mockImplementation(async (_cmd, args) => {
+        if (args[0] === "has-session") {
+          return { exitCode: 1, stdout: "", stderr: "" };
+        }
+        if (args[0] === "list-sessions" || args[0] === "list-panes") {
+          return { exitCode: 1, stdout: "", stderr: "no server running" };
+        }
+        if (_cmd === "ps") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (_cmd === "launchctl") {
+          return { exitCode: 113, stdout: "", stderr: "service not found" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      await manager.reconcileAgents();
+
+      const reconciled = await manager.getAgent(agent.id);
+      expect(reconciled!.status).toBe("error");
+      expect(reconciled!.latestEvent?.type).toBe("blocked");
+      expect(reconciled!.latestEvent?.message).toContain("Launch failed");
+      expect(reconciled!.latestEvent?.message).toContain("unexpected argument '--append-system-prompt'");
+      expect(reconciled!.lastError).toContain("unexpected argument '--append-system-prompt'");
     });
 
     it("should capture a missing-session diagnostic snapshot", async () => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -535,6 +535,43 @@ describe("AgentManager", () => {
       expect(reconciled!.lastError).toContain("unexpected argument '--append-system-prompt'");
     });
 
+    it("should not classify a clean exit as an error from generic stderr text", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      await manager.completeSetup(agent.id, {
+        effectiveCwd: "/tmp",
+        worktreePath: null,
+        worktreeBranch: null
+      });
+      await writeFile(`/tmp/dispatch_${agent.tmuxSession}.exit`, "EXIT:0");
+      await writeFile(`/tmp/dispatch_setup_${agent.id}.log`, "warning: previous command printed an error banner\n");
+
+      const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
+      const mockRunCommand = vi.mocked(runCommand);
+      mockRunCommand.mockImplementation(async (_cmd, args) => {
+        if (args[0] === "has-session") {
+          return { exitCode: 1, stdout: "", stderr: "" };
+        }
+        if (args[0] === "list-sessions" || args[0] === "list-panes") {
+          return { exitCode: 1, stdout: "", stderr: "no server running" };
+        }
+        if (_cmd === "ps") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (_cmd === "launchctl") {
+          return { exitCode: 113, stdout: "", stderr: "service not found" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      await manager.reconcileAgents();
+
+      const reconciled = await manager.getAgent(agent.id);
+      expect(reconciled!.status).toBe("stopped");
+      expect(reconciled!.latestEvent?.type).toBe("idle");
+      expect(reconciled!.latestEvent?.message).toContain("Session ended normally.");
+      expect(reconciled!.latestEvent?.message).toContain("error banner");
+    });
+
     it("should capture a missing-session diagnostic snapshot", async () => {
       const tempHome = await mkdtemp(path.join(os.tmpdir(), "dispatch-agent-manager-home-"));
       const previousHome = process.env.HOME;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -368,23 +368,6 @@ export function DashboardLayout(): JSX.Element {
   // ── Derived values ────────────────────────────────────────────────────
   const isAttached = connState === "connected" && Boolean(connectedAgentId);
   const hasActiveAgent = Boolean(validatedSelectedAgentId);
-  const showHeaderStatus = connState !== "disconnected";
-
-
-
-  const statusText = useMemo(() => {
-    if (connState === "reconnecting") {
-      if (connectedAgent) return `Reconnecting to session ${connectedAgent.name}...`;
-      return "Reconnecting session...";
-    }
-    if (connState === "connected" && connectedAgent) {
-      if (connectedAgent.latestEvent?.message) return connectedAgent.latestEvent.message;
-      return `Connected to session ${connectedAgent.name}`;
-    }
-    if (apiState === "down") return "Unable to reach API service.";
-    return "Tap an agent row to focus it.";
-  }, [apiState, connectedAgent, connState]);
-
   // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
     const activeCwd = agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
@@ -595,8 +578,6 @@ export function DashboardLayout(): JSX.Element {
               leftOpen={leftPanelOpen}
               mediaOpen={mediaPanelOpen}
               isMobile={isMobile}
-              showHeaderStatus={showHeaderStatus}
-              statusText={statusText}
               showReconnectIndicator={connState === "reconnecting"}
               hasActiveAgent={hasActiveAgent}
               unseenMediaCount={unseenMediaCount}

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -8,8 +8,6 @@ type AppHeaderProps = {
   leftOpen: boolean;
   mediaOpen: boolean;
   isMobile: boolean;
-  showHeaderStatus: boolean;
-  statusText: string;
   showReconnectIndicator: boolean;
   hasActiveAgent: boolean;
   unseenMediaCount: number;
@@ -21,8 +19,6 @@ export function AppHeader({
   leftOpen,
   mediaOpen,
   isMobile,
-  showHeaderStatus,
-  statusText,
   showReconnectIndicator,
   hasActiveAgent,
   unseenMediaCount,
@@ -30,6 +26,8 @@ export function AppHeader({
   setMediaOpen,
 }: AppHeaderProps): JSX.Element {
   const { iconColor } = useIconColor();
+  const showLeftToggle = isMobile ? !leftOpen : !leftOpen;
+  const showMediaToggle = hasActiveAgent && (!mediaOpen || isMobile);
 
   return (
     <header
@@ -38,61 +36,29 @@ export function AppHeader({
         "relative flex min-h-14 min-w-0 items-center gap-2 border-b-2 border-b-border bg-surface px-3 py-2 pt-[env(safe-area-inset-top)]"
       )}
     >
-      <div
-        className={cn(
-          "flex items-center overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-out",
-          isMobile ? "shrink-0" : leftOpen ? "max-w-0 shrink opacity-0" : "max-w-24 shrink-0 opacity-100"
-        )}
-        aria-hidden={!isMobile && leftOpen}
-      >
-        {isMobile ? (
-          !leftOpen ? (
-            <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
-              <PanelRightOpen className="h-4 w-4" />
-            </Button>
-          ) : null
-        ) : (
+      <div className="flex min-w-0 flex-1 items-center">
+        {showLeftToggle ? (
           <div
             className={cn(
-              "flex items-center gap-1 transition-[opacity,transform] duration-300 ease-out",
-              leftOpen
-                ? "pointer-events-none -translate-x-3 opacity-0"
-                : "translate-x-0 opacity-100 delay-150"
+              "inline-flex items-center gap-1"
             )}
           >
             <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
               <PanelRightOpen className="h-4 w-4" />
             </Button>
-            <img
-              src={`/icons/${iconColor}/brand-icon.svg`}
-              alt="Dispatch logo"
-              className="h-6 w-auto object-contain"
-            />
+            {!isMobile ? (
+              <img
+                src={`/icons/${iconColor}/brand-icon.svg`}
+                alt="Dispatch logo"
+                className="h-6 w-auto object-contain"
+              />
+            ) : null}
           </div>
-        )}
+        ) : <div />}
       </div>
 
-      {showHeaderStatus ? (
-        <div className="min-w-0 flex-1 overflow-hidden px-1">
-          <span
-            data-testid="app-header-status"
-            title={statusText}
-            className="block overflow-hidden text-[11px] leading-tight text-ellipsis sm:text-xs"
-            style={{
-              display: "-webkit-box",
-              WebkitBoxOrient: "vertical",
-              WebkitLineClamp: 2
-            }}
-          >
-            {statusText}
-          </span>
-        </div>
-      ) : (
-        <div className="flex-1" />
-      )}
-
-      <div className="ml-auto flex shrink-0 items-center gap-1">
-        {hasActiveAgent && (!mediaOpen || isMobile) ? (
+      <div className="ml-3 flex shrink-0 items-center gap-1">
+        {showMediaToggle ? (
           <Button
             size="icon"
             variant="ghost"

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -42,6 +42,7 @@ export function PersonaAgentRow({
   const childIsStopped = childState === "stopped";
   const childIsActive = childState === "active";
   const colorVar = `var(--chart-${(childIndex % 4) + 1})`;
+  const personaMessage = child.latestEvent?.message?.split("\n")[0] ?? null;
 
   return (
     <div
@@ -49,7 +50,7 @@ export function PersonaAgentRow({
       className={cn(
         "flex items-center gap-2 border-r-2 px-2 py-1.5 transition-colors duration-200",
         hasFeedback && "cursor-pointer hover:bg-muted/50",
-        childIsStopped && "opacity-50",
+        childIsStopped && child.status !== "error" && "opacity-50",
         isSelected ? "border-r-status-done" : "border-r-transparent"
       )}
     >
@@ -71,6 +72,14 @@ export function PersonaAgentRow({
         {child.latestEvent ? (
           <div className="mt-0.5 text-[10px]">
             <span className={cn("font-medium", latestEventColor(child.latestEvent.type))}>{latestEventLabel(child.latestEvent.type)}</span>
+          </div>
+        ) : null}
+        {child.status === "error" && personaMessage ? (
+          <div
+            className="mt-0.5 truncate text-[10px] text-status-blocked/90"
+            title={child.latestEvent?.message ?? child.lastError ?? undefined}
+          >
+            {personaMessage}
           </div>
         ) : null}
       </div>

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -6,15 +6,16 @@ test.describe("App shell", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("renders the main layout — sidebar, header, terminal pane, and status footer", async ({
+  test("renders the main layout with a slim terminal header row", async ({
     page,
   }) => {
     await loadApp(page);
 
     await expect(page.getByTestId("agent-sidebar")).toBeVisible();
-    await expect(page.getByTestId("app-header")).toBeVisible();
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
     await expect(page.getByTestId("status-footer")).toBeVisible();
+    await expect(page.getByTestId("app-header")).toBeVisible();
+    await expect(page.getByTestId("app-header-status")).toHaveCount(0);
   });
 
   test("shows the empty-state prompt when no agent is selected", async ({ page }) => {

--- a/e2e/header-overflow.spec.ts
+++ b/e2e/header-overflow.spec.ts
@@ -7,12 +7,12 @@ test.describe("Header overflow", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("long agent status messages stay constrained inside the header", async ({ page, request }) => {
+  test("long agent status messages do not appear inside the slim terminal header", async ({ page, request }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
     });
     const longMessage =
-      "This is a deliberately long agent description used to verify the header keeps its width constrained and truncates the message instead of letting the layout grow past the viewport width while a session is attached and actively reporting status updates.";
+      "This is a deliberately long agent description used to verify that status text no longer reserves a dedicated header row or pushes the terminal layout beyond the viewport width while a session is attached and actively reporting status updates.";
 
     await setAgentLatestEventViaAPI(request, agent.id, { type: "working", message: longMessage });
     await loadApp(page);
@@ -21,39 +21,24 @@ test.describe("Header overflow", () => {
     await agentCard.waitFor({ state: "visible", timeout: 10_000 });
     await page.getByTestId(`agent-row-${agent.id}`).click();
 
-    const status = page.getByTestId("app-header-status");
-    await expect(status).toBeVisible({ timeout: 10_000 });
-    await expect(status).toHaveAttribute("title", longMessage);
-    await expect(status).toContainText("This is a deliberately long agent description");
-
     const dimensions = await page.evaluate(() => {
       const header = document.querySelector("[data-testid='app-header']");
       const statusText = document.querySelector("[data-testid='app-header-status']");
       const main = document.querySelector("main");
-      const statusRect = statusText?.getBoundingClientRect();
       return {
         viewportWidth: window.innerWidth,
         documentScrollWidth: document.documentElement.scrollWidth,
         headerWidth: header?.getBoundingClientRect().width ?? 0,
-        headerScrollWidth: header?.scrollWidth ?? 0,
         mainWidth: main?.getBoundingClientRect().width ?? 0,
-        statusClientWidth: statusText?.clientWidth ?? 0,
-        statusScrollWidth: statusText?.scrollWidth ?? 0,
-        statusClientHeight: statusText?.clientHeight ?? 0,
-        statusScrollHeight: statusText?.scrollHeight ?? 0,
-        statusHeight: statusRect?.height ?? 0,
-        lineClamp: statusText ? window.getComputedStyle(statusText).webkitLineClamp : null
+        statusNodeCount: statusText ? 1 : 0,
       };
     });
 
+    await expect(page.getByTestId("app-header")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("app-header-status")).toHaveCount(0);
+
     expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
     expect(dimensions.headerWidth).toBeLessThanOrEqual(dimensions.mainWidth);
-    expect(dimensions.headerScrollWidth).toBeLessThanOrEqual(dimensions.headerWidth);
-    expect(dimensions.lineClamp).toBe("2");
-    expect(dimensions.statusHeight).toBeGreaterThan(20);
-    expect(
-      dimensions.statusScrollWidth > dimensions.statusClientWidth ||
-      dimensions.statusScrollHeight > dimensions.statusClientHeight
-    ).toBeTruthy();
+    expect(dimensions.statusNodeCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- restore a slim dedicated terminal header row and remove the floating overlay approach
- keep the terminal header controls while removing the visible status message from that area
- fix Codex persona launches by normalizing persona system-prompt args into a valid Codex startup prompt
- surface persona launch failures more clearly as blocked/error states in the child persona row

## Why
The overlay version reclaimed space, but the dedicated header turned out to be a simpler and more stable UX. Separately, the first Codex-launched persona exposed that persona startup still assumed Claude-style `--append-system-prompt` behavior, which caused Codex persona agents to fail immediately and look inert in the UI.

## Impact
- the terminal area keeps a familiar header strip, but without the low-value status text taking horizontal space
- the UI avoids overlay-specific click layering issues while preserving left/media controls
- Codex persona agents can launch correctly
- if persona startup fails again, the failure is much more obvious in the UI instead of appearing idle or silently unattached

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run finalize:web`
- `pnpm run test:e2e`

## Notes
- validation screenshots were captured during local review, including the persona blocked-state row
- no live service was patched; changes were validated in the worktree/dev stack only
