### PR TITLE
Add agent port guard to prevent shadowing prod (CRU-103)

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -89,6 +89,7 @@ export function loadConfig(): AppConfig {
 
   validateConfig(config);
   assertSafeDatabaseConfig(config);
+  assertSafePortConfig(config);
   return config;
 }
 
@@ -148,5 +149,20 @@ export function assertSafeDatabaseConfig(
       throw error;
     }
     // URL parsing failed — let the database client report the connection error.
+  }
+}
+
+export function assertSafePortConfig(
+  config: Pick<AppConfig, "port">,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const isAgentContext = Boolean(env.DISPATCH_AGENT_ID);
+  if (!isAgentContext) return;
+
+  if (config.port === 6767) {
+    throw new Error(
+      "Refusing to bind to production port 6767 from an agent context. " +
+        "Start local servers with dispatch-dev so DISPATCH_PORT points at an isolated port."
+    );
   }
 }

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { assertSafeDatabaseConfig } from "../src/config.js";
+import { assertSafeDatabaseConfig, assertSafePortConfig } from "../src/config.js";
 
 describe("database safety config", () => {
   it("refuses the production database from a Dispatch agent context", () => {
@@ -27,6 +27,26 @@ describe("database safety config", () => {
         { databaseUrl: "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch" },
         { DISPATCH_AGENT_ID: "agt_test", DISPATCH_ALLOW_AGENT_PROD_DB: "1" }
       )
+    ).not.toThrow();
+  });
+});
+
+describe("port safety config", () => {
+  it("refuses production port 6767 from an agent context", () => {
+    expect(() =>
+      assertSafePortConfig({ port: 6767 }, { DISPATCH_AGENT_ID: "agt_test" })
+    ).toThrow("Refusing to bind to production port 6767");
+  });
+
+  it("allows non-production ports from an agent context", () => {
+    expect(() =>
+      assertSafePortConfig({ port: 9123 }, { DISPATCH_AGENT_ID: "agt_test" })
+    ).not.toThrow();
+  });
+
+  it("allows production port outside agent context", () => {
+    expect(() =>
+      assertSafePortConfig({ port: 6767 }, {})
     ).not.toThrow();
   });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 6767}`,
+        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT}`,
         changeOrigin: true,
         ws: true
       }

--- a/bin/install-launchd
+++ b/bin/install-launchd
@@ -67,15 +67,14 @@ if [[ ! -f "$SERVER_ENV" ]]; then
   fi
 fi
 
-# Set DISPATCH_PORT in server .env if specified
-if [[ -n "$PORT" ]]; then
-  if grep -q '^DISPATCH_PORT=' "$SERVER_ENV"; then
-    sed -i '' "s/^DISPATCH_PORT=.*/DISPATCH_PORT=$PORT/" "$SERVER_ENV"
-  else
-    echo "DISPATCH_PORT=$PORT" >> "$SERVER_ENV"
-  fi
-  echo "==> set DISPATCH_PORT=$PORT in $SERVER_ENV"
+# Always write DISPATCH_PORT to server .env (required by the server)
+PORT="${PORT:-6767}"
+if grep -q '^DISPATCH_PORT=' "$SERVER_ENV"; then
+  sed -i '' "s/^DISPATCH_PORT=.*/DISPATCH_PORT=$PORT/" "$SERVER_ENV"
+else
+  echo "DISPATCH_PORT=$PORT" >> "$SERVER_ENV"
 fi
+echo "==> set DISPATCH_PORT=$PORT in $SERVER_ENV"
 
 # Check out the latest release tag so the install runs a known-good version
 # and the server can detect future updates via release.json.


### PR DESCRIPTION
## Summary
- Adds `assertSafePortConfig` that refuses to bind to port 6767 in agent context, preventing agents from shadowing the production server
- Updates `install-launchd` to always write `DISPATCH_PORT=6767` to `.env` (previously only wrote when `--port` was passed)
- Removes hardcoded `6767` fallback from Vite proxy config (dispatch-dev always sets `DISPATCH_PORT`)

Closes CRU-103

## Test plan
- [x] New unit tests for `assertSafePortConfig` (agent+6767 throws, agent+other passes, non-agent passes)
- [x] Type checking passes (`pnpm run check`)
- [x] Unit tests pass (`pnpm run test` — 213 passed)
- [x] Web finalization passes (`pnpm run finalize:web`)
- [x] E2E tests pass (`pnpm run test:e2e` — 95 passed)
- [ ] After deploy: add `DISPATCH_PORT=6767` to existing prod `.env` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)