### PR TITLE
Add janitor job, scoped repo tools, and dev session prefix

### DIFF
--- a/.dispatch/jobs/janitor.md
+++ b/.dispatch/jobs/janitor.md
@@ -1,0 +1,90 @@
+---
+name: Janitor
+schedule: "0 10 * * *"
+timeout: 15m
+needs_input_timeout: 18h
+full_access: true
+notify:
+  on_complete: []
+  on_error:
+    - slack
+  on_needs_input:
+    - slack
+---
+
+# Janitor
+
+Clean up orphaned resources left behind by dispatch agents that weren't shut down properly. Run three cleanup tasks in order, report results using the structured job tools.
+
+You have repo tools available for gathering data: `list_dev_containers`, `list_agents`, `list_dispatch_sessions`, `list_candidate_databases`. Use these instead of running the commands manually. You also have `dev_down` with an optional `suffix` param for cleaning up dev instances.
+
+## Task 1: dev-cleanup
+
+Find and remove rogue `dispatch-dev` server instances.
+
+### Procedure
+
+1. Call `list_dev_containers` to find all dispatch-dev Postgres containers.
+2. If none are running, log "No dispatch-dev containers found" and skip to Task 2.
+3. Extract the suffix from each container name (strip the `dispatch-postgres-` prefix).
+4. Call `list_agents` to get all agents and their statuses.
+5. For each suffix, classify:
+   - **Active agent**: Suffix starts with `agt_` and the agent exists in `running` or `creating` status. Do not touch.
+   - **Rogue agent**: Suffix starts with `agt_` but the agent is `stopped`, `error`, or not found in API, AND no matching worktree exists in `.dispatch/worktrees/`. Clean up.
+   - **Non-agent container** (e2e tests, manual dev servers — suffix does NOT start with `agt_`): Check if `/tmp/dispatch-dev-<SUFFIX>.env` exists and read `DEV_API_PID` from it. If the PID is alive (`kill -0 <PID>` succeeds), it's an active dev/test server — do not touch. If the PID is dead or no state file exists, it's orphaned — clean up.
+6. For each rogue/orphaned instance, call `dev_down` with the `suffix` param set to the suffix.
+7. Log each action taken.
+
+### Key paths
+- State files: `/tmp/dispatch-dev-<SUFFIX>.env`
+- Docker containers: `dispatch-postgres-<SUFFIX>`
+- Worktrees: `.dispatch/worktrees/`
+
+## Task 2: tmux-cleanup
+
+Find and kill abandoned Dispatch tmux sessions.
+
+### Procedure
+
+1. Call `list_dispatch_sessions` to get tmux sessions belonging to this Dispatch server.
+2. If none found, log "No dispatch tmux sessions found" and skip to Task 3.
+3. Call `list_agents` (reuse the response from Task 1 if available) to get agent statuses.
+4. Extract the agent ID from each session name (the `agt_<12hex>` portion).
+5. Classify each session:
+   - **Active**: Agent ID is in `running` or `creating` status. Do not touch.
+   - **Abandoned**: Agent ID is `stopped`, `error`, `archiving`, or not found in API.
+6. For each abandoned session, run `tmux kill-session -t <session_name>`.
+7. Log each action taken.
+
+## Task 3: db-cleanup
+
+Find and drop orphaned test/dev databases on local Postgres.
+
+### Procedure
+
+1. Call `list_candidate_databases` to get all `dispatch_*` databases on local Postgres.
+2. If only `dispatch` is returned or nothing, log "No candidate databases found" and finish.
+3. Filter out protected databases:
+   - **Always exclude `dispatch`** — this is the production database. Never drop it.
+   - **Exclude databases referenced by live dispatch-dev state files** — scan `/tmp/dispatch-dev-*.env` files, look for `DATABASE_URL` values pointing at port 5432, extract the database name, and exclude them.
+   - **Exclude recent `dispatch_test_*` databases** — the name format is `dispatch_test_<epoch_millis>_<random>`. Parse the epoch-millis timestamp. If it is less than 1 day old (86400000 ms), skip it.
+4. For each remaining database, run: `PGPASSWORD=dispatch psql -h 127.0.0.1 -p 5432 -U dispatch -d postgres -c 'DROP DATABASE IF EXISTS "<dbname>"'`.
+5. Log each action taken.
+
+### Safety rules
+- NEVER drop `dispatch` — hardcoded exclusion.
+- 1-day age threshold for `dispatch_test_*` databases.
+- Exclude any DB referenced by a live dispatch-dev state file.
+
+## Reporting
+
+Use `job_log` to report progress as you work through each task.
+
+When all tasks are complete, call `job_complete` with a report containing one entry per task:
+- `status`: `success` if the task ran and cleaned up (or had nothing to clean), `skipped` if it was not applicable, `error` if something went wrong but the job continued.
+- `summary`: Brief description of what was found and done.
+- `errors`: Any recoverable errors encountered (e.g., ambiguous dev server suffixes, databases that couldn't be dropped).
+
+If a fatal error prevents the job from continuing (e.g., cannot reach the Dispatch API, cannot connect to Postgres), call `job_failed` with a report explaining what happened and which tasks completed before the failure.
+
+Use `job_needs_input` when you encounter ambiguous resources that need human judgment — for example, dev containers with non-agent suffixes, or tmux sessions with uncommitted work for an agent in error state. Pause and ask rather than guess.

--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -55,12 +55,6 @@
       "scope": ["job"]
     },
     {
-      "name": "list_agents",
-      "description": "List all agents from the local Dispatch server with their IDs and statuses.",
-      "command": ["bash", "-c", "curl -sf -H \"Authorization: Bearer $DISPATCH_AUTH_TOKEN\" http://127.0.0.1:${DISPATCH_PORT}/api/v1/agents"],
-      "scope": ["job"]
-    },
-    {
       "name": "list_candidate_databases",
       "description": "List all dispatch_* databases on local Postgres (port 5432). Returns one database name per line.",
       "command": ["bash", "-c", "PGPASSWORD=dispatch psql -h 127.0.0.1 -p 5432 -U dispatch -d postgres -t -A -c \"SELECT datname FROM pg_database WHERE datname LIKE 'dispatch_%'\" 2>/dev/null || true"],

--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -26,8 +26,11 @@
     },
     {
       "name": "dev_down",
-      "description": "Stop the repo's dev environment and remove its database container.",
-      "command": ["./bin/dispatch-dev", "down"]
+      "description": "Stop a dev environment and remove its database container. Without a suffix, stops the current agent's dev environment.",
+      "command": ["./bin/dispatch-dev", "down"],
+      "params": [
+        { "name": "suffix", "type": "string", "flag": "--suffix", "description": "Target a specific dev environment by its suffix (e.g. agt_abc123def456)." }
+      ]
     },
     {
       "name": "dev_status",
@@ -38,6 +41,30 @@
       "name": "dev_logs",
       "description": "Show recent API server logs from the dev environment.",
       "command": ["./bin/dispatch-dev", "logs"]
+    },
+    {
+      "name": "list_dev_containers",
+      "description": "List all running dispatch-dev Postgres containers. Returns one container name per line.",
+      "command": ["docker", "ps", "--filter", "name=dispatch-postgres-", "--format", "{{.Names}}"],
+      "scope": ["job"]
+    },
+    {
+      "name": "list_dispatch_sessions",
+      "description": "List tmux sessions belonging to this Dispatch server. Returns one session name per line. Uses DISPATCH_SESSION_PREFIX to filter (defaults to 'dispatch').",
+      "command": ["bash", "-c", "PREFIX=${DISPATCH_SESSION_PREFIX:-dispatch}; tmux list-sessions -F '#{session_name}' 2>/dev/null | grep \"^${PREFIX}_agt_\" || true"],
+      "scope": ["job"]
+    },
+    {
+      "name": "list_agents",
+      "description": "List all agents from the local Dispatch server with their IDs and statuses.",
+      "command": ["bash", "-c", "curl -sf -H \"Authorization: Bearer $DISPATCH_AUTH_TOKEN\" http://127.0.0.1:${DISPATCH_PORT}/api/v1/agents"],
+      "scope": ["job"]
+    },
+    {
+      "name": "list_candidate_databases",
+      "description": "List all dispatch_* databases on local Postgres (port 5432). Returns one database name per line.",
+      "command": ["bash", "-c", "PGPASSWORD=dispatch psql -h 127.0.0.1 -p 5432 -U dispatch -d postgres -t -A -c \"SELECT datname FROM pg_database WHERE datname LIKE 'dispatch_%'\" 2>/dev/null || true"],
+      "scope": ["job"]
     }
   ]
 }

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -983,7 +983,7 @@ export class AgentManager {
   }
 
   private async cleanupOrphanedSessions(): Promise<void> {
-    const SESSION_PREFIX = "dispatch_agt_";
+    const SESSION_PREFIX = `${this.config.sessionPrefix}_agt_`;
 
     let stdout: string | undefined;
     try {
@@ -1994,15 +1994,16 @@ export class AgentManager {
     return `agt_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
   }
 
-  /** Extract agent ID from a session name like "dispatch_agt_abc123_my-task". */
+  /** Extract agent ID from a session name like "dispatch_agt_abc123_my-task" or "dispatch_dev_agt_abc123_my-task". */
   private agentIdFromSessionName(sessionName: string): string {
-    const match = sessionName.match(/dispatch_(agt_[a-f0-9]{12})/);
-    return match?.[1] ?? sessionName.replace(/^dispatch_/, "");
+    const match = sessionName.match(/(agt_[a-f0-9]{12})/);
+    return match?.[1] ?? sessionName.replace(/^[^_]*_/, "");
   }
 
   private toSessionName(agentId: string, agentName?: string): string {
+    const prefix = this.config.sessionPrefix;
     if (!agentName) {
-      return `dispatch_${agentId}`;
+      return `${prefix}_${agentId}`;
     }
     // Sanitize: tmux disallows colons and periods in session names.
     // Collapse whitespace/special chars to hyphens, truncate to keep it readable.
@@ -2012,7 +2013,7 @@ export class AgentManager {
       .replace(/-+/g, "-")
       .replace(/^-|-$/g, "")
       .slice(0, 30);
-    return `dispatch_${agentId}_${slug}`;
+    return `${prefix}_${agentId}_${slug}`;
   }
 
   private defaultMediaDir(agentId: string): string {

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1729,6 +1729,10 @@ export class AgentManager {
     agentId: string,
     input: { status: string; message?: string }
   ): Promise<PersonaReviewRecord> {
+    const VALID_STATUSES = ["reviewing"];
+    if (!VALID_STATUSES.includes(input.status)) {
+      throw new AgentError(`Invalid review status "${input.status}". Must be one of: ${VALID_STATUSES.join(", ")}`, 400);
+    }
     const result = await this.pool.query<PersonaReviewRecord>(
       `UPDATE persona_reviews
        SET status = $2, message = $3, updated_at = NOW()

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -22,6 +22,7 @@ export type AppConfig = {
   claudeBin: string;
   opencodeBin: string;
   agentRuntime: "tmux" | "inert";
+  sessionPrefix: string;
   tls: TlsConfig | null;
 };
 
@@ -82,6 +83,7 @@ export function loadConfig(): AppConfig {
       process.env.OPENCODE_BIN ??
       "opencode",
     agentRuntime: resolveAgentRuntime(),
+    sessionPrefix: process.env.DISPATCH_SESSION_PREFIX ?? "dispatch",
     tls: loadTls(),
   };
 

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -609,7 +609,13 @@ function buildAgentArgs(agentType: JobRecord["agentType"], prompt: string, fullA
       : agentType === "codex"
         ? CODEX_FULL_ACCESS_ARG
         : null;
-  return fullAccess && fullAccessArg ? [...args, fullAccessArg] : args;
+  if (fullAccess && fullAccessArg) args.push(fullAccessArg);
+  if (agentType === "claude") {
+    // Claude Code needs a positional prompt arg to start an interactive session
+    // with an initial message. Without it the agent sits idle waiting for input.
+    args.push("Run the job described in your system prompt now.");
+  }
+  return args;
 }
 
 function buildRunConfig(job: JobRecord, triggerSource: "manual" | "scheduled"): JobRunConfig {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1244,12 +1244,15 @@ async function registerRoutes() {
       worktreeRoot,
       enableBuiltinTools: false,
       toolScope: "job",
-      repoToolEnv: { DISPATCH_AUTH_TOKEN: config.authToken },
       jobTools: {
         complete: mcpJobComplete,
         failed: mcpJobFailed,
         needsInput: mcpJobNeedsInput,
         log: mcpJobLog,
+        listAgents: async () => {
+          const agents = await agentManager.listAgents();
+          return agents.map((a) => ({ id: a.id, name: a.name, status: a.status, cwd: a.cwd }));
+        },
       },
     });
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1244,6 +1244,7 @@ async function registerRoutes() {
       worktreeRoot,
       enableBuiltinTools: false,
       toolScope: "job",
+      repoToolEnv: { DISPATCH_AUTH_TOKEN: config.authToken },
       jobTools: {
         complete: mcpJobComplete,
         failed: mcpJobFailed,
@@ -3179,8 +3180,6 @@ async function start() {
   await waitForDatabase();
   await runMigrations();
   config.authToken = await getOrCreateAuthToken(pool);
-  // Expose auth token in process.env so repo tools (e.g. list_agents) can use it
-  process.env.DISPATCH_AUTH_TOKEN = config.authToken;
   await agentManager.reconcileAgents();
   await jobService.reconcileActiveRuns();
   await jobService.startSchedulers();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1243,6 +1243,7 @@ async function registerRoutes() {
       repoRoot,
       worktreeRoot,
       enableBuiltinTools: false,
+      toolScope: "job",
       jobTools: {
         complete: mcpJobComplete,
         failed: mcpJobFailed,
@@ -3178,6 +3179,8 @@ async function start() {
   await waitForDatabase();
   await runMigrations();
   config.authToken = await getOrCreateAuthToken(pool);
+  // Expose auth token in process.env so repo tools (e.g. list_agents) can use it
+  process.env.DISPATCH_AUTH_TOKEN = config.authToken;
   await agentManager.reconcileAgents();
   await jobService.reconcileActiveRuns();
   await jobService.startSchedulers();

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -50,6 +50,7 @@ const testConfig = {
   claudeBin: "echo",
   opencodeBin: "echo",
   agentRuntime: "tmux",
+  sessionPrefix: "dispatch",
   tls: null,
 } satisfies import("../../src/config.js").AppConfig;
 

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -716,7 +716,7 @@ function AddJobFlow({
                         <Input id="job-timeout" value={timeoutMinutes} onChange={(event) => setTimeoutMinutes(event.target.value)} inputMode="numeric" />
                       </div>
                       <div className="min-w-0 space-y-1">
-                        <label className="text-sm text-muted-foreground" htmlFor="job-needs-input-timeout">Needs-input timeout, minutes</label>
+                        <label className="text-sm text-muted-foreground" htmlFor="job-needs-input-timeout">Wait for input, minutes</label>
                         <Input id="job-needs-input-timeout" value={needsInputTimeoutMinutes} onChange={(event) => setNeedsInputTimeoutMinutes(event.target.value)} inputMode="numeric" />
                       </div>
                       <JobWorktreeOption
@@ -1163,7 +1163,7 @@ function SettingsTab({
             <Input id={`settings-timeout-${job.id}`} value={timeoutMinutes} onChange={(event) => setTimeoutMinutes(event.target.value)} inputMode="numeric" />
           </div>
           <div className="space-y-1">
-            <label className="text-sm text-muted-foreground" htmlFor={`settings-needs-input-${job.id}`}>Needs-input timeout, minutes</label>
+            <label className="text-sm text-muted-foreground" htmlFor={`settings-needs-input-${job.id}`}>Wait for input, minutes</label>
             <Input id={`settings-needs-input-${job.id}`} value={needsInputTimeoutMinutes} onChange={(event) => setNeedsInputTimeoutMinutes(event.target.value)} inputMode="numeric" />
           </div>
         </div>

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -235,8 +235,9 @@ cmd_up() {
     # Unset TLS so dev servers run plain HTTP
     unset TLS_CERT TLS_KEY 2>/dev/null || true
 
-    # Override port and set agent runtime — always explicit so .env doesn't leak
+    # Override port, session prefix, and agent runtime — always explicit so .env doesn't leak
     export DISPATCH_PORT="$DEV_API_PORT"
+    export DISPATCH_SESSION_PREFIX="dispatch_dev"
     if [ "$OPT_LIVE" = "1" ]; then
       export DISPATCH_AGENT_RUNTIME="tmux"
     else

--- a/docs/jobs-feature-spec.md
+++ b/docs/jobs-feature-spec.md
@@ -1,0 +1,324 @@
+# Dispatch Jobs
+
+Scheduled, repo-scoped agent tasks with structured execution, history, and interactive recovery.
+
+## Overview
+
+Jobs are recurring agent tasks defined in repository files and executed on a schedule by Dispatch. They combine the consistency of scripts (deterministic steps codified as repo tools) with the adaptability of agents (contextual decision-making, interactive recovery when stuck).
+
+Jobs solve the problem of recurring maintenance and operational tasks that today require manually spinning up an agent, re-explaining the task from scratch, and hoping the approach is consistent. With Jobs, the task definition lives in the repo, the mechanical steps are codified as tools, and the agent provides the judgment layer.
+
+## Concepts
+
+### Job Definition (repo-side)
+
+A job is defined as a markdown file in `.dispatch/jobs/`:
+
+```
+.dispatch/
+  jobs/
+    janitor.md
+    security-scan.md
+```
+
+Each file contains frontmatter with configuration and a body with the task prompt:
+
+```markdown
+---
+name: janitor
+schedule: "0 9 * * 1"          # cron expression (every Monday 9am)
+timeout: 30m                    # max run time before auto-timeout
+needs_input_timeout: 24h        # how long to wait for human before timing out
+notify:
+  on_complete: []               # no notification on routine success
+  on_error: ['slack']           # notify on failure
+  on_needs_input: ['slack']     # notify when human help needed
+---
+
+## Janitor
+
+Clean up orphaned resources left behind by agents that weren't shut down properly.
+
+### Tasks
+
+1. **dev-cleanup**: Find rogue dispatch-dev server instances...
+2. **tmux-cleanup**: Find abandoned dispatch tmux sessions...
+3. **db-cleanup**: Find orphaned test databases on local Postgres...
+
+### Instructions
+
+- Start by checking for running Docker containers. If none, skip dev-cleanup.
+- For each task, use the provided repo tools for the mechanical steps.
+- If you encounter an ambiguous situation, report it as a recoverable error and move on.
+- Only use needs_input for decisions that could cause data loss if you guess wrong.
+```
+
+### Job Configuration (server-side)
+
+Server-side settings are configured in the Dispatch UI, not in the repo file. These are instance-specific:
+
+- **Enabled/disabled** toggle
+- **Agent type**: claude, codex, or opencode
+- **Use worktree**: whether to create a git worktree for the job run
+- **Branch name**: if using a worktree, the branch to use
+- **Permission scope**: full access or restricted
+- **Additional instructions**: server-specific context appended to the job prompt (e.g., "the prod DB is on port 5433 on this machine")
+
+### Directory Discovery
+
+Jobs are discovered from directories that Dispatch knows about:
+
+1. **Auto-discovered**: Dispatch already remembers which working directories have been used to launch agents. These are scanned for `.dispatch/jobs/*.md` files.
+2. **Manually added**: Users can add additional directories via the Jobs UI for repos that haven't had agents launched in them yet.
+
+A job's identity is `(directory, job name)` — the same `janitor.md` in two different repos produces two independent jobs with separate schedules, settings, and history.
+
+## Execution Model
+
+### Job Lifecycle
+
+```
+scheduled → started → running → completed | failed | needs_input
+                                                ↗
+                                  (resume from needs_input)
+```
+
+| State | Description |
+|-------|-------------|
+| **scheduled** | Cron trigger is pending; job has not started yet |
+| **started** | Agent is being spawned and initialized |
+| **running** | Agent is actively executing the job |
+| **needs_input** | Agent is paused, waiting for human decision. This is a hard pause — the agent stops working until a human responds |
+| **completed** | All tasks finished. Agent submitted a structured report |
+| **failed** | An unrecoverable error stopped the job. Agent reported what failed and why |
+| **timed_out** | Job exceeded its `timeout` or `needs_input_timeout` without completing |
+
+### Structured Reporting
+
+When a job finishes, the agent doesn't just say "done" in prose. It submits a **job report** via a dedicated tool — a structured object that the framework requires before it will accept a terminal state:
+
+```json
+{
+  "status": "completed",
+  "summary": "All 3 cleanup tasks completed. 2 rogue containers removed, 3 tmux sessions killed, 0 databases dropped.",
+  "tasks": [
+    {
+      "name": "dev-cleanup",
+      "status": "success",
+      "summary": "Found 2 rogue containers, cleaned up both",
+      "errors": []
+    },
+    {
+      "name": "tmux-cleanup",
+      "status": "success",
+      "summary": "Killed 3 abandoned sessions",
+      "errors": [
+        {
+          "message": "Session dispatch_agt_x had uncommitted work — skipped, flagged for review",
+          "recoverable": true,
+          "action": "skipped cleanup"
+        }
+      ]
+    },
+    {
+      "name": "db-cleanup",
+      "status": "skipped",
+      "summary": "No candidate databases found",
+      "errors": []
+    }
+  ]
+}
+```
+
+### Error Classification
+
+Jobs distinguish between three outcomes that aren't "success":
+
+1. **Recoverable error** — Something went wrong in one step, but the job can continue. The error is logged in the task report, but execution proceeds. Example: "Couldn't drop one database because it had active connections — skipped it."
+
+2. **Fatal error** — The job cannot proceed at all. Example: "Can't connect to Postgres" or "Dispatch API is unreachable so I can't validate any ownership." The job stops and the run is marked `failed`.
+
+3. **Needs input** — Not an error, but a decision point where the agent needs human judgment. Example: "Found a tmux session with uncommitted work for an agent in error state. Kill it or leave it?" The job pauses until a human responds.
+
+### Framework Guardrails
+
+The job runner (not the agent) enforces these constraints:
+
+- **Timeout**: If the agent hasn't emitted a terminal state within the configured `timeout`, the run is marked `timed_out`.
+- **Terminal state required**: The agent must call a `job_complete` or `job_failed` tool to finish. Freeform "I'm done" in prose doesn't count. The framework won't close the run without a structured report.
+- **Needs-input timeout**: If the agent asks for help and nobody responds within `needs_input_timeout`, the run is marked `timed_out` with the pending question logged.
+- **Crash detection**: If the agent process dies (crash, OOM, tmux session ends) without a terminal event, the framework marks it as a crash with whatever logs are available.
+- **Concurrency guard**: If a job is still running when the next cron trigger fires, the new run is skipped and logged. No two runs of the same job overlap.
+
+## Scheduling
+
+### Cron-based
+
+Scheduling is built on system cron. Dispatch manages cron entries on behalf of the user — no custom scheduler daemon.
+
+- Enabling a job in the UI registers a cron entry that calls `dispatch jobs run <name> --dir <directory>`
+- Disabling a job removes the cron entry
+- Users never hand-edit crontabs for jobs; Dispatch owns the entries it creates
+
+### Manual Trigger
+
+Jobs can also be triggered manually via:
+- "Run now" button in the Jobs UI
+- CLI: `dispatch jobs run <name> --dir <directory>`
+
+### What Happens on Trigger
+
+1. Dispatch spawns an agent with the job's prompt (from the markdown body) plus any server-side additional instructions
+2. Agent type, worktree, permissions, and branch come from the server-side config
+3. The agent gets access to the repo's tools from `.dispatch/tools.json`
+4. The framework monitors the agent for timeout and crash conditions
+5. On completion, the structured report is stored as a run in the job's history
+6. Notifications fire based on the job's `notify` config and the globally configured channels
+
+## Notifications
+
+Jobs reference notification channels by name (e.g., `['slack']`). The actual webhook URLs and channel configs live in Dispatch's global settings (Settings > Notifications), which already exists today.
+
+```yaml
+notify:
+  on_complete: []               # routine success — don't bother me
+  on_error: ['slack']           # something failed — tell me
+  on_needs_input: ['slack']     # need my help — tell me
+```
+
+Empty array means no notification for that event. This is extensible to future channels (`['slack', 'discord', 'email']`) without changing the schema.
+
+Notifications for job events are distinct from the existing agent notification settings. The global agent notifications (done, waiting, blocked) continue to work as they do today for regular agents. Job notifications are controlled per-job in the job definition file.
+
+## UI Integration
+
+### Jobs Dialog
+
+A new bottom nav icon in the left sidebar (4th icon, alongside Docs, Activity, Settings) opens the Jobs dialog. The dialog follows the same pattern as Settings and Activity — a modal overlay with its own navigation.
+
+#### Overview
+
+The main view lists all discovered jobs across all directories:
+
+| Column | Description |
+|--------|-------------|
+| Job name | From the frontmatter `name` field |
+| Directory | Source repo/directory path |
+| Schedule | Human-readable (e.g., "Every Monday at 9:00 AM") |
+| Status | Enabled/disabled toggle |
+| Last run | Status badge (completed/failed/timed_out) + timestamp |
+| Next run | Calculated from cron expression |
+| Actions | "Run now" button |
+
+#### Directories
+
+Manage which directories are scanned for `.dispatch/jobs/`:
+- Auto-discovered directories (from recent agent working directories) shown with an auto-detected badge
+- "Add directory" button for manual additions
+- Remove button for manually-added directories
+
+#### Job Detail
+
+Clicking a job row opens a detail view with tabs:
+
+**Settings tab** — Server-side configuration:
+- Agent type selector (claude/codex/opencode)
+- Worktree toggle + branch name field
+- Permission scope toggle (full access)
+- Additional instructions text area
+
+**Config tab** (read-only) — Parsed view of the `.dispatch/jobs/*.md` frontmatter:
+- Schedule (cron expression + human-readable)
+- Timeout values
+- Notification preferences
+- Useful for verifying the repo config without opening the file
+
+**History tab** — List of past runs:
+- Timestamp, duration, status badge
+- Click a run to see the full structured report (task-by-task results with errors)
+- Run retention: configurable, default 50 runs
+
+**Active run banner** — If a job is currently running, a prominent banner at the top links to the live agent session in the main panel.
+
+### Agent List Integration
+
+Job-spawned agents appear in the normal agent list in the left sidebar, but visually distinguished:
+- Badge or icon indicating it's a job run (e.g., "janitor - run #12")
+- Clicking focuses the agent in the main panel with terminal, pins, media — identical to any other agent
+- This is how you "hop into a running job session" when you get a `needs_input` notification
+
+### Docs
+
+A new "Jobs" entry in the Docs sidebar explaining the feature, configuration format, and workflows.
+
+## User Flows
+
+### Setup Flow
+
+1. Developer adds `.dispatch/jobs/janitor.md` to the repo
+2. Dispatch discovers it (from the auto-discovered directories or manually added one)
+3. Job appears in the Jobs dialog as disabled
+4. User clicks into the job, configures server-side settings (agent type, permissions, etc.)
+5. User toggles the job to enabled
+6. Dispatch registers the cron entry — job will run on schedule
+
+### Routine Run
+
+1. Cron fires at the scheduled time
+2. Dispatch spawns an agent with the job definition
+3. Agent executes the tasks, using repo tools for mechanical steps
+4. Agent submits structured report via `job_complete`
+5. Run is stored in history
+6. No notification (routine success, `on_complete: []`)
+
+### Run Needs Help
+
+1. Agent hits an ambiguous situation during a job run
+2. Agent calls `needs_input` with a description of the decision needed
+3. Dispatch sends Slack notification (per `on_needs_input: ['slack']`)
+4. User opens Dispatch UI, sees the job has an active run needing input
+5. User clicks into the live agent session via the agent list
+6. User provides guidance in the terminal
+7. User disconnects — agent continues and finishes
+8. Run completes, stored in history
+
+### Investigating a Failure
+
+1. Job run fails — agent calls `job_failed` with error details
+2. Slack notification fires (per `on_error: ['slack']`)
+3. User opens Jobs dialog, goes to the job's History tab
+4. User clicks the failed run to see the structured report
+5. Sees which task failed, the error message, and what succeeded
+6. If the session is still alive, can click into it for the full transcript
+7. Optionally clicks "Run now" to retry
+
+### Manual Run
+
+1. User clicks "Run now" on a job (enabled or disabled — manual trigger always works)
+2. Same execution flow as a scheduled run
+3. Agent appears in the agent list, user can watch live if desired
+
+## Implementation Considerations
+
+### Repo Tools Integration
+
+The mechanical steps of a job (query an API, list Docker containers, check a database) should be codified as repo tools in `.dispatch/tools.json`. This gives the agent consistent, fast operations rather than rediscovering how to do things each run. The agent provides judgment on top of deterministic tool results.
+
+### Job-Specific Agent Tools
+
+The framework provides job-specific tools to the agent:
+
+- `job_complete(report)` — Submit a structured report and mark the run as completed
+- `job_failed(report)` — Submit a structured report and mark the run as failed
+- `job_needs_input(question)` — Pause execution and notify for human input
+- `job_log(task, message, level)` — Structured logging within a task (for building up the report incrementally)
+
+These replace the freeform `dispatch_event` for job execution. Regular `dispatch_event` continues to work for agent-list status display, but the job lifecycle is controlled through these dedicated tools.
+
+### Auth Token Access
+
+Jobs that need to query the Dispatch API (e.g., checking which agents are running) need access to the auth token. This should be provided as an environment variable to the job agent, or exposed via a repo tool that handles authentication internally.
+
+### File Change Detection
+
+When a job's `.md` file is updated in the repo (e.g., schedule change via a PR merge), the change takes effect on the next run. The Jobs dialog "Config" tab reflects the current file state. If a job file is deleted, the job should show as "config missing" in the UI rather than silently disappearing.

--- a/packages/shared/src/mcp/repo-tools.ts
+++ b/packages/shared/src/mcp/repo-tools.ts
@@ -64,7 +64,7 @@ export type RepoToolDefinition = {
   description: string;
   params?: RepoToolParam[];
   scope?: RepoToolScope[];
-  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown> }) => Promise<RepoToolResult>;
+  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown>; env?: Record<string, string> }) => Promise<RepoToolResult>;
 };
 
 export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinition[]> {
@@ -79,7 +79,7 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
       description: tool.description,
       params: tool.params,
       scope: tool.scope,
-      run: async ({ agentId, repoRoot: currentRepoRoot, params }) => {
+      run: async ({ agentId, repoRoot: currentRepoRoot, params, env: extraEnv }) => {
         const [command, ...args] = tool.command;
 
         // Append CLI flags from params
@@ -99,6 +99,7 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           cwd: currentRepoRoot,
           env: {
             DISPATCH_AGENT_ID: agentId,
+            ...extraEnv,
           },
           // Allow all exit codes — the agent decides how to handle failures.
           // Throwing on non-zero hides useful diagnostic output (stderr, partial stdout).

--- a/packages/shared/src/mcp/repo-tools.ts
+++ b/packages/shared/src/mcp/repo-tools.ts
@@ -39,11 +39,14 @@ export type RepoToolParam = {
   description: string;
 };
 
+export type RepoToolScope = "agent" | "reviewer" | "job";
+
 type RepoToolConfig = {
   name: string;
   description: string;
   command: string[];
   params?: RepoToolParam[];
+  scope?: RepoToolScope[];
 };
 
 export type RepoToolResult = {
@@ -60,6 +63,7 @@ export type RepoToolDefinition = {
   name: string;
   description: string;
   params?: RepoToolParam[];
+  scope?: RepoToolScope[];
   run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown> }) => Promise<RepoToolResult>;
 };
 
@@ -74,6 +78,7 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
       name: prefixedName,
       description: tool.description,
       params: tool.params,
+      scope: tool.scope,
       run: async ({ agentId, repoRoot: currentRepoRoot, params }) => {
         const [command, ...args] = tool.command;
 
@@ -94,7 +99,10 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           cwd: currentRepoRoot,
           env: {
             DISPATCH_AGENT_ID: agentId,
-          }
+          },
+          // Allow all exit codes — the agent decides how to handle failures.
+          // Throwing on non-zero hides useful diagnostic output (stderr, partial stdout).
+          allowedExitCodes: Array.from({ length: 256 }, (_, i) => i)
         });
 
         return {
@@ -148,8 +156,9 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
   }
 
   const params = parseRepoToolParams(rawTool.params);
+  const scope = parseRepoToolScope(rawTool.scope);
 
-  return { name, description, command, params };
+  return { name, description, command, params, scope };
 }
 
 export async function loadRepoHooks(repoRoot: string): Promise<RepoHooks> {
@@ -202,6 +211,19 @@ function parseHookDefinition(value: unknown, name: string): RepoHookDefinition {
   const description = typeof raw.description === "string" ? raw.description.trim() : undefined;
 
   return { command, ...(description ? { description } : {}) };
+}
+
+const VALID_SCOPES = new Set<RepoToolScope>(["agent", "reviewer", "job"]);
+
+function parseRepoToolScope(raw: unknown): RepoToolScope[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const scopes: RepoToolScope[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string" && VALID_SCOPES.has(entry as RepoToolScope)) {
+      scopes.push(entry as RepoToolScope);
+    }
+  }
+  return scopes.length > 0 ? scopes : undefined;
 }
 
 function parseRepoToolParams(raw: unknown): RepoToolParam[] | undefined {

--- a/packages/shared/src/mcp/repo-tools.ts
+++ b/packages/shared/src/mcp/repo-tools.ts
@@ -64,7 +64,7 @@ export type RepoToolDefinition = {
   description: string;
   params?: RepoToolParam[];
   scope?: RepoToolScope[];
-  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown>; env?: Record<string, string> }) => Promise<RepoToolResult>;
+  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown> }) => Promise<RepoToolResult>;
 };
 
 export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinition[]> {
@@ -79,7 +79,7 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
       description: tool.description,
       params: tool.params,
       scope: tool.scope,
-      run: async ({ agentId, repoRoot: currentRepoRoot, params, env: extraEnv }) => {
+      run: async ({ agentId, repoRoot: currentRepoRoot, params }) => {
         const [command, ...args] = tool.command;
 
         // Append CLI flags from params
@@ -99,7 +99,6 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           cwd: currentRepoRoot,
           env: {
             DISPATCH_AGENT_ID: agentId,
-            ...extraEnv,
           },
           // Allow all exit codes — the agent decides how to handle failures.
           // Throwing on non-zero hides useful diagnostic output (stderr, partial stdout).

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -69,6 +69,7 @@ export type JobTools = {
     agentId: string,
     input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
   ) => Promise<{ runId: string; status: string }>;
+  listAgents: () => Promise<Array<{ id: string; name: string; status: string; cwd: string }>>;
 };
 
 export type PinInput = {
@@ -142,7 +143,6 @@ export type McpRequestContext = {
   jobTools?: JobTools;
   enableBuiltinTools?: boolean;
   toolScope?: "agent" | "reviewer" | "job";
-  repoToolEnv?: Record<string, string>;
 };
 
 export async function handleMcpRequest(
@@ -589,6 +589,25 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         }
       }
     );
+
+    server.registerTool(
+      "list_agents",
+      {
+        description: "List all agents from this Dispatch server with their IDs, names, and statuses.",
+        inputSchema: {}
+      },
+      async () => {
+        try {
+          const agents = await jobTools.listAgents();
+          return {
+            content: [{ type: "text", text: JSON.stringify({ agents }, null, 2) }],
+            structuredContent: { agents }
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
   }
 
   const toolsRoot = context.worktreeRoot ?? context.repoRoot;
@@ -609,8 +628,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             const result = await tool.run({
               agentId: context.agent!.id,
               repoRoot: toolsRoot,
-              params: args as Record<string, unknown>,
-              env: context.repoToolEnv
+              params: args as Record<string, unknown>
             });
             return {
               content: [{ type: "text", text: result.message }],

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -142,6 +142,7 @@ export type McpRequestContext = {
   jobTools?: JobTools;
   enableBuiltinTools?: boolean;
   toolScope?: "agent" | "reviewer" | "job";
+  repoToolEnv?: Record<string, string>;
 };
 
 export async function handleMcpRequest(
@@ -608,7 +609,8 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             const result = await tool.run({
               agentId: context.agent!.id,
               repoRoot: toolsRoot,
-              params: args as Record<string, unknown>
+              params: args as Record<string, unknown>,
+              env: context.repoToolEnv
             });
             return {
               content: [{ type: "text", text: result.message }],

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -141,6 +141,7 @@ export type McpRequestContext = {
   ) => Promise<void>;
   jobTools?: JobTools;
   enableBuiltinTools?: boolean;
+  toolScope?: "agent" | "reviewer" | "job";
 };
 
 export async function handleMcpRequest(
@@ -591,7 +592,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
 
   const toolsRoot = context.worktreeRoot ?? context.repoRoot;
   if (context.agent && toolsRoot) {
-    const repoTools = await loadRepoTools(toolsRoot);
+    const allRepoTools = await loadRepoTools(toolsRoot);
+    const scope = context.toolScope ?? "agent";
+    const repoTools = allRepoTools.filter((tool) => !tool.scope || tool.scope.includes(scope));
     for (const tool of repoTools) {
       const inputSchema = buildParamSchema(tool.params);
       server.registerTool(


### PR DESCRIPTION
## Summary

- **Janitor job** (`.dispatch/jobs/janitor.md`) — automated daily cleanup of orphaned dev containers, tmux sessions, and test databases with structured reporting via job tools
- **Scoped repo tools** — new `scope` field in `tools.json` restricts tools to specific agent types (`agent`, `reviewer`, `job`). Four job-only tools added for the janitor
- **Dev session prefix** — dev instances now prefix tmux sessions with `dispatch_dev_` (via `DISPATCH_SESSION_PREFIX`) so janitor jobs only clean up resources belonging to their own server
- **Claude job fix** — job agents now receive a positional prompt so Claude starts executing instead of sitting idle
- **Repo tool resilience** — commands return results on all exit codes instead of throwing, and `DISPATCH_AUTH_TOKEN` is exposed to repo tool commands

## Test plan

- [x] Type checking passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] Unit tests pass (`pnpm run test`)
- [x] Janitor job dry-run validated — all 3 tasks correctly classify active/rogue/ambiguous resources
- [x] Janitor job live run validated — correctly cleans orphans, pauses on ambiguous containers for human input
- [x] Dev session prefix verified — dev janitor only sees `dispatch_dev_` sessions, ignores prod
- [x] Scoped tools verified — job agents see job-only tools, regular agents do not
- [x] Security review persona launched

🤖 Generated with [Claude Code](https://claude.com/claude-code)