### PR TITLE
[codex] Theme log views

### DIFF
--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -60,6 +60,7 @@ hljs.registerLanguage("objectivec", objectivec);
 hljs.registerLanguage("nim", nim);
 
 import { Button } from "@/components/ui/button";
+import { LogStream } from "@/components/ui/log-stream";
 import { useCopyText } from "@/hooks/use-copy";
 import { cn } from "@/lib/utils";
 
@@ -169,11 +170,15 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   }
 
   if (content === null) {
-    return <div className="grid h-full place-items-center text-sm text-muted-foreground">Loading...</div>;
+    return (
+      <div className="grid h-full place-items-center text-sm text-[hsl(var(--log-stream-muted-foreground))]">
+        Loading...
+      </div>
+    );
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
+    <LogStream className="min-h-full overflow-auto p-0">
       {highlightedHtml ? (
         <pre className={cn("p-4 text-sm leading-relaxed", shouldWrapText && textWrapClassName)}>
           <code
@@ -182,11 +187,11 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
           />
         </pre>
       ) : (
-        <pre className={cn("p-4 text-sm leading-relaxed text-foreground", shouldWrapText && textWrapClassName)}>
+        <pre className={cn("p-4 text-sm leading-relaxed", shouldWrapText && textWrapClassName)}>
           <code className={cn(shouldWrapText && textWrapClassName)}>{content}</code>
         </pre>
       )}
-    </div>
+    </LogStream>
   );
 }
 
