### PR TITLE
feat: user-to-agent file sharing via media sidebar upload (#CRU-107)

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1356,6 +1356,7 @@ async function registerRoutes() {
       upsertEvent: mcpUpsertEvent,
       renameSession: mcpRenameSession,
       shareMedia: mcpShareMedia,
+      listMedia: mcpListMedia,
       submitFeedback: mcpSubmitFeedback,
       listPersonas: mcpListPersonas,
       launchPersona: mcpLaunchPersona,
@@ -2793,35 +2794,39 @@ async function registerRoutes() {
 
     const isText = isTextFile(fileName);
     const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? (isText ? "text" : "screenshot");
-    const validSources = ["screenshot", "stream", "simulator", "text"];
+    const validSources = ["screenshot", "stream", "simulator", "text", "user"];
     const source = validSources.includes(sourceField) ? sourceField : (isText ? "text" : "screenshot");
     const description = (data.fields.description as { value?: string } | undefined)?.value ?? null;
-    if (!description) {
-      return reply.code(400).send({ error: "A description field is required." });
-    }
 
     const mediaDir = resolveMediaDir(agent.id, agent.mediaDir);
     await mkdir(mediaDir, { recursive: true });
 
     const buffer = await data.toBuffer();
-    const filePath = path.join(mediaDir, fileName);
+
+    // Timestamp filenames to prevent collisions (matches mcpShareMedia pattern)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
+    const ext = path.extname(fileName);
+    const base = path.basename(fileName, ext);
+    const timestampedFileName = `${base}-${timestamp}${ext}`;
+
+    const filePath = path.join(mediaDir, timestampedFileName);
     await writeFile(filePath, buffer);
 
     const result = await pool.query<{ id: number; created_at: Date }>(
       `INSERT INTO media (agent_id, file_name, source, size_bytes, description)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING id, created_at`,
-      [id, fileName, source, buffer.length, description]
+      [id, timestampedFileName, source, buffer.length, description]
     );
 
     const row = result.rows[0];
     const mediaRecord = {
       id: row.id,
-      fileName,
+      fileName: timestampedFileName,
       source,
       sizeBytes: buffer.length,
       createdAt: row.created_at.toISOString(),
-      url: `/api/v1/agents/${id}/media/${encodeURIComponent(fileName)}`
+      url: `/api/v1/agents/${id}/media/${encodeURIComponent(timestampedFileName)}`
     };
 
     uiEventBroker.publish({ type: "media.changed", agentId: id });
@@ -4515,4 +4520,41 @@ async function mcpShareMedia(
     source,
     description: opts.description
   };
+}
+
+async function mcpListMedia(
+  agentId: string,
+  opts: { source?: string }
+): Promise<Array<{ fileName: string; filePath: string; source: string; description: string | null; sizeBytes: number; createdAt: string }>> {
+  const agent = await agentManager.getAgent(agentId);
+  if (!agent) throw new Error("Agent not found.");
+
+  const mediaDir = resolveMediaDir(agentId, agent.mediaDir);
+
+  const whereClause = opts.source
+    ? `WHERE agent_id = $1 AND source = $2`
+    : `WHERE agent_id = $1`;
+  const params: (string | number)[] = opts.source ? [agentId, opts.source] : [agentId];
+
+  const result = await pool.query<{
+    file_name: string;
+    source: string;
+    description: string | null;
+    size_bytes: number;
+    created_at: Date;
+  }>(
+    `SELECT file_name, source, description, size_bytes, created_at
+     FROM media ${whereClause}
+     ORDER BY created_at DESC LIMIT 100`,
+    params
+  );
+
+  return result.rows.map((row) => ({
+    fileName: row.file_name,
+    filePath: path.join(mediaDir, row.file_name),
+    source: row.source,
+    description: row.description ?? null,
+    sizeBytes: row.size_bytes,
+    createdAt: row.created_at.toISOString(),
+  }));
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2789,7 +2789,7 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "Invalid file name." });
     }
     if (!isMediaFile(fileName)) {
-      return reply.code(400).send({ error: "Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4 or text files (txt/md/json/yaml/ts/py/etc)." });
+      return reply.code(400).send({ error: "Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc)." });
     }
 
     const isText = isTextFile(fileName);
