### PR TITLE
Add activity, history, and feedback summary MCP tools

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -161,6 +161,114 @@ type AgentLatestEventInput = {
   metadata?: Record<string, unknown>;
 };
 
+// ── Activity / History / Feedback summary types ──────────────────────
+
+export type ActivitySummaryResult = {
+  period: { start: string; end: string };
+  projects: Array<{
+    directory: string;
+    totalWorkingMs: number;
+    agentCount: number;
+    sessionCount: number;
+    outcomes: {
+      done: number;
+      idle: number;
+      blocked: number;
+      error: number;
+    };
+  }>;
+  totals: {
+    totalWorkingMs: number;
+    agentCount: number;
+    sessionCount: number;
+  };
+  topAgents: Array<{
+    id: string;
+    name: string;
+    project: string;
+    totalWorkingMs: number;
+    latestEventMessage: string;
+    latestEventType: string;
+  }>;
+};
+
+export type AgentHistoryEntry = {
+  id: string;
+  name: string;
+  type: string;
+  project: string;
+  status: string;
+  createdAt: string;
+  latestEventType: string | null;
+  latestEventMessage: string | null;
+  pins: Array<{ label: string; value: string; type: string }>;
+  git: {
+    branch: string | null;
+    worktreeBranch: string | null;
+  } | null;
+  events?: Array<{
+    type: string;
+    message: string;
+    createdAt: string;
+  }>;
+  feedback?: Array<{
+    id: number;
+    persona: string;
+    severity: string;
+    description: string;
+    filePath: string | null;
+    suggestion: string | null;
+    status: string;
+  }>;
+  reviews?: Array<{
+    persona: string;
+    status: string;
+    verdict: string | null;
+    summary: string | null;
+    filesReviewed: string[] | null;
+  }>;
+};
+
+export type AgentHistoryResult = {
+  agents: AgentHistoryEntry[];
+  total: number;
+  hasMore: boolean;
+};
+
+export type FeedbackSummaryResult = {
+  period: { start: string; end: string };
+  totalFindings: number;
+  bySeverity: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+    info: number;
+  };
+  byStatus: {
+    open: number;
+    fixed: number;
+    ignored: number;
+    dismissed: number;
+  };
+  groups: Array<{
+    key: string;
+    count: number;
+    bySeverity: { critical: number; high: number; medium: number; low: number; info: number };
+    topFindings: Array<{
+      description: string;
+      count: number;
+      severity: string;
+      exampleFilePath: string | null;
+    }>;
+  }>;
+  reviewVerdicts: {
+    total: number;
+    approved: number;
+    changesRequested: number;
+  };
+};
+
 export type AgentTerminalAccess =
   | { mode: "tmux"; sessionName: string }
   | { mode: "inert"; message: string };
@@ -1837,6 +1945,511 @@ export class AgentManager {
       [sinceDays]
     );
     return result.rows;
