### PR TITLE
Add Turborepo for monorepo build orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 npm-debug.log*
 .DS_Store
 dist
+.turbo
 .env
 .env.local
 data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,16 +33,14 @@
 
 ## Pre-Completion Checks (Mandatory)
 Before marking any task as done, run the following checks and fix any failures:
-1. **Type checking**: `pnpm run check` (runs `tsc --noEmit` for backend + web).
-2. **Web finalization**: If any files under `apps/web/` changed, run `pnpm run finalize:web` (type check + production build).
-3. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
-4. **Unit tests**: `pnpm run test` (Vitest) if backend logic changed.
+1. **Verify**: `pnpm run verify` — runs lint, type checking, unit tests, and production build across all packages in one command (powered by Turborepo with caching).
+2. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
 - Do not consider a task complete until all applicable checks pass.
 - If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
 
 ## Web Finalization
-- If any files under `apps/web/` changed, run `pnpm run finalize:web` before marking the task complete.
-- After running `pnpm run finalize:web`, verify the served app via an explicitly started local dev stack when the task affects UI/theme/rendering behavior.
+- If any files under `apps/web/` changed, `pnpm run verify` already covers type checking and production build.
+- After running `pnpm run verify`, verify the served app via an explicitly started local dev stack when the task affects UI/theme/rendering behavior.
 - After UI/theme/rendering validation on an isolated dev stack, leave that stack running for the user to inspect unless they explicitly ask you to tear it down.
 - In the final response, include the exact local URLs/ports for the running validation stack and the cleanup command(s) needed to stop it later.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,16 +60,14 @@ dispatch/
 
 ## Pre-Completion Checks (Mandatory)
 Before marking any task as done, run the following checks and fix any failures:
-1. **Type checking**: `pnpm run check` (runs `tsc --noEmit` for backend + web).
-2. **Web finalization**: If any files under `apps/web/` changed, run `pnpm run finalize:web` (type check + production build).
-3. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
-4. **Unit tests**: `pnpm run test` (Vitest) if backend logic changed.
+1. **Verify**: `pnpm run verify` — runs lint, type checking, unit tests, and production build across all packages in one command (powered by Turborepo with caching).
+2. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
 - Do not consider a task complete until all applicable checks pass.
 - If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
 
 ## Web Finalization
