### PR TITLE
[codex] Clarify pin guidance in launch prompt

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1467,7 +1467,7 @@ export class AgentManager {
       "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
       "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
       "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
-      "Use dispatch_pin to surface key info in the sidebar. Update pins when values change; delete stale ones. " +
+      "Use dispatch_pin to surface key info in the sidebar, especially values users may need to copy/paste later such as URLs, commands, branch names, IDs, tokens, simulator UDIDs, and other short reusable values. Update pins when values change; delete stale ones. " +
       "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions). " +
       "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1468,7 +1468,7 @@ export class AgentManager {
       "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
       "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
       "Use dispatch_pin to surface key info in the sidebar, especially values users may need to copy/paste later such as URLs, commands, branch names, IDs, tokens, simulator UDIDs, and other short reusable values. Update pins when values change; delete stale ones. " +
-      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions). " +
+      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
       "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -17,7 +17,7 @@ type AgentType = "codex" | "claude" | "opencode";
 type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
 type ArchivePhase = "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
-type PinType = "string" | "url" | "port" | "code" | "pr" | "filename";
+type PinType = "string" | "url" | "port" | "code" | "pr" | "filename" | "markdown";
 
 export type AgentPin = {
   label: string;

--- a/apps/server/src/pins.ts
+++ b/apps/server/src/pins.ts
@@ -1,4 +1,51 @@
-const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename"] as const;
+const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename", "markdown"] as const;
+const MAX_MARKDOWN_LENGTH = 2000;
+const MAX_MARKDOWN_CODE_BLOCK_LINES = 20;
+
+function stripFencedCodeBlocks(value: string): { sanitized: string; codeBlocks: string[] } {
+  const codeBlocks: string[] = [];
+  const sanitized = value.replace(/```[^\n]*\n([\s\S]*?)```/g, (_match, body: string) => {
+    codeBlocks.push(body);
+    return "";
+  });
+  return { sanitized, codeBlocks };
+}
+
+function validateMarkdownPinValue(value: string): void {
+  if (value.length > MAX_MARKDOWN_LENGTH) {
+    throw new Error(`Markdown pins must be ${MAX_MARKDOWN_LENGTH} characters or fewer.`);
+  }
+
+  const { sanitized, codeBlocks } = stripFencedCodeBlocks(value);
+
+  for (const block of codeBlocks) {
+    const lineCount = block.replace(/\n$/, "").split("\n").length;
+    if (lineCount > MAX_MARKDOWN_CODE_BLOCK_LINES) {
+      throw new Error(`Markdown pin code blocks must be ${MAX_MARKDOWN_CODE_BLOCK_LINES} lines or fewer.`);
+    }
+  }
+
+  const disallowedPatterns: Array<[RegExp, string]> = [
+    [/!\[[^\]]*]\((?:[^()\\]|\\.)+\)/, "Markdown pins do not support images."],
+    [/\[[^\]]+]\((?:[^()\\]|\\.)+\)/, "Markdown pins do not support links."],
+    [/\[[^\]]+]\[[^\]]*]/, "Markdown pins do not support reference-style links."],
+    [/^\s*\[[^\]]+]:\s*\S+/m, "Markdown pins do not support reference-style links."],
+    [/<\/?[A-Za-z][^>]*>/, "Markdown pins do not support raw HTML."],
+    [/^\s{0,3}#{1,6}\s/m, "Markdown pins do not support headings."],
+    [/^\s{0,3}>\s/m, "Markdown pins do not support blockquotes."],
+    [/^\s{0,3}\d+\.\s/m, "Markdown pins only support flat bullet lists."],
+    [/^(?: {2,}|\t+)[-*+]\s/m, "Markdown pins do not support nested lists."],
+    [/^(?: {2,}|\t+)\d+\.\s/m, "Markdown pins do not support nested lists."],
+    [/^\s*\|.+\|\s*$/m, "Markdown pins do not support tables."],
+    [/^\s*\|?\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*\|?\s*$/m, "Markdown pins do not support tables."],
+  ];
+
+  for (const [pattern, message] of disallowedPatterns) {
+    if (pattern.test(sanitized)) {
+      throw new Error(message);
+    }
+  }
+}
 
 export type PinType = (typeof VALID_PIN_TYPES)[number];
 
@@ -34,5 +81,9 @@ export function validatePinValue(type: PinType, value: string): void {
         throw new Error("Port pins must be integers between 0 and 65535.");
       }
     }
