### PR TITLE
Add review_status instructions to persona feedback guidance

### DIFF
--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -116,7 +116,12 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 ### How to submit feedback
 - Call \`dispatch_feedback\` for each finding with: severity, file path, line number, description, and a concrete suggestion.
 - Only flag issues that are within the scope of the changes (the diff below). Do not flag pre-existing issues unless directly caused or worsened by the new changes.
-- Call \`dispatch_event\` with type \`done\` when your review is complete.
+
+### Review lifecycle
+- Call \`review_status\` with status \`reviewing\` and a short message when you begin reviewing.
+- Call \`dispatch_feedback\` for each finding as you go.
+- When finished, call \`review_status\` with status \`complete\`, a \`verdict\` (\`approve\` or \`request_changes\`), and a \`summary\` of your findings.
+- Then call \`dispatch_event\` with type \`done\`.
 
 ### Severity levels
 - **critical**: Exploitable vulnerability, data loss risk, or broken core functionality


### PR DESCRIPTION
## Summary
- The `review_status` MCP tool was added in #245 but the standard feedback guidance injected into persona prompts was never updated to instruct agents to call it
- Reviews stayed in "reviewing" status forever because agents had no instruction to call `review_status` with `complete`
- Adds a "Review lifecycle" section to `STANDARD_FEEDBACK_GUIDANCE` in `loader.ts` that tells persona agents to call `review_status` at start (`reviewing`) and end (`complete` with verdict + summary)

## Test plan
- [x] `pnpm run check` passes
- [x] All persona-loader unit tests pass
- [ ] Launch a review persona and verify it calls `review_status` with `complete` at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)