### PR TITLE
fix: preserve prompt editor height on short screens

### DIFF
--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -1462,7 +1462,7 @@ function PromptTab({
           value={prompt}
           onChange={(event) => setPrompt(event.target.value)}
           placeholder="Describe what the agent should do..."
-          className="mt-2 h-[max(16rem,calc(100dvh-21rem))] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          className="mt-2 h-[max(16rem,calc(100dvh-21rem))] min-h-64 shrink-0 w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {saveError ? <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{saveError}</div> : null}
         {saved ? <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">Prompt saved.</div> : null}


### PR DESCRIPTION
## Summary
- keep the job prompt editor from shrinking below the intended expanded size on short desktop viewports
- add a real minimum height and shrink guard to the saved-job prompt textarea

## Why
The prompt editor was expanded in the previous change, but the textarea could still collapse inside the flex layout on short desktop heights. That undercut the UX goal of making prompt editing roomier.

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- validated the short viewport case at `1280x500` on the isolated dev stack
- Dispatch screenshot: `edit-job-prompt-short-viewport-2026-04-13-04-50-20-086.png`