### PR TITLE
Add dispatch_notify MCP tool for agent-initiated Slack notifications

### DIFF
--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -17,12 +17,38 @@ const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color
   blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
 };
 
+const NOTIFY_LEVELS = ["info", "success", "warning", "error"] as const;
+export type NotifyLevel = (typeof NOTIFY_LEVELS)[number];
+
+const LEVEL_CONFIG: Record<NotifyLevel, { emoji: string; color: string }> = {
+  info: { emoji: "\u2139\ufe0f", color: "#3b82f6" },
+  success: { emoji: "\u2705", color: "#22c55e" },
+  warning: { emoji: "\u26a0\ufe0f", color: "#f59e0b" },
+  error: { emoji: "\ud83d\udead", color: "#ef4444" },
+};
+
+export type NotifyInput = {
+  message: string;
+  title?: string;
+  level?: NotifyLevel;
+  respectFocus?: boolean;
+};
+
+export type NotifyResult = {
+  sent: boolean;
+  reason?: string;
+};
+
 const SLACK_WEBHOOK_PREFIX = "https://hooks.slack.com/";
 const SETTING_WEBHOOK_URL = "slack_webhook_url";
 const SETTING_NOTIFY_EVENTS = "slack_notify_events";
 
 /** Short-lived cache to avoid DB reads on every agent event. */
 const CACHE_TTL_MS = 10_000;
