### PR TITLE
feat: add Autonomous Review option for agents

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -74,6 +74,7 @@ export type AgentRecord = {
     filesReviewed: string[] | null;
     updatedAt: string;
   } | null;
+  autoReview: boolean;
   cliSessionId: string | null;
   createdAt: string;
   updatedAt: string;
@@ -100,6 +101,7 @@ type CreateAgentInput = {
   persona?: string;
   parentAgentId?: string;
   personaContext?: string;
+  autoReview?: boolean;
   cliSessionId?: string;
   jobRunId?: string;
 };
@@ -384,12 +386,12 @@ export class AgentManager {
     const initialSetupPhase: SetupPhase = useWorktree ? "worktree" : "session";
     await this.pool.query(
       `
-      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, cli_session_id, updated_at)
-      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13, NOW())
+      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, cli_session_id, auto_review, updated_at)
+      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13, $14, NOW())
       `,
       [id, name, type, originalCwd, tmuxSession, mediaDir, JSON.stringify(agentArgs), fullAccess, initialSetupPhase,
         input.persona ?? null, input.parentAgentId ?? null, input.personaContext ?? null,
-        cliSessionId]
+        cliSessionId, input.autoReview ?? false]
     );
 
     if (this.config.agentRuntime === "inert") {
@@ -439,7 +441,8 @@ export class AgentManager {
           cliSessionId ?? undefined,
           false,
           input.jobRunId,
-          this.shouldSuggestSessionRename(name, id, { persona: input.persona, jobRunId: input.jobRunId })
+          this.shouldSuggestSessionRename(name, id, { persona: input.persona, jobRunId: input.jobRunId }),
+          !input.persona && !input.jobRunId && (input.autoReview ?? false)
         );
         const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
 
@@ -584,7 +587,8 @@ export class AgentManager {
         agent.agentArgs ?? [],
         agent.fullAccess ?? false,
         cliSessionId ?? undefined,
-        shouldResume
+        shouldResume,
+        agent.autoReview ?? false
       );
       await this.setAgentStatus(id, "running", null, tmuxSession);
       await this.setSystemLatestEvent(id, {
@@ -1509,7 +1513,8 @@ export class AgentManager {
     agentArgs: string[],
     fullAccess: boolean,
     cliSessionId?: string,
-    resume?: boolean
+    resume?: boolean,
+    autoReview?: boolean
   ): Promise<void> {
     if (this.config.agentRuntime === "inert") {
       await mkdir(mediaDir, { recursive: true });
@@ -1526,7 +1531,8 @@ export class AgentManager {
       cliSessionId,
       resume,
       undefined,
-      this.shouldSuggestSessionRename(agentName, agentId, { persona })
+      this.shouldSuggestSessionRename(agentName, agentId, { persona }),
+      !persona && (autoReview ?? false)
     );
     const exitFile = `/tmp/dispatch_${sessionName}.exit`;
     const sessionLogFile = `/tmp/dispatch_setup_${agentId}.log`;
@@ -1629,7 +1635,8 @@ export class AgentManager {
     cliSessionId?: string,
     resume?: boolean,
     jobRunId?: string,
-    suggestSessionRename?: boolean
+    suggestSessionRename?: boolean,
+    autoReview?: boolean
   ): string {
     const agentId = this.agentIdFromSessionName(sessionName);
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
@@ -1647,7 +1654,18 @@ export class AgentManager {
         "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done. " +
         "Use dispatch_pin to surface key info in the sidebar, especially values users may need to copy/paste later such as URLs, commands, branch names, IDs, tokens, simulator UDIDs, and other short reusable values. Update pins when values change; delete stale ones. " +
         "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
-        "For longer artifacts, write to a file via dispatch_share and pin a reference.";
+        "For longer artifacts, write to a file via dispatch_share and pin a reference." +
+        (autoReview
+          ? " Autonomous Review is enabled for this session. Before marking your task as done, you must run at least one persona review: " +
+            "(1) Call list_personas to see which reviewers are available for this project. " +
+            "(2) Choose 1–3 personas based on the nature of your changes — always pick at least 1 that is most relevant; add a 2nd or 3rd only if the changes span multiple concern areas. " +
+            "If no personas are available or none are relevant, note that in your response and proceed to done. " +
+            "(3) Launch each chosen persona via dispatch_launch_persona with thorough context: what you changed, key files, areas of concern, and what is NOT in scope. " +
+            "(4) After launching, poll dispatch_get_feedback every 60–90 seconds until all persona reviews reach a terminal status. " +
+            "(5) For each feedback item: critical/high severity — address the issue then resolve; medium — use judgment, fix if straightforward or resolve with a comment; low/info — acknowledge and resolve. " +
+            "(6) Only emit your final done event after all launched reviews have completed and all actionable feedback has been addressed or resolved. " +
+            "Do not skip Autonomous Review even if your changes seem minor — the user opted in to this workflow."
+          : "");
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(
@@ -2662,6 +2680,7 @@ export class AgentManager {
         persona,
         parent_agent_id AS "parentAgentId",
         persona_context AS "personaContext",
+        auto_review AS "autoReview",
         cli_session_id AS "cliSessionId",
         (SELECT json_build_object(
            'status', pr.status,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1656,15 +1656,7 @@ export class AgentManager {
         "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
         "For longer artifacts, write to a file via dispatch_share and pin a reference." +
         (autoReview
-          ? " Autonomous Review is enabled for this session. Before marking your task as done, you must run at least one persona review: " +
-            "(1) Call list_personas to see which reviewers are available for this project. " +
-            "(2) Choose 1–3 personas based on the nature of your changes — always pick at least 1 that is most relevant; add a 2nd or 3rd only if the changes span multiple concern areas. " +
-            "If no personas are available or none are relevant, note that in your response and proceed to done. " +
-            "(3) Launch each chosen persona via dispatch_launch_persona with thorough context: what you changed, key files, areas of concern, and what is NOT in scope. " +
-            "(4) After launching, poll dispatch_get_feedback every 60–90 seconds until all persona reviews reach a terminal status. " +
-            "(5) For each feedback item: critical/high severity — address the issue then resolve; medium — use judgment, fix if straightforward or resolve with a comment; low/info — acknowledge and resolve. " +
-            "(6) Only emit your final done event after all launched reviews have completed and all actionable feedback has been addressed or resolved. " +
-            "Do not skip Autonomous Review even if your changes seem minor — the user opted in to this workflow."
+          ? " Autonomous Review is enabled. Before emitting done, call list_personas, pick 1–3 relevant reviewers, launch them via dispatch_launch_persona with context about your changes, then poll dispatch_get_feedback until all reviews complete. Address critical/high feedback before resolving; medium and below can be resolved with a comment. Do not emit done until all reviews are resolved."
           : "");
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;

--- a/apps/server/src/db/migrations/0012_auto-review.sql
+++ b/apps/server/src/db/migrations/0012_auto-review.sql
@@ -1,0 +1,5 @@
+-- Add auto_review flag for Autonomous Review feature.
+-- When true, the agent will launch persona reviews and address feedback
+-- before marking its task as complete.
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS auto_review BOOLEAN NOT NULL DEFAULT false;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1347,6 +1347,7 @@ async function registerRoutes() {
       renameSession: mcpRenameSession,
       shareMedia: mcpShareMedia,
       submitFeedback: mcpSubmitFeedback,
+      listPersonas: mcpListPersonas,
       launchPersona: mcpLaunchPersona,
       getFeedback: mcpGetFeedback,
       resolveFeedback: mcpResolveFeedback,
@@ -2921,6 +2922,7 @@ async function registerRoutes() {
       persona?: unknown;
       parentAgentId?: unknown;
       personaContext?: unknown;
+      autoReview?: unknown;
     };
 
     if (typeof body?.cwd !== "string") {
@@ -2994,6 +2996,7 @@ async function registerRoutes() {
         persona: typeof body.persona === "string" ? body.persona : undefined,
         parentAgentId: typeof body.parentAgentId === "string" ? body.parentAgentId : undefined,
         personaContext: typeof body.personaContext === "string" ? body.personaContext : undefined,
+        autoReview: body.autoReview === true,
       });
       queueGitContextRefresh([agent.id]);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
@@ -4256,6 +4259,13 @@ async function mcpJobLog(
 ): Promise<{ runId: string; status: string }> {
   const run = await jobService.logForAgent(agentId, input);
   return { runId: run.id, status: run.status };
+}
+
+async function mcpListPersonas(
+  agentCwd: string
+): Promise<Array<{ slug: string; name: string; description: string }>> {
+  const personas = await loadPersonas(agentCwd);
+  return personas.map(({ slug, name, description }) => ({ slug, name, description }));
 }
 
 async function mcpLaunchPersona(

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -142,6 +142,23 @@ describe("AgentManager", () => {
       expect(agent.fullAccess).toBe(true);
     });
 
+    it("should persist autoReview", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        autoReview: true,
+        useWorktree: false,
+      });
+      expect(agent.autoReview).toBe(true);
+    });
+
+    it("should default autoReview to false", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+      expect(agent.autoReview).toBe(false);
+    });
+
     it("should reject non-absolute paths", async () => {
       await expect(manager.createAgent({ cwd: "relative/path" })).rejects.toThrow(
         "absolute path"
@@ -275,6 +292,73 @@ describe("AgentManager", () => {
       }
     });
 
+    it("should include autonomous review guidance when autoReview is true", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        autoReview: true,
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).toContain("Autonomous Review is enabled");
+      expect(setupScript).toContain("list_personas");
+      expect(setupScript).toContain("dispatch_launch_persona");
+      expect(setupScript).toContain("dispatch_get_feedback");
+    });
+
+    it("should not include autonomous review guidance when autoReview is false", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        autoReview: false,
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("Autonomous Review is enabled");
+    });
+
+    it("should not include autonomous review guidance for persona agents even if autoReview is true", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        autoReview: true,
+        persona: "security-review",
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("Autonomous Review is enabled");
+    });
+
+    it("should include autonomous review guidance for Codex agents", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        autoReview: true,
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).toContain("Autonomous Review is enabled");
+      expect(setupScript).toContain("list_personas");
+    });
+
+    it("should not include autonomous review guidance for job agents", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        autoReview: true,
+        jobRunId: "run_abc123",
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      expect(setupScript).not.toContain("Autonomous Review is enabled");
+      expect(setupScript).toContain("Dispatch job startup rules");
+    });
+
     it("should generate a setup script with worktree steps when useWorktree is true", async () => {
       const agent = await manager.createAgent({ cwd: "/tmp", type: "claude", useWorktree: true });
 
@@ -339,6 +423,26 @@ describe("AgentManager", () => {
       expect(fetched).not.toBeNull();
       expect(fetched!.id).toBe(created.id);
       expect(fetched!.name).toBe("fetch-me");
+    });
+
+    it("should round-trip autoReview through getAgent", async () => {
+      const created = await manager.createAgent({ cwd: "/tmp", autoReview: true, useWorktree: false });
+      const fetched = await manager.getAgent(created.id);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.autoReview).toBe(true);
+    });
+
+    it("should include autoReview in listAgents results", async () => {
+      await manager.createAgent({ name: "review-on", cwd: "/tmp", autoReview: true, useWorktree: false });
+      await manager.createAgent({ name: "review-off", cwd: "/tmp", autoReview: false, useWorktree: false });
+
+      const agents = await manager.listAgents();
+      const reviewOn = agents.find((a) => a.name === "review-on");
+      const reviewOff = agents.find((a) => a.name === "review-off");
+
+      expect(reviewOn!.autoReview).toBe(true);
+      expect(reviewOff!.autoReview).toBe(false);
     });
 
     it("should rename an agent", async () => {

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -233,6 +233,21 @@ feedbackFormat: checklist
     const personas = await loadPersonas("/tmp/nonexistent-dispatch-test");
     expect(personas).toEqual([]);
   });
+
+  it("can be safely projected to slug/name/description without leaking body", async () => {
+    const personas = await loadPersonas(tmpRoot);
+    const projected = personas.map(({ slug, name, description }) => ({ slug, name, description }));
+
+    expect(projected).toHaveLength(2);
+    for (const p of projected) {
+      expect(Object.keys(p).sort()).toEqual(["description", "name", "slug"]);
+      expect(p.slug).toBeTruthy();
+      expect(p.name).toBeTruthy();
+      // Ensure the body text does not leak into the projected fields
+      expect(JSON.stringify(p)).not.toContain("# Security Reviewer");
+      expect(JSON.stringify(p)).not.toContain("# Design Reviewer");
+    }
+  });
 });
 
 describe("loadPersonaBySlug", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";
 import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
-import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom, baseBranchByCwdAtom } from "@/lib/store";
+import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom, baseBranchByCwdAtom, autoReviewByCwdAtom } from "@/lib/store";
 import { AgentSidebar, AgentSidebarContent } from "@/components/app/agent-sidebar";
 import { ActivityPane } from "@/components/app/activity-pane";
 import { DocsPane } from "@/components/app/docs-pane";
@@ -163,6 +163,7 @@ export function DashboardLayout(): JSX.Element {
   const [lastUsedAgentType, setLastUsedAgentType] = useState<AgentType | null>(() => readLastUsedAgentType());
   const [createType, setCreateType] = useState<AgentType>("codex");
   const [createFullAccess, setCreateFullAccess] = useAtom(fullAccessByCwdAtom(createCwd));
+  const [createAutoReview, setCreateAutoReview] = useAtom(autoReviewByCwdAtom(createCwd));
   const [createBaseBranch, setCreateBaseBranch] = useAtom(baseBranchByCwdAtom(createCwd));
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
@@ -478,6 +479,7 @@ export function DashboardLayout(): JSX.Element {
             cwd: createCwd.trim(),
             type: createType,
             fullAccess: createFullAccess,
+            autoReview: createAutoReview,
             useWorktree: createUseWorktree,
             worktreeBranch: createWorktreeBranch.trim() || undefined,
             baseBranch: createBaseBranch !== "main" ? createBaseBranch : undefined,
@@ -501,7 +503,7 @@ export function DashboardLayout(): JSX.Element {
         setCreating(false);
       }
     },
-    [createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia]
+    [createAutoReview, createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia]
   );
 
   const borderForAgentState = (state: AgentVisualState): string => {
@@ -825,6 +827,7 @@ export function DashboardLayout(): JSX.Element {
         createType={createType}
         createCwd={createCwd}
         createFullAccess={createFullAccess}
+        createAutoReview={createAutoReview}
         createUseWorktree={createUseWorktree}
         createWorktreeBranch={createWorktreeBranch}
         createBaseBranch={createBaseBranch}
@@ -836,6 +839,7 @@ export function DashboardLayout(): JSX.Element {
         setCreateType={setCreateType}
         setCreateCwd={setCreateCwd}
         setCreateFullAccess={setCreateFullAccess}
+        setCreateAutoReview={setCreateAutoReview}
         setCreateUseWorktree={setCreateUseWorktree}
         setCreateWorktreeBranch={setCreateWorktreeBranch}
         setCreateBaseBranch={setCreateBaseBranch}

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -30,6 +30,7 @@ type CreateAgentDialogProps = {
   createType: AgentType;
   createCwd: string;
   createFullAccess: boolean;
+  createAutoReview: boolean;
   createUseWorktree: boolean;
   createWorktreeBranch: string;
   createBaseBranch: string;
@@ -41,6 +42,7 @@ type CreateAgentDialogProps = {
   setCreateType: (value: AgentType) => void;
   setCreateCwd: (cwd: string) => void;
   setCreateFullAccess: (value: boolean | ((current: boolean) => boolean)) => void;
+  setCreateAutoReview: (value: boolean | ((current: boolean) => boolean)) => void;
   setCreateUseWorktree: (value: boolean | ((current: boolean) => boolean)) => void;
   setCreateWorktreeBranch: (value: string) => void;
   setCreateBaseBranch: (value: string) => void;
@@ -54,6 +56,7 @@ export function CreateAgentDialog({
   createType,
   createCwd,
   createFullAccess,
+  createAutoReview,
   createUseWorktree,
   createWorktreeBranch,
   createBaseBranch,
@@ -65,6 +68,7 @@ export function CreateAgentDialog({
   setCreateType,
   setCreateCwd,
   setCreateFullAccess,
+  setCreateAutoReview,
   setCreateUseWorktree,
   setCreateWorktreeBranch,
   setCreateBaseBranch,
@@ -323,6 +327,22 @@ export function CreateAgentDialog({
               <span className="block text-sm font-medium text-foreground">Start in full access mode</span>
               <span className="block text-xs text-muted-foreground">
                 Starts the selected agent with its most permissive supported execution mode.
+              </span>
+            </span>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+            <Checkbox
+              checked={createAutoReview}
+              onCheckedChange={() => setCreateAutoReview((current) => !current)}
+              className="mt-0.5"
+              title="Toggle autonomous review"
+              data-testid="create-agent-auto-review"
+            />
+            <span className="space-y-1">
+              <span className="block text-sm font-medium text-foreground">Autonomous Review</span>
+              <span className="block text-xs text-muted-foreground">
+                Agent will launch persona reviews and address feedback before completing.
               </span>
             </span>
           </label>

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -46,6 +46,7 @@ export type Agent = {
     filesReviewed: string[] | null;
     updatedAt: string;
   } | null;
+  autoReview?: boolean;
   hasStream?: boolean;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -41,3 +41,8 @@ export const fullAccessByCwdAtom = atomFamily((cwd: string) =>
 export const baseBranchByCwdAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage(`dispatch:baseBranch:${cwd}`, "main"),
 );
+
+/** Per-directory autonomous review preference, backed by localStorage (sync read). */
+export const autoReviewByCwdAtom = atomFamily((cwd: string) =>
+  atomWithLocalStorage(`dispatch:autoReview:${cwd}`, false),
+);

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -65,6 +65,64 @@ test.describe("Agent CRUD", () => {
     await expect(page.getByTestId("terminal-inert-state")).toContainText("Agent running in inert mode");
   });
 
+  test("create dialog shows autonomous review checkbox that can be toggled", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    // Open the create dialog
+    await page.getByTestId("create-agent-button").click();
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    // The autonomous review checkbox should be visible and unchecked by default
+    const autoReviewCheckbox = page.getByTestId("create-agent-auto-review");
+    await expect(autoReviewCheckbox).toBeVisible();
+    await expect(autoReviewCheckbox).toHaveAttribute("aria-checked", "false");
+
+    // Toggle it on by clicking the label text (avoids double-toggle from label+button)
+    await form.getByText("Autonomous Review").click();
+    await expect(autoReviewCheckbox).toHaveAttribute("aria-checked", "true");
+
+    // Toggle it back off
+    await form.getByText("Autonomous Review").click();
+    await expect(autoReviewCheckbox).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("POST /api/v1/agents accepts autoReview flag", async ({ request }) => {
+    const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+    const agentName = `e2e-agent-${Date.now()}`;
+
+    const res = await request.post("/api/v1/agents", {
+      headers: AUTH_HEADER,
+      data: {
+        name: agentName,
+        cwd: "/tmp",
+        useWorktree: false,
+        autoReview: true,
+      },
+    });
+    expect(res.status()).toBe(201);
+    const { agent } = (await res.json()) as { agent: { id: string; autoReview: boolean } };
+    expect(agent.autoReview).toBe(true);
+  });
+
+  test("POST /api/v1/agents defaults autoReview to false when omitted", async ({ request }) => {
+    const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
+    const res = await request.post("/api/v1/agents", {
+      headers: AUTH_HEADER,
+      data: {
+        name: `e2e-agent-${Date.now()}`,
+        cwd: "/tmp",
+        useWorktree: false,
+      },
+    });
+    expect(res.status()).toBe(201);
+    const { agent } = (await res.json()) as { agent: { id: string; autoReview: boolean } };
+    expect(agent.autoReview).toBe(false);
+  });
+
   test("cancel create dialog does not create an agent", async ({ page }) => {
     await loadApp(page);
 

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -106,6 +106,7 @@ const AGENT_TOOLS = new Set([
   "dispatch_pin",
   "dispatch_share",
   "dispatch_feedback",
+  "list_personas",
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
@@ -123,6 +124,7 @@ const JOB_TOOLS = new Set([
   "job_needs_input",
   "job_log",
   "list_agents",
+  "list_personas",
   "list_recent_persona_reviews",
   "list_recent_feedback",
   "get_activity_summary",
@@ -201,6 +203,9 @@ export type McpRequestContext = {
     agentId: string,
     feedback: FeedbackInput
   ) => Promise<{ id: number }>;
+  listPersonas?: (
+    agentCwd: string
+  ) => Promise<Array<{ slug: string; name: string; description: string }>>;
   launchPersona?: (
     agentId: string,
     opts: { persona: string; context: string }
@@ -553,6 +558,35 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   if (allowed.has("dispatch_pin")) registerPinTool(server, context);
   if (allowed.has("dispatch_share")) registerShareTool(server, context);
   if (allowed.has("dispatch_feedback")) registerFeedbackTool(server, context);
+
+  // ── list_personas ────────────────────────────────────────────────
+  if (allowed.has("list_personas") && context.agent && context.listPersonas) {
+    const personaRoot = context.worktreeRoot ?? context.repoRoot;
+    const listPersonas = context.listPersonas;
+
+    server.registerTool(
+      "list_personas",
+      {
+        description:
+          "List the persona reviewers available for this project. Returns each persona's slug, name, and description. Use this to decide which personas to launch via dispatch_launch_persona.",
+        inputSchema: {}
+      },
+      async () => {
+        if (!personaRoot) {
+          return { content: [{ type: "text", text: JSON.stringify({ personas: [] }, null, 2) }], structuredContent: { personas: [] } };
+        }
+        try {
+          const personas = await listPersonas(personaRoot);
+          return {
+            content: [{ type: "text", text: JSON.stringify({ personas }, null, 2) }],
+            structuredContent: { personas }
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
 
   // ── dispatch_launch_persona ───────────────────────────────────────
   if (allowed.has("dispatch_launch_persona") && context.agent && context.launchPersona) {


### PR DESCRIPTION
## Summary
- Adds an **Autonomous Review** option when creating agents — when enabled, the agent discovers available personas via a new `list_personas` MCP tool, launches 1-3 relevant reviews, monitors feedback, and addresses/resolves items before completing
- New `list_personas` MCP tool exposed to agent and job scopes (not reviewers), returns persona slug/name/description without leaking the full prompt body
- Preference persists per working directory via localStorage, matching the existing full-access and base-branch patterns

## Changes
- **DB**: Migration `0012_auto-review.sql` — `auto_review BOOLEAN DEFAULT false` on agents table
- **Server**: `autoReview` flows through `CreateAgentInput` → INSERT → agent row → `buildAgentCommand` (guidance injection, skipped for persona/job agents) → `startAgentSession` (resume)
- **MCP**: `list_personas` tool registered in `AGENT_TOOLS` and `JOB_TOOLS`, uses resolved `worktreeRoot ?? repoRoot` (not raw cwd)
- **API**: `autoReview` accepted and passed through the create agent route
- **Web**: `autoReviewByCwdAtom` in store, checkbox in create dialog, wired into POST body
- **Types**: `autoReview` added to server agent row type and web `Agent` type

## Test plan
- [x] Unit: `autoReview` persists as true, defaults to false
- [x] Unit: Guidance injected for Claude and Codex agents when enabled
- [x] Unit: Guidance excluded for persona agents and job agents
- [x] Unit: `autoReview` round-trips through `getAgent` and `listAgents`
- [x] Unit: `loadPersonas` projection strips body without leaking prompt content
- [x] E2E: Create dialog checkbox visible and toggleable
- [x] E2E: API accepts `autoReview: true` and defaults to `false` when omitted
- [x] Type check, production build, 323 unit tests, 103 E2E tests all pass
- [x] UI validated in browser via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)