### PR TITLE
feat: add optional initial prompt to agent creation

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -104,6 +104,7 @@ type CreateAgentInput = {
   autoReview?: boolean;
   cliSessionId?: string;
   jobRunId?: string;
+  initialPrompt?: string;
 };
 
 type WorktreeCleanupMode = "auto" | "keep" | "force";
@@ -442,7 +443,8 @@ export class AgentManager {
           false,
           input.jobRunId,
           this.shouldSuggestSessionRename(name, id, { persona: input.persona, jobRunId: input.jobRunId }),
-          !input.persona && !input.jobRunId && (input.autoReview ?? false)
+          !input.persona && !input.jobRunId && (input.autoReview ?? false),
+          input.initialPrompt
         );
         const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
 
@@ -1636,7 +1638,8 @@ export class AgentManager {
     resume?: boolean,
     jobRunId?: string,
     suggestSessionRename?: boolean,
-    autoReview?: boolean
+    autoReview?: boolean,
+    initialPrompt?: string
   ): string {
     const agentId = this.agentIdFromSessionName(sessionName);
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
@@ -1746,15 +1749,18 @@ export class AgentManager {
         ? (resume ? `--resume ${this.shellEscape(cliSessionId)}` : `--session-id ${this.shellEscape(cliSessionId)}`)
         : "";
       const flags = [mcpFlag, systemFlag, sessionFlag].filter(Boolean).join(" ");
-      if (args.length === 0) {
+      // initialPrompt becomes the first user message (positional arg to Claude Code CLI)
+      const allArgs = initialPrompt ? [...args, initialPrompt] : args;
+      if (allArgs.length === 0) {
         return `${envPrefix} ${this.shellEscape(cliBin)} ${flags}`;
       }
-      const escaped = args.map((arg) => this.shellEscape(arg)).join(" ");
+      const escaped = allArgs.map((arg) => this.shellEscape(arg)).join(" ");
       return `${envPrefix} ${this.shellEscape(cliBin)} ${flags} ${escaped}`;
     }
 
     if (type === "opencode") {
-      const startupPrompt = appendedSystemPrompt ? `${launchGuidance}\n\n${appendedSystemPrompt}` : launchGuidance;
+      const promptParts = [launchGuidance, appendedSystemPrompt, initialPrompt].filter(Boolean);
+      const startupPrompt = promptParts.join("\n\n");
       const promptFlag = `--prompt ${this.shellEscape(startupPrompt)}`;
       const sessionFlag = (resume && cliSessionId) ? `--session ${this.shellEscape(cliSessionId)}` : "";
       const flagParts = [promptFlag, sessionFlag].filter(Boolean).join(" ");
@@ -1777,7 +1783,8 @@ export class AgentManager {
     if (resume && cliSessionId) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} resume ${this.shellEscape(cliSessionId)} ${codexMcpFlags}`;
     }
-    const startupPrompt = appendedSystemPrompt ? `${launchGuidance}\n\n${appendedSystemPrompt}` : launchGuidance;
+    const codexPromptParts = [launchGuidance, appendedSystemPrompt, initialPrompt].filter(Boolean);
+    const startupPrompt = codexPromptParts.join("\n\n");
     if (passthroughArgs.length === 0) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(startupPrompt)}`;
     }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2923,6 +2923,7 @@ async function registerRoutes() {
       parentAgentId?: unknown;
       personaContext?: unknown;
       autoReview?: unknown;
+      initialPrompt?: unknown;
     };
 
     if (typeof body?.cwd !== "string") {
@@ -2956,6 +2957,10 @@ async function registerRoutes() {
 
     if (body.baseBranch !== undefined && typeof body.baseBranch !== "string") {
       return reply.code(400).send({ error: "baseBranch must be a string when provided." });
+    }
+
+    if (body.initialPrompt !== undefined && typeof body.initialPrompt !== "string") {
+      return reply.code(400).send({ error: "initialPrompt must be a string when provided." });
     }
 
     const agentArgs = providedAgentArgs as string[] | undefined;
@@ -2997,6 +3002,7 @@ async function registerRoutes() {
         parentAgentId: typeof body.parentAgentId === "string" ? body.parentAgentId : undefined,
         personaContext: typeof body.personaContext === "string" ? body.personaContext : undefined,
         autoReview: body.autoReview === true,
+        initialPrompt: typeof body.initialPrompt === "string" ? body.initialPrompt.trim() || undefined : undefined,
       });
       queueGitContextRefresh([agent.id]);
       uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -167,6 +167,7 @@ export function DashboardLayout(): JSX.Element {
   const [createBaseBranch, setCreateBaseBranch] = useAtom(baseBranchByCwdAtom(createCwd));
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
+  const [createInitialPrompt, setCreateInitialPrompt] = useState("");
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
 
@@ -483,6 +484,7 @@ export function DashboardLayout(): JSX.Element {
             useWorktree: createUseWorktree,
             worktreeBranch: createWorktreeBranch.trim() || undefined,
             baseBranch: createBaseBranch !== "main" ? createBaseBranch : undefined,
+            initialPrompt: createInitialPrompt.trim() || undefined,
           }),
         });
 
@@ -490,6 +492,7 @@ export function DashboardLayout(): JSX.Element {
         setCreateName("");
         setCreateUseWorktree(true);
         setCreateWorktreeBranch("");
+        setCreateInitialPrompt("");
         window.localStorage.setItem(LAST_USED_CWD_KEY, createCwd.trim());
         window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
         setLastUsedAgentType(createType);
@@ -503,7 +506,7 @@ export function DashboardLayout(): JSX.Element {
         setCreating(false);
       }
     },
-    [createAutoReview, createBaseBranch, createCwd, createFullAccess, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia]
+    [createAutoReview, createBaseBranch, createCwd, createFullAccess, createInitialPrompt, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia]
   );
 
   const borderForAgentState = (state: AgentVisualState): string => {
@@ -834,6 +837,7 @@ export function DashboardLayout(): JSX.Element {
         creating={creating}
         cwdHistory={cwdHistory}
         enabledAgentTypes={enabledAgentTypes}
+        initialPrompt={createInitialPrompt}
         setOpen={setCreateOpen}
         setCreateName={setCreateName}
         setCreateType={setCreateType}
@@ -843,6 +847,7 @@ export function DashboardLayout(): JSX.Element {
         setCreateUseWorktree={setCreateUseWorktree}
         setCreateWorktreeBranch={setCreateWorktreeBranch}
         setCreateBaseBranch={setCreateBaseBranch}
+        setInitialPrompt={setCreateInitialPrompt}
         onSubmit={handleCreateAgent}
         onRemoveCwdHistory={handleRemoveCwdHistory}
       />

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, GitBranch, Loader2 } from "lucide-react";
+import { Check, ChevronDown, GitBranch, Loader2, ChevronLeft } from "lucide-react";
 
 import { PathInput } from "@/components/app/path-input";
 import { Button } from "@/components/ui/button";
@@ -37,6 +37,7 @@ type CreateAgentDialogProps = {
   creating: boolean;
   cwdHistory: string[];
   enabledAgentTypes: AgentType[];
+  initialPrompt: string;
   setOpen: (open: boolean) => void;
   setCreateName: (name: string) => void;
   setCreateType: (value: AgentType) => void;
@@ -46,6 +47,7 @@ type CreateAgentDialogProps = {
   setCreateUseWorktree: (value: boolean | ((current: boolean) => boolean)) => void;
   setCreateWorktreeBranch: (value: string) => void;
   setCreateBaseBranch: (value: string) => void;
+  setInitialPrompt: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
   onRemoveCwdHistory: (dir: string) => void;
 };
@@ -63,6 +65,7 @@ export function CreateAgentDialog({
   creating,
   cwdHistory,
   enabledAgentTypes,
+  initialPrompt,
   setOpen,
   setCreateName,
   setCreateType,
@@ -72,9 +75,28 @@ export function CreateAgentDialog({
   setCreateUseWorktree,
   setCreateWorktreeBranch,
   setCreateBaseBranch,
+  setInitialPrompt,
   onSubmit,
   onRemoveCwdHistory
 }: CreateAgentDialogProps): JSX.Element {
+
+  // --- Step state: "config" is the main form, "prompt" is the initial prompt textarea ---
+  const [step, setStep] = useState<"config" | "prompt">("config");
+  const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset step when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setStep("config");
+    }
+  }, [open]);
+
+  // Auto-focus textarea when entering prompt step
+  useEffect(() => {
+    if (step === "prompt") {
+      requestAnimationFrame(() => promptTextareaRef.current?.focus());
+    }
+  }, [step]);
 
   // --- Agent type dropdown state ---
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
@@ -134,229 +156,292 @@ export function CreateAgentDialog({
           if (typeDropdownOpen || branchDropdownOpen) {
             e.preventDefault();
           }
+          if (step === "prompt") {
+            e.preventDefault();
+            setStep("config");
+          }
         }}
       >
-        <DialogHeader>
-          <DialogTitle>Create Agent</DialogTitle>
-          <DialogDescription>Name, type, and working directory for a new agent session.</DialogDescription>
-        </DialogHeader>
+        {step === "config" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create Agent</DialogTitle>
+              <DialogDescription>Name, type, and working directory for a new agent session.</DialogDescription>
+            </DialogHeader>
 
-        <form data-testid="create-agent-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
-          <div className="relative space-y-1" ref={typeCmdRef}>
-            <label className="text-sm text-muted-foreground">Type</label>
-            <button
-              ref={typeTriggerRef}
-              type="button"
-              role="combobox"
-              tabIndex={0}
-              aria-expanded={typeDropdownOpen}
-              onClick={() => setTypeDropdownOpen((prev) => !prev)}
-              onKeyDown={(e) => {
-                if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  if (!typeDropdownOpen) setTypeDropdownOpen(true);
-                }
-              }}
-              className={cn(
-                "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm",
-                "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
-              )}
-            >
-              {AGENT_TYPE_LABELS[createType]}
-              <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", typeDropdownOpen && "rotate-180")} />
-            </button>
-            {typeDropdownOpen ? (
-              <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
-                <Command shouldFilter={false} ref={(el) => { if (el) requestAnimationFrame(() => el.focus()); }} onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); setTypeDropdownOpen(false); requestAnimationFrame(() => typeTriggerRef.current?.focus()); } }}>
-                  <CommandList>
-                    <CommandGroup>
-                      {enabledAgentTypes.map((agentType) => (
-                        <CommandItem
-                          key={agentType}
-                          value={agentType}
-                          onSelect={() => {
-                            setCreateType(agentType);
-                            setTypeDropdownOpen(false);
-                            requestAnimationFrame(() => typeTriggerRef.current?.focus());
-                          }}
-                        >
-                          <Check className={cn("mr-2 h-3 w-3 shrink-0", agentType === createType ? "opacity-100" : "opacity-0")} />
-                          {AGENT_TYPE_LABELS[agentType]}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
+            <form data-testid="create-agent-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
+              <div className="relative space-y-1" ref={typeCmdRef}>
+                <label className="text-sm text-muted-foreground">Type</label>
+                <button
+                  ref={typeTriggerRef}
+                  type="button"
+                  role="combobox"
+                  tabIndex={0}
+                  aria-expanded={typeDropdownOpen}
+                  onClick={() => setTypeDropdownOpen((prev) => !prev)}
+                  onKeyDown={(e) => {
+                    if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      if (!typeDropdownOpen) setTypeDropdownOpen(true);
+                    }
+                  }}
+                  className={cn(
+                    "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm",
+                    "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+                  )}
+                >
+                  {AGENT_TYPE_LABELS[createType]}
+                  <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", typeDropdownOpen && "rotate-180")} />
+                </button>
+                {typeDropdownOpen ? (
+                  <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
+                    <Command shouldFilter={false} ref={(el) => { if (el) requestAnimationFrame(() => el.focus()); }} onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); setTypeDropdownOpen(false); requestAnimationFrame(() => typeTriggerRef.current?.focus()); } }}>
+                      <CommandList>
+                        <CommandGroup>
+                          {enabledAgentTypes.map((agentType) => (
+                            <CommandItem
+                              key={agentType}
+                              value={agentType}
+                              onSelect={() => {
+                                setCreateType(agentType);
+                                setTypeDropdownOpen(false);
+                                requestAnimationFrame(() => typeTriggerRef.current?.focus());
+                              }}
+                            >
+                              <Check className={cn("mr-2 h-3 w-3 shrink-0", agentType === createType ? "opacity-100" : "opacity-0")} />
+                              {AGENT_TYPE_LABELS[agentType]}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </div>
+                ) : null}
               </div>
-            ) : null}
-          </div>
 
-          <div className="space-y-1">
-            <label className="text-sm text-muted-foreground">Name</label>
-            <Input
-              autoFocus
-              value={createName}
-              onChange={(event) => setCreateName(event.target.value)}
-              placeholder="agent name (optional)"
-              data-testid="create-agent-name"
-            />
-          </div>
-
-          <PathInput
-            value={createCwd}
-            onChange={setCreateCwd}
-            label="Working directory"
-            history={cwdHistory}
-            onRemoveHistory={onRemoveCwdHistory}
-            data-testid="create-agent-cwd"
-            historyItemTestId="create-agent-cwd-history-option"
-          />
-
-          <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-            <label className="flex cursor-pointer items-start gap-3">
-              <Checkbox
-                checked={createUseWorktree}
-                onCheckedChange={() => setCreateUseWorktree((current) => !current)}
-                className="mt-0.5"
-                title="Toggle git worktree"
-                data-testid="create-agent-worktree"
-              />
-              <span className="space-y-1">
-                <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                  <GitBranch className="h-3.5 w-3.5" />
-                  Create git worktree
-                </span>
-                <span className="block text-xs text-muted-foreground">
-                  Creates an isolated worktree and branch for this agent.
-                </span>
-              </span>
-            </label>
-            {createUseWorktree ? (
-              <div className="ml-8 w-[calc(100%-2rem)] space-y-2">
-                <div className="relative" ref={branchCmdRef}>
-                  <label className="mb-1 block text-xs text-muted-foreground">Base branch</label>
-                  <button
-                    ref={branchTriggerRef}
-                    type="button"
-                    role="combobox"
-                    tabIndex={0}
-                    aria-expanded={branchDropdownOpen}
-                    data-testid="create-agent-base-branch"
-                    onClick={() => branchDropdownOpen ? setBranchDropdownOpen(false) : openBranchDropdown()}
-                    onKeyDown={(e) => {
-                      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        if (!branchDropdownOpen) openBranchDropdown();
-                      }
-                    }}
-                    className={cn(
-                      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 font-mono text-xs",
-                      "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
-                    )}
-                  >
-                    {createBaseBranch}
-                    {branchesLoading ? (
-                      <Loader2 className="ml-2 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-                    ) : (
-                      <ChevronDown className={cn("ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform", branchDropdownOpen && "rotate-180")} />
-                    )}
-                  </button>
-                  {branchDropdownOpen ? (
-                    <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
-                      <Command
-                        onKeyDown={(e) => {
-                          if (e.key === "Escape") {
-                            e.preventDefault();
-                            setBranchDropdownOpen(false);
-                            requestAnimationFrame(() => branchTriggerRef.current?.focus());
-                          }
-                        }}
-                      >
-                        <CommandInput ref={branchInputRef} placeholder="Search branches..." className="font-mono text-xs" />
-                        <CommandList>
-                          {branchesLoading ? (
-                            <CommandLoading>
-                              <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                                Loading branches...
-                              </div>
-                            </CommandLoading>
-                          ) : null}
-                          <CommandEmpty>No matching branches.</CommandEmpty>
-                          <CommandGroup>
-                            {allBranches.map((branch) => (
-                              <CommandItem
-                                key={branch}
-                                value={branch}
-                                data-testid="create-agent-base-branch-option"
-                                className="font-mono"
-                                onSelect={() => {
-                                  setCreateBaseBranch(branch);
-                                  setBranchDropdownOpen(false);
-                                  requestAnimationFrame(() => branchTriggerRef.current?.focus());
-                                }}
-                              >
-                                <Check className={cn("mr-2 h-3 w-3 shrink-0", branch === createBaseBranch ? "opacity-100" : "opacity-0")} />
-                                {branch}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </div>
-                  ) : null}
-                </div>
+              <div className="space-y-1">
+                <label className="text-sm text-muted-foreground">Name</label>
                 <Input
-                  value={createWorktreeBranch}
-                  onChange={(event) => setCreateWorktreeBranch(event.target.value)}
-                  placeholder="branch name (auto-generated if empty)"
-                  data-testid="create-agent-worktree-branch"
+                  autoFocus
+                  value={createName}
+                  onChange={(event) => setCreateName(event.target.value)}
+                  placeholder="agent name (optional)"
+                  data-testid="create-agent-name"
                 />
               </div>
-            ) : null}
-          </div>
 
-          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-            <Checkbox
-              checked={createFullAccess}
-              onCheckedChange={() => setCreateFullAccess((current) => !current)}
-              className="mt-0.5"
-              title="Toggle full access"
-            />
-            <span className="space-y-1">
-              <span className="block text-sm font-medium text-foreground">Start in full access mode</span>
-              <span className="block text-xs text-muted-foreground">
-                Starts the selected agent with its most permissive supported execution mode.
-              </span>
-            </span>
-          </label>
+              <PathInput
+                value={createCwd}
+                onChange={setCreateCwd}
+                label="Working directory"
+                history={cwdHistory}
+                onRemoveHistory={onRemoveCwdHistory}
+                data-testid="create-agent-cwd"
+                historyItemTestId="create-agent-cwd-history-option"
+              />
 
-          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-            <Checkbox
-              checked={createAutoReview}
-              onCheckedChange={() => setCreateAutoReview((current) => !current)}
-              className="mt-0.5"
-              title="Toggle autonomous review"
-              data-testid="create-agent-auto-review"
-            />
-            <span className="space-y-1">
-              <span className="block text-sm font-medium text-foreground">Autonomous Review</span>
-              <span className="block text-xs text-muted-foreground">
-                Agent will launch persona reviews and address feedback before completing.
-              </span>
-            </span>
-          </label>
+              <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <Checkbox
+                    checked={createUseWorktree}
+                    onCheckedChange={() => setCreateUseWorktree((current) => !current)}
+                    className="mt-0.5"
+                    title="Toggle git worktree"
+                    data-testid="create-agent-worktree"
+                  />
+                  <span className="space-y-1">
+                    <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                      <GitBranch className="h-3.5 w-3.5" />
+                      Create git worktree
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      Creates an isolated worktree and branch for this agent.
+                    </span>
+                  </span>
+                </label>
+                {createUseWorktree ? (
+                  <div className="ml-8 w-[calc(100%-2rem)] space-y-2">
+                    <div className="relative" ref={branchCmdRef}>
+                      <label className="mb-1 block text-xs text-muted-foreground">Base branch</label>
+                      <button
+                        ref={branchTriggerRef}
+                        type="button"
+                        role="combobox"
+                        tabIndex={0}
+                        aria-expanded={branchDropdownOpen}
+                        data-testid="create-agent-base-branch"
+                        onClick={() => branchDropdownOpen ? setBranchDropdownOpen(false) : openBranchDropdown()}
+                        onKeyDown={(e) => {
+                          if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            if (!branchDropdownOpen) openBranchDropdown();
+                          }
+                        }}
+                        className={cn(
+                          "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 font-mono text-xs",
+                          "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+                        )}
+                      >
+                        {createBaseBranch}
+                        {branchesLoading ? (
+                          <Loader2 className="ml-2 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                        ) : (
+                          <ChevronDown className={cn("ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform", branchDropdownOpen && "rotate-180")} />
+                        )}
+                      </button>
+                      {branchDropdownOpen ? (
+                        <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
+                          <Command
+                            onKeyDown={(e) => {
+                              if (e.key === "Escape") {
+                                e.preventDefault();
+                                setBranchDropdownOpen(false);
+                                requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                              }
+                            }}
+                          >
+                            <CommandInput ref={branchInputRef} placeholder="Search branches..." className="font-mono text-xs" />
+                            <CommandList>
+                              {branchesLoading ? (
+                                <CommandLoading>
+                                  <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                    Loading branches...
+                                  </div>
+                                </CommandLoading>
+                              ) : null}
+                              <CommandEmpty>No matching branches.</CommandEmpty>
+                              <CommandGroup>
+                                {allBranches.map((branch) => (
+                                  <CommandItem
+                                    key={branch}
+                                    value={branch}
+                                    data-testid="create-agent-base-branch-option"
+                                    className="font-mono"
+                                    onSelect={() => {
+                                      setCreateBaseBranch(branch);
+                                      setBranchDropdownOpen(false);
+                                      requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                                    }}
+                                  >
+                                    <Check className={cn("mr-2 h-3 w-3 shrink-0", branch === createBaseBranch ? "opacity-100" : "opacity-0")} />
+                                    {branch}
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </div>
+                      ) : null}
+                    </div>
+                    <Input
+                      value={createWorktreeBranch}
+                      onChange={(event) => setCreateWorktreeBranch(event.target.value)}
+                      placeholder="branch name (auto-generated if empty)"
+                      data-testid="create-agent-worktree-branch"
+                    />
+                  </div>
+                ) : null}
+              </div>
 
-          <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)} data-testid="create-agent-cancel">
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-submit">
-              {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
-              Create
-            </Button>
-          </div>
-        </form>
+              <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                <Checkbox
+                  checked={createFullAccess}
+                  onCheckedChange={() => setCreateFullAccess((current) => !current)}
+                  className="mt-0.5"
+                  title="Toggle full access"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">Start in full access mode</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Starts the selected agent with its most permissive supported execution mode.
+                  </span>
+                </span>
+              </label>
+
+              <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                <Checkbox
+                  checked={createAutoReview}
+                  onCheckedChange={() => setCreateAutoReview((current) => !current)}
+                  className="mt-0.5"
+                  title="Toggle autonomous review"
+                  data-testid="create-agent-auto-review"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">Autonomous Review</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Agent will launch persona reviews and address feedback before completing.
+                  </span>
+                </span>
+              </label>
+
+              <div className="flex justify-end gap-2 pt-1">
+                <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)} data-testid="create-agent-cancel">
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="default"
+                  tabIndex={0}
+                  disabled={creating || !createCwd.trim()}
+                  data-testid="create-agent-with-prompt"
+                  onClick={() => setStep("prompt")}
+                >
+                  Create with prompt
+                </Button>
+                <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-submit">
+                  {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                  Create
+                </Button>
+              </div>
+            </form>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Initial Prompt</DialogTitle>
+              <DialogDescription>This prompt will be sent as the agent's first message.</DialogDescription>
+            </DialogHeader>
+
+            <form data-testid="create-agent-prompt-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
+              <textarea
+                ref={promptTextareaRef}
+                value={initialPrompt}
+                onChange={(event) => setInitialPrompt(event.target.value)}
+                placeholder="Enter instructions for the agent..."
+                data-testid="create-agent-initial-prompt"
+                className={cn(
+                  "flex min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm",
+                  "ring-offset-background placeholder:text-muted-foreground",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  "resize-y"
+                )}
+              />
+
+              <div className="flex justify-between pt-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  tabIndex={0}
+                  onClick={() => setStep("config")}
+                  data-testid="create-agent-prompt-back"
+                >
+                  <ChevronLeft className="mr-1 h-4 w-4" />
+                  Back
+                </Button>
+                <div className="flex gap-2">
+                  <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-prompt-submit">
+                    {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                    Create
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- Adds a two-step modal flow for creating agents with an initial prompt
- Step 1: existing config form with new "Create with prompt" button alongside Cancel and Create
- Step 2: large textarea for entering the initial prompt, with Back/Cancel/Create buttons
- Backend passes the prompt as a positional CLI arg for Claude (first user message) or appends it to the startup prompt for Codex/OpenCode
- No DB column needed — prompt is ephemeral, used only at creation time

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (103 passed)
- [x] Unit tests pass (323 passed)
- [x] UI validated via Playwright (config step, prompt step, back navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)