### PR TITLE
Fix review agent collapsing parent in sidebar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -392,7 +392,9 @@ export function DashboardLayout(): JSX.Element {
   const attachToAgent = useCallback(
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
-      ensureAuxExpanded(agent.id);
+      // Child persona agents are rendered inside their parent's expanded card,
+      // so expand the parent instead of the child to keep it visible.
+      ensureAuxExpanded(agent.parentAgentId ?? agent.id);
       refreshMedia(agent.id);
       await ensureTerminalConnected(true, true, agent.id);
     },
@@ -402,7 +404,7 @@ export function DashboardLayout(): JSX.Element {
   const startAgent = useCallback(
     async (agent: Agent) => {
       setSelectedAgentId(agent.id);
-      ensureAuxExpanded(agent.id);
+      ensureAuxExpanded(agent.parentAgentId ?? agent.id);
       await api(`/api/v1/agents/${agent.id}/start`, {
         method: "POST",
         body: JSON.stringify({}),


### PR DESCRIPTION
## Summary
- When connecting to a child review (persona) agent via `attachToAgent` or `startAgent`, the sidebar was collapsing the parent agent card — hiding the review agent that was just selected.
- Root cause: `ensureAuxExpanded` was called with the child agent's ID, but child agents render inside the parent's expanded card. Setting expanded to the child ID collapsed the parent.
- Fix: use `agent.parentAgentId ?? agent.id` so child persona agents expand their parent instead.

## Test plan
- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — 91 passed, 6 skipped
- [x] Visual validation with mock parent + child review agent in dev instance — parent stays expanded when clicking child reviewer