### PR TITLE
chore: tune persona prompts based on weekly review

### DIFF
--- a/.dispatch/personas/architecture-review.md
+++ b/.dispatch/personas/architecture-review.md
@@ -40,4 +40,5 @@ Your review MUST focus exclusively on the code that was changed in the diff belo
 2. Explore surrounding code to understand context and existing patterns.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 4. **Make findings actionable.** Each finding should include a concrete suggestion for what to change. Avoid abstract observations like "this could be cleaner" — specify what the better structure looks like and where to apply it.
+5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are well-designed. If the architecture is sound, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
 

--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -42,3 +42,4 @@ Treat the supplied diff as the hard review boundary.
 1. Read the diff carefully first to understand exactly what changed.
 2. Use `grep` and `read` to explore context around the changes.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+4. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are correctly implemented. If the security posture is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change or a concrete risk.

--- a/.dispatch/personas/frontend-ux-review.md
+++ b/.dispatch/personas/frontend-ux-review.md
@@ -43,4 +43,5 @@ Your review MUST focus exclusively on the code that was changed in the diff belo
 2. Trace the component hierarchy and prop flow in surrounding code for context.
 3. Think about what a user would experience, not just whether the code is correct.
 4. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that work correctly. If the UX is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
 

--- a/.dispatch/personas/infra-review.md
+++ b/.dispatch/personas/infra-review.md
@@ -41,4 +41,5 @@ You have deep expertise in Unix systems, shell scripting, process management, an
 ## How to review
 1. Read the changed files carefully. Use `grep` and `read` to trace how changes interact with the OS layer.
 2. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+3. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are correctly implemented. If the infrastructure is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
 

--- a/.dispatch/personas/product-review.md
+++ b/.dispatch/personas/product-review.md
@@ -40,4 +40,5 @@ Your review MUST focus exclusively on user-facing impact introduced by the chang
 2. Explore surrounding UI and API context to understand user-facing impact.
 3. Think like a user, not a developer. Focus on what someone experiences, not how it's implemented.
 4. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that work well. If the product experience is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify a user-facing gap or concern.
 


### PR DESCRIPTION
## Summary

Weekly persona review analysis (2026-04-05 to 2026-04-12) found that **28% of all feedback items (74/262) were info-severity positive affirmations** that got ignored. This adds noise without actionable signal.

This PR adds explicit "only submit feedback for actual issues" guidance to 5 persona prompts that were missing it:
- `architecture-review.md`
- `backend-security-review.md`
- `frontend-ux-review.md`
- `infra-review.md`
- `product-review.md`

The `e2e-tester` persona already had this guidance.

## Rationale

- **262 total findings** across 9 personas, 64 reviews (100% completion rate)
- **74 info-severity items** — mostly positive observations like "Good use of atomic state transition" — were consistently ignored
- **115 items ignored overall (44%)** — reducing info noise should improve the signal-to-noise ratio
- All personas produce high-quality, specific findings when flagging actual issues — the problem is volume of non-actionable items, not quality

## Test plan
- [ ] Verify persona prompts render correctly when loaded
- [ ] Monitor next week's persona reviews for reduced info-severity volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)