### PR TITLE
[codex] Polish mobile sidebar navigation and overflow behavior

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
+import { useTemporaryState } from "@/hooks/use-temporary-state";
 import { AGENT_TYPES, type AgentType, isAgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
 import { Button } from "@/components/ui/button";
 
@@ -514,6 +515,43 @@ export function DashboardLayout(): JSX.Element {
     return "bg-status-waiting";
   };
 
+  const [pulsingNavItem, setPulsingNavItem] = useTemporaryState<string | null>(null, 260);
+  const [pendingNavPulse, setPendingNavPulse] = useState<string | null>(null);
+
+  const currentNavItem = (() => {
+    if (location.pathname.startsWith("/jobs")) return "jobs";
+    if (location.pathname.startsWith("/activity")) return "activity";
+    if (location.pathname.startsWith("/docs")) return "docs";
+    if (location.pathname.startsWith("/settings")) return "settings";
+    return "agents";
+  })();
+  const prevNavItemRef = useRef(currentNavItem);
+
+  useEffect(() => {
+    const previousNavItem = prevNavItemRef.current;
+    prevNavItemRef.current = currentNavItem;
+
+    if (!isMobile) return;
+    if (currentNavItem !== "agents" || previousNavItem === "agents") return;
+
+    setMobileMediaOpen(false);
+    setMobileLeftOpen(true);
+  }, [currentNavItem, isMobile, setMobileLeftOpen, setMobileMediaOpen]);
+
+  useEffect(() => {
+    if (!pendingNavPulse || pendingNavPulse !== currentNavItem) return;
+    setPulsingNavItem(pendingNavPulse);
+    setPendingNavPulse(null);
+  }, [currentNavItem, pendingNavPulse, setPulsingNavItem]);
+
+  const triggerNavAnimation = useCallback((navItem: string) => {
+    if (navItem === currentNavItem) {
+      setPulsingNavItem(navItem);
+      return;
+    }
+    setPendingNavPulse(navItem);
+  }, [currentNavItem, setPulsingNavItem]);
+
   // ── Navigation callbacks for overlay panes ────────────────────────────
   const openSettings = useCallback(() => navigate("/settings"), [navigate]);
   const openDocs = useCallback(() => navigate("/docs"), [navigate]);
@@ -556,6 +594,8 @@ export function DashboardLayout(): JSX.Element {
               connectedAgentId={connectedAgentId}
               onOpenFeedbackDetail={setFeedbackDetail}
               feedbackDetailState={feedbackDetail}
+              pulsingNavItem={pulsingNavItem}
+              triggerNavAnimation={triggerNavAnimation}
             />
           </div>
         ) : null}
