### PR TITLE
[codex] Include archived agents in summaries

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -2011,7 +2011,6 @@ export class AgentManager {
     // Build conditions for agents table queries
     const agentConditions = [
       "parent_agent_id IS NULL",
-      "deleted_at IS NULL",
       "created_at >= $1",
       "created_at <= $2",
     ];
@@ -2033,7 +2032,7 @@ export class AgentManager {
             COALESCE(ae.project_dir, a.cwd) AS project_dir
           FROM agent_events ae
           JOIN agents a ON a.id = ae.agent_id
-            AND a.deleted_at IS NULL AND a.parent_agent_id IS NULL
+            AND a.parent_agent_id IS NULL
           WHERE ae.created_at < $1
           ORDER BY ae.agent_id, ae.created_at DESC
         ),
@@ -2042,7 +2041,7 @@ export class AgentManager {
                  COALESCE(ae.project_dir, a.cwd) AS project_dir
           FROM agent_events ae
           JOIN agents a ON a.id = ae.agent_id
-            AND a.deleted_at IS NULL AND a.parent_agent_id IS NULL
+            AND a.parent_agent_id IS NULL
           WHERE ae.created_at >= $1 AND ae.created_at <= $2
         ),
         all_events AS (
@@ -2189,7 +2188,6 @@ export class AgentManager {
     includeChildren: boolean;
   }): Promise<AgentHistoryResult> {
     const conditions: string[] = [
-      "deleted_at IS NULL",
       "created_at >= $1",
       "created_at <= $2",
     ];

--- a/apps/server/test/db/summary-tools.test.ts
+++ b/apps/server/test/db/summary-tools.test.ts
@@ -259,7 +259,7 @@ describe("getActivitySummary", () => {
     expect(result.totals.sessionCount).toBe(1);
   });
 
-  it("excludes deleted agents from session counts", async () => {
+  it("includes archived parent agents in session counts", async () => {
     await insertAgent("a1", { latestEventType: "done" });
     await insertAgent("a2", { latestEventType: "done" });
     await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
@@ -269,7 +269,7 @@ describe("getActivitySummary", () => {
       end: new Date(),
     });
 
-    expect(result.totals.sessionCount).toBe(1);
+    expect(result.totals.sessionCount).toBe(2);
   });
 
   it("returns top agents sorted by working time", async () => {
@@ -526,7 +526,7 @@ describe("getAgentHistory", () => {
     expect(result.total).toBe(1);
   });
 
-  it("excludes deleted agents", async () => {
+  it("includes archived parent agents", async () => {
     await insertAgent("a1");
     await insertAgent("a2");
     await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
@@ -542,8 +542,8 @@ describe("getAgentHistory", () => {
       includeChildren: false,
     });
 
-    expect(result.agents).toHaveLength(1);
-    expect(result.agents[0].id).toBe("a1");
+    expect(result.agents).toHaveLength(2);
+    expect(result.agents.map((agent) => agent.id).sort()).toEqual(["a1", "a2"]);
   });
 });
 
@@ -755,5 +755,25 @@ describe("getFeedbackSummary", () => {
 
     expect(result.totalFindings).toBe(1);
     expect(result.groups[0].topFindings[0].description).toBe("Recent");
+  });
+
+  it("includes feedback and review verdicts for archived parent agents", async () => {
+    await insertAgent("parent");
+    await insertAgent("reviewer", { persona: "sec", parentAgentId: "parent" });
+    await insertFeedback("reviewer", { description: "Archived parent finding" });
+    await insertReview("reviewer", "parent", "sec", { verdict: "approve" });
+    await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'parent'");
+
+    const result = await manager.getFeedbackSummary({
+      start: daysAgo(7),
+      end: new Date(),
+      groupBy: "persona",
+    });
+
+    expect(result.totalFindings).toBe(1);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].topFindings[0].description).toBe("Archived parent finding");
+    expect(result.reviewVerdicts.total).toBe(1);
+    expect(result.reviewVerdicts.approved).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- include archived parent agents in `get_activity_summary` instead of filtering them out by `deleted_at`
- include archived parent agents in `get_agent_history` while preserving the existing parent/child nesting behavior
- add regression coverage proving archived parents still appear in activity/history and still contribute to feedback summary results

## Why
Archived and soft-deleted agents hold most completed work, but these analytics tools were filtering them out even though the activity UI still shows them.

## Root Cause
`get_activity_summary` and `get_agent_history` explicitly required `deleted_at IS NULL`, which dropped archived parent sessions from counts and history results. That made the analytics tools disagree with the UI and with the underlying completed work.

## Impact
Analytics consumers now see the same archived completed work that the activity UI already includes, while child agents remain nested under parents unless `include_children` is requested.

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`
