### PR TITLE
[codex] Harden job migrations

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -86,6 +86,7 @@ export function loadConfig(): AppConfig {
   };
 
   validateConfig(config);
+  assertSafeDatabaseConfig(config);
   return config;
 }
 
@@ -119,4 +120,31 @@ function validateConfig(config: AppConfig): void {
     // URL parsing failed — not our problem to warn about here
   }
 
+}
+
+export function assertSafeDatabaseConfig(
+  config: Pick<AppConfig, "databaseUrl">,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  if (env.DISPATCH_ALLOW_AGENT_PROD_DB === "1") return;
+
+  const isAgentContext = Boolean(env.DISPATCH_AGENT_ID);
+  if (!isAgentContext) return;
+
+  try {
+    const dbUrl = new URL(config.databaseUrl);
+    const databaseName = dbUrl.pathname.replace(/^\/+/, "");
+    if (databaseName !== "dispatch") return;
+
+    throw new Error(
+      "Refusing to use the production 'dispatch' database from a Dispatch agent context. " +
+        "Start local servers with dispatch-dev so DATABASE_URL points at an isolated database, " +
+        "or set DISPATCH_ALLOW_AGENT_PROD_DB=1 for an intentional production operation."
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Refusing to use")) {
+      throw error;
+    }
+    // URL parsing failed — let the database client report the connection error.
+  }
 }

--- a/apps/server/src/db/migrations/0005_jobs-file-path-unique.sql
+++ b/apps/server/src/db/migrations/0005_jobs-file-path-unique.sql
@@ -24,4 +24,39 @@ BEGIN
   END IF;
 END $$;
 
-ALTER TABLE jobs ADD CONSTRAINT jobs_directory_file_path_key UNIQUE (directory, file_path);
+DO $$
+DECLARE
+  directory_attnum SMALLINT;
+  file_path_attnum SMALLINT;
+  existing_unique BOOLEAN;
+BEGIN
+  SELECT attnum INTO directory_attnum
+  FROM pg_attribute
+  WHERE attrelid = 'jobs'::regclass
+    AND attname = 'directory';
+
+  SELECT attnum INTO file_path_attnum
+  FROM pg_attribute
+  WHERE attrelid = 'jobs'::regclass
+    AND attname = 'file_path';
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'jobs'::regclass
+      AND contype = 'u'
+      AND conkey = ARRAY[directory_attnum, file_path_attnum]
+    UNION ALL
+    SELECT 1
+    FROM pg_index
+    WHERE indrelid = 'jobs'::regclass
+      AND indisunique
+      AND indisvalid
+      AND indpred IS NULL
+      AND indkey::text = directory_attnum::TEXT || ' ' || file_path_attnum::TEXT
+  ) INTO existing_unique;
+
+  IF NOT existing_unique THEN
+    ALTER TABLE jobs ADD CONSTRAINT jobs_directory_file_path_key UNIQUE (directory, file_path);
+  END IF;
+END $$;

--- a/apps/server/src/db/migrations/0006_jobs-schedule-repair.sql
+++ b/apps/server/src/db/migrations/0006_jobs-schedule-repair.sql
@@ -1,0 +1,6 @@
+-- Repair databases where an early revision of 0004_jobs-schedule was recorded
+-- before all job configuration columns had been added.
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS timeout_ms INTEGER;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS needs_input_timeout_ms INTEGER;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS notify JSONB;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS prompt TEXT;

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { assertSafeDatabaseConfig } from "../src/config.js";
+
+describe("database safety config", () => {
+  it("refuses the production database from a Dispatch agent context", () => {
+    expect(() =>
+      assertSafeDatabaseConfig(
+        { databaseUrl: "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch" },
+        { DISPATCH_AGENT_ID: "agt_test" }
+      )
+    ).toThrow("Refusing to use the production 'dispatch' database");
+  });
+
+  it("allows isolated dispatch-dev databases from a Dispatch agent context", () => {
+    expect(() =>
+      assertSafeDatabaseConfig(
+        { databaseUrl: "postgres://dispatch:dispatch@127.0.0.1:5433/dispatch_agt_test" },
+        { DISPATCH_AGENT_ID: "agt_test" }
+      )
+    ).not.toThrow();
+  });
+
+  it("allows an explicit production override", () => {
+    expect(() =>
+      assertSafeDatabaseConfig(
+        { databaseUrl: "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch" },
+        { DISPATCH_AGENT_ID: "agt_test", DISPATCH_ALLOW_AGENT_PROD_DB: "1" }
+      )
+    ).not.toThrow();
+  });
+});

