### PR TITLE
[codex] Add agent session rename MCP tool and harden scoped auth

### DIFF
--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -31,8 +31,14 @@ Your job is to review backend code changes for correctness, security vulnerabili
 ## Scope — IMPORTANT
 Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If a security concern existed before this diff, it is out of scope.
 
+Treat the supplied diff as the hard review boundary.
+- Do not audit unrelated files or adjacent subsystems just because they are security-sensitive.
+- Do not report repo-wide hardening ideas, existing authorization gaps, or legacy issues unless a changed line directly introduces, exposes, or materially worsens them.
+- If you inspect surrounding code for context, your final findings must still point back to the changed behavior in this diff.
+- If you find zero in-scope issues, approve the review instead of filling the report with unrelated observations.
+- In your final summary, mention only changed files or directly impacted downstream surfaces.
+
 ## How to review
 1. Read the diff carefully first to understand exactly what changed.
 2. Use `grep` and `read` to explore context around the changes.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
-

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -7,6 +7,7 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Pool } from "pg";
 
 import type { AppConfig } from "../config.js";
+import { createAgentMcpToken, createJobMcpToken } from "../auth.js";
 import { createGitWorktree, cleanupGitWorktree } from "@dispatch/shared/git/worktree.js";
 import { runCommand } from "@dispatch/shared/lib/run-command.js";
 import { loadRepoHooks } from "@dispatch/shared/mcp/repo-tools.js";
@@ -1706,6 +1707,9 @@ export class AgentManager {
     const envPrefix = envPrefixParts.join(" ");
     const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
     const dispatchMcpUrl = this.dispatchMcpUrl(agentId, jobRunId);
+    const dispatchMcpToken = jobRunId
+      ? createJobMcpToken(this.config.authToken, jobRunId, agentId)
+      : createAgentMcpToken(this.config.authToken, agentId);
     const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
     const { passthroughArgs, appendedSystemPrompt } = this.normalizeAgentArgsForType(type, args);
 
@@ -1716,7 +1720,7 @@ export class AgentManager {
             type: "http",
             url: dispatchMcpUrl,
             headers: {
-              Authorization: `Bearer ${this.config.authToken}`
+              Authorization: `Bearer ${dispatchMcpToken}`
             }
           }
         }
@@ -1758,7 +1762,7 @@ export class AgentManager {
       "-c",
       this.shellEscape(`mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`)
     ].join(" ");
-    const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${this.shellEscape(this.config.authToken)}`;
+    const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${this.shellEscape(dispatchMcpToken)}`;
     // Codex resume: `codex resume <sessionId>` with MCP flags
     if (resume && cliSessionId) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} resume ${this.shellEscape(cliSessionId)} ${codexMcpFlags}`;
@@ -2705,7 +2709,7 @@ export class AgentManager {
 
   private shouldSuggestSessionRename(
     agentName: string | null | undefined,
-    _agentId: string,
+    agentId: string,
     opts: { persona?: string | null; jobRunId?: string }
   ): boolean {
     if (opts.persona || opts.jobRunId) {
@@ -2713,7 +2717,7 @@ export class AgentManager {
     }
 
     const trimmed = agentName?.trim();
-    return !!trimmed && /^agent-[a-z0-9]{6}$/i.test(trimmed);
+    return trimmed === `agent-${agentId.slice(-6)}`;
   }
 
   private defaultMediaDir(agentId: string): string {
@@ -2953,10 +2957,13 @@ export class AgentManager {
     // Opencode: write opencode.json with the Dispatch MCP server config.
     if (agentType === "opencode") {
       const dispatchMcpUrl = this.dispatchMcpUrl(agentId, params.jobRunId);
+      const dispatchMcpToken = params.jobRunId
+        ? createJobMcpToken(authToken, params.jobRunId, agentId)
+        : createAgentMcpToken(authToken, agentId);
       const mcpEntry = JSON.stringify({
         type: "remote",
         url: dispatchMcpUrl,
-        headers: { Authorization: `Bearer ${authToken}` },
+        headers: { Authorization: `Bearer ${dispatchMcpToken}` },
       });
       lines.push(
         `# --- Configure opencode MCP ---`,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -319,6 +319,20 @@ export class AgentManager {
     return (result.rows[0] as AgentRecord | undefined) ?? null;
   }
 
