### PR TITLE
docs: remove stale AUTH_TOKEN refs, fix server entrypoint path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,6 @@ DISPATCH_PORT=6767
 DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
 MEDIA_ROOT=~/.dispatch/media
 
-# Authentication token for API access (generate with: openssl rand -hex 32)
-AUTH_TOKEN=
-
 # Agent runtime — "tmux" (default when tmux is installed) or "inert" (no-op, for dev/test)
 # DISPATCH_AGENT_RUNTIME=tmux
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
-> 5. Copy `.env.example` to `.env` and configure: set `AUTH_TOKEN` to a random value (use `openssl rand -hex 32`). The default host binds to localhost; set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections.
+> 5. Copy `.env.example` to `.env`. The defaults work for local-only use. Set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections. Authentication is handled automatically — the server generates a secure token on first run and stores it in the database.
 > 6. Register as a system service:
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
 >    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/main.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -152,7 +152,6 @@ Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 | `DISPATCH_HOST` | `127.0.0.1` | Interface to bind the API server to. Set `0.0.0.0` only when the machine must accept remote connections. |
 | `DISPATCH_PORT` | `6767` | HTTP port the server listens on |
 | `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
-| `AUTH_TOKEN` | — | API authentication token for MCP endpoints (generate with `openssl rand -hex 32`) |
 | `MEDIA_ROOT` | `~/.dispatch/media` | File upload storage path |
 | `DISPATCH_AGENT_RUNTIME` | `tmux` | Agent runtime mode (`tmux` or `inert` for dev/test) |
 | `DISPATCH_COPY_DISPLAY` | — | Virtual X display for clipboard image paste on Linux (e.g. `:99`) |

--- a/docs/11-backend-compatibility-checklist.md
+++ b/docs/11-backend-compatibility-checklist.md
@@ -27,7 +27,7 @@ Use this checklist for backend changes when running a single always-on tmux back
 
 1. Confirm boot path works in production mode:
    - `pnpm run build`
-   - `node apps/server/dist/server.js`
+   - `node apps/server/dist/main.js`
 2. Confirm tmux restart path works:
    - `bin/dispatch-server update`
 3. Confirm health endpoint remains stable:

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -37,7 +37,7 @@ Set up Dispatch on this machine. The repo is at https://github.com/selfcontained
 3. Run bin/preflight and fix any failures it reports.
 4. Start Postgres: brew services start postgresql@17
 5. Create the dispatch database: createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"
-6. Copy .env.example to .env. Generate a random AUTH_TOKEN (use openssl rand -hex 32).
+6. Copy .env.example to .env. The defaults work for local-only use.
 7. Run: nvm use && pnpm install && pnpm run build
 8. Verify locally: pnpm run start, then curl http://127.0.0.1:6767/api/v1/health — confirm it returns ok, then stop the server.
 9. Install the launchd service: bin/install-launchd --port 6767
@@ -116,20 +116,9 @@ cd dispatch
 cp .env.example .env
 ```
 
-Edit `.env` — the only value you must change is `AUTH_TOKEN` for a local-only setup:
+The defaults work for local-only use. Authentication is handled automatically — the server generates a secure token on first run and stores it in the database.
 
-```
-DISPATCH_HOST=127.0.0.1
-DISPATCH_PORT=6767
-DATABASE_URL=postgres://dispatch:dispatch@127.0.0.1:5432/dispatch
-AUTH_TOKEN=<generate-a-real-token>
-MEDIA_ROOT=~/.dispatch/media
-```
-
-Generate a token with `openssl rand -hex 32`.
-
-If this machine needs to accept remote connections, set `DISPATCH_HOST=0.0.0.0` explicitly in
-`~/.dispatch/server/.env` after installation.
+If this machine needs to accept remote connections, set `DISPATCH_HOST=0.0.0.0` in `.env` (and in `~/.dispatch/server/.env` after installation).
 
 ### 5. Build & verify locally
 


### PR DESCRIPTION
## Summary

Audited all documentation against the codebase. Found and fixed two categories of issues:

- **Stale AUTH_TOKEN references** — `AUTH_TOKEN` is no longer read from environment. The server auto-generates a secure token on first run via `getOrCreateAuthToken()` and persists it in the database. Removed all references telling users to manually generate and set this value.
- **Wrong server entrypoint** — Backend compatibility checklist referenced `server.js` instead of `main.js`.

## Files changed

- **`.env.example`** — Removed `AUTH_TOKEN=` line and its comment
- **`README.md`** — Updated Quick Install step 5 to remove AUTH_TOKEN instructions
- **`docs/10-operations-runbook.md`** — Removed AUTH_TOKEN row from configuration table
- **`docs/11-backend-compatibility-checklist.md`** — Fixed entrypoint path: `server.js` → `main.js`
- **`docs/12-new-machine-setup.md`** — Removed AUTH_TOKEN from agent setup prompt and step-by-step instructions

## Audit summary

### What was checked
- README.md features list, prerequisites, agent CLIs, setup instructions, operations section, docs index
- All 8 docs/*.md files against actual API routes, CLI tools, MCP tools, DB schema, and config
- CLAUDE.md project structure and developer instructions

### What was accurate (no changes needed)
- README features list — comprehensive and current
- README prerequisites and agent CLIs tables — correct
- README docs index — all 8 links valid, no dead links
- docs/03-api-spec.md — endpoints match actual routes
- docs/04-agent-lifecycle.md — states and transitions match DB schema and code
- docs/14-theming.md — architecture and instructions accurate
- docs/15-personas-and-feedback.md — accurate
- docs/16-notifications.md — accurate
- CLAUDE.md — project structure tree and all instructions accurate

## Test plan

- [x] Verified all doc links in README point to existing files
- [x] Verified `AUTH_TOKEN` is not referenced in `apps/server/src/config.ts`
- [x] Verified auth token is auto-generated via `getOrCreateAuthToken()` in `apps/server/src/auth.ts`
- [x] Verified server entrypoint is `dist/main.js` per `apps/server/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)