### PR TITLE
Add release channels (stable/latest)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           gh release create ${{ steps.version.outputs.tag }} \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release-notes/current.md \
+            --prerelease \
             dispatch-release.tar.gz
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -607,6 +607,16 @@ async function checkIsAdmin(): Promise<boolean> {
   return cachedIsAdmin;
 }
 
+function parseGhJson<T>(stdout: string): T {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error("GitHub CLI returned empty output");
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    throw new Error("Failed to parse GitHub CLI output");
+  }
+}
+
 function compareSemver(a: string, b: string): number {
   const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
   const pa = parse(a);
@@ -1370,9 +1380,37 @@ async function registerRoutes() {
       // Check admin permissions (cached for process lifetime)
       const isAdmin = await checkIsAdmin();
 
-      // Find latest tag from origin
-      const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
-      const latestTag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
+      // Read the configured release channel
+      const channelRaw = await getSetting(pool, "release_channel");
+      const channel = channelRaw === "latest" ? "latest" : "stable";
+
+      // Fetch recent releases in a single gh call. We request a small batch
+      // with isPrerelease so we can derive both the channel-filtered tag and
+      // the absolute latest tag without a second subprocess spawn.
+      let latestTag: string | null = null;
+      let absoluteLatestTag: string | null = null;
+      try {
+        const repo = await getGitHubRepo();
+        const ghResult = await runCommand("gh", [
+          "release", "list",
+          "--repo", repo,
+          "--limit", "10",
+          "--json", "tagName,isPrerelease"
+        ]);
+        const allReleases = parseGhJson<Array<{ tagName: string; isPrerelease: boolean }>>(ghResult.stdout);
+        absoluteLatestTag = allReleases[0]?.tagName ?? null;
+        if (channel === "stable") {
+          latestTag = allReleases.find((r) => !r.isPrerelease)?.tagName ?? null;
+        } else {
+          latestTag = allReleases[0]?.tagName ?? null;
+        }
+      } catch {
+        // Fallback to git tags (sees all releases regardless of channel)
+        const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
+        const fallbackTag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
+        latestTag = fallbackTag;
+        absoluteLatestTag = fallbackTag;
+      }
 
       const updateAvailable = !!(currentTag && latestTag && compareSemver(latestTag, currentTag) > 0);
 
@@ -1382,15 +1420,14 @@ async function registerRoutes() {
         latestRelease = await fetchLatestReleaseMetadata(latestTag);
       }
 
-      // Admin-only: unreleased commits on main
+      // Admin-only: unreleased commits on main.
+      // Compare the absolute latest tag (across all channels) to main so
+      // admins see the real unreleased count regardless of channel.
       let unreleasedCount = 0;
       let commits: Array<{ sha: string; subject: string }> = [];
       let refMissing = false;
 
-      // Compare latest release tag to main to find truly unreleased commits.
-      // Using latestTag (not currentTag) ensures that instances running an
-      // older version don't show already-released commits as "unreleased".
-      const compareTag = latestTag ?? currentTag;
+      const compareTag = absoluteLatestTag ?? currentTag;
       if (isAdmin && compareTag) {
         const refCheck = await runCommand(
           "git", ["-C", serverDir, "rev-parse", "--verify", compareTag],
@@ -1429,6 +1466,7 @@ async function registerRoutes() {
 
       return {
         currentTag,
+        channel,
         isAdmin,
         latestTag,
         updateAvailable,
@@ -1436,6 +1474,92 @@ async function registerRoutes() {
         unreleasedCount,
         commits,
         refMissing
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  // --- Release channel ---
+
+  const RELEASE_CHANNEL_KEY = "release_channel";
+  const VALID_CHANNELS = ["stable", "latest"] as const;
+  type ReleaseChannel = (typeof VALID_CHANNELS)[number];
+
+  app.get("/api/v1/release/channel", async () => {
+    const raw = await getSetting(pool, RELEASE_CHANNEL_KEY);
+    const channel: ReleaseChannel = raw === "latest" ? "latest" : "stable";
+    return { channel };
+  });
+
+  app.post("/api/v1/release/channel", async (request, reply) => {
+    const body = request.body as { channel?: unknown } | undefined;
+    if (!body?.channel || !VALID_CHANNELS.includes(body.channel as ReleaseChannel)) {
+      return reply.code(400).send({ error: `channel must be one of: ${VALID_CHANNELS.join(", ")}` });
+    }
+    await setSetting(pool, RELEASE_CHANNEL_KEY, body.channel as string);
+    return { channel: body.channel };
+  });
+
+  // --- Release admin check ---
+
+  app.get("/api/v1/release/admin-check", async () => {
+    const isAdmin = await checkIsAdmin();
+    return { isAdmin };
+  });
+
+  // --- Promote release (remove pre-release flag) ---
+
+  app.post("/api/v1/release/promote", async (request, reply) => {
+    const isAdmin = await checkIsAdmin();
+    if (!isAdmin) {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const body = request.body as { tag?: unknown } | undefined;
+    if (!body?.tag || typeof body.tag !== "string" || !/^v\d+\.\d+\.\d+$/.test(body.tag)) {
+      return reply.code(400).send({ error: "tag is required and must be a semver tag (e.g. v0.11.18)" });
+    }
+
+    try {
+      const repo = await getGitHubRepo();
+      await runCommand("gh", [
+        "release", "edit", body.tag,
+        "--repo", repo,
+        "--prerelease=false"
+      ]);
+      return { ok: true, tag: body.tag };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  // --- Recent releases list ---
+
+  app.get("/api/v1/releases", async (_, reply) => {
+    try {
+      const repo = await getGitHubRepo();
+      const result = await runCommand("gh", [
+        "release", "list",
+        "--repo", repo,
+        "--limit", "10",
+        "--json", "tagName,publishedAt,isPrerelease,url"
+      ]);
+      const releases = parseGhJson<Array<{
+        tagName: string;
+        publishedAt: string;
+        isPrerelease: boolean;
+        url: string;
+      }>>(result.stdout);
+      return {
+        releases: releases.map((r) => ({
+          tag: r.tagName,
+          publishedAt: r.publishedAt,
+          isPrerelease: r.isPrerelease,
+          url: r.url
+        }))
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -1485,8 +1609,8 @@ async function registerRoutes() {
   app.post("/api/v1/release/update", async (request, reply) => {
     const body = request.body as { tag?: unknown } | undefined;
 
-    if (!body?.tag || typeof body.tag !== "string" || !body.tag.startsWith("v")) {
-      return reply.code(400).send({ error: "tag is required and must be a version tag (e.g. v0.2.31)" });
+    if (!body?.tag || typeof body.tag !== "string" || !/^v\d+\.\d+\.\d+$/.test(body.tag)) {
+      return reply.code(400).send({ error: "tag is required and must be a semver tag (e.g. v0.2.31)" });
     }
 
     const tag = body.tag as string;

--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -1,0 +1,339 @@
+import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap } from "lucide-react";
+import { OperationTakeover } from "@/components/app/release-manager";
+import type { ReleaseInfo, ReleaseVersionType, UseReleaseStreamResult } from "@/hooks/use-release-stream";
+import { cn } from "@/lib/utils";
+
+type GitHubRelease = {
+  tag: string;
+  publishedAt: string;
+  isPrerelease: boolean;
+  url: string;
+};
+
+const VERSION_CONFIG: Record<ReleaseVersionType, {
+  icon: typeof ShieldCheck;
+  color: string;
+  border: string;
+  bg: string;
+  hover: string;
+}> = {
+  patch: {
+    icon: ShieldCheck,
+    color: "text-status-working",
+    border: "border-status-working/30",
+    bg: "bg-status-working/10",
+    hover: "hover:border-status-working/60 hover:bg-status-working/20"
+  },
+  minor: {
+    icon: Sparkles,
+    color: "text-status-done",
+    border: "border-status-done/30",
+    bg: "bg-status-done/10",
+    hover: "hover:border-status-done/60 hover:bg-status-done/20"
+  },
+  major: {
+    icon: Zap,
+    color: "text-violet-400",
+    border: "border-violet-500/30",
+    bg: "bg-violet-500/10",
+    hover: "hover:border-violet-500/60 hover:bg-violet-500/20"
+  }
+};
+
+const CREATE_PHASES = ["preflight", "triggering", "watching", "done"] as const;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function cleanError(raw: string): string {
+  const stderrMatch = raw.match(/stderr=(.+)$/s);
+  if (stderrMatch) {
+    const stderr = stderrMatch[1].trim();
+    return stderr.replace(/^fatal:\s*/i, "");
+  }
+  return raw;
+}
+
+type ReleasesAdminProps = {
+  stream: UseReleaseStreamResult;
+};
+
+export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
+  const { job, postRestartPolling, connectStream, setJob, status } = stream;
+
+  const [info, setInfo] = useState<ReleaseInfo | null>(null);
+  const [infoLoading, setInfoLoading] = useState(false);
+  const [infoError, setInfoError] = useState<string | null>(null);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+  const [releases, setReleases] = useState<GitHubRelease[]>([]);
+  const [releasesLoading, setReleasesLoading] = useState(false);
+  const [promotingTag, setPromotingTag] = useState<string | null>(null);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
+
+  const fetchInfo = useCallback(async () => {
+    setInfoLoading(true);
+    setInfoError(null);
+    try {
+      const res = await fetch("/api/v1/release/info");
+      if (!res.ok) {
+        const err = (await res.json()) as { error?: string };
+        setInfoError(cleanError(err.error ?? "Failed to load release info"));
+        return;
+      }
+      setInfo((await res.json()) as ReleaseInfo);
+    } catch (err) {
+      setInfoError(err instanceof Error ? cleanError(err.message) : "Failed to load release info");
+    } finally {
+      setInfoLoading(false);
+    }
+  }, []);
+
+  const fetchReleases = useCallback(async () => {
+    setReleasesLoading(true);
+    try {
+      const res = await fetch("/api/v1/releases");
+      if (res.ok) {
+        const data = (await res.json()) as { releases: GitHubRelease[] };
+        setReleases(data.releases);
+      }
+    } catch { /* ignore */ }
+    finally { setReleasesLoading(false); }
+  }, []);
+
+  useEffect(() => {
+    void fetchInfo();
+    void fetchReleases();
+  }, [fetchInfo, fetchReleases]);
+
+  const handleRelease = async (versionType: ReleaseVersionType) => {
+    setReleaseError(null);
+    const res = await fetch("/api/v1/release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ versionType })
+    });
+    if (!res.ok) {
+      const err = (await res.json()) as { error?: string };
+      setReleaseError(cleanError(err.error ?? "Failed to start release"));
+      return;
+    }
+    setJob({ jobType: "create", versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
+    connectStream();
+  };
+
+  const handlePromote = async (tag: string) => {
+    setPromotingTag(tag);
+    setPromoteError(null);
+    try {
+      const res = await fetch("/api/v1/release/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tag })
+      });
+      if (res.ok) {
+        setReleases((prev) => prev.map((r) => r.tag === tag ? { ...r, isPrerelease: false } : r));
+      } else {
+        const err = (await res.json()) as { error?: string };
+        setPromoteError(cleanError(err.error ?? `Failed to promote ${tag}`));
+      }
+    } catch (err) {
+      setPromoteError(err instanceof Error ? cleanError(err.message) : `Failed to promote ${tag}`);
+    } finally {
+      setPromotingTag(null);
+    }
+  };
+
+  // Only show takeover for create jobs
+  const createJob = job?.jobType === "create" ? job : null;
+  const isDone = createJob?.phase === "done";
+  const isFailed = createJob?.phase === "failed";
+  const showTakeover = createJob !== null;
+
+  if (showTakeover) {
+    return (
+      <OperationTakeover
+        job={createJob!}
+        phasesOrder={[...CREATE_PHASES]}
+        isDone={isDone}
+        isFailed={isFailed}
+        isRestarting={false}
+        postRestartPolling={postRestartPolling}
+        status={status}
+        onDismiss={() => {
+          setJob(null);
+          setReleaseError(null);
+          // Refresh data after a release was created
+          void fetchInfo();
+          void fetchReleases();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      {/* Unreleased commits */}
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Unreleased changes</div>
+
+        {infoLoading && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Loading...
+          </div>
+        )}
+
+        {infoError && (
+          <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {infoError}
+          </div>
+        )}
+
+        {info && !infoLoading && (
+          <>
+            {info.refMissing ? (
+              <div className="rounded border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-sm text-status-waiting">
+                Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
+              </div>
+            ) : info.unreleasedCount === 0 ? (
+              <div className="text-sm text-muted-foreground">No unreleased commits on main</div>
+            ) : (
+              <div>
+                <div className="mb-2 text-sm text-muted-foreground">
+                  {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
+                  <span className="font-mono">main</span>
+                </div>
+                <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
+                  {info.commits.map((c) => (
+                    <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
+                      <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
+                      <span className="text-foreground">{c.subject}</span>
+                    </div>
+                  ))}
+                  {info.unreleasedCount > info.commits.length && (
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      +{info.unreleasedCount - info.commits.length} more
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Create release */}
+      {info && (info.refMissing || info.unreleasedCount > 0) && (
+        <div>
+          <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Create release</div>
+
+          {releaseError && (
+            <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {releaseError}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
+              const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
+              return (
+                <button
+                  key={type}
+                  onClick={() => void handleRelease(type)}
+                  className={cn(
+                    "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
+                    border, bg, hover
+                  )}
+                >
+                  <Icon className={cn("h-5 w-5", color)} />
+                  <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="border-t border-border" />
+
+      {/* Recent releases */}
+      <div>
+        <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Recent releases</div>
+
+        {promoteError && (
+          <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {promoteError}
+          </div>
+        )}
+
+        {releasesLoading && releases.length === 0 && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Loading...
+          </div>
+        )}
+
+        {releases.length > 0 && (
+          <div className="flex flex-col gap-1">
+            {releases.map((r) => (
+              <div
+                key={r.tag}
+                className="flex items-center gap-3 rounded border border-border px-3 py-2.5"
+              >
+                <span className="font-mono text-sm font-semibold text-foreground">{r.tag}</span>
+                <span className={cn(
+                  "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                  r.isPrerelease
+                    ? "bg-status-waiting/15 text-status-waiting"
+                    : "bg-green-500/15 text-green-400"
+                )}>
+                  {r.isPrerelease ? "pre-release" : "stable"}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(r.publishedAt)}
+                </span>
+                <div className="ml-auto flex items-center gap-2">
+                  {r.isPrerelease && (
+                    <button
+                      onClick={() => void handlePromote(r.tag)}
+                      disabled={promotingTag === r.tag}
+                      className="rounded border border-green-500/30 bg-green-500/10 px-2.5 py-1 text-xs font-medium text-green-400 transition-all hover:border-green-500/60 hover:bg-green-500/20 disabled:opacity-50"
+                    >
+                      {promotingTag === r.tag ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        "Promote"
+                      )}
+                    </button>
+                  )}
+                  {!r.isPrerelease && (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-green-500/50" />
+                  )}
+                  <a
+                    href={r.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!releasesLoading && releases.length === 0 && (
+          <div className="text-sm text-muted-foreground">No releases found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -1,92 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowDownToLine, CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap, XCircle } from "lucide-react";
-import { recordReleaseManagerPollFire } from "@/lib/energy-metrics";
-
+import { ArrowDownToLine, CheckCircle2, ChevronDown, ChevronRight, ExternalLink, Loader2, RefreshCw, Trash2, XCircle } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { OperationLog, PhaseProgress } from "@/components/app/release-shared";
+import { type ReleaseChannel, type ReleaseInfo, type ReleaseJob, type UseReleaseStreamResult } from "@/hooks/use-release-stream";
+import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type ReleaseVersionType = "patch" | "minor" | "major";
-type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
-type ReleaseJobType = "create" | "update";
-
-type ReleaseStatus = {
-  tag: string | null;
-  deployedAt: string | null;
+type AppVersionInfo = {
+  releaseTag: string | null;
+  version: string | null;
+  gitSha: string | null;
+  releaseNotes: string | null;
+  releaseUrl: string | null;
 };
 
-type ReleaseInfo = {
-  currentTag: string | null;
-  isAdmin: boolean;
-  latestTag: string | null;
-  updateAvailable: boolean;
-  latestRelease: { tag: string; publishedAt: string; url: string } | null;
-  unreleasedCount: number;
-  commits: Array<{ sha: string; subject: string }>;
-  refMissing?: boolean;
-};
-
-type ReleaseJob = {
-  jobType: ReleaseJobType;
-  versionType: ReleaseVersionType | null;
-  phase: ReleasePhase;
-  startedAt: string;
-  log: string[];
-  runUrl: string | null;
-  tag: string | null;
-  error: string | null;
-};
-
-type ReleaseStreamEvent =
-  | { type: "snapshot"; job: ReleaseJob | null }
-  | { type: "log"; line: string }
-  | { type: "log.replace"; line: string }
-  | { type: "log.rewind"; count: number }
-  | { type: "phase"; phase: ReleasePhase; error?: string }
-  | { type: "runUrl"; url: string }
-  | { type: "tag"; tag: string };
-
-const VERSION_CONFIG: Record<ReleaseVersionType, {
-  icon: typeof ShieldCheck;
-  color: string;
-  border: string;
-  bg: string;
-  hover: string;
-}> = {
-  patch: {
-    icon: ShieldCheck,
-    color: "text-status-working",
-    border: "border-status-working/30",
-    bg: "bg-status-working/10",
-    hover: "hover:border-status-working/60 hover:bg-status-working/20"
-  },
-  minor: {
-    icon: Sparkles,
-    color: "text-status-done",
-    border: "border-status-done/30",
-    bg: "bg-status-done/10",
-    hover: "hover:border-status-done/60 hover:bg-status-done/20"
-  },
-  major: {
-    icon: Zap,
-    color: "text-violet-400",
-    border: "border-violet-500/30",
-    bg: "bg-violet-500/10",
-    hover: "hover:border-violet-500/60 hover:bg-violet-500/20"
-  }
-};
-
-const PHASE_LABELS: Record<ReleasePhase, string> = {
-  preflight: "Pre-flight",
-  triggering: "Trigger workflow",
-  watching: "CI running",
-  fetching: "Fetching",
-  deploying: "Deploying",
-  restarting: "Restarting",
-  done: "Complete",
-  failed: "Failed"
-};
-
-const CREATE_PHASES: ReleasePhase[] = ["preflight", "triggering", "watching", "done"];
-const UPDATE_PHASES: ReleasePhase[] = ["fetching", "deploying", "restarting", "done"];
+const UPDATE_PHASES = ["fetching", "deploying", "restarting", "done"] as const;
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString(undefined, {
@@ -98,127 +26,60 @@ function formatDate(iso: string): string {
 }
 
 function cleanError(raw: string): string {
-  // Strip "Command failed (...), exitCode=N, stderr=" wrapper from internal errors
   const stderrMatch = raw.match(/stderr=(.+)$/s);
   if (stderrMatch) {
     const stderr = stderrMatch[1].trim();
-    // Strip "fatal: " prefix git adds
     return stderr.replace(/^fatal:\s*/i, "");
   }
   return raw;
 }
 
-export function ReleaseManager(): JSX.Element {
-  const [status, setStatus] = useState<ReleaseStatus | null>(null);
+type UpdatesSectionProps = {
+  stream: UseReleaseStreamResult;
+};
+
+export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
+  const { status, job, postRestartPolling, connectStream, setJob } = stream;
+
+  const [versionInfo, setVersionInfo] = useState<AppVersionInfo | null>(null);
+  const [notesExpanded, setNotesExpanded] = useState(false);
+  const [channel, setChannel] = useState<ReleaseChannel>("stable");
+  const [channelSaving, setChannelSaving] = useState(false);
   const [info, setInfo] = useState<ReleaseInfo | null>(null);
   const [infoLoading, setInfoLoading] = useState(false);
   const [infoError, setInfoError] = useState<string | null>(null);
-  const [job, setJob] = useState<ReleaseJob | null>(null);
-  const [releaseError, setReleaseError] = useState<string | null>(null);
-  const [postRestartPolling, setPostRestartPolling] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [reloading, setReloading] = useState(false);
 
-  const logRef = useRef<HTMLDivElement>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
-  const healthPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Fetch version info + channel on mount
+  useEffect(() => {
+    let cancelled = false;
+    void api<AppVersionInfo>("/api/v1/app/version")
+      .then((data) => { if (!cancelled) setVersionInfo(data); })
+      .catch(() => {});
+    void api<{ channel: ReleaseChannel }>("/api/v1/release/channel")
+      .then((data) => { if (!cancelled) setChannel(data.channel); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
 
-  const fetchStatus = useCallback(async () => {
+  const handleChannelChange = useCallback(async (value: ReleaseChannel) => {
+    setChannel(value);
+    setChannelSaving(true);
     try {
-      const res = await fetch("/api/v1/release/status");
-      if (res.ok) setStatus((await res.json()) as ReleaseStatus);
-    } catch { /* ignore */ }
-  }, []);
-
-  useEffect(() => { void fetchStatus(); }, [fetchStatus]);
-
-  // Auto-scroll log
-  useEffect(() => {
-    if (logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight;
+      await api("/api/v1/release/channel", {
+        method: "POST",
+        body: JSON.stringify({ channel: value }),
+      });
+      // Reset update info since channel changed
+      setInfo(null);
+    } catch {
+      // revert on error
+      setChannel((prev) => prev === "stable" ? "latest" : "stable");
+    } finally {
+      setChannelSaving(false);
     }
-  }, [job?.log]);
-
-  const startHealthPoll = useCallback((expectedTag: string | null) => {
-    setPostRestartPolling(true);
-    if (healthPollRef.current) clearInterval(healthPollRef.current);
-
-    healthPollRef.current = setInterval(async () => {
-      if (document.hidden) return; // skip polls while hidden
-      recordReleaseManagerPollFire();
-      try {
-        const res = await fetch("/api/v1/release/status");
-        if (res.ok) {
-          const data = (await res.json()) as ReleaseStatus;
-          if (data.tag && data.tag === expectedTag) {
-            clearInterval(healthPollRef.current!);
-            healthPollRef.current = null;
-            setPostRestartPolling(false);
-            setStatus(data);
-            setJob((prev) => prev ? { ...prev, phase: "done", tag: data.tag } : prev);
-            // App is confirmed running on new version — reload to pick up new UI
-            setTimeout(() => window.location.reload(), 1500);
-          }
-        }
-      } catch { /* server still down */ }
-    }, 2000);
   }, []);
-
-  const connectStream = useCallback(() => {
-    eventSourceRef.current?.close();
-    const es = new EventSource("/api/v1/release/stream");
-    eventSourceRef.current = es;
-
-    es.onmessage = (e) => {
-      const event = JSON.parse(e.data as string) as ReleaseStreamEvent;
-      if (event.type === "snapshot") {
-        setJob(event.job);
-        return;
-      }
-      setJob((prev) => {
-        if (!prev) return prev;
-        if (event.type === "log") return { ...prev, log: [...prev.log, event.line] };
-        if (event.type === "log.rewind") {
-          return { ...prev, log: prev.log.slice(0, -event.count) };
-        }
-        if (event.type === "log.replace") {
-          const updated = [...prev.log];
-          if (updated.length > 0) {
-            updated[updated.length - 1] = event.line;
-          } else {
-            updated.push(event.line);
-          }
-          return { ...prev, log: updated };
-        }
-        if (event.type === "phase") return { ...prev, phase: event.phase, error: event.error ?? prev.error };
-        if (event.type === "runUrl") return { ...prev, runUrl: event.url };
-        if (event.type === "tag") return { ...prev, tag: event.tag };
-        return prev;
-      });
-    };
-
-    es.onerror = () => {
-      setJob((prev) => {
-        // Only start health polling for update jobs (which restart the server).
-        // Release creation no longer restarts, so SSE errors during create
-        // are just normal disconnects.
-        if (prev?.jobType === "update" && (prev.phase === "restarting" || prev.phase === "deploying")) {
-          startHealthPoll(prev.tag);
-          return { ...prev, phase: "restarting" };
-        }
-        return prev;
-      });
-      es.close();
-      eventSourceRef.current = null;
-    };
-  }, [startHealthPoll]);
-
-  // On mount, connect to SSE so we pick up any in-progress or recently finished job
-  useEffect(() => {
-    connectStream();
-    return () => {
-      eventSourceRef.current?.close();
-      if (healthPollRef.current) clearInterval(healthPollRef.current);
-    };
-  }, [connectStream]);
 
   const handleCheckForUpdates = async () => {
     setInfoLoading(true);
@@ -240,7 +101,7 @@ export function ReleaseManager(): JSX.Element {
   };
 
   const handleUpdate = async (tag: string) => {
-    setReleaseError(null);
+    setUpdateError(null);
     const res = await fetch("/api/v1/release/update", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -248,321 +109,358 @@ export function ReleaseManager(): JSX.Element {
     });
     if (!res.ok) {
       const err = (await res.json()) as { error?: string };
-      setReleaseError(cleanError(err.error ?? "Failed to start update"));
+      setUpdateError(cleanError(err.error ?? "Failed to start update"));
       return;
     }
     setJob({ jobType: "update", versionType: null, phase: "fetching", startedAt: new Date().toISOString(), log: [], runUrl: null, tag, error: null });
     connectStream();
   };
 
-  const handleRelease = async (versionType: ReleaseVersionType) => {
-    setReleaseError(null);
-    const res = await fetch("/api/v1/release", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ versionType })
-    });
-    if (!res.ok) {
-      const err = (await res.json()) as { error?: string };
-      setReleaseError(cleanError(err.error ?? "Failed to start release"));
-      return;
+  const handleReload = useCallback(() => {
+    setReloading(true);
+    window.location.reload();
+  }, []);
+
+  const handleClearCacheAndReload = useCallback(async () => {
+    setReloading(true);
+    try {
+      if ("serviceWorker" in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((r) => r.unregister()));
+      }
+      if ("caches" in window) {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      }
+      window.location.reload();
+    } catch {
+      window.location.reload();
     }
-    setJob({ jobType: "create", versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
-    connectStream();
-  };
+  }, []);
 
-  const isActive = job !== null && !["done", "failed"].includes(job.phase) && !postRestartPolling;
-  const isDone = job?.phase === "done" || (!postRestartPolling && job?.phase === "restarting" && status?.tag === job?.tag);
-  const isFailed = job?.phase === "failed";
-  const isRestarting = job?.phase === "restarting" || postRestartPolling;
-  const showLog = job !== null;
+  // Only show takeover for update jobs
+  const updateJob = job?.jobType === "update" ? job : null;
+  const isDone = updateJob?.phase === "done" || (!postRestartPolling && updateJob?.phase === "restarting" && status?.tag === updateJob?.tag);
+  const isFailed = updateJob?.phase === "failed";
+  const isRestarting = updateJob?.phase === "restarting" || (updateJob !== null && postRestartPolling);
+  const showTakeover = updateJob !== null;
 
-  const phasesOrder = job?.jobType === "update" ? UPDATE_PHASES : CREATE_PHASES;
-  const phaseIndex = job ? phasesOrder.indexOf(job.phase) : -1;
+  if (showTakeover) {
+    return (
+      <OperationTakeover
+        job={updateJob!}
+        phasesOrder={[...UPDATE_PHASES]}
+        isDone={isDone}
+        isFailed={isFailed}
+        isRestarting={isRestarting}
+        postRestartPolling={postRestartPolling}
+        status={status}
+        onDismiss={() => { setJob(null); setInfo(null); setUpdateError(null); }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      {/* Current version */}
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Current version</div>
+        {status ? (
+          <div className="flex items-baseline gap-2">
+            <span className="font-mono text-xl font-bold text-foreground">{status.tag ?? "unknown"}</span>
+            {status.deployedAt ? (
+              <span className="text-xs text-muted-foreground">{formatDate(status.deployedAt)}</span>
+            ) : null}
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">Loading...</span>
+        )}
+
+        {versionInfo && (
+          <div className="mt-3 grid gap-2 rounded border border-border p-3 text-sm">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Release tag</span>
+              <span className="font-mono">{versionInfo.releaseTag ?? "unreleased"}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Package version</span>
+              <span className="font-mono">{versionInfo.version ?? "unknown"}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Git SHA</span>
+              <span className="font-mono">{versionInfo.gitSha ?? "unavailable"}</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Release notes — collapsible */}
+      {versionInfo?.releaseNotes && (
+        <div>
+          <button
+            onClick={() => setNotesExpanded(!notesExpanded)}
+            className="flex items-center gap-1.5 text-[10px] uppercase tracking-widest text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {notesExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            Release notes
+            {versionInfo.releaseUrl ? (
+              <a
+                className="ml-2 inline-flex items-center gap-1 text-xs normal-case tracking-normal text-blue-400 hover:underline"
+                href={versionInfo.releaseUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink className="h-3 w-3" />
+                GitHub
+              </a>
+            ) : null}
+          </button>
+          {notesExpanded && (
+            <div className="mt-2 rounded border border-border p-3">
+              <div className="max-h-56 overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+                {versionInfo.releaseNotes}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="border-t border-border" />
+
+      {/* Release channel */}
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release channel</div>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Choose which releases this instance follows.
+        </p>
+        <div className={cn("inline-flex rounded border border-border", channelSaving && "opacity-50 pointer-events-none")}>
+          {(["stable", "latest"] as ReleaseChannel[]).map((ch) => (
+            <button
+              key={ch}
+              onClick={() => void handleChannelChange(ch)}
+              className={cn(
+                "px-4 py-1.5 text-sm font-medium capitalize transition-colors",
+                channel === ch
+                  ? "bg-primary/15 text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+                ch === "stable" && "rounded-l border-r border-border",
+                ch === "latest" && "rounded-r"
+              )}
+            >
+              {ch}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Check for updates */}
+      <div className="flex flex-col gap-4">
+        {!info && !infoLoading && (
+          <button
+            onClick={() => void handleCheckForUpdates()}
+            className="self-start rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+          >
+            Check for updates
+          </button>
+        )}
+
+        {infoLoading && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Checking...
+          </div>
+        )}
+
+        {infoError && (
+          <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {infoError}
+          </div>
+        )}
+
+        {info && (
+          <>
+            {info.updateAvailable && info.latestTag ? (
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-2">
+                  <ArrowDownToLine className="h-4 w-4 text-blue-400" />
+                  <span className="text-sm text-foreground">
+                    <span className="font-mono font-semibold">{info.latestTag}</span> available
+                  </span>
+                  {info.latestRelease?.publishedAt && (
+                    <span className="text-xs text-muted-foreground">
+                      · {formatDate(info.latestRelease.publishedAt)}
+                    </span>
+                  )}
+                </div>
+
+                {info.latestRelease?.url && (
+                  <a
+                    href={info.latestRelease.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    View release on GitHub
+                  </a>
+                )}
+
+                {updateError && (
+                  <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                    {updateError}
+                  </div>
+                )}
+
+                <button
+                  onClick={() => void handleUpdate(info.latestTag!)}
+                  className="self-start rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
+                >
+                  Update to {info.latestTag}
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+                Up to date
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="border-t border-border" />
+
+      {/* Reload */}
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Reload</div>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Reload the app to pick up the latest version.
+        </p>
+        <div className="inline-flex items-stretch">
+          <button
+            onClick={handleReload}
+            disabled={reloading}
+            className="inline-flex items-center gap-2 rounded-l border border-r-0 border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", reloading && "animate-spin")} />
+            {reloading ? "Reloading..." : "Reload"}
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                disabled={reloading}
+                className="inline-flex items-center rounded-r border border-border px-1.5 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => void handleClearCacheAndReload()}
+                className="flex items-center whitespace-nowrap text-muted-foreground"
+              >
+                <Trash2 className="mr-2 h-3.5 w-3.5" />
+                Clear cache & reload
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Operation takeover (shared layout for update/create flows) ---
+
+type OperationTakeoverProps = {
+  job: ReleaseJob;
+  phasesOrder: string[];
+  isDone: boolean;
+  isFailed: boolean;
+  isRestarting: boolean;
+  postRestartPolling: boolean;
+  status: { tag: string | null; deployedAt: string | null } | null;
+  onDismiss: () => void;
+};
+
+export function OperationTakeover({
+  job,
+  phasesOrder,
+  isDone,
+  isFailed,
+  isRestarting,
+  postRestartPolling,
+  status,
+  onDismiss,
+}: OperationTakeoverProps): JSX.Element {
+  const logRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [job.log]);
 
   return (
     <div className="flex h-full min-h-0 flex-col md:flex-row">
       {/* Left column — controls */}
       <div className="flex md:w-[360px] shrink-0 flex-col gap-6 overflow-y-auto border-b md:border-b-0 md:border-r border-border p-4 md:p-6">
+        <PhaseProgress
+          job={job}
+          phasesOrder={phasesOrder}
+          isFailed={isFailed}
+          isRestarting={isRestarting}
+        />
 
-        {/* Current version */}
-        <div>
-          <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Deployed version</div>
-          {status ? (
-            <div className="flex items-baseline gap-2">
-              <span className="font-mono text-xl font-bold text-foreground">{status.tag ?? "unknown"}</span>
-              {status.deployedAt ? (
-                <span className="text-xs text-muted-foreground">{formatDate(status.deployedAt)}</span>
-              ) : null}
+        {job.runUrl && (
+          <a
+            href={job.runUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            View GitHub Actions run
+          </a>
+        )}
+
+        {isDone && (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              <span>
+                {job.jobType === "update" ? "Updated to" : "Released"}{" "}
+                <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
+              </span>
             </div>
-          ) : (
-            <span className="text-sm text-muted-foreground">Loading…</span>
-          )}
-        </div>
-
-        {/* Check for updates / info — hidden while an operation is active */}
-        {!isActive && !isDone && (
-          <div className="flex flex-col gap-4">
-            {!info && !infoLoading && (
-              <button
-                onClick={() => void handleCheckForUpdates()}
-                className="self-start rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
-              >
-                Check for updates
-              </button>
-            )}
-
-            {infoLoading && (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Fetching…
-              </div>
-            )}
-
-            {infoError && (
-              <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {infoError}
-              </div>
-            )}
-
-            {info && (
-              <>
-                {/* Update section — always visible */}
-                {info.updateAvailable && info.latestTag ? (
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-center gap-2">
-                      <ArrowDownToLine className="h-4 w-4 text-blue-400" />
-                      <span className="text-sm text-foreground">
-                        <span className="font-mono font-semibold">{info.latestTag}</span> available
-                      </span>
-                      {info.latestRelease?.publishedAt && (
-                        <span className="text-xs text-muted-foreground">
-                          · {formatDate(info.latestRelease.publishedAt)}
-                        </span>
-                      )}
-                    </div>
-
-                    {info.latestRelease?.url && (
-                      <a
-                        href={info.latestRelease.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        View release on GitHub
-                      </a>
-                    )}
-
-                    {releaseError && (
-                      <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                        {releaseError}
-                      </div>
-                    )}
-
-                    <button
-                      onClick={() => void handleUpdate(info.latestTag!)}
-                      className="self-start rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
-                    >
-                      Update to {info.latestTag}
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
-                    Up to date
-                  </div>
-                )}
-
-                {/* Create release section — admin only */}
-                {info.isAdmin && (
-                  <div className="flex flex-col gap-4 border-t border-border pt-4">
-                    <div className="text-[10px] uppercase tracking-widest text-muted-foreground">Create release</div>
-
-                    {info.refMissing ? (
-                      <div className="rounded border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-sm text-status-waiting">
-                        Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
-                      </div>
-                    ) : info.unreleasedCount === 0 ? (
-                      <div className="text-xs text-muted-foreground">No unreleased commits on main</div>
-                    ) : (
-                      <div>
-                        <div className="mb-2 text-xs text-muted-foreground">
-                          {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
-                          <span className="font-mono">main</span>
-                        </div>
-                        <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
-                          {info.commits.map((c) => (
-                            <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
-                              <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
-                              <span className="text-foreground">{c.subject}</span>
-                            </div>
-                          ))}
-                          {info.unreleasedCount > info.commits.length && (
-                            <div className="mt-1 text-xs text-muted-foreground">
-                              +{info.unreleasedCount - info.commits.length} more
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-
-                    {(info.refMissing || info.unreleasedCount > 0) && (
-                      <>
-                        {releaseError && (
-                          <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                            {releaseError}
-                          </div>
-                        )}
-
-                        <div className="flex flex-col gap-2">
-                          <div className="mb-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release type</div>
-                          {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
-                            const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
-                            return (
-                              <button
-                                key={type}
-                                onClick={() => void handleRelease(type)}
-                                className={cn(
-                                  "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
-                                  border, bg, hover
-                                )}
-                              >
-                                <Icon className={cn("h-5 w-5", color)} />
-                                <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
+            <button
+              onClick={onDismiss}
+              className="self-start rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+            >
+              Done
+            </button>
           </div>
         )}
 
-        {/* Phase progress — shown when a release/update is running or finished */}
-        {job && (
-          <div className="flex flex-col gap-4">
-            <div>
-              <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Progress</div>
-              <div className="flex flex-col gap-2">
-                {phasesOrder.filter((p) => p !== "done").map((phase, i) => {
-                  const current = phaseIndex === i;
-                  const done = phaseIndex > i || job.phase === "done";
-                  return (
-                    <div key={phase} className="flex items-center gap-3">
-                      <div className={cn(
-                        "h-2 w-2 rounded-full shrink-0",
-                        done && "bg-status-working",
-                        current && !isFailed && "animate-pulse bg-status-waiting",
-                        current && isFailed && "bg-destructive",
-                        !done && !current && "bg-muted"
-                      )} />
-                      <span className={cn(
-                        "text-sm",
-                        done && "text-muted-foreground",
-                        current && !isFailed && "text-foreground font-medium",
-                        current && isFailed && "text-destructive font-medium",
-                        !done && !current && "text-muted-foreground/50"
-                      )}>
-                        {PHASE_LABELS[phase]}
-                      </span>
-                      {current && isRestarting && phase === "restarting" && (
-                        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+        {isFailed && (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-start gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+              <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{job.error ? cleanError(job.error) : "Operation failed"}</span>
             </div>
-
-            {job.runUrl && (
-              <a
-                href={job.runUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
-              >
-                <ExternalLink className="h-3 w-3" />
-                View GitHub Actions run
-              </a>
-            )}
-
-            {isDone && (
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center gap-2 rounded border border-green-500/30 bg-green-500/10 px-3 py-2.5 text-sm text-green-400">
-                  <CheckCircle2 className="h-4 w-4 shrink-0" />
-                  <span>
-                    {job.jobType === "update" ? "Updated to" : "Released"}{" "}
-                    <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
-                  </span>
-                </div>
-
-                {/* After a release creation, offer to update or dismiss */}
-                {job.jobType === "create" && job.tag && (
-                  <>
-                    {releaseError && (
-                      <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                        {releaseError}
-                      </div>
-                    )}
-                    <div className="flex gap-2">
-                      <button
-                        onClick={() => void handleUpdate(job.tag!)}
-                        className="rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
-                      >
-                        Update to {job.tag}
-                      </button>
-                      <button
-                        onClick={() => { setJob(null); setInfo(null); setReleaseError(null); }}
-                        className="rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
-                      >
-                        Dismiss
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-
-            {isFailed && (
-              <div className="flex items-start gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
-                <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                <span>{job.error ? cleanError(job.error) : "Operation failed"}</span>
-              </div>
-            )}
+            <button
+              onClick={onDismiss}
+              className="self-start rounded border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+            >
+              Dismiss
+            </button>
           </div>
         )}
       </div>
 
       {/* Right column — log */}
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col p-2">
-        {showLog ? (
-          <div
-            ref={logRef}
-            className="min-h-0 flex-1 overflow-y-auto bg-black/60 p-4 font-mono text-[12px] leading-relaxed text-green-300"
-          >
-            {job!.log
-              .filter((line) => line.trim() !== "DISPATCH_RESTARTING")
-              .map((line, i) => (
-                <div key={i}>{line || "\u00A0"}</div>
-              ))}
-            {isRestarting && !job?.log.length && (
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Waiting for Dispatch to restart…
-              </div>
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground/40">
-            Log output will appear here
-          </div>
-        )}
-      </div>
+      <OperationLog logRef={logRef} job={job} isRestarting={isRestarting} postRestartPolling={postRestartPolling} />
     </div>
   );
 }

--- a/apps/web/src/components/app/release-shared.tsx
+++ b/apps/web/src/components/app/release-shared.tsx
@@ -1,0 +1,90 @@
+import { Loader2 } from "lucide-react";
+import type { ReleaseJob, ReleasePhase } from "@/hooks/use-release-stream";
+import { cn } from "@/lib/utils";
+
+const PHASE_LABELS: Record<ReleasePhase, string> = {
+  preflight: "Pre-flight",
+  triggering: "Trigger workflow",
+  watching: "CI running",
+  fetching: "Fetching",
+  deploying: "Deploying",
+  restarting: "Restarting",
+  done: "Complete",
+  failed: "Failed"
+};
+
+type PhaseProgressProps = {
+  job: ReleaseJob;
+  phasesOrder: string[];
+  isFailed: boolean;
+  isRestarting: boolean;
+};
+
+export function PhaseProgress({ job, phasesOrder, isFailed, isRestarting }: PhaseProgressProps): JSX.Element {
+  const phaseIndex = phasesOrder.indexOf(job.phase);
+
+  return (
+    <div>
+      <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Progress</div>
+      <div className="flex flex-col gap-2">
+        {phasesOrder.filter((p) => p !== "done").map((phase, i) => {
+          const current = phaseIndex === i;
+          const done = phaseIndex > i || job.phase === "done";
+          return (
+            <div key={phase} className="flex items-center gap-3">
+              <div className={cn(
+                "h-2 w-2 rounded-full shrink-0",
+                done && "bg-status-working",
+                current && !isFailed && "animate-pulse bg-status-waiting",
+                current && isFailed && "bg-destructive",
+                !done && !current && "bg-muted"
+              )} />
+              <span className={cn(
+                "text-sm",
+                done && "text-muted-foreground",
+                current && !isFailed && "text-foreground font-medium",
+                current && isFailed && "text-destructive font-medium",
+                !done && !current && "text-muted-foreground/50"
+              )}>
+                {PHASE_LABELS[phase as ReleasePhase] ?? phase}
+              </span>
+              {current && isRestarting && phase === "restarting" && (
+                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type OperationLogProps = {
+  logRef: React.Ref<HTMLDivElement>;
+  job: ReleaseJob;
+  isRestarting: boolean;
+  postRestartPolling: boolean;
+};
+
+export function OperationLog({ logRef, job, isRestarting, postRestartPolling }: OperationLogProps): JSX.Element {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col p-2">
+      <div
+        ref={logRef}
+        className="min-h-0 flex-1 overflow-y-auto bg-black/60 p-4 font-mono text-[12px] leading-relaxed text-green-300"
+      >
+        {job.log
+          .filter((line) => line.trim() !== "DISPATCH_RESTARTING")
+          .map((line, i) => (
+            <div key={i}>{line || "\u00A0"}</div>
+          ))}
+        {(isRestarting || postRestartPolling) && !job.log.length && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Waiting for Dispatch to restart...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,36 +1,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ArrowDownToLine, ArrowLeft, Bell, ChevronDown, ChevronRight, ExternalLink, Info, RefreshCw, Settings, Trash2, Users, X } from "lucide-react";
+import { ArrowDownToLine, ArrowLeft, Bell, ChevronRight, Package, Settings, Users, X } from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { NotificationSettings } from "@/components/app/notification-settings";
-import { ReleaseManager } from "@/components/app/release-manager";
+import { ReleasesAdmin } from "@/components/app/release-admin";
+import { UpdatesSection } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
+import { useReleaseStream } from "@/hooks/use-release-stream";
 import { type ThemeId, THEMES } from "@/hooks/use-theme";
 import { type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "general" | "agents" | "notifications" | "updates" | "about";
+type SettingsSection = "general" | "agents" | "notifications" | "updates" | "releases";
 
-const SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
+const BASE_SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
   { id: "general", label: "General", icon: Settings },
   { id: "agents", label: "Agents", icon: Users },
   { id: "notifications", label: "Notifications", icon: Bell },
   { id: "updates", label: "Updates", icon: ArrowDownToLine },
-  { id: "about", label: "About", icon: Info },
 ];
 
-type AppVersionInfo = {
-  releaseTag: string | null;
-  version: string | null;
-  gitSha: string | null;
-  releaseNotes: string | null;
-  releaseUrl: string | null;
-};
+const RELEASES_SECTION = { id: "releases" as SettingsSection, label: "Releases", icon: Package };
 
 function InstanceNameSettings(): JSX.Element {
   const { instanceName, setInstanceName, isSaving, saveError, didSave, clearSaveState } = useInstanceName();
@@ -117,154 +111,7 @@ function InstanceNameSettings(): JSX.Element {
   );
 }
 
-function AppSettings(): JSX.Element {
-  const [reloading, setReloading] = useState(false);
-  const [versionInfo, setVersionInfo] = useState<AppVersionInfo | null>(null);
-  const [versionError, setVersionError] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    void api<AppVersionInfo>("/api/v1/app/version")
-      .then((payload) => {
-        if (cancelled) return;
-        setVersionInfo(payload);
-        setVersionError(false);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setVersionError(true);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const handleReload = useCallback(() => {
-    setReloading(true);
-    window.location.reload();
-  }, []);
-
-  const handleClearCacheAndReload = useCallback(async () => {
-    setReloading(true);
-    try {
-      // Unregister all service workers and clear their caches
-      if ("serviceWorker" in navigator) {
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        await Promise.all(registrations.map((r) => r.unregister()));
-      }
-      if ("caches" in window) {
-        const keys = await caches.keys();
-        await Promise.all(keys.map((k) => caches.delete(k)));
-      }
-      window.location.reload();
-    } catch {
-      // If anything fails, just reload anyway
-      window.location.reload();
-    }
-  }, []);
-
-  return (
-    <div className="flex flex-col gap-6 p-4 md:p-6">
-      <div data-testid="app-version-card">
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
-          Current version
-        </div>
-        <p className="mb-3 text-sm text-muted-foreground">
-          Version information for the running app process.
-        </p>
-        <div className="grid gap-2 rounded border border-border p-3 text-sm">
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground">Release tag</span>
-            <span className="font-mono" data-testid="app-version-release-tag">
-              {versionInfo?.releaseTag ?? "unreleased"}
-            </span>
-          </div>
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground">Package version</span>
-            <span className="font-mono" data-testid="app-version-semver">
-              {versionInfo?.version ?? "unknown"}
-            </span>
-          </div>
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground">Git SHA</span>
-            <span className="font-mono" data-testid="app-version-git-sha">
-              {versionInfo?.gitSha ?? "unavailable"}
-            </span>
-          </div>
-        </div>
-        <div className="mt-4 rounded border border-border p-3">
-          <div className="mb-2 flex items-center gap-2">
-            <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
-              Release notes
-            </div>
-            {versionInfo?.releaseUrl ? (
-              <a
-                className="inline-flex items-center gap-1 text-xs text-blue-400 hover:underline"
-                href={versionInfo.releaseUrl}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <ExternalLink className="h-3 w-3" />
-                View on GitHub
-              </a>
-            ) : null}
-          </div>
-          <div
-            className="max-h-56 overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-muted-foreground"
-            data-testid="app-version-release-notes"
-          >
-            {versionInfo?.releaseNotes ?? "No release notes are stored for this build yet."}
-          </div>
-        </div>
-        {versionError ? (
-          <p className="mt-2 text-xs text-red-300">
-            Unable to load version metadata.
-          </p>
-        ) : null}
-      </div>
-
-      <div>
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
-          Reload
-        </div>
-        <p className="mb-3 text-sm text-muted-foreground">
-          Reload the app to pick up the latest version. Use the dropdown to clear cached data first if the app feels stuck.
-        </p>
-        <div className="inline-flex items-stretch">
-          <button
-            onClick={handleReload}
-            disabled={reloading}
-            className="inline-flex items-center gap-2 rounded-l border border-r-0 border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
-          >
-            <RefreshCw className={cn("h-3.5 w-3.5", reloading && "animate-spin")} />
-            {reloading ? "Reloading…" : "Reload"}
-          </button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                disabled={reloading}
-                className="inline-flex items-center rounded-r border border-border px-1.5 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
-              >
-                <ChevronDown className="h-3.5 w-3.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={() => void handleClearCacheAndReload()}
-                className="flex items-center whitespace-nowrap text-muted-foreground"
-              >
-                <Trash2 className="mr-2 h-3.5 w-3.5" />
-                Clear cache & reload
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-    </div>
-  );
-}
+// AppSettings (About) has been merged into UpdatesSection in release-manager.tsx
 
 type WorktreeLocation = "sibling" | "nested";
 
@@ -463,8 +310,10 @@ function AppearanceSettings({
   );
 }
 
+const ALL_VALID_SECTIONS: SettingsSection[] = ["general", "agents", "notifications", "updates", "releases"];
+
 function isValidSection(value: string | undefined): value is SettingsSection {
-  return value !== undefined && SECTIONS.some((s) => s.id === value);
+  return value !== undefined && ALL_VALID_SECTIONS.includes(value as SettingsSection);
 }
 
 type SettingsPaneProps = {
@@ -502,13 +351,33 @@ export function SettingsPane({
 }: SettingsPaneProps): JSX.Element {
   const resolvedInitial = isValidSection(initialSection) ? initialSection : "general";
   const [activeSection, setActiveSectionState] = useState<SettingsSection | null>(resolvedInitial);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const releaseStream = useReleaseStream();
+
+  // Check admin status on mount
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api<{ isAdmin: boolean }>("/api/v1/release/admin-check")
+      .then((data) => { if (!cancelled) setIsAdmin(data.isAdmin); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [open]);
+
+  const sections = isAdmin ? [...BASE_SECTIONS, RELEASES_SECTION] : BASE_SECTIONS;
 
   // Sync from URL when initialSection changes (e.g. navigating directly to /settings/appearance)
   useEffect(() => {
     if (open && isValidSection(initialSection)) {
-      setActiveSectionState(initialSection);
+      // Don't navigate to releases if not admin
+      if (initialSection === "releases" && !isAdmin) {
+        setActiveSectionState("general");
+      } else {
+        setActiveSectionState(initialSection);
+      }
     }
-  }, [open, initialSection]);
+  }, [open, initialSection, isAdmin]);
 
   const setActiveSection = useCallback((section: SettingsSection | null) => {
     setActiveSectionState(section);
@@ -544,7 +413,7 @@ export function SettingsPane({
             )}
             <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               {activeSection !== null ? (
-                <span className="md:hidden">{SECTIONS.find((s) => s.id === activeSection)?.label ?? "Settings"}</span>
+                <span className="md:hidden">{sections.find((s) => s.id === activeSection)?.label ?? "Settings"}</span>
               ) : null}
               <span className={activeSection !== null ? "hidden md:inline" : ""}>Settings</span>
             </span>
@@ -558,7 +427,7 @@ export function SettingsPane({
           <div className="flex min-h-0 flex-1">
             {/* Desktop nav — always visible */}
             <nav className="hidden md:flex w-40 shrink-0 flex-col border-r border-border py-2">
-              {SECTIONS.map(({ id, label, icon: Icon }) => (
+              {sections.map(({ id, label, icon: Icon }) => (
                 <div
                   key={id}
                   onClick={() => setActiveSection(id)}
@@ -578,7 +447,7 @@ export function SettingsPane({
             {/* Mobile nav — section list, shown when no section selected */}
             {activeSection === null && (
               <nav className="flex flex-1 flex-col md:hidden">
-                {SECTIONS.map(({ id, label, icon: Icon }) => (
+                {sections.map(({ id, label, icon: Icon }) => (
                   <button
                     key={id}
                     onClick={() => setActiveSection(id)}
@@ -619,8 +488,8 @@ export function SettingsPane({
                 </div>
               )}
               {activeSection === "notifications" && <NotificationSettings />}
-              {activeSection === "updates" && <ReleaseManager />}
-              {activeSection === "about" && <AppSettings />}
+              {activeSection === "updates" && <UpdatesSection stream={releaseStream} />}
+              {activeSection === "releases" && isAdmin && <ReleasesAdmin stream={releaseStream} />}
             </div>
           </div>
         </DialogPrimitive.Content>

--- a/apps/web/src/hooks/use-release-stream.ts
+++ b/apps/web/src/hooks/use-release-stream.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { recordReleaseManagerPollFire } from "@/lib/energy-metrics";
+
+export type ReleaseVersionType = "patch" | "minor" | "major";
+export type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
+export type ReleaseJobType = "create" | "update";
+
+export type ReleaseChannel = "stable" | "latest";
+
+export type ReleaseInfo = {
+  currentTag: string | null;
+  channel: ReleaseChannel;
+  isAdmin: boolean;
+  latestTag: string | null;
+  updateAvailable: boolean;
+  latestRelease: { tag: string; publishedAt: string; url: string } | null;
+  unreleasedCount: number;
+  commits: Array<{ sha: string; subject: string }>;
+  refMissing?: boolean;
+};
+
+export type ReleaseStatus = {
+  tag: string | null;
+  deployedAt: string | null;
+};
+
+export type ReleaseJob = {
+  jobType: ReleaseJobType;
+  versionType: ReleaseVersionType | null;
+  phase: ReleasePhase;
+  startedAt: string;
+  log: string[];
+  runUrl: string | null;
+  tag: string | null;
+  error: string | null;
+};
+
+type ReleaseStreamEvent =
+  | { type: "snapshot"; job: ReleaseJob | null }
+  | { type: "log"; line: string }
+  | { type: "log.replace"; line: string }
+  | { type: "log.rewind"; count: number }
+  | { type: "phase"; phase: ReleasePhase; error?: string }
+  | { type: "runUrl"; url: string }
+  | { type: "tag"; tag: string };
+
+export type UseReleaseStreamResult = {
+  status: ReleaseStatus | null;
+  job: ReleaseJob | null;
+  postRestartPolling: boolean;
+  connectStream: () => void;
+  fetchStatus: () => Promise<void>;
+  setJob: React.Dispatch<React.SetStateAction<ReleaseJob | null>>;
+};
+
+export function useReleaseStream(): UseReleaseStreamResult {
+  const [status, setStatus] = useState<ReleaseStatus | null>(null);
+  const [job, setJob] = useState<ReleaseJob | null>(null);
+  const [postRestartPolling, setPostRestartPolling] = useState(false);
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const healthPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/release/status");
+      if (res.ok) setStatus((await res.json()) as ReleaseStatus);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { void fetchStatus(); }, [fetchStatus]);
+
+  const startHealthPoll = useCallback((expectedTag: string | null) => {
+    setPostRestartPolling(true);
+    if (healthPollRef.current) clearInterval(healthPollRef.current);
+
+    healthPollRef.current = setInterval(async () => {
+      if (document.hidden) return;
+      recordReleaseManagerPollFire();
+      try {
+        const res = await fetch("/api/v1/release/status");
+        if (res.ok) {
+          const data = (await res.json()) as ReleaseStatus;
+          if (data.tag && data.tag === expectedTag) {
+            clearInterval(healthPollRef.current!);
+            healthPollRef.current = null;
+            setPostRestartPolling(false);
+            setStatus(data);
+            setJob((prev) => prev ? { ...prev, phase: "done", tag: data.tag } : prev);
+            setTimeout(() => window.location.reload(), 1500);
+          }
+        }
+      } catch { /* server still down */ }
+    }, 2000);
+  }, []);
+
+  const connectStream = useCallback(() => {
+    eventSourceRef.current?.close();
+    const es = new EventSource("/api/v1/release/stream");
+    eventSourceRef.current = es;
+
+    es.onmessage = (e) => {
+      const event = JSON.parse(e.data as string) as ReleaseStreamEvent;
+      if (event.type === "snapshot") {
+        setJob(event.job);
+        return;
+      }
+      setJob((prev) => {
+        if (!prev) return prev;
+        if (event.type === "log") return { ...prev, log: [...prev.log, event.line] };
+        if (event.type === "log.rewind") {
+          return { ...prev, log: prev.log.slice(0, -event.count) };
+        }
+        if (event.type === "log.replace") {
+          const updated = [...prev.log];
+          if (updated.length > 0) {
+            updated[updated.length - 1] = event.line;
+          } else {
+            updated.push(event.line);
+          }
+          return { ...prev, log: updated };
+        }
+        if (event.type === "phase") return { ...prev, phase: event.phase, error: event.error ?? prev.error };
+        if (event.type === "runUrl") return { ...prev, runUrl: event.url };
+        if (event.type === "tag") return { ...prev, tag: event.tag };
+        return prev;
+      });
+    };
+
+    es.onerror = () => {
+      setJob((prev) => {
+        if (prev?.jobType === "update" && (prev.phase === "restarting" || prev.phase === "deploying")) {
+          startHealthPoll(prev.tag);
+          return { ...prev, phase: "restarting" };
+        }
+        return prev;
+      });
+      es.close();
+      eventSourceRef.current = null;
+    };
+  }, [startHealthPoll]);
+
+  useEffect(() => {
+    connectStream();
+    return () => {
+      eventSourceRef.current?.close();
+      if (healthPollRef.current) clearInterval(healthPollRef.current);
+    };
+  }, [connectStream]);
+
+  return { status, job, postRestartPolling, connectStream, fetchStatus, setJob };
+}

--- a/bin/dispatch-deploy
+++ b/bin/dispatch-deploy
@@ -16,17 +16,21 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/deploy-common.sh"
 usage() {
   cat <<USAGE
 Usage: bin/dispatch-deploy <tag>
-       bin/dispatch-deploy --latest
+       bin/dispatch-deploy --latest [--channel <stable|latest>]
 
 Checks out a verified release tag in the server directory, builds, reloads
 the launchd service, and verifies Dispatch comes back up healthy.
 
 On failure, attempts automatic rollback to the previously deployed tag.
 
+Options:
+  --channel <stable|latest>  Release channel filter for --latest (default: stable)
+
 Examples:
-  bin/dispatch-deploy v0.2.0    # deploy a specific tag
-  bin/dispatch-deploy --latest  # deploy the latest tag
-  bin/dispatch-deploy v0.1.0    # rollback to a previous tag
+  bin/dispatch-deploy v0.2.0                    # deploy a specific tag
+  bin/dispatch-deploy --latest                  # deploy latest stable tag
+  bin/dispatch-deploy --latest --channel latest # deploy latest tag (including pre-releases)
+  bin/dispatch-deploy v0.1.0                    # rollback to a previous tag
 USAGE
 }
 
@@ -120,14 +124,30 @@ current_tag() {
 
 resolve_tag() {
   local tag="$1"
+  local channel="${2:-stable}"
   if [[ "$tag" == "--latest" ]]; then
     git -C "$SERVER_DIR" fetch --tags --quiet
-    tag=$(git -C "$SERVER_DIR" tag --sort=-version:refname | grep '^v' | head -1)
+    local gh_available=false
+    # Try channel-aware resolution via gh CLI
+    if command -v gh &>/dev/null; then
+      gh_available=true
+      local gh_args=("release" "list" "--repo" "$REPO" "--limit" "1" "--json" "tagName" "--jq" ".[0].tagName")
+      if [[ "$channel" == "stable" ]]; then
+        gh_args+=("--exclude-pre-releases")
+      fi
+      tag=$(gh "${gh_args[@]}" 2>/dev/null || echo "")
+    fi
+    # Only fall back to git tags if gh CLI is unavailable (not installed
+    # or not authenticated). If gh ran successfully but returned no results,
+    # that means no release matches the channel — don't bypass the filter.
+    if [[ -z "$tag" && "$gh_available" == "false" ]]; then
+      tag=$(git -C "$SERVER_DIR" tag --sort=-version:refname | grep '^v' | head -1)
+    fi
     if [[ -z "$tag" ]]; then
-      echo "error: no release tags found" >&2
+      echo "error: no release tags found for channel '$channel'" >&2
       exit 1
     fi
-    echo "resolved latest tag: $tag" >&2
+    echo "resolved latest tag: $tag (channel: $channel)" >&2
   fi
   echo "$tag"
 }
@@ -274,7 +294,17 @@ If you can fix the issue, do so and redeploy with: bin/dispatch-deploy $tag"
 }
 
 main() {
-  local tag="${1:-}"
+  local tag=""
+  local channel="stable"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --channel) channel="$2"; shift 2 ;;
+      --help|-h) usage; exit 0 ;;
+      *) tag="$1"; shift ;;
+    esac
+  done
+
   if [[ -z "$tag" ]]; then
     usage
     exit 1
@@ -295,7 +325,7 @@ main() {
   echo "==> fetching tags"
   git -C "$SERVER_DIR" fetch --tags --quiet
 
-  tag=$(resolve_tag "$tag")
+  tag=$(resolve_tag "$tag" "$channel")
 
   if ! git -C "$SERVER_DIR" rev-parse "$tag" >/dev/null 2>&1; then
     echo "error: tag '$tag' not found" >&2

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -24,16 +24,16 @@ test.describe("Settings pane", () => {
     await expect(generalNav).not.toBeVisible({ timeout: 3_000 });
   });
 
-  test("shows version metadata in the App section", async ({ page }) => {
+  test("shows version metadata in the Updates section", async ({ page }) => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByRole("navigation").getByText("About", { exact: true }).click();
+    await page.getByRole("navigation").getByText("Updates", { exact: true }).click();
 
-    await expect(page.getByTestId("app-version-card")).toBeVisible();
-    await expect(page.getByTestId("app-version-semver")).not.toHaveText("");
-    await expect(page.getByTestId("app-version-git-sha")).not.toHaveText("");
-    await expect(page.getByTestId("app-version-release-notes")).not.toHaveText("");
+    // Version info is displayed in the Updates section
+    await expect(page.getByText("Current version")).toBeVisible();
+    await expect(page.getByText("Release tag")).toBeVisible();
+    await expect(page.getByText("Release channel")).toBeVisible();
   });
 
   test("agent type settings filter the create-agent dialog", async ({ page }) => {


### PR DESCRIPTION
## Summary
- All new GitHub releases are created as pre-releases by default (`--prerelease` flag in workflow)
- Each instance picks a release channel (stable/latest) that controls which versions appear when checking for updates
- Admins can promote pre-releases to stable via a new Releases section in settings
- Settings UI restructured: merged About into Updates, added admin-only Releases section

## Changes

**Backend**
- New endpoints: `GET/POST /release/channel`, `POST /release/promote`, `GET /releases`, `GET /release/admin-check`
- `/release/info` now filters by channel using `gh release list` (single call derives both channel-filtered and absolute latest tags)
- `parseGhJson()` helper for safer gh CLI output parsing
- Semver regex validation on tag inputs

**Deploy**
- `dispatch-deploy` accepts `--channel <stable|latest>` flag (defaults to stable)
- Git-tag fallback only activates when `gh` is unavailable, not when it returns empty results

**Frontend**
- `UpdatesSection`: version info, collapsible release notes, channel selector, update flow, reload
- `ReleasesAdmin` (admin-only): unreleased commits, create release, recent releases list with promote buttons
- Shared `useReleaseStream` hook for SSE connection + job state
- Shared `PhaseProgress` and `OperationLog` components
- Takeover pattern: sections switch to side-by-side log view during operations

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — production build passes
- [x] `pnpm run test` — 239 unit tests pass
- [x] `pnpm run test:e2e` — 96 E2E tests pass
- [x] Playwright UI validation: Updates and Releases sections render correctly
- [ ] After merge: verify first release is created as pre-release on GitHub
- [ ] Verify promote button flips pre-release flag
- [ ] Verify stable-channel instance only sees promoted releases