### PR TITLE
Fix releases list: gh release list doesn't support url field

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1554,20 +1554,19 @@ async function registerRoutes() {
         "release", "list",
         "--repo", repo,
         "--limit", "10",
-        "--json", "tagName,publishedAt,isPrerelease,url"
+        "--json", "tagName,publishedAt,isPrerelease"
       ]);
       const releases = parseGhJson<Array<{
         tagName: string;
         publishedAt: string;
         isPrerelease: boolean;
-        url: string;
       }>>(result.stdout);
       return {
         releases: releases.map((r) => ({
           tag: r.tagName,
           publishedAt: r.publishedAt,
           isPrerelease: r.isPrerelease,
-          url: r.url
+          url: `https://github.com/${repo}/releases/tag/${r.tagName}`
         }))
       };
     } catch (err) {

--- a/apps/server/test/gh-release-fields.test.ts
+++ b/apps/server/test/gh-release-fields.test.ts
@@ -1,0 +1,73 @@
+import { execSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Validates that the JSON field names used in `gh release list` calls
+ * throughout the codebase are actually supported by the gh CLI.
+ *
+ * This test exists because `gh release list --json` and `gh release view --json`
+ * support different field sets. Using an invalid field (e.g. "url" on list)
+ * causes a silent failure that breaks the releases admin UI.
+ */
+
+const GH_AVAILABLE = (() => {
+  try {
+    execSync("gh --version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function getAvailableFields(subcommand: "list" | "view"): string[] {
+  // gh release list --json x gives an error listing valid fields
+  try {
+    execSync(`gh release ${subcommand} --json __invalid_field__ 2>&1`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return [];
+  } catch (err) {
+    const stderr = (err as { stderr?: string }).stderr ?? "";
+    const stdout = (err as { stdout?: string }).stdout ?? "";
+    const output = stderr + stdout;
+    // Extract field names from "Available fields:" section
+    const match = output.match(/Available fields:\n([\s\S]+?)(?:\n\n|$)/);
+    if (!match) return [];
+    return match[1]
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+}
+
+describe.skipIf(!GH_AVAILABLE)("gh release list JSON fields", () => {
+  it("supports the fields used by GET /api/v1/releases", () => {
+    const available = getAvailableFields("list");
+    expect(available.length).toBeGreaterThan(0);
+
+    // Fields used in GET /api/v1/releases
+    for (const field of ["tagName", "publishedAt", "isPrerelease"]) {
+      expect(available, `field "${field}" should be available on gh release list`).toContain(field);
+    }
+  });
+
+  it("supports the fields used by GET /api/v1/release/info", () => {
+    const available = getAvailableFields("list");
+    expect(available.length).toBeGreaterThan(0);
+
+    // Fields used in the channel-aware tag resolution
+    for (const field of ["tagName", "isPrerelease"]) {
+      expect(available, `field "${field}" should be available on gh release list`).toContain(field);
+    }
+  });
+
+  it("does NOT support 'url' on gh release list (regression guard)", () => {
+    const available = getAvailableFields("list");
+    expect(available.length).toBeGreaterThan(0);
+
+    // url is only available on `gh release view`, not `gh release list`.
+    // This test guards against accidentally adding it back.
+    expect(available).not.toContain("url");
+  });
+});


### PR DESCRIPTION
## Summary
- `gh release list --json` doesn't support the `url` field (only `gh release view` does)
- This caused the `/api/v1/releases` endpoint to error, resulting in "No releases found" in the Releases admin section
- Fix: remove `url` from the `--json` fields and construct the URL from `repo + tagName` instead

## Test plan
- [x] `gh release list --json tagName,publishedAt,isPrerelease` returns data successfully
- [ ] Releases section shows the release list with promote buttons after deploy