### PR TITLE
[codex] Add dispatch job execution foundation

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -92,6 +92,7 @@ type CreateAgentInput = {
   parentAgentId?: string;
   personaContext?: string;
   cliSessionId?: string;
+  jobRunId?: string;
 };
 
 type WorktreeCleanupMode = "auto" | "keep" | "force";
@@ -284,7 +285,7 @@ export class AgentManager {
         await this.ensureNoExistingSession(tmuxSession);
 
         // Build the agent command that the setup script will exec into
-        const agentCommand = this.buildAgentCommand(type, agentArgs, mediaDir, tmuxSession, fullAccess, cliSessionId ?? undefined, false);
+        const agentCommand = this.buildAgentCommand(type, agentArgs, mediaDir, tmuxSession, fullAccess, cliSessionId ?? undefined, false, input.jobRunId);
         const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
 
         // Generate a setup script that handles worktree creation, env copy,
@@ -300,6 +301,7 @@ export class AgentManager {
           agentName: name,
           agentCommand,
           exitFile,
+          jobRunId: input.jobRunId,
         });
 
         const setupScriptPath = `/tmp/dispatch_setup_${id}.sh`;
@@ -1456,21 +1458,23 @@ export class AgentManager {
     sessionName: string,
     fullAccess: boolean,
     cliSessionId?: string,
-    resume?: boolean
+    resume?: boolean,
+    jobRunId?: string
   ): string {
     const agentId = this.agentIdFromSessionName(sessionName);
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
-    const launchGuidance =
-      `[dispatch:${agentId}] ` +
-      "Dispatch startup rules: " +
-      "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
-      "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
-      "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
-      "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
-      "Use dispatch_pin to surface key info in the sidebar, especially values users may need to copy/paste later such as URLs, commands, branch names, IDs, tokens, simulator UDIDs, and other short reusable values. Update pins when values change; delete stale ones. " +
-      "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
-      "For longer artifacts, write to a file via dispatch_share and pin a reference.";
+    const launchGuidance = jobRunId
+      ? `[dispatch:${agentId}] Dispatch job startup rules: You are running a Dispatch job run (${jobRunId}). Do not use normal agent lifecycle tools such as dispatch_event; job agents have a dedicated MCP route. Use job_log for progress, use repo tools when relevant, and call a job terminal tool when the job is complete, failed, or needs input.`
+      : `[dispatch:${agentId}] ` +
+        "Dispatch startup rules: " +
+        "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
+        "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
+        "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
+        "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
+        "Use dispatch_pin to surface key info in the sidebar, especially values users may need to copy/paste later such as URLs, commands, branch names, IDs, tokens, simulator UDIDs, and other short reusable values. Update pins when values change; delete stale ones. " +
+        "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
+        "For longer artifacts, write to a file via dispatch_share and pin a reference.";
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(
@@ -1523,7 +1527,7 @@ export class AgentManager {
 
     const envPrefix = envPrefixParts.join(" ");
     const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
-    const dispatchMcpUrl = this.dispatchMcpUrl(agentId);
+    const dispatchMcpUrl = this.dispatchMcpUrl(agentId, jobRunId);
     const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
     const { passthroughArgs, appendedSystemPrompt } = this.normalizeAgentArgsForType(type, args);
 
@@ -1589,8 +1593,9 @@ export class AgentManager {
     return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(startupPrompt)}`;
   }
 
-  private dispatchMcpUrl(agentId: string): string {
-    return `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}/api/mcp/${agentId}`;
+  private dispatchMcpUrl(agentId: string, jobRunId?: string): string {
+    const path = jobRunId ? `/api/mcp/jobs/${jobRunId}/${agentId}` : `/api/mcp/${agentId}`;
+    return `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}${path}`;
   }
 
   private shellEscape(value: string): string {
@@ -1921,6 +1926,7 @@ export class AgentManager {
     agentName: string;
     agentCommand: string;
     exitFile: string;
+    jobRunId?: string;
   }): string {
     const {
       agentId,
@@ -2094,10 +2100,9 @@ export class AgentManager {
       ``,
     );
 
-    // Opencode: write opencode.json with dispatch MCP server config so the agent
-    // can call dispatch_event, dispatch_pin, etc.
+    // Opencode: write opencode.json with the Dispatch MCP server config.
     if (agentType === "opencode") {
-      const dispatchMcpUrl = this.dispatchMcpUrl(agentId);
+      const dispatchMcpUrl = this.dispatchMcpUrl(agentId, params.jobRunId);
       const mcpEntry = JSON.stringify({
         type: "remote",
         url: dispatchMcpUrl,

--- a/apps/server/src/db/migrations/0003_jobs.sql
+++ b/apps/server/src/db/migrations/0003_jobs.sql
@@ -1,0 +1,50 @@
+-- Dispatch Jobs foundation.
+
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id TEXT PRIMARY KEY,
+  directory TEXT NOT NULL,
+  name TEXT NOT NULL,
+  file_path TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  agent_type TEXT NOT NULL DEFAULT 'codex',
+  use_worktree BOOLEAN NOT NULL DEFAULT false,
+  branch_name TEXT,
+  full_access BOOLEAN NOT NULL DEFAULT false,
+  additional_instructions TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (directory, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_directory ON jobs(directory);
+CREATE INDEX IF NOT EXISTS idx_jobs_name ON jobs(name);
+
+CREATE TABLE IF NOT EXISTS job_runs (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  status TEXT NOT NULL,
+  report JSONB,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  pending_question TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  status_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  duration_ms INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_runs_job_id ON job_runs(job_id);
+CREATE INDEX IF NOT EXISTS idx_job_runs_agent_id ON job_runs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_job_runs_status ON job_runs(status);
+CREATE INDEX IF NOT EXISTS idx_job_runs_started_at ON job_runs(started_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_job_runs_one_active_per_job
+  ON job_runs(job_id)
+  WHERE status IN ('started', 'running', 'needs_input');
+
+-- Down Migration
+
+DROP TABLE IF EXISTS job_runs;
+DROP TABLE IF EXISTS jobs;

--- a/apps/server/src/jobs/cli.ts
+++ b/apps/server/src/jobs/cli.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+type ParsedArgs = {
+  command: "run";
+  name: string;
+  dir: string;
+  noWait: boolean;
+};
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const response = await fetch(`${resolveServerUrl()}/api/v1/jobs/run`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeader(),
+    },
+    body: JSON.stringify({
+      name: args.name,
+      directory: args.dir,
+      wait: !args.noWait,
+    }),
+  });
+
+  const text = await response.text();
+  let body: unknown = text;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+
+  if (!response.ok) {
+    const message = isRecord(body) && typeof body.error === "string" ? body.error : text || response.statusText;
+    throw new Error(message);
+  }
+
+  console.log(JSON.stringify(body, null, 2));
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  if (args[0] !== "jobs" || args[1] !== "run") {
+    usage();
+  }
+  const name = args[2];
+  if (!name || name.startsWith("-")) usage();
+  let dir = process.cwd();
+  let noWait = false;
+  for (let i = 3; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--dir") {
+      const value = args[++i];
+      if (!value) usage();
+      dir = value;
+      continue;
+    }
+    if (arg === "--no-wait") {
+      noWait = true;
+      continue;
+    }
+    usage();
+  }
+  return { command: "run", name, dir, noWait };
+}
+
+function resolveServerUrl(): string {
+  const explicit = process.env.DISPATCH_URL?.trim();
+  if (explicit) return explicit.replace(/\/+$/, "");
+  const host = process.env.DISPATCH_HOST?.trim() || "127.0.0.1";
+  const port = process.env.DISPATCH_PORT?.trim() || "6767";
+  const scheme = process.env.DISPATCH_SCHEME?.trim() || "http";
+  return `${scheme}://${host}:${port}`;
+}
+
+function authHeader(): Record<string, string> {
+  const token = process.env.DISPATCH_AUTH_TOKEN?.trim();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function usage(): never {
+  console.error("Usage: dispatch jobs run <name> --dir <directory> [--no-wait]");
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/server/src/jobs/parser.ts
+++ b/apps/server/src/jobs/parser.ts
@@ -1,0 +1,222 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type JobNotifyConfig = {
+  onComplete: string[];
+  onError: string[];
+  onNeedsInput: string[];
+};
+
+export type JobDefinition = {
+  name: string;
+  schedule: string | null;
+  timeoutMs: number;
+  needsInputTimeoutMs: number;
+  fullAccess: boolean;
+  notify: JobNotifyConfig;
+  body: string;
+  filePath: string;
+  directory: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_NEEDS_INPUT_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+export async function readJobDefinition(directory: string, name: string): Promise<JobDefinition> {
+  const normalizedName = normalizeJobName(name);
+  const normalizedDirectory = path.resolve(directory);
+  const filePath = path.join(normalizedDirectory, ".dispatch", "jobs", `${normalizedName}.md`);
+  const raw = await readFile(filePath, "utf8");
+  return parseJobDefinition(raw, { directory: normalizedDirectory, filePath, fallbackName: normalizedName });
+}
+
+export function parseJobDefinition(raw: string, opts: {
+  directory: string;
+  filePath: string;
+  fallbackName?: string;
+}): JobDefinition {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  const parsed = parseSimpleYaml(frontmatter);
+  const name = readString(parsed.name, "name") ?? opts.fallbackName;
+  if (!name) throw new Error("Job frontmatter must include name.");
+  const prompt = body.trim();
+  if (!prompt) throw new Error("Job markdown body must include prompt instructions.");
+
+  const schedule = readString(parsed.schedule, "schedule");
+  if (schedule && !isValidCronSchedule(schedule)) {
+    throw new Error("schedule must be a 5-field cron expression.");
+  }
+
+  return {
+    name,
+    schedule,
+    timeoutMs: parseDuration(readString(parsed.timeout, "timeout") ?? "30m", "timeout"),
+    needsInputTimeoutMs: parseDuration(readString(parsed.needs_input_timeout, "needs_input_timeout") ?? "24h", "needs_input_timeout"),
+    fullAccess: readBoolean(parsed.full_access, "full_access") ?? false,
+    notify: parseNotifyConfig(parsed.notify),
+    body: prompt,
+    filePath: opts.filePath,
+    directory: path.resolve(opts.directory)
+  };
+}
+
+function normalizeJobName(name: string): string {
+  const normalized = name.trim();
+  if (!normalized) throw new Error("Job name is required.");
+  if (normalized.includes("/") || normalized.includes("\\") || normalized === "." || normalized === "..") {
+    throw new Error("Job name must be a file stem, not a path.");
+  }
+  return normalized.endsWith(".md") ? normalized.slice(0, -3) : normalized;
+}
+
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } {
+  const normalized = raw.replace(/^\uFEFF/, "");
+  if (!normalized.startsWith("---\n") && !normalized.startsWith("---\r\n")) {
+    throw new Error("Job file must start with YAML frontmatter delimited by ---.");
+  }
+  const newline = normalized.startsWith("---\r\n") ? "\r\n" : "\n";
+  const close = normalized.indexOf(`${newline}---`, 3);
+  if (close === -1) throw new Error("Job frontmatter is missing closing --- delimiter.");
+  const afterClose = close + newline.length + 3;
+  const bodyStart = normalized.slice(afterClose).startsWith("\r\n") ? afterClose + 2 : normalized.slice(afterClose).startsWith("\n") ? afterClose + 1 : afterClose;
+  return {
+    frontmatter: normalized.slice(3 + newline.length, close),
+    body: normalized.slice(bodyStart)
+  };
+}
+
+function parseSimpleYaml(input: string): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let currentMap: Record<string, unknown> | null = null;
+  let currentListKey: string | null = null;
+  for (const [index, rawLine] of input.split(/\r?\n/).entries()) {
+    const line = stripComment(rawLine);
+    if (!line.trim()) continue;
+
+    const indent = line.match(/^\s*/)?.[0].length ?? 0;
+    const trimmed = line.trim();
+    if (indent > 0 && trimmed.startsWith("- ")) {
+      const list = currentMap && currentListKey ? currentMap[currentListKey] : null;
+      if (!Array.isArray(list)) {
+        throw new Error(`Unexpected frontmatter list item on line ${index + 1}: ${rawLine}`);
+      }
+      list.push(unwrapQuoted(trimmed.slice(2).trim()));
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+    if (!match) throw new Error(`Invalid frontmatter line ${index + 1}: ${rawLine}`);
+
+    const [, key, rawValue = ""] = match;
+    if (indent === 0) {
+      if (rawValue === "") {
+        const nested: Record<string, unknown> = {};
+        root[key] = nested;
+        currentMap = nested;
+      } else {
+        root[key] = parseScalar(rawValue);
+        currentMap = null;
+      }
+      currentListKey = null;
+      continue;
+    }
+
+    if (!currentMap) throw new Error(`Unexpected nested frontmatter line ${index + 1}: ${rawLine}`);
+    if (rawValue === "") {
+      currentMap[key] = [];
+      currentListKey = key;
+    } else {
+      currentMap[key] = parseScalar(rawValue);
+      currentListKey = null;
+    }
+  }
+  return root;
+}
+
+function stripComment(line: string): string {
+  let quoted = false;
+  let quote = "";
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if ((char === "'" || char === '"') && line[i - 1] !== "\\") {
+      if (!quoted) {
+        quoted = true;
+        quote = char;
+      } else if (quote === char) {
+        quoted = false;
+      }
+    }
+    if (!quoted && char === "#" && (i === 0 || /\s/.test(line[i - 1]))) {
+      return line.slice(0, i).trimEnd();
+    }
+  }
+  return line;
+}
+
+function parseScalar(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const body = trimmed.slice(1, -1).trim();
+    if (!body) return [];
+    return body.split(",").map((part) => unwrapQuoted(part.trim())).filter(Boolean);
+  }
+  return unwrapQuoted(trimmed);
+}
+
+function unwrapQuoted(value: string): string {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function readString(value: unknown, name: string): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") throw new Error(`${name} must be a string.`);
+  return value.trim();
+}
+
+function readBoolean(value: unknown, name: string): boolean | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "boolean") throw new Error(`${name} must be a boolean.`);
+  return value;
+}
+
+function parseNotifyConfig(value: unknown): JobNotifyConfig {
+  const notify = isRecord(value) ? value : {};
+  return {
+    onComplete: parseStringArray(notify.on_complete, "notify.on_complete"),
+    onError: parseStringArray(notify.on_error, "notify.on_error"),
+    onNeedsInput: parseStringArray(notify.on_needs_input, "notify.on_needs_input")
+  };
+}
+
+function parseStringArray(value: unknown, name: string): string[] {
+  if (value === undefined || value === null || value === "") return [];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${name} must be a string array.`);
+  }
+  return value.map((item) => item.trim()).filter(Boolean);
+}
+
+function parseDuration(value: string, name: string): number {
+  const match = value.trim().match(/^(\d+)(ms|s|m|h|d)$/);
+  if (!match) throw new Error(`${name} must be a duration like 30m, 24h, or 10s.`);
+  const amount = Number(match[1]);
+  if (!Number.isSafeInteger(amount) || amount <= 0) throw new Error(`${name} must be a positive duration.`);
+  const unit = match[2];
+  const multipliers: Record<string, number> = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+  return amount * multipliers[unit];
+}
+
+function isValidCronSchedule(value: string): boolean {
+  const fields = value.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  return fields.every((field) => field.length > 0 && /^[A-Za-z0-9*/,\-]+$/.test(field));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/server/src/jobs/report.ts
+++ b/apps/server/src/jobs/report.ts
@@ -1,0 +1,139 @@
+export type JobTaskStatus = "success" | "skipped" | "error";
+export type JobReportStatus = "completed" | "failed" | "running";
+
+export type JobReportError = {
+  message: string;
+  recoverable?: boolean;
+  action?: string;
+};
+
+export type JobReportLog = {
+  message: string;
+  level: "debug" | "info" | "warn" | "error";
+  createdAt: string;
+};
+
+export type JobReportTask = {
+  name: string;
+  status: JobTaskStatus;
+  summary: string;
+  errors?: JobReportError[];
+  logs?: JobReportLog[];
+};
+
+export type JobReport = {
+  status: JobReportStatus;
+  summary: string;
+  tasks: JobReportTask[];
+};
+
+export function validateTerminalJobReport(value: unknown, expectedStatus: "completed" | "failed"): JobReport {
+  const report = validateJobReport(value);
+  if (report.status !== expectedStatus) {
+    throw new Error(`report.status must be "${expectedStatus}".`);
+  }
+  return report;
+}
+
+export function validateJobReport(value: unknown): JobReport {
+  if (!isRecord(value)) throw new Error("report must be an object.");
+  const status = value.status;
+  if (status !== "completed" && status !== "failed" && status !== "running") {
+    throw new Error('report.status must be one of: "completed", "failed", "running".');
+  }
+  const summary = readNonEmptyString(value.summary, "report.summary");
+  if (!Array.isArray(value.tasks)) throw new Error("report.tasks must be an array.");
+  const tasks = value.tasks.map((task, index) => validateTask(task, index));
+  return { status, summary, tasks };
+}
+
+export function appendJobLog(report: JobReport | null, input: {
+  task: string;
+  message: string;
+  level: "debug" | "info" | "warn" | "error";
+}): JobReport {
+  const taskName = input.task.trim();
+  const message = input.message.trim();
+  if (!taskName) throw new Error("task must be a non-empty string.");
+  if (!message) throw new Error("message must be a non-empty string.");
+
+  const next: JobReport = report
+    ? {
+        status: report.status,
+        summary: report.summary,
+        tasks: report.tasks.map((task) => ({ ...task, errors: task.errors ? [...task.errors] : undefined, logs: task.logs ? [...task.logs] : undefined }))
+      }
+    : { status: "running", summary: "Job is running.", tasks: [] };
+
+  let task = next.tasks.find((candidate) => candidate.name === taskName);
+  if (!task) {
+    task = { name: taskName, status: "success", summary: "", logs: [] };
+    next.tasks.push(task);
+  }
+
+  task.logs = [
+    ...(task.logs ?? []),
+    {
+      message,
+      level: input.level,
+      createdAt: new Date().toISOString()
+    }
+  ];
+  return next;
+}
+
+function validateTask(value: unknown, index: number): JobReportTask {
+  if (!isRecord(value)) throw new Error(`report.tasks[${index}] must be an object.`);
+  const status = value.status;
+  if (status !== "success" && status !== "skipped" && status !== "error") {
+    throw new Error(`report.tasks[${index}].status must be one of: "success", "skipped", "error".`);
+  }
+  const task: JobReportTask = {
+    name: readNonEmptyString(value.name, `report.tasks[${index}].name`),
+    status,
+    summary: typeof value.summary === "string" ? value.summary : ""
+  };
+  if (value.errors !== undefined) {
+    if (!Array.isArray(value.errors)) throw new Error(`report.tasks[${index}].errors must be an array.`);
+    task.errors = value.errors.map((error, errorIndex) => validateTaskError(error, index, errorIndex));
+  }
+  if (value.logs !== undefined) {
+    if (!Array.isArray(value.logs)) throw new Error(`report.tasks[${index}].logs must be an array.`);
+    task.logs = value.logs.map((log, logIndex) => validateTaskLog(log, index, logIndex));
+  }
+  return task;
+}
+
+function validateTaskError(value: unknown, taskIndex: number, errorIndex: number): JobReportError {
+  if (!isRecord(value)) throw new Error(`report.tasks[${taskIndex}].errors[${errorIndex}] must be an object.`);
+  const error: JobReportError = {
+    message: readNonEmptyString(value.message, `report.tasks[${taskIndex}].errors[${errorIndex}].message`)
+  };
+  if (typeof value.recoverable === "boolean") error.recoverable = value.recoverable;
+  if (typeof value.action === "string") error.action = value.action;
+  return error;
+}
+
+function validateTaskLog(value: unknown, taskIndex: number, logIndex: number): JobReportLog {
+  if (!isRecord(value)) throw new Error(`report.tasks[${taskIndex}].logs[${logIndex}] must be an object.`);
+  const level = value.level;
+  if (level !== "debug" && level !== "info" && level !== "warn" && level !== "error") {
+    throw new Error(`report.tasks[${taskIndex}].logs[${logIndex}].level must be one of: "debug", "info", "warn", "error".`);
+  }
+  return {
+    message: readNonEmptyString(value.message, `report.tasks[${taskIndex}].logs[${logIndex}].message`),
+    level,
+    createdAt: typeof value.createdAt === "string" ? value.createdAt : new Date().toISOString()
+  };
+}
+
+function readNonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -1,0 +1,293 @@
+import { readFile } from "node:fs/promises";
+
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import type { AgentManager } from "../agents/manager.js";
+import type { AppConfig } from "../config.js";
+import { runCommand } from "@dispatch/shared/lib/run-command.js";
+import type { JobDefinition } from "./parser.js";
+import { readJobDefinition } from "./parser.js";
+import { JobStore, type JobRecord, type JobRunConfig, type JobRunRecord } from "./store.js";
+
+type RunJobInput = {
+  name: string;
+  directory: string;
+  wait?: boolean;
+};
+
+export type RunJobResult = {
+  jobId: string;
+  runId: string;
+  agentId: string;
+  status: JobRunRecord["status"];
+  report: JobRunRecord["report"];
+};
+
+const TERMINAL_STATUSES = new Set<JobRunRecord["status"]>(["completed", "failed", "timed_out", "crashed"]);
+const ACTIVE_RUN_STATUSES = new Set<JobRunRecord["status"]>(["started", "running", "needs_input"]);
+const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
+const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
+
+export class JobService {
+  private readonly store: JobStore;
+  private readonly monitors = new Map<string, Promise<JobRunRecord>>();
+
+  constructor(
+    pool: Pool,
+    private readonly agentManager: AgentManager,
+    private readonly logger: FastifyBaseLogger,
+    private readonly config: AppConfig
+  ) {
+    this.store = new JobStore(pool);
+  }
+
+  async runJob(input: RunJobInput): Promise<RunJobResult> {
+    const definition = await readJobDefinition(input.directory, input.name);
+    const job = await this.store.upsertJobFromDefinition(definition);
+    const activeRun = await this.store.findActiveRun(job.id);
+    if (activeRun) {
+      throw new Error(`Job "${job.name}" already has active run ${activeRun.id} (${activeRun.status}).`);
+    }
+
+    let run = await this.store.createRun(job.id, buildRunConfig(definition));
+    const prompt = buildJobPrompt(definition, {
+      jobId: job.id,
+      runId: run.id,
+      additionalInstructions: job.additionalInstructions
+    });
+
+    try {
+      const agent = await this.agentManager.createAgent({
+        name: `job-${job.name}-${run.id.slice(0, 8)}`,
+        type: job.agentType,
+        cwd: job.directory,
+        agentArgs: buildAgentArgs(job.agentType, prompt, job.fullAccess),
+        fullAccess: job.fullAccess,
+        useWorktree: job.useWorktree,
+        worktreeBranch: job.branchName ?? undefined,
+        jobRunId: run.id
+      });
+      run = await this.store.attachAgent(run.id, agent.id);
+      this.startMonitor(run.id);
+      if (input.wait !== false) {
+        run = await this.waitForTerminal(run.id);
+      }
+      return {
+        jobId: job.id,
+        runId: run.id,
+        agentId: agent.id,
+        status: run.status,
+        report: run.report
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const crashed = await this.markCrashed(run, `Job failed to start: ${message}`, "spawn-agent");
+      throw new Error(`Job run ${crashed.id} failed to start: ${message}`);
+    }
+  }
+
+  async reconcileActiveRuns(): Promise<void> {
+    const runs = await this.store.listActiveRuns();
+    for (const run of runs) {
+      this.startMonitor(run.id);
+    }
+  }
+
+  async getActiveRunForAgent(agentId: string): Promise<JobRunRecord | null> {
+    return await this.store.getActiveRunForAgent(agentId);
+  }
+
+  async getLatestRunForAgent(agentId: string): Promise<JobRunRecord | null> {
+    return await this.store.getLatestRunForAgent(agentId);
+  }
+
+  async completeRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+    const run = await this.store.completeRunForAgent(agentId, report);
+    this.monitors.delete(run.id);
+    return run;
+  }
+
+  async failRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+    const run = await this.store.failRunForAgent(agentId, report);
+    this.monitors.delete(run.id);
+    return run;
+  }
+
+  async markNeedsInputForAgent(agentId: string, question: string): Promise<JobRunRecord> {
+    return await this.store.markNeedsInputForAgent(agentId, question);
+  }
+
+  async logForAgent(
+    agentId: string,
+    input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+  ): Promise<JobRunRecord> {
+    return await this.store.logForAgent(agentId, input);
+  }
+
+  private startMonitor(runId: string): void {
+    if (this.monitors.has(runId)) return;
+    const monitor = this.monitorRun(runId)
+      .catch(async (error) => {
+        this.logger.warn({ err: error, runId }, "Job monitor failed.");
+        const run = await this.store.getRun(runId);
+        if (run && ACTIVE_RUN_STATUSES.has(run.status)) {
+          return await this.markCrashed(run, error instanceof Error ? error.message : String(error));
+        }
+        if (run) return run;
+        throw error;
+      })
+      .finally(() => {
+        this.monitors.delete(runId);
+      });
+    this.monitors.set(runId, monitor);
+  }
+
+  private async waitForTerminal(runId: string): Promise<JobRunRecord> {
+    const monitor = this.monitors.get(runId);
+    if (monitor) return await monitor;
+    const run = await this.store.getRun(runId);
+    if (!run) throw new Error(`Job run ${runId} not found.`);
+    return run;
+  }
+
+  private async monitorRun(runId: string): Promise<JobRunRecord> {
+    let current = await this.store.getRun(runId);
+    if (!current) throw new Error(`Job run ${runId} not found.`);
+
+    while (ACTIVE_RUN_STATUSES.has(current.status)) {
+      const now = Date.now();
+      const startedAt = new Date(current.startedAt).getTime();
+      const statusUpdatedAt = new Date(current.statusUpdatedAt).getTime();
+      if (now - startedAt >= current.config.timeoutMs) {
+        return await this.markTimedOut(current, "Job execution timeout elapsed before the agent reported completion.");
+      }
+      if (current.status === "needs_input" && now - statusUpdatedAt >= current.config.needsInputTimeoutMs) {
+        return await this.markTimedOut(current, "Job timed out waiting for human input.");
+      }
+      if (current.agentId && await this.agentSessionCrashed(current.agentId)) {
+        return await this.markCrashed(current, "Agent session ended before reporting a terminal job state.");
+      }
+      await sleep(2_000);
+      const refreshed = await this.store.getRun(runId);
+      if (!refreshed) throw new Error(`Job run ${runId} disappeared.`);
+      current = refreshed;
+    }
+
+    if (!TERMINAL_STATUSES.has(current.status)) {
+      this.logger.warn({ runId, status: current.status }, "Job monitor stopped on unexpected status.");
+    }
+    return current;
+  }
+
+  private async agentSessionCrashed(agentId: string): Promise<boolean> {
+    const agent = await this.agentManager.getAgent(agentId);
+    if (!agent) return true;
+    if (agent.status === "error" || agent.status === "stopped") return true;
+    if (this.config.agentRuntime === "inert") return false;
+    if (!agent.tmuxSession) return false;
+    const tmux = await runCommand("tmux", ["has-session", "-t", agent.tmuxSession], { allowedExitCodes: [0, 1] });
+    return tmux.exitCode !== 0;
+  }
+
+  private async markTimedOut(run: JobRunRecord, message: string): Promise<JobRunRecord> {
+    return await this.store.markTimedOut(run.id, {
+      status: "failed",
+      summary: message,
+      tasks: [
+        {
+          name: "guardrails",
+          status: "error",
+          summary: "The job runner timed out the execution.",
+          errors: [{ message, recoverable: true, action: "Inspect the agent session and rerun when ready." }]
+        }
+      ]
+    });
+  }
+
+  private async markCrashed(run: JobRunRecord, message: string, taskName = "guardrails"): Promise<JobRunRecord> {
+    const diagnostics = run.agentId ? await this.readAgentDiagnostics(run.agentId) : "";
+    const fullMessage = diagnostics ? `${message}\n\n${diagnostics}` : message;
+    this.logger.warn({ runId: run.id, agentId: run.agentId }, message);
+    return await this.store.markCrashed(run.id, {
+      status: "failed",
+      summary: message,
+      tasks: [
+        {
+          name: taskName,
+          status: "error",
+          summary: "The job runner detected an agent crash.",
+          errors: [{ message: fullMessage, recoverable: true, action: "Review the agent terminal logs and rerun the job." }]
+        }
+      ]
+    });
+  }
+
+  private async readAgentDiagnostics(agentId: string): Promise<string> {
+    const sections: string[] = [];
+    const setupLog = await readFile(`/tmp/dispatch_setup_${agentId}.log`, "utf8").catch(() => "");
+    if (setupLog.trim()) {
+      sections.push(`Setup log tail:\n${setupLog.trim().split("\n").slice(-20).join("\n")}`);
+    }
+
+    const agent = await this.agentManager.getAgent(agentId);
+    if (agent?.tmuxSession) {
+      const pane = await runCommand("tmux", ["capture-pane", "-pt", agent.tmuxSession], { allowedExitCodes: [0, 1] });
+      if (pane.exitCode === 0 && pane.stdout.trim()) {
+        sections.push(`Terminal pane tail:\n${pane.stdout.trim().split("\n").slice(-40).join("\n")}`);
+      }
+    }
+
+    return sections.join("\n\n");
+  }
+}
+
+function buildAgentArgs(agentType: JobRecord["agentType"], prompt: string, fullAccess: boolean): string[] {
+  const args = ["--append-system-prompt", prompt];
+  const fullAccessArg =
+    agentType === "claude"
+      ? CLAUDE_FULL_ACCESS_ARG
+      : agentType === "codex"
+        ? CODEX_FULL_ACCESS_ARG
+        : null;
+  return fullAccess && fullAccessArg ? [...args, fullAccessArg] : args;
+}
+
+function buildRunConfig(definition: JobDefinition): JobRunConfig {
+  return {
+    directory: definition.directory,
+    filePath: definition.filePath,
+    name: definition.name,
+    schedule: definition.schedule,
+    timeoutMs: definition.timeoutMs,
+    needsInputTimeoutMs: definition.needsInputTimeoutMs,
+    notify: definition.notify
+  };
+}
+
+function buildJobPrompt(definition: JobDefinition, opts: {
+  jobId: string;
+  runId: string;
+  additionalInstructions: JobRecord["additionalInstructions"];
+}): string {
+  const additional = opts.additionalInstructions?.trim()
+    ? `\n\nAdditional server-side instructions:\n${opts.additionalInstructions.trim()}`
+    : "";
+  return [
+    "You are running as a Dispatch Job agent.",
+    `Job ID: ${opts.jobId}`,
+    `Run ID: ${opts.runId}`,
+    "Use the job-specific MCP tools for lifecycle control.",
+    "Call job_log for task-level progress.",
+    "Call exactly one terminal tool before stopping: job_complete(report), job_failed(report), or job_needs_input(question).",
+    "Terminal completed/failed states must include a structured report with status, summary, and tasks.",
+    "Use repo tools when they are relevant to the job.",
+    additional,
+    "\nJob prompt:",
+    definition.body
+  ].filter(Boolean).join("\n");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -1,0 +1,305 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import type { Pool } from "pg";
+
+import type { JobDefinition } from "./parser.js";
+import { appendJobLog, validateJobReport, validateTerminalJobReport, type JobReport } from "./report.js";
+
+export type JobRunStatus = "started" | "running" | "completed" | "failed" | "needs_input" | "timed_out" | "crashed";
+export type JobAgentType = "claude" | "codex" | "opencode";
+
+export type JobRecord = {
+  id: string;
+  directory: string;
+  name: string;
+  filePath: string | null;
+  enabled: boolean;
+  agentType: JobAgentType;
+  useWorktree: boolean;
+  branchName: string | null;
+  fullAccess: boolean;
+  additionalInstructions: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type JobRunRecord = {
+  id: string;
+  jobId: string;
+  agentId: string | null;
+  status: JobRunStatus;
+  report: JobReport | null;
+  config: JobRunConfig;
+  pendingQuestion: string | null;
+  startedAt: string;
+  statusUpdatedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+  createdAt: string;
+};
+
+const ACTIVE_RUN_STATUSES: JobRunStatus[] = ["started", "running", "needs_input"];
+
+export type JobRunConfig = {
+  directory: string;
+  filePath: string;
+  name: string;
+  schedule: string | null;
+  timeoutMs: number;
+  needsInputTimeoutMs: number;
+  notify: JobDefinition["notify"];
+};
+
+export class JobStore {
+  constructor(private readonly pool: Pool) {}
+
+  async upsertJobFromDefinition(definition: JobDefinition): Promise<JobRecord> {
+    const id = randomUUID();
+    const result = await this.pool.query(
+      `
+      INSERT INTO jobs (id, directory, name, file_path, full_access)
+      VALUES ($1, $2, $3, $4, $5)
+      ON CONFLICT (directory, name)
+      DO UPDATE SET file_path = EXCLUDED.file_path, full_access = EXCLUDED.full_access, updated_at = NOW()
+      RETURNING ${this.jobColumns()}
+      `,
+      [id, path.resolve(definition.directory), definition.name, definition.filePath, definition.fullAccess]
+    );
+    return mapJob(result.rows[0]);
+  }
+
+  async findActiveRun(jobId: string): Promise<JobRunRecord | null> {
+    const result = await this.pool.query(
+      `
+      SELECT ${this.runColumns()}
+      FROM job_runs
+      WHERE job_id = $1 AND status = ANY($2::text[])
+      ORDER BY started_at DESC
+      LIMIT 1
+      `,
+      [jobId, ACTIVE_RUN_STATUSES]
+    );
+    return result.rows[0] ? mapRun(result.rows[0]) : null;
+  }
+
+  async createRun(jobId: string, config: JobRunConfig): Promise<JobRunRecord> {
+    const id = randomUUID();
+    try {
+      const result = await this.pool.query(
+        `
+        INSERT INTO job_runs (id, job_id, status, config)
+        VALUES ($1, $2, 'started', $3::jsonb)
+        RETURNING ${this.runColumns()}
+        `,
+        [id, jobId, JSON.stringify(config)]
+      );
+      return mapRun(result.rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        const activeRun = await this.findActiveRun(jobId);
+        throw new Error(`Job already has active run ${activeRun?.id ?? "unknown"}.`);
+      }
+      throw error;
+    }
+  }
+
+  async attachAgent(runId: string, agentId: string): Promise<JobRunRecord> {
+    const result = await this.pool.query(
+      `
+      UPDATE job_runs
+      SET agent_id = $2, status = 'running', status_updated_at = NOW()
+      WHERE id = $1
+      RETURNING ${this.runColumns()}
+      `,
+      [runId, agentId]
+    );
+    if (!result.rows[0]) throw new Error(`Job run ${runId} not found.`);
+    return mapRun(result.rows[0]);
+  }
+
+  async completeRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+    return this.setTerminalRunForAgent(agentId, "completed", validateTerminalJobReport(report, "completed"));
+  }
+
+  async failRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+    return this.setTerminalRunForAgent(agentId, "failed", validateTerminalJobReport(report, "failed"));
+  }
+
+  async markNeedsInputForAgent(agentId: string, question: string): Promise<JobRunRecord> {
+    const trimmed = question.trim();
+    if (!trimmed) throw new Error("question must be a non-empty string.");
+    const result = await this.pool.query(
+      `
+      UPDATE job_runs
+      SET status = 'needs_input',
+          pending_question = $2,
+          status_updated_at = NOW(),
+          completed_at = NULL,
+          duration_ms = NULL
+      WHERE agent_id = $1 AND status = ANY($3::text[])
+      RETURNING ${this.runColumns()}
+      `,
+      [agentId, trimmed, ACTIVE_RUN_STATUSES]
+    );
+    if (!result.rows[0]) throw new Error(`No active job run found for agent ${agentId}.`);
+    return mapRun(result.rows[0]);
+  }
+
+  async logForAgent(agentId: string, input: {
+    task: string;
+    message: string;
+    level: "debug" | "info" | "warn" | "error";
+  }): Promise<JobRunRecord> {
+    const run = await this.getActiveRunForAgent(agentId);
+    if (!run) throw new Error(`No active job run found for agent ${agentId}.`);
+    const report = appendJobLog(run.report, input);
+    const result = await this.pool.query(
+      `
+      UPDATE job_runs
+      SET report = $2::jsonb
+      WHERE id = $1
+      RETURNING ${this.runColumns()}
+      `,
+      [run.id, JSON.stringify(report)]
+    );
+    return mapRun(result.rows[0]);
+  }
+
+  async markTimedOut(runId: string, report: JobReport): Promise<JobRunRecord> {
+    return this.setTerminalRun(runId, "timed_out", validateJobReport(report));
+  }
+
+  async markCrashed(runId: string, report: JobReport): Promise<JobRunRecord> {
+    return this.setTerminalRun(runId, "crashed", validateJobReport(report));
+  }
+
+  async getRun(runId: string): Promise<JobRunRecord | null> {
+    const result = await this.pool.query(`SELECT ${this.runColumns()} FROM job_runs WHERE id = $1`, [runId]);
+    return result.rows[0] ? mapRun(result.rows[0]) : null;
+  }
+
+  async getActiveRunForAgent(agentId: string): Promise<JobRunRecord | null> {
+    const result = await this.pool.query(
+      `
+      SELECT ${this.runColumns()}
+      FROM job_runs
+      WHERE agent_id = $1 AND status = ANY($2::text[])
+      ORDER BY started_at DESC
+      LIMIT 1
+      `,
+      [agentId, ACTIVE_RUN_STATUSES]
+    );
+    return result.rows[0] ? mapRun(result.rows[0]) : null;
+  }
+
+  async getLatestRunForAgent(agentId: string): Promise<JobRunRecord | null> {
+    const result = await this.pool.query(
+      `
+      SELECT ${this.runColumns()}
+      FROM job_runs
+      WHERE agent_id = $1
+      ORDER BY started_at DESC
+      LIMIT 1
+      `,
+      [agentId]
+    );
+    return result.rows[0] ? mapRun(result.rows[0]) : null;
+  }
+
+  async listActiveRuns(): Promise<JobRunRecord[]> {
+    const result = await this.pool.query(
+      `
+      SELECT ${this.runColumns()}
+      FROM job_runs
+      WHERE status = ANY($1::text[])
+      ORDER BY started_at ASC
+      `,
+      [ACTIVE_RUN_STATUSES]
+    );
+    return result.rows.map((row) => mapRun(row));
+  }
+
+  private async setTerminalRunForAgent(
+    agentId: string,
+    status: "completed" | "failed",
+    report: JobReport
+  ): Promise<JobRunRecord> {
+    const run = await this.getActiveRunForAgent(agentId);
+    if (!run) throw new Error(`No active job run found for agent ${agentId}.`);
+    return this.setTerminalRun(run.id, status, report);
+  }
+
+  private async setTerminalRun(
+    runId: string,
+    status: Exclude<JobRunStatus, "started" | "running" | "needs_input">,
+    report: JobReport
+  ): Promise<JobRunRecord> {
+    const result = await this.pool.query(
+      `
+      UPDATE job_runs
+      SET status = $2,
+          report = $3::jsonb,
+          pending_question = NULL,
+          status_updated_at = NOW(),
+          completed_at = NOW(),
+          duration_ms = GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - started_at)) * 1000)::integer)
+      WHERE id = $1 AND status = ANY($4::text[])
+      RETURNING ${this.runColumns()}
+      `,
+      [runId, status, JSON.stringify(report), ACTIVE_RUN_STATUSES]
+    );
+    if (!result.rows[0]) {
+      const existing = await this.getRun(runId);
+      if (!existing) throw new Error(`Job run ${runId} not found.`);
+      throw new Error(`Job run ${runId} is no longer active (${existing.status}).`);
+    }
+    return mapRun(result.rows[0]);
+  }
+
+  private jobColumns(): string {
+    return `
+      id,
+      directory,
+      name,
+      file_path AS "filePath",
+      enabled,
+      agent_type AS "agentType",
+      use_worktree AS "useWorktree",
+      branch_name AS "branchName",
+      full_access AS "fullAccess",
+      additional_instructions AS "additionalInstructions",
+      created_at AS "createdAt",
+      updated_at AS "updatedAt"
+    `;
+  }
+
+  private runColumns(): string {
+    return `
+      id,
+      job_id AS "jobId",
+      agent_id AS "agentId",
+      status,
+      report,
+      config,
+      pending_question AS "pendingQuestion",
+      started_at AS "startedAt",
+      status_updated_at AS "statusUpdatedAt",
+      completed_at AS "completedAt",
+      duration_ms AS "durationMs",
+      created_at AS "createdAt"
+    `;
+  }
+}
+
+function mapJob(row: Record<string, unknown>): JobRecord {
+  return row as JobRecord;
+}
+
+function mapRun(row: Record<string, unknown>): JobRunRecord {
+  return row as JobRunRecord;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "23505";
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,6 +64,7 @@ import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { isPinType, validatePinValue } from "./pins.js";
+import { JobService } from "./jobs/service.js";
 import { randomUUID } from "node:crypto";
 import { ReleaseLogStreamProcessor } from "./release-log-stream.js";
 import {
@@ -85,6 +86,7 @@ const slackNotifier = new SlackNotifier(pool, app.log);
 slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 agentManager.onLatestEvent((agent) => void slackNotifier.onAgentEvent(agent));
 const terminalTokenStore = new TerminalTokenStore(60_000);
+const jobService = new JobService(pool, agentManager, app.log, config);
 const activeArchives = new Set<Promise<void>>();
 const archivingAgentIds = new Set<string>();
 
@@ -828,6 +830,11 @@ const ChangePasswordBodySchema = z.object({
   currentPassword: z.string().min(1, "Current password is required."),
   newPassword: z.string().min(8, "New password must be at least 8 characters."),
 });
+const RunJobBodySchema = z.object({
+  name: z.string().min(1, "Job name is required."),
+  directory: z.string().min(1, "Job directory is required."),
+  wait: z.boolean().optional(),
+});
 
 async function registerRoutes() {
   const cookieSecret = await getOrCreateCookieSecret(pool);
@@ -1018,6 +1025,24 @@ async function registerRoutes() {
   });
 
   // ---------------------------------------------------------------------------
+  // Jobs routes
+  // ---------------------------------------------------------------------------
+
+  app.post("/api/v1/jobs/run", async (request, reply) => {
+    const parsed = RunJobBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0].message });
+    }
+
+    try {
+      return await jobService.runJob(parsed.data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
   // MCP routes
   // ---------------------------------------------------------------------------
 
@@ -1026,12 +1051,53 @@ async function registerRoutes() {
     await handleMcpRequest(request.raw, reply.raw, request.body);
   });
 
+  app.post("/api/mcp/jobs/:runId/:agentId", async (request, reply) => {
+    const params = request.params as { runId?: string; agentId?: string };
+    const runId = params.runId ?? "";
+    const agentId = params.agentId ?? "";
+    const agent = await agentManager.getAgent(agentId);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+    const run = await jobService.getActiveRunForAgent(agentId);
+    if (!run || run.id !== runId || run.agentId !== agentId) {
+      return reply.code(404).send({ error: "Active job run not found for agent." });
+    }
+
+    let repoRoot: string | null = null;
+    let worktreeRoot: string | null = null;
+    try {
+      repoRoot = await resolveRepoRoot(agent.cwd);
+      worktreeRoot = await resolveWorktreeRoot(agent.cwd);
+    } catch {
+      // Agent may not be in a git repository — MCP still works, just without repo context.
+    }
+
+    reply.hijack();
+    await handleMcpRequest(request.raw, reply.raw, request.body, {
+      agent,
+      repoRoot,
+      worktreeRoot,
+      enableBuiltinTools: false,
+      jobTools: {
+        complete: mcpJobComplete,
+        failed: mcpJobFailed,
+        needsInput: mcpJobNeedsInput,
+        log: mcpJobLog,
+      },
+    });
+  });
+
   app.post("/api/mcp/:agentId", async (request, reply) => {
     const params = request.params as { agentId?: string };
     const agentId = params.agentId ?? "";
     const agent = await agentManager.getAgent(agentId);
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });
+    }
+    const jobRun = await jobService.getLatestRunForAgent(agentId);
+    if (jobRun) {
+      return reply.code(403).send({ error: "Job agents must use the job-scoped MCP route." });
     }
 
     let repoRoot: string | null = null;
@@ -2870,6 +2936,7 @@ async function start() {
   await runMigrations();
   config.authToken = await getOrCreateAuthToken(pool);
   await agentManager.reconcileAgents();
+  await jobService.reconcileActiveRuns();
   const agents = await agentManager.listAgents();
   queueGitContextRefresh(agents.map((agent) => agent.id));
   startGitContextRefreshLoop();
@@ -3636,6 +3703,29 @@ async function mcpDeletePin(
 ): Promise<void> {
   const agent = await agentManager.deletePin(agentId, label);
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+}
+
+async function mcpJobComplete(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {
+  const run = await jobService.completeRunForAgent(agentId, report);
+  return { runId: run.id, status: run.status };
+}
+
+async function mcpJobFailed(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {
+  const run = await jobService.failRunForAgent(agentId, report);
+  return { runId: run.id, status: run.status };
+}
+
+async function mcpJobNeedsInput(agentId: string, question: string): Promise<{ runId: string; status: string }> {
+  const run = await jobService.markNeedsInputForAgent(agentId, question);
+  return { runId: run.id, status: run.status };
+}
+
+async function mcpJobLog(
+  agentId: string,
+  input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+): Promise<{ runId: string; status: string }> {
+  const run = await jobService.logForAgent(agentId, input);
+  return { runId: run.id, status: run.status };
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/test/db/migrations.test.ts
+++ b/apps/server/test/db/migrations.test.ts
@@ -27,6 +27,8 @@ describe("migrations", () => {
     expect(tableNames).toContain("media");
     expect(tableNames).toContain("media_seen");
     expect(tableNames).toContain("simulator_reservations");
+    expect(tableNames).toContain("jobs");
+    expect(tableNames).toContain("job_runs");
     expect(tableNames).toContain("pgmigrations");
   });
 

--- a/apps/server/test/jobs/parser.test.ts
+++ b/apps/server/test/jobs/parser.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { parseJobDefinition } from "../../src/jobs/parser.js";
+
+describe("parseJobDefinition", () => {
+  it("parses job frontmatter and markdown body", () => {
+    const job = parseJobDefinition(`---
+name: janitor
+schedule: "0 * * * *"
+timeout: 10s
+needs_input_timeout: 2h
+full_access: true
+notify:
+  on_complete:
+    - slack
+  on_error:
+    - slack
+    - email
+  on_needs_input: []
+---
+# Clean up
+
+Remove stale files.
+`, { directory: "/tmp/repo", filePath: "/tmp/repo/.dispatch/jobs/janitor.md" });
+
+    expect(job.name).toBe("janitor");
+    expect(job.schedule).toBe("0 * * * *");
+    expect(job.timeoutMs).toBe(10_000);
+    expect(job.needsInputTimeoutMs).toBe(7_200_000);
+    expect(job.fullAccess).toBe(true);
+    expect(job.notify.onComplete).toEqual(["slack"]);
+    expect(job.notify.onError).toEqual(["slack", "email"]);
+    expect(job.body).toContain("Remove stale files.");
+  });
+
+  it("returns clear validation errors", () => {
+    expect(() => parseJobDefinition(`---
+name: bad
+timeout: forever
+---
+Body
+`, { directory: "/tmp/repo", filePath: "/tmp/repo/.dispatch/jobs/bad.md" })).toThrow("timeout must be a duration");
+  });
+
+  it("validates cron schedule shape", () => {
+    expect(() => parseJobDefinition(`---
+name: bad-schedule
+schedule: "* * *"
+---
+Body
+`, { directory: "/tmp/repo", filePath: "/tmp/repo/.dispatch/jobs/bad-schedule.md" })).toThrow("schedule must be a 5-field cron expression");
+  });
+});

--- a/apps/server/test/jobs/store.test.ts
+++ b/apps/server/test/jobs/store.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Pool } from "pg";
+
+import { JobStore } from "../../src/jobs/store.js";
+import { getTestDatabaseUrl, runTestMigrations, setupTestDb, teardownTestDb } from "../db/setup.js";
+
+let pool: Pool;
+let store: JobStore;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+  await runTestMigrations();
+  store = new JobStore(pool);
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+describe("JobStore", () => {
+  it("upserts jobs, tracks runs, and requires terminal structured reports", async () => {
+    expect(getTestDatabaseUrl()).toContain("dispatch_test_");
+    const job = await store.upsertJobFromDefinition({
+      name: "janitor",
+      schedule: null,
+      timeoutMs: 1_000,
+      needsInputTimeoutMs: 1_000,
+      fullAccess: false,
+      notify: { onComplete: [], onError: [], onNeedsInput: [] },
+      body: "Do work",
+      directory: "/tmp/repo",
+      filePath: "/tmp/repo/.dispatch/jobs/janitor.md"
+    });
+    const run = await store.createRun(job.id, {
+      directory: "/tmp/repo",
+      filePath: "/tmp/repo/.dispatch/jobs/janitor.md",
+      name: "janitor",
+      schedule: null,
+      timeoutMs: 1_000,
+      needsInputTimeoutMs: 1_000,
+      notify: { onComplete: [], onError: [], onNeedsInput: [] },
+    });
+    await expect(store.createRun(job.id, {
+      directory: "/tmp/repo",
+      filePath: "/tmp/repo/.dispatch/jobs/janitor.md",
+      name: "janitor",
+      schedule: null,
+      timeoutMs: 1_000,
+      needsInputTimeoutMs: 1_000,
+      notify: { onComplete: [], onError: [], onNeedsInput: [] },
+    })).rejects.toThrow(`Job already has active run ${run.id}.`);
+    await pool.query(
+      `INSERT INTO agents (id, name, status, cwd) VALUES ('agent-1', 'Job Agent', 'running', '/tmp/repo')`
+    );
+
+    await expect(store.findActiveRun(job.id)).resolves.toMatchObject({ id: run.id, status: "started" });
+    await store.attachAgent(run.id, "agent-1");
+    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({ id: run.id });
+    await store.logForAgent("agent-1", { task: "clean", message: "started", level: "info" });
+
+    await expect(store.completeRunForAgent("agent-1", {
+      status: "failed",
+      summary: "Wrong terminal status",
+      tasks: [{ name: "clean", status: "error", summary: "bad" }]
+    })).rejects.toThrow('report.status must be "completed"');
+
+    const completed = await store.completeRunForAgent("agent-1", {
+      status: "completed",
+      summary: "Finished",
+      tasks: [{ name: "clean", status: "success", summary: "ok" }]
+    });
+    expect(completed.status).toBe("completed");
+    expect(completed.report?.summary).toBe("Finished");
+    await expect(store.findActiveRun(job.id)).resolves.toBeNull();
+    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({ id: run.id, status: "completed" });
+
+    await expect(store.markTimedOut(run.id, {
+      status: "failed",
+      summary: "Late timeout",
+      tasks: [{ name: "guardrails", status: "error", summary: "too late" }]
+    })).rejects.toThrow("is no longer active (completed)");
+    await expect(store.failRunForAgent("agent-1", {
+      status: "failed",
+      summary: "Late failure",
+      tasks: [{ name: "clean", status: "error", summary: "too late" }]
+    })).rejects.toThrow("No active job run found for agent agent-1.");
+
+    const rerun = await store.createRun(job.id, {
+      directory: "/tmp/repo",
+      filePath: "/tmp/repo/.dispatch/jobs/janitor.md",
+      name: "janitor",
+      schedule: null,
+      timeoutMs: 1_000,
+      needsInputTimeoutMs: 1_000,
+      notify: { onComplete: [], onError: [], onNeedsInput: [] },
+    });
+    expect(rerun.status).toBe("started");
+  });
+});

--- a/bin/dispatch
+++ b/bin/dispatch
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "$ROOT_DIR/apps/server/dist/jobs/cli.js" ]]; then
+  exec node "$ROOT_DIR/apps/server/dist/jobs/cli.js" "$@"
+fi
+
+exec pnpm --dir "$ROOT_DIR" --filter @dispatch/server exec tsx src/jobs/cli.ts "$@"

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -187,15 +187,33 @@ cmd_up() {
     fi
 
     DEV_CONTAINER_SUFFIX="$SUFFIX"
-    DEV_DB_PORT="${RESTART_DB_PORT:-$(find_free_port)}"
     DEV_COMPOSE_PROJECT="dispatch-dev-${SUFFIX}"
 
-    echo "Starting database on port ${DEV_DB_PORT}..."
+    local db_attempt=1
+    local db_max_attempts=5
+    local compose_output
+    compose_output="$(log_dir)/db-up.log"
+    while [ $db_attempt -le $db_max_attempts ]; do
+      DEV_DB_PORT="${RESTART_DB_PORT:-$(find_free_port)}"
 
-    DISPATCH_DB_NAME="$DEV_CONTAINER_SUFFIX" DISPATCH_DB_PORT="$DEV_DB_PORT" \
-      $compose -f "${SCRIPT_DIR}/docker-compose.yml" -p "$DEV_COMPOSE_PROJECT" up -d --wait 2>&1
+      echo "Starting database on port ${DEV_DB_PORT}..."
 
-    echo "Database ready on port ${DEV_DB_PORT}"
+      if DISPATCH_DB_NAME="$DEV_CONTAINER_SUFFIX" DISPATCH_DB_PORT="$DEV_DB_PORT" \
+        $compose -f "${SCRIPT_DIR}/docker-compose.yml" -p "$DEV_COMPOSE_PROJECT" up -d --wait >"$compose_output" 2>&1; then
+        cat "$compose_output"
+        echo "Database ready on port ${DEV_DB_PORT}"
+        break
+      fi
+
+      cat "$compose_output"
+      if [ -n "${RESTART_DB_PORT:-}" ] || ! grep -q "address already in use" "$compose_output" || [ $db_attempt -eq $db_max_attempts ]; then
+        exit 1
+      fi
+
+      echo "Database port ${DEV_DB_PORT} was claimed before Docker could bind it; retrying..." >&2
+      $compose -f "${SCRIPT_DIR}/docker-compose.yml" -p "$DEV_COMPOSE_PROJECT" down -v >/dev/null 2>&1 || true
+      db_attempt=$((db_attempt + 1))
+    done
   fi
 
   # --- API Server ---

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -56,6 +56,16 @@ export type GetFeedbackResult = {
   personas: PersonaFeedbackGroup[];
 };
 
+export type JobTools = {
+  complete: (agentId: string, report: unknown) => Promise<{ runId: string; status: string }>;
+  failed: (agentId: string, report: unknown) => Promise<{ runId: string; status: string }>;
+  needsInput: (agentId: string, question: string) => Promise<{ runId: string; status: string }>;
+  log: (
+    agentId: string,
+    input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+  ) => Promise<{ runId: string; status: string }>;
+};
+
 export type PinInput = {
   label: string;
   value?: string;
@@ -100,6 +110,8 @@ export type McpRequestContext = {
     agentId: string,
     label: string
   ) => Promise<void>;
+  jobTools?: JobTools;
+  enableBuiltinTools?: boolean;
 };
 
 export async function handleMcpRequest(
@@ -128,59 +140,61 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   });
   const defaultCwd = context.agent?.cwd ?? undefined;
 
-  server.registerTool(
-    "create_pr",
-    {
-      description: "Create a GitHub pull request for the current branch.",
-      inputSchema: {
-        cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
-        baseBranch: z.string().default("main").describe("Base branch to target."),
-        title: z.string().optional().describe("Explicit PR title."),
-        body: z.string().optional().describe("Explicit PR body."),
-        draft: z.boolean().default(false).describe("Create the PR as a draft."),
-        fillFromCommits: z.boolean().default(false).describe("Let gh derive title/body from commits.")
+  if (context.enableBuiltinTools !== false) {
+    server.registerTool(
+      "create_pr",
+      {
+        description: "Create a GitHub pull request for the current branch.",
+        inputSchema: {
+          cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
+          baseBranch: z.string().default("main").describe("Base branch to target."),
+          title: z.string().optional().describe("Explicit PR title."),
+          body: z.string().optional().describe("Explicit PR body."),
+          draft: z.boolean().default(false).describe("Create the PR as a draft."),
+          fillFromCommits: z.boolean().default(false).describe("Let gh derive title/body from commits.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await createPr({
+            ...args,
+            cwd: resolveCwd(args.cwd, defaultCwd)
+          });
+          return {
+            content: [{ type: "text", text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.` }],
+            structuredContent: result
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
       }