@@ -371,7 +376,12 @@ export function MediaLightbox({
           </Button>
         </div>
       </div>
-      <div className="mx-auto min-h-0 w-full max-w-4xl overflow-auto border-x border-border bg-black touch-pinch-zoom">
+      <div
+        className={cn(
+          "mx-auto min-h-0 w-full max-w-4xl overflow-auto border-x border-border touch-pinch-zoom",
+          isText ? "bg-[hsl(var(--log-stream-bg))]" : "bg-black"
+        )}
+      >
         {isText ? (
           <TextViewer src={item.src} fileName={item.file.name} />
         ) : isVideo ? (

--- a/apps/web/src/components/app/release-shared.tsx
+++ b/apps/web/src/components/app/release-shared.tsx
@@ -1,5 +1,6 @@
 import { Loader2 } from "lucide-react";
 import type { ReleaseJob, ReleasePhase } from "@/hooks/use-release-stream";
+import { LogStream } from "@/components/ui/log-stream";
 import { cn } from "@/lib/utils";
 
 const PHASE_LABELS: Record<ReleasePhase, string> = {
@@ -69,22 +70,19 @@ type OperationLogProps = {
 export function OperationLog({ logRef, job, isRestarting, postRestartPolling }: OperationLogProps): JSX.Element {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col p-2">
-      <div
-        ref={logRef}
-        className="min-h-0 flex-1 overflow-y-auto bg-black/60 p-4 font-mono text-[12px] leading-relaxed text-green-300"
-      >
+      <LogStream viewportRef={logRef}>
         {job.log
           .filter((line) => line.trim() !== "DISPATCH_RESTARTING")
           .map((line, i) => (
             <div key={i}>{line || "\u00A0"}</div>
           ))}
         {(isRestarting || postRestartPolling) && !job.log.length && (
-          <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="flex items-center gap-2 text-[hsl(var(--log-stream-muted-foreground))]">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             Waiting for Dispatch to restart...
           </div>
         )}
-      </div>
+      </LogStream>
     </div>
   );
 }

--- a/apps/web/src/components/ui/log-stream.tsx
+++ b/apps/web/src/components/ui/log-stream.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, Ref } from "react";
+import { cn } from "@/lib/utils";
+
+type LogStreamProps = HTMLAttributes<HTMLDivElement> & {
+  viewportRef?: Ref<HTMLDivElement>;
+};
+
+export function LogStream({ viewportRef, className, ...props }: LogStreamProps): JSX.Element {
+  return (
+    <div
+      ref={viewportRef}
+      className={cn(
+        "min-h-0 flex-1 overflow-y-auto rounded-md border p-4 font-mono text-[12px] leading-relaxed shadow-inner",
+        "border-[hsl(var(--log-stream-border))] bg-[hsl(var(--log-stream-bg))] text-[hsl(var(--log-stream-foreground))]",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -39,6 +39,10 @@
   /* Surface & terminal */
   --surface: 50 15% 5%;
   --terminal-bg: 0 0% 8%;
+  --log-stream-bg: 48 10% 10%;
+  --log-stream-foreground: 145 44% 78%;
+  --log-stream-muted-foreground: 42 10% 64%;
+  --log-stream-border: 40 10% 20%;
 }
 
 [data-theme="cool-navy"] {
@@ -75,6 +79,10 @@
 
   --surface: 225 16% 7%;
   --terminal-bg: 225 16% 7%;
+  --log-stream-bg: 222 16% 10%;
+  --log-stream-foreground: 164 52% 76%;
+  --log-stream-muted-foreground: 220 8% 67%;
+  --log-stream-border: 220 11% 23%;
 }
 
 [data-theme="oled-black"] {
@@ -111,6 +119,10 @@
 
   --surface: 0 0% 2%;
   --terminal-bg: 0 0% 0%;
+  --log-stream-bg: 0 0% 5%;
+  --log-stream-foreground: 153 55% 74%;
+  --log-stream-muted-foreground: 0 0% 58%;
+  --log-stream-border: 0 0% 14%;
 }
 
 [data-theme="solarized-dark"] {
@@ -147,6 +159,10 @@
 
   --surface: 192 100% 8%;
   --terminal-bg: 192 100% 11%;
+  --log-stream-bg: 192 62% 13%;
+  --log-stream-foreground: 182 21% 71%;
+  --log-stream-muted-foreground: 194 14% 48%;
+  --log-stream-border: 192 40% 24%;
 }
 
 [data-theme="light"] {
@@ -183,6 +199,10 @@
 
   --surface: 207 22% 90%;
   --terminal-bg: 210 23% 95%;
+  --log-stream-bg: 210 29% 97%;
+  --log-stream-foreground: 153 63% 26%;
+  --log-stream-muted-foreground: 211 11% 39%;
+  --log-stream-border: 208 20% 82%;
 }
 
 [data-theme="vaporwave"] {
@@ -219,6 +239,10 @@
 
   --surface: 262 52% 4%;
   --terminal-bg: 262 52% 6%;
+  --log-stream-bg: 262 38% 10%;
+  --log-stream-foreground: 181 78% 78%;
+  --log-stream-muted-foreground: 270 20% 58%;
+  --log-stream-border: 262 30% 18%;
 }
 
 [data-theme="midnight"] {
@@ -255,6 +279,10 @@
 
   --surface: 0 0% 2%;
   --terminal-bg: 0 0% 0%;
+  --log-stream-bg: 220 12% 6%;
+  --log-stream-foreground: 194 90% 74%;
+  --log-stream-muted-foreground: 220 8% 60%;
+  --log-stream-border: 220 11% 16%;
 }
 
 [data-theme="matrix"] {
@@ -291,6 +319,10 @@
 
   --surface: 145 24% 2%;
   --terminal-bg: 150 20% 1.5%;
+  --log-stream-bg: 145 32% 4%;
+  --log-stream-foreground: 139 94% 82%;
+  --log-stream-muted-foreground: 138 25% 58%;
+  --log-stream-border: 145 25% 14%;
 }
 
 [data-theme="mytra"] {
@@ -327,6 +359,10 @@
 
   --surface: 220 12% 4%;
   --terminal-bg: 0 0% 1%;
+  --log-stream-bg: 228 18% 9%;
+  --log-stream-foreground: 226 28% 84%;
+  --log-stream-muted-foreground: 220 12% 60%;
+  --log-stream-border: 228 14% 18%;
 }
 
 * {


### PR DESCRIPTION
## What changed
- added a shared `LogStream` shell for log/text surfaces
- switched the release takeover operation log to the themed log shell
- switched the media lightbox text/log viewer to the same themed shell
- added per-theme log stream tokens for the supported app themes

## Why
The app had log-like surfaces that were still hard-coded to a dark terminal look, which broke visual consistency in non-default themes and especially in light mode. This change makes those log views follow the active app theme while keeping the monospace/log affordances intact.

## User impact
- release logs in the update/release takeover flow now match the selected app theme
- text-based media artifacts such as `.log` files now render in the same themed log treatment inside the lightbox
- light theme now has a readable light-mode log surface instead of falling back to a dark panel

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- Playwright manual validation on isolated dev stack
- captured dark and light screenshots of the themed log lightbox

## Notes
- validation stack left running for inspection during implementation:
  - web: `http://127.0.0.1:63028`
  - api: `http://127.0.0.1:63020`
- cleanup: `dispatch-dev down`