--- a/apps/server/test/db/migration-repair.test.ts
+++ b/apps/server/test/db/migration-repair.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Pool } from "pg";
+
+import { runMigrations } from "../../src/db/migrate.js";
+import { setupTestDb, teardownTestDb, getTestDatabaseUrl } from "./setup.js";
+
+let pool: Pool;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+describe("migration drift repair", () => {
+  it("repairs databases where 0004 was recorded before all job columns existed", async () => {
+    await runMigrations({
+      databaseUrl: getTestDatabaseUrl(),
+      count: 3,
+    });
+
+    await pool.query(`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS schedule TEXT`);
+    await pool.query(
+      `INSERT INTO pgmigrations (name, run_on) VALUES ($1, NOW())`,
+      ["0004_jobs-schedule"]
+    );
+
+    await expect(runMigrations(getTestDatabaseUrl())).resolves.not.toThrow();
+
+    const cols = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'jobs'`
+    );
+    const colNames = cols.rows.map((r: { column_name: string }) => r.column_name);
+
+    expect(colNames).toContain("schedule");
+    expect(colNames).toContain("timeout_ms");
+    expect(colNames).toContain("needs_input_timeout_ms");
+    expect(colNames).toContain("notify");
+    expect(colNames).toContain("prompt");
+
+    const applied = await pool.query(`SELECT name FROM pgmigrations ORDER BY run_on`);
+    const appliedNames = applied.rows.map((r: { name: string }) => r.name);
+    expect(appliedNames).toContain("0006_jobs-schedule-repair");
+  });
+
+  it("allows 0005 to be safely re-run during manual recovery", async () => {
+    await pool.query(
+      `DELETE FROM pgmigrations
+       WHERE name IN ('0005_jobs-file-path-unique', '0006_jobs-schedule-repair')`
+    );
+
+    await expect(runMigrations(getTestDatabaseUrl())).resolves.not.toThrow();
+
+    const constraints = await pool.query(
+      `SELECT conname FROM pg_constraint
+       WHERE conrelid = 'jobs'::regclass
+         AND contype = 'u'
+         AND conname = 'jobs_directory_file_path_key'`
+    );
+    expect(constraints.rowCount).toBe(1);
+  });
+
+  it("treats an equivalent standalone unique index as satisfying 0005", async () => {
+    await pool.query(`DELETE FROM pgmigrations`);
+    await pool.query(`DROP TABLE IF EXISTS job_runs`);
+    await pool.query(`DROP TABLE IF EXISTS jobs`);
+
+    await runMigrations({
+      databaseUrl: getTestDatabaseUrl(),
+      count: 4,
+    });
+    await pool.query(`DROP INDEX IF EXISTS jobs_directory_file_path_key`);
+    await pool.query(
+      `CREATE UNIQUE INDEX jobs_directory_file_path_key ON jobs (directory, file_path)`
+    );
+
+    await expect(runMigrations(getTestDatabaseUrl())).resolves.not.toThrow();
+
+    const indexes = await pool.query(
+      `SELECT indexname
+       FROM pg_indexes
+       WHERE tablename = 'jobs'
+         AND indexname = 'jobs_directory_file_path_key'`
+    );
+    expect(indexes.rowCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Harden the job migration path after the v0.9.33 update incident where an early revision of `0004_jobs-schedule` could be recorded before all later job configuration columns existed.

## What changed

- Added `0006_jobs-schedule-repair.sql` to restore missing `jobs` columns when `0004` was already recorded.
- Made `0005_jobs-file-path-unique.sql` idempotent for manual recovery by detecting an existing unique constraint or standalone unique index on `(directory, file_path)` before adding the constraint.
- Added a config guard that refuses to use the production `dispatch` database from a Dispatch agent context unless `DISPATCH_ALLOW_AGENT_PROD_DB=1` is explicitly set.
- Added targeted tests for migration drift repair, manual `0005` recovery, standalone unique index recovery, and the database safety guard.

## Root cause

A dev process could start outside `dispatch-dev` and authenticate against the default production database URL. If it applied an early version of `0004`, later shipped changes to that same migration were skipped because `pgmigrations` already marked `0004` as applied.

## Validation

- `pnpm --filter @dispatch/server test -- config.test.ts`
- `pnpm --filter @dispatch/server test -- test/db/migration-repair.test.ts`
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`

`pnpm run finalize:web` was not run because this patch does not change files under `apps/web/`.
