### PR TITLE
Validate Slack webhook URL to prevent SSRF

### DIFF
--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -17,6 +17,7 @@ const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color
   blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
 };
 
+const SLACK_WEBHOOK_PREFIX = "https://hooks.slack.com/";
 const SETTING_WEBHOOK_URL = "slack_webhook_url";
 const SETTING_NOTIFY_EVENTS = "slack_notify_events";
 
@@ -28,6 +29,19 @@ type CachedSettings = {
   notifyEvents: NotifyEventType[];
   expiresAt: number;
 };
+
+/**
+ * Validate that a webhook URL points to Slack's official endpoint.
+ * Prevents SSRF by rejecting internal/arbitrary URLs.
+ */
+export function isValidSlackWebhookUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.href.startsWith(SLACK_WEBHOOK_PREFIX);
+  } catch {
+    return false;
+  }
+}
 
 export class SlackNotifier {
   private cachedSettings: CachedSettings | null = null;
@@ -51,6 +65,9 @@ export class SlackNotifier {
     if (!url) {
       await deleteSetting(this.pool, SETTING_WEBHOOK_URL);
     } else {
+      if (!isValidSlackWebhookUrl(url)) {
+        throw new Error("Invalid webhook URL: must start with https://hooks.slack.com/");
+      }
       await setSetting(this.pool, SETTING_WEBHOOK_URL, url);
     }
     this.invalidateCache();
@@ -116,6 +133,9 @@ export class SlackNotifier {
   }
 
   async sendTestMessage(webhookUrl: string): Promise<{ ok: boolean; error?: string }> {
+    if (!isValidSlackWebhookUrl(webhookUrl)) {
+      return { ok: false, error: "Invalid webhook URL: must start with https://hooks.slack.com/" };
+    }
     try {
       const res = await this.postToSlack(webhookUrl, {
         username: "Dispatch",

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -59,7 +59,7 @@ import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { handleMcpRequest } from "@dispatch/shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
-import { SlackNotifier } from "./notifications/slack.js";
+import { SlackNotifier, isValidSlackWebhookUrl } from "./notifications/slack.js";
 import { JobNotifier } from "./notifications/job-notifier.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
@@ -1771,6 +1771,9 @@ async function registerRoutes() {
       if (typeof body.webhookUrl !== "string") {
         return reply.code(400).send({ error: "webhookUrl must be a string." });
       }
+      if (body.webhookUrl && !isValidSlackWebhookUrl(body.webhookUrl)) {
+        return reply.code(400).send({ error: "webhookUrl must start with https://hooks.slack.com/" });
+      }
       await slackNotifier.setWebhookUrl(body.webhookUrl);
     }
 
@@ -1789,6 +1792,9 @@ async function registerRoutes() {
     const url = typeof body?.webhookUrl === "string" ? body.webhookUrl : await slackNotifier.getWebhookUrl();
     if (!url) {
       return reply.code(400).send({ error: "No webhook URL provided or configured." });
+    }
+    if (!isValidSlackWebhookUrl(url)) {
+      return reply.code(400).send({ error: "webhookUrl must start with https://hooks.slack.com/" });
     }
     return slackNotifier.sendTestMessage(url);
   });

--- a/apps/server/test/slack-notifier.test.ts
+++ b/apps/server/test/slack-notifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-import { SlackNotifier } from "../src/notifications/slack.js";
+import { SlackNotifier, isValidSlackWebhookUrl } from "../src/notifications/slack.js";
 import type { AgentRecord } from "../src/agents/manager.js";
 
 // Stub the DB settings module so SlackNotifier never hits a real DB.
@@ -62,6 +62,47 @@ const mockLog = {
   silent: vi.fn(),
   level: "debug",
 } as unknown as import("fastify").FastifyBaseLogger;
+
+describe("isValidSlackWebhookUrl", () => {
+  it("accepts valid Slack webhook URLs", () => {
+    expect(isValidSlackWebhookUrl("https://hooks.slack.com/services/T00/B00/xxx")).toBe(true);
+    expect(isValidSlackWebhookUrl("https://hooks.slack.com/workflows/T00/B00/xxx")).toBe(true);
+  });
+
+  it("rejects non-Slack URLs", () => {
+    expect(isValidSlackWebhookUrl("https://evil.com/hooks.slack.com/")).toBe(false);
+    expect(isValidSlackWebhookUrl("http://hooks.slack.com/services/T00/B00/xxx")).toBe(false);
+    expect(isValidSlackWebhookUrl("https://hooks.slack.com.evil.com/foo")).toBe(false);
+    expect(isValidSlackWebhookUrl("https://169.254.169.254/latest/meta-data")).toBe(false);
+    expect(isValidSlackWebhookUrl("file:///etc/passwd")).toBe(false);
+    expect(isValidSlackWebhookUrl("http://localhost:8080")).toBe(false);
+    expect(isValidSlackWebhookUrl("not-a-url")).toBe(false);
+    expect(isValidSlackWebhookUrl("")).toBe(false);
+  });
+});
+
+describe("SlackNotifier webhook URL validation", () => {
+  it("rejects invalid URLs in setWebhookUrl", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await expect(notifier.setWebhookUrl("http://169.254.169.254/")).rejects.toThrow(
+      "Invalid webhook URL: must start with https://hooks.slack.com/"
+    );
+  });
+
+  it("allows clearing the webhook URL with empty string", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await expect(notifier.setWebhookUrl("")).resolves.toBeUndefined();
+  });
+
+  it("rejects invalid URLs in sendTestMessage", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const result = await notifier.sendTestMessage("http://internal-service:8080/");
+    expect(result).toEqual({
+      ok: false,
+      error: "Invalid webhook URL: must start with https://hooks.slack.com/",
+    });
+  });
+});
 
 describe("SlackNotifier focus suppression", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Add `isValidSlackWebhookUrl()` that ensures webhook URLs start with `https://hooks.slack.com/` to prevent SSRF attacks via internal/arbitrary URLs
- Validate in `SlackNotifier.setWebhookUrl()`, `sendTestMessage()`, and at the API route level for both `/notifications/settings` and `/notifications/test`
- Add unit tests covering valid URLs, SSRF payloads (metadata endpoint, file://, localhost), and edge cases

Closes CRU-39

## Test plan
- [x] Unit tests for `isValidSlackWebhookUrl` (valid Slack URLs, SSRF vectors, malformed input)
- [x] Unit tests for `setWebhookUrl` rejection and `sendTestMessage` rejection
- [x] Type checking passes (`pnpm run check`)
- [x] All 239 unit tests pass
- [x] All 94 E2E tests pass