+  }
+
+  // --- Activity / History / Feedback Summaries ---
+
+  async getActivitySummary(params: {
+    start: Date;
+    end: Date;
+    project?: string;
+  }): Promise<ActivitySummaryResult> {
+    const rangeStart = params.start;
+    const rangeEnd = params.end;
+
+    // Build optional project filter for working-time CTE
+    const wtProjectFilter = params.project ? "AND project_dir = $3" : "";
+    const wtParams: unknown[] = [rangeStart, rangeEnd];
+    if (params.project) wtParams.push(params.project);
+
+    // Build conditions for agents table queries
+    const agentConditions = [
+      "parent_agent_id IS NULL",
+      "deleted_at IS NULL",
+      "created_at >= $1",
+      "created_at <= $2",
+    ];
+    const agentParams: unknown[] = [rangeStart, rangeEnd];
+    if (params.project) {
+      agentParams.push(params.project);
+      agentConditions.push(`COALESCE(git_context->>'repoRoot', cwd) = $${agentParams.length}`);
+    }
+    const agentWhere = `WHERE ${agentConditions.join(" AND ")}`;
+
+    // Run all three queries in parallel
+    const [workingTimeResult, sessionResult, agentMetaResult] = await Promise.all([
+      // Query 1: Working time per agent per project via SQL window functions
+      this.pool.query<{ agentId: string; projectDir: string; totalWorkingMs: string }>(
+        `WITH boundary AS (
+          SELECT DISTINCT ON (ae.agent_id)
+            ae.agent_id, ae.event_type,
+            $1::timestamptz AS effective_at,
+            COALESCE(ae.project_dir, a.cwd) AS project_dir
+          FROM agent_events ae
+          JOIN agents a ON a.id = ae.agent_id
+            AND a.deleted_at IS NULL AND a.parent_agent_id IS NULL
+          WHERE ae.created_at < $1
+          ORDER BY ae.agent_id, ae.created_at DESC
+        ),
+        in_range AS (
+          SELECT ae.agent_id, ae.event_type, ae.created_at AS effective_at,
+                 COALESCE(ae.project_dir, a.cwd) AS project_dir
+          FROM agent_events ae
+          JOIN agents a ON a.id = ae.agent_id
+            AND a.deleted_at IS NULL AND a.parent_agent_id IS NULL
+          WHERE ae.created_at >= $1 AND ae.created_at <= $2
+        ),
+        all_events AS (
+          SELECT * FROM boundary UNION ALL SELECT * FROM in_range
+        ),
+        with_next AS (
+          SELECT agent_id, event_type, effective_at, project_dir,
+                 LEAD(effective_at) OVER (PARTITION BY agent_id ORDER BY effective_at) AS next_at
+          FROM all_events
+        )
+        SELECT
+          agent_id AS "agentId",
+          project_dir AS "projectDir",
+          COALESCE(SUM(
+            CASE WHEN event_type = 'working'
+            THEN EXTRACT(EPOCH FROM (
+              COALESCE(next_at, LEAST($2::timestamptz, NOW())) - effective_at
+            )) * 1000
+            ELSE 0 END
+          ), 0)::bigint AS "totalWorkingMs"
+        FROM with_next
+        WHERE project_dir IS NOT NULL ${wtProjectFilter}
+        GROUP BY agent_id, project_dir`,
+        wtParams
+      ),
+
+      // Query 2: Session counts and outcomes by project
+      this.pool.query<{
+        projectDir: string; sessionCount: string; doneCount: string;
+        idleCount: string; blockedCount: string; errorCount: string;
+      }>(
+        `SELECT
+          COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
+          COUNT(*)::int AS "sessionCount",
+          COUNT(*) FILTER (WHERE latest_event_type = 'done')::int AS "doneCount",
+          COUNT(*) FILTER (WHERE latest_event_type = 'idle')::int AS "idleCount",
+          COUNT(*) FILTER (WHERE latest_event_type = 'blocked')::int AS "blockedCount",
+          COUNT(*) FILTER (WHERE status = 'error')::int AS "errorCount"
+        FROM agents
+        ${agentWhere}
+        GROUP BY COALESCE(git_context->>'repoRoot', cwd)`,
+        agentParams
+      ),
+
+      // Query 3: Agent metadata for top agents list
+      this.pool.query<{
+        id: string; name: string; projectDir: string;
+        latestEventType: string | null; latestEventMessage: string | null;
+      }>(
+        `SELECT id, name,
+          COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
+          latest_event_type AS "latestEventType",
+          latest_event_message AS "latestEventMessage"
+        FROM agents
+        ${agentWhere}`,
+        agentParams
+      ),
+    ]);
+
+    // Aggregate working time by project and by agent
+    const projectWorkingTime = new Map<string, { totalWorkingMs: number; agents: Set<string> }>();
+    const workingTimeByAgent = new Map<string, { project: string; totalWorkingMs: number }>();
+
+    for (const row of workingTimeResult.rows) {
+      const ms = Number(row.totalWorkingMs);
+
+      // Per-project aggregation
+      const proj = projectWorkingTime.get(row.projectDir) ?? { totalWorkingMs: 0, agents: new Set() };
+      proj.totalWorkingMs += ms;
+      proj.agents.add(row.agentId);
+      projectWorkingTime.set(row.projectDir, proj);
+
+      // Per-agent aggregation (for top agents)
+      const agent = workingTimeByAgent.get(row.agentId);
+      if (agent) {
+        agent.totalWorkingMs += ms;
+      } else {
+        workingTimeByAgent.set(row.agentId, { project: row.projectDir, totalWorkingMs: ms });
+      }
+    }
+
+    // Index session data by project
+    const sessionsByProject = new Map(sessionResult.rows.map((r) => [r.projectDir, r]));
+
+    // Merge project-level data
+    const allProjectDirs = new Set([...projectWorkingTime.keys(), ...sessionsByProject.keys()]);
+    const projects = [...allProjectDirs]
+      .map((dir) => {
+        const working = projectWorkingTime.get(dir);
+        const sessions = sessionsByProject.get(dir);
+        return {
+          directory: dir,
+          totalWorkingMs: working?.totalWorkingMs ?? 0,
+          agentCount: working?.agents.size ?? 0,
+          sessionCount: Number(sessions?.sessionCount ?? 0),
+          outcomes: {
+            done: Number(sessions?.doneCount ?? 0),
+            idle: Number(sessions?.idleCount ?? 0),
+            blocked: Number(sessions?.blockedCount ?? 0),
+            error: Number(sessions?.errorCount ?? 0),
+          },
+        };
+      })
+      .sort((a, b) => b.totalWorkingMs - a.totalWorkingMs);
+
+    // Build top agents list
+    const agentMeta = new Map(agentMetaResult.rows.map((r) => [r.id, r]));
+    const topAgents = [...workingTimeByAgent.entries()]
+      .sort((a, b) => b[1].totalWorkingMs - a[1].totalWorkingMs)
+      .slice(0, 10)
+      .map(([id, data]) => {
+        const meta = agentMeta.get(id);
+        return {
+          id,
+          name: meta?.name ?? id,
+          project: data.project,
+          totalWorkingMs: data.totalWorkingMs,
+          latestEventMessage: meta?.latestEventMessage ?? "",
+          latestEventType: meta?.latestEventType ?? "",
+        };
+      });
+
+    return {
+      period: { start: rangeStart.toISOString(), end: rangeEnd.toISOString() },
+      projects,
+      totals: {
+        totalWorkingMs: projects.reduce((sum, p) => sum + p.totalWorkingMs, 0),
+        agentCount: new Set(workingTimeResult.rows.map((r) => r.agentId)).size,
+        sessionCount: projects.reduce((sum, p) => sum + p.sessionCount, 0),
+      },
+      topAgents,
+    };
+  }
+
+  async getAgentHistory(params: {
+    start: Date;
+    end: Date;
+    project?: string;
+    limit: number;
+    offset: number;
+    includeEvents: boolean;
+    includeFeedback: boolean;
+    includeReviews: boolean;
+    includeChildren: boolean;
+  }): Promise<AgentHistoryResult> {
+    const conditions: string[] = [
+      "deleted_at IS NULL",
+      "created_at >= $1",
+      "created_at <= $2",
+    ];
+    const queryParams: unknown[] = [params.start, params.end];
+
+    if (!params.includeChildren) {
+      conditions.push("parent_agent_id IS NULL");
+    }
+    if (params.project) {
+      queryParams.push(params.project);
+      conditions.push(`COALESCE(git_context->>'repoRoot', cwd) = $${queryParams.length}`);
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`;
+
+    // Count + paginated list in parallel
+    const [countResult, listResult] = await Promise.all([
+      this.pool.query<{ count: string }>(
+        `SELECT COUNT(*)::int AS count FROM agents ${whereClause}`,
+        queryParams
+      ),
+      this.pool.query<{
+        id: string; name: string; type: string; status: string;
+        projectDir: string; createdAt: string;
+        latestEventType: string | null; latestEventMessage: string | null;
+        pins: AgentPin[]; gitContext: AgentGitContext | null;
+        worktreeBranch: string | null;
+        persona: string | null; parentAgentId: string | null;
+      }>(
+        `SELECT id, name, type, status,
+          COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
+          created_at AS "createdAt",
+          latest_event_type AS "latestEventType",
+          latest_event_message AS "latestEventMessage",
+          pins,
+          git_context AS "gitContext",
+          worktree_branch AS "worktreeBranch",
+          persona,
+          parent_agent_id AS "parentAgentId"
+        FROM agents ${whereClause}
+        ORDER BY created_at DESC
+        LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`,
+        [...queryParams, params.limit, params.offset]
+      ),
+    ]);
+
+    const total = Number(countResult.rows[0]?.count ?? 0);
+    const agentIds = listResult.rows.map((a) => a.id);
+    // Parent agent IDs for feedback/review lookups (when children are shown standalone,
+    // feedback still groups under parent)
+    const parentAgentIds = listResult.rows
+      .filter((a) => !a.parentAgentId)
+      .map((a) => a.id);
+
+    // Fetch related data in parallel
+    const [eventsRows, feedbackRows, reviewsRows] = await Promise.all([
+      params.includeEvents && agentIds.length > 0
+        ? this.pool.query<{
+            agentId: string; type: string; message: string; createdAt: string;
+          }>(
+            `SELECT agent_id AS "agentId", event_type AS type, message,
+                    created_at AS "createdAt"
+             FROM (
+               SELECT *, ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at ASC) AS rn
+               FROM agent_events
+               WHERE agent_id = ANY($1)
+             ) ranked
+             WHERE rn <= 200
+             ORDER BY agent_id, created_at ASC`,
+            [agentIds]
+          ).then((r) => r.rows)
+        : [],
+      params.includeFeedback && parentAgentIds.length > 0
+        ? this.pool.query<{
+            parentAgentId: string; id: number; persona: string; severity: string;
+            description: string; filePath: string | null; suggestion: string | null;
+            status: string;
+          }>(
+            `SELECT a.parent_agent_id AS "parentAgentId",
+                    f.id, a.persona, f.severity, f.description,
+                    f.file_path AS "filePath", f.suggestion, f.status
+             FROM agent_feedback f
+             JOIN agents a ON a.id = f.agent_id
+             WHERE a.parent_agent_id = ANY($1)
+             ORDER BY f.created_at ASC`,
+            [parentAgentIds]
+          ).then((r) => r.rows)
+        : [],
+      params.includeReviews && parentAgentIds.length > 0
+        ? this.pool.query<{
+            parentAgentId: string; persona: string; status: string;
+            verdict: string | null; summary: string | null;
+            filesReviewed: string[] | null;
+          }>(
+            `SELECT parent_agent_id AS "parentAgentId", persona, status,
+                    verdict, summary, files_reviewed AS "filesReviewed"
+             FROM persona_reviews
+             WHERE parent_agent_id = ANY($1)
+             ORDER BY created_at ASC`,
+            [parentAgentIds]
+          ).then((r) => r.rows)
+        : [],
+    ]);
+
+    // Group related data by agent ID
+    const eventsByAgent = new Map<string, Array<{ type: string; message: string; createdAt: string }>>();
+    for (const row of eventsRows) {
+      const list = eventsByAgent.get(row.agentId) ?? [];
+      list.push({ type: row.type, message: row.message, createdAt: row.createdAt });
+      eventsByAgent.set(row.agentId, list);
+    }
+
+    const feedbackByParent = new Map<string, Array<{
+      id: number; persona: string; severity: string; description: string;
+      filePath: string | null; suggestion: string | null; status: string;
+    }>>();
+    for (const row of feedbackRows) {
+      const list = feedbackByParent.get(row.parentAgentId) ?? [];
+      list.push({
+        id: row.id, persona: row.persona, severity: row.severity,
+        description: row.description, filePath: row.filePath,
+        suggestion: row.suggestion, status: row.status,
+      });
+      feedbackByParent.set(row.parentAgentId, list);
+    }
+
+    const reviewsByParent = new Map<string, Array<{
+      persona: string; status: string; verdict: string | null;
+      summary: string | null; filesReviewed: string[] | null;
+    }>>();
+    for (const row of reviewsRows) {
+      const list = reviewsByParent.get(row.parentAgentId) ?? [];
+      list.push({
+        persona: row.persona, status: row.status,
+        verdict: row.verdict, summary: row.summary,
+        filesReviewed: row.filesReviewed,
+      });
+      reviewsByParent.set(row.parentAgentId, list);
+    }
+
+    const agents: AgentHistoryEntry[] = listResult.rows.map((a) => ({
+      id: a.id,
+      name: a.name,
+      type: a.type,
+      project: a.projectDir,
+      status: a.status,
+      createdAt: a.createdAt,
+      latestEventType: a.latestEventType,
+      latestEventMessage: a.latestEventMessage,
+      pins: (a.pins ?? []).map((p) => ({ label: p.label, value: p.value, type: p.type })),
+      git: a.gitContext
+        ? { branch: a.gitContext.branch ?? null, worktreeBranch: a.worktreeBranch }
+        : null,
+      ...(params.includeEvents ? { events: eventsByAgent.get(a.id) ?? [] } : {}),
+      ...(params.includeFeedback ? { feedback: feedbackByParent.get(a.id) ?? [] } : {}),
+      ...(params.includeReviews ? { reviews: reviewsByParent.get(a.id) ?? [] } : {}),
+    }));
+
+    return { agents, total, hasMore: params.offset + params.limit < total };
+  }
+
+  async getFeedbackSummary(params: {
+    start: Date;
+    end: Date;
+    project?: string;
+    groupBy: "persona" | "severity" | "directory";
+  }): Promise<FeedbackSummaryResult> {
+    const rangeStart = params.start;
+    const rangeEnd = params.end;
+
+    const feedbackConditions = ["f.created_at >= $1", "f.created_at <= $2"];
+    const feedbackParams: unknown[] = [rangeStart, rangeEnd];
+    if (params.project) {
+      feedbackParams.push(params.project);
+      feedbackConditions.push(
+        `COALESCE(pa.git_context->>'repoRoot', pa.cwd, a.cwd) = $${feedbackParams.length}`
+      );
+    }
+
+    const verdictConditions = ["pr.created_at >= $1", "pr.created_at <= $2"];
+    const verdictParams: unknown[] = [rangeStart, rangeEnd];
+    if (params.project) {
+      verdictParams.push(params.project);
+      verdictConditions.push(
+        `COALESCE(pa.git_context->>'repoRoot', pa.cwd) = $${verdictParams.length}`
+      );
+    }
+
+    // Fetch feedback rows and verdict aggregates in parallel
+    const [feedbackResult, verdictResult] = await Promise.all([
+      this.pool.query<{
+        persona: string; severity: string; description: string;
+        filePath: string | null; status: string; projectRoot: string;
+      }>(
+        `SELECT a.persona, f.severity, f.description,
+                f.file_path AS "filePath", f.status,
+                COALESCE(pa.git_context->>'repoRoot', pa.cwd, a.cwd) AS "projectRoot"
+         FROM agent_feedback f
+         JOIN agents a ON a.id = f.agent_id
+         LEFT JOIN agents pa ON pa.id = a.parent_agent_id
+         WHERE ${feedbackConditions.join(" AND ")}
+         ORDER BY f.created_at ASC`,
+        feedbackParams
+      ),
+
+      this.pool.query<{ total: string; approved: string; changesRequested: string }>(
+        `SELECT
+          COUNT(*)::int AS total,
+          COUNT(*) FILTER (WHERE pr.verdict = 'approve')::int AS approved,
+          COUNT(*) FILTER (WHERE pr.verdict = 'request_changes')::int AS "changesRequested"
+         FROM persona_reviews pr
+         JOIN agents pa ON pa.id = pr.parent_agent_id
+         WHERE ${verdictConditions.join(" AND ")}`,
+        verdictParams
+      ),
+    ]);
+
+    const rows = feedbackResult.rows;
+
+    // Aggregate severity and status totals
+    const bySeverity = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+    const byStatus = { open: 0, fixed: 0, ignored: 0, dismissed: 0 };
+    for (const row of rows) {
+      if (row.severity in bySeverity) bySeverity[row.severity as keyof typeof bySeverity]++;
+      if (row.status in byStatus) byStatus[row.status as keyof typeof byStatus]++;
+    }
+
+    // Group by requested dimension
+    const groupMap = new Map<string, typeof rows>();
+    for (const row of rows) {
+      let key: string;
+      switch (params.groupBy) {
+        case "persona":
+          key = row.persona ?? "unknown";
+          break;
+        case "severity":
+          key = row.severity;
+          break;
+        case "directory": {
+          if (!row.filePath) {
+            key = "(no file)";
+            break;
+          }
+          const root = row.projectRoot;
+          const relative = root && row.filePath.startsWith(root)
+            ? row.filePath.slice(root.length + 1)
+            : row.filePath;
+          // Extract directory (drop the filename)
+          const lastSlash = relative.lastIndexOf("/");
+          key = lastSlash > 0 ? relative.slice(0, lastSlash) : ".";
+          break;
+        }
+      }
+      const list = groupMap.get(key) ?? [];
+      list.push(row);
+      groupMap.set(key, list);
+    }
+
+    // Build groups with top findings (exact match deduplication)
+    const groups = [...groupMap.entries()]
+      .map(([key, items]) => {
+        const groupSev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+        const descCounts = new Map<string, { count: number; severity: string; filePath: string | null }>();
+
+        for (const item of items) {
+          if (item.severity in groupSev) groupSev[item.severity as keyof typeof groupSev]++;
+          const existing = descCounts.get(item.description);
+          if (existing) {
+            existing.count++;
+          } else {
+            descCounts.set(item.description, {
+              count: 1,
+              severity: item.severity,
+              filePath: item.filePath,
+            });
+          }
+        }
+
+        const topFindings = [...descCounts.entries()]
+          .sort((a, b) => b[1].count - a[1].count)
+          .slice(0, 5)
+          .map(([description, data]) => ({
+            description,
+            count: data.count,
+            severity: data.severity,
+            exampleFilePath: data.filePath,
+          }));
+
+        return { key, count: items.length, bySeverity: groupSev, topFindings };
+      })
+      .sort((a, b) => b.count - a.count);
+
+    const verdict = verdictResult.rows[0];
+
+    return {
+      period: { start: rangeStart.toISOString(), end: rangeEnd.toISOString() },
+      totalFindings: rows.length,
+      bySeverity,
+      byStatus,
+      groups,
+      reviewVerdicts: {
+        total: Number(verdict?.total ?? 0),
+        approved: Number(verdict?.approved ?? 0),
+        changesRequested: Number(verdict?.changesRequested ?? 0),
+      },
+    };
   }
 
   // --- Media ---

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1277,6 +1277,9 @@ async function registerRoutes() {
         },
         listRecentPersonaReviews: (sinceDays: number) => agentManager.listRecentPersonaReviews(sinceDays),
         listRecentFeedback: (sinceDays: number) => agentManager.listRecentFeedback(sinceDays),
+        getActivitySummary: (params) => agentManager.getActivitySummary(params),
+        getAgentHistory: (params) => agentManager.getAgentHistory(params),
+        getFeedbackSummary: (params) => agentManager.getFeedbackSummary(params),
       },
     });
   });
@@ -1323,6 +1326,9 @@ async function registerRoutes() {
       getParentContext: mcpGetParentContext,
       updateReviewStatus: mcpUpdateReviewStatus,
       completeReview: mcpCompleteReview,
+      getActivitySummary: (params) => agentManager.getActivitySummary(params) as Promise<Record<string, unknown>>,
+      getAgentHistory: (params) => agentManager.getAgentHistory(params) as Promise<Record<string, unknown>>,
+      getFeedbackSummary: (params) => agentManager.getFeedbackSummary(params) as Promise<Record<string, unknown>>,
     });
   });
 

--- a/apps/server/test/db/summary-tools.test.ts
+++ b/apps/server/test/db/summary-tools.test.ts
@@ -1,0 +1,759 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import type { Pool } from "pg";
+
+import { setupTestDb, teardownTestDb, runTestMigrations } from "./setup.js";
+
+// Mock runCommand so AgentManager never touches tmux
+vi.mock("@dispatch/shared/lib/run-command.js", () => ({
+  runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+}));
+
+const { AgentManager } = await import("../../src/agents/manager.js");
+
+let pool: Pool;
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+  child: () => noopLogger,
+  silent: () => {},
+  level: "silent",
+} as unknown as import("fastify").FastifyBaseLogger;
+
+const testConfig = {
+  host: "127.0.0.1",
+  port: 6767,
+  databaseUrl: "",
+  authToken: "test-token",
+  mediaRoot: "/tmp/dispatch-test-media",
+  dispatchBinDir: "/tmp",
+  codexBin: "echo",
+  claudeBin: "echo",
+  opencodeBin: "echo",
+  agentRuntime: "inert",
+  sessionPrefix: "dispatch",
+  tls: null,
+} satisfies import("../../src/config.js").AppConfig;
+
+let manager: InstanceType<typeof AgentManager>;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+  await runTestMigrations();
+  manager = new AgentManager(pool, noopLogger, testConfig);
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await pool.query("DELETE FROM agent_token_usage");
+  await pool.query("DELETE FROM agent_feedback");
+  await pool.query("DELETE FROM persona_reviews");
+  await pool.query("DELETE FROM agent_events");
+  await pool.query("DELETE FROM media_seen");
+  await pool.query("DELETE FROM media");
+  await pool.query("DELETE FROM agents");
+});
+
+// Helpers to insert test data directly
+async function insertAgent(
+  id: string,
+  opts: {
+    name?: string;
+    type?: string;
+    status?: string;
+    cwd?: string;
+    persona?: string | null;
+    parentAgentId?: string | null;
+    latestEventType?: string | null;
+    createdAt?: Date;
+    gitContext?: object | null;
+  } = {}
+): Promise<void> {
+  const now = opts.createdAt ?? new Date();
+  await pool.query(
+    `INSERT INTO agents (id, name, type, status, cwd, persona, parent_agent_id,
+      latest_event_type, latest_event_message, created_at, updated_at, git_context, pins)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10, $11, '[]'::jsonb)`,
+    [
+      id,
+      opts.name ?? id,
+      opts.type ?? "claude",
+      opts.status ?? "stopped",
+      opts.cwd ?? "/projects/test",
+      opts.persona ?? null,
+      opts.parentAgentId ?? null,
+      opts.latestEventType ?? "done",
+      opts.latestEventType ? `Agent ${opts.latestEventType}` : null,
+      now,
+      opts.gitContext ? JSON.stringify(opts.gitContext) : null,
+    ]
+  );
+}
+
+async function insertEvent(
+  agentId: string,
+  eventType: string,
+  createdAt: Date,
+  opts: { projectDir?: string } = {}
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO agent_events (agent_id, event_type, message, created_at, project_dir)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [agentId, eventType, `Agent ${eventType}`, createdAt, opts.projectDir ?? "/projects/test"]
+  );
+}
+
+async function insertFeedback(
+  agentId: string,
+  opts: {
+    severity?: string;
+    filePath?: string | null;
+    description?: string;
+    status?: string;
+    createdAt?: Date;
+  } = {}
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO agent_feedback (agent_id, severity, file_path, description, status, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [
+      agentId,
+      opts.severity ?? "medium",
+      opts.filePath ?? null,
+      opts.description ?? "Test finding",
+      opts.status ?? "open",
+      opts.createdAt ?? new Date(),
+    ]
+  );
+}
+
+async function insertReview(
+  agentId: string,
+  parentAgentId: string,
+  persona: string,
+  opts: {
+    verdict?: string | null;
+    summary?: string | null;
+    status?: string;
+    createdAt?: Date;
+  } = {}
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, status, verdict, summary, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
+    [
+      agentId,
+      parentAgentId,
+      persona,
+      opts.status ?? "complete",
+      opts.verdict ?? "approve",
+      opts.summary ?? "Looks good",
+      opts.createdAt ?? new Date(),
+    ]
+  );
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 86_400_000);
+}
+
+function hoursAgo(hours: number): Date {
+  return new Date(Date.now() - hours * 3_600_000);
+}
+
+// ── getActivitySummary ──────────────────────────────────────────────
+
+describe("getActivitySummary", () => {
+  it("returns empty results when no data exists", async () => {
+    const result = await manager.getActivitySummary({
+      start: daysAgo(7),
+      end: new Date(),
+    });
+
+    expect(result.projects).toHaveLength(0);
+    expect(result.totals.totalWorkingMs).toBe(0);
+    expect(result.totals.agentCount).toBe(0);
+    expect(result.totals.sessionCount).toBe(0);
+    expect(result.topAgents).toHaveLength(0);
+  });
+
+  it("computes working time from event pairs", async () => {
+    await insertAgent("a1", { cwd: "/projects/test" });
+
+    // working for 1 hour, then done
+    const start = hoursAgo(3);
+    const afterOneHour = new Date(start.getTime() + 3_600_000);
+    await insertEvent("a1", "working", start);
+    await insertEvent("a1", "done", afterOneHour);
+
+    const result = await manager.getActivitySummary({
+      start: daysAgo(1),
+      end: new Date(),
+    });
+
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].directory).toBe("/projects/test");
+    // Working time should be ~1 hour (3600000ms)
+    expect(result.projects[0].totalWorkingMs).toBeGreaterThanOrEqual(3_500_000);
+    expect(result.projects[0].totalWorkingMs).toBeLessThanOrEqual(3_700_000);
+    expect(result.projects[0].agentCount).toBe(1);
+  });
+
+  it("groups by project and counts sessions/outcomes", async () => {
+    const gitA = { repoRoot: "/projects/alpha" };
+    const gitB = { repoRoot: "/projects/beta" };
+
+    const created = hoursAgo(2);
+    await insertAgent("a1", { gitContext: gitA, latestEventType: "done", createdAt: created });
+    await insertAgent("a2", { gitContext: gitA, latestEventType: "done", createdAt: created });
+    await insertAgent("a3", { gitContext: gitB, latestEventType: "blocked", createdAt: created });
+    // error agent with no latest event — insert directly to avoid default
+    await pool.query(
+      `INSERT INTO agents (id, name, type, status, cwd, created_at, updated_at, git_context, pins)
+       VALUES ('a4', 'a4', 'claude', 'error', '/projects/test', $1, $1, $2, '[]'::jsonb)`,
+      [created, JSON.stringify(gitA)]
+    );
+
+    const result = await manager.getActivitySummary({
+      start: daysAgo(7),
+      end: new Date(),
+    });
+
+    expect(result.projects.length).toBeGreaterThanOrEqual(2);
+
+    const alpha = result.projects.find((p) => p.directory === "/projects/alpha");
+    const beta = result.projects.find((p) => p.directory === "/projects/beta");
+
+    expect(alpha).toBeDefined();
+    expect(alpha!.sessionCount).toBe(3);
+    expect(alpha!.outcomes.done).toBe(2);
+    expect(alpha!.outcomes.error).toBe(1);
+
+    expect(beta).toBeDefined();
+    expect(beta!.sessionCount).toBe(1);
+    expect(beta!.outcomes.blocked).toBe(1);
+  });
+
+  it("filters by project", async () => {
+    const gitA = { repoRoot: "/projects/alpha" };
+    const gitB = { repoRoot: "/projects/beta" };
+
+    await insertAgent("a1", { gitContext: gitA, latestEventType: "done" });
+    await insertAgent("a2", { gitContext: gitB, latestEventType: "done" });
+
+    const result = await manager.getActivitySummary({
+      start: daysAgo(7),
+      end: new Date(),
+      project: "/projects/alpha",
+    });
+
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].directory).toBe("/projects/alpha");
+    expect(result.totals.sessionCount).toBe(1);
+  });
+
+  it("excludes deleted agents from session counts", async () => {
+    await insertAgent("a1", { latestEventType: "done" });
+    await insertAgent("a2", { latestEventType: "done" });
+    await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
+
+    const result = await manager.getActivitySummary({
+      start: daysAgo(7),
+      end: new Date(),
+    });
+
+    expect(result.totals.sessionCount).toBe(1);
+  });
+
+  it("returns top agents sorted by working time", async () => {
+    await insertAgent("a1", { name: "Short worker" });
+    await insertAgent("a2", { name: "Long worker" });
+
+    // a1 works 1 hour
+    await insertEvent("a1", "working", hoursAgo(5));
+    await insertEvent("a1", "done", hoursAgo(4));
+
+    // a2 works 3 hours
+    await insertEvent("a2", "working", hoursAgo(6));
+    await insertEvent("a2", "done", hoursAgo(3));
+
+    const result = await manager.getActivitySummary({
+      start: daysAgo(1),
+      end: new Date(),
+    });
+
+    expect(result.topAgents.length).toBeGreaterThanOrEqual(2);
+    expect(result.topAgents[0].name).toBe("Long worker");
+    expect(result.topAgents[1].name).toBe("Short worker");
+    expect(result.topAgents[0].totalWorkingMs).toBeGreaterThan(
+      result.topAgents[1].totalWorkingMs
+    );
+  });
+
+  it("handles boundary events for working time across range start", async () => {
+    await insertAgent("a1");
+
+    // Agent started working before the range, finishes inside the range
+    await insertEvent("a1", "working", hoursAgo(10));
+    await insertEvent("a1", "done", hoursAgo(8));
+
+    // Query a 9-hour window — the working event is before range start
+    const result = await manager.getActivitySummary({
+      start: hoursAgo(9),
+      end: new Date(),
+    });
+
+    // Should count ~1 hour of working time (from range start to done event)
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].totalWorkingMs).toBeGreaterThanOrEqual(3_400_000);
+    expect(result.projects[0].totalWorkingMs).toBeLessThanOrEqual(3_700_000);
+  });
+});
+
+// ── getAgentHistory ─────────────────────────────────────────────────
+
+describe("getAgentHistory", () => {
+  it("returns empty results when no agents exist", async () => {
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("returns parent agents only by default", async () => {
+    await insertAgent("parent", { name: "Parent Agent" });
+    await insertAgent("child", {
+      name: "Security Review",
+      persona: "security-review",
+      parentAgentId: "parent",
+    });
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].name).toBe("Parent Agent");
+  });
+
+  it("includes children when requested", async () => {
+    await insertAgent("parent", { name: "Parent Agent" });
+    await insertAgent("child", {
+      name: "Security Review",
+      persona: "security-review",
+      parentAgentId: "parent",
+    });
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: true,
+    });
+
+    expect(result.agents).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it("paginates correctly", async () => {
+    await insertAgent("a1", { createdAt: hoursAgo(3) });
+    await insertAgent("a2", { createdAt: hoursAgo(2) });
+    await insertAgent("a3", { createdAt: hoursAgo(1) });
+
+    const page1 = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 2,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(page1.agents).toHaveLength(2);
+    expect(page1.total).toBe(3);
+    expect(page1.hasMore).toBe(true);
+
+    const page2 = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 2,
+      offset: 2,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(page2.agents).toHaveLength(1);
+    expect(page2.hasMore).toBe(false);
+  });
+
+  it("includes events when requested", async () => {
+    await insertAgent("a1");
+    await insertEvent("a1", "working", hoursAgo(2));
+    await insertEvent("a1", "done", hoursAgo(1));
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: true,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents[0].events).toBeDefined();
+    expect(result.agents[0].events).toHaveLength(2);
+    expect(result.agents[0].events![0].type).toBe("working");
+    expect(result.agents[0].events![1].type).toBe("done");
+  });
+
+  it("includes feedback grouped by parent agent", async () => {
+    await insertAgent("parent");
+    await insertAgent("reviewer", {
+      persona: "security-review",
+      parentAgentId: "parent",
+    });
+    await insertFeedback("reviewer", {
+      severity: "high",
+      description: "SQL injection risk",
+      filePath: "/src/db.ts",
+    });
+    await insertFeedback("reviewer", {
+      severity: "low",
+      description: "Missing type annotation",
+    });
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: true,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].feedback).toBeDefined();
+    expect(result.agents[0].feedback).toHaveLength(2);
+    expect(result.agents[0].feedback![0].severity).toBe("high");
+    expect(result.agents[0].feedback![0].persona).toBe("security-review");
+  });
+
+  it("includes reviews grouped by parent agent", async () => {
+    await insertAgent("parent");
+    await insertAgent("reviewer", {
+      persona: "security-review",
+      parentAgentId: "parent",
+    });
+    await insertReview("reviewer", "parent", "security-review", {
+      verdict: "approve",
+      summary: "All clear",
+    });
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: true,
+      includeChildren: false,
+    });
+
+    expect(result.agents[0].reviews).toBeDefined();
+    expect(result.agents[0].reviews).toHaveLength(1);
+    expect(result.agents[0].reviews![0].verdict).toBe("approve");
+    expect(result.agents[0].reviews![0].persona).toBe("security-review");
+  });
+
+  it("filters by project", async () => {
+    const gitA = { repoRoot: "/projects/alpha" };
+    const gitB = { repoRoot: "/projects/beta" };
+
+    await insertAgent("a1", { gitContext: gitA });
+    await insertAgent("a2", { gitContext: gitB });
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      project: "/projects/alpha",
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].project).toBe("/projects/alpha");
+    expect(result.total).toBe(1);
+  });
+
+  it("excludes deleted agents", async () => {
+    await insertAgent("a1");
+    await insertAgent("a2");
+    await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
+
+    const result = await manager.getAgentHistory({
+      start: daysAgo(7),
+      end: new Date(),
+      limit: 20,
+      offset: 0,
+      includeEvents: false,
+      includeFeedback: false,
+      includeReviews: false,
+      includeChildren: false,
+    });
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].id).toBe("a1");
+  });
+});
+
+// ── getFeedbackSummary ──────────────────────────────────────────────
+
+describe("getFeedbackSummary", () => {
+  it("returns empty results when no feedback exists", async () => {
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(14),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.totalFindings).toBe(0);
+    expect(result.groups).toHaveLength(0);
+    expect(result.reviewVerdicts.total).toBe(0);
+  });
+
+  it("aggregates severity and status counts", async () => {
+    await insertAgent("parent");
+    await insertAgent("reviewer", { persona: "sec", parentAgentId: "parent" });
+
+    await insertFeedback("reviewer", { severity: "critical", status: "fixed" });
+    await insertFeedback("reviewer", { severity: "high", status: "open" });
+    await insertFeedback("reviewer", { severity: "medium", status: "open" });
+    await insertFeedback("reviewer", { severity: "low", status: "ignored" });
+    await insertFeedback("reviewer", { severity: "info", status: "open" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.totalFindings).toBe(5);
+    expect(result.bySeverity).toEqual({
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      info: 1,
+    });
+    expect(result.byStatus.open).toBe(3);
+    expect(result.byStatus.fixed).toBe(1);
+    expect(result.byStatus.ignored).toBe(1);
+  });
+
+  it("groups by persona", async () => {
+    await insertAgent("parent");
+    await insertAgent("sec-rev", { persona: "security-review", parentAgentId: "parent" });
+    await insertAgent("ux-rev", { persona: "ux-review", parentAgentId: "parent" });
+
+    await insertFeedback("sec-rev", { description: "SQL injection" });
+    await insertFeedback("sec-rev", { description: "XSS risk" });
+    await insertFeedback("ux-rev", { description: "Poor contrast" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.groups).toHaveLength(2);
+    const secGroup = result.groups.find((g) => g.key === "security-review");
+    const uxGroup = result.groups.find((g) => g.key === "ux-review");
+    expect(secGroup).toBeDefined();
+    expect(secGroup!.count).toBe(2);
+    expect(uxGroup).toBeDefined();
+    expect(uxGroup!.count).toBe(1);
+  });
+
+  it("groups by severity", async () => {
+    await insertAgent("parent");
+    await insertAgent("rev", { persona: "sec", parentAgentId: "parent" });
+
+    await insertFeedback("rev", { severity: "high" });
+    await insertFeedback("rev", { severity: "high" });
+    await insertFeedback("rev", { severity: "low" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "severity",
+    });
+
+    expect(result.groups).toHaveLength(2);
+    const highGroup = result.groups.find((g) => g.key === "high");
+    expect(highGroup!.count).toBe(2);
+  });
+
+  it("groups by directory relative to project root", async () => {
+    await insertAgent("parent", {
+      cwd: "/projects/test",
+      gitContext: { repoRoot: "/projects/test" },
+    });
+    await insertAgent("rev", {
+      persona: "sec",
+      parentAgentId: "parent",
+      cwd: "/projects/test",
+    });
+
+    await insertFeedback("rev", { filePath: "/projects/test/src/auth/login.ts" });
+    await insertFeedback("rev", { filePath: "/projects/test/src/auth/token.ts" });
+    await insertFeedback("rev", { filePath: "/projects/test/src/db/query.ts" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "directory",
+    });
+
+    expect(result.groups.length).toBeGreaterThanOrEqual(2);
+    const authGroup = result.groups.find((g) => g.key === "src/auth");
+    const dbGroup = result.groups.find((g) => g.key === "src/db");
+    expect(authGroup).toBeDefined();
+    expect(authGroup!.count).toBe(2);
+    expect(dbGroup).toBeDefined();
+    expect(dbGroup!.count).toBe(1);
+  });
+
+  it("deduplicates top findings by description", async () => {
+    await insertAgent("parent");
+    await insertAgent("rev", { persona: "sec", parentAgentId: "parent" });
+
+    // Same description repeated 3 times
+    await insertFeedback("rev", { description: "Unused import", severity: "low" });
+    await insertFeedback("rev", { description: "Unused import", severity: "low" });
+    await insertFeedback("rev", { description: "Unused import", severity: "low" });
+    await insertFeedback("rev", { description: "Missing error handling", severity: "high" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.groups).toHaveLength(1);
+    const group = result.groups[0];
+    expect(group.topFindings).toHaveLength(2);
+    expect(group.topFindings[0].description).toBe("Unused import");
+    expect(group.topFindings[0].count).toBe(3);
+    expect(group.topFindings[1].description).toBe("Missing error handling");
+    expect(group.topFindings[1].count).toBe(1);
+  });
+
+  it("aggregates review verdicts", async () => {
+    await insertAgent("p1");
+    await insertAgent("p2");
+    await insertAgent("r1", { persona: "sec", parentAgentId: "p1" });
+    await insertAgent("r2", { persona: "sec", parentAgentId: "p2" });
+    await insertAgent("r3", { persona: "ux", parentAgentId: "p1" });
+
+    await insertReview("r1", "p1", "sec", { verdict: "approve" });
+    await insertReview("r2", "p2", "sec", { verdict: "request_changes" });
+    await insertReview("r3", "p1", "ux", { verdict: "approve" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.reviewVerdicts.total).toBe(3);
+    expect(result.reviewVerdicts.approved).toBe(2);
+    expect(result.reviewVerdicts.changesRequested).toBe(1);
+  });
+
+  it("filters by project", async () => {
+    const gitA = { repoRoot: "/projects/alpha" };
+    const gitB = { repoRoot: "/projects/beta" };
+
+    await insertAgent("p1", { gitContext: gitA });
+    await insertAgent("p2", { gitContext: gitB });
+    await insertAgent("r1", { persona: "sec", parentAgentId: "p1", cwd: "/projects/alpha" });
+    await insertAgent("r2", { persona: "sec", parentAgentId: "p2", cwd: "/projects/beta" });
+
+    await insertFeedback("r1", { description: "Alpha finding" });
+    await insertFeedback("r2", { description: "Beta finding" });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      project: "/projects/alpha",
+      groupBy: "persona",
+    });
+
+    expect(result.totalFindings).toBe(1);
+    expect(result.groups[0].topFindings[0].description).toBe("Alpha finding");
+  });
+
+  it("respects date range boundaries", async () => {
+    await insertAgent("parent");
+    await insertAgent("rev", { persona: "sec", parentAgentId: "parent" });
+
+    await insertFeedback("rev", {
+      description: "Recent",
+      createdAt: hoursAgo(1),
+    });
+    await insertFeedback("rev", {
+      description: "Old",
+      createdAt: daysAgo(30),
+    });
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.totalFindings).toBe(1);
+    expect(result.groups[0].topFindings[0].description).toBe("Recent");
+  });
+});

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -82,6 +82,16 @@ export type JobTools = {
     description: string; suggestion: string | null;
     mediaRef: string | null; status: string; createdAt: string;
   }>>;
+  getActivitySummary: (params: { start: Date; end: Date; project?: string }) => Promise<Record<string, unknown>>;
+  getAgentHistory: (params: {
+    start: Date; end: Date; project?: string; limit: number; offset: number;
+    includeEvents: boolean; includeFeedback: boolean;
+    includeReviews: boolean; includeChildren: boolean;
+  }) => Promise<Record<string, unknown>>;
+  getFeedbackSummary: (params: {
+    start: Date; end: Date; project?: string;
+    groupBy: "persona" | "severity" | "directory";
+  }) => Promise<Record<string, unknown>>;
 };
 
 // ── Tool sets per agent type ──────────────────────────────────────────
@@ -97,6 +107,9 @@ const AGENT_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
+  "get_activity_summary",
+  "get_agent_history",
+  "get_feedback_summary",
 ]);
 
 const JOB_TOOLS = new Set([
@@ -109,6 +122,9 @@ const JOB_TOOLS = new Set([
   "list_agents",
   "list_recent_persona_reviews",
   "list_recent_feedback",
+  "get_activity_summary",
+  "get_agent_history",
+  "get_feedback_summary",
 ]);
 
 const PERSONA_TOOLS = new Set([
@@ -194,6 +210,19 @@ export type McpRequestContext = {
     agentId: string,
     input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
   ) => Promise<void>;
+  getActivitySummary?: (
+    params: { start: Date; end: Date; project?: string }
+  ) => Promise<Record<string, unknown>>;
+  getAgentHistory?: (
+    params: {
+      start: Date; end: Date; project?: string; limit: number; offset: number;
+      includeEvents: boolean; includeFeedback: boolean;
+      includeReviews: boolean; includeChildren: boolean;
+    }
+  ) => Promise<Record<string, unknown>>;
+  getFeedbackSummary?: (
+    params: { start: Date; end: Date; project?: string; groupBy: "persona" | "severity" | "directory" }
+  ) => Promise<Record<string, unknown>>;
   jobTools?: JobTools;
   toolScope?: "agent" | "reviewer" | "job";
 };
@@ -536,6 +565,141 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           const result = await resolveFeedback(agentId, args.feedbackId, args.status);
           return {
             content: [{ type: "text", text: `Feedback #${result.id} marked as ${result.status}.` }]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── Summary / analytics tools (available to both agents and jobs) ──
