### PR TITLE
docs: update for recent features and fix stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,16 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `dispatch_get_feedback` | Retrieve feedback findings for review |
 | `dispatch_resolve_feedback` | Mark a feedback item as fixed or ignored |
 | `dispatch_launch_persona` | Launch a persona child agent for automated review |
+| `dispatch_notify` | Send a Slack notification from the agent (requires webhook configured) |
 | `create_pr` | Create a GitHub pull request |
 | `get_pr_status` | Check PR CI status and reviews |
+| `get_activity_summary` | Summarize agent activity over a time range |
+| `get_agent_history` | Get detailed agent session history |
+| `get_feedback_summary` | Aggregate persona review feedback for pattern detection |
 
 Persona agents additionally get: `review_status`, `get_parent_context`.
 
-Job agents additionally get: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`.
+Job agents additionally get: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`, `dispatch_notify`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`.
 
 Repos can define custom tools in `.dispatch/tools.json` — these are exposed to agents with a `repo_` prefix.
 

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -274,6 +274,11 @@ Query params: `project`, `type`, `sort` (`recent` | `oldest`), `limit`, `offset`
 |--------|------|-------------|
 | GET | `/release/status` | Current deployed release tag and timestamp |
 | GET | `/release/info` | Latest available version and unreleased commits |
+| GET | `/release/channel` | Get current release channel (stable or latest) |
+| POST | `/release/channel` | Set release channel |
+| GET | `/release/admin-check` | Check if current instance is a release admin |
+| POST | `/release/promote` | Promote a pre-release to stable (admin only) |
+| GET | `/releases` | List recent GitHub releases |
 | POST | `/release` | Trigger new release (`versionType`: major/minor/patch) |
 | POST | `/release/update` | Update to a specific release tag |
 | GET | `/release/stream` | SSE stream for release operation progress |

--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -6,6 +6,7 @@
 - `running`
 - `stopping`
 - `stopped`
+- `archiving` (async cleanup during deletion — worktree check, cleanup, finalization)
 - `error`
 - `unknown` (transient reconciliation state after restart)
 
@@ -19,7 +20,11 @@
 - `running -> stopping -> stopped`
 - `running -> error` if stop command fails and process remains inconsistent
 
-3. Restart backend reconciliation
+3. Delete
+- `running|stopped -> archiving -> (soft deleted)` via archive phases: `stopping` → `worktree-check` → `worktree-cleanup` → `finalizing`
+- Returns HTTP 202 immediately; cleanup runs in the background
+
+4. Restart backend reconciliation
 - `unknown -> running` if tmux session exists
 - `unknown -> stopped` if session absent
 

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -81,6 +81,12 @@ The **release workflow** (GitHub Actions):
 ```bash
 # Deploy a specific tag (also used for rollback)
 bin/dispatch-deploy v1.2.3
+
+# Deploy the latest stable release
+bin/dispatch-deploy --latest
+
+# Deploy the latest release from the "latest" channel (includes pre-releases)
+bin/dispatch-deploy --latest --channel latest
 ```
 
 `bin/dispatch-deploy` operates on `~/.dispatch/server/` and:
@@ -154,6 +160,8 @@ Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 | `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
 | `AUTH_TOKEN` | — | API authentication token for MCP endpoints (generate with `openssl rand -hex 32`) |
 | `MEDIA_ROOT` | `~/.dispatch/media` | File upload storage path |
+| `TLS_CERT` | — | Path to TLS certificate file (enables HTTPS when both cert and key are set) |
+| `TLS_KEY` | — | Path to TLS private key file |
 
 Changes to `.env` require a service restart to take effect.
 

--- a/docs/14-theming.md
+++ b/docs/14-theming.md
@@ -5,16 +5,16 @@ Dispatch supports multiple color themes. Themes are defined as sets of CSS custo
 ## Architecture overview
 
 ```
-web/src/index.css          ← Theme CSS variable definitions (:root + [data-theme="..."])
-web/tailwind.config.ts     ← Maps CSS vars to Tailwind color utilities
-web/src/hooks/use-theme.ts ← React hook + theme registry (ThemeId, THEMES array)
-web/src/components/app/settings-pane.tsx ← Appearance UI (theme picker)
-web/index.html             ← Inline script for flash-free theme on load
+apps/web/src/index.css          ← Theme CSS variable definitions (:root + [data-theme="..."])
+apps/web/tailwind.config.ts     ← Maps CSS vars to Tailwind color utilities
+apps/web/src/hooks/use-theme.ts ← React hook + theme registry (ThemeId, THEMES array)
+apps/web/src/components/app/settings-pane.tsx ← Appearance UI (theme picker)
+apps/web/index.html             ← Inline script for flash-free theme on load
 ```
 
 ## CSS custom properties
 
