### PR TITLE
Add jobs overview dashboard with metrics, chart, and activity feed

### DIFF
--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -337,6 +337,17 @@ export class JobService {
     return { job, runs };
   }
 
+  async getStats(): Promise<{
+    stats: { totalRuns: number; successCount: number; failureCount: number; avgDurationMs: number | null; daily: Array<{ day: string; completed: number; failed: number }> };
+    recentRuns: Array<{ id: string; jobId: string; status: string; startedAt: string; durationMs: number | null; jobName: string }>;
+  }> {
+    const [stats, recentRuns] = await Promise.all([
+      this.store.getRunStats(7),
+      this.store.listRecentRuns(5),
+    ]);
+    return { stats, recentRuns };
+  }
+
   async listAvailableJobs(input: { directory?: string; force?: boolean } = {}): Promise<{ directories: AvailableJobsDirectory[] }> {
     const configuredJobs = await this.store.listJobs();
     const configuredByFilePath = new Map(configuredJobs.map((job) => [job.filePath, job]));

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -346,6 +346,88 @@ export class JobStore {
     return result.rows.map((row) => mapRun(row));
   }
 
+  async listRecentRuns(limit = 10): Promise<Array<{
+    id: string;
+    jobId: string;
+    status: JobRunStatus;
+    startedAt: string;
+    durationMs: number | null;
+    jobName: string;
+  }>> {
+    const result = await this.pool.query(
+      `
+      SELECT
+        job_runs.id,
+        job_runs.job_id AS "jobId",
+        job_runs.status,
+        job_runs.started_at AS "startedAt",
+        job_runs.duration_ms AS "durationMs",
+        j.name AS "jobName"
+      FROM job_runs
+      JOIN jobs j ON j.id = job_runs.job_id
+      ORDER BY job_runs.started_at DESC
+      LIMIT $1
+      `,
+      [limit]
+    );
+    return result.rows as Array<{
+      id: string;
+      jobId: string;
+      status: JobRunStatus;
+      startedAt: string;
+      durationMs: number | null;
+      jobName: string;
+    }>;
+  }
+
+  async getRunStats(sinceDays = 7): Promise<{
+    totalRuns: number;
+    successCount: number;
+    failureCount: number;
+    avgDurationMs: number | null;
+    daily: Array<{ day: string; completed: number; failed: number }>;
+  }> {
+    const [aggregates, daily] = await Promise.all([
+      this.pool.query(
+        `
+        SELECT
+          COUNT(*)::int AS "totalRuns",
+          COUNT(*) FILTER (WHERE status = 'completed')::int AS "successCount",
+          COUNT(*) FILTER (WHERE status IN ('failed', 'timed_out', 'crashed'))::int AS "failureCount",
+          ROUND(AVG(duration_ms) FILTER (WHERE duration_ms IS NOT NULL))::int AS "avgDurationMs"
+        FROM job_runs
+        WHERE started_at >= NOW() - make_interval(days => $1)
+        `,
+        [sinceDays]
+      ),
+      this.pool.query(
+        `
+        SELECT
+          TO_CHAR(started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+          COUNT(*) FILTER (WHERE status = 'completed')::int AS completed,
+          COUNT(*) FILTER (WHERE status IN ('failed', 'timed_out', 'crashed'))::int AS failed
+        FROM job_runs
+        WHERE started_at >= NOW() - make_interval(days => $1)
+        GROUP BY day
+        ORDER BY day ASC
+        `,
+        [sinceDays]
+      ),
+    ]);
+    const row = aggregates.rows[0];
+    return {
+      totalRuns: row.totalRuns ?? 0,
+      successCount: row.successCount ?? 0,
+      failureCount: row.failureCount ?? 0,
+      avgDurationMs: row.avgDurationMs ?? null,
+      daily: daily.rows.map((r) => ({
+        day: r.day as string,
+        completed: r.completed as number,
+        failed: r.failed as number,
+      })),
+    };
+  }
+
   async getJob(jobId: string): Promise<JobRecord | null> {
     const result = await this.pool.query(
       `SELECT ${this.jobColumns()} FROM jobs WHERE id = $1`,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1193,6 +1193,15 @@ async function registerRoutes() {
     }
   });
 
+  app.get("/api/v1/jobs/stats", async (_request, reply) => {
+    try {
+      return await jobService.getStats();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return reply.code(500).send({ error: message });
+    }
+  });
+
   app.get("/api/v1/jobs/history", async (request, reply) => {
     const parsed = JobHistoryParamsSchema.safeParse(request.query);
     if (!parsed.success) {

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -11,7 +11,11 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { type AddJobConfig, type AvailableJobsDirectory, type Job, type JobRun, type JobRunStatus, useAvailableJobs, useJobActions, useJobHistory, useJobs } from "@/hooks/use-jobs";
+import { Bar, BarChart, XAxis } from "recharts";
+import { type AddJobConfig, type AvailableJobsDirectory, type Job, type JobRun, type JobRunStatus, useAvailableJobs, useJobActions, useJobHistory, useJobs, useJobStats } from "@/hooks/use-jobs";
+import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, type ChartConfig } from "@/components/ui/chart";
+import { StatCard } from "@/components/app/stat-card";
+import { formatRelativeTime } from "@/lib/format";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
@@ -136,11 +140,13 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
   const [availableJobsForceKey, setAvailableJobsForceKey] = useState(0);
   const [actionErrorByJobId, _setActionErrorByJobId] = useState<Record<string, string>>({});
   const [justAddedJobId, setJustAddedJobId] = useState<string | null>(null);
-  const selectedJob = jobs.find((job) => job.id === routeJobId) ?? null;
+  const showOverview = routeJobId === "overview";
+  const selectedJob = showOverview ? null : (jobs.find((job) => job.id === routeJobId) ?? null);
   const tab: DetailTab = routeSection === "prompt" || routeSection === "history" ? routeSection : "configure";
   const history = useJobHistory(selectedJob);
   const activeRunAgent = useActiveRun(selectedJob, agents);
   const availableJobs = useAvailableJobs(open, manualScanDirectory, availableJobsForceKey);
+  const jobStats = useJobStats(open && !selectedJob);
 
   const selectJob = (job: Job) => {
     setIsAddingJob(false);
@@ -154,7 +160,7 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
     setJustAddedJobId(null);
   };
 
-  const showDetailPane = !!selectedJob;
+  const showDetailPane = !!selectedJob || showOverview;
 
   return (
     <section className="flex h-full min-h-0 min-w-0 overflow-hidden bg-background text-foreground" aria-labelledby="jobs-page-title">
@@ -204,6 +210,13 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                   </div>
                 ) : (
                   <div>
+                    <button
+                      className="flex w-full items-center gap-2 border-b border-border px-3 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/40 md:hidden"
+                      onClick={() => navigate("/jobs/overview")}
+                    >
+                      <Activity className="h-3.5 w-3.5" />
+                      <span>Overview</span>
+                    </button>
                     {jobs.map((job) => {
                       const actionError = actionErrorByJobId[job.id];
                           return (
@@ -298,12 +311,16 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                   />
                   </div>
                 ) : (
-                  <div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground">
-                    <div>
-                      <AlarmClock className="mx-auto mb-3 h-8 w-8" />
-                      <div className="font-medium text-foreground">Select a job</div>
-                      <div className="mt-1 max-w-sm text-sm">Use jobs for recurring maintenance, scheduled checks, and repeatable agent workflows that should run without manual prompting.</div>
-                    </div>
+                  <div className="flex h-full min-h-0 flex-col">
+                    {showOverview && (
+                      <div className="flex min-h-14 items-center gap-3 border-b border-border bg-card px-4 pt-[env(safe-area-inset-top)] md:hidden">
+                        <Button variant="ghost" size="icon" aria-label="Back to jobs" onClick={() => navigate("/jobs")}>
+                          <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                        <div className="text-sm font-semibold">Overview</div>
+                      </div>
+                    )}
+                    <JobsOverview jobs={jobs} stats={jobStats.data ?? null} statsLoading={jobStats.isLoading} onSelectJob={selectJob} />
                   </div>
                 )}
               </div>
@@ -343,6 +360,234 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
         />
       </AddJobDialog>
     </section>
+  );
+}
+
+function formatTimeUntil(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (Number.isNaN(ms) || ms < 0) return "now";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "< 1m";
+  if (mins < 60) return `in ${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  if (hours < 24) return remMins > 0 ? `in ${hours}h ${remMins}m` : `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+}
+
+function formatTimeUntilDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const isTomorrow = date.toDateString() === tomorrow.toDateString();
+  const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  if (isToday) return `Today at ${time}`;
+  if (isTomorrow) return `Tomorrow at ${time}`;
+  return date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+function JobsOverview({ jobs, stats, statsLoading, onSelectJob }: {
+  jobs: Job[];
+  stats: import("@/hooks/use-jobs").JobStats | null;
+  statsLoading: boolean;
+  onSelectJob: (job: Job) => void;
+}) {
+  const upcomingJobs = useMemo(() => {
+    return jobs
+      .filter((j) => j.nextRun)
+      .sort((a, b) => new Date(a.nextRun!).getTime() - new Date(b.nextRun!).getTime())
+      .slice(0, 5);
+  }, [jobs]);
+
+  const recentRuns = stats?.recentRuns ?? [];
+  const metrics = stats?.stats ?? null;
+  const hasAnyData = jobs.length > 0;
+
+  const successRate = metrics && metrics.totalRuns > 0
+    ? Math.round((metrics.successCount / metrics.totalRuns) * 100)
+    : null;
+
+  const dailyChartData = useMemo(() => {
+    if (!metrics?.daily?.length) return [];
+    const byDay = new Map(metrics.daily.map((d) => [d.day, d]));
+    const days: Array<{ day: string; label: string; completed: number; failed: number }> = [];
+    const now = new Date();
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      const entry = byDay.get(key);
+      days.push({
+        day: key,
+        label: d.toLocaleDateString(undefined, { weekday: "short" }),
+        completed: entry?.completed ?? 0,
+        failed: entry?.failed ?? 0,
+      });
+    }
+    return days;
+  }, [metrics?.daily]);
+
+  if (!hasAnyData) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground">
+        <div>
+          <AlarmClock className="mx-auto mb-3 h-8 w-8" />
+          <div className="font-medium text-foreground">No jobs yet</div>
+          <div className="mt-1 max-w-sm text-sm">Use jobs for recurring maintenance, scheduled checks, and repeatable agent workflows that should run without manual prompting.</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="mx-auto max-w-2xl space-y-6 p-6">
+        {/* Loading */}
+        {statsLoading && !metrics && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {/* Stats + Chart row */}
+        {metrics && metrics.totalRuns > 0 && (
+          <div className="grid gap-4 sm:grid-cols-[1fr_1.5fr]">
+            <div className="grid grid-cols-2 gap-3">
+              <StatCard label="Total Runs" value={metrics.totalRuns} sub="Last 7 days" />
+              <StatCard
+                label="Success Rate"
+                value={successRate !== null ? `${successRate}%` : "-"}
+                sub="Last 7 days"
+                variant={successRate !== null && successRate < 80 ? "warning" : undefined}
+              />
+              <StatCard
+                label="Avg Duration"
+                value={metrics.avgDurationMs ? formatDuration(metrics.avgDurationMs) : "-"}
+                sub="Last 7 days"
+              />
+              <StatCard
+                label="Failures"
+                value={metrics.failureCount}
+                sub="Last 7 days"
+                variant={metrics.failureCount > 0 ? "warning" : undefined}
+              />
+            </div>
+            {dailyChartData.length > 0 && (
+              <div className="rounded-md border border-border bg-muted/40 p-3">
+                <DailyRunsChart data={dailyChartData} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Upcoming */}
+        {upcomingJobs.length > 0 && (
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              <Clock className="h-3.5 w-3.5" />
+              Upcoming
+            </div>
+            <div className="divide-y divide-border rounded-md border border-border bg-muted/40">
+              {upcomingJobs.map((job) => (
+                <button
+                  key={job.id}
+                  className="flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
+                  onClick={() => onSelectJob(job)}
+                >
+                  <span className="font-medium text-foreground">{job.name}</span>
+                  <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{formatTimeUntil(job.nextRun!)}</span>
+                    <span className="hidden text-muted-foreground/60 sm:inline">{formatTimeUntilDate(job.nextRun!)}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Recent Activity */}
+        {recentRuns.length > 0 && (
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              <Activity className="h-3.5 w-3.5" />
+              Recent Activity
+            </div>
+            <div className="divide-y divide-border rounded-md border border-border bg-muted/40">
+              {recentRuns.filter((run) => jobs.some((j) => j.id === run.jobId)).map((run) => {
+                const job = jobs.find((j) => j.id === run.jobId)!;
+                return (
+                  <button
+                    key={run.id}
+                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
+                    onClick={() => onSelectJob(job)}
+                  >
+                    <Badge className={cn("shrink-0 gap-1 text-[11px]", statusClasses(run.status))}>
+                      {statusIcon(run.status)}
+                      {run.status}
+                    </Badge>
+                    <span className="min-w-0 flex-1 truncate font-medium text-foreground">{run.jobName}</span>
+                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatDuration(run.durationMs)}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground/60">{formatRelativeTime(run.startedAt)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Empty metrics state — jobs exist but no runs yet */}
+        {metrics && metrics.totalRuns === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 text-center text-muted-foreground">
+            <AlarmClock className="mb-3 h-8 w-8" />
+            <div className="font-medium text-foreground">Select a job</div>
+            <div className="mt-1 max-w-sm text-sm">
+              {upcomingJobs.length > 0
+                ? "Your scheduled jobs are set up. Run history and metrics will appear here after the first run."
+                : "Run a job to start tracking activity and metrics here."}
+            </div>
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+const dailyRunsChartConfig = {
+  completed: { label: "Completed", color: "hsl(var(--chart-1))" },
+  failed: { label: "Failed", color: "hsl(var(--status-blocked))" },
+} satisfies ChartConfig;
+
+function DailyRunsChart({ data }: { data: Array<{ day: string; label: string; completed: number; failed: number }> }) {
+  return (
+    <ChartContainer config={dailyRunsChartConfig} className="aspect-[2/1] w-full">
+      <BarChart data={data} barCategoryGap="20%">
+        <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={6} tick={{ fontSize: 11 }} />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              formatter={(value, name, item) => (
+                <>
+                  <div className="h-2.5 w-2.5 shrink-0 rounded-[2px]" style={{ backgroundColor: item.color }} />
+                  <div className="flex flex-1 items-center justify-between gap-4">
+                    <span className="text-muted-foreground">{dailyRunsChartConfig[name as keyof typeof dailyRunsChartConfig]?.label ?? name}</span>
+                    <span className="font-mono font-medium tabular-nums text-foreground">{value as number}</span>
+                  </div>
+                </>
+              )}
+              labelFormatter={(label) => label as string}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent className="gap-2" />} />
+        <Bar dataKey="completed" stackId="runs" fill="var(--color-completed)" radius={0} />
+        <Bar dataKey="failed" stackId="runs" fill="var(--color-failed)" radius={[2, 2, 0, 0]} />
+      </BarChart>
+    </ChartContainer>
   );
 }
 

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -128,7 +128,7 @@ function useActiveRun(job: Job | null, agents: Agent[]) {
 
 export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer }: JobsPaneProps): JSX.Element {
   const navigate = useNavigate();
-  const { jobId: routeJobId, section: routeSection } = useParams();
+  const { jobId: routeJobId, section: routeSection, runId: routeRunId } = useParams();
   const { iconColor } = useIconColor();
   const { instanceName } = useInstanceName();
   const { data: jobs = [], isLoading, error } = useJobs(open);
@@ -292,6 +292,10 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                     }}
                     history={history.data?.runs ?? []}
                     historyLoading={history.isLoading}
+                    selectedRunId={routeRunId ?? null}
+                    onSelectRun={(runId) => {
+                      navigate(`/jobs/${selectedJob.id}/history/${runId}`);
+                    }}
                     activeRunAgent={activeRunAgent}
                     onOpenAgent={onOpenAgent}
                     onRunNow={async (job) => { await runNow.mutateAsync(job); }}
@@ -320,7 +324,13 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                         <div className="text-sm font-semibold">Overview</div>
                       </div>
                     )}
-                    <JobsOverview jobs={jobs} stats={jobStats.data ?? null} statsLoading={jobStats.isLoading} onSelectJob={selectJob} />
+                    <JobsOverview
+                      jobs={jobs}
+                      stats={jobStats.data ?? null}
+                      statsLoading={jobStats.isLoading}
+                      onSelectJob={selectJob}
+                      onSelectRun={(jobId, runId) => navigate(`/jobs/${jobId}/history/${runId}`)}
+                    />
                   </div>
                 )}
               </div>
@@ -390,11 +400,12 @@ function formatTimeUntilDate(iso: string): string {
   return date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
 }
 
-function JobsOverview({ jobs, stats, statsLoading, onSelectJob }: {
+function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
   jobs: Job[];
   stats: import("@/hooks/use-jobs").JobStats | null;
   statsLoading: boolean;
   onSelectJob: (job: Job) => void;
+  onSelectRun: (jobId: string, runId: string) => void;
 }) {
   const upcomingJobs = useMemo(() => {
     return jobs
@@ -518,12 +529,11 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob }: {
             </div>
             <div className="divide-y divide-border rounded-md border border-border bg-muted/40">
               {recentRuns.filter((run) => jobs.some((j) => j.id === run.jobId)).map((run) => {
-                const job = jobs.find((j) => j.id === run.jobId)!;
                 return (
                   <button
                     key={run.id}
                     className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
-                    onClick={() => onSelectJob(job)}
+                    onClick={() => onSelectRun(run.jobId, run.id)}
                   >
                     <Badge className={cn("shrink-0 gap-1 text-[11px]", statusClasses(run.status))}>
                       {statusIcon(run.status)}
@@ -1056,6 +1066,8 @@ function JobDetail({
   isRemoving,
   justAdded,
   onDismissAdded,
+  selectedRunId,
+  onSelectRun,
 }: {
   className?: string;
   job: Job;
@@ -1063,6 +1075,8 @@ function JobDetail({
   onTabChange: (tab: DetailTab) => void;
   history: JobRun[];
   historyLoading: boolean;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
   activeRunAgent: Agent | null;
   onOpenAgent: (agent: Agent) => Promise<void>;
   onRunNow: (job: Job) => Promise<void>;
@@ -1162,7 +1176,7 @@ function JobDetail({
 
       {tab === "history" ? (
         <div className="min-h-0 flex-1">
-          <HistoryTab runs={history} loading={historyLoading} />
+          <HistoryTab runs={history} loading={historyLoading} selectedRunId={selectedRunId} onSelectRun={onSelectRun} />
         </div>
       ) : (
         <ScrollArea className="min-h-0 flex-1 pr-1">
@@ -1607,9 +1621,8 @@ function PromptTab({
   );
 }
 
-function HistoryTab({ runs, loading }: { runs: JobRun[]; loading: boolean }) {
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-  const selectedRun = runs.find((run) => run.id === selectedRunId) ?? runs[0] ?? null;
+function HistoryTab({ runs, loading, selectedRunId, onSelectRun }: { runs: JobRun[]; loading: boolean; selectedRunId: string | null; onSelectRun: (runId: string) => void }) {
+  const selectedRun = (selectedRunId ? runs.find((run) => run.id === selectedRunId) : null) ?? runs[0] ?? null;
   return (
     <div className="mt-4 grid h-full min-h-0 gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
       <div className="space-y-2 overflow-y-auto pr-1">
@@ -1622,7 +1635,7 @@ function HistoryTab({ runs, loading }: { runs: JobRun[]; loading: boolean }) {
             key={run.id}
             type="button"
             className={cn("w-full rounded-md border border-border bg-background/50 p-3 text-left hover:bg-muted/40", selectedRun?.id === run.id && "border-primary/60 bg-muted/60")}
-            onClick={() => setSelectedRunId(run.id)}
+            onClick={() => onSelectRun(run.id)}
           >
             <div className="flex items-center justify-between gap-2">
               <span className="font-mono text-xs">{run.id.slice(0, 8)}</span>

--- a/apps/web/src/components/app/stat-card.tsx
+++ b/apps/web/src/components/app/stat-card.tsx
@@ -1,16 +1,20 @@
+import { cn } from "@/lib/utils";
+
 export function StatCard({
   label,
   value,
   sub,
+  variant,
 }: {
   label: string;
   value: string | number;
   sub?: string;
+  variant?: "warning";
 }) {
   return (
     <div className="min-w-[7rem] max-w-[14rem] flex-1 basis-[7rem] rounded-md border border-border bg-muted/40 px-2.5 py-2 sm:px-4 sm:py-3">
       <p className="text-[10px] sm:text-xs text-muted-foreground">{label}</p>
-      <p className="mt-0.5 sm:mt-1 text-lg sm:text-2xl font-semibold text-foreground">{value}</p>
+      <p className={cn("mt-0.5 sm:mt-1 text-lg sm:text-2xl font-semibold", variant === "warning" ? "text-status-blocked" : "text-foreground")}>{value}</p>
       {sub && <p className="mt-0.5 text-[10px] sm:text-xs text-muted-foreground">{sub}</p>}
     </div>
   );

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -149,6 +149,27 @@ export function useJobHistory(job: Job | null) {
   });
 }
 
+export type JobStats = {
+  stats: {
+    totalRuns: number;
+    successCount: number;
+    failureCount: number;
+    avgDurationMs: number | null;
+    daily: Array<{ day: string; completed: number; failed: number }>;
+  };
+  recentRuns: Array<{ id: string; jobId: string; status: JobRunStatus; startedAt: string; durationMs: number | null; jobName: string }>;
+};
+
+export function useJobStats(enabled = true) {
+  return useQuery<JobStats>({
+    queryKey: ["jobs", "stats"],
+    queryFn: () => api<JobStats>("/api/v1/jobs/stats"),
+    enabled,
+    refetchInterval: enabled ? 15_000 : false,
+    refetchOnWindowFocus: false,
+  });
+}
+
 export function useAvailableJobs(enabled: boolean, directory?: string | null, forceKey = 0) {
   return useQuery<{ directories: AvailableJobsDirectory[] }>({
     queryKey: ["jobs", "available", directory?.trim() ?? "", forceKey],

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -38,6 +38,7 @@ export const router = createBrowserRouter([
               { path: "jobs", element: <></> },
               { path: "jobs/:jobId", element: <></> },
               { path: "jobs/:jobId/:section", element: <></> },
+              { path: "jobs/:jobId/:section/:runId", element: <></> },
             ],
           },
         ],


### PR DESCRIPTION
## Summary

- Replace the empty "Select a job" state with an overview dashboard showing aggregate metrics, a daily runs bar chart, upcoming scheduled runs, and recent activity across all jobs
- New `GET /api/v1/jobs/stats` endpoint returning 7-day aggregate stats (runs, success rate, avg duration, failures), daily breakdown, and last 5 runs across all jobs
- Mobile support via `/jobs/overview` route with back navigation
- Uses existing `StatCard` component and recharts `ChartContainer` patterns from the activity page, with theme-aware chart colors

## Files changed

- `apps/server/src/jobs/store.ts` — `listRecentRuns()` and `getRunStats()` queries
- `apps/server/src/jobs/service.ts` — `getStats()` method
- `apps/server/src/server.ts` — `GET /api/v1/jobs/stats` endpoint
- `apps/web/src/hooks/use-jobs.ts` — `useJobStats` hook + `JobStats` type
- `apps/web/src/components/app/jobs-pane.tsx` — `JobsOverview`, `DailyRunsChart`, mobile overview route
- `apps/web/src/components/app/stat-card.tsx` — Added `variant` prop for warning color

## Test plan

- [x] Type check passes (`pnpm run check`)
- [x] Production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (95/95)
- [x] Validated desktop layout with seeded test data via Playwright
- [x] Validated mobile layout (390x844) — Overview link, back button, responsive chart
- [x] Verified empty states: no jobs, jobs with no runs, jobs with runs
- [x] Backend security review persona: approved (3 items fixed)
- [x] Frontend UX review persona: approved (3 items fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)