### PR TITLE
Fix: don't show log takeover for completed release/update jobs

### DIFF
--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -154,7 +154,9 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
   const createJob = job?.jobType === "create" ? job : null;
   const isDone = createJob?.phase === "done";
   const isFailed = createJob?.phase === "failed";
-  const showTakeover = createJob !== null;
+  // Only show takeover for active or just-failed jobs, not stale done jobs
+  // that persist in server memory from a previous release.
+  const showTakeover = createJob !== null && !isDone;
 
   if (showTakeover) {
     return (

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -143,7 +143,8 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const isDone = updateJob?.phase === "done" || (!postRestartPolling && updateJob?.phase === "restarting" && status?.tag === updateJob?.tag);
   const isFailed = updateJob?.phase === "failed";
   const isRestarting = updateJob?.phase === "restarting" || (updateJob !== null && postRestartPolling);
-  const showTakeover = updateJob !== null;
+  // Only show takeover for active jobs, not stale done jobs from server memory
+  const showTakeover = updateJob !== null && !isDone;
 
   if (showTakeover) {
     return (


### PR DESCRIPTION
## Summary
- The SSE snapshot sends the last completed job from server memory, which caused the Releases and Updates sections to show the takeover log view on every page load after a release
- Now only active (non-done) jobs trigger the takeover — completed jobs are ignored on reconnect

## Test plan
- [ ] Do a release, then reload the page — Releases section should show the normal list view, not the log takeover
- [ ] Start a release, navigate away, come back while it's still running — should show the takeover with live log