@@ -4055,8 +4055,15 @@ function isTextFile(name: string): boolean {
   return TEXT_EXTENSIONS.has(ext);
 }
 
+const DOCUMENT_EXTENSIONS = new Set([".pdf"]);
+
+function isDocumentFile(name: string): boolean {
+  const ext = path.extname(name).toLowerCase();
+  return DOCUMENT_EXTENSIONS.has(ext);
+}
+
 function isMediaFile(name: string): boolean {
-  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name) || isTextFile(name);
+  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name) || isTextFile(name) || isDocumentFile(name);
 }
 
 function mimeType(name: string): string {
@@ -4110,6 +4117,10 @@ function mimeType(name: string): string {
 
   if (/\.ya?ml$/i.test(name)) {
     return "text/yaml";
+  }
+
+  if (/\.pdf$/i.test(name)) {
+    return "application/pdf";
   }
 
   if (isTextFile(name)) {
@@ -4446,7 +4457,7 @@ async function mcpShareMedia(
   if (!agent) throw new Error("Agent not found.");
 
   if (!isMediaFile(opts.filePath)) {
-    throw new Error("Unsupported file type. Use png/jpg/jpeg/gif/webp/mp4 or text files (txt/md/json/yaml/ts/py/etc).");
+    throw new Error("Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc).");
   }
 
   const isText = isTextFile(opts.filePath);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -231,6 +231,21 @@ export function DashboardLayout(): JSX.Element {
   const focusedAgentHasStream = focusedAgentId ? streamingAgentIds.has(focusedAgentId) : false;
   const focusedAgentStreamUrl = focusedAgentId ? `/api/v1/agents/${focusedAgentId}/stream` : null;
 
+  const uploadFile = useCallback(async (agentId: string, file: File) => {
+    const form = new FormData();
+    form.append("file", file, file.name);
+    form.append("source", "user");
+    const res = await fetch(`/api/v1/agents/${agentId}/media`, {
+      method: "POST",
+      credentials: "include",
+      body: form,
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null) as { error?: string } | null;
+      throw new Error(body?.error ?? `Upload failed (${res.status})`);
+    }
+  }, []);
+
   const ensureAuxExpanded = useCallback((agentId: string) => {
     setExpandedAgentId(agentId);
   }, [setExpandedAgentId]);
@@ -748,6 +763,7 @@ export function DashboardLayout(): JSX.Element {
             hasStream={focusedAgentHasStream}
             streamUrl={focusedAgentStreamUrl}
             openLightbox={openLightbox}
+            onUploadFile={uploadFile}
           />
         </div>
         ) : null}
@@ -820,6 +836,7 @@ export function DashboardLayout(): JSX.Element {
               streamUrl={focusedAgentStreamUrl}
               openLightbox={openLightbox}
               onRequestClose={() => setMobileMediaOpen(false)}
+              onUploadFile={uploadFile}
             />
         </MobileSlidePanel>
       ) : null}

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -322,6 +322,7 @@ export function MediaLightbox({
   }
 
   const isText = item.file.source === "text" || isTextFile(item.file.name);
+  const isDocument = /\.pdf$/i.test(item.file.name);
   const isVideo = /\.mp4/i.test(item.src);
   const displayName = stripTimestamp(item.file.name);
 
@@ -379,10 +380,12 @@ export function MediaLightbox({
       <div
         className={cn(
           "mx-auto min-h-0 w-full max-w-4xl overflow-auto border-x border-border touch-pinch-zoom",
-          isText ? "bg-[hsl(var(--log-stream-bg))]" : "bg-black"
+          isDocument ? "bg-white" : isText ? "bg-[hsl(var(--log-stream-bg))]" : "bg-black"
         )}
       >
-        {isText ? (
+        {isDocument ? (
+          <iframe src={item.src} title={displayName} className="h-full w-full" />
+        ) : isText ? (
           <TextViewer src={item.src} fileName={item.file.name} />
         ) : isVideo ? (
           <video

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -284,6 +284,16 @@ export function MediaLightbox({
   const canGoPrev = currentIndex > 0;
   const canGoNext = currentIndex >= 0 && currentIndex < totalItems - 1;
 
+  // Allow pinch-to-zoom while lightbox is open by relaxing the viewport meta tag
+  useEffect(() => {
+    if (!item) return;
+    const meta = document.querySelector<HTMLMetaElement>("meta[name=viewport]");
+    if (!meta) return;
+    const original = meta.content;
+    meta.content = "width=device-width, initial-scale=1.0";
+    return () => { meta.content = original; };
+  }, [item]);
+
   useEffect(() => {
     if (!item) {
       return;
@@ -335,21 +345,21 @@ export function MediaLightbox({
       className="fixed inset-0 z-[120] grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_1fr_auto] bg-black/90 p-2 sm:p-6"
       data-testid="media-lightbox"
     >
-      <div className="mx-auto flex w-full max-w-4xl items-center gap-1 overflow-hidden rounded-t-lg border border-b-0 border-border bg-surface px-2 py-1.5 sm:px-4 sm:py-2">
+      <div className="mx-auto flex w-full max-w-4xl items-center gap-3 overflow-hidden rounded-t-lg border border-b-0 border-border bg-surface px-3 py-2 sm:px-4 sm:py-2.5">
         <span className="min-w-0 shrink truncate text-xs font-medium text-foreground sm:text-sm">{displayName}</span>
-        <div className="ml-auto flex shrink-0 items-center">
+        <div className="ml-auto flex shrink-0 items-center gap-2 sm:gap-3">
           <MediaActions src={item.src} fileName={item.file.name} isText={isText} />
-          <div className="mx-1 hidden h-4 w-px bg-border sm:block" />
+          <div className="mx-0.5 h-5 w-px bg-border" />
           <Button
             aria-label="Previous media item"
             data-testid="media-lightbox-prev"
             disabled={!canGoPrev}
             size="icon"
             variant="ghost"
-            className="h-7 w-7"
+            className="h-11 w-11 sm:h-9 sm:w-9"
             onClick={() => setLightboxIndex(currentIndex - 1)}
           >
-            <ChevronLeft className="h-3.5 w-3.5" />
+            <ChevronLeft className="h-6 w-6 sm:h-5 sm:w-5" />
           </Button>
           <span className="hidden text-xs tabular-nums text-muted-foreground sm:inline">
             {totalItems > 0 ? `${currentIndex + 1}/${totalItems}` : ""}
@@ -360,20 +370,20 @@ export function MediaLightbox({
             disabled={!canGoNext}
             size="icon"
             variant="ghost"
-            className="h-7 w-7"
+            className="h-11 w-11 sm:h-9 sm:w-9"
             onClick={() => setLightboxIndex(currentIndex + 1)}
           >
-            <ChevronRight className="h-3.5 w-3.5" />
+            <ChevronRight className="h-6 w-6 sm:h-5 sm:w-5" />
           </Button>
-          <div className="mx-1 hidden h-4 w-px bg-border sm:block" />
+          <div className="mx-0.5 h-5 w-px bg-border" />
           <Button
             aria-label="Close"
             size="icon"
             variant="ghost"
-            className="h-7 w-7"
+            className="h-11 w-11 sm:h-9 sm:w-9"
             onClick={() => setLightboxIndex(null)}
           >
-            <X className="h-3.5 w-3.5" />
+            <X className="h-6 w-6 sm:h-5 sm:w-5" />
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -115,7 +115,7 @@ type MediaLightboxItem = {
     name: string;
     size: number;
     updatedAt: string;
-    source?: "screenshot" | "stream" | "simulator" | "text";
+    source?: "screenshot" | "stream" | "simulator" | "text" | "user";
   };
 };
 

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -401,7 +401,7 @@ export function MediaLightbox({
       </div>
       <div className="mx-auto flex w-full max-w-4xl items-center gap-2 rounded-b-lg border border-t-0 border-border bg-surface px-2 py-1.5 text-xs text-muted-foreground sm:gap-3 sm:px-4 sm:py-2">
         {item.caption ? <span className="min-w-0 truncate">{item.caption}</span> : null}
-        {item.file.source ? <span className="flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">{item.file.source}</span> : null}
+        {item.file.source ? <span className="flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">{item.file.source === "user" ? "your upload" : item.file.source}</span> : null}
         <span className="ml-auto flex-none">{sizeLabel}</span>
         <span className="hidden flex-none sm:inline">{new Date(item.file.updatedAt).toLocaleString()}</span>
       </div>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useEffect, useRef } from "react";
-import { ChevronRight, ExternalLink, FileText, MonitorPlay, X, Image, File as FileIcon, Video } from "lucide-react";
+import { ChevronRight, ExternalLink, FileText, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
 import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
@@ -8,6 +8,9 @@ import { MediaActions, isTextFile, stripTimestamp } from "@/components/app/media
 import { PinsPanel } from "@/components/app/pins-panel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+
+const ACCEPTED_EXTENSIONS =
+  ".png,.jpg,.jpeg,.gif,.webp,.mp4,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
 
 
 function fileExtension(name: string): string {
@@ -27,6 +30,7 @@ type MediaSidebarSharedProps = {
   hasStream: boolean;
   streamUrl: string | null;
   unseenMediaCount: number;
+  onUploadFile?: (agentId: string, file: File) => Promise<void>;
 };
 
 type MediaSidebarProps = MediaSidebarSharedProps & {
@@ -83,11 +87,51 @@ function MediaContent({
   openLightbox,
   hasStream,
   streamUrl,
-}: Pick<MediaSidebarSharedProps, "mediaFiles" | "selectedAgentId" | "animatingMediaKeys" | "mediaViewportRef" | "openLightbox" | "hasStream" | "streamUrl">): JSX.Element {
+  onUploadFile,
+}: Pick<MediaSidebarSharedProps, "mediaFiles" | "selectedAgentId" | "animatingMediaKeys" | "mediaViewportRef" | "openLightbox" | "hasStream" | "streamUrl" | "onUploadFile">): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file || !selectedAgentId || !onUploadFile) return;
+      try {
+        await onUploadFile(selectedAgentId, file);
+      } catch {
+        // upload errors are non-fatal — the SSE refresh will show the file if it landed
+      }
+      // Reset input so the same file can be re-uploaded
+      e.target.value = "";
+    },
+    [selectedAgentId, onUploadFile]
+  );
+
   return (
     <>
       {hasStream && streamUrl && selectedAgentId ? (
         <LiveStreamSection streamUrl={streamUrl} selectedAgentId={selectedAgentId} />
+      ) : null}
+
+      {/* Upload button bar */}
+      {selectedAgentId && onUploadFile ? (
+        <div className="flex items-center border-b-2 border-border px-3 py-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            accept={ACCEPTED_EXTENSIONS}
+            onChange={handleFileChange}
+          />
+          <Button
+            size="sm"
+            variant="default"
+            className="h-7 gap-1.5 text-xs"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="h-3 w-3" />
+            Share file
+          </Button>
+        </div>
       ) : null}
 
       <div
@@ -104,7 +148,7 @@ function MediaContent({
                 <FileIcon className="h-8 w-8 text-muted-foreground" />
               </div>
               <div className="mt-4">
-                {selectedAgentId ? "No media yet. Agents can share screenshots, videos and documents." : "Focus an agent to view media."}
+                {selectedAgentId ? "No media yet. Share files or wait for agents to share screenshots, videos and documents." : "Focus an agent to view media."}
               </div>
             </div>
           </div>
@@ -117,6 +161,7 @@ function MediaContent({
 
             const isStream = file.source === "stream";
             const isText = file.source === "text" || isTextFile(file.name);
+            const isUser = file.source === "user";
 
             return (
               <article
@@ -135,7 +180,15 @@ function MediaContent({
                     <span className="ml-auto text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</span>
                   </div>
                 ) : (
-                  <div className="mb-2 text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</div>
+                  <div className="mb-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <span>{new Date(file.updatedAt).toLocaleString()}</span>
+                    {isUser ? (
+                      <span className="ml-auto flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                        <User className="h-2.5 w-2.5" />
+                        Shared by you
+                      </span>
+                    ) : null}
+                  </div>
                 )}
                 {isText ? (
                   <button
@@ -199,7 +252,8 @@ export function MediaSidebarContent({
   onRequestClose,
   closeButtonIcon = "x",
   className,
-  unseenMediaCount
+  unseenMediaCount,
+  onUploadFile
 }: MediaSidebarContentProps & { unseenMediaCount: number }): JSX.Element {
   const [activeTab, setActiveTab] = useAtom(mediaSidebarTabAtom);
   const prevAgentIdRef = useRef(selectedAgentId);
@@ -282,6 +336,7 @@ export function MediaSidebarContent({
           openLightbox={openLightbox}
           hasStream={hasStream}
           streamUrl={streamUrl}
+          onUploadFile={onUploadFile}
         />
       </div>
     </aside>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
-import { ChevronRight, ExternalLink, FileText, Loader2, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
+import { Check, ChevronRight, ExternalLink, FileText, Loader2, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
 import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
@@ -92,6 +92,8 @@ function MediaContent({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadSuccess, setUploadSuccess] = useState(false);
+  const successTimerRef = useRef<number | null>(null);
 
   const handleFileChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -99,8 +101,15 @@ function MediaContent({
       if (!file || !selectedAgentId || !onUploadFile) return;
       setUploading(true);
       setUploadError(null);
+      setUploadSuccess(false);
       try {
         await onUploadFile(selectedAgentId, file);
+        setUploadSuccess(true);
+        if (successTimerRef.current) window.clearTimeout(successTimerRef.current);
+        successTimerRef.current = window.setTimeout(() => {
+          setUploadSuccess(false);
+          successTimerRef.current = null;
+        }, 4000);
       } catch (err) {
         setUploadError(err instanceof Error ? err.message : "Upload failed");
       } finally {
@@ -124,26 +133,31 @@ function MediaContent({
 
       {/* Upload button bar */}
       {selectedAgentId && onUploadFile ? (
-        <div className="flex items-center gap-2 border-b-2 border-border px-3 py-2">
-          <input
-            ref={fileInputRef}
-            type="file"
-            className="hidden"
-            accept={ACCEPTED_EXTENSIONS}
-            onChange={handleFileChange}
-          />
-          <Button
-            size="sm"
-            variant="default"
-            className="h-7 gap-1.5 text-xs"
-            disabled={uploading}
-            onClick={triggerFilePicker}
-          >
-            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
-            {uploading ? "Uploading…" : "Share file"}
-          </Button>
-          {uploadError ? (
-            <span className="truncate text-xs text-destructive">{uploadError}</span>
+        <div className="border-b-2 border-border px-3 py-2">
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept={ACCEPTED_EXTENSIONS}
+              onChange={handleFileChange}
+            />
+            <Button
+              size="sm"
+              variant="default"
+              className="h-7 gap-1.5 text-xs"
+              disabled={uploading}
+              onClick={triggerFilePicker}
+            >
+              {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : uploadSuccess ? <Check className="h-3 w-3" /> : <Upload className="h-3 w-3" />}
+              {uploading ? "Uploading…" : uploadSuccess ? "Shared" : "Share file"}
+            </Button>
+            {uploadError ? (
+              <span className="truncate text-xs text-destructive">{uploadError}</span>
+            ) : null}
+          </div>
+          {uploadSuccess ? (
+            <p className="mt-1 text-[11px] text-muted-foreground">Tell the agent about the file so it knows to look.</p>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,5 +1,5 @@
-import { type RefObject, useCallback, useEffect, useRef } from "react";
-import { ChevronRight, ExternalLink, FileText, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { ChevronRight, ExternalLink, FileText, Loader2, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
 import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
@@ -90,21 +90,31 @@ function MediaContent({
   onUploadFile,
 }: Pick<MediaSidebarSharedProps, "mediaFiles" | "selectedAgentId" | "animatingMediaKeys" | "mediaViewportRef" | "openLightbox" | "hasStream" | "streamUrl" | "onUploadFile">): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   const handleFileChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (!file || !selectedAgentId || !onUploadFile) return;
+      setUploading(true);
+      setUploadError(null);
       try {
         await onUploadFile(selectedAgentId, file);
-      } catch {
-        // upload errors are non-fatal — the SSE refresh will show the file if it landed
+      } catch (err) {
+        setUploadError(err instanceof Error ? err.message : "Upload failed");
+      } finally {
+        setUploading(false);
       }
       // Reset input so the same file can be re-uploaded
       e.target.value = "";
     },
     [selectedAgentId, onUploadFile]
   );
+
+  const triggerFilePicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
 
   return (
     <>
@@ -114,7 +124,7 @@ function MediaContent({
 
       {/* Upload button bar */}
       {selectedAgentId && onUploadFile ? (
-        <div className="flex items-center border-b-2 border-border px-3 py-2">
+        <div className="flex items-center gap-2 border-b-2 border-border px-3 py-2">
           <input
             ref={fileInputRef}
             type="file"
@@ -126,11 +136,15 @@ function MediaContent({
             size="sm"
             variant="default"
             className="h-7 gap-1.5 text-xs"
-            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            onClick={triggerFilePicker}
           >
-            <Upload className="h-3 w-3" />
-            Share file
+            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
+            {uploading ? "Uploading…" : "Share file"}
           </Button>
+          {uploadError ? (
+            <span className="truncate text-xs text-destructive">{uploadError}</span>
+          ) : null}
         </div>
       ) : null}
 
@@ -148,7 +162,15 @@ function MediaContent({
                 <FileIcon className="h-8 w-8 text-muted-foreground" />
               </div>
               <div className="mt-4">
-                {selectedAgentId ? "No media yet. Share files or wait for agents to share screenshots, videos and documents." : "Focus an agent to view media."}
+                {selectedAgentId ? (
+                  <>
+                    No media yet.{" "}
+                    <button className="underline hover:text-foreground" onClick={triggerFilePicker}>
+                      Share a file
+                    </button>{" "}
+                    or wait for agents to share screenshots, videos and documents.
+                  </>
+                ) : "Focus an agent to view media."}
               </div>
             </div>
           </div>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const ACCEPTED_EXTENSIONS =
-  ".png,.jpg,.jpeg,.gif,.webp,.mp4,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
+  ".png,.jpg,.jpeg,.gif,.webp,.mp4,.pdf,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
 
 
 function fileExtension(name: string): string {
@@ -197,6 +197,7 @@ function MediaContent({
 
             const isStream = file.source === "stream";
             const isText = file.source === "text" || isTextFile(file.name);
+            const isDocument = /\.pdf$/i.test(file.name);
             const isUser = file.source === "user";
 
             return (
@@ -226,7 +227,7 @@ function MediaContent({
                     ) : null}
                   </div>
                 )}
-                {isText ? (
+                {isText || isDocument ? (
                   <button
                     className={cn(
                       "block w-full overflow-hidden rounded border-2 bg-muted/50 p-3 text-left",

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -72,7 +72,7 @@ export type MediaFile = {
   updatedAt: string;
   url: string;
   seen?: boolean;
-  source?: "screenshot" | "stream" | "simulator" | "text";
+  source?: "screenshot" | "stream" | "simulator" | "text" | "user";
   description?: string | null;
 };
 

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -1137,7 +1137,7 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
     "dispatch_share",
     {
       description:
-        "Upload a media file or text snippet to Dispatch for sharing. Supports images (png/jpg/jpeg/gif/webp), video (mp4), and text files (txt/md/json/yaml/ts/py/go/rs/sh/sql/etc). Use source 'simulator' to capture from an iOS Simulator. For text snippets, pass content directly with a name (e.g. name='config.yaml') instead of writing to a file first. To update a previously shared file, pass its fileName (from the original response) in the 'update' parameter.",
+        "Upload a media file or text snippet to Dispatch for sharing. Supports images (png/jpg/jpeg/gif/webp), video (mp4), documents (pdf), and text files (txt/md/json/yaml/ts/py/go/rs/sh/sql/etc). Use source 'simulator' to capture from an iOS Simulator. For text snippets, pass content directly with a name (e.g. name='config.yaml') instead of writing to a file first. To update a previously shared file, pass its fileName (from the original response) in the 'update' parameter.",
       inputSchema: {
         filePath: z
           .string()

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -109,6 +109,7 @@ const AGENT_TOOLS = new Set([
   "dispatch_notify",
   "dispatch_pin",
   "dispatch_share",
+  "dispatch_list_media",
   "dispatch_feedback",
   "list_personas",
   "dispatch_launch_persona",
@@ -203,6 +204,10 @@ export type McpRequestContext = {
     agentId: string,
     opts: { filePath: string; description: string; source?: string; name?: string; update?: string }
   ) => Promise<MediaResult>;
+  listMedia?: (
+    agentId: string,
+    opts: { source?: string }
+  ) => Promise<Array<{ fileName: string; filePath: string; source: string; description: string | null; sizeBytes: number; createdAt: string }>>;
   submitFeedback?: (
     agentId: string,
     feedback: FeedbackInput
@@ -563,6 +568,39 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
 
   if (allowed.has("dispatch_pin")) registerPinTool(server, context);
   if (allowed.has("dispatch_share")) registerShareTool(server, context);
+
+  // ── dispatch_list_media ──────────────────────────────────────────
+  if (allowed.has("dispatch_list_media") && context.agent && context.listMedia) {
+    const agentId = context.agent.id;
+    const listMedia = context.listMedia;
+
+    server.registerTool(
+      "dispatch_list_media",
+      {
+        description:
+          "List media files shared with or by this agent. Returns metadata only — use file reading tools to access content via filePath.",
+        inputSchema: {
+          source: z
+            .string()
+            .optional()
+            .describe(
+              'Optional source filter (e.g. "user", "screenshot", "text", "simulator", "stream"). Omit to list all media.'
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const items = await listMedia(agentId, { source: args.source });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(items, null, 2) }],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
   if (allowed.has("dispatch_feedback")) registerFeedbackTool(server, context);
 
   // ── list_personas ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Backend**: Add `"user"` source type to media upload endpoint, make description optional, timestamp filenames to prevent collisions. New `mcpListMedia` backend function.
- **New MCP tool**: `dispatch_list_media` in AGENT_TOOLS — agents can discover shared files with optional source filter, returns metadata (fileName, filePath, source, description, sizeBytes, createdAt).
- **Frontend**: "Share file" upload button in Media tab with native file picker, "Shared by you" badge on user-uploaded files, updated empty state copy.

## Test plan

- [x] Type checking passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] 330 unit tests pass (`pnpm run test`)
- [x] 110 E2E tests pass (`pnpm run test:e2e`)
- [x] Manual testing on live dev instance — upload button visible, file picker works, files appear with animation and "Shared by you" indicator

Closes CRU-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)