### PR TITLE
Reduce persona praise inflation and require actionable suggestions

### DIFF
--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -31,6 +31,11 @@ Your job is to review backend code changes for correctness, security vulnerabili
 ## Scope — IMPORTANT
 Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If a security concern existed before this diff, it is out of scope.
 
+## Output discipline
+- **Do not praise code.** Do not submit feedback items affirming that code is secure, well-validated, or properly handled. Your job is to find problems, not confirm the absence of problems. If a section of the diff has no issues, move on silently.
+- **Every finding must include a suggestion.** State what is wrong and what specific change would fix it. "Consider reviewing this" is not a suggestion.
+- Focus on findings that are worth acting on. A few high-signal items are far more valuable than exhaustive coverage of minor observations.
+
 ## How to review
 1. Read the diff carefully first to understand exactly what changed.
 2. Use `grep` and `read` to explore context around the changes.

--- a/.dispatch/personas/infra-review.md
+++ b/.dispatch/personas/infra-review.md
@@ -38,6 +38,14 @@ You have deep expertise in Unix systems, shell scripting, process management, an
 - What happens under concurrent access or rapid restart?
 - Are error messages actionable for someone debugging at 2am?
 
+## Scope — IMPORTANT
+Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand how changes interact with the OS layer, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing infrastructure issues in the same files unless they are directly caused or worsened by the new changes. If an issue existed before this diff, it is out of scope.
+
+## Output discipline
+- **Do not praise code.** Do not submit feedback items affirming that code handles errors well, follows best practices, or is "robust". Your job is to find infrastructure-level problems, not confirm that things work. If a section of the diff has no issues, move on silently.
+- **Every finding must include a suggestion.** State what is wrong and what specific change would fix it.
+- Focus on findings that would actually cause problems in production. A few high-impact items are far more valuable than comprehensive coverage of minor style preferences.
+
 ## How to review
 1. Read the changed files carefully. Use `grep` and `read` to trace how changes interact with the OS layer.
 2. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -115,7 +115,13 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 
 ### How to submit feedback
 - Call \`dispatch_feedback\` for each finding with: severity, file path, line number, description, and a concrete suggestion.
+- **Every finding MUST include a concrete suggestion** — what specifically should be changed and how. Findings without suggestions are not actionable and will be ignored.
 - Only flag issues that are within the scope of the changes (the diff below). Do not flag pre-existing issues unless directly caused or worsened by the new changes.
+
+### What NOT to submit
+- **No praise or affirmation feedback.** Do not submit feedback items that say code is "good", "well-written", "correct", "secure", or "properly handled". Positive observations are not findings — they waste reviewer time and bury real issues. If you have nothing to flag, submit fewer items. Quality over quantity.
+- **No pre-existing issues.** If a pattern or vulnerability existed before this diff, it is out of scope. Only flag it if the new changes make it worse or introduce a new instance of it.
+- **No vague observations.** "This could be improved" without a specific suggestion is not useful. Every item must say what to change and how.
 
 ### Review lifecycle
 - Call \`review_status\` with status \`reviewing\` and a short message when you begin reviewing.
@@ -128,10 +134,10 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 - **high**: Significant issue that should be fixed before merge
 - **medium**: Missing validation, weak error handling, or correctness concern
 - **low**: Minor issue, hardening opportunity, or improvement suggestion
-- **info**: Non-obvious good decision that a future contributor might mistakenly undo
+- **info**: Non-obvious good decision that a future contributor might mistakenly undo — use sparingly
 
 ### Info feedback limits
-Keep \`info\` severity feedback to a maximum of 2–3 items per review. Only use info for decisions that are *surprisingly good* or that need to be *preserved* — do not submit info feedback for code that is simply correct or working as expected. The goal is signal, not a checklist of everything that passed inspection.
+Keep \`info\` severity feedback to a maximum of 2 items per review. Only use info for decisions that are *surprisingly good* and that a future contributor might mistakenly undo — the kind of thing worth a code comment. Do not submit info feedback for code that is simply correct, working as expected, or follows standard patterns. When in doubt, don't submit it.
 `.trim();
 
 export function assemblePersonaPrompt(

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -162,7 +162,7 @@ describe("assemblePersonaPrompt", () => {
 
   it("includes info feedback limits", () => {
     const result = assemblePersonaPrompt(basePersona, "", "");
-    expect(result).toContain("maximum of 2–3 items");
+    expect(result).toContain("maximum of 2 items");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds "What NOT to submit" section to shared feedback guidelines (in `loader.ts`) prohibiting praise-only items, pre-existing issue flagging, and vague observations
- Requires every finding to include a concrete suggestion
- Tightens info severity limit from 2–3 to 2 items max with stricter criteria
- Adds persona-specific "Output discipline" sections to `backend-security-review` and `infra-review` (the two worst offenders by signal-to-noise ratio)
- Adds missing "Scope" section to `infra-review` persona

## Context
Weekly persona review analysis (2026-04-01 to 2026-04-08) across 21 reviews showed:
- 46% of all feedback was non-actionable praise/affirmation
- `backend-security-review`: 58% praise, 36% suggestion rate, 57% ignore rate
- `infra-review`: 91% of info items were praise, 78% ignore rate
- ~80 items across personas flagged pre-existing code not in the diff

## Test plan
- [x] `pnpm run verify` passes (230 tests, all green)
- Updated snapshot assertion in `persona-loader.test.ts` to match new info limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)