### PR TITLE
chore: tune persona prompts based on weekly review

### DIFF
--- a/.dispatch/personas/architecture-review.md
+++ b/.dispatch/personas/architecture-review.md
@@ -39,4 +39,5 @@ Your review MUST focus exclusively on the code that was changed in the diff belo
 1. Read the diff carefully first to understand exactly what changed.
 2. Explore surrounding code to understand context and existing patterns.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+4. **Make findings actionable.** Each finding should include a concrete suggestion for what to change. Avoid abstract observations like "this could be cleaner" — specify what the better structure looks like and where to apply it.
 

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -28,4 +28,5 @@ Your testing MUST focus exclusively on the features and flows introduced or modi
 ## How to report findings
 - Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 - Include screenshot references (`mediaRef`) when visual.
+- **Only submit feedback for actual bugs or issues.** Do not submit positive observations or affirmations about things that work correctly. If everything works as expected, say so in your review summary and approve with zero feedback items.
 

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -130,8 +130,8 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 - **low**: Minor issue, hardening opportunity, or improvement suggestion
 - **info**: Non-obvious good decision that a future contributor might mistakenly undo
 
-### Info feedback limits
-Keep \`info\` severity feedback to a maximum of 2–3 items per review. Only use info for decisions that are *surprisingly good* or that need to be *preserved* — do not submit info feedback for code that is simply correct or working as expected. The goal is signal, not a checklist of everything that passed inspection.
+### Info feedback limits — STRICT
+Do NOT submit positive affirmations, praise, or "good job" feedback. Feedback like "Good defense-in-depth...", "Good design decision...", or "This is well-structured..." is noise and will be ignored — do not submit it. The \`info\` severity is ONLY for non-obvious decisions that a future contributor might mistakenly undo. Limit to at most 2 items per review. If you have nothing critical to preserve, submit zero info items.
 `.trim();
 
 export function assemblePersonaPrompt(

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -162,7 +162,8 @@ describe("assemblePersonaPrompt", () => {
 
   it("includes info feedback limits", () => {
     const result = assemblePersonaPrompt(basePersona, "", "");
-    expect(result).toContain("maximum of 2–3 items");
+    expect(result).toContain("Info feedback limits");
+    expect(result).toContain("Do NOT submit positive affirmations");
   });
 });
 


### PR DESCRIPTION
## Summary

Weekly persona review analysis (Apr 4–11) found that **45% of all feedback (173/382 items) is info-severity positive affirmations** that get systematically ignored. This is the single biggest source of noise across all personas.

### Changes

- **Shared feedback guidance** (`loader.ts`): Strengthened info-severity limits — explicitly bans praise/affirmation feedback ("Good defense-in-depth...", "Good design decision..."), caps info items at 2 per review, allows zero
- **e2e-tester**: Added explicit instruction to only submit feedback for actual bugs/issues, not positive observations (produced 0 real findings in its only review this week)
- **architecture-review**: Added actionability guidance — findings must include concrete suggestions, not abstract observations (has highest open rate at 13.6%, suggesting findings aren't actionable enough)

### Key metrics from the review

| Persona | Reviews | Feedback | Fix Rate | Ignore Rate | Assessment |
|---|---|---|---|---|---|
| frontend-ux-review | 24 | 89 | 50% | 46% | High volume, good signal on high/medium items |
| backend-security-review | 14 | 173 | 46% | 51% | Found real security bypasses, but drowning in info praise |
| architecture-review | 8 | 55 | 43% | 43% | Highest open rate — findings need to be more actionable |
| infra-review | 6 | 34 | 50% | 44% | Best signal-to-noise — found the only critical bug |
| product-review | 2 | 19 | 73% | 27% | Highest fix rate, very actionable findings |
| e2e-tester | 1 | 2 | 0% | 0% | Only produced affirmations, no actual issues |

🤖 Generated with [Claude Code](https://claude.com/claude-code)