### PR TITLE
Move docs icon to header and harden dev server port safety

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -61,6 +61,17 @@ function resolveAgentRuntime(): "tmux" | "inert" {
   }
 }
 
+function resolvePort(): string {
+  const port = process.env.DISPATCH_PORT ?? process.env.PORT;
+  if (!port) {
+    throw new Error(
+      "DISPATCH_PORT is not set. " +
+        "Use dispatch-dev for local development, or set DISPATCH_PORT explicitly."
+    );
+  }
+  return port;
+}
+
 function parsePort(value: string): number {
   const port = Number(value);
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
@@ -72,7 +83,7 @@ function parsePort(value: string): number {
 export function loadConfig(): AppConfig {
   const config: AppConfig = {
     host: process.env.DISPATCH_HOST ?? process.env.HOST ?? "127.0.0.1",
-    port: parsePort(process.env.DISPATCH_PORT ?? process.env.PORT ?? "6767"),
+    port: parsePort(resolvePort()),
     databaseUrl:
       process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
     authToken: "", // resolved from DB in start() via getOrCreateAuthToken()
@@ -165,12 +176,14 @@ export function assertSafePortConfig(
   env: NodeJS.ProcessEnv = process.env
 ): void {
   const isAgentContext = Boolean(env.DISPATCH_AGENT_ID);
-  if (!isAgentContext) return;
+  const isDevServer = env.DISPATCH_SESSION_PREFIX === "dispatch_dev";
 
-  if (config.port === 6767) {
+  if ((isAgentContext || isDevServer) && config.port === 6767) {
     throw new Error(
-      "Refusing to bind to production port 6767 from an agent context. " +
-        "Start local servers with dispatch-dev so DISPATCH_PORT points at an isolated port."
+      "Refusing to bind to production port 6767 from a dev/agent context. " +
+        "Start local servers with dispatch-dev so DISPATCH_PORT points at an isolated port. " +
+        "If DISPATCH_PORT=6767 is set in .env, remove it — production port config belongs " +
+        "only in the launchd/systemd service environment."
     );
   }
 }

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -38,13 +38,19 @@ describe("port safety config", () => {
     ).toThrow("Refusing to bind to production port 6767");
   });
 
+  it("refuses production port 6767 from a dev server context", () => {
+    expect(() =>
+      assertSafePortConfig({ port: 6767 }, { DISPATCH_SESSION_PREFIX: "dispatch_dev" })
+    ).toThrow("Refusing to bind to production port 6767");
+  });
+
   it("allows non-production ports from an agent context", () => {
     expect(() =>
       assertSafePortConfig({ port: 9123 }, { DISPATCH_AGENT_ID: "agt_test" })
     ).not.toThrow();
   });
 
-  it("allows production port outside agent context", () => {
+  it("allows production port outside agent/dev context", () => {
     expect(() =>
       assertSafePortConfig({ port: 6767 }, {})
     ).not.toThrow();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -537,7 +537,6 @@ export function DashboardLayout(): JSX.Element {
               onOpenCreateDialog={openCreateDialog}
               enabledAgentTypes={enabledAgentTypes}
               lastUsedAgentType={lastUsedAgentType}
-              onOpenDocs={openDocs}
               onOpenActivity={openActivity}
               onOpenJobs={openJobs}
               onOpenSettings={openSettings}
@@ -591,6 +590,7 @@ export function DashboardLayout(): JSX.Element {
                 unseenMediaCount={unseenMediaCount}
                 setLeftOpen={handleSetLeftPanelOpen}
                 setMediaOpen={handleSetMediaPanelOpen}
+                onOpenDocs={openDocs}
               />
             ) : null}
 
@@ -704,7 +704,6 @@ export function DashboardLayout(): JSX.Element {
             onOpenCreateDialog={(type?: AgentType) => { setMobileLeftOpen(false); openCreateDialog(type); }}
             enabledAgentTypes={enabledAgentTypes}
             lastUsedAgentType={lastUsedAgentType}
-            onOpenDocs={() => { setMobileLeftOpen(false); openDocs(); }}
             onOpenActivity={() => { setMobileLeftOpen(false); openActivity(); }}
             onOpenJobs={() => { setMobileLeftOpen(false); openJobs(); }}
             onOpenSettings={() => { setMobileLeftOpen(false); openSettings(); }}

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   Activity,
-  BookOpenText,
   Bot,
   ChevronDown,
   ChevronLeft,
@@ -30,7 +29,6 @@ type AgentSidebarSharedProps = {
   onOpenCreateDialog: (type?: AgentType) => void;
   enabledAgentTypes: AgentType[];
   lastUsedAgentType: AgentType | null;
-  onOpenDocs: () => void;
   onOpenActivity: () => void;
   onOpenJobs: () => void;
   onOpenSettings: () => void;
@@ -72,7 +70,6 @@ export function AgentSidebarContent({
   onOpenCreateDialog,
   enabledAgentTypes,
   lastUsedAgentType,
-  onOpenDocs,
   onOpenActivity,
   onOpenJobs,
   onOpenSettings,
@@ -241,18 +238,6 @@ export function AgentSidebarContent({
               </button>
             </TooltipTrigger>
             <TooltipContent>Activity</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={onOpenDocs}
-                data-testid="docs-button"
-                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-              >
-                <BookOpenText className="h-5 w-5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Documentation</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -1,6 +1,7 @@
-import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
+import { BookOpenText, PanelLeftOpen, PanelRightOpen } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { cn } from "@/lib/utils";
 
@@ -13,6 +14,7 @@ type AppHeaderProps = {
   unseenMediaCount: number;
   setLeftOpen: (open: boolean) => void;
   setMediaOpen: (open: boolean) => void;
+  onOpenDocs: () => void;
 };
 
 export function AppHeader({
@@ -24,6 +26,7 @@ export function AppHeader({
   unseenMediaCount,
   setLeftOpen,
   setMediaOpen,
+  onOpenDocs,
 }: AppHeaderProps): JSX.Element {
   const { iconColor } = useIconColor();
   const showLeftToggle = isMobile ? !leftOpen : !leftOpen;
@@ -58,6 +61,22 @@ export function AppHeader({
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-1">
+        <TooltipProvider delayDuration={120}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={onOpenDocs}
+                data-testid="docs-button"
+                title="Documentation"
+              >
+                <BookOpenText className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Documentation</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         {showMediaToggle ? (
           <Button
             size="icon"

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -177,6 +177,18 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                     ) : null}
                   </div>
                 </div>
+                <div className="ml-auto">
+                  <TooltipProvider delayDuration={120}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button size="icon" variant="ghost" onClick={() => navigate("/docs")} data-testid="docs-button" title="Documentation">
+                          <BookOpenText className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Documentation</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
               </div>
 
               <div className="mt-2 flex h-14 items-center border-b border-border px-3">
@@ -258,7 +270,6 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
               </div>
               <JobsNav
                 onOpenAgents={() => navigate("/")}
-                onOpenDocs={() => navigate("/docs")}
                 onOpenActivity={() => navigate("/activity")}
                 onOpenJobs={() => navigate("/jobs")}
                 onOpenSettings={() => navigate("/settings")}
@@ -605,13 +616,11 @@ function DailyRunsChart({ data }: { data: Array<{ day: string; label: string; co
 
 function JobsNav({
   onOpenAgents,
-  onOpenDocs,
   onOpenActivity,
   onOpenJobs,
   onOpenSettings,
 }: {
   onOpenAgents: () => void;
-  onOpenDocs: () => void;
   onOpenActivity: () => void;
   onOpenJobs: () => void;
   onOpenSettings: () => void;
@@ -642,14 +651,6 @@ function JobsNav({
             </button>
           </TooltipTrigger>
           <TooltipContent>Activity</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button onClick={onOpenDocs} data-testid="docs-button" className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
-              <BookOpenText className="h-5 w-5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Documentation</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -247,7 +247,13 @@ cmd_up() {
       export DATABASE_URL="postgres://dispatch:dispatch@127.0.0.1:${DEV_DB_PORT}/dispatch_${DEV_CONTAINER_SUFFIX}"
     fi
 
-    pnpm run dev >> "$(log_dir)/api.log" 2>&1 &
+    # Build shared package (server dependency) before starting
+    pnpm --filter @dispatch/shared run build >> "$(log_dir)/api.log" 2>&1
+
+    # Run the server directly, bypassing turbo. Turbo loads the root .env
+    # and overrides shell-exported vars like DISPATCH_PORT, which can cause the
+    # dev server to bind to the production port.
+    pnpm --filter @dispatch/server exec tsx watch src/server.ts >> "$(log_dir)/api.log" 2>&1 &
     echo $! > "$(log_dir)/api.pid"
   )
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": [
+    "DISPATCH_HOST",
+    "DISPATCH_AGENT_RUNTIME",
+    "DISPATCH_SESSION_PREFIX",
+    "DISPATCH_AGENT_ID",
+    "DATABASE_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Move the documentation icon from the sidebar footer to the right side of the header (agents page) and sidebar header (jobs page)
- Fix critical issue where `dispatch-dev` could bind to production port 6767 due to turbo's strict env mode stripping `DISPATCH_PORT`
- Server now requires `DISPATCH_PORT` to be explicitly set (no silent fallback to 6767)
- `dispatch-dev` bypasses turbo and runs the server directly to avoid env var stripping
- Added `globalPassThroughEnv` to `turbo.json` for critical vars (intentionally excludes `DISPATCH_PORT`)
- Removed `DISPATCH_PORT` from all repo `.env` files — production port config belongs only in the launchd service environment

## Test plan
- [x] `pnpm run verify` — 7/7 tasks pass, 231 unit tests pass
- [x] `pnpm run test:e2e` — 95 passed, 6 skipped
- [x] Visual validation: docs icon visible in header (agents page) and sidebar header (jobs page), removed from both footers
- [x] `dispatch-dev up` binds API server to assigned port, NOT 6767

🤖 Generated with [Claude Code](https://claude.com/claude-code)