### PR TITLE
Add Linux clipboard image paste support via xclip + Xvfb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ AUTH_TOKEN=
 # Agent runtime — "tmux" (default when tmux is installed) or "inert" (no-op, for dev/test)
 # DISPATCH_AGENT_RUNTIME=tmux
 
+# Virtual X display for clipboard image paste on Linux (requires Xvfb + xclip)
+# DISPATCH_COPY_DISPLAY=:99
+
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > Clone https://github.com/selfcontained/dispatch.git and install it as a persistent service on this machine. Steps:
 >
 > 1. Clone the repo to `~/.dispatch/server`.
-> 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3` on Linux).
+> 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
 > 5. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The other defaults are usually fine.
 > 6. Register as a system service:
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
->    - **Linux**: Create a systemd user service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/server.js` with `EnvironmentFile=~/.dispatch/server/.env`. Enable with `systemctl --user enable --now dispatch`.
+>    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/server.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.
 > 7. Verify: `curl http://127.0.0.1:6767/api/v1/health`
 > 8. Check which agent CLIs are installed (`claude --version`, `codex --version`, `opencode --version`). In the Dispatch UI under Settings, disable any agent types whose CLI is not installed.
 
@@ -47,6 +47,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 |---|---|---|
 | **Docker** | Isolated dev databases via `dispatch-dev` | macOS: `brew install --cask docker` / Linux: [docs.docker.com](https://docs.docker.com/engine/install/) |
 | **Xcode** (full) | iOS Simulator, `xcrun simctl` (macOS only) | App Store |
+| **xclip + Xvfb** | Clipboard image paste (Linux only) | `apt install xclip xvfb` |
 
 ### Agent CLIs
 

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1515,6 +1515,12 @@ export class AgentManager {
       `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`
     ];
 
+    // Forward the clipboard display to agent sessions so CLI tools can read
+    // images pasted via the browser clipboard (xclip needs a DISPLAY).
+    if (process.platform === "linux" && process.env.DISPATCH_COPY_DISPLAY) {
+      envPrefixParts.push(`DISPATCH_COPY_DISPLAY=${this.shellEscape(process.env.DISPATCH_COPY_DISPLAY)}`);
+    }
+
     // When TLS is enabled with a CA cert, tell agent CLI tools to trust it
     // so loopback MCP connections don't fail certificate verification.
     // TLS_CA should point at the CA that signed the server cert (e.g. mkcert's rootCA.pem).

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1458,7 +1458,7 @@ async function registerRoutes() {
     };
   });
 
-  // Write an image from the browser clipboard to the host's macOS pasteboard.
+  // Write an image from the browser clipboard to the host's system clipboard.
   // This bridges remote browser sessions to the local system clipboard so that
   // CLI tools (e.g. Claude CLI) can read pasted images via native APIs.
   app.post("/api/v1/clipboard/image", async (request, reply) => {
@@ -1477,19 +1477,33 @@ async function registerRoutes() {
     await writeFile(tmpPath, buffer);
 
     try {
-      const pasteboardClass = ext === "jpg" ? "JPEG" : "PNGf";
-      await new Promise<void>((resolve, reject) => {
-        const proc = spawn("osascript", [
-          "-e",
-          `set the clipboard to (read (POSIX file "${tmpPath}") as «class ${pasteboardClass}»)`
-        ]);
-        proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`osascript exited ${code}`)));
-        proc.on("error", reject);
-      });
+      if (os.platform() === "darwin") {
+        const pasteboardClass = ext === "jpg" ? "JPEG" : "PNGf";
+        await new Promise<void>((resolve, reject) => {
+          const proc = spawn("osascript", [
+            "-e",
+            `set the clipboard to (read (POSIX file "${tmpPath}") as «class ${pasteboardClass}»)`
+          ]);
+          proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`osascript exited ${code}`)));
+          proc.on("error", reject);
+        });
+      } else {
+        const display = process.env.DISPATCH_COPY_DISPLAY;
+        if (!display) {
+          return reply.code(500).send({ error: "DISPATCH_COPY_DISPLAY is not set. Clipboard image paste on Linux requires Xvfb and xclip." });
+        }
+        await new Promise<void>((resolve, reject) => {
+          const proc = spawn("xclip", ["-selection", "clipboard", "-t", mime, "-i", tmpPath], {
+            env: { ...process.env, DISPLAY: display }
+          });
+          proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`xclip exited ${code}`)));
+          proc.on("error", reject);
+        });
+      }
       return reply.code(200).send({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return reply.code(500).send({ error: `Failed to write to pasteboard: ${message}` });
+      return reply.code(500).send({ error: `Failed to write to clipboard: ${message}` });
     } finally {
       await unlink(tmpPath).catch(() => {});
     }


### PR DESCRIPTION
## Summary
- Make the `POST /api/v1/clipboard/image` endpoint platform-aware: macOS continues using `osascript`, Linux uses `xclip` with a virtual X display
- New `DISPATCH_COPY_DISPLAY` env var configures the X display for clipboard operations; forwarded to agent tmux sessions automatically
- Returns a clear error on Linux if `DISPATCH_COPY_DISPLAY` is not set
- README install prompt updated with Xvfb systemd service setup and xclip/xvfb as dependencies

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 210 unit tests pass
- [x] `pnpm run test:e2e` — 91 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)