### PR TITLE
Add SSE events for job lifecycle, replace client polling

### DIFF
--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -96,6 +96,7 @@ export class JobService {
 
     // Everything below reads from the DB record only
     let run = await this.store.createRun(job.id, buildRunConfig(job, input.triggerSource ?? "manual"));
+    this.emitRunStateChange(run);
     const prompt = buildJobPrompt(job, run.id);
 
     try {
@@ -110,6 +111,7 @@ export class JobService {
         jobRunId: run.id
       });
       run = await this.store.attachAgent(run.id, agent.id);
+      this.emitRunStateChange(run);
       this.startMonitor(run.id);
       if (input.wait !== false) {
         run = await this.waitForTerminal(run.id);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -90,6 +90,7 @@ const jobService = new JobService(pool, agentManager, app.log, config);
 const jobNotifier = new JobNotifier(pool, app.log);
 const JOB_TERMINAL_STATUSES = new Set(["completed", "failed", "timed_out", "crashed"]);
 jobService.onRunStateChange((run) => {
+  uiEventBroker.publish({ type: "job.changed" });
   void jobNotifier.onJobRunStateChange(run).catch((err) => {
     app.log.warn({ err, runId: run.id }, "Job run state notification failed");
   });
@@ -161,7 +162,8 @@ type UiEvent =
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string }
   | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
-  | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord };
+  | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
+  | { type: "job.changed" };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -1136,7 +1138,9 @@ async function registerRoutes() {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
     try {
-      return await jobService.addJob(parsed.data);
+      const result = await jobService.addJob(parsed.data);
+      uiEventBroker.publish({ type: "job.changed" });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return reply.code(500).send({ error: message });
@@ -1149,7 +1153,9 @@ async function registerRoutes() {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
     try {
-      return await jobService.updateJob(parsed.data);
+      const result = await jobService.updateJob(parsed.data);
+      uiEventBroker.publish({ type: "job.changed" });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return reply.code(500).send({ error: message });
@@ -1162,7 +1168,9 @@ async function registerRoutes() {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
     try {
-      return await jobService.removeJob(parsed.data);
+      const result = await jobService.removeJob(parsed.data);
+      uiEventBroker.publish({ type: "job.changed" });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return reply.code(500).send({ error: message });
@@ -1175,7 +1183,9 @@ async function registerRoutes() {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
     try {
-      return await jobService.enableJob(parsed.data);
+      const result = await jobService.enableJob(parsed.data);
+      uiEventBroker.publish({ type: "job.changed" });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return reply.code(500).send({ error: message });
@@ -1188,7 +1198,9 @@ async function registerRoutes() {
       return reply.code(400).send({ error: parsed.error.issues[0].message });
     }
     try {
-      return await jobService.disableJob(parsed.data);
+      const result = await jobService.disableJob(parsed.data);
+      uiEventBroker.publish({ type: "job.changed" });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return reply.code(500).send({ error: message });

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -94,7 +94,6 @@ export function useJobs(enabled = true) {
     queryKey: ["jobs"],
     queryFn: () => api<Job[]>("/api/v1/jobs"),
     enabled,
-    refetchInterval: enabled ? 10_000 : false,
     refetchOnWindowFocus: false,
   });
 }
@@ -108,7 +107,6 @@ export function useJobHistory(job: Job | null) {
       return api(`/api/v1/jobs/history?${params.toString()}`);
     },
     enabled: !!job,
-    refetchInterval: job ? 10_000 : false,
     refetchOnWindowFocus: false,
   });
 }
@@ -129,7 +127,6 @@ export function useJobStats(enabled = true) {
     queryKey: ["jobs", "stats"],
     queryFn: () => api<JobStats>("/api/v1/jobs/stats"),
     enabled,
-    refetchInterval: enabled ? 15_000 : false,
     refetchOnWindowFocus: false,
   });
 }

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -13,7 +13,8 @@ type UiEvent =
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string }
   | { type: "feedback.created"; agentId: string }
-  | { type: "feedback.updated"; agentId: string };
+  | { type: "feedback.updated"; agentId: string }
+  | { type: "job.changed" };
 
 export function useSSE(
   authState: AuthState,
@@ -39,6 +40,10 @@ export function useSSE(
           setStreamingAgentIds(
             new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
           );
+          // A snapshot means a fresh SSE connection (initial or reconnect).
+          // Invalidate job queries so they refetch — the snapshot only
+          // carries agents, so jobs could be stale after a reconnect.
+          void queryClient.invalidateQueries({ queryKey: ["jobs"] });
           return;
         }
 
@@ -96,6 +101,12 @@ export function useSSE(
 
         if (payload.type === "feedback.created" || payload.type === "feedback.updated") {
           void queryClient.invalidateQueries({ queryKey: ["feedback"] });
+          return;
+        }
+
+        if (payload.type === "job.changed") {
+          void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+          return;
         }
       } catch {}
     };

--- a/e2e/jobs-sse.spec.ts
+++ b/e2e/jobs-sse.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect } from "@playwright/test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import http from "http";
+
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
+const AUTH_HEADER = { Authorization: `Bearer ${AUTH_TOKEN}` };
+const HEADERS = { ...AUTH_HEADER, "Content-Type": "application/json" };
+
+const devPort = process.env.E2E_PORT ?? "8788";
+const protocol = process.env.TLS_CERT ? "https" : "http";
+const SSE_BASE_URL = `${protocol}://127.0.0.1:${devPort}`;
+
+/**
+ * Collect SSE events from /api/v1/events using raw HTTP (EventSource isn't
+ * available in Node). Returns a handle with the collected events and a
+ * cleanup function.
+ */
+function openSSEStream(baseURL: string): {
+  events: Array<{ type: string; [key: string]: unknown }>;
+  ready: Promise<void>;
+  close: () => void;
+} {
+  const events: Array<{ type: string; [key: string]: unknown }> = [];
+  const url = new URL("/api/v1/events", baseURL);
+  let req: http.ClientRequest | null = null;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    req = http.get(
+      url,
+      { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } },
+      (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`SSE stream returned ${res.statusCode}`));
+          return;
+        }
+        let buffer = "";
+        res.on("data", (chunk: Buffer) => {
+          buffer += chunk.toString();
+          // Parse complete SSE messages (double newline delimited)
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop()!; // keep incomplete tail
+          for (const part of parts) {
+            const dataLine = part
+              .split("\n")
+              .find((l) => l.startsWith("data: "));
+            if (!dataLine) continue;
+            try {
+              const payload = JSON.parse(dataLine.slice(6));
+              events.push(payload);
+              // Resolve ready after receiving snapshot (first event)
+              if (payload.type === "snapshot") resolve();
+            } catch {}
+          }
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+  });
+
+  return {
+    events,
+    ready,
+    close: () => req?.destroy(),
+  };
+}
+
+/** Wait until events array contains at least `count` events matching predicate. */
+async function waitForEvents(
+  events: Array<{ type: string }>,
+  predicate: (e: { type: string }) => boolean,
+  count: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (events.filter(predicate).length >= count) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  const matched = events.filter(predicate).length;
+  throw new Error(
+    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms). All events: ${JSON.stringify(events.map((e) => e.type))}`,
+  );
+}
+
+test.describe("Jobs SSE events", () => {
+  const jobDir = join(tmpdir(), `dispatch-e2e-sse-${Date.now()}`);
+  mkdirSync(jobDir, { recursive: true });
+
+  test("job config mutations emit job.changed SSE events", async ({
+    request,
+  }) => {
+    const sse = openSSEStream(SSE_BASE_URL);
+    try {
+      await sse.ready;
+      // Clear snapshot from events count
+      const baselineCount = sse.events.filter(
+        (e) => e.type === "job.changed",
+      ).length;
+
+      // 1. Create a job → expect job.changed
+      const createRes = await request.post("/api/v1/jobs", {
+        headers: HEADERS,
+        data: {
+          name: "SSE Test Job",
+          directory: jobDir,
+          prompt: "SSE test prompt.",
+          schedule: "0 * * * *",
+          timeoutMs: 120000,
+          needsInputTimeoutMs: 86400000,
+        },
+      });
+      expect(createRes.ok()).toBeTruthy();
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 1,
+      );
+
+      // 2. Update the job → expect another job.changed
+      const updateRes = await request.patch("/api/v1/jobs", {
+        headers: HEADERS,
+        data: {
+          name: "SSE Test Job",
+          directory: jobDir,
+          schedule: "*/30 * * * *",
+          enabled: true,
+        },
+      });
+      expect(updateRes.ok()).toBeTruthy();
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 2,
+      );
+
+      // 3. Enable the job → expect another job.changed
+      const enableRes = await request.post("/api/v1/jobs/enable", {
+        headers: HEADERS,
+        data: { name: "SSE Test Job", directory: jobDir },
+      });
+      expect(enableRes.ok()).toBeTruthy();
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 3,
+      );
+
+      // 4. Disable the job → expect another job.changed
+      const disableRes = await request.post("/api/v1/jobs/disable", {
+        headers: HEADERS,
+        data: { name: "SSE Test Job", directory: jobDir },
+      });
+      expect(disableRes.ok()).toBeTruthy();
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 4,
+      );
+
+      // 5. Delete the job → expect another job.changed
+      const deleteRes = await request.delete("/api/v1/jobs", {
+        headers: HEADERS,
+        data: { name: "SSE Test Job", directory: jobDir },
+      });
+      expect(deleteRes.ok()).toBeTruthy();
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 5,
+      );
+    } finally {
+      sse.close();
+    }
+  });
+
+  test("running a job emits job.changed for started and running transitions", async ({
+    request,
+  }) => {
+    const runDir = join(tmpdir(), `dispatch-e2e-sse-run-${Date.now()}`);
+    mkdirSync(runDir, { recursive: true });
+
+    // Create a job to run
+    const createRes = await request.post("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "SSE Run Job",
+        directory: runDir,
+        prompt:
+          'Call job_complete immediately with status "completed", summary "done", and one task "check" with status "success".',
+        schedule: "0 * * * *",
+        timeoutMs: 120000,
+        needsInputTimeoutMs: 86400000,
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+
+    const sse = openSSEStream(SSE_BASE_URL);
+    try {
+      await sse.ready;
+      const baselineCount = sse.events.filter(
+        (e) => e.type === "job.changed",
+      ).length;
+
+      // Run the job (non-blocking)
+      const runRes = await request.post("/api/v1/jobs/run", {
+        headers: HEADERS,
+        data: { name: "SSE Run Job", directory: runDir, wait: false },
+      });
+      expect(runRes.ok()).toBeTruthy();
+
+      // We should get at least 2 job.changed events: one for "started", one for "running"
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "job.changed",
+        baselineCount + 2,
+      );
+    } finally {
+      sse.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added a `job.changed` SSE event pushed through the existing `/api/v1/events` endpoint for all job lifecycle transitions (run `started`, `running`, `completed`, `failed`, `needs_input`, `timed_out`, `crashed`) and config mutations (add, update, delete, enable, disable)
- Client handles `job.changed` by invalidating all `["jobs"]` queries, replacing the 10-15s polling intervals previously used in `useJobs`, `useJobHistory`, and `useJobStats`
- Job queries also refresh on SSE reconnect (snapshot handler) to prevent stale data after connection drops

## Test plan
- [x] `pnpm run check` — all type checks pass
- [x] `pnpm run finalize:web` — production build succeeds
- [x] `pnpm run test:e2e` — 96 passed, 6 skipped (pre-existing)
- [x] New E2E tests in `e2e/jobs-sse.spec.ts`:
  - Verifies `job.changed` SSE events for all 5 config mutations (create, update, enable, disable, delete)
  - Verifies `job.changed` SSE events for `started` and `running` run transitions
- [x] Backend security review persona — approved, one medium finding (stale data on reconnect) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)