### PR TITLE
fix: send source field before file in upload FormData

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -238,8 +238,8 @@ export function DashboardLayout(): JSX.Element {
 
   const uploadFile = useCallback(async (agentId: string, file: File) => {
     const form = new FormData();
-    form.append("file", file, file.name);
     form.append("source", "user");
+    form.append("file", file, file.name);
     const res = await fetch(`/api/v1/agents/${agentId}/media`, {
       method: "POST",
       credentials: "include",


### PR DESCRIPTION
## Summary

- Fix user-uploaded files showing source as `"screenshot"` instead of `"user"`
- Root cause: `FormData.append("source", "user")` was after the file append — Fastify multipart's `request.file()` consumes the stream up to the file part, so fields after the file may not be available in `data.fields`
- Fix: move the source field before the file in the FormData

## Test plan

- [x] Type checking passes
- [x] Upload a file via media sidebar and verify source is `"user"` (not `"screenshot"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)