### PR TITLE
Nest review agents under parent in agent history table

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2119,7 +2119,7 @@ async function registerRoutes() {
           COALESCE((
             SELECT SUM(input_tokens + cache_creation_tokens + cache_read_tokens + output_tokens)
             FROM agent_token_usage WHERE agent_id = a.id
-          ), 0)::int AS "totalTokens"
+          ), 0)::bigint AS "totalTokens"
          FROM agents a
          ${whereClause}
          ORDER BY ${sortSql}
@@ -2131,25 +2131,18 @@ async function registerRoutes() {
     const parentIds = agentsResult.rows.map((a: { id: string }) => a.id);
 
     // Fetch child (persona/review) agents for these parents
-    let childrenByParent: Record<string, Array<{
+    type ChildAgent = {
       id: string;
       name: string;
       persona: string | null;
       status: string;
       totalTokens: number;
       createdAt: string;
-    }>> = {};
+    };
+    const childrenByParent = new Map<string, ChildAgent[]>();
 
     if (parentIds.length > 0) {
-      const childResult = await pool.query<{
-        id: string;
-        name: string;
-        persona: string | null;
-        status: string;
-        totalTokens: number;
-        createdAt: string;
-        parentAgentId: string;
-      }>(
+      const childResult = await pool.query<ChildAgent & { parentAgentId: string }>(
         `SELECT
           a.id,
           a.name,
@@ -2158,7 +2151,7 @@ async function registerRoutes() {
           COALESCE((
             SELECT SUM(input_tokens + cache_creation_tokens + cache_read_tokens + output_tokens)
             FROM agent_token_usage WHERE agent_id = a.id
-          ), 0)::int AS "totalTokens",
+          ), 0)::bigint AS "totalTokens",
           a.created_at AS "createdAt",
           a.parent_agent_id AS "parentAgentId"
          FROM agents a
@@ -2168,8 +2161,9 @@ async function registerRoutes() {
       );
       for (const child of childResult.rows) {
         const pid = child.parentAgentId;
-        if (!childrenByParent[pid]) childrenByParent[pid] = [];
-        childrenByParent[pid].push({
+        let list = childrenByParent.get(pid);
+        if (!list) { list = []; childrenByParent.set(pid, list); }
+        list.push({
           id: child.id,
           name: child.name,
           persona: child.persona,
@@ -2181,7 +2175,7 @@ async function registerRoutes() {
     }
 
     const agents = agentsResult.rows.map((agent: { id: string; totalTokens: number }) => {
-      const children = childrenByParent[agent.id] ?? [];
+      const children = childrenByParent.get(agent.id) ?? [];
       const childTokens = children.reduce((sum, c) => sum + c.totalTokens, 0);
       return {
         ...agent,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2061,7 +2061,7 @@ async function registerRoutes() {
       : "created_at";
     const order = typeof query.order === "string" && query.order === "asc" ? "ASC" : "DESC";
 
-    const conditions: string[] = [];
+    const conditions: string[] = ["a.parent_agent_id IS NULL"];
     const params: unknown[] = [];
 
     if (search) {
@@ -2128,7 +2128,69 @@ async function registerRoutes() {
       ),
     ]);
 
-    return { agents: agentsResult.rows, total: countResult.rows[0]?.total ?? 0, limit, offset };
+    const parentIds = agentsResult.rows.map((a: { id: string }) => a.id);
+
+    // Fetch child (persona/review) agents for these parents
+    let childrenByParent: Record<string, Array<{
+      id: string;
+      name: string;
+      persona: string | null;
+      status: string;
+      totalTokens: number;
+      createdAt: string;
+    }>> = {};
+
+    if (parentIds.length > 0) {
+      const childResult = await pool.query<{
+        id: string;
+        name: string;
+        persona: string | null;
+        status: string;
+        totalTokens: number;
+        createdAt: string;
+        parentAgentId: string;
+      }>(
+        `SELECT
+          a.id,
+          a.name,
+          a.persona,
+          a.status,
+          COALESCE((
+            SELECT SUM(input_tokens + cache_creation_tokens + cache_read_tokens + output_tokens)
+            FROM agent_token_usage WHERE agent_id = a.id
+          ), 0)::int AS "totalTokens",
+          a.created_at AS "createdAt",
+          a.parent_agent_id AS "parentAgentId"
+         FROM agents a
+         WHERE a.parent_agent_id = ANY($1)
+         ORDER BY a.created_at ASC`,
+        [parentIds]
+      );
+      for (const child of childResult.rows) {
+        const pid = child.parentAgentId;
+        if (!childrenByParent[pid]) childrenByParent[pid] = [];
+        childrenByParent[pid].push({
+          id: child.id,
+          name: child.name,
+          persona: child.persona,
+          status: child.status,
+          totalTokens: child.totalTokens,
+          createdAt: child.createdAt,
+        });
+      }
+    }
+
+    const agents = agentsResult.rows.map((agent: { id: string; totalTokens: number }) => {
+      const children = childrenByParent[agent.id] ?? [];
+      const childTokens = children.reduce((sum, c) => sum + c.totalTokens, 0);
+      return {
+        ...agent,
+        children,
+        groupTotalTokens: agent.totalTokens + childTokens,
+      };
+    });
+
+    return { agents, total: countResult.rows[0]?.total ?? 0, limit, offset };
   });
 
   app.get("/api/v1/history/agents/:id", async (request, reply) => {

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -98,6 +98,18 @@ function AgentHistoryList({
     [debouncedSearch, type, project, range, sort, order]
   );
 
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
   const { data, isLoading } = useHistoryAgents(filters);
   const { data: projects } = useHistoryProjects();
 
@@ -233,36 +245,91 @@ function AgentHistoryList({
                 </tr>
               ))}
 
-            {data?.agents.map((agent) => (
-              <tr
-                key={agent.id}
-                className="cursor-pointer border-b border-border/50 transition-colors hover:bg-muted/30"
-                onClick={() => onSelect(agent.id)}
-              >
-                <td className="px-3 py-2.5 sm:px-5">
-                  <div className="flex items-center gap-2">
-                    <AgentTypeIcon type={agent.type} />
-                    <span className="truncate font-medium text-foreground">
-                      {agent.name}
-                    </span>
-                  </div>
-                </td>
-                <td className="hidden px-2 py-2.5 text-muted-foreground sm:table-cell">
-                  <span className="truncate" title={agent.gitContext?.repoRoot ?? agent.cwd}>
-                    {shortProjectName(agent.gitContext?.repoRoot ?? agent.cwd)}
-                  </span>
-                </td>
-                <td className="px-2 py-2.5 text-muted-foreground">
-                  {formatDuration(agent.durationMs)}
-                </td>
-                <td className="px-2 py-2.5 text-muted-foreground">
-                  {agent.totalTokens > 0 ? formatTokenCount(agent.totalTokens) : "—"}
-                </td>
-                <td className="px-2 py-2.5 pr-3 text-muted-foreground sm:pr-5">
-                  {formatRelativeTime(agent.createdAt)}
-                </td>
-              </tr>
-            ))}
+            {data?.agents.map((agent) => {
+              const hasChildren = agent.children.length > 0;
+              const isExpanded = expandedIds.has(agent.id);
+              return (
+                <Fragment key={agent.id}>
+                  <tr
+                    className="cursor-pointer border-b border-border/50 transition-colors hover:bg-muted/30"
+                    onClick={() => onSelect(agent.id)}
+                  >
+                    <td className="px-3 py-2.5 sm:px-5">
+                      <div className="flex items-center gap-1.5">
+                        {hasChildren ? (
+                          <button
+                            onClick={(e) => toggleExpanded(agent.id, e)}
+                            className="flex-shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                          >
+                            {isExpanded
+                              ? <ChevronDown className="h-3.5 w-3.5" />
+                              : <ChevronRight className="h-3.5 w-3.5" />}
+                          </button>
+                        ) : (
+                          <span className="w-[18px] flex-shrink-0" />
+                        )}
+                        <AgentTypeIcon type={agent.type} />
+                        <span className="truncate font-medium text-foreground">
+                          {agent.name}
+                        </span>
+                        {hasChildren && (
+                          <span className="flex-shrink-0 flex h-4 w-4 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground">
+                            {agent.children.length}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="hidden px-2 py-2.5 text-muted-foreground sm:table-cell">
+                      <span className="truncate" title={agent.gitContext?.repoRoot ?? agent.cwd}>
+                        {shortProjectName(agent.gitContext?.repoRoot ?? agent.cwd)}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 text-muted-foreground">
+                      {formatDuration(agent.durationMs)}
+                    </td>
+                    <td className="px-2 py-2.5 text-muted-foreground">
+                      {hasChildren ? (
+                        <div>
+                          <span>{formatTokenCount(agent.groupTotalTokens)}</span>
+                          <span className="ml-1 text-[10px] text-muted-foreground/60">
+                            ({formatTokenCount(agent.totalTokens)})
+                          </span>
+                        </div>
+                      ) : (
+                        agent.totalTokens > 0 ? formatTokenCount(agent.totalTokens) : "—"
+                      )}
+                    </td>
+                    <td className="px-2 py-2.5 pr-3 text-muted-foreground sm:pr-5">
+                      {formatRelativeTime(agent.createdAt)}
+                    </td>
+                  </tr>
+                  {hasChildren && isExpanded && agent.children.map((child) => (
+                    <tr
+                      key={child.id}
+                      className="cursor-pointer border-b border-border/30 bg-muted/10 transition-colors hover:bg-muted/30"
+                      onClick={() => onSelect(child.id)}
+                    >
+                      <td colSpan={3} className="py-2 pl-10 pr-3 sm:pl-12 sm:pr-5">
+                        <div className="flex items-center gap-2">
+                          <Badge className="h-4 px-1.5 text-[10px] font-normal">
+                            {child.persona ?? "review"}
+                          </Badge>
+                          <span className="truncate text-muted-foreground">
+                            {child.name}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-2 py-2 text-muted-foreground">
+                        {child.totalTokens > 0 ? formatTokenCount(child.totalTokens) : "—"}
+                      </td>
+                      <td className="px-2 py-2 pr-3 text-muted-foreground sm:pr-5">
+                        {formatRelativeTime(child.createdAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              );
+            })}
 
             {data && data.agents.length === 0 && !isLoading && (
               <tr>

--- a/apps/web/src/hooks/use-agent-history.ts
+++ b/apps/web/src/hooks/use-agent-history.ts
@@ -8,6 +8,15 @@ const HISTORY_QUERY_OPTIONS = {
 
 // ── Types ──────────────────────────────────────────────────────────
 
+export type HistoryChildAgent = {
+  id: string;
+  name: string;
+  persona: string | null;
+  status: string;
+  totalTokens: number;
+  createdAt: string;
+};
+
 export type HistoryAgent = {
   id: string;
   name: string;
@@ -33,6 +42,8 @@ export type HistoryAgent = {
   updatedAt: string;
   durationMs: number;
   totalTokens: number;
+  children: HistoryChildAgent[];
+  groupTotalTokens: number;
 };
 
 export type HistoryAgentsResponse = {


### PR DESCRIPTION
## Summary
- Review/persona agents are now grouped under their parent in the history list instead of appearing as standalone rows
- Parent rows show a circular badge with child count and aggregated group token totals (individual tokens shown in parentheses)
- Expanding a parent reveals indented child rows with persona badges, individual tokens, and timestamps
- Child rows use `colSpan={3}` to avoid layout shift on expand/collapse

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (91/91)
- [x] Visual validation with mock data in dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)