### PR TITLE
Remember last used base branch when creating agents

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -496,7 +496,9 @@ export function DashboardLayout(): JSX.Element {
         setCreateWorktreeBranch("");
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
-        window.localStorage.setItem(LAST_USED_BASE_BRANCH_KEY, createBaseBranch);
+        if (createUseWorktree) {
+          window.localStorage.setItem(LAST_USED_BASE_BRANCH_KEY, createBaseBranch);
+        }
         setLastUsedAgentType(createType);
         setCwdHistory(addToCwdHistory(createCwd.trim()));
         setSelectedAgentId(payload.agent.id);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";
-import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom } from "@/lib/store";
+import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom, baseBranchByCwdAtom } from "@/lib/store";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { AppHeader } from "@/components/app/app-header";
 import { ActivityPane } from "@/components/app/activity-pane";
@@ -44,7 +44,6 @@ const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
 const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
-const LAST_USED_BASE_BRANCH_KEY = "dispatch:lastUsedBaseBranch";
 const CWD_HISTORY_KEY = "dispatch:cwdHistory";
 const CWD_HISTORY_MAX = 20;
 
@@ -63,12 +62,6 @@ function readLastUsedAgentType(): AgentType | null {
   if (typeof window === "undefined") return null;
   const stored = window.localStorage.getItem(LAST_USED_TYPE_KEY)?.trim();
   return stored && isAgentType(stored) ? stored : null;
-}
-
-function readLastUsedBaseBranch(): string {
-  if (typeof window === "undefined") return "main";
-  const stored = window.localStorage.getItem(LAST_USED_BASE_BRANCH_KEY)?.trim();
-  return stored && stored.length > 0 ? stored : "main";
 }
 
 function readCwdHistory(): string[] {
@@ -169,9 +162,9 @@ export function DashboardLayout(): JSX.Element {
   const [lastUsedAgentType, setLastUsedAgentType] = useState<AgentType | null>(() => readLastUsedAgentType());
   const [createType, setCreateType] = useState<AgentType>("codex");
   const [createFullAccess, setCreateFullAccess] = useAtom(fullAccessByCwdAtom(createCwd));
+  const [createBaseBranch, setCreateBaseBranch] = useAtom(baseBranchByCwdAtom(createCwd));
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
-  const [createBaseBranch, setCreateBaseBranch] = useState(() => readLastUsedBaseBranch());
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
 
@@ -496,9 +489,6 @@ export function DashboardLayout(): JSX.Element {
         setCreateWorktreeBranch("");
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
-        if (createUseWorktree) {
-          window.localStorage.setItem(LAST_USED_BASE_BRANCH_KEY, createBaseBranch);
-        }
         setLastUsedAgentType(createType);
         setCwdHistory(addToCwdHistory(createCwd.trim()));
         setSelectedAgentId(payload.agent.id);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,7 @@ const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
 const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
+const LAST_USED_BASE_BRANCH_KEY = "dispatch:lastUsedBaseBranch";
 const CWD_HISTORY_KEY = "dispatch:cwdHistory";
 const CWD_HISTORY_MAX = 20;
 
@@ -62,6 +63,12 @@ function readLastUsedAgentType(): AgentType | null {
   if (typeof window === "undefined") return null;
   const stored = window.localStorage.getItem(LAST_USED_TYPE_KEY)?.trim();
   return stored && isAgentType(stored) ? stored : null;
+}
+
+function readLastUsedBaseBranch(): string {
+  if (typeof window === "undefined") return "main";
+  const stored = window.localStorage.getItem(LAST_USED_BASE_BRANCH_KEY)?.trim();
+  return stored && stored.length > 0 ? stored : "main";
 }
 
 function readCwdHistory(): string[] {
@@ -164,7 +171,7 @@ export function DashboardLayout(): JSX.Element {
   const [createFullAccess, setCreateFullAccess] = useAtom(fullAccessByCwdAtom(createCwd));
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
-  const [createBaseBranch, setCreateBaseBranch] = useState("main");
+  const [createBaseBranch, setCreateBaseBranch] = useState(() => readLastUsedBaseBranch());
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
 
@@ -487,9 +494,9 @@ export function DashboardLayout(): JSX.Element {
         setCreateName("");
         setCreateUseWorktree(true);
         setCreateWorktreeBranch("");
-        setCreateBaseBranch("main");
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
+        window.localStorage.setItem(LAST_USED_BASE_BRANCH_KEY, createBaseBranch);
         setLastUsedAgentType(createType);
         setCwdHistory(addToCwdHistory(createCwd.trim()));
         setSelectedAgentId(payload.agent.id);

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -98,13 +98,17 @@ export function CreateAgentDialog({
     try {
       const result = await api<{ branches: string[] }>(`/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`);
       setRemoteBranches(result.branches);
+      // If the pre-selected branch doesn't exist in the fetched list, fall back to "main"
+      if (createBaseBranch !== "main" && !result.branches.includes(createBaseBranch)) {
+        setCreateBaseBranch("main");
+      }
     } catch {
       setRemoteBranches([]);
     } finally {
       setBranchesLoading(false);
       setBranchesFetchedForCwd(cwd);
     }
-  }, [createCwd]);
+  }, [createCwd, createBaseBranch, setCreateBaseBranch]);
 
   const openBranchDropdown = useCallback(() => {
     setBranchDropdownOpen(true);

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -98,9 +98,9 @@ export function CreateAgentDialog({
     try {
       const result = await api<{ branches: string[] }>(`/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`);
       setRemoteBranches(result.branches);
-      // If the pre-selected branch doesn't exist in the fetched list, fall back to "main"
-      if (createBaseBranch !== "main" && !result.branches.includes(createBaseBranch)) {
-        setCreateBaseBranch("main");
+      // If the pre-selected branch doesn't exist in the fetched list, fall back to the first available branch
+      if (!result.branches.includes(createBaseBranch)) {
+        setCreateBaseBranch(result.branches[0] ?? "main");
       }
     } catch {
       setRemoteBranches([]);

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -36,3 +36,8 @@ export const expandedAgentIdAtom = atomWithLocalStorage<string | null>("dispatch
 export const fullAccessByCwdAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage(`dispatch:fullAccess:${cwd}`, false),
 );
+
+/** Per-directory last-used base branch, backed by localStorage (sync read). */
+export const baseBranchByCwdAtom = atomFamily((cwd: string) =>
+  atomWithLocalStorage(`dispatch:baseBranch:${cwd}`, "main"),
+);


### PR DESCRIPTION
## Summary
- Persists the selected base branch to localStorage after agent creation
- New agent dialog now defaults to the previously used base branch instead of always resetting to "main"
- Follows the existing pattern used for CWD and agent type persistence

## Test plan
- [x] `pnpm run finalize:web` passes
- [x] E2E tests pass (94/94)
- [ ] Create an agent with a non-main base branch, close dialog, reopen — verify branch is remembered

🤖 Generated with [Claude Code](https://claude.com/claude-code)