### PR TITLE
Add MIT license for open-source release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brad Harris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,6 +2,7 @@
   "name": "@dispatch/server",
   "version": "0.11.11",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "@dispatch/web",
   "version": "0.11.11",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dispatch",
   "version": "0.11.11",
   "private": true,
+  "license": "MIT",
   "description": "Local-first control plane for remote Codex CLI agents with simulator media",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dispatch/shared",
   "version": "0.11.11",
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./lib/run-command.js": "./dist/lib/run-command.js",


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file (copyright Brad Harris 2026)
- Add `"license": "MIT"` to all 4 package.json files (root, server, web, shared)
- Addresses CRU-47

## Test plan
- [x] `pnpm run verify` passes (lint, types, tests, build)
- [ ] Confirm LICENSE file renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)