+
+/** Rate limit for agent-initiated notifications: max per window. */
+const NOTIFY_RATE_LIMIT = 5;
+const NOTIFY_RATE_WINDOW_MS = 60_000;
 
 type CachedSettings = {
   webhookUrl: string | null;
@@ -46,6 +72,8 @@ export function isValidSlackWebhookUrl(url: string): boolean {
 export class SlackNotifier {
   private cachedSettings: CachedSettings | null = null;
   private isFocused: ((agentId: string) => boolean) | null = null;
+  /** Per-agent rate limit tracking for dispatch_notify calls. */
+  private notifyTimestamps: Map<string, number[]> = new Map();
 
   constructor(
     private pool: Pool,
@@ -159,6 +187,89 @@ export class SlackNotifier {
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
     }
+  }
+
+  /**
+   * Agent-initiated notification via the dispatch_notify MCP tool.
+   * Bypasses focus filtering by default (agents explicitly chose to notify).
+   */
+  async sendNotification(agent: AgentRecord, input: NotifyInput): Promise<NotifyResult> {
+    // Rate limit check
+    if (this.isRateLimited(agent.id)) {
+      return { sent: false, reason: "Rate limited — max 5 notifications per minute per agent." };
+    }
+
+    // Respect focus if explicitly requested
+    if (input.respectFocus && this.isFocused?.(agent.id)) {
+      return { sent: false, reason: "Notification suppressed — user is focused on this agent." };
+    }
+
+    const settings = await this.getCachedSettings();
+    if (!settings.webhookUrl) {
+      return { sent: false, reason: "No Slack webhook configured." };
+    }
+
+    try {
+      const level = input.level ?? "info";
+      const cfg = LEVEL_CONFIG[level];
+      const agentName = agent.name || agent.id.slice(0, 8);
+
+      const blocks: SlackBlock[] = [];
+
+      // Title + message
+      const titleLine = input.title
+        ? `*${cfg.emoji} ${input.title}*`
+        : `*${cfg.emoji} Notification from "${agentName}"*`;
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: `${titleLine}\n${input.message}` },
+      });
+
+      // Context line
+      const branch = agent.gitContext?.branch;
+      const contextParts: string[] = [];
+      contextParts.push(`Agent: ${agentName}`);
+      if (branch) contextParts.push(`Branch: \`${branch}\``);
+      blocks.push({
+        type: "context",
+        elements: [{ type: "mrkdwn", text: contextParts.join("  \u00b7  ") }],
+      });
+
+      const fallback = input.title
+        ? `${input.title}: ${input.message}`
+        : `Notification from "${agentName}": ${input.message}`;
+
+      const res = await this.postToSlack(settings.webhookUrl, {
+        username: "Dispatch",
+        attachments: [{ color: cfg.color, fallback, blocks }],
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        this.log.warn({ status: res.status, body }, "Slack webhook returned error for dispatch_notify");
+        return { sent: false, reason: `Slack returned ${res.status}: ${body}` };
+      }
+
+      this.recordNotifyTimestamp(agent.id);
+      return { sent: true };
+    } catch (err) {
+      this.log.warn({ err, agentId: agent.id }, "Failed to send agent-initiated notification");
+      return { sent: false, reason: err instanceof Error ? err.message : "Unknown error" };
+    }
+  }
+
+  private isRateLimited(agentId: string): boolean {
+    const now = Date.now();
+    const timestamps = this.notifyTimestamps.get(agentId) ?? [];
+    const recent = timestamps.filter((t) => now - t < NOTIFY_RATE_WINDOW_MS);
+    this.notifyTimestamps.set(agentId, recent);
+    return recent.length >= NOTIFY_RATE_LIMIT;
+  }
+
+  private recordNotifyTimestamp(agentId: string): void {
+    const timestamps = this.notifyTimestamps.get(agentId) ?? [];
+    timestamps.push(Date.now());
+    this.notifyTimestamps.set(agentId, timestamps);
   }
 
   private async getCachedSettings(): Promise<{ webhookUrl: string | null; notifyEvents: NotifyEventType[] }> {

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -69,6 +69,14 @@ export function isValidSlackWebhookUrl(url: string): boolean {
   }
 }
 
+/**
+ * Escape Slack special mention syntax (<!channel>, <!here>, <!everyone>)
+ * in agent-provided content to prevent mrkdwn injection.
+ */
+function sanitizeSlackMrkdwn(text: string): string {
+  return text.replace(/<!([^>]*)>/g, "&lt;!$1&gt;");
+}
+
 export class SlackNotifier {
   private cachedSettings: CachedSettings | null = null;
   private isFocused: ((agentId: string) => boolean) | null = null;
@@ -214,15 +222,20 @@ export class SlackNotifier {
       const cfg = LEVEL_CONFIG[level];
       const agentName = agent.name || agent.id.slice(0, 8);
 
+      // Sanitize agent-provided content to prevent Slack mrkdwn injection
+      // (<!channel>, <!here>, <!everyone> mentions, and <url|label> link spoofing)
+      const safeMessage = sanitizeSlackMrkdwn(input.message);
+      const safeTitle = input.title ? sanitizeSlackMrkdwn(input.title) : undefined;
+
       const blocks: SlackBlock[] = [];
 
       // Title + message
-      const titleLine = input.title
-        ? `*${cfg.emoji} ${input.title}*`
+      const titleLine = safeTitle
+        ? `*${cfg.emoji} ${safeTitle}*`
         : `*${cfg.emoji} Notification from "${agentName}"*`;
       blocks.push({
         type: "section",
-        text: { type: "mrkdwn", text: `${titleLine}\n${input.message}` },
+        text: { type: "mrkdwn", text: `${titleLine}\n${safeMessage}` },
       });
 
       // Context line
@@ -235,9 +248,9 @@ export class SlackNotifier {
         elements: [{ type: "mrkdwn", text: contextParts.join("  \u00b7  ") }],
       });
 
-      const fallback = input.title
-        ? `${input.title}: ${input.message}`
-        : `Notification from "${agentName}": ${input.message}`;
+      const fallback = safeTitle
+        ? `${safeTitle}: ${safeMessage}`
+        : `Notification from "${agentName}": ${safeMessage}`;
 
       const res = await this.postToSlack(settings.webhookUrl, {
         username: "Dispatch",
@@ -262,7 +275,11 @@ export class SlackNotifier {
     const now = Date.now();
     const timestamps = this.notifyTimestamps.get(agentId) ?? [];
     const recent = timestamps.filter((t) => now - t < NOTIFY_RATE_WINDOW_MS);
-    this.notifyTimestamps.set(agentId, recent);
+    if (recent.length === 0) {
+      this.notifyTimestamps.delete(agentId);
+    } else {
+      this.notifyTimestamps.set(agentId, recent);
+    }
     return recent.length >= NOTIFY_RATE_LIMIT;
   }
 

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg";
 import type { FastifyBaseLogger } from "fastify";
 
+import type { NotifyInput, NotifyResult } from "@dispatch/shared/mcp/server.js";
 import type { AgentRecord } from "../agents/manager.js";
 import { getSetting, setSetting, deleteSetting } from "../db/settings.js";
 
@@ -17,27 +18,14 @@ const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color
   blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
 };
 
-const NOTIFY_LEVELS = ["info", "success", "warning", "error"] as const;
-export type NotifyLevel = (typeof NOTIFY_LEVELS)[number];
-
-const LEVEL_CONFIG: Record<NotifyLevel, { emoji: string; color: string }> = {
+const LEVEL_CONFIG: Record<string, { emoji: string; color: string }> = {
   info: { emoji: "\u2139\ufe0f", color: "#3b82f6" },
   success: { emoji: "\u2705", color: "#22c55e" },
   warning: { emoji: "\u26a0\ufe0f", color: "#f59e0b" },
   error: { emoji: "\ud83d\udead", color: "#ef4444" },
 };
 
-export type NotifyInput = {
-  message: string;
-  title?: string;
-  level?: NotifyLevel;
-  respectFocus?: boolean;
-};
-
-export type NotifyResult = {
-  sent: boolean;
-  reason?: string;
-};
+export type { NotifyInput, NotifyResult };
 
 const SLACK_WEBHOOK_PREFIX = "https://hooks.slack.com/";
 const SETTING_WEBHOOK_URL = "slack_webhook_url";
@@ -252,6 +240,10 @@ export class SlackNotifier {
         ? `${safeTitle}: ${safeMessage}`
         : `Notification from "${agentName}": ${safeMessage}`;
 
+      // Record timestamp optimistically — over-counting is safer than under-counting
+      // for a rate limiter protecting a webhook.
+      this.recordNotifyTimestamp(agent.id);
+
       const res = await this.postToSlack(settings.webhookUrl, {
         username: "Dispatch",
         attachments: [{ color: cfg.color, fallback, blocks }],
@@ -263,7 +255,6 @@ export class SlackNotifier {
         return { sent: false, reason: `Slack returned ${res.status}: ${body}` };
       }
 
-      this.recordNotifyTimestamp(agent.id);
       return { sent: true };
     } catch (err) {
       this.log.warn({ err, agentId: agent.id }, "Failed to send agent-initiated notification");

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -18,7 +18,7 @@ const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color
   blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
 };
 
-const LEVEL_CONFIG: Record<string, { emoji: string; color: string }> = {
+const LEVEL_CONFIG: Record<NonNullable<NotifyInput["level"]>, { emoji: string; color: string }> = {
   info: { emoji: "\u2139\ufe0f", color: "#3b82f6" },
   success: { emoji: "\u2705", color: "#22c55e" },
   warning: { emoji: "\u26a0\ufe0f", color: "#f59e0b" },
@@ -58,8 +58,8 @@ export function isValidSlackWebhookUrl(url: string): boolean {
 }
 
 /**
- * Escape Slack special mention syntax (<!channel>, <!here>, <!everyone>)
- * in agent-provided content to prevent mrkdwn injection.
+ * Escape Slack broadcast mention syntax (<!channel>, <!here>, <!everyone>)
+ * in agent-provided content. Regular mrkdwn formatting and links are preserved.
  */
 function sanitizeSlackMrkdwn(text: string): string {
   return text.replace(/<!([^>]*)>/g, "&lt;!$1&gt;");
@@ -210,8 +210,8 @@ export class SlackNotifier {
       const cfg = LEVEL_CONFIG[level];
       const agentName = agent.name || agent.id.slice(0, 8);
 
-      // Sanitize agent-provided content to prevent Slack mrkdwn injection
-      // (<!channel>, <!here>, <!everyone> mentions, and <url|label> link spoofing)
+      // Sanitize agent-provided content to prevent broadcast mentions
+      // (<!channel>, <!here>, <!everyone>). Regular mrkdwn links are allowed.
       const safeMessage = sanitizeSlackMrkdwn(input.message);
       const safeTitle = input.title ? sanitizeSlackMrkdwn(input.title) : undefined;
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -59,7 +59,7 @@ import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { handleMcpRequest } from "@dispatch/shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
-import { SlackNotifier, isValidSlackWebhookUrl } from "./notifications/slack.js";
+import { SlackNotifier, isValidSlackWebhookUrl, type NotifyInput, type NotifyResult } from "./notifications/slack.js";
 import { JobNotifier } from "./notifications/job-notifier.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
@@ -3962,8 +3962,8 @@ async function mcpUpsertEvent(
 
 async function mcpSendNotify(
   agentId: string,
-  input: { message: string; title?: string; level?: "info" | "success" | "warning" | "error"; respectFocus?: boolean }
-): Promise<{ sent: boolean; reason?: string }> {
+  input: NotifyInput
+): Promise<NotifyResult> {
   const agent = await agentManager.getAgent(agentId);
   if (!agent) throw new Error("Agent not found.");
   return slackNotifier.sendNotification(agent, input);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1265,6 +1265,7 @@ async function registerRoutes() {
       agent,
       repoRoot,
       worktreeRoot,
+      sendNotify: mcpSendNotify,
       toolScope: "job",
       jobTools: {
         complete: mcpJobComplete,
@@ -1312,6 +1313,7 @@ async function registerRoutes() {
       },
       repoRoot,
       worktreeRoot,
+      sendNotify: mcpSendNotify,
       upsertEvent: mcpUpsertEvent,
       shareMedia: mcpShareMedia,
       submitFeedback: mcpSubmitFeedback,
@@ -3956,6 +3958,15 @@ async function mcpUpsertEvent(
     metadata: event.metadata
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+}
+
+async function mcpSendNotify(
+  agentId: string,
+  input: { message: string; title?: string; level?: "info" | "success" | "warning" | "error"; respectFocus?: boolean }
+): Promise<{ sent: boolean; reason?: string }> {
+  const agent = await agentManager.getAgent(agentId);
+  if (!agent) throw new Error("Agent not found.");
+  return slackNotifier.sendNotification(agent, input);
 }
 
 async function mcpSubmitFeedback(

--- a/apps/server/test/slack-notifier.test.ts
+++ b/apps/server/test/slack-notifier.test.ts
@@ -265,4 +265,37 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     const contextText = body.attachments[0].blocks[1].elements[0].text;
     expect(contextText).toContain("feat/notify");
   });
+
+  it("sanitizes Slack mrkdwn injection in message and title", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await notifier.sendNotification(makeAgent(), {
+      message: "Check this <!channel> and <!here> ping",
+      title: "Alert <!everyone>",
+    });
+
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const messageText = body.attachments[0].blocks[0].text.text;
+    expect(messageText).not.toContain("<!channel>");
+    expect(messageText).not.toContain("<!here>");
+    expect(messageText).not.toContain("<!everyone>");
+    expect(messageText).toContain("&lt;!channel&gt;");
+    expect(messageText).toContain("&lt;!everyone&gt;");
+  });
+
+  it("cleans up expired rate limit entries from the map", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const agent = makeAgent();
+    const map = (notifier as unknown as { notifyTimestamps: Map<string, number[]> }).notifyTimestamps;
+
+    // Seed with expired timestamps (>60s ago)
+    map.set(agent.id, [Date.now() - 120_000]);
+    expect(map.has(agent.id)).toBe(true);
+
+    // Trigger isRateLimited via sendNotification — expired entries get pruned,
+    // and if empty the map entry is deleted entirely
+    notifier.setFocusCheck(() => true);
+    await notifier.sendNotification(agent, { message: "trigger cleanup", respectFocus: true });
+
+    expect(map.has(agent.id)).toBe(false);
+  });
 });

--- a/apps/server/test/slack-notifier.test.ts
+++ b/apps/server/test/slack-notifier.test.ts
@@ -170,3 +170,99 @@ describe("SlackNotifier focus suppression", () => {
     expect(mockLog.debug).not.toHaveBeenCalled();
   });
 });
+
+describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
+  beforeEach(() => {
+    fetchSpy.mockClear();
+  });
+
+  it("sends a notification with default level", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const result = await notifier.sendNotification(makeAgent(), { message: "Hello from agent" });
+
+    expect(result).toEqual({ sent: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.username).toBe("Dispatch");
+    expect(body.attachments[0].color).toBe("#3b82f6"); // info blue
+    expect(body.attachments[0].blocks[0].text.text).toContain("Hello from agent");
+  });
+
+  it("uses custom title and level", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const result = await notifier.sendNotification(makeAgent(), {
+      message: "All tests passed",
+      title: "CI Report",
+      level: "success",
+    });
+
+    expect(result).toEqual({ sent: true });
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.attachments[0].color).toBe("#22c55e"); // success green
+    expect(body.attachments[0].blocks[0].text.text).toContain("CI Report");
+  });
+
+  it("bypasses focus filtering by default", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck(() => true); // agent is focused
+
+    const result = await notifier.sendNotification(makeAgent(), { message: "Important update" });
+
+    expect(result).toEqual({ sent: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects focus when respectFocus is true", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    notifier.setFocusCheck(() => true);
+
+    const result = await notifier.sendNotification(makeAgent(), {
+      message: "Skippable update",
+      respectFocus: true,
+    });
+
+    expect(result).toEqual({ sent: false, reason: "Notification suppressed — user is focused on this agent." });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns gracefully when no webhook is configured", async () => {
+    const { getSetting } = await import("../src/db/settings.js");
+    vi.mocked(getSetting).mockResolvedValueOnce(null); // webhook URL
+    vi.mocked(getSetting).mockResolvedValueOnce(null); // notify events
+
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const result = await notifier.sendNotification(makeAgent(), { message: "test" });
+
+    expect(result).toEqual({ sent: false, reason: "No Slack webhook configured." });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rate limits after 5 notifications in a minute", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const agent = makeAgent();
+
+    // Send 5 — should all succeed
+    for (let i = 0; i < 5; i++) {
+      const result = await notifier.sendNotification(agent, { message: `msg ${i}` });
+      expect(result.sent).toBe(true);
+    }
+
+    // 6th should be rate limited
+    const result = await notifier.sendNotification(agent, { message: "one too many" });
+    expect(result).toEqual({ sent: false, reason: "Rate limited — max 5 notifications per minute per agent." });
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("includes branch in context when available", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    const agent = makeAgent({
+      gitContext: { branch: "feat/notify", defaultBranch: "main" },
+    });
+
+    await notifier.sendNotification(agent, { message: "branch test" });
+
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const contextText = body.attachments[0].blocks[1].elements[0].text;
+    expect(contextText).toContain("feat/notify");
+  });
+});

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -460,8 +460,8 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           "Requires a Slack webhook to be configured in Dispatch settings. " +
           "Rate limited to 5 messages per minute.",
         inputSchema: {
-          message: z.string().describe("The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc)."),
-          title: z.string().optional().describe("Optional title displayed above the message. Defaults to 'Notification from <agent>'."),
+          message: z.string().max(3000).describe("The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc). Max 3000 characters."),
+          title: z.string().max(150).optional().describe("Optional title displayed above the message. Defaults to 'Notification from <agent>'. Max 150 characters."),
           level: z.enum(["info", "success", "warning", "error"]).default("info")
             .describe("Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."),
           respectFocus: z.boolean().default(false)

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -91,6 +91,7 @@ const AGENT_TOOLS = new Set([
   "create_pr",
   "get_pr_status",
   "dispatch_event",
+  "dispatch_notify",
   "dispatch_pin",
   "dispatch_share",
   "dispatch_feedback",
@@ -102,6 +103,7 @@ const AGENT_TOOLS = new Set([
 const JOB_TOOLS = new Set([
   "create_pr",
   "get_pr_status",
+  "dispatch_notify",
   "job_complete",
   "job_failed",
   "job_needs_input",
@@ -146,10 +148,26 @@ export type ParentContextResult = {
   media: Array<{ fileName: string; description: string | null; source: string; createdAt: string }>;
 };
 
+export type NotifyInput = {
+  message: string;
+  title?: string;
+  level?: "info" | "success" | "warning" | "error";
+  respectFocus?: boolean;
+};
+
+export type NotifyResult = {
+  sent: boolean;
+  reason?: string;
+};
+
 export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
   worktreeRoot: string | null;
+  sendNotify?: (
+    agentId: string,
+    input: NotifyInput
+  ) => Promise<NotifyResult>;
   upsertEvent?: (
     agentId: string,
     event: { type: string; message: string; metadata?: Record<string, unknown> }
@@ -420,6 +438,48 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           });
           return {
             content: [{ type: "text", text: `Updated ${agentId}: ${args.type} - ${args.message}` }]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_notify ───────────────────────────────────────────────
+  if (allowed.has("dispatch_notify") && context.agent && context.sendNotify) {
+    const agentId = context.agent.id;
+    const sendNotify = context.sendNotify;
+
+    server.registerTool(
+      "dispatch_notify",
+      {
+        description:
+          "Send a Slack notification. Use this to proactively share summaries, results, or important updates " +
+          "with the user via Slack. The message supports Slack mrkdwn formatting. " +
+          "Requires a Slack webhook to be configured in Dispatch settings. " +
+          "Rate limited to 5 messages per minute.",
+        inputSchema: {
+          message: z.string().describe("The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc)."),
+          title: z.string().optional().describe("Optional title displayed above the message. Defaults to 'Notification from <agent>'."),
+          level: z.enum(["info", "success", "warning", "error"]).default("info")
+            .describe("Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."),
+          respectFocus: z.boolean().default(false)
+            .describe("When true, the notification is suppressed if the user is actively viewing this agent in Dispatch. Default false — notifications are always sent."),
+        }
+      },
+      async (args) => {
+        try {
+          const result = await sendNotify(agentId, {
+            message: args.message,
+            title: args.title,
+            level: args.level as NotifyInput["level"],
+            respectFocus: args.respectFocus,
+          });
+          return {
+            content: [{ type: "text", text: result.sent
+              ? "Notification sent to Slack."
+              : `Notification not sent: ${result.reason}` }]
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary
- Adds a new `dispatch_notify` MCP tool available to agents and job agents, allowing them to proactively send Slack messages via the configured webhook
- Supports Slack mrkdwn formatting, semantic levels (`info`/`success`/`warning`/`error` with corresponding colors/emoji), optional title, and a `respectFocus` flag (defaults to `false` so explicit notifications bypass focus suppression)
- Rate limited to 5 messages per minute per agent; returns gracefully when no webhook is configured
- Includes 7 new unit tests covering default behavior, custom levels, focus bypass/respect, no-webhook graceful handling, rate limiting, and branch context

## Design decisions
- **Focus bypass by default**: Unlike automated status notifications, `dispatch_notify` calls are deliberate agent decisions — suppressing them silently would be surprising. The `respectFocus` opt-in lets callers suppress if desired.
- **Rate limiting**: In-memory sliding window (5/min/agent) prevents runaway loops from spamming Slack.
- **No file attachments yet**: Slack webhooks can't upload files and media URLs are local. Proper attachment support will come with Slack bot token integration (future work).

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Unit tests pass — 7 new tests for `sendNotification` (17 total in slack-notifier.test.ts)
- [x] E2E tests pass (96 passed, 6 pre-existing skips)