### PR TITLE
Fix launchd wrapper to use main.js entry point

### DIFF
--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -12,4 +12,4 @@
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 cd "$ROOT_DIR"
-exec node "$ROOT_DIR/apps/server/dist/server.js"
+exec node "$ROOT_DIR/apps/server/dist/main.js"


### PR DESCRIPTION
## Summary
- Updates `bin/dispatch-launchd-wrapper` to run `main.js` instead of `server.js`
- `server.js` was refactored to only export `start()` without calling it; `main.js` is the actual entry point that imports `start()` and sets up error/signal handlers

## Test plan
- [ ] Verify launchd-managed server starts correctly after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)