### PR TITLE
docs: fix stale references across README, CLAUDE.md, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,6 @@ dispatch/
 ├── scripts/                   # e2e-isolated.sh, generate-icon-colors.ts
 ├── .dispatch/                 # repo-level Dispatch config
 │   ├── config.json            # repo-level settings (e.g. Linear integration)
-│   ├── jobs/                  # job prompt templates (*.md)
 │   ├── personas/              # persona definitions (*.md)
 │   └── tools.json             # repo-specific MCP tools + lifecycle hooks
 └── docs/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > 5. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The default host binds to localhost; set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections.
 > 6. Register as a system service:
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
->    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/server.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.
+>    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/main.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.
 > 7. Verify: `curl http://127.0.0.1:6767/api/v1/health`
 > 8. Check which agent CLIs are installed (`claude --version`, `codex --version`, `opencode --version`). In the Dispatch UI under Settings, disable any agent types whose CLI is not installed.
 
@@ -27,7 +27,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 - Persist each agent in `tmux` so browser disconnects do not kill work.
 - Git worktree isolation for parallel agent work on separate branches.
 - MCP-based tooling with repo-specific custom tools (`.dispatch/tools.json`).
-- Jobs — scheduled, repo-scoped agent tasks with structured reporting and interactive recovery (`.dispatch/jobs/`).
+- Jobs — scheduled, repo-scoped agent tasks with structured reporting and interactive recovery.
 - Personas — reusable agent roles for automated code review with structured feedback (`.dispatch/personas/`).
 - GitHub integration — PR creation and CI status checks via MCP tools.
 - Slack notifications with focus-aware suppression.

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -86,7 +86,7 @@ For persona agents (launched via `dispatch_launch_persona`):
 
 ### `DELETE /agents/:id`
 
-Query params: `force=true`, `cleanupWorktree=true`
+Query params: `cleanupWorktree=auto|keep|force` (default: `auto` — cleans up worktree if no unmerged/uncommitted changes; `keep` preserves worktree; `force` always removes)
 
 ## Agent Setup
 

--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -30,7 +30,7 @@
 
 ## tmux Session Contract
 
-- Session name: `dispatch_agt_<agentId>_<name>`
+- Session name: `<prefix>_<agentId>_<sanitizedName>` (prefix defaults to `dispatch`, configurable via `DISPATCH_SESSION_PREFIX`)
 - Window name: `main`
 - Agent process starts in configured `cwd`
 - Closing browser terminal must only detach client, not terminate tmux
@@ -40,14 +40,10 @@
 Example launch command:
 
 ```bash
-tmux new-session -d -s dispatch_<agentId> -c "<cwd>" "codex"
+tmux new-session -d -s <sessionName> -c "<cwd>" "bash <setupScript>"
 ```
 
-Optional with args:
-
-```bash
-tmux new-session -d -s dispatch_<agentId> -c "<cwd>" "codex <args>"
-```
+The setup script sources `~/.dispatch/env`, configures the MCP server, and launches the agent CLI.
 
 ## Agent Environment
 
@@ -71,13 +67,13 @@ Standard shell profiles (`~/.bashrc`, `~/.zshrc`, etc.) are **not** sourced — 
 Preferred soft stop:
 
 ```bash
-tmux send-keys -t dispatch_<agentId> C-c
+tmux send-keys -t <sessionName> C-c
 ```
 
 Fallback hard stop:
 
 ```bash
-tmux kill-session -t dispatch_<agentId>
+tmux kill-session -t <sessionName>
 ```
 
 ## Reconciliation Routine (on startup)

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -13,7 +13,7 @@ Dispatch runs as a **launchd LaunchAgent** (`com.dispatch.server`) — a macOS-n
 
 The server binary lives in a **separate checkout** at `~/.dispatch/server/` (independent from your working copy at `~/dev/apps/dispatch`). This means `git checkout`, deploys, and agent activity in the main repo never interfere with the running server.
 
-**Postgres** runs in Docker (`dispatch-postgres`, port 5432).
+**Postgres** runs via Homebrew (`brew services start postgresql@17`, port 5432). Docker is available for isolated dev databases via `dispatch-dev`.
 
 **Server port**: 6767 (set via `DISPATCH_PORT` in `~/.dispatch/server/.env`).
 
@@ -39,15 +39,15 @@ launchctl load ~/Library/LaunchAgents/com.dispatch.server.plist
 
 ## Database
 
-Postgres runs via Docker Compose. Start/stop with:
+Production uses Homebrew Postgres (native, no Docker overhead):
 
 ```bash
-docker compose up -d postgres     # start
-docker compose stop postgres      # stop (data preserved)
-docker compose down postgres      # stop + remove container (data preserved in volume)
+brew services start postgresql@17   # start (auto-starts at boot)
+brew services stop postgresql@17    # stop
+pg_isready                          # check status
 ```
 
-Data is persisted in the `dispatch_pgdata` Docker volume.
+For development, `dispatch-dev up` creates an isolated Docker Postgres container on a free port — no manual setup needed.
 
 ## Release Pipeline
 


### PR DESCRIPTION
## Summary

Audited all documentation against the actual codebase and fixed stale references:

- **README.md**: Fixed server entry point in Quick Install (`server.js` → `main.js`), removed stale `.dispatch/jobs/` reference from features list (jobs are now fully DB-backed)
- **CLAUDE.md**: Removed non-existent `.dispatch/jobs/` directory from project structure tree
- **docs/03-api-spec.md**: Fixed `DELETE /agents/:id` query params — was `force=true, cleanupWorktree=true`, now correctly documents `cleanupWorktree=auto|keep|force`
- **docs/04-agent-lifecycle.md**: Fixed tmux session name format to reflect `{prefix}_{agentId}_{sanitizedName}` pattern, updated launch contract to show setup script flow instead of direct CLI invocation
- **docs/10-operations-runbook.md**: Fixed database section — production uses Homebrew Postgres (not Docker), Docker is only for dev via `dispatch-dev`

## Audit scope

Surveyed all API routes (93 endpoints), web app routes, CLI tools (11 bin scripts), MCP tools (31 tools), database schema (12 tables, 11 migrations), configuration, and git/GitHub integrations. Compared every concrete claim in README.md, CLAUDE.md, and 8 docs/*.md files against the codebase.

## What was NOT changed

- docs/11-backend-compatibility-checklist.md — accurate
- docs/12-new-machine-setup.md — accurate
- docs/14-theming.md — accurate
- docs/15-personas-and-feedback.md — accurate
- docs/16-notifications.md — accurate

No docs were created or deleted — all existing docs are still relevant and no major undocumented features were found.

## Test plan

- [x] All doc links in README.md verified to exist
- [x] `pnpm run check` passes
- [x] No code changes — docs only