-All theme colors live in `web/src/index.css`. The default theme is defined on `:root`. Additional themes use `[data-theme="<id>"]` selectors.
+All theme colors live in `apps/web/src/index.css`. The default theme is defined on `:root`. Additional themes use `[data-theme="<id>"]` selectors.
 
 ### Base tokens (shadcn/ui standard)
 
@@ -64,7 +64,7 @@ All values use **bare HSL components** without the `hsl()` wrapper — this allo
 
 ## Tailwind integration
 
-`web/tailwind.config.ts` maps CSS vars to Tailwind utilities. The status colors use `<alpha-value>` for opacity support:
+`apps/web/tailwind.config.ts` maps CSS vars to Tailwind utilities. The status colors use `<alpha-value>` for opacity support:
 
 ```ts
 status: {
@@ -90,7 +90,7 @@ The `surface` and `terminal-bg` colors are also available as `bg-surface` and `b
 
 ### Step 1: Define the CSS variables
 
-Add a new `[data-theme="your-theme-id"]` block in `web/src/index.css`. You must define **every** variable listed above. Copy an existing theme block as a starting point:
+Add a new `[data-theme="your-theme-id"]` block in `apps/web/src/index.css`. You must define **every** variable listed above. Copy an existing theme block as a starting point:
 
 ```css
 [data-theme="midnight"] {
@@ -178,8 +178,8 @@ That's it — the theme picker, localStorage persistence, flash-free loading, an
 
 | File | What to edit |
 |---|---|
-| `web/src/index.css` | Add `[data-theme="..."]` CSS variable block |
-| `web/src/hooks/use-theme.ts` | Add to `ThemeId` type and `THEMES` array |
-| `web/tailwind.config.ts` | Only if adding new semantic color tokens (rarely needed) |
-| `web/src/components/app/settings-pane.tsx` | Only if changing the picker UI itself |
-| `web/index.html` | Only if changing the flash-prevention script |
+| `apps/web/src/index.css` | Add `[data-theme="..."]` CSS variable block |
+| `apps/web/src/hooks/use-theme.ts` | Add to `ThemeId` type and `THEMES` array |
+| `apps/web/tailwind.config.ts` | Only if adding new semantic color tokens (rarely needed) |
+| `apps/web/src/components/app/settings-pane.tsx` | Only if changing the picker UI itself |
+| `apps/web/index.html` | Only if changing the flash-prevention script |


### PR DESCRIPTION
## Summary

Audited all documentation against the current codebase and updated stale or missing content.

### Files updated

- **README.md** — Added 4 missing MCP tools to the tools table: `dispatch_notify`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`. Updated job agent tool list to include analytics and notification tools.

- **docs/03-api-spec.md** — Added 5 missing release management endpoints: `GET/POST /release/channel`, `GET /release/admin-check`, `POST /release/promote`, `GET /releases`. These were added in the release channels feature (#290).

- **docs/04-agent-lifecycle.md** — Added `archiving` state and archive phases (`stopping` → `worktree-check` → `worktree-cleanup` → `finalizing`) for async agent deletion. Added delete transition documentation.

- **docs/10-operations-runbook.md** — Added `--latest` and `--channel` flag examples to the deploy section. Added `TLS_CERT` and `TLS_KEY` to the configuration table.

- **docs/14-theming.md** — Fixed all file paths from `web/src/` shorthand to full monorepo paths `apps/web/src/` (architecture overview, inline references, and file reference table).

### Not changed (verified accurate)

- **CLAUDE.md** — Project structure tree and all referenced scripts/paths are correct.
- **docs/11-backend-compatibility-checklist.md** — Guidelines doc, still accurate.
- **docs/12-new-machine-setup.md** — Setup instructions verified against current bin scripts.
- **docs/15-personas-and-feedback.md** — Matches current persona/feedback implementation.
- **docs/16-notifications.md** — Matches current notification system.

### Assessment

Docs were mostly up-to-date. The main gaps were from three recent features that added new MCP tools and API endpoints (dispatch_notify, analytics tools, release channels) without corresponding doc updates. The theming doc had shorthand paths that didn't match the monorepo layout. No docs needed deletion — all existing docs describe current features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)