### PR TITLE
[codex] Default Dispatch host to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Production server settings. For local development, use bin/dispatch-dev
 # which auto-selects free ports and creates an isolated database.
 
-DISPATCH_HOST=0.0.0.0
+DISPATCH_HOST=127.0.0.1
 DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 MEDIA_ROOT=~/.dispatch/media

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
-> 5. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The other defaults are usually fine.
+> 5. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The default host binds to localhost; set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections.
 > 6. Register as a system service:
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
 >    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/server.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -149,6 +149,7 @@ Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 
 | Variable | Default | Description |
 |---|---|---|
+| `DISPATCH_HOST` | `127.0.0.1` | Interface to bind the API server to. Set `0.0.0.0` only when the machine must accept remote connections. |
 | `DISPATCH_PORT` | `6767` | HTTP port the server listens on |
 | `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
 | `MEDIA_ROOT` | `/tmp/dispatch-media` | File upload storage path |

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -116,10 +116,10 @@ cd dispatch
 cp .env.example .env
 ```
 
-Edit `.env` — the only value you must change is `AUTH_TOKEN`:
+Edit `.env` — the only value you must change is `AUTH_TOKEN` for a local-only setup:
 
 ```
-DISPATCH_HOST=0.0.0.0
+DISPATCH_HOST=127.0.0.1
 DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 AUTH_TOKEN=<generate-a-real-token>
@@ -127,6 +127,9 @@ MEDIA_ROOT=~/.dispatch/media
 ```
 
 Generate a token with `openssl rand -hex 32`.
+
+If this machine needs to accept remote connections, set `DISPATCH_HOST=0.0.0.0` explicitly in
+`~/.dispatch/server/.env` after installation.
 
 ### 5. Build & verify locally
 


### PR DESCRIPTION
## Summary
- change the example and documented default server bind host to `127.0.0.1`
- document that `DISPATCH_HOST=0.0.0.0` must be set explicitly when remote access is intended
- keep production/public binding as an explicit machine-local env choice rather than the default install behavior

## Why
New installs were being guided toward a public bind by default. The server already supports a localhost default and warns on `0.0.0.0`, so the safer behavior is to make remote exposure opt-in in the templates and setup docs.

## Notes
- The live machine change to `~/.dispatch/server/.env` was applied locally to keep production explicitly on `DISPATCH_HOST=0.0.0.0`, but that file is outside the repository and is not part of this PR.

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`
- started an isolated `dispatch-dev` stack and verified the app loads on loopback-only URLs via Playwright
