### PR TITLE
fix: remove remaining packages/shared references

### DIFF
--- a/.dispatch/personas/architecture-review.md
+++ b/.dispatch/personas/architecture-review.md
@@ -20,7 +20,7 @@ Your job is to review code changes for architectural fit, abstraction quality, n
 - Is the abstraction level appropriate — not too early, not too late?
 - Are there near-duplicates that should be consolidated, or premature abstractions that should be inlined?
 - Do function/component signatures make sense? Are they easy to use correctly and hard to use incorrectly?
-- Is shared code actually shared, or forced into `@dispatch/shared` without real reuse?
+- Is shared code actually shared, or prematurely abstracted without real reuse?
 
 ### Naming & Readability
 - Do names accurately describe what things do?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
               -f target_commitish="main" \
               --jq '.body' > release-notes/current.md
           fi
-          git add package.json apps/*/package.json packages/*/package.json pnpm-lock.yaml release-notes/current.md
+          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
           git commit -m "Release ${NEW_VERSION}"
           # Pull in any commits that landed on main during the CI run
           git pull --rebase origin main

--- a/apps/server/test/pack-release.test.ts
+++ b/apps/server/test/pack-release.test.ts
@@ -10,8 +10,7 @@ const OUTPUT = `/tmp/dispatch-pack-release-test-${process.pid}.tar.gz`;
 
 const BUILDS_EXIST =
   existsSync(path.join(REPO_ROOT, "apps/server/dist")) &&
-  existsSync(path.join(REPO_ROOT, "apps/web/dist")) &&
-  existsSync(path.join(REPO_ROOT, "packages/shared/dist"));
+  existsSync(path.join(REPO_ROOT, "apps/web/dist"));
 
 function run(args = ""): string {
   return execSync(`${BIN} ${args}`, {
@@ -47,7 +46,6 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     const files = tarList();
     expect(files.some((f) => f.startsWith("apps/server/dist/"))).toBe(true);
     expect(files.some((f) => f.startsWith("apps/web/dist/"))).toBe(true);
-    expect(files.some((f) => f.startsWith("packages/shared/dist/"))).toBe(true);
   });
 
   it("includes package.json files for dependency install", () => {
@@ -55,7 +53,6 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     expect(files).toContain("package.json");
     expect(files).toContain("apps/server/package.json");
     expect(files).toContain("apps/web/package.json");
-    expect(files).toContain("packages/shared/package.json");
   });
 
   it("includes pnpm workspace config and lockfile", () => {

--- a/bin/pack-release
+++ b/bin/pack-release
@@ -8,7 +8,7 @@ set -euo pipefail
 # Usage: bin/pack-release [--output <path>]
 #
 # The tarball includes:
-#   - Pre-built dist/ directories (server, web, shared)
+#   - Pre-built dist/ directories (server, web)
 #   - package.json files + lockfile (for native module install on host)
 #   - bin/ scripts (deploy, server management, launchd wrapper)
 #   - Database migrations (SQL, read from source at runtime)
@@ -48,7 +48,6 @@ OUTPUT="${OUTPUT:-$ROOT_DIR/dispatch-release.tar.gz}"
 missing=()
 [[ -d "$ROOT_DIR/apps/server/dist" ]]   || missing+=("apps/server/dist")
 [[ -d "$ROOT_DIR/apps/web/dist" ]]      || missing+=("apps/web/dist")
-[[ -d "$ROOT_DIR/packages/shared/dist" ]] || missing+=("packages/shared/dist")
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "error: missing build outputs — run 'pnpm run build' first:" >&2
@@ -68,11 +67,9 @@ trap 'rm -f "$MANIFEST"' EXIT
 cat > "$MANIFEST" <<'LIST'
 apps/server/dist
 apps/web/dist
-packages/shared/dist
 package.json
 apps/server/package.json
 apps/web/package.json
-packages/shared/package.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
 .nvmrc


### PR DESCRIPTION
## Summary
Follow-up to #326 — removes leftover `packages/shared` references that caused the release workflow to fail:

- `.github/workflows/release.yml`: remove `packages/*/package.json` from `git add`
- `bin/pack-release`: remove `packages/shared/dist` validation check and tarball entries
- `apps/server/test/pack-release.test.ts`: remove shared package assertions
- `.dispatch/personas/architecture-review.md`: update stale `@dispatch/shared` mention

## Test plan
- [x] Type check passes
- [x] Unit tests: 31 files, 330 tests passed
- [x] E2E: 112 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)