+  async renameAgent(id: string, name: string): Promise<AgentRecord> {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      throw new AgentError("Agent name must not be empty.", 400);
+    }
+
+    await this.getRequiredAgent(id);
+    await this.pool.query(
+      `UPDATE agents SET name = $2, updated_at = NOW() WHERE id = $1`,
+      [id, trimmed]
+    );
+    return (await this.getAgent(id)) as AgentRecord;
+  }
+
   /** Harvest token usage for an agent, scoped to its CLI session if known. */
   async harvestAgentTokens(agent: AgentRecord): Promise<void> {
     await harvestTokenUsage(this.pool, {
@@ -415,7 +429,17 @@ export class AgentManager {
         await this.ensureNoExistingSession(tmuxSession);
 
         // Build the agent command that the setup script will exec into
-        const agentCommand = this.buildAgentCommand(type, agentArgs, mediaDir, tmuxSession, fullAccess, cliSessionId ?? undefined, false, input.jobRunId);
+        const agentCommand = this.buildAgentCommand(
+          type,
+          agentArgs,
+          mediaDir,
+          tmuxSession,
+          fullAccess,
+          cliSessionId ?? undefined,
+          false,
+          input.jobRunId,
+          this.shouldSuggestSessionRename(name, id, { persona: input.persona, jobRunId: input.jobRunId })
+        );
         const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
 
         // Generate a setup script that handles worktree creation, env copy,
@@ -553,6 +577,8 @@ export class AgentManager {
         tmuxSession,
         agent.cwd,
         agent.mediaDir ?? this.defaultMediaDir(id),
+        agent.name,
+        agent.persona,
         agent.type,
         agent.agentArgs ?? [],
         agent.fullAccess ?? false,
@@ -1476,6 +1502,8 @@ export class AgentManager {
     sessionName: string,
     cwd: string,
     mediaDir: string,
+    agentName: string,
+    persona: string | null,
     type: AgentType,
     agentArgs: string[],
     fullAccess: boolean,
@@ -1488,7 +1516,17 @@ export class AgentManager {
     }
 
     await mkdir(mediaDir, { recursive: true });
-    const agentCommand = this.buildAgentCommand(type, agentArgs, mediaDir, sessionName, fullAccess, cliSessionId, resume);
+    const agentCommand = this.buildAgentCommand(
+      type,
+      agentArgs,
+      mediaDir,
+      sessionName,
+      fullAccess,
+      cliSessionId,
+      resume,
+      undefined,
+      this.shouldSuggestSessionRename(agentName, agentId, { persona })
+    );
     const exitFile = `/tmp/dispatch_${sessionName}.exit`;
     const sessionLogFile = `/tmp/dispatch_setup_${agentId}.log`;
     const wrappedCommand = `bash -c 'exec 2> >(tee "${sessionLogFile}" >&2); ${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`;
@@ -1589,7 +1627,8 @@ export class AgentManager {
     fullAccess: boolean,
     cliSessionId?: string,
     resume?: boolean,
-    jobRunId?: string
+    jobRunId?: string,
+    suggestSessionRename?: boolean
   ): string {
     const agentId = this.agentIdFromSessionName(sessionName);
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
@@ -1599,6 +1638,9 @@ export class AgentManager {
       : `[dispatch:${agentId}] ` +
         "Dispatch startup rules: " +
         "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
+        (suggestSessionRename
+          ? "If your session still has the default generated name, update it to a short goal or topic using dispatch_rename_session. "
+          : "") +
         "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
         "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +
         "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
@@ -2659,6 +2701,19 @@ export class AgentManager {
       .replace(/^-|-$/g, "")
       .slice(0, 30);
     return `${prefix}_${agentId}_${slug}`;
+  }
+
+  private shouldSuggestSessionRename(
+    agentName: string | null | undefined,
+    _agentId: string,
+    opts: { persona?: string | null; jobRunId?: string }
+  ): boolean {
+    if (opts.persona || opts.jobRunId) {
+      return false;
+    }
+
+    const trimmed = agentName?.trim();
+    return !!trimmed && /^agent-[a-z0-9]{6}$/i.test(trimmed);
   }
 
   private defaultMediaDir(agentId: string): string {

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -13,6 +13,20 @@ function hashToken(token: string): string {
   return crypto.createHash("sha256").update(token).digest("hex");
 }
 
+function createMcpScopeToken(secret: string, scope: string): string {
+  const payload = Buffer.from(scope, "utf-8").toString("base64url");
+  const signature = crypto.createHmac("sha256", secret).update(scope).digest("base64url");
+  return `${payload}.${signature}`;
+}
+
+function validateMcpScopeToken(secret: string, token: string, expectedScope: string): boolean {
+  const expected = createMcpScopeToken(secret, expectedScope);
+  const actualBuffer = Buffer.from(token, "utf-8");
+  const expectedBuffer = Buffer.from(expected, "utf-8");
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
 export async function isPasswordSet(pool: Pool): Promise<boolean> {
   return (await getSetting(pool, "password_hash")) !== null;
 }
@@ -89,6 +103,22 @@ export async function getOrCreateAuthToken(pool: Pool): Promise<string> {
   const token = crypto.randomBytes(32).toString("hex");
   await setSetting(pool, "auth_token", token);
   return token;
+}
+
+export function createAgentMcpToken(secret: string, agentId: string): string {
+  return createMcpScopeToken(secret, `agent:${agentId}`);
+}
+
+export function validateAgentMcpToken(secret: string, token: string, agentId: string): boolean {
+  return validateMcpScopeToken(secret, token, `agent:${agentId}`);
+}
+
+export function createJobMcpToken(secret: string, runId: string, agentId: string): string {
+  return createMcpScopeToken(secret, `job:${runId}:${agentId}`);
+}
+
+export function validateJobMcpToken(secret: string, token: string, runId: string, agentId: string): boolean {
+  return validateMcpScopeToken(secret, token, `job:${runId}:${agentId}`);
 }
 
 /**

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -208,7 +208,7 @@ export class SlackNotifier {
     try {
       const level = input.level ?? "info";
       const cfg = LEVEL_CONFIG[level];
-      const agentName = agent.name || agent.id.slice(0, 8);
+      const agentName = sanitizeSlackMrkdwn(agent.name || agent.id.slice(0, 8));
 
       // Sanitize agent-provided content to prevent broadcast mentions
       // (<!channel>, <!here>, <!everyone>). Regular mrkdwn links are allowed.
@@ -311,7 +311,7 @@ export class SlackNotifier {
     event: { type: string; message: string },
     cfg: { emoji: string; verb: string; color: string }
   ): Promise<void> {
-    const agentName = agent.name || agent.id.slice(0, 8);
+    const agentName = sanitizeSlackMrkdwn(agent.name || agent.id.slice(0, 8));
     const branch = agent.gitContext?.branch;
     const elapsed = this.formatElapsed(agent.createdAt);
     const agentType = agent.type ? agent.type.charAt(0).toUpperCase() + agent.type.slice(1) : "Agent";

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -49,7 +49,9 @@ import {
   changePassword,
   cleanExpiredSessions,
   getOrCreateAuthToken,
-  getOrCreateCookieSecret
+  getOrCreateCookieSecret,
+  validateAgentMcpToken,
+  validateJobMcpToken
 } from "./auth.js";
 import { loadConfig } from "./config.js";
 import { createPool } from "./db/client.js";
@@ -1252,6 +1254,10 @@ async function registerRoutes() {
     const params = request.params as { runId?: string; agentId?: string };
     const runId = params.runId ?? "";
     const agentId = params.agentId ?? "";
+    const bearerToken = getBearerToken(request);
+    if (bearerToken && !validateJobMcpToken(config.authToken, bearerToken, runId, agentId)) {
+      return reply.code(403).send({ error: "Invalid MCP token for the requested job agent route." });
+    }
     const agent = await agentManager.getAgent(agentId);
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });
@@ -1298,6 +1304,10 @@ async function registerRoutes() {
   app.post("/api/mcp/:agentId", async (request, reply) => {
     const params = request.params as { agentId?: string };
     const agentId = params.agentId ?? "";
+    const bearerToken = getBearerToken(request);
+    if (bearerToken && !validateAgentMcpToken(config.authToken, bearerToken, agentId)) {
+      return reply.code(403).send({ error: "Invalid MCP token for the requested agent route." });
+    }
     const agent = await agentManager.getAgent(agentId);
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });
@@ -4210,6 +4220,14 @@ async function mcpRenameSession(
   const agent = await agentManager.renameAgent(agentId, name);
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
   return { id: agent.id, name: agent.name };
+}
+
+function getBearerToken(request: { headers: Record<string, unknown> }): string | null {
+  const authHeader = request.headers.authorization;
+  if (typeof authHeader !== "string" || !authHeader.startsWith("Bearer ")) {
+    return null;
+  }
+  return authHeader.slice(7);
 }
 
 async function mcpJobComplete(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1328,6 +1328,7 @@ async function registerRoutes() {
       worktreeRoot,
       sendNotify: mcpSendNotify,
       upsertEvent: mcpUpsertEvent,
+      renameSession: mcpRenameSession,
       shareMedia: mcpShareMedia,
       submitFeedback: mcpSubmitFeedback,
       launchPersona: mcpLaunchPersona,
@@ -4200,6 +4201,15 @@ async function mcpGetParentContext(
       createdAt: m.createdAt
     }))
   };
+}
+
+async function mcpRenameSession(
+  agentId: string,
+  name: string
+): Promise<{ id: string; name: string }> {
+  const agent = await agentManager.renameAgent(agentId, name);
+  uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+  return { id: agent.id, name: agent.name };
 }
 
 async function mcpJobComplete(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {

--- a/apps/server/test/auth.test.ts
+++ b/apps/server/test/auth.test.ts
@@ -14,6 +14,10 @@ import {
   cleanExpiredSessions,
   getOrCreateAuthToken,
   getOrCreateCookieSecret,
+  createAgentMcpToken,
+  validateAgentMcpToken,
+  createJobMcpToken,
+  validateJobMcpToken,
 } from "../src/auth.js";
 
 let pool: Pool;
@@ -137,5 +141,22 @@ describe("auth token and cookie secret", () => {
     const token = await getOrCreateAuthToken(pool);
     const secret = await getOrCreateCookieSecret(pool);
     expect(token).not.toBe(secret);
+  });
+
+  it("creates agent-scoped MCP tokens that only validate for that agent", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+    const token = createAgentMcpToken(secret, "agt_123456abcdef");
+
+    expect(validateAgentMcpToken(secret, token, "agt_123456abcdef")).toBe(true);
+    expect(validateAgentMcpToken(secret, token, "agt_otheragent")).toBe(false);
+  });
+
+  it("creates job-scoped MCP tokens that bind both run and agent", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+    const token = createJobMcpToken(secret, "run_123", "agt_123456abcdef");
+
+    expect(validateJobMcpToken(secret, token, "run_123", "agt_123456abcdef")).toBe(true);
+    expect(validateJobMcpToken(secret, token, "run_other", "agt_123456abcdef")).toBe(false);
+    expect(validateJobMcpToken(secret, token, "run_123", "agt_otheragent")).toBe(false);
   });
 });

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -174,6 +174,27 @@ describe("AgentManager", () => {
       expect(setupScript).toContain("mcp_servers.dispatch.bearer_token_env_var=");
       expect(setupScript).toContain("DISPATCH_AUTH_TOKEN=");
       expect(setupScript).toContain("do not start repo work or infer a task from branch/worktree context alone");
+      expect(setupScript).toContain("dispatch_rename_session");
+    });
+
+    it("should skip rename guidance when the user provided a custom name", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", type: "codex", name: "bug bash", useWorktree: false });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("dispatch_rename_session");
+    });
+
+    it("should skip rename guidance for persona agents", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        name: "security-review-123456",
+        persona: "security-review",
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("dispatch_rename_session");
     });
 
     it("should translate appended system prompts into a single Codex startup prompt", async () => {
@@ -308,6 +329,20 @@ describe("AgentManager", () => {
       expect(fetched).not.toBeNull();
       expect(fetched!.id).toBe(created.id);
       expect(fetched!.name).toBe("fetch-me");
+    });
+
+    it("should rename an agent", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+
+      const renamed = await manager.renameAgent(agent.id, "Investigate flaky e2e");
+
+      expect(renamed.name).toBe("Investigate flaky e2e");
+    });
+
+    it("should reject empty agent names when renaming", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+
+      await expect(manager.renameAgent(agent.id, "   ")).rejects.toThrow("Agent name must not be empty.");
     });
   });
 

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -22,6 +22,7 @@ vi.mock("@dispatch/shared/lib/run-command.js", () => ({
 
 // We need to dynamically import AgentManager AFTER the mock is in place
 const { AgentManager, AgentError } = await import("../../src/agents/manager.js");
+const { createAgentMcpToken } = await import("../../src/auth.js");
 const execFileAsync = promisify(execFile);
 
 let pool: Pool;
@@ -184,6 +185,13 @@ describe("AgentManager", () => {
       expect(setupScript).not.toContain("dispatch_rename_session");
     });
 
+    it("should skip rename guidance for custom names that resemble the default pattern", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", type: "codex", name: "agent-foobar", useWorktree: false });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("dispatch_rename_session");
+    });
+
     it("should skip rename guidance for persona agents", async () => {
       const agent = await manager.createAgent({
         cwd: "/tmp",
@@ -258,7 +266,7 @@ describe("AgentManager", () => {
         expect(config.mcp.dispatch).toEqual({
           type: "remote",
           url: `http://127.0.0.1:6767/api/mcp/${agent.id}`,
-          headers: { Authorization: "Bearer test-token" },
+          headers: { Authorization: `Bearer ${createAgentMcpToken("test-token", agent.id)}` },
         });
       } finally {
         await rm(tempDir, { recursive: true, force: true });

--- a/apps/server/test/slack-notifier.test.ts
+++ b/apps/server/test/slack-notifier.test.ts
@@ -282,6 +282,39 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     expect(messageText).toContain("&lt;!everyone&gt;");
   });
 
+  it("sanitizes renamed agent names in dispatch_notify payloads", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await notifier.sendNotification(makeAgent({ name: "<!channel>" }), {
+      message: "safe body",
+    });
+
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const sectionText = body.attachments[0].blocks[0].text.text;
+    const contextText = body.attachments[0].blocks[1].elements[0].text;
+    const fallback = body.attachments[0].fallback;
+
+    expect(sectionText).not.toContain("<!channel>");
+    expect(contextText).not.toContain("<!channel>");
+    expect(fallback).not.toContain("<!channel>");
+    expect(sectionText).toContain("&lt;!channel&gt;");
+    expect(contextText).toContain("&lt;!channel&gt;");
+    expect(fallback).toContain("&lt;!channel&gt;");
+  });
+
+  it("sanitizes renamed agent names in event notifications", async () => {
+    const notifier = new SlackNotifier(null as never, mockLog);
+    await notifier.onAgentEvent(makeAgent({ name: "<!here>" }));
+
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const sectionText = body.attachments[0].blocks[0].text.text;
+    const fallback = body.attachments[0].fallback;
+
+    expect(sectionText).not.toContain("<!here>");
+    expect(fallback).not.toContain("<!here>");
+    expect(sectionText).toContain("&lt;!here&gt;");
+    expect(fallback).toContain("&lt;!here&gt;");
+  });
+
   it("cleans up expired rate limit entries from the map", async () => {
     const notifier = new SlackNotifier(null as never, mockLog);
     const agent = makeAgent();

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -101,6 +101,7 @@ const AGENT_TOOLS = new Set([
   "create_pr",
   "get_pr_status",
   "dispatch_event",
+  "dispatch_rename_session",
   "dispatch_notify",
   "dispatch_pin",
   "dispatch_share",
@@ -188,6 +189,10 @@ export type McpRequestContext = {
     agentId: string,
     event: { type: string; message: string; metadata?: Record<string, unknown> }
   ) => Promise<void>;
+  renameSession?: (
+    agentId: string,
+    name: string
+  ) => Promise<{ id: string; name: string }>;
   shareMedia?: (
     agentId: string,
     opts: { filePath: string; description: string; source?: string; name?: string; update?: string }
@@ -467,6 +472,34 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           });
           return {
             content: [{ type: "text", text: `Updated ${agentId}: ${args.type} - ${args.message}` }]
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_rename_session ───────────────────────────────────────
+  if (allowed.has("dispatch_rename_session") && context.agent && context.renameSession) {
+    const agentId = context.agent.id;
+    const renameSession = context.renameSession;
+
+    server.registerTool(
+      "dispatch_rename_session",
+      {
+        description:
+          "Update the current session's display name. Use this to rename a default-generated session to a short goal or topic, or when the user explicitly asks for a rename.",
+        inputSchema: {
+          name: z.string().min(1).max(120).describe("New session display name.")
+        }
+      },
+      async (args) => {
+        try {
+          const result = await renameSession(agentId, args.name);
+          return {
+            content: [{ type: "text", text: `Renamed session to \"${result.name}\".` }],
+            structuredContent: result
           };
         } catch (error) {
           return toToolError(error);


### PR DESCRIPTION
## What changed
- added a new normal-agent MCP tool, `dispatch_rename_session`, so standard agents can rename their own session display name
- added startup guidance to rename default-generated sessions to a short goal/topic, while excluding user-named sessions, persona agents, and job agents
- hardened Slack notifications so agent-controlled session names are escaped before being interpolated into mrkdwn or fallback text
- replaced the old process-wide bearer-token trust model for scoped MCP routes with signed scoped tokens bound to the target agent or job run
- tightened the backend security review persona guidance to stay anchored to the supplied diff

## Why
The rename tool was the requested feature, but it introduced follow-up concerns that needed to be closed before review:
- agent-controlled names now flow into Slack notifications
- the old agent-scoped MCP route trusted a global bearer token plus the `:agentId` path param, which made cross-agent tool invocation possible for any agent able to issue raw HTTP requests
- the initial rename-guidance heuristic could misclassify custom names like `agent-foobar` as autogenerated

## Impact
- normal agents can rename their own sessions through MCP
- scoped MCP credentials now match the specific agent or job route they are issued for
- custom session names no longer trigger the autogenerated-name rename prompt unless they exactly match that agent's true generated default
- Slack notifications are safer when session names are agent-controlled

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`