### PR TITLE
[codex] Add Mytra theme

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -50,7 +50,8 @@
           'oled-black': { background: '#000000', foreground: '#f0f0f0', themeColor: '#000000' },
           'solarized-dark': { background: '#00212b', foreground: '#8ea4a9', themeColor: '#00212b' },
           light: { background: '#ffffff', foreground: '#171717', themeColor: '#ffffff' },
-          vaporwave: { background: '#12081e', foreground: '#eddcff', themeColor: '#12081e' }
+          vaporwave: { background: '#12081e', foreground: '#eddcff', themeColor: '#12081e' },
+          mytra: { background: '#020202', foreground: '#d9dde4', themeColor: '#020202' }
         };
         var selected = palette[theme] || palette.default;
         if (theme && theme !== 'default') {

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "cool-navy" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight";
+export type ThemeId = "default" | "cool-navy" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight" | "mytra";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -166,6 +166,33 @@ const MATRIX: TerminalPalette = {
   brightWhite: "#effff2",
 };
 
+/** Mytra — matte black, machined steel, and indigo-violet light */
+const MYTRA: TerminalPalette = {
+  minimumContrastRatio: 4.5,
+  foreground: "#d9dde4",
+  background: "#020202",
+  cursor: "#6c63ff",
+  cursorAccent: "#020202",
+  selectionBackground: "#1e2232",
+  selectionInactiveBackground: "#151821",
+  black: "#020202",
+  red: "#c96b72",
+  green: "#7ca2a0",
+  yellow: "#b6bec9",
+  blue: "#6c63ff",
+  magenta: "#8b73ff",
+  cyan: "#9ea6ff",
+  white: "#d9dde4",
+  brightBlack: "#4f5662",
+  brightRed: "#e08b92",
+  brightGreen: "#95bcba",
+  brightYellow: "#c8d0da",
+  brightBlue: "#948cff",
+  brightMagenta: "#ac97ff",
+  brightCyan: "#c1c7ff",
+  brightWhite: "#f3f6fb",
+};
+
 export const THEMES: ThemeDefinition[] = [
   {
     id: "cool-navy",
@@ -187,6 +214,13 @@ export const THEMES: ThemeDefinition[] = [
     description: "Phosphor green on near-black terminal glass",
     swatches: ["#020403", "#0a0f0b", "#1fa34a", "#6bff8f"],
     terminal: MATRIX,
+  },
+  {
+    id: "mytra",
+    label: "Mytra",
+    description: "Matte black with machined steel and indigo-violet light",
+    swatches: ["#020202", "#20242c", "#5c6778", "#6c63ff"],
+    terminal: MYTRA,
   },
   {
     id: "midnight",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -293,6 +293,42 @@
   --terminal-bg: 150 20% 1.5%;
 }
 
+[data-theme="mytra"] {
+  --background: 0 0% 1%;
+  --foreground: 219 16% 89%;
+  --card: 225 10% 9%;
+  --card-foreground: 219 16% 89%;
+  --popover: 225 10% 9%;
+  --popover-foreground: 219 16% 89%;
+  --primary: 244 100% 69%;
+  --primary-foreground: 0 0% 6%;
+  --muted: 222 9% 14%;
+  --muted-foreground: 220 11% 62%;
+  --accent: 222 9% 14%;
+  --accent-foreground: 219 16% 89%;
+  --destructive: 354 52% 61%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 225 10% 21%;
+  --input: 225 10% 21%;
+  --ring: 244 100% 69%;
+
+  --status-working: 186 58% 58%;
+  --status-blocked: 354 52% 61%;
+  --status-waiting: 233 28% 73%;
+  --status-done: 229 57% 71%;
+  --status-idle: 222 8% 44%;
+
+  --chart-1: 244 100% 69%;
+  --chart-2: 229 57% 71%;
+  --chart-3: 186 58% 58%;
+  --chart-4: 267 72% 72%;
+  --chart-5: 244 70% 58%;
+  --chart-6: 222 18% 55%;
+
+  --surface: 220 12% 4%;
+  --terminal-bg: 0 0% 1%;
+}
+
 * {
   @apply border-border;
 }
@@ -307,6 +343,39 @@ body {
 body {
   @apply bg-background text-foreground antialiased;
   font-family: "JetBrains Mono", Menlo, monospace;
+}
+
+html[data-theme="mytra"] body {
+  background-image:
+    radial-gradient(circle at top center, hsl(var(--primary) / 0.18), transparent 22%),
+    radial-gradient(circle at 50% 18%, hsl(var(--status-done) / 0.08), transparent 28%),
+    linear-gradient(180deg, hsl(var(--background)), hsl(var(--surface)));
+}
+
+html[data-theme="mytra"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    linear-gradient(180deg, hsl(var(--foreground) / 0.018), transparent 18%, transparent 84%, hsl(var(--foreground) / 0.02)),
+    radial-gradient(circle at 22% 24%, hsl(var(--primary) / 0.055), transparent 20%),
+    radial-gradient(circle at 78% 72%, hsl(var(--status-done) / 0.045), transparent 24%),
+    linear-gradient(118deg, transparent 0 64%, hsl(var(--primary) / 0.03) 72%, transparent 78%);
+  opacity: 0.32;
+}
+
+html[data-theme="mytra"] body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 50% -8%, hsl(var(--primary) / 0.22), transparent 24%),
+    radial-gradient(circle at 50% 108%, hsl(var(--status-done) / 0.12), transparent 30%);
+  opacity: 0.9;
 }
 
 html[data-theme="matrix"] body {


### PR DESCRIPTION
## Summary
- add a new `Mytra` Dispatch theme inspired by mytra.ai
- tune the palette toward matte black, machined steel, and indigo-violet accents
- refine the theme after UX review to restore semantic status color separation, soften the background treatment, and improve picker swatches

## What Changed
- added `mytra` to the theme registry and first-paint theme palette
- added dedicated Mytra UI tokens, atmospheric background styling, and terminal colors
- updated the theme picker metadata and swatches so Mytra is more distinguishable from other dark themes

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`