### PR TITLE
Add persona-specific MCP tools and review lifecycle

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1741,6 +1741,26 @@ export class AgentManager {
     agentId: string,
     input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
   ): Promise<PersonaReviewRecord> {
+    const VALID_VERDICTS = ["approve", "request_changes"];
+    if (!VALID_VERDICTS.includes(input.verdict)) {
+      throw new AgentError(`verdict must be one of: ${VALID_VERDICTS.join(", ")}`, 400);
+    }
+    if (input.summary.length > 10_000) {
+      throw new AgentError("summary exceeds 10,000 character limit.", 400);
+    }
+    if (input.message && input.message.length > 5_000) {
+      throw new AgentError("message exceeds 5,000 character limit.", 400);
+    }
+    if (input.filesReviewed) {
+      if (input.filesReviewed.length > 500) {
+        throw new AgentError("filesReviewed exceeds 500 item limit.", 400);
+      }
+      for (const filePath of input.filesReviewed) {
+        if (filePath.length > 500) {
+          throw new AgentError("Individual file path in filesReviewed exceeds 500 character limit.", 400);
+        }
+      }
+    }
     const result = await this.pool.query<PersonaReviewRecord>(
       `UPDATE persona_reviews
        SET status = 'complete', verdict = $2, summary = $3,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -65,6 +65,14 @@ export type AgentRecord = {
   persona: string | null;
   parentAgentId: string | null;
   personaContext: string | null;
+  review: {
+    status: string;
+    message: string | null;
+    verdict: string | null;
+    summary: string | null;
+    filesReviewed: string[] | null;
+    updatedAt: string;
+  } | null;
   cliSessionId: string | null;
   createdAt: string;
   updatedAt: string;
@@ -118,6 +126,20 @@ export type FeedbackInput = {
   description: string;
   suggestion?: string;
   mediaRef?: string;
+};
+
+export type PersonaReviewRecord = {
+  id: number;
+  agentId: string;
+  parentAgentId: string;
+  persona: string;
+  status: string;
+  message: string | null;
+  verdict: string | null;
+  summary: string | null;
+  filesReviewed: string[] | null;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type FeedbackRecord = {
@@ -1678,6 +1700,98 @@ export class AgentManager {
     }
   }
 
+  // --- Persona Reviews ---
+
+  async createPersonaReview(input: {
+    agentId: string;
+    parentAgentId: string;
+    persona: string;
+  }): Promise<PersonaReviewRecord> {
+    const result = await this.pool.query<PersonaReviewRecord>(
+      `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona)
+       VALUES ($1, $2, $3)
+       RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+                 persona, status, message, verdict, summary,
+                 files_reviewed AS "filesReviewed",
+                 created_at AS "createdAt", updated_at AS "updatedAt"`,
+      [input.agentId, input.parentAgentId, input.persona]
+    );
+    return result.rows[0]!;
+  }
+
+  async updatePersonaReviewStatus(
+    agentId: string,
+    input: { status: string; message?: string }
+  ): Promise<PersonaReviewRecord> {
+    const result = await this.pool.query<PersonaReviewRecord>(
+      `UPDATE persona_reviews
+       SET status = $2, message = $3, updated_at = NOW()
+       WHERE agent_id = $1
+       RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+                 persona, status, message, verdict, summary,
+                 files_reviewed AS "filesReviewed",
+                 created_at AS "createdAt", updated_at AS "updatedAt"`,
+      [agentId, input.status, input.message ?? null]
+    );
+    if (result.rowCount === 0) throw new AgentError("No persona review found for agent.", 404);
+    return result.rows[0]!;
+  }
+
+  async completePersonaReview(
+    agentId: string,
+    input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
+  ): Promise<PersonaReviewRecord> {
+    const result = await this.pool.query<PersonaReviewRecord>(
+      `UPDATE persona_reviews
+       SET status = 'complete', verdict = $2, summary = $3,
+           files_reviewed = $4::jsonb, message = $5, updated_at = NOW()
+       WHERE agent_id = $1
+       RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+                 persona, status, message, verdict, summary,
+                 files_reviewed AS "filesReviewed",
+                 created_at AS "createdAt", updated_at AS "updatedAt"`,
+      [agentId, input.verdict, input.summary, JSON.stringify(input.filesReviewed ?? []), input.message ?? null]
+    );
+    if (result.rowCount === 0) throw new AgentError("No persona review found for agent.", 404);
+    return result.rows[0]!;
+  }
+
+  async getPersonaReview(agentId: string): Promise<PersonaReviewRecord | null> {
+    const result = await this.pool.query<PersonaReviewRecord>(
+      `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+              persona, status, message, verdict, summary,
+              files_reviewed AS "filesReviewed",
+              created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM persona_reviews WHERE agent_id = $1`,
+      [agentId]
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async getPersonaReviewsByParent(parentAgentId: string): Promise<PersonaReviewRecord[]> {
+    const result = await this.pool.query<PersonaReviewRecord>(
+      `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+              persona, status, message, verdict, summary,
+              files_reviewed AS "filesReviewed",
+              created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM persona_reviews WHERE parent_agent_id = $1
+       ORDER BY created_at`,
+      [parentAgentId]
+    );
+    return result.rows;
+  }
+
+  // --- Media ---
+
+  async listMedia(agentId: string): Promise<Array<{ fileName: string; description: string | null; source: string; createdAt: string }>> {
+    const result = await this.pool.query<{ fileName: string; description: string | null; source: string; createdAt: string }>(
+      `SELECT file_name AS "fileName", description, source, created_at AS "createdAt"
+       FROM media WHERE agent_id = $1 ORDER BY created_at`,
+      [agentId]
+    );
+    return result.rows;
+  }
+
   // --- Feedback ---
 
   async submitFeedback(
@@ -1834,6 +1948,15 @@ export class AgentManager {
         parent_agent_id AS "parentAgentId",
         persona_context AS "personaContext",
         cli_session_id AS "cliSessionId",
+        (SELECT json_build_object(
+           'status', pr.status,
+           'message', pr.message,
+           'verdict', pr.verdict,
+           'summary', pr.summary,
+           'filesReviewed', pr.files_reviewed,
+           'updatedAt', pr.updated_at
+         ) FROM persona_reviews pr WHERE pr.agent_id = agents.id LIMIT 1
+        ) AS "review",
         created_at AS "createdAt",
         updated_at AS "updatedAt"
       FROM agents

--- a/apps/server/src/db/migrations/0006_persona-reviews.sql
+++ b/apps/server/src/db/migrations/0006_persona-reviews.sql
@@ -1,0 +1,16 @@
+CREATE TABLE persona_reviews (
+  id SERIAL PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  parent_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  persona TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'reviewing',
+  message TEXT,
+  verdict TEXT,
+  summary TEXT,
+  files_reviewed JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_persona_reviews_agent_id ON persona_reviews(agent_id);
+CREATE INDEX idx_persona_reviews_parent_agent_id ON persona_reviews(parent_agent_id);

--- a/apps/server/src/db/migrations/0007_persona-reviews.sql
+++ b/apps/server/src/db/migrations/0007_persona-reviews.sql
@@ -1,4 +1,4 @@
-CREATE TABLE persona_reviews (
+CREATE TABLE IF NOT EXISTS persona_reviews (
   id SERIAL PRIMARY KEY,
   agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   parent_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
@@ -12,5 +12,5 @@ CREATE TABLE persona_reviews (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_persona_reviews_agent_id ON persona_reviews(agent_id);
-CREATE INDEX idx_persona_reviews_parent_agent_id ON persona_reviews(parent_agent_id);
+CREATE INDEX IF NOT EXISTS idx_persona_reviews_agent_id ON persona_reviews(agent_id);
+CREATE INDEX IF NOT EXISTS idx_persona_reviews_parent_agent_id ON persona_reviews(parent_agent_id);

--- a/apps/server/src/jobs/cron.ts
+++ b/apps/server/src/jobs/cron.ts
@@ -1,5 +1,8 @@
 import { Cron } from "croner";
 
+/** Minimum allowed interval between cron runs (5 minutes). */
+const MIN_INTERVAL_MS = 5 * 60 * 1000;
+
 /**
  * Get the next scheduled run time for a cron expression.
  * Returns null if the expression is invalid.
@@ -22,5 +25,27 @@ export function validateCronExpression(schedule: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Check that a cron expression doesn't schedule runs more frequently than
+ * every 5 minutes. Returns an error message if the interval is too short,
+ * or null if the schedule is acceptable.
+ */
+export function validateCronInterval(schedule: string): string | null {
+  try {
+    const cron = new Cron(schedule);
+    const first = cron.nextRun();
+    if (!first) return null;
+    const second = cron.nextRun(first);
+    if (!second) return null;
+    const gap = second.getTime() - first.getTime();
+    if (gap < MIN_INTERVAL_MS) {
+      return `Schedule runs too frequently (every ${Math.round(gap / 1000)}s). Minimum interval is 5 minutes.`;
+    }
+    return null;
+  } catch {
+    return "Invalid cron expression.";
   }
 }

--- a/apps/server/src/jobs/parser.ts
+++ b/apps/server/src/jobs/parser.ts
@@ -72,7 +72,7 @@ export function parseJobDefinition(raw: string, opts: {
 function normalizeJobName(name: string): string {
   const normalized = name.trim();
   if (!normalized) throw new Error("Job name is required.");
-  if (normalized.includes("/") || normalized.includes("\\") || normalized.includes("..") || normalized === ".") {
+  if (normalized.includes("/") || normalized.includes("\\") || normalized.includes("..") || normalized === "." || normalized.includes("\0")) {
     throw new Error("Job name must be a file stem, not a path.");
   }
   return normalized.endsWith(".md") ? normalized.slice(0, -3) : normalized;

--- a/apps/server/src/jobs/report.ts
+++ b/apps/server/src/jobs/report.ts
@@ -35,6 +35,15 @@ export function validateTerminalJobReport(value: unknown, expectedStatus: "compl
   return report;
 }
 
+const MAX_SUMMARY_LENGTH = 10_000;
+const MAX_TASK_NAME_LENGTH = 200;
+const MAX_ERROR_MESSAGE_LENGTH = 10_000;
+const MAX_LOG_MESSAGE_LENGTH = 5_000;
+const MAX_TASKS = 100;
+const MAX_ERRORS_PER_TASK = 100;
+const MAX_LOGS_PER_TASK = 500;
+const MAX_REPORT_BYTES = 1_000_000; // 1 MB
+
 export function validateJobReport(value: unknown): JobReport {
   if (!isRecord(value)) throw new Error("report must be an object.");
   const status = value.status;
@@ -42,9 +51,16 @@ export function validateJobReport(value: unknown): JobReport {
     throw new Error('report.status must be one of: "completed", "failed", "running".');
   }
   const summary = readNonEmptyString(value.summary, "report.summary");
+  if (summary.length > MAX_SUMMARY_LENGTH) throw new Error(`report.summary exceeds ${MAX_SUMMARY_LENGTH} character limit.`);
   if (!Array.isArray(value.tasks)) throw new Error("report.tasks must be an array.");
+  if (value.tasks.length > MAX_TASKS) throw new Error(`report.tasks exceeds ${MAX_TASKS} task limit.`);
   const tasks = value.tasks.map((task, index) => validateTask(task, index));
-  return { status, summary, tasks };
+  const report: JobReport = { status, summary, tasks };
+  const serialized = JSON.stringify(report);
+  if (Buffer.byteLength(serialized, "utf-8") > MAX_REPORT_BYTES) {
+    throw new Error(`Report exceeds ${MAX_REPORT_BYTES / 1_000_000}MB size limit.`);
+  }
+  return report;
 }
 
 export function appendJobLog(report: JobReport | null, input: {
@@ -67,18 +83,23 @@ export function appendJobLog(report: JobReport | null, input: {
 
   let task = next.tasks.find((candidate) => candidate.name === taskName);
   if (!task) {
+    if (next.tasks.length >= MAX_TASKS) {
+      throw new Error(`Cannot add task "${taskName}": report already has ${MAX_TASKS} tasks.`);
+    }
     task = { name: taskName, status: "success", summary: "", logs: [] };
     next.tasks.push(task);
   }
 
-  task.logs = [
+  const logs = [
     ...(task.logs ?? []),
     {
-      message,
+      message: message.slice(0, MAX_LOG_MESSAGE_LENGTH),
       level: input.level,
       createdAt: new Date().toISOString()
     }
   ];
+  // Keep only the most recent entries if we exceed the cap
+  task.logs = logs.length > MAX_LOGS_PER_TASK ? logs.slice(-MAX_LOGS_PER_TASK) : logs;
   return next;
 }
 
@@ -88,17 +109,18 @@ function validateTask(value: unknown, index: number): JobReportTask {
   if (status !== "success" && status !== "skipped" && status !== "error") {
     throw new Error(`report.tasks[${index}].status must be one of: "success", "skipped", "error".`);
   }
-  const task: JobReportTask = {
-    name: readNonEmptyString(value.name, `report.tasks[${index}].name`),
-    status,
-    summary: typeof value.summary === "string" ? value.summary : ""
-  };
+  const name = readNonEmptyString(value.name, `report.tasks[${index}].name`);
+  if (name.length > MAX_TASK_NAME_LENGTH) throw new Error(`report.tasks[${index}].name exceeds ${MAX_TASK_NAME_LENGTH} character limit.`);
+  const summary = typeof value.summary === "string" ? value.summary.slice(0, MAX_SUMMARY_LENGTH) : "";
+  const task: JobReportTask = { name, status, summary };
   if (value.errors !== undefined) {
     if (!Array.isArray(value.errors)) throw new Error(`report.tasks[${index}].errors must be an array.`);
+    if (value.errors.length > MAX_ERRORS_PER_TASK) throw new Error(`report.tasks[${index}].errors exceeds ${MAX_ERRORS_PER_TASK} error limit.`);
     task.errors = value.errors.map((error, errorIndex) => validateTaskError(error, index, errorIndex));
   }
   if (value.logs !== undefined) {
     if (!Array.isArray(value.logs)) throw new Error(`report.tasks[${index}].logs must be an array.`);
+    if (value.logs.length > MAX_LOGS_PER_TASK) throw new Error(`report.tasks[${index}].logs exceeds ${MAX_LOGS_PER_TASK} log limit.`);
     task.logs = value.logs.map((log, logIndex) => validateTaskLog(log, index, logIndex));
   }
   return task;
@@ -106,11 +128,12 @@ function validateTask(value: unknown, index: number): JobReportTask {
 
 function validateTaskError(value: unknown, taskIndex: number, errorIndex: number): JobReportError {
   if (!isRecord(value)) throw new Error(`report.tasks[${taskIndex}].errors[${errorIndex}] must be an object.`);
+  const message = readNonEmptyString(value.message, `report.tasks[${taskIndex}].errors[${errorIndex}].message`);
   const error: JobReportError = {
-    message: readNonEmptyString(value.message, `report.tasks[${taskIndex}].errors[${errorIndex}].message`)
+    message: message.slice(0, MAX_ERROR_MESSAGE_LENGTH)
   };
   if (typeof value.recoverable === "boolean") error.recoverable = value.recoverable;
-  if (typeof value.action === "string") error.action = value.action;
+  if (typeof value.action === "string") error.action = value.action.slice(0, MAX_ERROR_MESSAGE_LENGTH);
   return error;
 }
 

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -9,7 +9,7 @@ import type { AppConfig } from "../config.js";
 import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { readJobDefinition, jobFilePath } from "./parser.js";
 import { JobStore, type JobRecord, type JobRunConfig, type JobRunRecord, type JobWithLatestRun } from "./store.js";
-import { getNextRun, validateCronExpression } from "./cron.js";
+import { getNextRun, validateCronExpression, validateCronInterval } from "./cron.js";
 
 export type JobRunCallback = (run: JobRunRecord) => void;
 
@@ -164,6 +164,10 @@ export class JobService {
     }
     if (!validateCronExpression(schedule)) {
       throw new Error(`Job "${job.name}" has an invalid cron expression: "${schedule}"`);
+    }
+    const intervalError = validateCronInterval(schedule);
+    if (intervalError) {
+      throw new Error(`Job "${job.name}": ${intervalError}`);
     }
     const updated = await this.store.setEnabled(job.id, true);
     this.scheduleJob(updated);

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -188,19 +188,43 @@ export class JobStore {
     message: string;
     level: "debug" | "info" | "warn" | "error";
   }): Promise<JobRunRecord> {
-    const run = await this.getActiveRunForAgent(agentId);
-    if (!run) throw new Error(`No active job run found for agent ${agentId}.`);
-    const report = appendJobLog(run.report, input);
-    const result = await this.pool.query(
-      `
-      UPDATE job_runs
-      SET report = $2::jsonb
-      WHERE id = $1
-      RETURNING ${this.runColumns()}
-      `,
-      [run.id, JSON.stringify(report)]
-    );
-    return mapRun(result.rows[0]);
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const locked = await client.query(
+        `
+        SELECT ${this.runColumns()}
+        FROM job_runs
+        WHERE agent_id = $1 AND status = ANY($2::text[])
+        ORDER BY started_at DESC
+        LIMIT 1
+        FOR UPDATE
+        `,
+        [agentId, ACTIVE_RUN_STATUSES]
+      );
+      if (!locked.rows[0]) {
+        await client.query("ROLLBACK");
+        throw new Error(`No active job run found for agent ${agentId}.`);
+      }
+      const run = mapRun(locked.rows[0]);
+      const report = appendJobLog(run.report, input);
+      const result = await client.query(
+        `
+        UPDATE job_runs
+        SET report = $2::jsonb
+        WHERE id = $1
+        RETURNING ${this.runColumns()}
+        `,
+        [run.id, JSON.stringify(report)]
+      );
+      await client.query("COMMIT");
+      return mapRun(result.rows[0]);
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   async markTimedOut(runId: string, report: JobReport): Promise<JobRunRecord> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1196,8 +1196,8 @@ async function registerRoutes() {
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });
     }
-    const jobRun = await jobService.getLatestRunForAgent(agentId);
-    if (jobRun) {
+    const activeJobRun = await jobService.getActiveRunForAgent(agentId);
+    if (activeJobRun) {
       return reply.code(403).send({ error: "Job agents must use the job-scoped MCP route." });
     }
 
@@ -1212,7 +1212,12 @@ async function registerRoutes() {
 
     reply.hijack();
     await handleMcpRequest(request.raw, reply.raw, request.body, {
-      agent,
+      agent: {
+        id: agent.id,
+        cwd: agent.cwd,
+        persona: agent.persona,
+        parentAgentId: agent.parentAgentId,
+      },
       repoRoot,
       worktreeRoot,
       upsertEvent: mcpUpsertEvent,
@@ -1223,6 +1228,9 @@ async function registerRoutes() {
       resolveFeedback: mcpResolveFeedback,
       upsertPin: mcpUpsertPin,
       deletePin: mcpDeletePin,
+      getParentContext: mcpGetParentContext,
+      updateReviewStatus: mcpUpdateReviewStatus,
+      completeReview: mcpCompleteReview,
     });
   });
 
@@ -3808,6 +3816,50 @@ async function mcpDeletePin(
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }
 
+async function mcpUpdateReviewStatus(
+  agentId: string,
+  input: { status: string; message?: string }
+): Promise<void> {
+  const review = await agentManager.updatePersonaReviewStatus(agentId, input);
+  // Notify UI — the parent's agent card needs to re-render
+  const parent = await agentManager.getAgent(review.parentAgentId);
+  if (parent) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(parent) });
+}
+
+async function mcpCompleteReview(
+  agentId: string,
+  input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
+): Promise<void> {
+  const review = await agentManager.completePersonaReview(agentId, input);
+  const parent = await agentManager.getAgent(review.parentAgentId);
+  if (parent) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(parent) });
+}
+
+async function mcpGetParentContext(
+  parentAgentId: string
+): Promise<import("@dispatch/shared/mcp/server.js").ParentContextResult> {
+  const parent = await agentManager.getAgent(parentAgentId);
+  if (!parent) throw new Error("Parent agent not found.");
+
+  const pins = (parent.pins ?? []).map((p) => ({
+    label: p.label,
+    value: p.value,
+    type: p.type
+  }));
+
+  const media = await agentManager.listMedia(parentAgentId);
+
+  return {
+    pins,
+    media: media.map((m) => ({
+      fileName: m.fileName,
+      description: m.description,
+      source: m.source,
+      createdAt: m.createdAt
+    }))
+  };
+}
+
 async function mcpJobComplete(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {
   const run = await jobService.completeRunForAgent(agentId, report);
   return { runId: run.id, status: run.status };
@@ -3918,6 +3970,13 @@ async function mcpLaunchPersona(
     parentAgentId: agentId,
     personaContext: opts.context,
     cliSessionId,
+  });
+
+  // Create the persona review record
+  await agentManager.createPersonaReview({
+    agentId: agent.id,
+    parentAgentId: agentId,
+    persona: opts.persona,
   });
 
   queueGitContextRefresh([agent.id]);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2899,6 +2899,7 @@ async function registerRoutes() {
         body.status as "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
       );
       if (!updated) return reply.code(404).send({ error: "Feedback not found." });
+      uiEventBroker.publish({ type: "feedback.updated", agentId, feedback: updated });
       return { feedback: updated };
     } catch (error) {
       return handleAgentError(reply, error);

--- a/apps/server/test/db/migration-repair.test.ts
+++ b/apps/server/test/db/migration-repair.test.ts
@@ -49,7 +49,8 @@ describe("migration drift repair", () => {
   it("allows 0005 to be safely re-run during manual recovery", async () => {
     await pool.query(
       `DELETE FROM pgmigrations
-       WHERE name IN ('0005_jobs-file-path-unique', '0006_jobs-schedule-repair')`
+       WHERE name IN ('0005_jobs-file-path-unique', '0006_jobs-schedule-repair')
+          OR name > '0006'`
     );
 
     await expect(runMigrations(getTestDatabaseUrl())).resolves.not.toThrow();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,7 +16,7 @@ import { MediaSidebar, MediaSidebarContent } from "@/components/app/media-sideba
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
 import { StatusFooter } from "@/components/app/status-footer";
 import { TerminalPane } from "@/components/app/terminal-pane";
