### PR TITLE
[codex] Fix Dispatch MCP auth and server test resolution

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -105,6 +105,19 @@ export async function getOrCreateAuthToken(pool: Pool): Promise<string> {
   return token;
 }
 
+export function isMcpRoute(url: string): boolean {
+  return url === "/api/mcp" || url.startsWith("/api/mcp/");
+}
+
+export function shouldAcceptApiBearerToken(url: string, token: string, serverAuthToken: string): boolean {
+  if (token === serverAuthToken) {
+    return true;
+  }
+
+  // MCP routes perform their own scoped token validation in the route handlers.
+  return isMcpRoute(url);
+}
+
 export function createAgentMcpToken(secret: string, agentId: string): string {
   return createMcpScopeToken(secret, `agent:${agentId}`);
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -51,6 +51,7 @@ import {
   cleanExpiredSessions,
   getOrCreateAuthToken,
   getOrCreateCookieSecret,
+  shouldAcceptApiBearerToken,
   validateAgentMcpToken,
   validateJobMcpToken
 } from "./auth.js";
@@ -1000,19 +1001,11 @@ async function registerRoutes() {
     // If no password is set, all routes are open (first-run mode).
     if (!(await isPasswordSetCached())) return;
 
-    const isMcpRoute = url === "/api/mcp" || url.startsWith("/api/mcp/");
-
     // Bearer token is accepted on all API routes (for MCP agents, scripts, etc.)
     const authHeader = request.headers.authorization;
     if (authHeader?.startsWith("Bearer ")) {
       const token = authHeader.slice(7);
-      if (token === config.authToken) {
-        return;
-      }
-      // MCP routes validate scoped agent/job tokens in the route handlers.
-      // Let those requests through to the route-specific validator instead of
-      // rejecting them here because they don't match the raw server token.
-      if (isMcpRoute) {
+      if (shouldAcceptApiBearerToken(url, token, config.authToken)) {
         return;
       }
     }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1000,11 +1000,19 @@ async function registerRoutes() {
     // If no password is set, all routes are open (first-run mode).
     if (!(await isPasswordSetCached())) return;
 
+    const isMcpRoute = url === "/api/mcp" || url.startsWith("/api/mcp/");
+
     // Bearer token is accepted on all API routes (for MCP agents, scripts, etc.)
     const authHeader = request.headers.authorization;
     if (authHeader?.startsWith("Bearer ")) {
       const token = authHeader.slice(7);
       if (token === config.authToken) {
+        return;
+      }
+      // MCP routes validate scoped agent/job tokens in the route handlers.
+      // Let those requests through to the route-specific validator instead of
+      // rejecting them here because they don't match the raw server token.
+      if (isMcpRoute) {
         return;
       }
     }

--- a/apps/server/test/auth.test.ts
+++ b/apps/server/test/auth.test.ts
@@ -14,6 +14,7 @@ import {
   cleanExpiredSessions,
   getOrCreateAuthToken,
   getOrCreateCookieSecret,
+  shouldAcceptApiBearerToken,
   createAgentMcpToken,
   validateAgentMcpToken,
   createJobMcpToken,
@@ -158,5 +159,20 @@ describe("auth token and cookie secret", () => {
     expect(validateJobMcpToken(secret, token, "run_123", "agt_123456abcdef")).toBe(true);
     expect(validateJobMcpToken(secret, token, "run_other", "agt_123456abcdef")).toBe(false);
     expect(validateJobMcpToken(secret, token, "run_123", "agt_otheragent")).toBe(false);
+  });
+
+  it("lets scoped MCP bearer tokens through the global auth gate only for MCP routes", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+    const agentToken = createAgentMcpToken(secret, "agt_123456abcdef");
+
+    expect(shouldAcceptApiBearerToken("/api/mcp/agt_123456abcdef", agentToken, secret)).toBe(true);
+    expect(shouldAcceptApiBearerToken("/api/mcp/jobs/run_123/agt_123456abcdef", agentToken, secret)).toBe(true);
+    expect(shouldAcceptApiBearerToken("/api/v1/agents", agentToken, secret)).toBe(false);
+  });
+
+  it("still accepts the raw server auth token on non-MCP routes", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+
+    expect(shouldAcceptApiBearerToken("/api/v1/agents", secret, secret)).toBe(true);
   });
 });

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@dispatch/shared": path.resolve(__dirname, "../../packages/shared/dist"),
+    },
+  },
   test: {
     globals: true,
     testTimeout: 30_000,


### PR DESCRIPTION
## What changed

This fixes the Dispatch MCP/tooling path in two places:

- allow scoped MCP bearer tokens to reach the `/api/mcp/...` route validators instead of being rejected by the generic API auth hook
- make server Vitest resolve `@dispatch/shared/...` imports against the built workspace output so `pnpm run test` reliably exercises the compiled shared package

## Why

Normal Dispatch agent sessions are launched with an agent-scoped MCP bearer token, not the raw server auth token. The global API auth hook was only accepting the raw server token, so MCP requests could fail with `401 Authentication required` before the agent-specific MCP route had a chance to validate the scoped token.

While validating that fix, `pnpm run test` was also failing in Vitest even though `@dispatch/shared` had already been built. The shared package output existed and plain Node imports worked, but Vitest in `apps/server` was not resolving the workspace package consistently. Pointing the test runner at `packages/shared/dist` fixes that resolution path.

## Impact

- Dispatch-managed Codex/agent MCP sessions can authenticate against `/api/mcp/:agentId` using their scoped bearer token
- server tests now cover the same built shared-package surface the runtime expects
- no user-facing web behavior changes

## Validation

- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`
