### PR TITLE
docs: add missing MCP tool and env vars to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | Tool | Description |
 |------|-------------|
 | `dispatch_event` | Report agent status (working, blocked, waiting_user, done, idle) |
+| `dispatch_rename_session` | Update the current session's display name |
 | `dispatch_pin` | Surface key info in the sidebar (URLs, ports, PRs, files) |
 | `dispatch_share` | Upload screenshots and media to the agent's media pane |
 | `dispatch_feedback` | Submit structured review findings (severity, file refs, suggestions) |

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -160,6 +160,8 @@ Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 | `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
 | `AUTH_TOKEN` | — | API authentication token for MCP endpoints (generate with `openssl rand -hex 32`) |
 | `MEDIA_ROOT` | `~/.dispatch/media` | File upload storage path |
+| `DISPATCH_AGENT_RUNTIME` | `tmux` | Agent runtime mode (`tmux` or `inert` for dev/test) |
+| `DISPATCH_COPY_DISPLAY` | — | Virtual X display for clipboard image paste on Linux (e.g. `:99`) |
 | `TLS_CERT` | — | Path to TLS certificate file (enables HTTPS when both cert and key are set) |
 | `TLS_KEY` | — | Path to TLS private key file |
 


### PR DESCRIPTION
## Summary

Audited all documentation against the actual codebase and fixed the gaps found.

### Changes

**README.md**
- Added `dispatch_rename_session` to the MCP tools table — this agent tool was missing from the list

**docs/10-operations-runbook.md**
- Added `DISPATCH_AGENT_RUNTIME` and `DISPATCH_COPY_DISPLAY` to the configuration table — these env vars are documented in `.env.example` but were missing from the runbook's config reference

### Audit results

Performed a comprehensive audit of all documentation files against the codebase:

| File | Status |
|------|--------|
| README.md | 2 small gaps fixed (see above) |
| docs/03-api-spec.md | Accurate — all endpoints match codebase |
| docs/04-agent-lifecycle.md | Accurate — states, transitions, contracts all current |
| docs/10-operations-runbook.md | 2 env vars added to config table |
| docs/11-backend-compatibility-checklist.md | Accurate — all referenced commands exist |
| docs/12-new-machine-setup.md | Accurate — setup steps, paths, and commands all current |
| docs/14-theming.md | Accurate — file paths, CSS vars, and instructions all current |
| docs/15-personas-and-feedback.md | Accurate — matches persona system implementation |
| docs/16-notifications.md | Accurate — matches notification system implementation |
| CLAUDE.md | Accurate — project structure tree, scripts, and commands all match |

**Overall assessment:** Documentation is in good shape. The codebase has 70+ API endpoints, 23+ MCP tools, 12 database tables, and 8 doc files — and the docs accurately reflect nearly all of it. The only gaps were one missing MCP tool name and two missing environment variables in a config reference table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)