-    },
-    async (args) => {
-      try {
-        const result = await createPr({
-          ...args,
-          cwd: resolveCwd(args.cwd, defaultCwd)
-        });
-        return {
-          content: [{ type: "text", text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.` }],
-          structuredContent: result
-        };
-      } catch (error) {
-        return toToolError(error);
-      }
-    }
-  );
+    );
 
-  server.registerTool(
-    "get_pr_status",
-    {
-      description: "Fetch status details for a pull request.",
-      inputSchema: {
-        cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
-        prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch.")
+    server.registerTool(
+      "get_pr_status",
+      {
+        description: "Fetch status details for a pull request.",
+        inputSchema: {
+          cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
+          prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await getPrStatus({
+            ...args,
+            cwd: resolveCwd(args.cwd, defaultCwd)
+          });
+          return {
+            content: [{ type: "text", text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.` }],
+            structuredContent: result
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
       }
-    },
-    async (args) => {
-      try {
-        const result = await getPrStatus({
-          ...args,
-          cwd: resolveCwd(args.cwd, defaultCwd)
-        });
-        return {
-          content: [{ type: "text", text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.` }],
-          structuredContent: result
-        };
-      } catch (error) {
-        return toToolError(error);
-      }
-    }
-  );
+    );
+  }
 
   // TODO: Remove bin/dispatch-event and bin/dispatch-share once all agents use these MCP tools.
   if (context.agent && context.upsertEvent) {
@@ -529,6 +543,99 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           return {
             content: [{ type: "text", text: `Feedback #${result.id} marked as ${result.status}.` }]
           };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (context.agent && context.jobTools) {
+    const agentId = context.agent.id;
+    const jobTools = context.jobTools;
+    const reportSchema = z.object({
+      status: z.enum(["completed", "failed"]),
+      summary: z.string().min(1),
+      tasks: z.array(z.object({
+        name: z.string().min(1),
+        status: z.enum(["success", "skipped", "error"]),
+        summary: z.string(),
+        errors: z.array(z.object({
+          message: z.string().min(1),
+          recoverable: z.boolean().optional(),
+          action: z.string().optional()
+        })).optional()
+      }))
+    });
+
+    server.registerTool(
+      "job_complete",
+      {
+        description: "Submit the terminal structured report for a successful Dispatch job run.",
+        inputSchema: {
+          report: reportSchema.describe("Structured job report. report.status must be completed.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await jobTools.complete(agentId, args.report);
+          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+
+    server.registerTool(
+      "job_failed",
+      {
+        description: "Submit the terminal structured report for a failed Dispatch job run.",
+        inputSchema: {
+          report: reportSchema.describe("Structured job report. report.status must be failed.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await jobTools.failed(agentId, args.report);
+          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+
+    server.registerTool(
+      "job_needs_input",
+      {
+        description: "Pause a Dispatch job run when human input is required.",
+        inputSchema: {
+          question: z.string().min(1).describe("The question or decision needed from a human.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await jobTools.needsInput(agentId, args.question);
+          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+
+    server.registerTool(
+      "job_log",
+      {
+        description: "Append structured progress for a task within the active Dispatch job run.",
+        inputSchema: {
+          task: z.string().min(1).describe("Task name this log entry belongs to."),
+          message: z.string().min(1).describe("Progress message."),
+          level: z.enum(["debug", "info", "warn", "error"]).default("info").describe("Log severity.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await jobTools.log(agentId, args);
+          return { content: [{ type: "text", text: `Logged progress for job run ${result.runId}.` }], structuredContent: result };
         } catch (error) {
           return toToolError(error);
         }


### PR DESCRIPTION
## Summary

- Add Phase 1 Dispatch Jobs persistence with `jobs` and `job_runs` tables plus run config snapshots.
- Add markdown job parsing, structured job reports, job store/service orchestration, and a thin `dispatch jobs run` CLI that calls the server API.
- Add server-owned job monitoring with timeout, needs-input timeout, crash detection, startup reconciliation, and richer crash diagnostics.
- Add dedicated job MCP routes that expose job tools plus repo tools while hiding normal agent lifecycle tools like `dispatch_event`.
- Reuse the normal tmux-backed agent launch path with job-specific MCP URLs and launch guidance.

## Validation

- `pnpm run check`: passed
- `pnpm run test`: passed, 179 passed, 11 skipped
- `pnpm run test:e2e`: passed, 80 passed, 6 skipped
- `git diff --check`: passed

## Live Evidence

- Full-access job completed without manual job-tool approval.
- `job_needs_input` transitioned to `timed_out` after `needs_input_timeout`.
- Server restart reconciliation worked: an active detached job survived API process replacement and was marked `timed_out` by the replacement server.
- Evidence artifacts in Dispatch: `cru84-complete-job-evidence-2026-04-06-18-49-15-477.md` and `cru84-remaining-gaps-evidence-2026-04-06-19-03-28-580.md`.

## Notes

- No `apps/web/` source files changed, so `pnpm run finalize:web` was not applicable.
- A live validation stack is running at `http://127.0.0.1:64791` / `http://127.0.0.1:64797`; cleanup with `dispatch-dev down`.
