### PR TITLE
[codex] Persist reviewer agent type on parent sessions

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -66,6 +66,7 @@ export type AgentRecord = {
   persona: string | null;
   parentAgentId: string | null;
   personaContext: string | null;
+  reviewAgentType: AgentType | null;
   review: {
     status: string;
     message: string | null;
@@ -100,6 +101,7 @@ type CreateAgentInput = {
   persona?: string;
   parentAgentId?: string;
   personaContext?: string;
+  reviewAgentType?: AgentType | null;
   cliSessionId?: string;
   jobRunId?: string;
 };
@@ -384,11 +386,11 @@ export class AgentManager {
     const initialSetupPhase: SetupPhase = useWorktree ? "worktree" : "session";
     await this.pool.query(
       `
-      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, cli_session_id, updated_at)
-      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13, NOW())
+      INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, review_agent_type, cli_session_id, updated_at)
+      VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13, $14, NOW())
       `,
       [id, name, type, originalCwd, tmuxSession, mediaDir, JSON.stringify(agentArgs), fullAccess, initialSetupPhase,
-        input.persona ?? null, input.parentAgentId ?? null, input.personaContext ?? null,
+        input.persona ?? null, input.parentAgentId ?? null, input.personaContext ?? null, input.reviewAgentType ?? null,
         cliSessionId]
     );
 
@@ -536,6 +538,16 @@ export class AgentManager {
 
   async updateSetupPhase(id: string, phase: SetupPhase): Promise<void> {
     await this.setSetupPhase(id, phase);
+  }
+
+  async updateReviewAgentType(id: string, reviewAgentType: AgentType | null): Promise<void> {
+    const result = await this.pool.query(
+      `UPDATE agents SET review_agent_type = $2, updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL`,
+      [id, reviewAgentType]
+    );
+    if (result.rowCount === 0) {
+      throw new AgentError("Agent not found.", 404);
+    }
   }
 
   async startAgent(id: string): Promise<AgentRecord> {
@@ -2662,6 +2674,7 @@ export class AgentManager {
         persona,
         parent_agent_id AS "parentAgentId",
         persona_context AS "personaContext",
+        review_agent_type AS "reviewAgentType",
         cli_session_id AS "cliSessionId",
         (SELECT json_build_object(
            'status', pr.status,

--- a/apps/server/src/db/migrations/0012_agents-review-agent-type.sql
+++ b/apps/server/src/db/migrations/0012_agents-review-agent-type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS review_agent_type TEXT;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2640,6 +2640,40 @@ async function registerRoutes() {
     return { agent: withStreamFlag(agent) };
   });
 
+  app.patch("/api/v1/agents/:id/review-agent-type", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    const body = request.body as { reviewAgentType?: unknown } | null;
+
+    let reviewAgentType: typeof AGENT_TYPES[number] | null;
+    if (body?.reviewAgentType === null || body?.reviewAgentType === undefined) {
+      reviewAgentType = null;
+    } else if (typeof body.reviewAgentType === "string" && AGENT_TYPES.includes(body.reviewAgentType as typeof AGENT_TYPES[number])) {
+      reviewAgentType = body.reviewAgentType as typeof AGENT_TYPES[number];
+    } else {
+      return reply.code(400).send({ error: `reviewAgentType must be null or one of ${AGENT_TYPES.join(", ")}.` });
+    }
+
+    if (reviewAgentType) {
+      const enabledAgentTypes = await getEnabledAgentTypes(pool);
+      if (!enabledAgentTypes.includes(reviewAgentType)) {
+        return reply.code(400).send({ error: `${reviewAgentType} agents are disabled in settings.` });
+      }
+    }
+
+    try {
+      await agentManager.updateReviewAgentType(id, reviewAgentType);
+      const agent = await agentManager.getAgent(id);
+      if (!agent) {
+        return reply.code(404).send({ error: "Agent not found." });
+      }
+      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      return { agent: withStreamFlag(agent) };
+    } catch (error) {
+      return handleAgentError(reply, error);
+    }
+  });
+
   app.post("/api/v1/agents/:id/latest-event", async (request, reply) => {
     const params = request.params as { id?: string };
     const body = request.body as {
@@ -4260,10 +4294,20 @@ async function mcpJobLog(
 
 async function mcpLaunchPersona(
   agentId: string,
-  opts: { persona: string; context: string }
+  opts: { persona: string; context: string; agentType?: typeof AGENT_TYPES[number] }
 ): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
   const parent = await agentManager.getAgent(agentId);
   if (!parent) throw new Error("Parent agent not found.");
+
+  const personaAgentType = opts.agentType ?? parent.reviewAgentType ?? (parent.type === "claude" || parent.type === "opencode" ? parent.type : "codex");
+  if (!AGENT_TYPES.includes(personaAgentType)) {
+    throw new Error(`Unsupported persona agent type "${personaAgentType}".`);
+  }
+
+  const enabledAgentTypes = await getEnabledAgentTypes(pool);
+  if (!enabledAgentTypes.includes(personaAgentType)) {
+    throw new Error(`${personaAgentType} agents are disabled in settings.`);
+  }
 
   const parentCwd = parent.worktreePath ?? parent.cwd;
   // Try worktree root first (persona files may be uncommitted), then repo root
@@ -4300,8 +4344,8 @@ async function mcpLaunchPersona(
   const personaArgs: string[] = [`--append-system-prompt`, prompt];
   if (parent.fullAccess) {
     const fullAccessArg =
-      parent.type === "claude" ? CLAUDE_FULL_ACCESS_ARG
-      : parent.type === "codex" ? CODEX_FULL_ACCESS_ARG
+      personaAgentType === "claude" ? CLAUDE_FULL_ACCESS_ARG
+      : personaAgentType === "codex" ? CODEX_FULL_ACCESS_ARG
       : null;
     if (fullAccessArg) personaArgs.push(fullAccessArg);
   }
@@ -4309,11 +4353,11 @@ async function mcpLaunchPersona(
   // For Claude persona agents, pre-assign a session ID so we know exactly which
   // session file belongs to this agent. buildAgentCommand handles adding the
   // --session-id flag; we just store it on the agent record here.
-  const cliSessionId = parent.type === "claude" ? randomUUID() : undefined;
+  const cliSessionId = personaAgentType === "claude" ? randomUUID() : undefined;
 
   const agent = await agentManager.createAgent({
     name: `${opts.persona}-${agentId.slice(-6)}`,
-    type: parent.type,
+    type: personaAgentType,
     cwd: parentCwd,
     agentArgs: personaArgs,
     fullAccess: parent.fullAccess,

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -124,6 +124,11 @@ describe("AgentManager", () => {
       expect(agent.type).toBe("opencode");
     });
 
+    it("should persist reviewAgentType when provided", async () => {
+      const agent = await manager.createAgent({ type: "codex", reviewAgentType: "claude", cwd: "/tmp", useWorktree: false });
+      expect(agent.reviewAgentType).toBe("claude");
+    });
+
     it("should store agentArgs", async () => {
       const agent = await manager.createAgent({
         cwd: "/tmp",
@@ -353,6 +358,15 @@ describe("AgentManager", () => {
       const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
 
       await expect(manager.renameAgent(agent.id, "   ")).rejects.toThrow("Agent name must not be empty.");
+    });
+
+    it("should update reviewAgentType", async () => {
+      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+
+      await manager.updateReviewAgentType(agent.id, "opencode");
+      const updated = await manager.getAgent(agent.id);
+
+      expect(updated?.reviewAgentType).toBe("opencode");
     });
   });
 

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -45,6 +45,7 @@ export type AgentCardProps = {
   feedbackDetailState?: FeedbackDetailState;
   onRequestClose?: () => void;
   closeOnSessionAction?: boolean;
+  enabledAgentTypes: AgentType[];
 };
 
 export function AgentCard({
@@ -70,6 +71,7 @@ export function AgentCard({
   feedbackDetailState,
   onRequestClose,
   closeOnSessionAction = false,
+  enabledAgentTypes,
 }: AgentCardProps): JSX.Element {
   const state = getVisualState(agent);
   const isSelected = selectedAgentId === agent.id;
@@ -312,6 +314,7 @@ export function AgentCard({
                   {!isStopped && !agent.persona ? (
                     <PersonaLauncher
                       agent={agent}
+                      enabledAgentTypes={enabledAgentTypes}
                       sendTerminalInput={sendTerminalInput}
                       disabled={connectedAgentId !== agent.id}
                     />

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -212,6 +212,7 @@ export function AgentSidebarContent({
                 setStopTarget={setStopTarget}
                 setStopConfirmOpen={setStopConfirmOpen}
                 sendTerminalInput={sendTerminalInput}
+                enabledAgentTypes={enabledAgentTypes}
                 connectedAgentId={connectedAgentId}
                 onOpenFeedbackDetail={onOpenFeedbackDetail}
                 feedbackDetailState={feedbackDetailState}

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,6 +1,7 @@
-import { Sparkles } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
+import { Check, ChevronDown } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api";
+import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 
 type PersonaSummary = {
   slug: string;
@@ -19,13 +21,16 @@ type PersonaSummary = {
 
 export function PersonaLauncher({
   agent,
+  enabledAgentTypes,
   sendTerminalInput,
   disabled = false,
 }: {
   agent: Agent;
+  enabledAgentTypes: AgentType[];
   sendTerminalInput?: (data: string) => void;
   disabled?: boolean;
 }): JSX.Element | null {
+  const queryClient = useQueryClient();
   const cwd = agent.worktreePath ?? agent.cwd;
 
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
@@ -38,41 +43,88 @@ export function PersonaLauncher({
 
   if (personas.length === 0) return null;
 
+  const reviewAgentType = agent.reviewAgentType ?? (agent.type === "claude" || agent.type === "opencode" ? agent.type : "codex");
+
   const launchPersona = (slug: string) => {
     if (!sendTerminalInput) return;
     const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
     sendTerminalInput(message + "\r");
   };
 
+  const updateReviewAgentType = async (nextType: AgentType): Promise<void> => {
+    const result = await api<{ agent: Agent }>(`/api/v1/agents/${agent.id}/review-agent-type`, {
+      method: "PATCH",
+      body: JSON.stringify({ reviewAgentType: nextType }),
+    });
+    queryClient.setQueryData<Agent[]>(["agents"], (old) => old?.map((item) => (
+      item.id === result.agent.id ? result.agent : item
+    )) ?? [result.agent]);
+  };
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" disabled={disabled} className="gap-1.5 border border-border/60 bg-background/50 text-muted-foreground hover:text-foreground hover:bg-muted/60">
-          <Sparkles className="h-3 w-3" />
-          Launch Reviewer
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {personas.map((p, i) => {
-          const colorVar = `var(--chart-${(i % 4) + 1})`;
-          return (
-            <DropdownMenuItem key={p.slug} onClick={() => launchPersona(p.slug)}>
-              <div className="flex items-start gap-2.5">
-                <div
-                  className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-                  style={{ backgroundColor: `hsl(${colorVar})` }}
-                />
-                <div>
-                  <div className="text-sm font-medium" style={{ color: `hsl(${colorVar})` }}>{p.name}</div>
-                  {p.description ? (
-                    <div className="text-xs text-muted-foreground">{p.description}</div>
-                  ) : null}
+    <div className="flex items-center">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            disabled={disabled}
+            className="gap-1.5 rounded-r-none border border-border/60 border-r-0 bg-background/50 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            data-testid="launch-reviewer-button"
+          >
+            <AgentTypeIcon type={reviewAgentType} className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80" />
+            Launch Reviewer
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {personas.map((p, i) => {
+            const colorVar = `var(--chart-${(i % 4) + 1})`;
+            return (
+              <DropdownMenuItem key={p.slug} className="text-foreground" onClick={() => launchPersona(p.slug)}>
+                <div className="flex items-start gap-2.5">
+                  <div
+                    className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: `hsl(${colorVar})` }}
+                  />
+                  <div>
+                    <div className="text-sm font-medium" style={{ color: `hsl(${colorVar})` }}>{p.name}</div>
+                    {p.description ? (
+                      <div className="text-xs text-muted-foreground">{p.description}</div>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            disabled={disabled}
+            className="rounded-l-none border border-border/60 bg-background/50 px-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            data-testid="launch-reviewer-type-dropdown"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {enabledAgentTypes.map((agentType) => (
+            <DropdownMenuItem
+              key={agentType}
+              className="text-foreground"
+              onClick={() => { void updateReviewAgentType(agentType); }}
+              data-testid={`launch-reviewer-type-${agentType}`}
+            >
+              <span className="flex items-center gap-3">
+                <Check className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`} />
+                <span>{AGENT_TYPE_LABELS[agentType]}</span>
+              </span>
             </DropdownMenuItem>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -38,6 +38,7 @@ export type Agent = {
   persona?: string | null;
   parentAgentId?: string | null;
   personaContext?: string | null;
+  reviewAgentType?: "codex" | "claude" | "opencode" | null;
   review?: {
     status: string;
     message: string | null;

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -94,6 +94,9 @@ export type JobTools = {
   }) => Promise<Record<string, unknown>>;
 };
 
+const LAUNCH_PERSONA_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+type LaunchPersonaAgentType = (typeof LAUNCH_PERSONA_AGENT_TYPES)[number];
+
 // ── Tool sets per agent type ──────────────────────────────────────────
 // Each list defines which MCP tools are exposed to that agent type.
 // To add a tool to an agent type, just add its name here.
@@ -203,7 +206,7 @@ export type McpRequestContext = {
   ) => Promise<{ id: number }>;
   launchPersona?: (
     agentId: string,
-    opts: { persona: string; context: string }
+    opts: { persona: string; context: string; agentType?: LaunchPersonaAgentType }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
   getFeedback?: (
     agentId: string,
@@ -566,14 +569,16 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files.",
         inputSchema: {
           persona: z.string().describe("Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."),
-          context: z.string().max(100_000).describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention.")
+          context: z.string().max(100_000).describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention."),
+          agentType: z.enum(LAUNCH_PERSONA_AGENT_TYPES).optional().describe("Optional agent runtime override for the persona launch.")
         }
       },
       async (args) => {
         try {
           const result = await launchPersona(agentId, {
             persona: args.persona,
-            context: args.context
+            context: args.context,
+            agentType: args.agentType
           });
           return {
             content: [


### PR DESCRIPTION
## Summary
- persist a parent-agent `reviewAgentType` setting and use it as the default runtime for persona launches
- change the reviewer launcher to a split button where the primary action launches reviewers and the chevron updates the saved reviewer type
- update the launcher icon and selection state immediately from the server response, and keep the split button disabled state consistent across both halves

## Why
The earlier per-launch override design required injecting runtime instructions into the parent prompt. Persisting reviewer type on the parent session is cleaner: the UI controls the reviewer runtime preference, the parent agent still writes the review context, and persona launches resolve against server-owned state.

## Impact
- each parent agent session can keep a stable reviewer runtime preference across reviewer launches
- the `Launch Reviewer` button reflects the currently selected reviewer runtime for that session
- reviewer type changes no longer rely on SSE timing to update the visible selection

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`

## Notes
- PR is opened as draft
- local validation stack remains available at `http://127.0.0.1:62354` with API at `http://127.0.0.1:62346`
- cleanup command: `dispatch-dev down`