+  }
+
+  if (type === "markdown") {
+    validateMarkdownPinValue(value);
   }
 }

--- a/apps/server/test/pin-values.test.ts
+++ b/apps/server/test/pin-values.test.ts
@@ -43,6 +43,12 @@ describe("splitPinValues", () => {
     ]);
   });
 
+  it("does not split markdown pins", () => {
+    expect(splitPinValues("markdown", "**Status**\n- Ready\n- Branch: `feat/log-rotation`")).toEqual([
+      "**Status**\n- Ready\n- Branch: `feat/log-rotation`",
+    ]);
+  });
+
   it("preserves the original value when split delimiters produce no tokens", () => {
     expect(splitPinValues("filename", ",\n")).toEqual([",\n"]);
     expect(splitPinValues("port", " , \n ")).toEqual([" , \n "]);

--- a/apps/server/test/pins.test.ts
+++ b/apps/server/test/pins.test.ts
@@ -7,6 +7,7 @@ describe("pin validation", () => {
     expect(isPinType("string")).toBe(true);
     expect(isPinType("url")).toBe(true);
     expect(isPinType("port")).toBe(true);
+    expect(isPinType("markdown")).toBe(true);
     expect(isPinType("bogus")).toBe(false);
   });
 
@@ -34,6 +35,31 @@ describe("pin validation", () => {
     expect(() => validatePinValue("port", "localhost:3000")).toThrow(/integers/i);
     expect(() => validatePinValue("port", "-1")).toThrow(/integers/i);
     expect(() => validatePinValue("port", "65536")).toThrow(/0 and 65535/i);
+  });
+
+  it("accepts constrained markdown pins", () => {
+    expect(() => validatePinValue("markdown", "**Status**\n- Ready\n- Branch: `feat/log-rotation`\n\n```sh\npnpm run check\n```")).not.toThrow();
+  });
+
+  it("rejects markdown pins with links", () => {
+    expect(() => validatePinValue("markdown", "[Dispatch](https://github.com/selfcontained/dispatch)")).toThrow(/do not support links/i);
+  });
+
+  it("rejects markdown pins with images", () => {
+    expect(() => validatePinValue("markdown", "![diagram](https://example.com/image.png)")).toThrow(/do not support images/i);
+  });
+
+  it("rejects markdown pins with raw html", () => {
+    expect(() => validatePinValue("markdown", "<b>unsafe</b>")).toThrow(/do not support raw HTML/i);
+  });
+
+  it("rejects markdown pins with nested lists", () => {
+    expect(() => validatePinValue("markdown", "- top\n  - nested")).toThrow(/do not support nested lists/i);
+  });
+
+  it("rejects markdown pins with oversized code blocks", () => {
+    const longBlock = Array.from({ length: 21 }, (_, i) => `line ${i + 1}`).join("\n");
+    expect(() => validatePinValue("markdown", `\`\`\`txt\n${longBlock}\n\`\`\``)).toThrow(/code blocks must be 20 lines or fewer/i);
   });
 
   it("does not validate other pin types specially", () => {

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,8 +1,8 @@
 import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
 import { Markdown } from "@/components/ui/markdown";
+import { useCopyText } from "@/hooks/use-copy";
 import { splitPinValues } from "@/lib/pins";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
@@ -16,20 +16,11 @@ function formatPrDisplay(value: string): string {
 }
 
 function CopyButton({ value, title }: { value: string; title?: string }): JSX.Element {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 1500);
-    }).catch(() => {});
-  }, [value]);
+  const [copied, copyText] = useCopyText();
 
   return (
     <button
-      onClick={handleCopy}
+      onClick={() => copyText(value)}
       className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
       title={title ?? "Copy to clipboard"}
     >

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-reac
 import { useCallback, useRef, useState } from "react";
 
 import { type AgentPin } from "@/components/app/types";
+import { Markdown } from "@/components/ui/markdown";
 import { splitPinValues } from "@/lib/pins";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
@@ -39,6 +40,48 @@ function CopyButton({ value, title }: { value: string; title?: string }): JSX.El
 
 type ResolvedValue = { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | "file" | null };
 
+function shouldRenderMarkdownAsPlainText(value: string): boolean {
+  const sanitized = value.replace(/```[^\n]*\n[\s\S]*?```/g, "");
+  const unsupportedPatterns = [
+    /!\[[^\]]*]\((?:[^()\\]|\\.)+\)/,
+    /\[[^\]]+]\((?:[^()\\]|\\.)+\)/,
+    /\[[^\]]+]\[[^\]]*]/,
+    /^\s*\[[^\]]+]:\s*\S+/m,
+    /<\/?[A-Za-z][^>]*>/,
+    /^\s{0,3}#{1,6}\s/m,
+    /^\s{0,3}>\s/m,
+    /^\s{0,3}\d+\.\s/m,
+    /^(?: {2,}|\t+)[-*+]\s/m,
+    /^(?: {2,}|\t+)\d+\.\s/m,
+    /^\s*\|.+\|\s*$/m,
+    /^\s*\|?\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*\|?\s*$/m,
+  ];
+  return unsupportedPatterns.some((pattern) => pattern.test(sanitized));
+}
+
+function MarkdownPinBody({ value }: { value: string }): JSX.Element {
+  const renderAsPlainText = shouldRenderMarkdownAsPlainText(value);
+
+  return (
+    <div
+      className="min-w-0 max-h-48 overflow-y-auto overflow-x-hidden rounded-md border border-border/60 bg-background/40"
+      data-testid="markdown-pin-scroll"
+    >
+      <div className="p-2" data-testid="markdown-pin-body">
+        {renderAsPlainText ? (
+          <pre className="m-0 whitespace-pre-wrap break-words font-sans text-xs text-foreground">
+            {value}
+          </pre>
+        ) : (
+          <Markdown variant="pin">
+            {value}
+          </Markdown>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedValue {
   if (type === "pr" && SAFE_URL_RE.test(value)) {
     return { display: formatPrDisplay(value), tooltip: value, href: value, badge: false, icon: "pr" };
@@ -62,6 +105,10 @@ function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedVal
 }
 
 function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string }): JSX.Element {
+  if (type === "markdown") {
+    return <MarkdownPinBody value={value} />;
+  }
+
   const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
 
   return (
@@ -118,7 +165,7 @@ function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
   const isMulti = values.length > 1;
 
   return (
-    <div className="px-4 py-2.5 border-b border-border last:border-b-0">
+    <div className="px-4 py-2.5 border-b border-border last:border-b-0" data-testid="pin-item" data-pin-label={pin.label}>
       <div className="flex items-center gap-1">
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
           {pin.label}
@@ -146,7 +193,7 @@ export function PinsPanel({ pins, selectedAgentName }: PinsPanelProps): JSX.Elem
     return (
       <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
         {selectedAgentName
-          ? "No pins yet. Agents can pin URLs, files, ports, and other info here."
+          ? "No pins yet. Agents can pin URLs, files, ports, summaries, and other info here."
           : "Focus an agent to view pins."}
       </div>
     );

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -3,7 +3,7 @@ export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "arc
 export type AgentPin = {
   label: string;
   value: string;
-  type: "string" | "url" | "port" | "code" | "pr" | "filename";
+  type: "string" | "url" | "port" | "code" | "pr" | "filename" | "markdown";
 };
 
 export type Agent = {

--- a/apps/web/src/components/ui/markdown.tsx
+++ b/apps/web/src/components/ui/markdown.tsx
@@ -2,7 +2,34 @@ import ReactMarkdown from "react-markdown";
 
 import { cn } from "@/lib/utils";
 
-export function Markdown({ children, className }: { children: string; className?: string }): JSX.Element {
+type MarkdownProps = {
+  children: string;
+  className?: string;
+  variant?: "default" | "pin";
+};
+
+export function Markdown({ children, className, variant = "default" }: MarkdownProps): JSX.Element {
+  if (variant === "pin") {
+    return (
+      <div
+        className={cn(
+          "max-w-none text-xs text-foreground",
+          "[&_p]:my-1 [&_p]:[overflow-wrap:anywhere]",
+          "[&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-4",
+          "[&_li]:my-0.5 [&_li]:[overflow-wrap:anywhere]",
+          "[&_strong]:font-semibold [&_em]:italic",
+          "[&_pre]:my-1 [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:overflow-x-hidden [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-2",
+          "[&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] [&_code]:break-words [&_code]:whitespace-pre-wrap",
+          className,
+        )}
+      >
+        <ReactMarkdown allowedElements={["p", "ul", "li", "strong", "em", "code", "pre"]}>
+          {children}
+        </ReactMarkdown>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,7 +21,7 @@ type AgentResult = {
 type AgentPinRecord = {
   label: string;
   value: string;
-  type: "string" | "url" | "port" | "code" | "pr" | "filename";
+  type: "string" | "url" | "port" | "code" | "pr" | "filename" | "markdown";
 };
 
 /**

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -100,6 +100,11 @@ test.describe("Media sidebar", () => {
     const agent = await createAgentViaAPI(request, { name: `e2e-agent-pins-${Date.now()}` });
     await setAgentPinsViaDB(agent.id, [
       { label: "Notes", type: "string", value: "line 1\n\n  line 2" },
+      {
+        label: "Summary",
+        type: "markdown",
+        value: "**Status**\n- Ready for review\n- URL: https://example.com/visible\n- Branch: `feat/log-rotation`\n- Owner: **Dispatch**\n- Marker: 🚀\n- Step: validate in sidebar\n- Step: keep lines wrapped\n\n```sh\npnpm run check\npnpm run test\npnpm run finalize:web\npnpm run test:e2e\nnpm run lint || true\n```",
+      },
       { label: "Files", type: "filename", value: "one.ts,\ntwo.ts\nthree.ts" },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
       { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
@@ -116,8 +121,25 @@ test.describe("Media sidebar", () => {
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
 
-    const notesText = await mediaSidebar.locator("pre").textContent();
+    const notesText = await mediaSidebar.locator("[data-pin-label='Notes'] pre").textContent();
     expect(notesText).toBe("line 1\n\n  line 2");
+
+    const markdownPin = mediaSidebar.locator("[data-pin-label='Summary'] [data-testid='markdown-pin-body']");
+    await expect(markdownPin.getByText("Status", { exact: true })).toBeVisible();
+    await expect(markdownPin.locator("strong").first()).toHaveText("Status");
+    await expect(markdownPin.getByText("Ready for review", { exact: true })).toBeVisible();
+    await expect(markdownPin).toContainText("https://example.com/visible");
+    await expect(markdownPin.getByText("feat/log-rotation", { exact: true })).toBeVisible();
+    await expect(markdownPin).toContainText("pnpm run check");
+    await expect(markdownPin).toContainText("pnpm run test");
+    await expect(markdownPin.getByRole("link")).toHaveCount(0);
+
+    const scrollMetrics = await mediaSidebar.locator("[data-pin-label='Summary'] [data-testid='markdown-pin-scroll']").evaluate((el) => {
+      const container = el as HTMLElement;
+      return { clientHeight: container.clientHeight, scrollHeight: container.scrollHeight };
+    });
+    expect(scrollMetrics).not.toBeNull();
+    expect(scrollMetrics!.scrollHeight).toBeGreaterThan(scrollMetrics!.clientHeight);
 
     await expect(mediaSidebar.getByText("one.ts", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("two.ts", { exact: true })).toBeVisible();

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -59,7 +59,7 @@ export type GetFeedbackResult = {
 export type PinInput = {
   label: string;
   value?: string;
-  type?: "string" | "url" | "port" | "code" | "pr" | "filename";
+  type?: "string" | "url" | "port" | "code" | "pr" | "filename" | "markdown";
   delete?: boolean;
 };
 
@@ -228,7 +228,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       {
         description:
           "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info. To update a pin, set it again with the same label. To remove a pin, pass delete: true. " +
-          "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), the specific blocking question when in waiting_user state (string).",
+          "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), short structured summaries (markdown), the specific blocking question when in waiting_user state (string).",
         inputSchema: {
           label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
           value: z
@@ -237,9 +237,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             .optional()
             .describe("The value to display. Required unless delete is true."),
           type: z
-            .enum(["string", "url", "port", "code", "pr", "filename"])
+            .enum(["string", "url", "port", "code", "pr", "filename", "markdown"])
             .default("string")
-            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
+            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. 'markdown' renders constrained markdown for short summaries. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
           delete: z
             .boolean()
             .default(false)


### PR DESCRIPTION
## What changed
Updated Dispatch's shared `launchGuidance` prompt so agents are explicitly told to use pins for values users may need to copy/paste later, not just URLs and ports.

## Why
The previous guidance mentioned a few pin use cases, but it under-emphasized one of the highest-value cases: short reusable values the user may need to grab again during a task.

## Impact
This makes the pin guidance apply consistently across all repos launched through Dispatch, including values like commands, branch names, IDs, tokens, and simulator UDIDs.

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`