@@ -587,6 +627,8 @@ export function DashboardLayout(): JSX.Element {
                 agents={agents}
                 onOpenAgent={attachToAgent}
                 enabledAgentTypes={enabledAgentTypes}
+                pulsingNavItem={pulsingNavItem}
+                triggerNavAnimation={triggerNavAnimation}
               />
             ) : (
               <div className="relative min-h-0 min-w-0 pb-14 pt-14">
@@ -744,6 +786,8 @@ export function DashboardLayout(): JSX.Element {
             connectedAgentId={connectedAgentId}
             closeOnSessionAction={true}
             onRequestClose={() => setMobileLeftOpen(false)}
+            pulsingNavItem={pulsingNavItem}
+            triggerNavAnimation={triggerNavAnimation}
           />
         </MobileSlidePanel>
       ) : null}

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -50,6 +50,8 @@ type AgentSidebarSharedProps = {
   connectedAgentId?: string | null;
   onOpenFeedbackDetail?: (state: FeedbackDetailState) => void;
   feedbackDetailState?: FeedbackDetailState;
+  pulsingNavItem?: string | null;
+  triggerNavAnimation?: (navItem: string) => void;
 };
 
 type AgentSidebarProps = AgentSidebarSharedProps & {
@@ -92,6 +94,8 @@ export function AgentSidebarContent({
   connectedAgentId,
   onOpenFeedbackDetail,
   feedbackDetailState,
+  pulsingNavItem,
+  triggerNavAnimation,
   onRequestClose,
   closeOnSessionAction = false,
   closeButtonIcon = "x",
@@ -103,6 +107,23 @@ export function AgentSidebarContent({
   const defaultCreateType: AgentType = lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
     ? lastUsedAgentType
     : enabledAgentTypes[0] ?? "codex";
+
+  const navButtonClassName = (navItem: string, active = false): string => cn(
+    "rounded-md p-2 transition-colors hover:bg-muted/50 hover:text-foreground",
+    active ? "text-primary hover:text-primary/80" : "text-muted-foreground"
+  );
+
+  const triggerNavAnimationForKey = (event: React.KeyboardEvent<HTMLButtonElement>, navItem: string): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      triggerNavAnimation?.(navItem);
+    }
+  };
+
+  const renderNavIcon = (icon: JSX.Element): JSX.Element => (
+    <span className="flex items-center justify-center">
+      {icon}
+    </span>
+  );
 
   return (
     <aside data-testid="agent-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-r-2 border-border bg-card text-foreground", className)}>
@@ -165,7 +186,7 @@ export function AgentSidebarContent({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div data-testid="agent-sidebar-scroll" className="min-h-0 flex-1 overflow-y-auto">
         <TooltipProvider delayDuration={120}>
           {agents.length === 0 ? (
             <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
@@ -203,16 +224,18 @@ export function AgentSidebarContent({
         </TooltipProvider>
       </div>
       <TooltipProvider delayDuration={120}>
-        <div className="flex items-center justify-around border-t border-border py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <div className="flex items-center justify-around border-t border-border py-3 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                onPointerDown={() => triggerNavAnimation?.("agents")}
+                onKeyDown={(event) => triggerNavAnimationForKey(event, "agents")}
                 onClick={() => undefined}
                 aria-label="Agents"
                 data-testid="agents-button"
-                className="rounded-md p-2 text-primary transition-colors hover:text-primary/80"
+                className={cn(navButtonClassName("agents", true), pulsingNavItem === "agents" && "animate-sidebar-nav-pulse")}
               >
-                <Bot className="h-5 w-5" />
+                {renderNavIcon(<Bot className="h-5 w-5" />)}
               </button>
             </TooltipTrigger>
             <TooltipContent>Agents</TooltipContent>
@@ -220,12 +243,14 @@ export function AgentSidebarContent({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                onPointerDown={() => triggerNavAnimation?.("jobs")}
+                onKeyDown={(event) => triggerNavAnimationForKey(event, "jobs")}
                 onClick={onOpenJobs}
                 aria-label="Jobs"
                 data-testid="jobs-button"
-                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                className={cn(navButtonClassName("jobs"), pulsingNavItem === "jobs" && "animate-sidebar-nav-pulse")}
               >
-                <AlarmClock className="h-5 w-5" />
+                {renderNavIcon(<AlarmClock className="h-5 w-5" />)}
               </button>
             </TooltipTrigger>
             <TooltipContent>Jobs</TooltipContent>
@@ -233,11 +258,13 @@ export function AgentSidebarContent({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                onPointerDown={() => triggerNavAnimation?.("activity")}
+                onKeyDown={(event) => triggerNavAnimationForKey(event, "activity")}
                 onClick={onOpenActivity}
                 data-testid="activity-button"
-                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                className={cn(navButtonClassName("activity"), pulsingNavItem === "activity" && "animate-sidebar-nav-pulse")}
               >
-                <Activity className="h-5 w-5" />
+                {renderNavIcon(<Activity className="h-5 w-5" />)}
               </button>
             </TooltipTrigger>
             <TooltipContent>Activity</TooltipContent>
@@ -245,11 +272,13 @@ export function AgentSidebarContent({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                onPointerDown={() => triggerNavAnimation?.("docs")}
+                onKeyDown={(event) => triggerNavAnimationForKey(event, "docs")}
                 onClick={onOpenDocs}
                 data-testid="docs-button"
-                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                className={cn(navButtonClassName("docs"), pulsingNavItem === "docs" && "animate-sidebar-nav-pulse")}
               >
-                <BookOpenText className="h-5 w-5" />
+                {renderNavIcon(<BookOpenText className="h-5 w-5" />)}
               </button>
             </TooltipTrigger>
             <TooltipContent>Documentation</TooltipContent>
@@ -257,11 +286,13 @@ export function AgentSidebarContent({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                onPointerDown={() => triggerNavAnimation?.("settings")}
+                onKeyDown={(event) => triggerNavAnimationForKey(event, "settings")}
                 onClick={onOpenSettings}
                 data-testid="settings-button"
-                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                className={cn(navButtonClassName("settings"), pulsingNavItem === "settings" && "animate-sidebar-nav-pulse")}
               >
-                <Settings className="h-5 w-5" />
+                {renderNavIcon(<Settings className="h-5 w-5" />)}
               </button>
             </TooltipTrigger>
             <TooltipContent>Settings</TooltipContent>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -30,6 +30,8 @@ type JobsPaneProps = {
   onOpenAgent: (agent: Agent) => Promise<void>;
   enabledAgentTypes: AgentType[];
   footer?: React.ReactNode;
+  pulsingNavItem?: string | null;
+  triggerNavAnimation?: (navItem: string) => void;
 };
 
 type DetailTab = "configure" | "prompt" | "history";
@@ -132,7 +134,7 @@ function useActiveRun(job: Job | null, agents: Agent[]) {
   }, [agents, job]);
 }
 
-export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer }: JobsPaneProps): JSX.Element {
+export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer, pulsingNavItem, triggerNavAnimation }: JobsPaneProps): JSX.Element {
   const navigate = useNavigate();
   const { jobId: routeJobId, section: routeSection, runId: routeRunId } = useParams();
   const { iconColor } = useIconColor();
@@ -164,7 +166,7 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
 
   return (
     <section className="flex h-full min-h-0 min-w-0 overflow-hidden bg-background text-foreground" aria-labelledby="jobs-page-title">
-            <aside className={cn("flex h-full min-h-0 w-full flex-col overflow-hidden border-r-2 border-border bg-card md:w-[320px] md:shrink-0", showDetailPane && "hidden md:flex")}>
+            <aside data-testid="jobs-sidebar" className={cn("flex h-full min-h-0 w-full flex-col overflow-hidden border-r-2 border-border bg-card md:w-[320px] md:shrink-0", showDetailPane && "hidden md:flex")}>
               <div className="flex min-h-14 items-center px-3 pt-[env(safe-area-inset-top)]">
                 <div className="flex items-center gap-2.5">
                   <img src={`/icons/${iconColor}/brand-icon.svg`} alt="" className="h-7 w-7 shrink-0 object-contain" />
@@ -196,7 +198,7 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                 </div>
               </div>
 
-              <div className="min-h-0 flex-1 overflow-y-auto">
+              <div data-testid="jobs-sidebar-scroll" className="min-h-0 flex-1 overflow-y-auto">
                 {error ? (
                   <div className="m-3 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{error instanceof Error ? error.message : "Failed to load jobs."}</div>
                 ) : isLoading ? (
@@ -260,6 +262,8 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer 
                 onOpenActivity={() => navigate("/activity")}
                 onOpenJobs={() => navigate("/jobs")}
                 onOpenSettings={() => navigate("/settings")}
+                pulsingNavItem={pulsingNavItem}
+                triggerNavAnimation={triggerNavAnimation}
               />
             </aside>
 
@@ -706,19 +710,29 @@ function JobsNav({
   onOpenActivity,
   onOpenJobs,
   onOpenSettings,
+  pulsingNavItem,
+  triggerNavAnimation,
 }: {
   onOpenAgents: () => void;
   onOpenDocs: () => void;
   onOpenActivity: () => void;
   onOpenJobs: () => void;
   onOpenSettings: () => void;
+  pulsingNavItem?: string | null;
+  triggerNavAnimation?: (navItem: string) => void;
 }) {
+  const triggerNavAnimationForKey = (event: React.KeyboardEvent<HTMLButtonElement>, navItem: string): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      triggerNavAnimation?.(navItem);
+    }
+  };
+
   return (
     <TooltipProvider delayDuration={120}>
-      <div className="flex items-center justify-around border-t border-border py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+      <div className="flex items-center justify-around border-t border-border py-3 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenAgents} aria-label="Agents" data-testid="agents-button" className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+            <button onPointerDown={() => triggerNavAnimation?.("agents")} onKeyDown={(event) => triggerNavAnimationForKey(event, "agents")} onClick={onOpenAgents} aria-label="Agents" data-testid="agents-button" className={cn("rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground", pulsingNavItem === "agents" && "animate-sidebar-nav-pulse")}>
               <Bot className="h-5 w-5" />
             </button>
           </TooltipTrigger>
@@ -726,7 +740,7 @@ function JobsNav({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenJobs} aria-label="Jobs" data-testid="jobs-button" className="rounded-md p-2 text-primary transition-colors hover:text-primary/80">
+            <button onPointerDown={() => triggerNavAnimation?.("jobs")} onKeyDown={(event) => triggerNavAnimationForKey(event, "jobs")} onClick={onOpenJobs} aria-label="Jobs" data-testid="jobs-button" className={cn("rounded-md p-2 text-primary transition-colors hover:text-primary/80", pulsingNavItem === "jobs" && "animate-sidebar-nav-pulse")}>
               <AlarmClock className="h-5 w-5" />
             </button>
           </TooltipTrigger>
@@ -734,7 +748,7 @@ function JobsNav({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenActivity} data-testid="activity-button" className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+            <button onPointerDown={() => triggerNavAnimation?.("activity")} onKeyDown={(event) => triggerNavAnimationForKey(event, "activity")} onClick={onOpenActivity} data-testid="activity-button" className={cn("rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground", pulsingNavItem === "activity" && "animate-sidebar-nav-pulse")}>
               <Activity className="h-5 w-5" />
             </button>
           </TooltipTrigger>
@@ -742,7 +756,7 @@ function JobsNav({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenDocs} data-testid="docs-button" className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+            <button onPointerDown={() => triggerNavAnimation?.("docs")} onKeyDown={(event) => triggerNavAnimationForKey(event, "docs")} onClick={onOpenDocs} data-testid="docs-button" className={cn("rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground", pulsingNavItem === "docs" && "animate-sidebar-nav-pulse")}>
               <BookOpenText className="h-5 w-5" />
             </button>
           </TooltipTrigger>
@@ -750,7 +764,7 @@ function JobsNav({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button onClick={onOpenSettings} data-testid="settings-button" className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+            <button onPointerDown={() => triggerNavAnimation?.("settings")} onKeyDown={(event) => triggerNavAnimationForKey(event, "settings")} onClick={onOpenSettings} data-testid="settings-button" className={cn("rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground", pulsingNavItem === "settings" && "animate-sidebar-nav-pulse")}>
               <Settings className="h-5 w-5" />
             </button>
           </TooltipTrigger>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -90,7 +90,11 @@ function MediaContent({
         <LiveStreamSection streamUrl={streamUrl} selectedAgentId={selectedAgentId} />
       ) : null}
 
-      <div ref={mediaViewportRef} className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+      <div
+        ref={mediaViewportRef}
+        data-testid="media-panel-scroll"
+        className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]"
+      >
         {mediaFiles.length === 0 && !hasStream ? (
           <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
             <div className="flex flex-col items-center gap-2">

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -69,6 +69,28 @@ function shouldRenderMarkdownAsPlainText(value: string): boolean {
   return unsupportedPatterns.some((pattern) => pattern.test(sanitized));
 }
 
+function normalizeExternalHref(type: AgentPin["type"], value: string): string | null {
+  if (type !== "url" && type !== "pr") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const candidates = SAFE_URL_RE.test(trimmed) ? [trimmed] : type === "url" ? [`https://${trimmed}`, `http://${trimmed}`] : [trimmed];
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return parsed.toString();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 function MarkdownPinBody({ value }: { value: string }): JSX.Element {
   const renderAsPlainText = shouldRenderMarkdownAsPlainText(value);
 
@@ -94,14 +116,15 @@ function MarkdownPinBody({ value }: { value: string }): JSX.Element {
 }
 
 function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedValue {
-  if (type === "pr" && SAFE_URL_RE.test(value)) {
-    return { display: formatPrDisplay(value), tooltip: value, href: value, badge: false, icon: "pr" };
+  const href = normalizeExternalHref(type, value);
+  if (type === "pr" && href) {
+    return { display: formatPrDisplay(href), tooltip: value.trim(), href, badge: false, icon: "pr" };
   }
   if (type === "pr") {
     return { display: value, tooltip: value, href: null, badge: false, icon: "pr" };
   }
-  if (type === "url" && SAFE_URL_RE.test(value)) {
-    return { display: value, tooltip: value, href: value, badge: false, icon: null };
+  if (type === "url" && href) {
+    return { display: value.trim(), tooltip: value.trim(), href, badge: false, icon: null };
   }
   if (type === "url") {
     return { display: value, tooltip: value, href: null, badge: false, icon: null };
@@ -237,7 +260,7 @@ export function PinsPanel({ pins, selectedAgentName, selectedAgentWorkspaceRoot 
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+    <div data-testid="pins-panel-scroll" className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
       {pins.map((pin) => (
         <PinItem key={pin.label.toLowerCase()} pin={pin} workspaceRoot={selectedAgentWorkspaceRoot} />
       ))}

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -204,6 +204,7 @@ function PinValueRow({
           href={href}
           target="_blank"
           rel="noopener noreferrer"
+          data-testid="pin-open-link"
           className="ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
           title="Open in browser"
         >

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -76,17 +76,15 @@ function normalizeExternalHref(type: AgentPin["type"], value: string): string | 
   const trimmed = value.trim();
   if (!trimmed) return null;
 
-  const candidates = SAFE_URL_RE.test(trimmed) ? [trimmed] : type === "url" ? [`https://${trimmed}`, `http://${trimmed}`] : [trimmed];
+  const candidate = SAFE_URL_RE.test(trimmed) ? trimmed : type === "url" ? `http://${trimmed}` : trimmed;
 
-  for (const candidate of candidates) {
-    try {
-      const parsed = new URL(candidate);
-      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-        return parsed.toString();
-      }
-    } catch {
-      continue;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
     }
+  } catch {
+    return null;
   }
 
   return null;

--- a/apps/web/src/hooks/use-temporary-state.ts
+++ b/apps/web/src/hooks/use-temporary-state.ts
@@ -1,0 +1,19 @@
+import React from "react";
+
+export function useTemporaryState<T>(initialValue: T, durationMs: number): readonly [T, (value: T) => void] {
+  const [value, setValue] = React.useState(initialValue);
+
+  React.useEffect(() => {
+    if (Object.is(value, initialValue)) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setValue(initialValue);
+    }, durationMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [durationMs, initialValue, value]);
+
+  return [value, setValue] as const;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -725,11 +725,45 @@ html[data-theme="matrix"] [role="button"] {
   animation: persona-reviewing-pulse 2s ease-in-out infinite;
 }
 
+@keyframes sidebar-nav-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
+    background-color: transparent;
+  }
+  18% {
+    transform: scale(0.9);
+    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
+  }
+  58% {
+    transform: scale(1.3);
+    box-shadow: 0 0 0 8px hsl(var(--primary) / 0.18);
+    background-color: hsl(var(--primary) / 0.12);
+  }
+  82% {
+    transform: scale(1.06);
+    box-shadow: 0 0 0 4px hsl(var(--primary) / 0.08);
+    background-color: hsl(var(--primary) / 0.06);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
+    background-color: transparent;
+  }
+}
+
+.animate-sidebar-nav-pulse {
+  animation: sidebar-nav-pulse 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: center;
+  will-change: transform, box-shadow, background-color;
+}
+
 /* Persona reviewing row — subtle left-border shimmer */
 @keyframes persona-reviewing-shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
 .persona-reviewing-row {
   background-image: linear-gradient(
     90deg,
@@ -757,4 +791,8 @@ html[data-hidden] .animate-persona-reviewing {
 }
 html[data-hidden] .persona-reviewing-row {
   animation-play-state: paused;
+}
+html[data-hidden] .animate-sidebar-nav-pulse {
+  animation-play-state: paused;
+  will-change: auto;
 }

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -166,9 +166,8 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
     const devWebPin = mediaSidebar.locator("[data-pin-label='Dev Web']");
-    const devWebLinks = devWebPin.getByRole("link");
-    await expect(devWebLinks.first()).toHaveText("http://127.0.0.1:52804");
-    await expect(devWebLinks.first()).toHaveAttribute("href", "http://127.0.0.1:52804/");
+    await expect(devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })).toBeVisible();
+    await expect(devWebPin.getByTestId("pin-open-link")).toHaveAttribute("href", "http://127.0.0.1:52804/");
     await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();
     await expect(mediaSidebar.getByText("Review queue", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })).toBeVisible();

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -116,6 +116,7 @@ test.describe("Media sidebar", () => {
       { label: "Long file", type: "filename", value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx` },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
       { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
+      { label: "Dev Web", type: "url", value: "  http://127.0.0.1:52804 \n" },
       { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
       { label: "Review", type: "pr", value: "Review queue" },
       { label: "Agent ID", type: "code", value: "DISPATCH_AGENT_ID=agt_123" },
@@ -164,6 +165,9 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("4000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
+    const devWebPin = mediaSidebar.locator("[data-pin-label='Dev Web']");
+    await expect(devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })).toBeVisible();
+    await expect(devWebPin.getByTitle("Open in browser")).toHaveAttribute("href", "http://127.0.0.1:52804/");
     await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();
     await expect(mediaSidebar.getByText("Review queue", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })).toBeVisible();

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -166,8 +166,9 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
     const devWebPin = mediaSidebar.locator("[data-pin-label='Dev Web']");
-    await expect(devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })).toBeVisible();
-    await expect(devWebPin.getByTitle("Open in browser")).toHaveAttribute("href", "http://127.0.0.1:52804/");
+    const devWebLinks = devWebPin.getByRole("link");
+    await expect(devWebLinks.first()).toHaveText("http://127.0.0.1:52804");
+    await expect(devWebLinks.first()).toHaveAttribute("href", "http://127.0.0.1:52804/");
     await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();
     await expect(mediaSidebar.getByText("Review queue", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })).toBeVisible();

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -116,6 +116,7 @@ test.describe("Media sidebar", () => {
       { label: "Long file", type: "filename", value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx` },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
       { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
+      { label: "Local URL", type: "url", value: "127.0.0.1:8788/api/v1/health" },
       { label: "Dev Web", type: "url", value: "  http://127.0.0.1:52804 \n" },
       { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
       { label: "Review", type: "pr", value: "Review queue" },
@@ -165,6 +166,8 @@ test.describe("Media sidebar", () => {
     await expect(mediaSidebar.getByText("4000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
+    const localUrlPin = mediaSidebar.locator("[data-pin-label='Local URL']");
+    await expect(localUrlPin.getByRole("link", { name: "127.0.0.1:8788/api/v1/health" })).toHaveAttribute("href", "http://127.0.0.1:8788/api/v1/health");
     const devWebPin = mediaSidebar.locator("[data-pin-label='Dev Web']");
     await expect(devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })).toBeVisible();
     await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  loadApp,
+  setAgentLatestEventViaAPI,
+  setAgentPinsViaDB,
+  uploadMediaViaAPI,
+} from "./helpers";
+
+const AUTH_HEADERS = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+  "Content-Type": "application/json",
+};
+
+type ScrollMetrics = {
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+async function createJobViaAPI(
+  request: APIRequestContext,
+  name: string,
+  directory: string,
+  schedule = "*/30 * * * *"
+): Promise<void> {
+  const res = await request.post("/api/v1/jobs", {
+    headers: AUTH_HEADERS,
+    data: {
+      name,
+      directory,
+      prompt: `Overflow validation job ${name}.`,
+      schedule,
+      timeoutMs: 120000,
+      needsInputTimeoutMs: 86400000,
+    },
+  });
+
+  expect(res.ok(), `Failed to create job ${name}: ${await res.text()}`).toBeTruthy();
+}
+
+async function getScrollMetrics(locator: Locator): Promise<ScrollMetrics> {
+  return locator.evaluate((el) => {
+    const element = el as HTMLElement;
+    return {
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    };
+  });
+}
+
+async function expectOverflow(locator: Locator): Promise<void> {
+  await expect.poll(async () => {
+    const { clientHeight, scrollHeight } = await getScrollMetrics(locator);
+    return scrollHeight - clientHeight;
+  }).toBeGreaterThan(40);
+}
+
+async function scrollToBottom(locator: Locator): Promise<void> {
+  await locator.evaluate((el) => {
+    const element = el as HTMLElement;
+    element.scrollTop = element.scrollHeight;
+  });
+}
+
+async function getWindowScrollY(page: Page): Promise<number> {
+  return page.evaluate(() => window.scrollY);
+}
+
+async function seedOverflowAgents(request: APIRequestContext, count: number): Promise<Array<{ id: string; name: string }>> {
+  const created = await Promise.all(
+    Array.from({ length: count }, async (_, index) => {
+      const agent = await createAgentViaAPI(request, {
+        name: `e2e-agent-overflow-${Date.now()}-${index}`,
+        cwd: process.cwd(),
+      });
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "working",
+        message: `Overflow validation task ${index + 1}`,
+      });
+      return agent;
+    })
+  );
+
+  return created;
+}
+
+test.describe("Overflow layout", () => {
+  test.afterAll(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("agents workspace keeps sidebar, media, and terminal overflow isolated", async ({ page, request }) => {
+    const agents = await seedOverflowAgents(request, 24);
+    const focusAgent = agents[0]!;
+
+    await setAgentPinsViaDB(
+      focusAgent.id,
+      Array.from({ length: 24 }, (_, index) => ({
+        label: `Overflow pin ${index + 1}`,
+        type: "string" as const,
+        value: `Pinned value ${index + 1}\n${"detail ".repeat(18)}`,
+      }))
+    );
+
+    await Promise.all(
+      Array.from({ length: 14 }, (_, index) =>
+        uploadMediaViaAPI(request, focusAgent.id, `Overflow media item ${index + 1}`, `overflow-media-${index + 1}.png`)
+      )
+    );
+
+    await loadApp(page);
+    await page.getByText(focusAgent.name, { exact: true }).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+
+    const agentSidebarScroll = page.getByTestId("agent-sidebar-scroll");
+    const pinsPanelScroll = page.getByTestId("pins-panel-scroll");
+    const terminalPane = page.getByTestId("terminal-pane");
+
+    await expect(agentSidebarScroll).toBeVisible();
+    await expect(pinsPanelScroll).toBeVisible();
+    await expect(terminalPane).toBeVisible();
+    await expect(page.getByTestId("jobs-button")).toBeVisible();
+
+    await expectOverflow(agentSidebarScroll);
+    await expectOverflow(pinsPanelScroll);
+
+    const terminalBoxBefore = await terminalPane.boundingBox();
+    expect(terminalBoxBefore).not.toBeNull();
+    expect(terminalBoxBefore!.height).toBeGreaterThan(280);
+
+    await scrollToBottom(agentSidebarScroll);
+    await scrollToBottom(pinsPanelScroll);
+
+    await expect
+      .poll(async () => (await getScrollMetrics(agentSidebarScroll)).scrollTop)
+      .toBeGreaterThan(0);
+    await expect
+      .poll(async () => (await getScrollMetrics(pinsPanelScroll)).scrollTop)
+      .toBeGreaterThan(0);
+    await expect.poll(async () => getWindowScrollY(page)).toBe(0);
+
+    const terminalBoxAfterSidebarScroll = await terminalPane.boundingBox();
+    expect(terminalBoxAfterSidebarScroll).not.toBeNull();
+    expect(Math.abs(terminalBoxAfterSidebarScroll!.height - terminalBoxBefore!.height)).toBeLessThan(2);
+
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
+
+    const mediaPanelScroll = page.getByTestId("media-panel-scroll");
+    await expect(mediaPanelScroll).toBeVisible();
+    await expectOverflow(mediaPanelScroll);
+
+    await scrollToBottom(mediaPanelScroll);
+
+    await expect
+      .poll(async () => (await getScrollMetrics(mediaPanelScroll)).scrollTop)
+      .toBeGreaterThan(0);
+    await expect.poll(async () => getWindowScrollY(page)).toBe(0);
+
+    const terminalBoxAfterMediaScroll = await terminalPane.boundingBox();
+    expect(terminalBoxAfterMediaScroll).not.toBeNull();
+    expect(Math.abs(terminalBoxAfterMediaScroll!.height - terminalBoxBefore!.height)).toBeLessThan(2);
+  });
+
+  test("jobs page keeps sidebar overflow isolated from the shell", async ({ page, request }) => {
+    const stamp = Date.now();
+
+    await Promise.all(
+      Array.from({ length: 24 }, (_, index) =>
+        createJobViaAPI(
+          request,
+          `Overflow job ${stamp}-${index + 1}`,
+          `/tmp/dispatch-overflow-jobs/${stamp}/${index + 1}`
+        )
+      )
+    );
+
+    await loadApp(page);
+    await page.getByTestId("jobs-button").click();
+
+    const jobsSidebar = page.getByTestId("jobs-sidebar");
+    const jobsSidebarScroll = page.getByTestId("jobs-sidebar-scroll");
+
+    await expect(jobsSidebar).toBeVisible();
+    await expect(jobsSidebarScroll).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Jobs" })).toBeVisible();
+    await expect(page.getByTestId("agents-button")).toBeVisible();
+    await expect(page.getByTestId("settings-button")).toBeVisible();
+
+    await expectOverflow(jobsSidebarScroll);
+    await scrollToBottom(jobsSidebarScroll);
+
+    await expect
+      .poll(async () => (await getScrollMetrics(jobsSidebarScroll)).scrollTop)
+      .toBeGreaterThan(0);
+    await expect.poll(async () => getWindowScrollY(page)).toBe(0);
+  });
+});

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -33,4 +33,18 @@ test.describe("Sidebar interactions", () => {
     await expect(page.getByTestId("create-agent-form")).toBeVisible({ timeout: 3_000 });
     await expect(page.getByText("Create Agent")).toBeVisible();
   });
+
+  test("mobile navigation back to agents opens the sidebar", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await loadApp(page);
+
+    await page.getByTitle("Open agent sidebar").click();
+    await page.getByTestId("jobs-button").click();
+    await expect(page).toHaveURL(/\/jobs$/);
+
+    await page.getByTestId("agents-button").click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId("agent-sidebar")).toBeVisible();
+    await expect(page.getByTestId("terminal-pane")).toBeVisible();
+  });
 });

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { loadApp } from "./helpers";
 
+async function expectMobileSidebarOpen(page: import("@playwright/test").Page): Promise<void> {
+  const dialog = page.getByRole("dialog", { name: "Agent sidebar" });
+  await expect(dialog.getByTitle("Close sidebar")).toBeVisible();
+  await expect
+    .poll(async () => dialog.evaluate((el) => Math.round(el.getBoundingClientRect().left)))
+    .toBe(0);
+}
+
 test.describe("Sidebar interactions", () => {
   test("closing and reopening the left sidebar", async ({ page }) => {
     await loadApp(page);
@@ -39,12 +47,12 @@ test.describe("Sidebar interactions", () => {
     await loadApp(page);
 
     await page.getByTitle("Open agent sidebar").click();
+    await expectMobileSidebarOpen(page);
     await page.getByTestId("jobs-button").click();
     await expect(page).toHaveURL(/\/jobs$/);
 
     await page.getByTestId("agents-button").click();
     await expect(page).toHaveURL(/\/$/);
-    await expect(page.getByTestId("agent-sidebar")).toBeVisible();
-    await expect(page.getByTestId("terminal-pane")).toBeVisible();
+    await expectMobileSidebarOpen(page);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.2(@types/node@24.12.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@24.12.0)(happy-dom@18.0.1)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -2190,6 +2190,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
@@ -2221,6 +2224,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -3236,6 +3242,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@18.0.1:
+    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -4787,6 +4797,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -5010,6 +5023,10 @@ packages:
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -6989,6 +7006,11 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+    optional: true
+
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
@@ -7019,6 +7041,9 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -8273,6 +8298,13 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@18.0.1:
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/whatwg-mimetype': 3.0.2
+      whatwg-mimetype: 3.0.0
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -10170,6 +10202,9 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@6.21.0:
+    optional: true
+
   undici-types@7.16.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -10323,7 +10358,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.2(@types/node@24.12.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@24.12.0)(happy-dom@18.0.1)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -10347,10 +10382,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
+      happy-dom: 18.0.1
     transitivePeerDependencies:
       - msw
 
   webidl-conversions@4.0.2: {}
+
+  whatwg-mimetype@3.0.0:
+    optional: true
 
   whatwg-url@7.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- share and harden the sidebar footer nav pulse behavior across agents and jobs
- default mobile navigation back to Agents to the sidebar instead of the terminal, and add more bottom spacing to the mobile footer nav
- normalize URL pin links and add overflow-focused e2e coverage for agents, jobs, media, and terminal layout behavior

## Why
Mobile navigation on the agents page was landing users in the terminal even though the next action usually required opening the sidebar. The mobile footer icons also sat too close to the bottom edge, and the branch still needed regression coverage around pane overflow and pin link handling.

## Impact
- mobile users return to a more useful landing state on Agents
- footer nav interactions feel more consistent across Agents and Jobs
- pinned URLs with surrounding whitespace still open correctly
- overflow behavior in the left sidebar, jobs list, pins, media sidebar, and terminal shell is covered by e2e tests

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