+
+  // Resolve the callback: prefer context-level, fall back to jobTools
+  const getActivitySummary = context.getActivitySummary ?? context.jobTools?.getActivitySummary;
+  const getAgentHistory = context.getAgentHistory ?? context.jobTools?.getAgentHistory;
+  const getFeedbackSummary = context.getFeedbackSummary ?? context.jobTools?.getFeedbackSummary;
+
+  if (allowed.has("get_activity_summary") && getActivitySummary) {
+    const fn = getActivitySummary;
+    server.registerTool(
+      "get_activity_summary",
+      {
+        description:
+          "Get a high-level summary of agent activity in Dispatch over a time range — working time, session counts, outcomes, and top agents by project. Use this for activity digests and dashboards.",
+        inputSchema: {
+          start: z.string().datetime({ offset: true }).optional()
+            .describe("Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."),
+          end: z.string().datetime({ offset: true }).optional()
+            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
+          project: z.string().optional()
+            .describe("Filter to a specific project directory (exact match). If omitted, returns all projects."),
+        },
+      },
+      async (args) => {
+        try {
+          const end = args.end ? new Date(args.end) : new Date();
+          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 7 * 86_400_000);
+          if (start >= end) return toToolError(new Error("start must be before end"));
+          const result = await fn({ start, end, project: args.project });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (allowed.has("get_agent_history") && getAgentHistory) {
+    const fn = getAgentHistory;
+    server.registerTool(
+      "get_agent_history",
+      {
+        description:
+          "Get detailed agent session history — what agents worked on, their event timelines, feedback received, and persona review results. Use for deeper investigation after get_activity_summary or for building narrative summaries.",
+        inputSchema: {
+          start: z.string().datetime({ offset: true }).optional()
+            .describe("Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."),
+          end: z.string().datetime({ offset: true }).optional()
+            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
+          project: z.string().optional()
+            .describe("Filter to a specific project directory (exact match)."),
+          limit: z.number().int().min(1).max(50).default(20)
+            .describe("Max number of agent sessions to return (default 20, max 50)."),
+          offset: z.number().int().min(0).default(0)
+            .describe("Pagination offset."),
+          include_events: z.boolean().default(false)
+            .describe("Include the event timeline for each agent session (capped at 200 per agent). Can be verbose."),
+          include_feedback: z.boolean().default(true)
+            .describe("Include feedback findings for each agent session."),
+          include_reviews: z.boolean().default(true)
+            .describe("Include persona review summaries for each agent session."),
+          include_children: z.boolean().default(false)
+            .describe("Include child/persona agents as standalone entries (default: nested under parent)."),
+        },
+      },
+      async (args) => {
+        try {
+          const end = args.end ? new Date(args.end) : new Date();
+          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 7 * 86_400_000);
+          if (start >= end) return toToolError(new Error("start must be before end"));
+          const result = await fn({
+            start,
+            end,
+            project: args.project,
+            limit: args.limit,
+            offset: args.offset,
+            includeEvents: args.include_events,
+            includeFeedback: args.include_feedback,
+            includeReviews: args.include_reviews,
+            includeChildren: args.include_children,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (allowed.has("get_feedback_summary") && getFeedbackSummary) {
+    const fn = getFeedbackSummary;
+    server.registerTool(
+      "get_feedback_summary",
+      {
+        description:
+          "Aggregate persona review feedback to surface patterns — recurring issue types, hot spots in the codebase, and severity trends. Use for feedback pattern tracking and coaching check-ins.",
+        inputSchema: {
+          start: z.string().datetime({ offset: true }).optional()
+            .describe("Start of time range (ISO 8601 with timezone). Defaults to 14 days ago."),
+          end: z.string().datetime({ offset: true }).optional()
+            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
+          project: z.string().optional()
+            .describe("Filter to a specific project directory (exact match)."),
+          group_by: z.enum(["persona", "severity", "directory"]).default("persona")
+            .describe("Primary grouping for the summary."),
+        },
+      },
+      async (args) => {
+        try {
+          const end = args.end ? new Date(args.end) : new Date();
+          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 14 * 86_400_000);
+          if (start >= end) return toToolError(new Error("start must be before end"));
+          const result = await fn({
+            start,
+            end,
+            project: args.project,
+            groupBy: args.group_by,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## Summary

- Adds three new MCP tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`) to both `AGENT_TOOLS` and `JOB_TOOLS` sets
- New data layer methods on `AgentManager` with SQL-based working time computation (window functions), parameterized queries, and `start`/`end` Date params consistent with API routes
- Enables automated workflows: weekly development digests, feedback pattern tracking, coaching check-ins

## Tools

| Tool | Purpose |
|------|---------|
| `get_activity_summary` | Working time, session counts, outcomes, top agents — grouped by project |
| `get_agent_history` | Paginated sessions with optional events (capped 200/agent), feedback, reviews, pins |
| `get_feedback_summary` | Feedback aggregated by persona/severity/directory with top findings and review verdicts |

## Security review

Backend security review approved with all findings addressed:
- Bounded event queries (200 per agent cap)
- Filtered deleted/child agents from working time CTEs for consistency
- Added `start >= end` date validation
- SQL parameterization verified correct throughout

## Test plan

- [x] 25 unit tests (`apps/server/test/db/summary-tools.test.ts`)
- [x] Full unit test suite (264 passed)
- [x] E2E tests (96 passed)
- [x] Type checking clean
- [x] Manual validation: seeded dev instance, verified all 3 tools via MCP endpoint
- [x] UI regression check: activity metrics, history, feedback, jobs views all rendering correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)