### PR TITLE
Standardize jobs icon to AlarmClock with accent selected state

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -3,7 +3,7 @@ import {
   AlertTriangle,
   Archive,
   ChevronDown,
-  ListChecks,
+  AlarmClock,
   Loader2,
   Play,
   Pause,
@@ -126,7 +126,7 @@ export function AgentCard({
               className="border-status-working/45 bg-status-working/15 text-status-working"
               title="Job-spawned agent"
             >
-              <ListChecks className="mr-1 h-3 w-3" />
+              <AlarmClock className="mr-1 h-3 w-3" />
               Job
             </Badge>
           ) : null}

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -4,7 +4,7 @@ import {
   Bot,
   ChevronDown,
   ChevronLeft,
-  ListChecks,
+  AlarmClock,
   Settings,
   X
 } from "lucide-react";
@@ -210,7 +210,7 @@ export function AgentSidebarContent({
                 onClick={() => undefined}
                 aria-label="Agents"
                 data-testid="agents-button"
-                className="rounded-md bg-muted/50 p-2 text-foreground transition-colors hover:bg-muted/70"
+                className="rounded-md p-2 text-primary transition-colors hover:text-primary/80"
               >
                 <Bot className="h-5 w-5" />
               </button>
@@ -225,7 +225,7 @@ export function AgentSidebarContent({
                 data-testid="jobs-button"
                 className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
               >
-                <ListChecks className="h-5 w-5" />
+                <AlarmClock className="h-5 w-5" />
               </button>
             </TooltipTrigger>
             <TooltipContent>Jobs</TooltipContent>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -1,6 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import cronstrue from "cronstrue";
-import { Activity, AlarmClock, ArrowLeft, BookOpenText, Bot, Check, CheckCircle2, ChevronDown, Clock, GitBranch, History, ListChecks, Loader2, LoaderCircle, MessageSquareText, Play, Plus, RefreshCw, Search, Settings, Terminal, Trash2, X, XCircle } from "lucide-react";
+import { Activity, AlarmClock, ArrowLeft, BookOpenText, Bot, Check, CheckCircle2, ChevronDown, Clock, GitBranch, History, Loader2, LoaderCircle, MessageSquareText, Play, Plus, RefreshCw, Search, Settings, Terminal, Trash2, X, XCircle } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -372,8 +372,8 @@ function JobsNav({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenJobs} aria-label="Jobs" data-testid="jobs-button" className="rounded-md bg-muted/50 p-2 text-foreground transition-colors hover:bg-muted/70">
-              <ListChecks className="h-5 w-5" />
+            <button onClick={onOpenJobs} aria-label="Jobs" data-testid="jobs-button" className="rounded-md p-2 text-primary transition-colors hover:text-primary/80">
+              <AlarmClock className="h-5 w-5" />
             </button>
           </TooltipTrigger>
           <TooltipContent>Jobs</TooltipContent>


### PR DESCRIPTION
## Summary
- Standardize all "jobs" icons to `AlarmClock` (previously `ListChecks`) across sidebar footer, jobs pane header, and agent card badges
- Use `text-primary` accent color for the active/selected nav icon in the sidebar footer instead of the subtle `bg-muted/50` background style

## Test plan
- [x] `pnpm run finalize:web` — type check + production build pass
- [x] E2E tests — 95 passed, 6 skipped
- [x] Visual validation via Playwright on dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)