### PR TITLE
docs: add missing MCP tools and API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `dispatch_get_feedback` | Retrieve feedback findings for review |
 | `dispatch_resolve_feedback` | Mark a feedback item as fixed or ignored |
 | `dispatch_launch_persona` | Launch a persona child agent for automated review |
+| `dispatch_list_media` | List media files shared with or by this agent |
 | `dispatch_notify` | Send a Slack notification from the agent (requires webhook configured) |
+| `list_personas` | List available persona reviewers for this project |
 | `create_pr` | Create a GitHub pull request |
 | `get_pr_status` | Check PR CI status and reviews |
 | `get_activity_summary` | Summarize agent activity over a time range |

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -49,6 +49,7 @@
 | POST | `/agents` | Create new agent |
 | POST | `/agents/:id/start` | Start a stopped agent |
 | POST | `/agents/:id/stop` | Stop a running agent |
+| PATCH | `/agents/:id/review-agent-type` | Set preferred agent type for persona reviews |
 | DELETE | `/agents/:id` | Delete agent (soft delete) |
 
 ### `POST /agents` — Create Agent


### PR DESCRIPTION
## Summary

Audited all documentation against the actual codebase. The docs were in excellent shape — only three minor omissions found and fixed:

- **README.md**: Added `dispatch_list_media` and `list_personas` to the MCP tools table (both were available to agents but not documented in the README)
- **docs/03-api-spec.md**: Added `PATCH /agents/:id/review-agent-type` endpoint to the Agent Lifecycle table

## Audit report

### Files audited (no changes needed)

| File | Status |
|------|--------|
| `CLAUDE.md` | Project structure tree, scripts, paths all match reality |
| `docs/04-agent-lifecycle.md` | States, transitions, tmux contract all accurate |
| `docs/10-operations-runbook.md` | Service management, releases, diagnostics all current |
| `docs/11-backend-compatibility-checklist.md` | Guidelines accurate and actionable |
| `docs/12-new-machine-setup.md` | Prerequisites, steps, troubleshooting all correct |
| `docs/14-theming.md` | File references, architecture, instructions all valid |
| `docs/15-personas-and-feedback.md` | Persona system, feedback API, status values all accurate |
| `docs/16-notifications.md` | Slack integration, events, API endpoints all correct |

### Validation

- All `docs/*.md` links in README.md verified to point to existing files
- All file paths referenced in theming doc verified (index.css, tailwind.config.ts, use-theme.ts, settings-pane.tsx, index.html)
- `pnpm run check` passes
- No stale planning docs, roadmaps, or abandoned implementation docs found

### Overall assessment

The documentation is well-maintained and closely tracks the codebase. The only gaps were two MCP tools and one API endpoint that were added to the codebase but not reflected in the docs. No docs needed deletion, and no major feature areas lacked documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)