-import { type FeedbackDetailState, FeedbackDetailPanel } from "@/components/app/feedback-panel";
+import { type FeedbackDetailState, FeedbackDetailPanel, ReviewSummaryPanel } from "@/components/app/feedback-panel";
 import {
   type Agent,
   type AgentVisualState,
@@ -598,15 +598,24 @@ export function DashboardLayout(): JSX.Element {
             {!isMobile ? (
               <div className={cn("min-h-0 overflow-hidden transition-opacity duration-300", feedbackDetail ? "opacity-100" : "opacity-0")}>
                 {feedbackDetailRendered ? (
-                  <FeedbackDetailPanel
-                    key={feedbackDetailRendered.parentAgentId}
-                    parentAgentId={feedbackDetailRendered.parentAgentId}
-                    itemId={feedbackDetailRendered.itemId}
-                    isConnected={connectedAgentId === feedbackDetailRendered.parentAgentId}
-                    sendTerminalInput={sendTerminalInput}
-                    onClose={() => setFeedbackDetail(null)}
-                    onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
-                  />
+                  "summaryAgentId" in feedbackDetailRendered ? (
+                    <ReviewSummaryPanel
+                      key={`summary-${feedbackDetailRendered.summaryAgentId}`}
+                      parentAgentId={feedbackDetailRendered.parentAgentId}
+                      summaryAgentId={feedbackDetailRendered.summaryAgentId}
+                      onClose={() => setFeedbackDetail(null)}
+                    />
+                  ) : (
+                    <FeedbackDetailPanel
+                      key={feedbackDetailRendered.parentAgentId}
+                      parentAgentId={feedbackDetailRendered.parentAgentId}
+                      itemId={feedbackDetailRendered.itemId}
+                      isConnected={connectedAgentId === feedbackDetailRendered.parentAgentId}
+                      sendTerminalInput={sendTerminalInput}
+                      onClose={() => setFeedbackDetail(null)}
+                      onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
+                    />
+                  )
                 ) : null}
               </div>
             ) : null}

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -315,7 +315,7 @@ export function AgentCard({
                     onRequestClose={onRequestClose}
                     closeOnSessionAction={closeOnSessionAction}
                     onOpenDetail={onOpenFeedbackDetail}
-                    activeDetailItemId={feedbackDetailState?.parentAgentId === agent.id ? feedbackDetailState.itemId : null}
+                    activeDetailItemId={feedbackDetailState?.parentAgentId === agent.id && "itemId" in feedbackDetailState ? feedbackDetailState.itemId : null}
                     childAgents={childAgents}
                     selectedAgentId={selectedAgentId}
                     agentVisualState={getVisualState}

--- a/apps/web/src/components/app/agent-event-utils.ts
+++ b/apps/web/src/components/app/agent-event-utils.ts
@@ -18,6 +18,13 @@ export function latestEventColor(type: EventType): string {
   return "text-foreground/80";
 }
 
+export type ReviewVerdict = "approve" | "request_changes";
+
+export function reviewVerdictLabel(verdict: ReviewVerdict): string {
+  if (verdict === "approve") return "Approved";
+  return "Changes Requested";
+}
+
 export function formatRelativeTime(value: string): string {
   const date = new Date(value);
   const time = date.getTime();

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -365,9 +365,9 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
   },
   {
     id: "personas",
-    label: "Personas",
+    label: "Reviewers",
     icon: Users,
-    title: "Personas",
+    title: "Reviewers",
     content: (
       <>
         <P>

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -338,7 +338,7 @@ export function ParentFeedbackPanel({
     <>
       <div className="mt-1.5">
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
-          Personas{activeCount > 0 ? ` (${activeCount} findings)` : ""}
+          Reviewers{activeCount > 0 ? ` (${activeCount} findings)` : ""}
         </div>
         <div className="space-y-1.5">
           {childAgents.map((child, childIndex) => {
@@ -651,6 +651,10 @@ export function ParentFeedbackPanel({
                         </div>
                       </div>
                     ) : null}
+
+                    {!summary && (!filesReviewed || filesReviewed.length === 0) ? (
+                      <div className="text-sm text-muted-foreground">No summary available.</div>
+                    ) : null}
                   </div>
                 </>
               ) : null}
@@ -962,6 +966,10 @@ export function ReviewSummaryPanel({
               ))}
             </div>
           </div>
+        ) : null}
+
+        {!summary && (!filesReviewed || filesReviewed.length === 0) ? (
+          <div className="text-sm text-muted-foreground">No summary available.</div>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -3,7 +3,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Ban, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, MessageCircleQuestion, RotateCcw, Wrench, X } from "lucide-react";
 
 import { FrontTruncatedValue } from "@/components/app/agent-meta";
-import { PersonaAgentRow } from "@/components/app/persona-agent-row";
+import { reviewVerdictLabel } from "@/components/app/agent-event-utils";
+import { PersonaAgentRow, getVerdict, getReviewSummary, getFilesReviewed } from "@/components/app/persona-agent-row";
 import { type Agent, type AgentVisualState, type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,7 +16,10 @@ import { Markdown } from "@/components/ui/markdown";
 import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
-export type FeedbackDetailState = { parentAgentId: string; itemId: number } | null;
+export type FeedbackDetailState =
+  | { parentAgentId: string; itemId: number }
+  | { parentAgentId: string; summaryAgentId: string }
+  | null;
 
 const SEVERITY_DOT: Record<string, string> = {
   critical: "bg-red-500",
@@ -199,6 +203,7 @@ export function ParentFeedbackPanel({
 }): JSX.Element | null {
   const queryClient = useQueryClient();
   const [sheetItemId, setSheetItemId] = useState<number | null>(null);
+  const [summaryAgentId, setSummaryAgentId] = useState<string | null>(null);
   const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
   const [showResolvedAgents, setShowResolvedAgents] = useState<Set<string>>(new Set());
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -348,11 +353,16 @@ export function ParentFeedbackPanel({
             const hasAnyFeedback = unresolvedCount > 0 || resolvedCount > 0;
 
             const canTriage = isConnected && !!sendTerminalInput;
+            const childVerdict = getVerdict(child);
+            const childSummary = getReviewSummary(child);
             const handleTriage = unresolvedCount > 0
               ? () => {
                   if (!canTriage) return;
                   const personaName = child.persona ?? child.name;
-                  const message = `Review and triage the pending feedback from the "${personaName}" persona. Use the dispatch_get_feedback MCP tool to fetch the unresolved items, then address each one: fix the ones that should be fixed and resolve them as you go using dispatch_resolve_feedback. When done, provide a summary report explaining what you addressed and what you chose not to address along with why.`;
+                  const verdictContext = childVerdict
+                    ? `\n\nThe reviewer's verdict was: ${reviewVerdictLabel(childVerdict)}.${childSummary ? ` Their summary: "${childSummary}"` : ""}`
+                    : "";
+                  const message = `Review and triage the pending feedback from the "${personaName}" persona.${verdictContext}\n\nUse the dispatch_get_feedback MCP tool to fetch the unresolved items, then address each one: fix the ones that should be fixed and resolve them as you go using dispatch_resolve_feedback. When done, provide a summary report explaining what you addressed and what you chose not to address along with why.`;
                   sendTerminalInput!(message + "\r");
                 }
               : undefined;
@@ -390,6 +400,13 @@ export function ParentFeedbackPanel({
                       hasFeedback={hasAnyFeedback}
                       onTriage={handleTriage}
                       triageDisabled={!canTriage}
+                      onOpenSummary={() => {
+                        if (onOpenDetail) {
+                          onOpenDetail({ parentAgentId, summaryAgentId: child.id });
+                        } else {
+                          setSummaryAgentId(child.id);
+                        }
+                      }}
                     />
                   </div>
                 ) : null}
@@ -571,6 +588,76 @@ export function ParentFeedbackPanel({
           ) : null}
         </SheetContent>
       </Sheet> : null}
+
+      {/* Review summary sheet */}
+      {(() => {
+        const summaryAgent = summaryAgentId ? childAgents.find((a) => a.id === summaryAgentId) ?? null : null;
+        const verdict = summaryAgent ? getVerdict(summaryAgent) : undefined;
+        const summary = summaryAgent ? getReviewSummary(summaryAgent) : undefined;
+        const filesReviewed = summaryAgent ? getFilesReviewed(summaryAgent) : undefined;
+        const attr = summaryAgent ? personaAttribution.get(summaryAgent.id) : undefined;
+
+        return (
+          <Sheet open={!!summaryAgent} onOpenChange={(open) => { if (!open) setSummaryAgentId(null); }}>
+            <SheetContent side="bottom" hideCloseButton overlayClassName="z-[70]" className="z-[70] flex min-h-[30vh] max-h-[70vh] flex-col overflow-hidden px-6 py-5">
+              {summaryAgent ? (
+                <>
+                  <div className="absolute right-4 top-4 z-10">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0 opacity-70 hover:opacity-100"
+                      onClick={() => setSummaryAgentId(null)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <SheetHeader className="shrink-0">
+                    <div className="flex items-center gap-2 pr-16">
+                      {verdict ? (
+                        <Badge variant={verdict === "approve" ? "default" : "error"}>
+                          {reviewVerdictLabel(verdict)}
+                        </Badge>
+                      ) : null}
+                      <SheetTitle className="text-base flex-1">Review Summary</SheetTitle>
+                    </div>
+                    <SheetDescription className="text-xs text-muted-foreground flex items-center gap-1.5">
+                      {attr ? (
+                        <>
+                          <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
+                          <span style={{ color: attr.color }}>{attr.name}</span>
+                        </>
+                      ) : (
+                        <span>{summaryAgent.persona ?? summaryAgent.name}</span>
+                      )}
+                    </SheetDescription>
+                  </SheetHeader>
+
+                  <div className="mt-4 min-h-0 flex-1 space-y-3 overflow-y-auto">
+                    {summary ? (
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Summary</div>
+                        <Markdown className="text-sm text-foreground">{summary}</Markdown>
+                      </div>
+                    ) : null}
+
+                    {filesReviewed && filesReviewed.length > 0 ? (
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Files Reviewed</div>
+                        <div className="space-y-0.5">
+                          {filesReviewed.map((f) => (
+                            <div key={f} className="font-mono text-xs text-muted-foreground">{f}</div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </>
+              ) : null}
+            </SheetContent>
+          </Sheet>
+        );
+      })()}
     </>
   );
 }
@@ -796,6 +883,86 @@ export function FeedbackDetailPanel({
           statusLabel={STATUS_LABELS[item.status]}
           size="default"
         />
+      </div>
+    </div>
+  );
+}
+
+export function ReviewSummaryPanel({
+  parentAgentId,
+  summaryAgentId,
+  onClose,
+}: {
+  parentAgentId: string;
+  summaryAgentId: string;
+  onClose: () => void;
+}): JSX.Element | null {
+  const { personaAttribution } = useFeedbackData(parentAgentId);
+  const { data: allAgents = [] } = useQuery<Agent[]>({ queryKey: ["agents"], enabled: false });
+  const agent = allAgents.find((a) => a.id === summaryAgentId);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { panelRef.current?.focus(); }, [summaryAgentId]);
+
+  if (!agent) return null;
+
+  const verdict = getVerdict(agent);
+  const summary = getReviewSummary(agent);
+  const filesReviewed = getFilesReviewed(agent);
+  const attr = personaAttribution.get(agent.id);
+
+  return (
+    <div
+      ref={panelRef}
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") { e.stopPropagation(); onClose(); }
+      }}
+      className="flex h-full min-h-0 flex-col overflow-hidden border-t border-border bg-card px-6 py-4 outline-none"
+    >
+      <div className="flex items-center justify-between shrink-0 mb-3">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {verdict ? (
+            <Badge variant={verdict === "approve" ? "default" : "error"}>
+              {reviewVerdictLabel(verdict)}
+            </Badge>
+          ) : null}
+          <span className="text-base font-semibold truncate">Review Summary</span>
+          {attr ? (
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
+              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
+              <span style={{ color: attr.color }}>{attr.name}</span>
+            </span>
+          ) : null}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 ml-4 opacity-70 hover:opacity-100"
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
+        {summary ? (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Summary</div>
+            <Markdown className="text-sm text-foreground">{summary}</Markdown>
+          </div>
+        ) : null}
+
+        {filesReviewed && filesReviewed.length > 0 ? (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Files Reviewed</div>
+            <div className="space-y-0.5">
+              {filesReviewed.map((f) => (
+                <div key={f} className="font-mono text-xs text-muted-foreground">{f}</div>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -99,7 +99,7 @@ function MediaContent({
                 <Video className="h-8 w-8 text-muted-foreground" />
                 <FileIcon className="h-8 w-8 text-muted-foreground" />
               </div>
-              <div className="mt-20">
+              <div className="mt-4">
                 {selectedAgentId ? "No media yet. Agents can share screenshots, videos and documents." : "Focus an agent to view media."}
               </div>
             </div>

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -1,7 +1,6 @@
-import { ChevronRight, ListChecks, Terminal, X } from "lucide-react";
+import { Check, ChevronRight, Eye, ListChecks, Terminal, X, XCircle } from "lucide-react";
 
-import { AgentTypeIcon } from "@/components/app/agent-type-icon";
-import { latestEventLabel, latestEventColor } from "@/components/app/agent-event-utils";
+import { reviewVerdictLabel, type ReviewVerdict } from "@/components/app/agent-event-utils";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -21,7 +20,75 @@ export type PersonaAgentRowProps = {
   hasFeedback?: boolean;
   onTriage?: () => void;
   triageDisabled?: boolean;
+  onOpenSummary?: () => void;
 };
+
+function PersonaStatusIcon({ reviewStatus, verdict, className }: { reviewStatus?: string | null; verdict?: ReviewVerdict; className?: string }): JSX.Element {
+  // Review complete — show verdict icon
+  if (reviewStatus === "complete" && verdict) {
+    return <PersonaVerdictIcon verdict={verdict} className={className} />;
+  }
+
+  // Actively reviewing — pulsing eye
+  if (reviewStatus === "reviewing") {
+    return (
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center justify-center rounded-full",
+          "border border-status-working/50 bg-status-working/15 text-status-working",
+          "animate-persona-reviewing",
+          className
+        )}
+      >
+        <Eye className="h-3 w-3" />
+      </span>
+    );
+  }
+
+  // No review record yet — default icon
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full border",
+        "border-border bg-muted/40 text-muted-foreground",
+        className
+      )}
+    >
+      <Eye className="h-3 w-3" />
+    </span>
+  );
+}
+
+function PersonaVerdictIcon({ verdict, className }: { verdict?: ReviewVerdict; className?: string }): JSX.Element {
+  if (verdict === "approve") {
+    return (
+      <span className={cn("inline-flex shrink-0 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/15 text-emerald-500", className)}>
+        <Check className="h-3 w-3" />
+      </span>
+    );
+  }
+  // request_changes or unknown
+  return (
+    <span className={cn("inline-flex shrink-0 items-center justify-center rounded-full border border-orange-500/50 bg-orange-500/15 text-orange-500", className)}>
+      <XCircle className="h-3 w-3" />
+    </span>
+  );
+}
+
+export function getVerdict(child: Agent): ReviewVerdict | undefined {
+  const v = child.review?.verdict;
+  if (v === "approve" || v === "request_changes") return v;
+  return undefined;
+}
+
+export function getReviewSummary(child: Agent): string | undefined {
+  return child.review?.summary ?? undefined;
+}
+
+export function getFilesReviewed(child: Agent): string[] | undefined {
+  const f = child.review?.filesReviewed;
+  return Array.isArray(f) ? f : undefined;
+}
 
 export function PersonaAgentRow({
   child,
@@ -38,11 +105,16 @@ export function PersonaAgentRow({
   hasFeedback,
   onTriage,
   triageDisabled,
+  onOpenSummary,
 }: PersonaAgentRowProps): JSX.Element {
   const childIsStopped = childState === "stopped";
   const childIsActive = childState === "active";
   const colorVar = `var(--chart-${(childIndex % 4) + 1})`;
-  const personaMessage = child.latestEvent?.message?.split("\n")[0] ?? null;
+  const reviewStatus = child.review?.status ?? null;
+  const isReviewing = reviewStatus === "reviewing";
+  const verdict = getVerdict(child);
+  const hasSummary = !!getReviewSummary(child);
+  const reviewMessage = child.review?.message?.split("\n")[0] ?? null;
 
   return (
     <div
@@ -51,13 +123,18 @@ export function PersonaAgentRow({
         "flex items-center gap-2 border-r-2 px-2 py-1.5 transition-colors duration-200",
         hasFeedback && "cursor-pointer hover:bg-muted/50",
         childIsStopped && child.status !== "error" && "opacity-50",
-        isSelected ? "border-r-status-done" : "border-r-transparent"
+        isSelected ? "border-r-status-done" : "border-r-transparent",
+        isReviewing && "persona-reviewing-row"
       )}
     >
       {hasFeedback ? (
         <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isCollapsed && "rotate-90")} />
       ) : null}
-      <AgentTypeIcon type={child.type} eventType={child.status === "running" ? child.latestEvent?.type : null} className="h-3.5 w-3.5 shrink-0" />
+      <PersonaStatusIcon
+        reviewStatus={reviewStatus}
+        verdict={verdict}
+        className="h-5 w-5"
+      />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           <span className="truncate text-xs font-medium" style={{ color: `hsl(${colorVar})` }}>
@@ -69,17 +146,36 @@ export function PersonaAgentRow({
             <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium text-muted-foreground/60">{resolvedCount}</span>
           ) : null}
         </div>
-        {child.latestEvent ? (
-          <div className="mt-0.5 text-[10px]">
-            <span className={cn("font-medium", latestEventColor(child.latestEvent.type))}>{latestEventLabel(child.latestEvent.type)}</span>
-          </div>
-        ) : null}
-        {child.status === "error" && personaMessage ? (
+        <div className="mt-0.5 flex items-center gap-1.5 text-[10px]">
+          {verdict ? (
+            hasSummary && onOpenSummary ? (
+              <button
+                data-agent-control="true"
+                className={cn(
+                  "font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid transition-colors",
+                  verdict === "approve" ? "text-emerald-500 decoration-emerald-500/40 hover:decoration-emerald-500" : "text-orange-500 decoration-orange-500/40 hover:decoration-orange-500"
+                )}
+                onClick={(e) => { e.stopPropagation(); onOpenSummary(); }}
+              >
+                {reviewVerdictLabel(verdict)}
+              </button>
+            ) : (
+              <span className={cn("font-medium", verdict === "approve" ? "text-emerald-500" : "text-orange-500")}>
+                {reviewVerdictLabel(verdict)}
+              </span>
+            )
+          ) : isReviewing ? (
+            <span className="font-medium text-status-working">{reviewMessage ?? "Reviewing"}</span>
+          ) : child.status === "running" ? (
+            <span className="font-medium text-muted-foreground">Starting</span>
+          ) : null}
+        </div>
+        {child.status === "error" ? (
           <div
             className="mt-0.5 truncate text-[10px] text-status-blocked/90"
-            title={child.latestEvent?.message ?? child.lastError ?? undefined}
+            title={child.lastError ?? undefined}
           >
-            {personaMessage}
+            {child.lastError?.split("\n")[0] ?? "Error"}
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -186,7 +186,8 @@ export function PersonaAgentRow({
               <span data-agent-control="true" className={cn(triageDisabled && "cursor-not-allowed")}>
                 <button
                   aria-label="Auto-triage feedback"
-                  className={cn("rounded p-2 transition-colors", triageDisabled ? "text-muted-foreground/25 pointer-events-none" : "text-muted-foreground/50 hover:text-foreground")}
+                  disabled={triageDisabled}
+                  className={cn("rounded p-2 transition-colors", triageDisabled ? "text-muted-foreground/25" : "text-muted-foreground/50 hover:text-foreground")}
                   onClick={onTriage}
                 >
                   <ListChecks className="h-3.5 w-3.5" />

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -49,7 +49,7 @@ export function PersonaLauncher({
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" disabled={disabled} className="gap-1.5 border border-border/60 bg-background/50 text-muted-foreground hover:text-foreground hover:bg-muted/60">
           <Sparkles className="h-3 w-3" />
-          Launch Persona
+          Launch Reviewer
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -227,7 +227,7 @@ export function PinsPanel({ pins, selectedAgentName, selectedAgentWorkspaceRoot 
       <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
         <div className="flex flex-col items-center gap-2">
           <Pin className="h-8 w-8 text-muted-foreground" />
-          <div className="mt-20">
+          <div className="mt-4">
             {selectedAgentName
               ? "No pins yet. Agents can pin URLs, files, ports, summaries, and other info here."
               : "Focus an agent to view pins."}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -38,6 +38,14 @@ export type Agent = {
   persona?: string | null;
   parentAgentId?: string | null;
   personaContext?: string | null;
+  review?: {
+    status: string;
+    message: string | null;
+    verdict: string | null;
+    summary: string | null;
+    filesReviewed: string[] | null;
+    updatedAt: string;
+  } | null;
   hasStream?: boolean;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -636,6 +636,7 @@ html[data-theme="matrix"] [role="button"] {
   );
   background-size: 200% 100%;
   animation: persona-reviewing-shimmer 3s ease-in-out infinite;
+  border-radius: 0.375rem;
 }
 
 /* Pause GPU-composited animations when the page is hidden to reduce energy */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -611,11 +611,44 @@ html[data-theme="matrix"] [role="button"] {
   color: hsl(var(--status-waiting));      /* yellow for meta */
 }
 
+/* Persona reviewing animation — subtle pulse on the status icon */
+@keyframes persona-reviewing-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.animate-persona-reviewing {
+  animation: persona-reviewing-pulse 2s ease-in-out infinite;
+}
+
+/* Persona reviewing row — subtle left-border shimmer */
+@keyframes persona-reviewing-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.persona-reviewing-row {
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsl(var(--status-working) / 0.04) 40%,
+    hsl(var(--status-working) / 0.08) 50%,
+    hsl(var(--status-working) / 0.04) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: persona-reviewing-shimmer 3s ease-in-out infinite;
+}
+
 /* Pause GPU-composited animations when the page is hidden to reduce energy */
 html[data-hidden] .dispatch-reconnect-scan {
   animation-play-state: paused;
   will-change: auto;
 }
 html[data-hidden] .animate-spin {
+  animation-play-state: paused;
+}
+html[data-hidden] .animate-persona-reviewing {
+  animation-play-state: paused;
+}
+html[data-hidden] .persona-reviewing-row {
   animation-play-state: paused;
 }

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -15,7 +15,12 @@ import {
 } from "../git/worktree.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 
-export type McpAgent = { id: string; cwd: string };
+export type McpAgent = {
+  id: string;
+  cwd: string;
+  persona?: string | null;
+  parentAgentId?: string | null;
+};
 
 export type MediaResult = {
   fileName: string;
@@ -73,6 +78,19 @@ export type PinInput = {
   delete?: boolean;
 };
 
+export type ReviewVerdict = "approve" | "request_changes";
+
+export type ReviewCompletion = {
+  verdict: ReviewVerdict;
+  summary: string;
+  filesReviewed?: string[];
+};
+
+export type ParentContextResult = {
+  pins: Array<{ label: string; value: string; type: string }>;
+  media: Array<{ fileName: string; description: string | null; source: string; createdAt: string }>;
+};
+
 export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
@@ -110,6 +128,17 @@ export type McpRequestContext = {
     agentId: string,
     label: string
   ) => Promise<void>;
+  getParentContext?: (
+    parentAgentId: string
+  ) => Promise<ParentContextResult>;
+  updateReviewStatus?: (
+    agentId: string,
+    input: { status: string; message?: string }
+  ) => Promise<void>;
+  completeReview?: (
+    agentId: string,
+    input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
+  ) => Promise<void>;
   jobTools?: JobTools;
   enableBuiltinTools?: boolean;
 };
@@ -139,7 +168,129 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     version: "0.0.0"
   });
   const defaultCwd = context.agent?.cwd ?? undefined;
+  const isPersona = !!context.agent?.persona;
 
+  // ── Persona agents get a focused tool set ──────────────────────────
+  if (isPersona) {
+    const agentId = context.agent!.id;
+
+    // review_status — updates the persona_reviews record
+    if (context.updateReviewStatus && context.completeReview) {
+      const updateReviewStatus = context.updateReviewStatus;
+      const completeReview = context.completeReview;
+
+      server.registerTool(
+        "review_status",
+        {
+          description:
+            "Report review progress. Call with status 'reviewing' while actively reviewing code or testing. " +
+            "Call with status 'complete' when the review is finished — include a verdict and summary.",
+          inputSchema: {
+            status: z.enum(["reviewing", "complete"]).describe("Current review status."),
+            message: z.string().describe("Short description of current activity or final summary."),
+            verdict: z
+              .enum(["approve", "request_changes"])
+              .optional()
+              .describe("Review verdict. Required when status is 'complete'."),
+            summary: z
+              .string()
+              .optional()
+              .describe("Summary of the review findings. Required when status is 'complete'."),
+            filesReviewed: z
+              .array(z.string())
+              .optional()
+              .describe("List of file paths that were reviewed.")
+          }
+        },
+        async (args) => {
+          try {
+            if (args.status === "complete") {
+              if (!args.verdict) {
+                return toToolError(new Error("verdict is required when status is 'complete'."));
+              }
+              if (!args.summary) {
+                return toToolError(new Error("summary is required when status is 'complete'."));
+              }
+              await completeReview(agentId, {
+                verdict: args.verdict,
+                summary: args.summary,
+                filesReviewed: args.filesReviewed,
+                message: args.message
+              });
+              return {
+                content: [{ type: "text", text: `Review complete: ${args.verdict}. ${args.summary}` }]
+              };
+            }
+
+            await updateReviewStatus(agentId, {
+              status: "reviewing",
+              message: args.message
+            });
+            return {
+              content: [{ type: "text", text: `Reviewing: ${args.message}` }]
+            };
+          } catch (error) {
+            return toToolError(error);
+          }
+        }
+      );
+    }
+
+    // dispatch_pin
+    registerPinTool(server, context);
+
+    // dispatch_share
+    registerShareTool(server, context);
+
+    // dispatch_feedback
+    registerFeedbackTool(server, context);
+
+    // get_parent_context — persona-only tool to see parent's pins and media
+    if (context.agent!.parentAgentId && context.getParentContext) {
+      const parentAgentId = context.agent!.parentAgentId;
+      const getParentContext = context.getParentContext;
+
+      server.registerTool(
+        "get_parent_context",
+        {
+          description:
+            "Retrieve the parent agent's pins and shared media. Use this to discover dev server URLs, " +
+            "key files, screenshots, and other context the parent agent has surfaced.",
+          inputSchema: {}
+        },
+        async () => {
+          try {
+            const result = await getParentContext(parentAgentId);
+            const parts: string[] = [];
+            if (result.pins.length > 0) {
+              parts.push("Pins:");
+              for (const pin of result.pins) {
+                parts.push(`  ${pin.label} (${pin.type}): ${pin.value}`);
+              }
+            } else {
+              parts.push("No pins set by parent agent.");
+            }
+            if (result.media.length > 0) {
+              parts.push("\nShared media:");
+              for (const m of result.media) {
+                parts.push(`  ${m.fileName}: ${m.description ?? "(no description)"}`);
+              }
+            }
+            return {
+              content: [{ type: "text", text: parts.join("\n") }],
+              structuredContent: result
+            };
+          } catch (error) {
+            return toToolError(error);
+          }
+        }
+      );
+    }
+
+    return server;
+  }
+
+  // ── Standard agent tools ───────────────────────────────────────────
   if (context.enableBuiltinTools !== false) {
     server.registerTool(
       "create_pr",
@@ -232,214 +383,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     );
   }
 
-  if (context.agent && context.upsertPin && context.deletePin) {
-    const agentId = context.agent.id;
-    const upsertPin = context.upsertPin;
-    const deletePin = context.deletePin;
-
-    server.registerTool(
-      "dispatch_pin",
-      {
-        description:
-          "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info. To update a pin, set it again with the same label. To remove a pin, pass delete: true. " +
-          "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), short structured summaries (markdown), the specific blocking question when in waiting_user state (string).",
-        inputSchema: {
-          label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
-          value: z
-            .string()
-            .max(2000)
-            .optional()
-            .describe("The value to display. Required unless delete is true."),
-          type: z
-            .enum(["string", "url", "port", "code", "pr", "filename", "markdown"])
-            .default("string")
-            .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. 'markdown' renders constrained markdown for short summaries. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
-          delete: z
-            .boolean()
-            .default(false)
-            .describe("Set to true to remove the pin with this label.")
-        }
-      },
-      async (args) => {
-        try {
-          if (args.delete) {
-            await deletePin(agentId, args.label);
-            return {
-              content: [{ type: "text", text: `Removed pin "${args.label}".` }]
-            };
-          }
-          if (!args.value) {
-            return toToolError(new Error("value is required when not deleting a pin."));
-          }
-          await upsertPin(agentId, {
-            label: args.label,
-            value: args.value,
-            type: args.type ?? "string"
-          });
-          return {
-            content: [{ type: "text", text: `Pinned "${args.label}": ${args.value}` }]
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  if (context.agent && context.shareMedia) {
-    const agentId = context.agent.id;
-    const shareMedia = context.shareMedia;
-
-    server.registerTool(
-      "dispatch_share",
-      {
-        description:
-          "Upload a media file or text snippet to Dispatch for sharing. Supports images (png/jpg/jpeg/gif/webp), video (mp4), and text files (txt/md/json/yaml/ts/py/go/rs/sh/sql/etc). Use source 'simulator' to capture from an iOS Simulator. For text snippets, pass content directly with a name (e.g. name='config.yaml') instead of writing to a file first. To update a previously shared file, pass its fileName (from the original response) in the 'update' parameter.",
-        inputSchema: {
-          filePath: z
-            .string()
-            .optional()
-            .describe("Absolute path to the file to upload. Not required when source is 'simulator' or when content is provided."),
-          content: z
-            .string()
-            .optional()
-            .describe("Text content to share directly (max 32KB). Requires name param with a file extension (e.g. 'snippet.ts'). Use this for text snippets instead of writing to a temp file."),
-          description: z.string().describe("A short description of the shared media."),
-          source: z
-            .enum(["screenshot", "simulator", "text"])
-            .default("screenshot")
-            .describe("The source type of the media. Automatically set to 'text' when sharing text files."),
-          name: z
-            .string()
-            .optional()
-            .describe("Preferred file name for the upload. Required when using content param. Derived from the file path if omitted."),
-          simulatorUdid: z
-            .string()
-            .optional()
-            .describe("Simulator UDID for simulator screenshots. Defaults to 'booted'."),
-          update: z
-            .string()
-            .optional()
-            .describe("fileName of an existing shared media file to update (returned from a previous dispatch_share call). When set, the file content is replaced instead of creating a new file.")
-        }
-      },
-      async (args) => {
-        try {
-          let filePath = args.filePath;
-
-          if (args.content !== undefined) {
-            const MAX_CONTENT_BYTES = 32 * 1024;
-            if (Buffer.byteLength(args.content, "utf-8") > MAX_CONTENT_BYTES) {
-              return toToolError(new Error("content exceeds 32KB limit. Write to a file and use filePath instead."));
-            }
-            if (!args.name) {
-              return toToolError(new Error("name is required when using content param (e.g. 'snippet.ts')."));
-            }
-            const { writeFile: writeFileTmp } = await import("node:fs/promises");
-            const tmpDir = process.env.TMPDIR ?? "/tmp";
-            const timestamp = new Date()
-              .toISOString()
-              .replace(/[:.]/g, "-")
-              .replace("T", "-")
-              .replace("Z", "");
-            const tmpPath = `${tmpDir}/dispatch-text-${timestamp}-${args.name}`;
-            await writeFileTmp(tmpPath, args.content, "utf-8");
-            filePath = tmpPath;
-          } else if (args.source === "simulator") {
-            const { execFile } = await import("node:child_process");
-            const { promisify } = await import("node:util");
-            const execFileAsync = promisify(execFile);
-            const udid = args.simulatorUdid ?? "booted";
-            const timestamp = new Date()
-              .toISOString()
-              .replace(/[:.]/g, "-")
-              .replace("T", "-")
-              .replace("Z", "");
-            const tmpPath = `${process.env.TMPDIR ?? "/tmp"}/sim-${timestamp}.png`;
-            await execFileAsync("xcrun", ["simctl", "io", udid, "screenshot", "--type=png", tmpPath]);
-            filePath = tmpPath;
-          }
-
-          if (!filePath) {
-            return toToolError(new Error("filePath is required when source is not 'simulator' and content is not provided."));
-          }
-
-          const result = await shareMedia(agentId, {
-            filePath,
-            description: args.description,
-            source: args.source,
-            name: args.name,
-            update: args.update
-          });
-
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(result)
-              }
-            ],
-            structuredContent: result
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  if (context.agent && context.submitFeedback) {
-    const agentId = context.agent.id;
-    const submitFeedback = context.submitFeedback;
-
-    server.registerTool(
-      "dispatch_feedback",
-      {
-        description:
-          "Submit a structured feedback finding to Dispatch. Use this to report issues, suggestions, or observations about the code being reviewed. Each call creates one feedback item.",
-        inputSchema: {
-          severity: z
-            .enum(["critical", "high", "medium", "low", "info"])
-            .default("info")
-            .describe("Severity level of the finding."),
-          filePath: z
-            .string()
-            .optional()
-            .describe("File path relative to repo root where the issue was found."),
-          lineNumber: z
-            .number()
-            .optional()
-            .describe("Line number in the file."),
-          description: z.string().describe("What was found — the issue or observation."),
-          suggestion: z
-            .string()
-            .optional()
-            .describe("Suggested fix or action to take."),
-          mediaRef: z
-            .string()
-            .optional()
-            .describe("Filename of a previously shared media file (from dispatch_share) to attach.")
-        }
-      },
-      async (args) => {
-        try {
-          const result = await submitFeedback(agentId, {
-            severity: args.severity,
-            filePath: args.filePath,
-            lineNumber: args.lineNumber,
-            description: args.description,
-            suggestion: args.suggestion,
-            mediaRef: args.mediaRef
-          });
-          return {
-            content: [{ type: "text", text: `Feedback #${result.id} submitted.` }]
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
+  registerPinTool(server, context);
+  registerShareTool(server, context);
+  registerFeedbackTool(server, context);
 
   if (context.agent && context.launchPersona) {
     const agentId = context.agent.id;
@@ -674,6 +620,220 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   return server;
+}
+
+// ── Shared tool registrations (used by both persona and standard agents) ──
+
+function registerPinTool(server: McpServer, context: McpRequestContext): void {
+  if (!context.agent || !context.upsertPin || !context.deletePin) return;
+  const agentId = context.agent.id;
+  const upsertPin = context.upsertPin;
+  const deletePin = context.deletePin;
+
+  server.registerTool(
+    "dispatch_pin",
+    {
+      description:
+        "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info. To update a pin, set it again with the same label. To remove a pin, pass delete: true. " +
+        "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), short structured summaries (markdown), the specific blocking question when in waiting_user state (string).",
+      inputSchema: {
+        label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
+        value: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe("The value to display. Required unless delete is true."),
+        type: z
+          .enum(["string", "url", "port", "code", "pr", "filename", "markdown"])
+          .default("string")
+          .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. 'markdown' renders constrained markdown for short summaries. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
+        delete: z
+          .boolean()
+          .default(false)
+          .describe("Set to true to remove the pin with this label.")
+      }
+    },
+    async (args) => {
+      try {
+        if (args.delete) {
+          await deletePin(agentId, args.label);
+          return {
+            content: [{ type: "text", text: `Removed pin "${args.label}".` }]
+          };
+        }
+        if (!args.value) {
+          return toToolError(new Error("value is required when not deleting a pin."));
+        }
+        await upsertPin(agentId, {
+          label: args.label,
+          value: args.value,
+          type: args.type ?? "string"
+        });
+        return {
+          content: [{ type: "text", text: `Pinned "${args.label}": ${args.value}` }]
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+}
+
+function registerShareTool(server: McpServer, context: McpRequestContext): void {
+  if (!context.agent || !context.shareMedia) return;
+  const agentId = context.agent.id;
+  const shareMedia = context.shareMedia;
+
+  server.registerTool(
+    "dispatch_share",
+    {
+      description:
+        "Upload a media file or text snippet to Dispatch for sharing. Supports images (png/jpg/jpeg/gif/webp), video (mp4), and text files (txt/md/json/yaml/ts/py/go/rs/sh/sql/etc). Use source 'simulator' to capture from an iOS Simulator. For text snippets, pass content directly with a name (e.g. name='config.yaml') instead of writing to a file first. To update a previously shared file, pass its fileName (from the original response) in the 'update' parameter.",
+      inputSchema: {
+        filePath: z
+          .string()
+          .optional()
+          .describe("Absolute path to the file to upload. Not required when source is 'simulator' or when content is provided."),
+        content: z
+          .string()
+          .optional()
+          .describe("Text content to share directly (max 32KB). Requires name param with a file extension (e.g. 'snippet.ts'). Use this for text snippets instead of writing to a temp file."),
+        description: z.string().describe("A short description of the shared media."),
+        source: z
+          .enum(["screenshot", "simulator", "text"])
+          .default("screenshot")
+          .describe("The source type of the media. Automatically set to 'text' when sharing text files."),
+        name: z
+          .string()
+          .optional()
+          .describe("Preferred file name for the upload. Required when using content param. Derived from the file path if omitted."),
+        simulatorUdid: z
+          .string()
+          .optional()
+          .describe("Simulator UDID for simulator screenshots. Defaults to 'booted'."),
+        update: z
+          .string()
+          .optional()
+          .describe("fileName of an existing shared media file to update (returned from a previous dispatch_share call). When set, the file content is replaced instead of creating a new file.")
+      }
+    },
+    async (args) => {
+      try {
+        let filePath = args.filePath;
+
+        if (args.content !== undefined) {
+          const MAX_CONTENT_BYTES = 32 * 1024;
+          if (Buffer.byteLength(args.content, "utf-8") > MAX_CONTENT_BYTES) {
+            return toToolError(new Error("content exceeds 32KB limit. Write to a file and use filePath instead."));
+          }
+          if (!args.name) {
+            return toToolError(new Error("name is required when using content param (e.g. 'snippet.ts')."));
+          }
+          const { writeFile: writeFileTmp } = await import("node:fs/promises");
+          const tmpDir = process.env.TMPDIR ?? "/tmp";
+          const timestamp = new Date()
+            .toISOString()
+            .replace(/[:.]/g, "-")
+            .replace("T", "-")
+            .replace("Z", "");
+          const tmpPath = `${tmpDir}/dispatch-text-${timestamp}-${args.name}`;
+          await writeFileTmp(tmpPath, args.content, "utf-8");
+          filePath = tmpPath;
+        } else if (args.source === "simulator") {
+          const { execFile } = await import("node:child_process");
+          const { promisify } = await import("node:util");
+          const execFileAsync = promisify(execFile);
+          const udid = args.simulatorUdid ?? "booted";
+          const timestamp = new Date()
+            .toISOString()
+            .replace(/[:.]/g, "-")
+            .replace("T", "-")
+            .replace("Z", "");
+          const tmpPath = `${process.env.TMPDIR ?? "/tmp"}/sim-${timestamp}.png`;
+          await execFileAsync("xcrun", ["simctl", "io", udid, "screenshot", "--type=png", tmpPath]);
+          filePath = tmpPath;
+        }
+
+        if (!filePath) {
+          return toToolError(new Error("filePath is required when source is not 'simulator' and content is not provided."));
+        }
+
+        const result = await shareMedia(agentId, {
+          filePath,
+          description: args.description,
+          source: args.source,
+          name: args.name,
+          update: args.update
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result)
+            }
+          ],
+          structuredContent: result
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+}
+
+function registerFeedbackTool(server: McpServer, context: McpRequestContext): void {
+  if (!context.agent || !context.submitFeedback) return;
+  const agentId = context.agent.id;
+  const submitFeedback = context.submitFeedback;
+
+  server.registerTool(
+    "dispatch_feedback",
+    {
+      description:
+        "Submit a structured feedback finding to Dispatch. Use this to report issues, suggestions, or observations about the code being reviewed. Each call creates one feedback item.",
+      inputSchema: {
+        severity: z
+          .enum(["critical", "high", "medium", "low", "info"])
+          .default("info")
+          .describe("Severity level of the finding."),
+        filePath: z
+          .string()
+          .optional()
+          .describe("File path relative to repo root where the issue was found."),
+        lineNumber: z
+          .number()
+          .optional()
+          .describe("Line number in the file."),
+        description: z.string().describe("What was found — the issue or observation."),
+        suggestion: z
+          .string()
+          .optional()
+          .describe("Suggested fix or action to take."),
+        mediaRef: z
+          .string()
+          .optional()
+          .describe("Filename of a previously shared media file (from dispatch_share) to attach.")
+      }
+    },
+    async (args) => {
+      try {
+        const result = await submitFeedback(agentId, {
+          severity: args.severity,
+          filePath: args.filePath,
+          lineNumber: args.lineNumber,
+          description: args.description,
+          suggestion: args.suggestion,
+          mediaRef: args.mediaRef
+        });
+        return {
+          content: [{ type: "text", text: `Feedback #${result.id} submitted.` }]
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
 }
 
 function cwdSchema(defaultCwd: string | undefined, description: string): z.ZodType<string | undefined> {


### PR DESCRIPTION
## Summary

- Persona agents now get a focused MCP tool set (`review_status`, `dispatch_feedback`, `dispatch_share`, `dispatch_pin`, `get_parent_context`) instead of the full standard set — no PR, job, repo, or persona-launching tools
- Review lifecycle backed by a dedicated `persona_reviews` table created on persona launch, decoupled from the agent's `latestEvent`
- UI shows verdict-specific icons (green check for approve, orange X for request changes) with a clickable verdict label that opens a review summary panel
- Includes reviewing shimmer animation, auto-triage prompt enrichment with verdict context, and "Launch Reviewer" / "Reviewers" naming
- Fixes: SSE event missing on REST feedback status update, job log race condition (`SELECT FOR UPDATE`), null byte validation in job name parsing, input size limits on job reports and cron intervals

## Test plan

- [x] Type check (`pnpm run check`)
- [x] Web build (`pnpm run finalize:web`)
- [x] E2E tests (91 passed)
- [x] Unit tests (204 passed)
- [x] Playwright UI validation on dev instance — verdict icons, summary panel, reviewer labels
- [x] Two rounds of persona reviews on live dev instance testing the new tool set end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)