### PR TITLE
fix: improve create agent name field and auto review feedback resolution

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1671,7 +1671,7 @@ export class AgentManager {
         "Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). " +
         "For longer artifacts, write to a file via dispatch_share and pin a reference." +
         (autoReview
-          ? " Autonomous Review is enabled. Before emitting done, call list_personas, pick 1–3 relevant reviewers, launch them via dispatch_launch_persona with context about your changes, then poll dispatch_get_feedback until all reviews complete. Address critical/high feedback before resolving; medium and below can be resolved with a comment. Do not emit done until all reviews are resolved."
+          ? " Autonomous Review is enabled. Before emitting done, call list_personas, pick 1–3 relevant reviewers, launch them via dispatch_launch_persona with context about your changes, then poll dispatch_get_feedback until all reviews complete. Address critical/high feedback before resolving; medium and below can be resolved with a comment. After addressing each feedback item, call dispatch_resolve_feedback to mark it as fixed or ignored. Do not emit done until all reviews are resolved."
           : "");
 
     const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -225,9 +225,12 @@ export function CreateAgentDialog({
                   autoFocus
                   value={createName}
                   onChange={(event) => setCreateName(event.target.value)}
-                  placeholder="agent name (optional)"
+                  placeholder="agent name"
                   data-testid="create-agent-name"
                 />
+                <p className="text-xs text-muted-foreground">
+                  Leave blank and the agent will set its own name based on the task.
+                </p>
               </div>
 
               <PathInput

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -130,38 +130,6 @@ export function PathInput({
         </label>
       ) : null}
 
-      {showValidation ? (
-        <div className="mb-1.5 flex items-center gap-1.5 text-xs">
-          {validating ? (
-            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-          ) : pathValidation ? (
-            pathValidation.isDirectory ? (
-              <>
-                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                {pathValidation.isGitRepo ? (
-                  <>
-                    <GitBranch className="h-3 w-3 text-emerald-500" />
-                    <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
-                  </>
-                ) : (
-                  <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
-                )}
-              </>
-            ) : pathValidation.exists ? (
-              <>
-                <AlertCircle className="h-3 w-3 text-amber-500" />
-                <span className="text-amber-600 dark:text-amber-400">Not a directory</span>
-              </>
-            ) : (
-              <>
-                <AlertCircle className="h-3 w-3 text-amber-500" />
-                <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
-              </>
-            )
-          ) : null}
-        </div>
-      ) : null}
-
       <div className="relative" ref={cmdRef}>
         <div className="relative">
           {/* Ghost autocomplete overlay */}
@@ -267,6 +235,38 @@ export function PathInput({
           </div>
         ) : null}
       </div>
+
+      {showValidation ? (
+        <div className="flex h-5 items-center justify-end gap-1.5 text-xs">
+          {validating ? (
+            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+          ) : pathValidation ? (
+            pathValidation.isDirectory ? (
+              <>
+                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                {pathValidation.isGitRepo ? (
+                  <>
+                    <GitBranch className="h-3 w-3 text-emerald-500" />
+                    <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
+                  </>
+                ) : (
+                  <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
+                )}
+              </>
+            ) : pathValidation.exists ? (
+              <>
+                <AlertCircle className="h-3 w-3 text-amber-500" />
+                <span className="text-amber-600 dark:text-amber-400">Not a directory</span>
+              </>
+            ) : (
+              <>
+                <AlertCircle className="h-3 w-3 text-amber-500" />
+                <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
+              </>
+            )
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add helper text to the name field in the create agent dialog explaining that leaving it blank lets the agent set its own name based on the task
- Update autonomous review launch guidance to instruct agents to call `dispatch_resolve_feedback` to mark feedback items as fixed or ignored after addressing them

## Test plan
- [x] `pnpm run finalize:web` passes (type check + production build)
- [x] `pnpm run check` passes (full type check)
- [x] `pnpm run test:e2e` passes (103/103)
- [x] Validated UI in Playwright — helper text renders correctly under the name input

🤖 Generated with [Claude Code](https://claude.com/claude-code)