### PR TITLE
[codex] Refine session rename guidance

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1640,7 +1640,7 @@ export class AgentManager {
         "Dispatch startup rules: " +
         "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
         (suggestSessionRename
-          ? "If your session still has the default generated name, update it to a short goal or topic using dispatch_rename_session. "
+          ? "If your session still has the default generated name, wait until you understand the user's concrete task, then call dispatch_rename_session once with a short topic/goal/feature name. Use the session name as a stable label for the task, not as a live status update, and do not rename it again unless the user starts a separate task or explicitly asks for a rename. "
           : "") +
         "Call dispatch_event to report status. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). " +
         "Emit working at turn start and when shifting phases (e.g. research → coding → testing). Only use blocked when truly stuck — not for errors you are actively fixing. Emit a terminal event before your final response. " +

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -176,6 +176,8 @@ describe("AgentManager", () => {
       expect(setupScript).toContain("DISPATCH_AUTH_TOKEN=");
       expect(setupScript).toContain("do not start repo work or infer a task from branch/worktree context alone");
       expect(setupScript).toContain("dispatch_rename_session");
+      expect(setupScript).toContain("short topic/goal/feature name");
+      expect(setupScript).toContain("stable label for the task, not as a live status update");
     });
 
     it("should skip rename guidance when the user provided a custom name", async () => {


### PR DESCRIPTION
## What changed
- refined the startup guidance for `dispatch_rename_session` so agents wait until they understand the concrete task before renaming
- clarified that the session name should be a stable task label, not a live status field
- added assertions covering the new wording in the agent-manager startup script test

## Why
The existing guidance told agents to rename default-generated sessions, but it did not make timing or stability explicit. That led to inconsistent usage where some agents renamed too early or reused the session title as a status indicator.

## Impact
- agents should rename once, after they have a clear task
- session titles should remain anchored to the task/topic unless the user starts a separate task or explicitly asks for a rename
- launch-script coverage now checks for the more specific guidance

## Validation
- `pnpm --filter @dispatch/shared build`
- `pnpm --filter @dispatch/server test -- agent-manager.test.ts`