-- If any files under `apps/web/` changed, run `pnpm run finalize:web` before marking the task complete.
-- After running `pnpm run finalize:web`, verify the served app via `dispatch-dev` when the task affects UI/theme/rendering behavior.
+- If any files under `apps/web/` changed, `pnpm run verify` already covers type checking and production build.
+- After running `pnpm run verify`, verify the served app via `dispatch-dev` when the task affects UI/theme/rendering behavior.
 - After UI/theme/rendering validation on an isolated dev stack, leave that stack running for the user to inspect unless they explicitly ask you to tear it down.
 - In the final response, include the exact local URLs/ports for the running validation stack and the cleanup command(s) needed to stop it later.
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -61,10 +61,18 @@ function resolveAgentRuntime(): "tmux" | "inert" {
   }
 }
 
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return port;
+}
+
 export function loadConfig(): AppConfig {
   const config: AppConfig = {
     host: process.env.DISPATCH_HOST ?? process.env.HOST ?? "127.0.0.1",
-    port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 6767),
+    port: parsePort(process.env.DISPATCH_PORT ?? process.env.PORT ?? "6767"),
     databaseUrl:
       process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
     authToken: "", // resolved from DB in start() via getOrCreateAuthToken()

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,13 +3,6 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
 
-const apiPort = process.env.VITE_API_TARGET ?? process.env.DISPATCH_PORT;
-if (!apiPort) {
-  throw new Error(
-    "DISPATCH_PORT or VITE_API_TARGET must be set. Use dispatch-dev to start the dev environment.",
-  );
-}
-
 export default defineConfig({
   plugins: [
     react(),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,13 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
 
+const apiPort = process.env.VITE_API_TARGET ?? process.env.DISPATCH_PORT;
+if (!apiPort) {
+  throw new Error(
+    "DISPATCH_PORT or VITE_API_TARGET must be set. Use dispatch-dev to start the dev environment.",
+  );
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -51,7 +58,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 6767}`,
+        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT}`,
         changeOrigin: true,
         ws: true
       }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT}`,
+        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT ?? 6767}`,
         changeOrigin: true,
         ws: true
       }

--- a/package.json
+++ b/package.json
@@ -4,23 +4,25 @@
   "private": true,
   "description": "Local-first control plane for remote Codex CLI agents with simulator media",
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "engines": {
     "node": ">=22.0.0"
   },
   "scripts": {
-    "dev": "pnpm --filter @dispatch/server dev",
-    "build": "pnpm -r build",
-    "build:web": "pnpm --filter @dispatch/web build",
-    "check:web": "pnpm --filter @dispatch/web check",
-    "lint:web": "pnpm --filter @dispatch/web lint",
-    "finalize:web": "pnpm run check:web && pnpm run build:web",
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "build:web": "turbo build --filter=@dispatch/web",
+    "check": "turbo check",
+    "check:web": "turbo check --filter=@dispatch/web",
+    "lint:web": "turbo lint --filter=@dispatch/web",
+    "finalize:web": "turbo check build --filter=@dispatch/web",
     "start": "pnpm --filter @dispatch/server start",
     "release": "bin/dispatch-server update",
     "db:migrate": "pnpm --filter @dispatch/server db:migrate",
-    "check": "pnpm --filter @dispatch/shared build && pnpm --filter @dispatch/server check && pnpm run check:web",
-    "test": "pnpm --filter @dispatch/server test",
-    "test:watch": "pnpm --filter @dispatch/server test:watch",
+    "test": "turbo test",
+    "test:watch": "turbo test:watch",
     "test:e2e": "bash scripts/e2e-isolated.sh",
+    "verify": "turbo lint check test build",
     "prepare": "husky"
   },
   "pnpm": {
@@ -35,7 +37,7 @@
       "eslint --config apps/web/eslint.config.js"
     ],
     "**/*.{ts,tsx}": [
-      "bash -c 'pnpm run check'"
+      "bash -c 'turbo check'"
     ]
   },
   "devDependencies": {
@@ -44,6 +46,7 @@
     "lint-staged": "^16.4.0",
     "playwright": "^1.54.2",
     "sharp": "^0.34.5",
+    "turbo": "^2.9.5",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,8 @@
     "./mcp/repo-tools.js": "./dist/mcp/repo-tools.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
   },
   webServer: {
     command: process.env.E2E_SKIP_WEB_BUILD
-      ? "pnpm run dev"
-      : "pnpm run build:web && pnpm run dev",
+      ? "turbo build --filter=@dispatch/shared && pnpm --filter @dispatch/server dev"
+      : "turbo build --filter=@dispatch/web && pnpm --filter @dispatch/server dev",
     env: {
       DATABASE_URL: databaseUrl,
       DISPATCH_PORT: devPort,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      turbo:
+        specifier: ^2.9.5
+        version: 2.9.5
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2117,6 +2120,36 @@ packages:
     resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@turbo/darwin-64@2.9.5':
+    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.5':
+    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.5':
+    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.5':
+    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.5':
+    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.5':
+    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
+    cpu: [arm64]
+    os: [win32]
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4743,6 +4776,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turbo@2.9.5:
+    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6910,6 +6947,24 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.95.2
       react: 18.3.1
+
+  '@turbo/darwin-64@2.9.5':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.5':
+    optional: true
+
+  '@turbo/linux-64@2.9.5':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.5':
+    optional: true
+
+  '@turbo/windows-64@2.9.5':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.5':
+    optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -10104,6 +10159,15 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  turbo@2.9.5:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.5
+      '@turbo/darwin-arm64': 2.9.5
+      '@turbo/linux-64': 2.9.5
+      '@turbo/linux-arm64': 2.9.5
+      '@turbo/windows-64': 2.9.5
+      '@turbo/windows-arm64': 2.9.5
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "dev": {
+      "dependsOn": ["^build"],
+      "persistent": true,
+      "cache": false
+    },
+    "check": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {},
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "test:watch": {
+      "dependsOn": ["^build"],
+      "persistent": true,
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add Turborepo to handle build ordering, caching, and dev mode across the pnpm monorepo
- Fix `@dispatch/shared` not being built automatically in dev — adds `tsc --watch` dev script and `composite: true`
- Replace all manual `pnpm --filter` chains with `turbo` commands
- Add `pnpm run verify` — single command for lint + type checking + unit tests + production build
- Fix lint-staged to use `turbo check` (benefits from caching, was running full pipeline on every commit)
- Fix Playwright config to avoid `turbo dev` persistent processes blocking E2E server readiness
- Restore `DISPATCH_PORT ?? 6767` fallback in Vite proxy config (removed by #262)
- Add `parsePort()` validation in server config to catch invalid port values early
- Simplify CLAUDE.md/AGENTS.md pre-completion checks to `pnpm run verify` + `pnpm run test:e2e`

## Test plan

- [x] `pnpm run verify` passes (224 unit tests, lint, type checks, production build)
- [x] `pnpm run test:e2e` passes (95/101, 6 skipped tmux-dependent)
- [x] Turbo caching works — cached re-runs complete in ~40ms
- [x] Infra-review persona reviewed, findings addressed