### PR TITLE
Simplify app layout and include uncommitted persona diffs

### DIFF
--- a/apps/server/src/personas/review-diff.ts
+++ b/apps/server/src/personas/review-diff.ts
@@ -1,0 +1,75 @@
+type RunCommandResult = {
+  stdout: string;
+};
+
+type RunCommandFn = (
+  command: string,
+  args: string[],
+  options: { cwd: string }
+) => Promise<RunCommandResult>;
+
+function trimTrailingWhitespace(value: string): string {
+  return value.replace(/\s+$/u, "");
+}
+
+export async function buildPersonaReviewDiff(
+  cwd: string,
+  runCommand: RunCommandFn
+): Promise<string> {
+  let baseBranch = "main";
+  let baseBranchDetected = true;
+
+  try {
+    const headRef = await runCommand(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+      { cwd }
+    );
+    baseBranch = headRef.stdout.trim().replace(/^origin\//, "");
+  } catch {
+    baseBranchDetected = false;
+  }
+
+  try {
+    const [committedResult, uncommittedResult, untrackedResult] = await Promise.all([
+      runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd }),
+      runCommand("git", ["diff", "HEAD"], { cwd }),
+      runCommand("git", ["ls-files", "--others", "--exclude-standard"], { cwd }),
+    ]);
+
+    const committedDiff = trimTrailingWhitespace(committedResult.stdout);
+    const uncommittedDiff = trimTrailingWhitespace(uncommittedResult.stdout);
+    const untrackedFiles = untrackedResult.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const sections: string[] = [];
+
+    if (!baseBranchDetected) {
+      sections.push(
+        `(Note: base branch detection failed; committed diff was generated against "${baseBranch}". If this looks wrong, the repo may use a different default branch.)`
+      );
+    }
+
+    if (committedDiff) {
+      sections.push(`### Committed changes since ${baseBranch}\n${committedDiff}`);
+    }
+
+    if (uncommittedDiff) {
+      sections.push(`### Uncommitted working tree changes\n${uncommittedDiff}`);
+    }
+
+    if (untrackedFiles.length > 0) {
+      sections.push(`### Untracked files\n${untrackedFiles.map((file) => `- ${file}`).join("\n")}`);
+    }
+
+    if (sections.length === 0) {
+      return "(no committed or uncommitted changes detected)";
+    }
+
+    return sections.join("\n\n");
+  } catch {
+    return "(unable to generate diff)";
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -38,6 +38,7 @@ try {
 import { AgentError, AgentManager } from "./agents/manager.js";
 import type { AgentGitContext, AgentRecord, FeedbackRecord } from "./agents/manager.js";
 import { loadPersonas, loadPersonaBySlug, assemblePersonaPrompt } from "./personas/loader.js";
+import { buildPersonaReviewDiff } from "./personas/review-diff.js";
 import {
   isPasswordSet,
   setPassword,
@@ -4259,30 +4260,7 @@ async function mcpLaunchPersona(
     throw new Error(`Persona "${opts.persona}" not found in .dispatch/personas/.`);
   }
 
-  // Generate git diff for context — detect the base branch rather than assuming main
-  let diff = "";
-  try {
-    const { runCommand } = await import("@dispatch/shared/lib/run-command.js");
-    let baseBranch = "main";
-    let baseBranchDetected = true;
-    try {
-      const headRef = await runCommand(
-        "git", ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
-        { cwd: parentCwd }
-      );
-      // Returns e.g. "origin/main" — strip the remote prefix
-      baseBranch = headRef.stdout.trim().replace(/^origin\//, "");
-    } catch {
-      baseBranchDetected = false;
-    }
-    const diffResult = await runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd: parentCwd });
-    diff = diffResult.stdout;
-    if (!baseBranchDetected && !diff.trim()) {
-      diff = `(Note: base branch detection failed; diff was generated against "${baseBranch}". If this looks wrong, the repo may use a different default branch.)`;
-    }
-  } catch {
-    diff = "(unable to generate diff)";
-  }
+  const diff = await buildPersonaReviewDiff(parentCwd, runCommand);
 
   const prompt = assemblePersonaPrompt(persona, opts.context, diff);
 

--- a/apps/server/test/persona-review-diff.test.ts
+++ b/apps/server/test/persona-review-diff.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPersonaReviewDiff } from "../src/personas/review-diff.js";
+
+describe("buildPersonaReviewDiff", () => {
+  it("includes committed and uncommitted changes", async () => {
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
+        return { stdout: "origin/main\n" };
+      }
+      if (key === "diff main...HEAD") {
+        return { stdout: "diff --git a/a.ts b/a.ts\n" };
+      }
+      if (key === "diff HEAD") {
+        return { stdout: "diff --git a/b.ts b/b.ts\n" };
+      }
+      if (key === "ls-files --others --exclude-standard") {
+        return { stdout: "" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    };
+
+    const result = await buildPersonaReviewDiff("/repo", runCommand);
+
+    expect(result).toContain("### Committed changes since main");
+    expect(result).toContain("diff --git a/a.ts b/a.ts");
+    expect(result).toContain("### Uncommitted working tree changes");
+    expect(result).toContain("diff --git a/b.ts b/b.ts");
+  });
+
+  it("includes untracked files in the review context", async () => {
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
+        return { stdout: "origin/main\n" };
+      }
+      if (key === "diff main...HEAD" || key === "diff HEAD") {
+        return { stdout: "" };
+      }
+      if (key === "ls-files --others --exclude-standard") {
+        return { stdout: "new-file.ts\nnotes.md\n" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    };
+
+    const result = await buildPersonaReviewDiff("/repo", runCommand);
+
+    expect(result).toContain("### Untracked files");
+    expect(result).toContain("- new-file.ts");
+    expect(result).toContain("- notes.md");
+  });
+
+  it("notes when base branch detection fails", async () => {
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
+        throw new Error("no origin head");
+      }
+      if (key === "diff main...HEAD" || key === "diff HEAD" || key === "ls-files --others --exclude-standard") {
+        return { stdout: "" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    };
+
+    const result = await buildPersonaReviewDiff("/repo", runCommand);
+
+    expect(result).toContain('base branch detection failed; committed diff was generated against "main"');
+  });
+
+  it("returns a fallback when no changes are detected", async () => {
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
+        return { stdout: "origin/main\n" };
+      }
+      if (key === "diff main...HEAD" || key === "diff HEAD" || key === "ls-files --others --exclude-standard") {
+        return { stdout: "" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    };
+
+    const result = await buildPersonaReviewDiff("/repo", runCommand);
+
+    expect(result).toBe("(no committed or uncommitted changes detected)");
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";
+import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
 import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom, baseBranchByCwdAtom } from "@/lib/store";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
-import { AppHeader } from "@/components/app/app-header";
 import { ActivityPane } from "@/components/app/activity-pane";
 import { DocsPane } from "@/components/app/docs-pane";
 import { JobsPane } from "@/components/app/jobs-pane";
@@ -15,7 +15,6 @@ import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
 import { MediaLightbox } from "@/components/app/media-lightbox";
 import { MediaSidebar, MediaSidebarContent } from "@/components/app/media-sidebar";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
-import { StatusFooter } from "@/components/app/status-footer";
 import { TerminalPane } from "@/components/app/terminal-pane";
 import { type FeedbackDetailState, FeedbackDetailPanel, ReviewSummaryPanel } from "@/components/app/feedback-panel";
 import {
@@ -39,6 +38,7 @@ import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { AGENT_TYPES, type AgentType, isAgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
+import { Button } from "@/components/ui/button";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
@@ -567,12 +567,12 @@ export function DashboardLayout(): JSX.Element {
             className={cn(
               "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",
               jobsOpen
-                ? "grid-rows-[minmax(0,1fr)_auto]"
+                ? "grid-rows-[minmax(0,1fr)]"
                 : isMobile
-                ? "grid-rows-[auto_1fr_auto_auto]"
+                ? "grid-rows-[minmax(0,1fr)_auto]"
                 : feedbackDetail
-                  ? "grid-rows-[auto_1fr_1fr_auto]"
-                  : "grid-rows-[auto_1fr_0fr_auto]"
+                  ? "grid-rows-[minmax(0,1fr)_minmax(0,1fr)]"
+                  : "grid-rows-[minmax(0,1fr)_0fr]"
             )}
             onTransitionEnd={(e) => {
               if (e.propertyName === "grid-template-rows" && !feedbackDetail) {
@@ -580,19 +580,6 @@ export function DashboardLayout(): JSX.Element {
               }
             }}
           >
-            {!jobsOpen ? (
-              <AppHeader
-                leftOpen={leftPanelOpen}
-                mediaOpen={mediaPanelOpen}
-                isMobile={isMobile}
-                showReconnectIndicator={connState === "reconnecting"}
-                hasActiveAgent={hasActiveAgent}
-                unseenMediaCount={unseenMediaCount}
-                setLeftOpen={handleSetLeftPanelOpen}
-                setMediaOpen={handleSetMediaPanelOpen}
-              />
-            ) : null}
-
             {jobsOpen ? (
               <JobsPane
                 open={true}
@@ -600,26 +587,68 @@ export function DashboardLayout(): JSX.Element {
                 agents={agents}
                 onOpenAgent={attachToAgent}
                 enabledAgentTypes={enabledAgentTypes}
-                footer={
-                  <StatusFooter
-                    apiState={apiState}
-                    dbState={dbState}
-                    serviceDotClass={serviceDotClass}
-                  />
-                }
               />
             ) : (
-              <AgentsWorkspace onUnmount={handleAgentsWorkspaceUnmount}>
-                <TerminalPane
-                  isAttached={isAttached}
-                  connState={connState}
-                  statusMessage={statusMessage}
-                  terminalMode={terminalMode}
-                  terminalPlaceholderMessage={terminalPlaceholderMessage}
-                  terminalHostRef={terminalHostRef}
-                  archivePhase={selectedAgent?.status === "archiving" ? selectedAgent.archivePhase : null}
-                />
-              </AgentsWorkspace>
+              <div className="relative min-h-0 min-w-0 pb-14 pt-14">
+                {!leftPanelOpen ? (
+                  <div className="pointer-events-none absolute left-3 top-3 z-10">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="pointer-events-auto"
+                      onClick={() => handleSetLeftPanelOpen(true)}
+                      title="Open agent sidebar"
+                    >
+                      <PanelRightOpen className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ) : null}
+                {focusedAgent?.name ? (
+                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
+                    <div
+                      data-testid="current-session-name"
+                      className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
+                    >
+                      {focusedAgent.name}
+                    </div>
+                  </div>
+                ) : null}
+                {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
+                  <div className="pointer-events-none absolute right-3 top-3 z-10">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="pointer-events-auto relative"
+                      onClick={() => handleSetMediaPanelOpen(true)}
+                      title="Open media sidebar"
+                      data-testid="toggle-media-sidebar"
+                    >
+                      <PanelLeftOpen className="h-4 w-4" />
+                      {unseenMediaCount > 0 ? (
+                        <span className="absolute -right-1.5 -top-1.5 min-w-5 rounded-full border border-border bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+                          {unseenMediaCount}
+                        </span>
+                      ) : null}
+                    </Button>
+                  </div>
+                ) : null}
+                {connState === "reconnecting" ? (
+                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
+                    <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
+                  </div>
+                ) : null}
+                <AgentsWorkspace onUnmount={handleAgentsWorkspaceUnmount}>
+                  <TerminalPane
+                    isAttached={isAttached}
+                    connState={connState}
+                    statusMessage={statusMessage}
+                    terminalMode={terminalMode}
+                    terminalPlaceholderMessage={terminalPlaceholderMessage}
+                    terminalHostRef={terminalHostRef}
+                    archivePhase={selectedAgent?.status === "archiving" ? selectedAgent.archivePhase : null}
+                  />
+                </AgentsWorkspace>
+              </div>
             )}
 
             {!isMobile && !jobsOpen ? (
@@ -653,14 +682,6 @@ export function DashboardLayout(): JSX.Element {
             ) : null}
 
             {isMobile && !jobsOpen ? <MobileTerminalToolbar onSendInput={sendTerminalInput} ctrlPendingRef={ctrlPendingRef} /> : null}
-
-            {!jobsOpen ? (
-              <StatusFooter
-                apiState={apiState}
-                dbState={dbState}
-                serviceDotClass={serviceDotClass}
-              />
-            ) : null}
           </div>
         </main>
 
@@ -821,6 +842,9 @@ export function DashboardLayout(): JSX.Element {
         clearIconColorError={clearIconColorError}
         enabledAgentTypes={enabledAgentTypes}
         onEnabledAgentTypesChange={setEnabledAgentTypes}
+        apiState={apiState}
+        dbState={dbState}
+        serviceDotClass={serviceDotClass}
         initialSection={settingsSection}
         onSectionChange={(section) => navigate(section ? `/settings/${section}` : "/settings", { replace: true })}
       />

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -211,7 +211,7 @@ export function MediaSidebarContent({
   return (
     <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
       {/* Tab header */}
-      <div className="flex min-h-14 items-center border-b-2 border-border pt-[env(safe-area-inset-top)]">
+      <div className="flex min-h-14 items-center pt-[env(safe-area-inset-top)]">
         <div className="flex flex-1">
           <button
             onClick={() => setActiveTab("pins")}

--- a/apps/web/src/components/app/service-status.tsx
+++ b/apps/web/src/components/app/service-status.tsx
@@ -11,8 +11,11 @@ type ServiceStatusProps = {
 
 export function ServiceStatus({ icon, label, value, dotClass }: ServiceStatusProps): JSX.Element {
   return (
-    <div data-testid={`service-status-${label.toLowerCase()}`} className="flex items-center gap-2">
-      {icon}
+    <div
+      data-testid={`service-status-${label.toLowerCase()}`}
+      className="grid grid-cols-[0.875rem_2rem_0.625rem_minmax(0,1fr)] items-center gap-x-2"
+    >
+      <span className="flex h-3.5 w-3.5 items-center justify-center">{icon}</span>
       <span>{label}</span>
       <span data-testid={`service-dot-${label.toLowerCase()}`} className={cn("h-2.5 w-2.5 rounded-full", dotClass)} />
       <span className="hidden truncate uppercase sm:inline">{value}</span>

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ArrowDownToLine, ArrowLeft, Bell, ChevronRight, Package, Settings, Users, X } from "lucide-react";
+import { ArrowDownToLine, ArrowLeft, Bell, ChevronRight, Database, Package, Server, Settings, Users, X } from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { NotificationSettings } from "@/components/app/notification-settings";
 import { ReleasesAdmin } from "@/components/app/release-admin";
 import { UpdatesSection } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
+import { ServiceStatus } from "@/components/app/service-status";
+import { type ServiceState } from "@/components/app/types";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useReleaseStream } from "@/hooks/use-release-stream";
@@ -329,6 +331,9 @@ type SettingsPaneProps = {
   clearIconColorError: () => void;
   enabledAgentTypes: AgentType[];
   onEnabledAgentTypesChange: (agentTypes: AgentType[]) => void;
+  apiState: ServiceState;
+  dbState: ServiceState;
+  serviceDotClass: (state: ServiceState) => string;
   initialSection?: string;
   onSectionChange?: (section: string | null) => void;
 };
@@ -346,6 +351,9 @@ export function SettingsPane({
   clearIconColorError,
   enabledAgentTypes,
   onEnabledAgentTypesChange,
+  apiState,
+  dbState,
+  serviceDotClass,
   initialSection,
   onSectionChange,
 }: SettingsPaneProps): JSX.Element {
@@ -426,22 +434,33 @@ export function SettingsPane({
           {/* Body */}
           <div className="flex min-h-0 flex-1">
             {/* Desktop nav — always visible */}
-            <nav className="hidden md:flex w-40 shrink-0 flex-col border-r border-border py-2">
-              {sections.map(({ id, label, icon: Icon }) => (
-                <div
-                  key={id}
-                  onClick={() => setActiveSection(id)}
-                  className={cn(
-                    "flex cursor-pointer items-center gap-2.5 px-4 py-2.5 text-sm transition-colors",
-                    activeSection === id
-                      ? "bg-muted text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5 shrink-0" />
-                  {label}
+            <nav className="hidden w-48 shrink-0 flex-col border-r border-border py-2 md:flex">
+              <div>
+                {sections.map(({ id, label, icon: Icon }) => (
+                  <div
+                    key={id}
+                    onClick={() => setActiveSection(id)}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2.5 px-4 py-2.5 text-sm transition-colors",
+                      activeSection === id
+                        ? "bg-muted text-foreground"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5 shrink-0" />
+                    {label}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-auto border-t border-border px-4 pb-3 pt-4">
+                <div className="mb-3 text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                  System
                 </div>
-              ))}
+                <div className="space-y-2 text-xs text-muted-foreground">
+                  <ServiceStatus icon={<Server className="h-3.5 w-3.5" />} label="API" value={apiState} dotClass={serviceDotClass(apiState)} />
+                  <ServiceStatus icon={<Database className="h-3.5 w-3.5" />} label="DB" value={dbState} dotClass={serviceDotClass(dbState)} />
+                </div>
+              </div>
             </nav>
 
             {/* Mobile nav — section list, shown when no section selected */}
@@ -458,6 +477,15 @@ export function SettingsPane({
                     <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" />
                   </button>
                 ))}
+                <div className="mt-auto border-t border-border px-5 py-4">
+                  <div className="mb-3 text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                    System
+                  </div>
+                  <div className="space-y-3 text-xs text-muted-foreground">
+                    <ServiceStatus icon={<Server className="h-3.5 w-3.5" />} label="API" value={apiState} dotClass={serviceDotClass(apiState)} />
+                    <ServiceStatus icon={<Database className="h-3.5 w-3.5" />} label="DB" value={dbState} dotClass={serviceDotClass(dbState)} />
+                  </div>
+                </div>
               </nav>
             )}
 

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -6,16 +6,13 @@ test.describe("App shell", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("renders the main layout with a slim terminal header row", async ({
-    page,
-  }) => {
+  test("renders the main layout without dedicated header or footer chrome", async ({ page }) => {
     await loadApp(page);
 
     await expect(page.getByTestId("agent-sidebar")).toBeVisible();
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
-    await expect(page.getByTestId("status-footer")).toBeVisible();
-    await expect(page.getByTestId("app-header")).toBeVisible();
-    await expect(page.getByTestId("app-header-status")).toHaveCount(0);
+    await expect(page.getByTestId("status-footer")).toHaveCount(0);
+    await expect(page.getByTestId("app-header")).toHaveCount(0);
   });
 
   test("shows the empty-state prompt when no agent is selected", async ({ page }) => {
@@ -27,17 +24,20 @@ test.describe("App shell", () => {
     );
   });
 
-  test("status footer reports healthy API and DB", async ({ page }) => {
+  test("settings rail reports healthy API and DB", async ({ page }) => {
     await loadApp(page);
 
-    // Wait for health poll to succeed (the dots turn green = bg-emerald-500)
-    const apiDot = page.getByTestId("service-dot-api");
+    await page.getByTestId("settings-button").click();
+
+    const dialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(dialog).toBeVisible();
+
+    const apiDot = dialog.getByTestId("service-dot-api");
     await expect(apiDot).toBeVisible();
-    // The status text eventually shows "ok"
-    const apiStatus = page.getByTestId("service-status-api");
+    const apiStatus = dialog.getByTestId("service-status-api");
     await expect(apiStatus).toContainText("ok", { timeout: 10_000 });
 
-    const dbStatus = page.getByTestId("service-status-db");
+    const dbStatus = dialog.getByTestId("service-status-db");
     await expect(dbStatus).toContainText("ok", { timeout: 10_000 });
   });
 

--- a/e2e/energy-visibility.spec.ts
+++ b/e2e/energy-visibility.spec.ts
@@ -69,8 +69,9 @@ test.describe("Energy / visibility-aware pausing", () => {
     // data-hidden should be removed
     await expect(page.locator("html[data-hidden]")).not.toBeAttached();
 
-    // Health poll should resume — check API status still shows ok
-    const apiStatus = page.getByTestId("service-status-api");
+    // Health poll should resume — check API status in Settings still shows ok
+    await page.getByTestId("settings-button").click();
+    const apiStatus = page.getByRole("dialog", { name: "Settings" }).getByTestId("service-status-api");
     await expect(apiStatus).toContainText("ok", { timeout: 15_000 });
   });
 

--- a/e2e/header-overflow.spec.ts
+++ b/e2e/header-overflow.spec.ts
@@ -2,12 +2,12 @@ import { test, expect } from "@playwright/test";
 
 import { cleanupE2EAgents, createAgentViaAPI, loadApp, setAgentLatestEventViaAPI } from "./helpers";
 
-test.describe("Header overflow", () => {
+test.describe("Chrome overflow", () => {
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);
   });
 
-  test("long agent status messages do not appear inside the slim terminal header", async ({ page, request }) => {
+  test("long agent status messages do not recreate a dedicated header row", async ({ page, request }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
     });
@@ -22,23 +22,21 @@ test.describe("Header overflow", () => {
     await page.getByTestId(`agent-row-${agent.id}`).click();
 
     const dimensions = await page.evaluate(() => {
-      const header = document.querySelector("[data-testid='app-header']");
-      const statusText = document.querySelector("[data-testid='app-header-status']");
       const main = document.querySelector("main");
       return {
         viewportWidth: window.innerWidth,
         documentScrollWidth: document.documentElement.scrollWidth,
-        headerWidth: header?.getBoundingClientRect().width ?? 0,
         mainWidth: main?.getBoundingClientRect().width ?? 0,
-        statusNodeCount: statusText ? 1 : 0,
+        topPadding: Number.parseFloat(window.getComputedStyle(main ?? document.body).paddingTop || "0"),
+        headerNodeCount: document.querySelectorAll("[data-testid='app-header']").length,
       };
     });
 
-    await expect(page.getByTestId("app-header")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId("app-header-status")).toHaveCount(0);
+    await expect(page.getByTestId("app-header")).toHaveCount(0);
 
     expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
-    expect(dimensions.headerWidth).toBeLessThanOrEqual(dimensions.mainWidth);
-    expect(dimensions.statusNodeCount).toBe(0);
+    expect(dimensions.mainWidth).toBeGreaterThan(0);
+    expect(dimensions.topPadding).toBe(0);
+    expect(dimensions.headerNodeCount).toBe(0);
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -379,5 +379,5 @@ export async function loadApp(page: Page): Promise<void> {
   }
 
   await sidebar.waitFor({ state: "visible", timeout: 15_000 });
-  await page.getByTestId("status-footer").waitFor({ state: "visible", timeout: 10_000 });
+  await page.getByTestId("terminal-pane").waitFor({ state: "visible", timeout: 10_000 });
 }


### PR DESCRIPTION
## Summary
- simplify the main app shell by removing the center header/footer, moving health status into Settings, and refining the sidebar toggle/session-name strip
- align Settings system status rows and remove the right sidebar tab-header border
- fix persona review diff generation so review agents see committed changes, uncommitted worktree changes, and untracked files

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test
- pnpm run test:e2e