### PR TITLE
Fix mobile viewport scroll escape breaking overlay panes

### DIFF
--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -42,7 +42,7 @@ export const TerminalPane = memo(function TerminalPane({
   const showInertState = terminalMode === "inert" && isAttached;
 
   return (
-    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-terminal-bg">
+    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-terminal-bg touch-none">
       <div
         className={cn(
           "h-full w-full",

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -618,6 +618,7 @@ export function useTerminal(args: {
     };
     const onTouchMove = (e: TouchEvent) => {
       if (e.touches.length !== 1 || !screenEl) return;
+      e.preventDefault();
       const currentY = e.touches[0].clientY;
       const delta = touchY - currentY;
       touchY = currentY;
@@ -634,7 +635,7 @@ export function useTerminal(args: {
       }
     };
     host.addEventListener("touchstart", onTouchStart, { passive: true });
-    host.addEventListener("touchmove", onTouchMove, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: false });
 
     let dispatchingMouseDown = false;
     const onMouseDown = (e: MouseEvent) => {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -365,14 +365,21 @@ html[data-theme="matrix"] body::after {
     touch-action: none;
   }
 
-  /* Re-enable pan-y on explicitly scrollable containers so internal
-     scroll areas (sidebar lists, dialog bodies, etc.) still work. */
+  /* Re-enable pan on explicitly scrollable containers so internal
+     scroll areas (sidebar lists, dialog bodies, code blocks, etc.)
+     still work. */
   [style*="overflow"]:not([style*="hidden"]),
   .overflow-y-auto,
   .overflow-auto,
   .overflow-y-scroll,
   .overflow-scroll {
     touch-action: pan-y;
+    overscroll-behavior: contain;
+  }
+
+  .overflow-x-auto,
+  .overflow-x-scroll {
+    touch-action: pan-x pan-y;
     overscroll-behavior: contain;
   }
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -350,27 +350,31 @@ html[data-theme="matrix"] body::after {
   z-index: 1;
 }
 
-/* iPad PWA: prevent viewport jump when typing space in terminal.
-   The class is added by JS in main.tsx when navigator.standalone is true
-   on an iPad-class device. */
-html.ipad-pwa,
-html.ipad-pwa body {
-  position: fixed;
-  width: 100%;
-  overflow: clip;
-}
+/* Touch devices (phones + tablets): lock the viewport so touch-scroll
+   inside xterm or other internal scrollables cannot shift the body.
+   overflow:hidden alone is insufficient on mobile WebKit. */
+@media (pointer: coarse) {
+  html,
+  html body {
+    position: fixed;
+    width: 100%;
+    overflow: clip;
+  }
 
-html.ipad-pwa #root {
-  touch-action: none;
-}
+  #root {
+    touch-action: none;
+  }
 
-html.ipad-pwa [style*="overflow"]:not([style*="hidden"]),
-html.ipad-pwa .overflow-y-auto,
-html.ipad-pwa .overflow-auto,
-html.ipad-pwa .overflow-y-scroll,
-html.ipad-pwa .overflow-scroll {
-  touch-action: pan-y;
-  overscroll-behavior: contain;
+  /* Re-enable pan-y on explicitly scrollable containers so internal
+     scroll areas (sidebar lists, dialog bodies, etc.) still work. */
+  [style*="overflow"]:not([style*="hidden"]),
+  .overflow-y-auto,
+  .overflow-auto,
+  .overflow-y-scroll,
+  .overflow-scroll {
+    touch-action: pan-y;
+    overscroll-behavior: contain;
+  }
 }
 
 .terminal-font {


### PR DESCRIPTION
## Summary

On mobile, scrolling the terminal could cause the body to shift past its bounds (`overflow:hidden` is insufficient on mobile WebKit). Once offset, fixed-position overlays (activity, docs, settings panes) had misaligned touch targets — buttons appeared tappable but hits landed on the wrong element, making it impossible to close panes or switch tabs.

Three-layer fix:
- Apply `position:fixed` + `overflow:clip` to html/body on **all touch devices** via `@media (pointer: coarse)`, not just iPad PWA — this is the same proven technique already in use for iPad standalone mode
- Make terminal `touchmove` handler non-passive with `preventDefault()` to stop scroll propagation at the source
- Add `touch-none` to the terminal pane container as declarative belt-and-suspenders

## Test plan
- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — 91 passed, 6 skipped (terminal-live, pre-existing)
- [ ] Manual mobile validation: scroll terminal, open activity/docs/settings panes, verify tabs and close work
- [ ] Verify desktop unaffected (`@media (pointer: coarse)` doesn't apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)