### PR TITLE
Use TypeScript project references for shared package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 npm-debug.log*
 .DS_Store
 dist
+*.tsbuildinfo
 .env
 .env.local
 data

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/main.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "start": "node dist/main.js",
-    "check": "tsc --noEmit",
+    "check": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:migrate": "tsx src/db/migrate.ts"

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -4,5 +4,8 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/shared" }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "pnpm --filter @dispatch/server start",
     "release": "bin/dispatch-server update",
     "db:migrate": "pnpm --filter @dispatch/server db:migrate",
-    "check": "pnpm --filter @dispatch/shared build && pnpm --filter @dispatch/server check && pnpm run check:web",
+    "check": "pnpm --filter @dispatch/server check && pnpm run check:web",
     "test": "pnpm --filter @dispatch/server test",
     "test:watch": "pnpm --filter @dispatch/server test:watch",
     "test:e2e": "bash scripts/e2e-isolated.sh",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## Summary
- Adds `composite: true` to `@dispatch/shared` tsconfig and project references from the server, so `tsc -b` auto-builds shared when it's stale
- Removes the manual `pnpm --filter @dispatch/shared build` step from the root `check` script — no longer needed
- Adds `*.tsbuildinfo` to `.gitignore` for the incremental build cache files

This eliminates the recurring issue where agents (and developers) had to manually build the shared package before type-checking or building the server.

## Test plan
- [x] `pnpm run check` passes from clean state (no pre-built `dist/`)
- [x] Dev server starts and serves correctly
- [x] Agent launch works (exercises shared package imports at runtime)
- [x] 302 unit tests pass
- [x] 100 E2E tests pass
- [x] Production build/launch path unchanged (`node dist/main.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)