### PR TITLE
[codex] Fix release log dedupe and filename pin display

### DIFF
--- a/apps/server/src/release-log-stream.ts
+++ b/apps/server/src/release-log-stream.ts
@@ -1,0 +1,140 @@
+export type ReleaseLogSink = {
+  append(line: string): void;
+  replace(line: string): void;
+  rewind(count: number): void;
+};
+
+function isCsiFinalByte(char: string): boolean {
+  return /^[\x40-\x7e]$/.test(char);
+}
+
+function parseCursorCount(raw: string): number {
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+export class ReleaseLogStreamProcessor {
+  private readonly sink: ReleaseLogSink;
+  private readonly onLine?: (line: string) => void;
+  private currentLine = "";
+  private escapeBuffer = "";
+  private lastWasCR = false;
+  private streamLineCount = 0;
+
+  constructor(sink: ReleaseLogSink, onLine?: (line: string) => void) {
+    this.sink = sink;
+    this.onLine = onLine;
+  }
+
+  push(chunk: Buffer | string): void {
+    const input = typeof chunk === "string" ? chunk : chunk.toString();
+    for (const char of input) {
+      if (this.escapeBuffer) {
+        this.escapeBuffer += char;
+        if (this.escapeBuffer.startsWith("\x1b[")) {
+          if (this.escapeBuffer.length > 2 && isCsiFinalByte(char)) {
+            this.handleCsi(this.escapeBuffer);
+            this.escapeBuffer = "";
+          }
+          continue;
+        }
+
+        if (char === "\u0007" || this.escapeBuffer.endsWith("\x1b\\")) {
+          this.escapeBuffer = "";
+        }
+        continue;
+      }
+
+      if (char === "\x1b") {
+        this.escapeBuffer = char;
+        continue;
+      }
+
+      if (char === "\r") {
+        this.flushCarriageReturn();
+        continue;
+      }
+
+      if (char === "\n") {
+        this.flushNewline();
+        continue;
+      }
+
+      this.currentLine += char;
+    }
+  }
+
+  finish(): void {
+    if (!this.currentLine) {
+      return;
+    }
+
+    if (this.lastWasCR) {
+      this.replaceLine(this.currentLine);
+    } else {
+      this.appendLine(this.currentLine);
+    }
+    this.currentLine = "";
+    this.lastWasCR = false;
+  }
+
+  private handleCsi(sequence: string): void {
+    const match = sequence.match(/^\x1b\[([0-9;?]*)([@-~])$/);
+    if (!match) {
+      return;
+    }
+
+    const [, rawParams, command] = match;
+    const params = rawParams.replace(/^\?/, "").split(";").filter(Boolean);
+
+    if (command === "A" || command === "F") {
+      this.rewindLines(parseCursorCount(params[0] ?? ""));
+      return;
+    }
+
+    if (command === "H" || command === "f") {
+      this.rewindLines(this.streamLineCount);
+      this.currentLine = "";
+      this.lastWasCR = false;
+    }
+  }
+
+  private flushCarriageReturn(): void {
+    this.replaceLine(this.currentLine);
+    this.currentLine = "";
+    this.lastWasCR = true;
+  }
+
+  private flushNewline(): void {
+    if (this.lastWasCR) {
+      this.replaceLine(this.currentLine);
+    } else {
+      this.appendLine(this.currentLine);
+    }
+    this.currentLine = "";
+    this.lastWasCR = false;
+  }
+
+  private appendLine(line: string): void {
+    this.sink.append(line);
+    this.streamLineCount += 1;
+    this.onLine?.(line);
+  }
+
+  private replaceLine(line: string): void {
+    this.sink.replace(line);
+    if (this.streamLineCount === 0) {
+      this.streamLineCount = 1;
+    }
+    this.onLine?.(line);
+  }
+
+  private rewindLines(count: number): void {
+    const actual = Math.min(count, this.streamLineCount);
+    if (actual <= 0) {
+      return;
+    }
+    this.sink.rewind(actual);
+    this.streamLineCount -= actual;
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -65,6 +65,7 @@ import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { isPinType, validatePinValue } from "./pins.js";
 import { randomUUID } from "node:crypto";
+import { ReleaseLogStreamProcessor } from "./release-log-stream.js";
 import {
   computeActivityStats,
   computeDailyStatus,
@@ -467,11 +468,6 @@ function rewindReleaseLog(job: ReleaseJob, count: number): void {
   }
 }
 
-/** Strip ANSI escape sequences for clean log display */
-function stripAnsi(str: string): string {
-  return str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
-}
-
 function setReleasePhase(job: ReleaseJob, phase: ReleasePhase, error?: string): void {
   job.phase = phase;
   broadcastReleaseEvent({ type: "phase", phase, error });
@@ -491,45 +487,14 @@ function streamProcess(
       stdio: ["ignore", "pipe", "pipe"]
     });
 
-    let buffer = "";
-    let lastWasCR = false;
+    const processor = new ReleaseLogStreamProcessor({
+      append: (line) => appendReleaseLog(job, line),
+      replace: (line) => replaceReleaseLog(job, line),
+      rewind: (count) => rewindReleaseLog(job, count)
+    }, onLine);
+
     const processChunk = (chunk: Buffer): void => {
-      buffer += chunk.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const rawLine of lines) {
-        // Detect ANSI cursor-up sequence (ESC[<N>A) used by tools like
-        // `gh run watch` to redraw multi-line output blocks in-place.
-        const cursorUpMatch = rawLine.match(/\x1b\[(\d+)A/);
-        if (cursorUpMatch) {
-          rewindReleaseLog(job, parseInt(cursorUpMatch[1], 10));
-        }
-
-        const line = stripAnsi(rawLine);
-
-        // A line may contain \r-separated segments (in-place terminal updates).
-        // Only the final segment matters; earlier ones were meant to be overwritten.
-        const crParts = line.split("\r").filter(Boolean);
-        if (crParts.length > 1 || lastWasCR) {
-          // Replace the previous log entry with the last \r segment
-          const final = crParts[crParts.length - 1] ?? "";
-          replaceReleaseLog(job, final);
-          onLine?.(final);
-        } else {
-          appendReleaseLog(job, crParts[0] ?? line);
-          onLine?.(crParts[0] ?? line);
-        }
-        lastWasCR = false;
-      }
-      // If the remaining buffer contains \r, the next output will overwrite
-      if (buffer.includes("\r")) {
-        const crParts = buffer.split("\r").filter(Boolean);
-        const final = crParts[crParts.length - 1] ?? "";
-        replaceReleaseLog(job, final);
-        onLine?.(final);
-        buffer = "";
-        lastWasCR = true;
-      }
+      processor.push(chunk);
     };
 
     child.stdout.on("data", processChunk);
@@ -537,10 +502,7 @@ function streamProcess(
 
     child.on("error", (err) => reject(err));
     child.on("close", (code) => {
-      if (buffer) {
-        appendReleaseLog(job, buffer);
-        onLine?.(buffer);
-      }
+      processor.finish();
       if (code !== 0) {
         reject(new Error(`Process exited with code ${code}`));
       } else {

--- a/apps/server/test/release-log-stream.test.ts
+++ b/apps/server/test/release-log-stream.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { ReleaseLogStreamProcessor } from "../src/release-log-stream.js";
+
+function createHarness() {
+  const log: string[] = [];
+
+  const processor = new ReleaseLogStreamProcessor({
+    append(line) {
+      log.push(line);
+    },
+    replace(line) {
+      if (log.length > 0) {
+        log[log.length - 1] = line;
+      } else {
+        log.push(line);
+      }
+    },
+    rewind(count) {
+      if (count > 0) {
+        log.splice(-count);
+      }
+    }
+  });
+
+  return { log, processor };
+}
+
+describe("ReleaseLogStreamProcessor", () => {
+  it("dedupes cursor-up redraw blocks", () => {
+    const { log, processor } = createHarness();
+
+    processor.push("* main Release · 12345\n");
+    processor.push("Triggered via workflow_dispatch\n");
+    processor.push("\nJOBS\n");
+    processor.push("* release (ID 999)\n");
+    processor.push("✓ Set up job\n");
+    processor.push("* Install dependencies\n");
+    processor.push("* Build\n");
+    processor.push("Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n");
+
+    processor.push("\x1b[9A\x1b[J");
+    processor.push("* main Release · 12345\n");
+    processor.push("Triggered via workflow_dispatch\n");
+    processor.push("\nJOBS\n");
+    processor.push("* release (ID 999)\n");
+    processor.push("✓ Set up job\n");
+    processor.push("✓ Install dependencies\n");
+    processor.push("* Build\n");
+    processor.push("Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n");
+
+    processor.push("\x1b[9A\x1b[J");
+    processor.push("✓ main Release · 12345\n");
+    processor.push("Triggered via workflow_dispatch\n");
+    processor.push("\nJOBS\n");
+    processor.push("✓ release (ID 999)\n");
+    processor.push("✓ Set up job\n");
+    processor.push("✓ Install dependencies\n");
+    processor.push("✓ Build\n\n");
+    processor.finish();
+
+    expect(log).toEqual([
+      "✓ main Release · 12345",
+      "Triggered via workflow_dispatch",
+      "",
+      "JOBS",
+      "✓ release (ID 999)",
+      "✓ Set up job",
+      "✓ Install dependencies",
+      "✓ Build",
+      ""
+    ]);
+  });
+
+  it("handles full redraws via cursor-home sequences", () => {
+    const { log, processor } = createHarness();
+
+    processor.push("* first pass\n");
+    processor.push("* still running\n");
+    processor.push("\x1b[H\x1b[J");
+    processor.push("✓ completed\n");
+    processor.finish();
+
+    expect(log).toEqual(["✓ completed"]);
+  });
+
+  it("handles split ansi chunks and carriage-return replacements", () => {
+    const { log, processor } = createHarness();
+
+    processor.push("Downloading");
+    processor.push("\r");
+    processor.push("Downloading.");
+    processor.push("\rDownloading..\n");
+
+    processor.push("\x1b[");
+    processor.push("1A\x1b[J");
+    processor.push("Done\n");
+    processor.finish();
+
+    expect(log).toEqual(["Done"]);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -627,6 +627,7 @@ export function DashboardLayout(): JSX.Element {
             mediaFiles={mediaFiles}
             selectedAgentId={focusedAgentId}
             selectedAgentName={focusedAgent?.name ?? null}
+            selectedAgentWorkspaceRoot={focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null}
             selectedAgentPins={focusedAgent?.pins ?? []}
             animatingMediaKeys={animatingMediaKeys}
             unseenMediaCount={unseenMediaCount}
@@ -694,6 +695,7 @@ export function DashboardLayout(): JSX.Element {
               mediaFiles={mediaFiles}
               selectedAgentId={focusedAgentId}
               selectedAgentName={focusedAgent?.name ?? null}
+              selectedAgentWorkspaceRoot={focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null}
               selectedAgentPins={focusedAgent?.pins ?? []}
               animatingMediaKeys={animatingMediaKeys}
               unseenMediaCount={unseenMediaCount}

--- a/apps/web/src/components/app/agent-meta.tsx
+++ b/apps/web/src/components/app/agent-meta.tsx
@@ -10,7 +10,19 @@ type AgentMetaProps = {
   truncateStart?: boolean;
 };
 
-export function FrontTruncatedValue({ value, mono }: { value: string; mono: boolean }): JSX.Element {
+type FrontTruncatedValueProps = {
+  value: string;
+  mono: boolean;
+  className?: string;
+  tooltipClassName?: string;
+};
+
+export function FrontTruncatedValue({
+  value,
+  mono,
+  className,
+  tooltipClassName,
+}: FrontTruncatedValueProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
   const [display, setDisplay] = useState(value);
 
@@ -53,12 +65,12 @@ export function FrontTruncatedValue({ value, mono }: { value: string; mono: bool
       <TooltipTrigger asChild>
         <div
           ref={containerRef}
-          className={cn("text-foreground whitespace-nowrap overflow-hidden", mono && "font-mono text-[11px]")}
+          className={cn("text-foreground whitespace-nowrap overflow-hidden", mono && "font-mono text-[11px]", className)}
         >
           {display}
         </div>
       </TooltipTrigger>
-      <TooltipContent side="right" className="max-w-[360px] break-all text-xs font-mono">
+      <TooltipContent side="right" className={cn("max-w-[360px] break-all text-xs font-mono", tooltipClassName)}>
         {value}
       </TooltipContent>
     </Tooltip>

--- a/apps/web/src/components/app/agent-meta.tsx
+++ b/apps/web/src/components/app/agent-meta.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useLayoutEffect } from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type AgentMetaProps = {
@@ -63,19 +63,22 @@ export function FrontTruncatedValue({
   }, [value]);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          ref={containerRef}
-          className={cn("text-foreground whitespace-nowrap overflow-hidden", mono && "font-mono text-[11px]", className)}
-        >
-          {display}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent side="right" className={cn("max-w-[360px] break-all text-xs font-mono", tooltipClassName)}>
-        {tooltipValue ?? value}
-      </TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            ref={containerRef}
+            className={cn("text-foreground whitespace-nowrap overflow-hidden", mono && "font-mono text-[11px]", className)}
+            title={tooltipValue ?? value}
+          >
+            {display}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="right" className={cn("max-w-[360px] break-all text-xs font-mono", tooltipClassName)}>
+          {tooltipValue ?? value}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/apps/web/src/components/app/agent-meta.tsx
+++ b/apps/web/src/components/app/agent-meta.tsx
@@ -15,6 +15,7 @@ type FrontTruncatedValueProps = {
   mono: boolean;
   className?: string;
   tooltipClassName?: string;
+  tooltipValue?: string;
 };
 
 export function FrontTruncatedValue({
@@ -22,6 +23,7 @@ export function FrontTruncatedValue({
   mono,
   className,
   tooltipClassName,
+  tooltipValue,
 }: FrontTruncatedValueProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
   const [display, setDisplay] = useState(value);
@@ -71,7 +73,7 @@ export function FrontTruncatedValue({
         </div>
       </TooltipTrigger>
       <TooltipContent side="right" className={cn("max-w-[360px] break-all text-xs font-mono", tooltipClassName)}>
-        {value}
+        {tooltipValue ?? value}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -19,6 +19,7 @@ type MediaSidebarSharedProps = {
   mediaFiles: MediaFile[];
   selectedAgentId: string | null;
   selectedAgentName: string | null;
+  selectedAgentWorkspaceRoot: string | null;
   selectedAgentPins: AgentPin[];
   animatingMediaKeys: Set<string>;
   mediaViewportRef: RefObject<HTMLDivElement>;
@@ -175,6 +176,7 @@ export function MediaSidebarContent({
   mediaFiles,
   selectedAgentId,
   selectedAgentName,
+  selectedAgentWorkspaceRoot,
   selectedAgentPins,
   animatingMediaKeys,
   mediaViewportRef,
@@ -254,7 +256,11 @@ export function MediaSidebarContent({
 
       {/* Tab content — both panels stay mounted so refs (e.g. IntersectionObserver) remain attached */}
       <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "pins" && "hidden")}>
-        <PinsPanel pins={selectedAgentPins} selectedAgentName={selectedAgentName} />
+        <PinsPanel
+          pins={selectedAgentPins}
+          selectedAgentName={selectedAgentName}
+          selectedAgentWorkspaceRoot={selectedAgentWorkspaceRoot}
+        />
       </div>
       <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "media" && "hidden")}>
         <MediaContent

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy, ExternalLink, FileText, GitPullRequest } from "lucide-react";
 
+import { FrontTruncatedValue } from "@/components/app/agent-meta";
 import { type AgentPin } from "@/components/app/types";
 import { Markdown } from "@/components/ui/markdown";
 import { useCopyText } from "@/hooks/use-copy";
@@ -30,6 +31,24 @@ function CopyButton({ value, title }: { value: string; title?: string }): JSX.El
 }
 
 type ResolvedValue = { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | "file" | null };
+
+function trimFilenameForDisplay(value: string, workspaceRoot: string | null): string {
+  if (!workspaceRoot) {
+    return value;
+  }
+
+  const normalizedRoot = workspaceRoot.endsWith("/") ? workspaceRoot.slice(0, -1) : workspaceRoot;
+  if (!normalizedRoot) {
+    return value;
+  }
+
+  if (value === normalizedRoot) {
+    return ".";
+  }
+
+  const prefix = `${normalizedRoot}/`;
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
 
 function shouldRenderMarkdownAsPlainText(value: string): boolean {
   const sanitized = value.replace(/```[^\n]*\n[\s\S]*?```/g, "");
@@ -95,12 +114,21 @@ function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedVal
   return { display: value, tooltip: value, href: null, badge: false, icon: null };
 }
 
-function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string }): JSX.Element {
+function PinValueRow({
+  type,
+  value,
+  workspaceRoot,
+}: {
+  type: AgentPin["type"];
+  value: string;
+  workspaceRoot: string | null;
+}): JSX.Element {
   if (type === "markdown") {
     return <MarkdownPinBody value={value} />;
   }
 
-  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, value);
+  const displayValue = type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : value;
+  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, displayValue);
 
   return (
     <div className="flex items-center gap-1.5">
@@ -117,12 +145,21 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
           {display}
         </a>
       ) : badge ? (
-        <span
-          className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
-          title={tooltip}
-        >
-          {display}
-        </span>
+        type === "filename" ? (
+          <FrontTruncatedValue
+            value={display}
+            mono
+            className="min-w-0 rounded bg-muted px-1.5 py-0.5"
+            tooltipClassName="max-w-[480px]"
+          />
+        ) : (
+          <span
+            className="min-w-0 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+            title={tooltip}
+          >
+            {display}
+          </span>
+        )
       ) : (
         <ScrollArea className="min-w-0 max-h-32">
           {type === "string" ? (
@@ -151,7 +188,7 @@ function PinValueRow({ type, value }: { type: AgentPin["type"]; value: string })
   );
 }
 
-function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
+function PinItem({ pin, workspaceRoot }: { pin: AgentPin; workspaceRoot: string | null }): JSX.Element {
   const values = splitPinValues(pin.type, pin.value);
   const isMulti = values.length > 1;
 
@@ -167,7 +204,7 @@ function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
       </div>
       <div className="flex flex-col gap-1 mt-1">
         {values.map((v, i) => (
-          <PinValueRow key={i} type={pin.type} value={v} />
+          <PinValueRow key={i} type={pin.type} value={v} workspaceRoot={workspaceRoot} />
         ))}
       </div>
     </div>
@@ -177,9 +214,10 @@ function PinItem({ pin }: { pin: AgentPin }): JSX.Element {
 type PinsPanelProps = {
   pins: AgentPin[];
   selectedAgentName: string | null;
+  selectedAgentWorkspaceRoot: string | null;
 };
 
-export function PinsPanel({ pins, selectedAgentName }: PinsPanelProps): JSX.Element {
+export function PinsPanel({ pins, selectedAgentName, selectedAgentWorkspaceRoot }: PinsPanelProps): JSX.Element {
   if (pins.length === 0) {
     return (
       <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
@@ -193,7 +231,7 @@ export function PinsPanel({ pins, selectedAgentName }: PinsPanelProps): JSX.Elem
   return (
     <div className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
       {pins.map((pin) => (
-        <PinItem key={pin.label.toLowerCase()} pin={pin} />
+        <PinItem key={pin.label.toLowerCase()} pin={pin} workspaceRoot={selectedAgentWorkspaceRoot} />
       ))}
     </div>
   );

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -32,22 +32,24 @@ function CopyButton({ value, title }: { value: string; title?: string }): JSX.El
 
 type ResolvedValue = { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | "file" | null };
 
-function trimFilenameForDisplay(value: string, workspaceRoot: string | null): string {
+function trimFilenameForDisplay(value: string, workspaceRoot: string | null): { display: string; tooltip: string } {
   if (!workspaceRoot) {
-    return value;
+    return { display: value, tooltip: value };
   }
 
   const normalizedRoot = workspaceRoot.endsWith("/") ? workspaceRoot.slice(0, -1) : workspaceRoot;
   if (!normalizedRoot) {
-    return value;
+    return { display: value, tooltip: value };
   }
 
   if (value === normalizedRoot) {
-    return ".";
+    return { display: "./", tooltip: value };
   }
 
   const prefix = `${normalizedRoot}/`;
-  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+  return value.startsWith(prefix)
+    ? { display: value.slice(prefix.length), tooltip: value }
+    : { display: value, tooltip: value };
 }
 
 function shouldRenderMarkdownAsPlainText(value: string): boolean {
@@ -127,8 +129,9 @@ function PinValueRow({
     return <MarkdownPinBody value={value} />;
   }
 
-  const displayValue = type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : value;
-  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, displayValue);
+  const filenameValue = type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : null;
+  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, filenameValue?.display ?? value);
+  const tooltipValue = filenameValue?.tooltip ?? tooltip;
 
   return (
     <div className="flex items-center gap-1.5">
@@ -151,6 +154,7 @@ function PinValueRow({
             mono
             className="min-w-0 rounded bg-muted px-1.5 py-0.5"
             tooltipClassName="max-w-[480px]"
+            tooltipValue={tooltipValue}
           />
         ) : (
           <span

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -97,7 +97,8 @@ test.describe("Media sidebar", () => {
   });
 
   test("preserves string pin whitespace and splits filename pins", async ({ page, request }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-pins-${Date.now()}` });
+    const workspaceRoot = process.cwd();
+    const agent = await createAgentViaAPI(request, { name: `e2e-agent-pins-${Date.now()}`, cwd: workspaceRoot });
     await setAgentPinsViaDB(agent.id, [
       { label: "Notes", type: "string", value: "line 1\n\n  line 2" },
       {
@@ -106,6 +107,7 @@ test.describe("Media sidebar", () => {
         value: "**Status**\n- Ready for review\n- URL: https://example.com/visible\n- Branch: `feat/log-rotation`\n- Owner: **Dispatch**\n- Marker: 🚀\n- Step: validate in sidebar\n- Step: keep lines wrapped\n\n```sh\npnpm run check\npnpm run test\npnpm run finalize:web\npnpm run test:e2e\nnpm run lint || true\n```",
       },
       { label: "Files", type: "filename", value: "one.ts,\ntwo.ts\nthree.ts" },
+      { label: "Long file", type: "filename", value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx` },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
       { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
       { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
@@ -144,6 +146,11 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("one.ts", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("two.ts", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("three.ts", { exact: true })).toBeVisible();
+    const longFilePin = mediaSidebar.locator("[data-pin-label='Long file']");
+    await expect(longFilePin).toContainText("pins-panel.tsx");
+    await expect(longFilePin).toContainText("apps/web/src/components/app/pins-panel.tsx");
+    await expect(longFilePin).not.toContainText(workspaceRoot);
+    await expect(longFilePin).not.toContainText("pins-panel.tsx/");
     await expect(mediaSidebar.getByText("3000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("4000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -1,6 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { cleanupE2EAgents, createAgentViaAPI, loadApp, setAgentPinsViaDB, uploadMediaViaAPI } from "./helpers";
+
+async function openMediaSidebarForAgent(page: Page, agent: { id: string; name: string }) {
+  await page.getByText(agent.name, { exact: true }).click();
+  await expect(page.getByTestId(`agent-card-${agent.id}`)).toHaveClass(/bg-muted\/60/);
+  const toggle = page.getByTestId("toggle-media-sidebar");
+  await expect(toggle).toBeVisible();
+  await toggle.evaluate((el) => (el as HTMLButtonElement).click());
+}
 
 test.describe("Media sidebar", () => {
   test.afterAll(async ({ request }) => {
@@ -15,8 +23,7 @@ test.describe("Media sidebar", () => {
 
     await loadApp(page);
 
-    await page.getByText(firstAgent.name, { exact: true }).click();
-    await page.getByTestId("toggle-media-sidebar").click();
+    await openMediaSidebarForAgent(page, firstAgent);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
@@ -44,8 +51,7 @@ test.describe("Media sidebar", () => {
 
     await loadApp(page);
 
-    await page.getByText(agent.name, { exact: true }).click();
-    await page.getByTestId("toggle-media-sidebar").click();
+    await openMediaSidebarForAgent(page, agent);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
@@ -78,8 +84,7 @@ test.describe("Media sidebar", () => {
     await uploadMediaViaAPI(request, agent.id, "Seen test image", "seen-test.png");
 
     await loadApp(page);
-    await page.getByText(agent.name, { exact: true }).click();
-    await page.getByTestId("toggle-media-sidebar").click();
+    await openMediaSidebarForAgent(page, agent);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
@@ -107,6 +112,7 @@ test.describe("Media sidebar", () => {
         value: "**Status**\n- Ready for review\n- URL: https://example.com/visible\n- Branch: `feat/log-rotation`\n- Owner: **Dispatch**\n- Marker: 🚀\n- Step: validate in sidebar\n- Step: keep lines wrapped\n\n```sh\npnpm run check\npnpm run test\npnpm run finalize:web\npnpm run test:e2e\nnpm run lint || true\n```",
       },
       { label: "Files", type: "filename", value: "one.ts,\ntwo.ts\nthree.ts" },
+      { label: "Workspace root", type: "filename", value: workspaceRoot },
       { label: "Long file", type: "filename", value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx` },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
       { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
@@ -117,14 +123,13 @@ test.describe("Media sidebar", () => {
 
     await loadApp(page);
 
-    await page.getByText(agent.name, { exact: true }).click();
-    await page.getByTestId("toggle-media-sidebar").click();
+    await openMediaSidebarForAgent(page, agent);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
 
-    const notesText = await mediaSidebar.locator("[data-pin-label='Notes'] pre").textContent();
-    expect(notesText).toBe("line 1\n\n  line 2");
+    const notesPre = mediaSidebar.locator("[data-pin-label='Notes'] pre");
+    await expect(notesPre).toHaveText("line 1\n\n  line 2");
 
     const markdownPin = mediaSidebar.locator("[data-pin-label='Summary'] [data-testid='markdown-pin-body']");
     await expect(markdownPin.getByText("Status", { exact: true })).toBeVisible();
@@ -146,6 +151,10 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("one.ts", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("two.ts", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("three.ts", { exact: true })).toBeVisible();
+    const workspaceRootPin = mediaSidebar.locator("[data-pin-label='Workspace root']");
+    await expect(workspaceRootPin).toContainText("./");
+    await workspaceRootPin.locator("div").nth(1).hover();
+    await expect(page.getByRole("tooltip")).toContainText(workspaceRoot);
     const longFilePin = mediaSidebar.locator("[data-pin-label='Long file']");
     await expect(longFilePin).toContainText("pins-panel.tsx");
     await expect(longFilePin).toContainText("apps/web/src/components/app/pins-panel.tsx");

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -127,6 +127,7 @@ test.describe("Media sidebar", () => {
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
+    await mediaSidebar.getByRole("button", { name: "Pins" }).evaluate((el) => (el as HTMLButtonElement).click());
 
     const notesPre = mediaSidebar.locator("[data-pin-label='Notes'] pre");
     await expect(notesPre).toHaveText("line 1\n\n  line 2");
@@ -153,8 +154,7 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("three.ts", { exact: true })).toBeVisible();
     const workspaceRootPin = mediaSidebar.locator("[data-pin-label='Workspace root']");
     await expect(workspaceRootPin).toContainText("./");
-    await workspaceRootPin.locator("div").nth(1).hover();
-    await expect(page.getByRole("tooltip")).toContainText(workspaceRoot);
+    await expect(workspaceRootPin.locator(`[title="${workspaceRoot}"]`)).toHaveText("./");
     const longFilePin = mediaSidebar.locator("[data-pin-label='Long file']");
     await expect(longFilePin).toContainText("pins-panel.tsx");
     await expect(longFilePin).toContainText("apps/web/src/components/app/pins-panel.tsx");


### PR DESCRIPTION
## Summary
- replace the release workflow log stream parser with a stateful processor that handles redraw/control sequences so `gh run watch` updates in place instead of duplicating blocks
- trim filename pins relative to the focused agent workspace and keep front truncation for long values without bidi slash artifacts
- add regression coverage for both the release log parser and the pins sidebar behavior

## Root Cause
- the release log handler only understood a narrow subset of terminal redraw behavior, so newer `gh run watch` output could leave duplicate blocks in the UI
- filename pins were using a display-direction trick to force left clipping, which reordered leading `/` characters and produced confusing trailing slash artifacts

## Impact
- release workflow logs in Settings > Updates should update in place again instead of appending duplicate snapshots
- pinned filenames are easier to scan because they prefer paths relative to the current agent workspace and still truncate from the front when needed

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- manual Playwright validation on an isolated dev stack
