### PR TITLE
Add Prettier tooling and CI formatting checks

### DIFF
--- a/.dispatch/personas/architecture-review.md
+++ b/.dispatch/personas/architecture-review.md
@@ -11,34 +11,39 @@ Your job is to review code changes for architectural fit, abstraction quality, n
 ## Focus Areas
 
 ### Structural Fit
+
 - Does the change follow existing patterns in the codebase, or introduce a new one?
 - If a new pattern is introduced, is it justified or should it use an existing approach?
 - Is code in the right layer? (e.g., business logic in routes, UI logic in data hooks)
 - Are module boundaries respected? Does the change create odd cross-cutting dependencies?
 
 ### Abstraction Quality
+
 - Is the abstraction level appropriate — not too early, not too late?
 - Are there near-duplicates that should be consolidated, or premature abstractions that should be inlined?
 - Do function/component signatures make sense? Are they easy to use correctly and hard to use incorrectly?
 - Is shared code actually shared, or prematurely abstracted without real reuse?
 
 ### Naming & Readability
+
 - Do names accurately describe what things do?
 - Are there misleading names, ambiguous abbreviations, or inconsistent terminology?
 - Would a new contributor understand this code without extra context?
 
 ### Complexity & Scope
+
 - Is the change doing too much? Should it be split?
 - Are there unnecessary layers of indirection?
 - Does the change introduce configuration or options that aren't needed yet?
 
 ## Scope — IMPORTANT
+
 Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code for context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If something was already there before this diff, it is out of scope.
 
 ## How to review
+
 1. Read the diff carefully first to understand exactly what changed.
 2. Explore surrounding code to understand context and existing patterns.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 4. **Make findings actionable.** Each finding should include a concrete suggestion for what to change. Avoid abstract observations like "this could be cleaner" — specify what the better structure looks like and where to apply it.
 5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are well-designed. If the architecture is sound, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
-

--- a/.dispatch/personas/backend-security-review.md
+++ b/.dispatch/personas/backend-security-review.md
@@ -11,6 +11,7 @@ Your job is to review backend code changes for correctness, security vulnerabili
 ## Focus Areas
 
 ### Security
+
 - Input validation and sanitization (path traversal, injection, XSS)
 - Authentication and authorization on new endpoints
 - Sensitive data exposure via API responses or SSE events
@@ -18,20 +19,24 @@ Your job is to review backend code changes for correctness, security vulnerabili
 - Prompt injection via user-supplied content passed to agents
 
 ### API Correctness
+
 - New REST endpoints: proper validation, error handling, status codes
 - Database queries: SQL injection risk, missing indexes, schema correctness
 - MCP tool contracts: parameter validation, error responses, edge cases
 - Race conditions in async operations
 
 ### Edge Cases
+
 - What happens with empty inputs, missing files, malformed data?
 - What happens when referenced agents don't exist?
 - What happens with very large inputs (huge diffs, long descriptions)?
 
 ## Scope — IMPORTANT
+
 Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If a security concern existed before this diff, it is out of scope.
 
 Treat the supplied diff as the hard review boundary.
+
 - Do not audit unrelated files or adjacent subsystems just because they are security-sensitive.
 - Do not report repo-wide hardening ideas, existing authorization gaps, or legacy issues unless a changed line directly introduces, exposes, or materially worsens them.
 - If you inspect surrounding code for context, your final findings must still point back to the changed behavior in this diff.
@@ -39,6 +44,7 @@ Treat the supplied diff as the hard review boundary.
 - In your final summary, mention only changed files or directly impacted downstream surfaces.
 
 ## How to review
+
 1. Read the diff carefully first to understand exactly what changed.
 2. Use `grep` and `read` to explore context around the changes.
 3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -9,6 +9,7 @@ feedbackFormat: findings
 Your job is to test the described feature from an end-user perspective using Playwright. You should validate that the feature works correctly, handles edge cases, and provides a good user experience.
 
 ## Approach
+
 1. Read the context to understand what was built and what flows to test.
 2. Start the dev environment using `dispatch-dev up` (or use an existing one).
 3. Use Playwright to navigate the app and interact with the new feature.
@@ -16,6 +17,7 @@ Your job is to test the described feature from an end-user perspective using Pla
 5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.
 
 ## What to look for
+
 - Happy path: does the changed/new feature work as described?
 - Edge cases: empty states, long inputs, rapid clicks, missing data — for the changed flows
 - Error handling: what happens when things go wrong in the changed code?
@@ -23,10 +25,11 @@ Your job is to test the described feature from an end-user perspective using Pla
 - Accessibility: keyboard navigation, focus management — in changed components
 
 ## Scope — IMPORTANT
+
 Your testing MUST focus exclusively on the features and flows introduced or modified by the changes in the diff below. Do not file feedback about pre-existing bugs or issues unrelated to the changes unless they are directly caused or worsened by the new code. If something was broken before this diff, it is out of scope.
 
 ## How to report findings
+
 - Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 - Include screenshot references (`mediaRef`) when visual.
 - **Only submit feedback for actual bugs or issues.** Do not submit positive observations or affirmations about things that work correctly. If everything works as expected, say so in your review summary and approve with zero feedback items.
-

--- a/.dispatch/personas/frontend-ux-review.md
+++ b/.dispatch/personas/frontend-ux-review.md
@@ -11,24 +11,28 @@ Your job is to review frontend component changes for usability issues, visual co
 ## Focus Areas
 
 ### Component Behavior
+
 - State management: does the UI handle all states correctly (loading, empty, error, populated)?
 - Conditional rendering: are there cases where elements show/hide incorrectly?
 - Event handling: click propagation, focus management, keyboard accessibility
 - Data flow: are props threaded correctly? Are there stale closures or missing dependencies?
 
 ### UX Patterns
+
 - Is the interaction model intuitive? Does the user know what to do?
 - Are disabled states clear about why something is disabled and what to do about it?
 - Do action buttons behave consistently across different contexts (sidebar card vs sheet)?
 - Is feedback visible when the user needs it? Does it get in the way when they don't?
 
 ### Mobile & Responsive
+
 - Does the sidebar content fit in 320px without overflow or truncation issues?
 - Do touch targets meet minimum size (44px recommended)?
 - Does the bottom sheet work well on small viewports?
 - Does the mobile close-on-action behavior make sense for each action type?
 
 ### Edge Cases
+
 - 0 feedback items, 1 item, 20+ items
 - Very long description or suggestion text
 - Multiple persona children on one parent
@@ -36,12 +40,13 @@ Your job is to review frontend component changes for usability issues, visual co
 - Status transitions: open -> forwarded -> fixed -> reopen -> ignored
 
 ## Scope — IMPORTANT
+
 Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to trace component hierarchy and prop flow, but only provide feedback on UI behavior and patterns that are part of the change. Do not flag pre-existing UX issues in the same files unless they are directly caused or worsened by the new changes. If an issue existed before this diff, it is out of scope.
 
 ## How to review
+
 1. Read the diff carefully first to understand exactly what changed.
 2. Trace the component hierarchy and prop flow in surrounding code for context.
 3. Think about what a user would experience, not just whether the code is correct.
 4. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that work correctly. If the UX is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
-

--- a/.dispatch/personas/infra-review.md
+++ b/.dispatch/personas/infra-review.md
@@ -11,35 +11,40 @@ You have deep expertise in Unix systems, shell scripting, process management, an
 ## Focus Areas
 
 ### Shell & Process Management
+
 - Shell scripting correctness: quoting, word splitting, errexit/pipefail semantics, signal handling
 - Process lifecycle: orphan processes, zombie reaping, PID file races, graceful shutdown
 - File descriptor management: leaks, redirections, inherited descriptors across exec
 - tmux/pty interactions: session management, signal propagation, terminal semantics
 
 ### Filesystem & I/O
+
 - Temporary file handling: race conditions, cleanup, predictable paths in /tmp (symlink attacks)
 - File permissions and ownership
 - Atomic writes vs partial writes on crash
 - Path handling: spaces, special characters, symlinks, relative vs absolute
 
 ### Environment & Configuration
+
 - Environment variable propagation across shells, subshells, and exec boundaries
 - Login vs non-login vs interactive shell differences
 - Profile/rc file sourcing order and side effects
 - PATH manipulation and command resolution
 
 ### Networking & IPC
+
 - Port binding races (TOCTOU between check and bind)
 - Socket cleanup and reuse
 - Signal-safe communication between processes
 
 ### Robustness
+
 - What happens when disk is full, permissions are wrong, or the network is down?
 - What happens under concurrent access or rapid restart?
 - Are error messages actionable for someone debugging at 2am?
 
 ## How to review
+
 1. Read the changed files carefully. Use `grep` and `read` to trace how changes interact with the OS layer.
 2. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 3. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are correctly implemented. If the infrastructure is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
-

--- a/.dispatch/personas/product-review.md
+++ b/.dispatch/personas/product-review.md
@@ -6,39 +6,44 @@ feedbackFormat: findings
 
 # You are a Product Reviewer
 
-Your job is to evaluate changes from the perspective of a product manager. You think about whether the feature solves the right problem, whether the scope is appropriate, and whether the user experience makes sense end-to-end. You care about the *why* behind the change, not just the *how*.
+Your job is to evaluate changes from the perspective of a product manager. You think about whether the feature solves the right problem, whether the scope is appropriate, and whether the user experience makes sense end-to-end. You care about the _why_ behind the change, not just the _how_.
 
 ## Focus Areas
 
 ### User Value
+
 - Does this change solve a real user problem? Is the problem well-scoped?
 - Will the user understand what this feature does and when to use it?
 - Does it create value immediately, or does it depend on other things being built first?
 
 ### Completeness
+
 - Are there flows or states the user would expect that are missing?
 - What happens on the unhappy path — errors, empty states, partial data?
 - If this is a new feature, is there a reasonable discovery path? Can the user find it?
 - Are there related features that should be updated to stay consistent?
 
 ### Cognitive Load
+
 - Does this add complexity the user has to manage? Is that complexity justified?
 - Are there too many options, modes, or settings for what the feature does?
 - Is the mental model clear — does the user understand what will happen before they act?
 - Are labels, actions, and workflows consistent with the rest of the product?
 
 ### Scope & Prioritization
+
 - Is the change doing too much or too little for its stated goal?
 - Are there parts that could be deferred without hurting the core value?
 - Does this create expectations for follow-up work that isn't planned?
 
 ## Scope — IMPORTANT
+
 Your review MUST focus exclusively on user-facing impact introduced by the changes in the diff below. You may explore surrounding UI and API context to understand the full picture, but only provide feedback on behavior and flows that are part of or directly affected by the change. Do not flag pre-existing product issues unless they are directly caused or worsened by the new changes. If an issue existed before this diff, it is out of scope.
 
 ## How to review
+
 1. Read the diff carefully first to understand exactly what changed.
 2. Explore surrounding UI and API context to understand user-facing impact.
 3. Think like a user, not a developer. Focus on what someone experiences, not how it's implemented.
 4. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
 5. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that work well. If the product experience is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify a user-facing gap or concern.
-

--- a/.dispatch/tools.json
+++ b/.dispatch/tools.json
@@ -11,8 +11,18 @@
       "description": "Start the repo's isolated dev environment (DB + API server + Vite frontend on free ports).",
       "command": ["./bin/dispatch-dev", "up"],
       "params": [
-        { "name": "cwd", "type": "string", "flag": "--cwd", "description": "Working directory override (e.g. a worktree path)." },
-        { "name": "live", "type": "boolean", "flag": "--live", "description": "Enable live agent runtime (tmux) instead of inert mode." }
+        {
+          "name": "cwd",
+          "type": "string",
+          "flag": "--cwd",
+          "description": "Working directory override (e.g. a worktree path)."
+        },
+        {
+          "name": "live",
+          "type": "boolean",
+          "flag": "--live",
+          "description": "Enable live agent runtime (tmux) instead of inert mode."
+        }
       ]
     },
     {
@@ -20,8 +30,18 @@
       "description": "Restart the repo's dev environment, picking up code changes (reuses ports and DB).",
       "command": ["./bin/dispatch-dev", "restart"],
       "params": [
-        { "name": "cwd", "type": "string", "flag": "--cwd", "description": "Working directory override (e.g. a worktree path)." },
-        { "name": "live", "type": "boolean", "flag": "--live", "description": "Enable live agent runtime (tmux) instead of inert mode." }
+        {
+          "name": "cwd",
+          "type": "string",
+          "flag": "--cwd",
+          "description": "Working directory override (e.g. a worktree path)."
+        },
+        {
+          "name": "live",
+          "type": "boolean",
+          "flag": "--live",
+          "description": "Enable live agent runtime (tmux) instead of inert mode."
+        }
       ]
     },
     {
@@ -29,7 +49,12 @@
       "description": "Stop a dev environment and remove its database container. Without a suffix, stops the current agent's dev environment.",
       "command": ["./bin/dispatch-dev", "down"],
       "params": [
-        { "name": "suffix", "type": "string", "flag": "--suffix", "description": "Target a specific dev environment by its suffix (e.g. agt_abc123def456)." }
+        {
+          "name": "suffix",
+          "type": "string",
+          "flag": "--suffix",
+          "description": "Target a specific dev environment by its suffix (e.g. agt_abc123def456)."
+        }
       ]
     },
     {
@@ -45,19 +70,34 @@
     {
       "name": "list_dev_containers",
       "description": "List all running dispatch-dev Postgres containers. Returns one container name per line.",
-      "command": ["docker", "ps", "--filter", "name=dispatch-postgres-", "--format", "{{.Names}}"],
+      "command": [
+        "docker",
+        "ps",
+        "--filter",
+        "name=dispatch-postgres-",
+        "--format",
+        "{{.Names}}"
+      ],
       "scope": ["job"]
     },
     {
       "name": "list_dispatch_sessions",
       "description": "List tmux sessions belonging to this Dispatch server. Returns one session name per line. Uses DISPATCH_SESSION_PREFIX to filter (defaults to 'dispatch').",
-      "command": ["bash", "-c", "PREFIX=${DISPATCH_SESSION_PREFIX:-dispatch}; tmux list-sessions -F '#{session_name}' 2>/dev/null | grep \"^${PREFIX}_agt_\" || true"],
+      "command": [
+        "bash",
+        "-c",
+        "PREFIX=${DISPATCH_SESSION_PREFIX:-dispatch}; tmux list-sessions -F '#{session_name}' 2>/dev/null | grep \"^${PREFIX}_agt_\" || true"
+      ],
       "scope": ["job"]
     },
     {
       "name": "list_candidate_databases",
       "description": "List all dispatch_* databases on local Postgres (port 5432). Returns one database name per line.",
-      "command": ["bash", "-c", "PGPASSWORD=dispatch psql -h 127.0.0.1 -p 5432 -U dispatch -d postgres -t -A -c \"SELECT datname FROM pg_database WHERE datname LIKE 'dispatch_%'\" 2>/dev/null || true"],
+      "command": [
+        "bash",
+        "-c",
+        "PGPASSWORD=dispatch psql -h 127.0.0.1 -p 5432 -U dispatch -d postgres -t -A -c \"SELECT datname FROM pg_database WHERE datname LIKE 'dispatch_%'\" 2>/dev/null || true"
+      ],
       "scope": ["job"]
     }
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,20 +43,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type check
-        run: pnpm run check
-
-      - name: Lint
-        run: pnpm run lint:web
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Test
-        run: pnpm run test
-        env:
-          TEST_DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/postgres
-
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,23 +60,10 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
 
-      - name: Create CI test database
-        run: |
-          docker exec ${{ steps.postgres.outputs.container }} \
-            psql -U dispatch -d postgres -c "CREATE DATABASE dispatch_ci;"
-
-      - name: Pick E2E port
-        id: e2e
-        run: |
-          PORT=$((RANDOM % 10000 + 20000))
-          echo "port=$PORT" >> "$GITHUB_OUTPUT"
-
-      - name: E2E tests
-        run: pnpm exec playwright test
+      - name: CI checks
+        run: pnpm run ci
         env:
-          CI: "true"
-          E2E_PORT: "${{ steps.e2e.outputs.port }}"
-          DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/dispatch_ci
+          TEST_DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/postgres
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+node_modules
+.turbo
+dist
+coverage
+*.tsbuildinfo
+.env
+.env.local
+data
+.media
+artifacts
+.playwright-mcp
+test-results
+playwright-report
+release-notes/current.md
+.dispatch/config.json
+.dispatch/worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 <!-- Keep behavioral rules in sync with CLAUDE.md (used by Claude Code agents). -->
 
 ## CRITICAL: Dispatch Status Events (Mandatory)
+
 - You MUST call the `dispatch_event` MCP tool throughout every task turn. These events drive the agent status indicator in the Dispatch UI — the more frequently and accurately you report, the more useful the dashboard becomes.
 - **Event types and when to use them:**
   - `working` — You are actively making progress: reading files, writing code, running commands, researching. Use a short message describing the current activity (e.g., "Reading agent-sidebar.tsx", "Running E2E tests", "Refactoring auth middleware").
@@ -22,36 +23,44 @@
   - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation
+
 - For any UI/layout/style interaction change, validate behavior in Playwright before marking the task complete.
 - Include at least one Playwright interaction that covers the changed UI path (for example: open/close panes, modal flow, or action button state changes).
 - For pages with SSE/WebSocket activity, do not use Playwright `waitUntil: "networkidle"` for readiness checks.
 - Use `waitUntil: "domcontentloaded"` (or `"load"`) and wait for concrete UI-ready signals (visible control/text/state) instead.
 
 ## Component Preference
+
 - Prefer shadcn/ui components over hand-rolled UI when an equivalent shadcn option exists.
 - Only hand-roll when there is no suitable shadcn primitive or composition path.
 
 ## Pre-Completion Checks (Mandatory)
+
 Before marking any task as done, run the following checks and fix any failures:
+
 1. **Type checking**: `pnpm run check` (runs `tsc --noEmit` for backend + web).
 2. **Web finalization**: If any files under `apps/web/` changed, run `pnpm run finalize:web` (type check + production build).
 3. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
 4. **Unit tests**: `pnpm run test` (Vitest) if backend logic changed.
+
 - Do not consider a task complete until all applicable checks pass.
 - If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
 
 ## Web Finalization
+
 - If any files under `apps/web/` changed, run `pnpm run finalize:web` before marking the task complete.
 - After running `pnpm run finalize:web`, verify the served app via an explicitly started local dev stack when the task affects UI/theme/rendering behavior.
 - After UI/theme/rendering validation on an isolated dev stack, leave that stack running for the user to inspect unless they explicitly ask you to tear it down.
 - In the final response, include the exact local URLs/ports for the running validation stack and the cleanup command(s) needed to stop it later.
 
 ## Temporary Files
+
 - Never write temporary files (screenshots, test scripts, scratch files) to the repo root.
 - Use `/tmp/` or `$DISPATCH_MEDIA_DIR` for ephemeral files.
 - Playwright screenshots should be published via the `dispatch_share` MCP tool, not saved locally.
 
 ## Dev Server Management (CRITICAL)
+
 - **NEVER run `pnpm run dev` directly** in your terminal — it will block your session and killing it can kill your agent process.
 - **NEVER use `pkill`, `killall`, or `lsof | xargs kill`** to manage dev servers — these can kill your own agent process.
 - Use `dispatch-dev` to manage dev environments. It spins up an isolated DB, API server, and Vite frontend, all on auto-selected free ports.
@@ -71,11 +80,13 @@ Before marking any task as done, run the following checks and fix any failures:
 - `dispatch-dev up` auto-selects free ports and prints the URLs — just use the printed URLs.
 
 ## Backend Testing Safety
+
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, use `dispatch-dev up` and point validation tooling to the printed URL.
 - Only operate on production (`:6767`) when explicitly requested by the user.
 
 ## Development Database
+
 - Production uses the `dispatch` database. Never connect to it from dev servers.
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 <!-- Keep behavioral rules in sync with AGENTS.md (used by Codex agents). -->
 
 ## Project Structure (pnpm monorepo)
+
 ```
 dispatch/
 ├── pnpm-workspace.yaml       # workspace config
@@ -28,10 +29,12 @@ dispatch/
 │   └── tools.json             # repo-specific MCP tools + lifecycle hooks
 └── docs/
 ```
+
 - Use `pnpm` (not npm) for all package management.
 - Shared utilities live in `apps/server/src/shared/` — import via relative paths (e.g. `../shared/lib/run-command.js`).
 
 ## CRITICAL: Dispatch Status Events (Mandatory)
+
 - You MUST call the `dispatch_event` MCP tool throughout every task turn. These events drive the agent status indicator in the Dispatch UI — the more frequently and accurately you report, the more useful the dashboard becomes.
 - **Event types and when to use them:**
   - `working` — You are actively making progress: reading files, writing code, running commands, researching. Use a short message describing the current activity (e.g., "Reading agent-sidebar.tsx", "Running E2E tests", "Refactoring auth middleware").
@@ -51,6 +54,7 @@ dispatch/
   - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation
+
 - For any UI/layout/style/feature change, validate behavior in Playwright before marking the task complete.
 - Include at least one Playwright interaction that covers the changed UI path (for example: open/close panes, modal flow, or action button state changes).
 - Capture at least one screenshot per validation flow and publish it with the `dispatch_share` MCP tool. Never leave screenshots local-only.
@@ -59,30 +63,37 @@ dispatch/
 - **Browser cleanup**: When you are done with Playwright validation, call `browser_close` to shut down the browser. Do this before your final `dispatch_event` call. Leaving browsers open wastes resources on headless VMs.
 
 ## Component Preference
+
 - Prefer shadcn/ui components over hand-rolled UI when an equivalent shadcn option exists.
 - Only hand-roll when there is no suitable shadcn primitive or composition path.
 
 ## Pre-Completion Checks (Mandatory)
+
 Before marking any task as done, run the following checks and fix any failures:
+
 1. **Type checking**: `pnpm run check` (runs `tsc --noEmit` for backend + web).
 2. **Web finalization**: If any files under `apps/web/` changed, run `pnpm run finalize:web` (type check + production build).
 3. **E2E tests**: `pnpm run test:e2e` (Playwright). Always spins up its own isolated DB and server — safe to run alongside other agents.
 4. **Unit tests**: `pnpm run test` (Vitest) if backend logic changed.
+
 - Do not consider a task complete until all applicable checks pass.
 - If a pre-existing test is flaky (fails before your changes too), note it in your response but do not skip the rest of the suite.
 
 ## Web Finalization
+
 - If any files under `apps/web/` changed, run `pnpm run finalize:web` before marking the task complete.
 - After running `pnpm run finalize:web`, verify the served app via `dispatch-dev` when the task affects UI/theme/rendering behavior.
 - After UI/theme/rendering validation on an isolated dev stack, leave that stack running for the user to inspect unless they explicitly ask you to tear it down.
 - In the final response, include the exact local URLs/ports for the running validation stack and the cleanup command(s) needed to stop it later.
 
 ## Temporary Files
+
 - Never write temporary files (screenshots, test scripts, scratch files) to the repo root.
 - Use `/tmp/` or `$DISPATCH_MEDIA_DIR` for ephemeral files.
 - Playwright screenshots should be published via the `dispatch_share` MCP tool, not saved locally.
 
 ## Dev Server Management (CRITICAL)
+
 - **NEVER run `pnpm run dev` directly** in your terminal — it will block your session and killing it can kill your agent process.
 - **NEVER use `pkill`, `killall`, or `lsof | xargs kill`** to manage dev servers — these can kill your own agent process.
 - Use `dispatch-dev` to manage dev environments. It spins up an isolated DB, API server, and Vite frontend, all on auto-selected free ports. The suffix is derived from `DISPATCH_AGENT_ID` automatically in agent sessions.
@@ -100,19 +111,23 @@ Before marking any task as done, run the following checks and fix any failures:
 - `dispatch-dev up` auto-selects free ports and prints the URLs — just use the printed URLs.
 
 ## Backend Testing Safety
+
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
 - When backend changes need local validation, use `dispatch-dev up` and point validation tooling to the printed URL.
 - Only operate on production (`:6767`) when explicitly requested by the user.
 
 ## Development Database
+
 - Production uses the `dispatch` database. Never connect to it from dev servers.
 - `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
 - Migrations run automatically on API server start.
 
 ## Agent Pins
+
 - Agents use `dispatch_pin` to surface key info (URLs, files, ports, PRs, decisions) in the sidebar. Types: `url`, `port`, `code`, `string`, `pr`, `filename`, `markdown`. List-like types support comma/newline-delimited multi-value.
 
 ## Personas
+
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.
 - Provide a thorough context briefing in the `context` parameter: what was built, key files changed, areas of concern, and any specific instructions from the user.
 - Be explicit about scope in the context — tell the persona what the changes are and what is NOT in scope. This helps them avoid flagging pre-existing issues.

--- a/README.md
+++ b/README.md
@@ -46,32 +46,32 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 
 ## Prerequisites
 
-| Dependency | Purpose | macOS | Linux |
-|---|---|---|---|
-| **Build tools** | Compile native npm modules (node-pty) | `xcode-select --install` | `apt install build-essential python3` |
-| **Node.js 22+** | Runtime | `nvm install 22` | `nvm install 22` |
-| **pnpm** | Package manager | `npm i -g pnpm` | `npm i -g pnpm` |
-| **PostgreSQL 14+** | Database | `brew install postgresql@17` | `apt install postgresql` |
-| **tmux** | Agent session management | `brew install tmux` | `apt install tmux` |
-| **At least one agent CLI** | The agents Dispatch runs | See below | See below |
+| Dependency                 | Purpose                               | macOS                        | Linux                                 |
+| -------------------------- | ------------------------------------- | ---------------------------- | ------------------------------------- |
+| **Build tools**            | Compile native npm modules (node-pty) | `xcode-select --install`     | `apt install build-essential python3` |
+| **Node.js 22+**            | Runtime                               | `nvm install 22`             | `nvm install 22`                      |
+| **pnpm**                   | Package manager                       | `npm i -g pnpm`              | `npm i -g pnpm`                       |
+| **PostgreSQL 14+**         | Database                              | `brew install postgresql@17` | `apt install postgresql`              |
+| **tmux**                   | Agent session management              | `brew install tmux`          | `apt install tmux`                    |
+| **At least one agent CLI** | The agents Dispatch runs              | See below                    | See below                             |
 
 ### Optional
 
-| Dependency | Purpose | Install |
-|---|---|---|
-| **Docker** | Isolated dev databases via `dispatch-dev` | macOS: `brew install --cask docker` / Linux: [docs.docker.com](https://docs.docker.com/engine/install/) |
-| **Xcode** (full) | iOS Simulator, `xcrun simctl` (macOS only) | App Store |
-| **xclip + Xvfb** | Clipboard image paste (Linux only) | `apt install xclip xvfb` |
+| Dependency       | Purpose                                    | Install                                                                                                 |
+| ---------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| **Docker**       | Isolated dev databases via `dispatch-dev`  | macOS: `brew install --cask docker` / Linux: [docs.docker.com](https://docs.docker.com/engine/install/) |
+| **Xcode** (full) | iOS Simulator, `xcrun simctl` (macOS only) | App Store                                                                                               |
+| **xclip + Xvfb** | Clipboard image paste (Linux only)         | `apt install xclip xvfb`                                                                                |
 
 ### Agent CLIs
 
 Dispatch spawns agents via their CLI tools. Install at least one:
 
-| Agent | Install | Authenticate |
-|---|---|---|
-| **Claude** | `npm install -g @anthropic-ai/claude-code` | `claude` (follow login prompts) |
-| **Codex** | `npm install -g codex` | Set `OPENAI_API_KEY` in your shell profile |
-| **OpenCode** | `npm install -g opencode` | Set `ANTHROPIC_API_KEY` in your shell profile |
+| Agent        | Install                                    | Authenticate                                  |
+| ------------ | ------------------------------------------ | --------------------------------------------- |
+| **Claude**   | `npm install -g @anthropic-ai/claude-code` | `claude` (follow login prompts)               |
+| **Codex**    | `npm install -g codex`                     | Set `OPENAI_API_KEY` in your shell profile    |
+| **OpenCode** | `npm install -g opencode`                  | Set `ANTHROPIC_API_KEY` in your shell profile |
 
 The agent CLI must be authenticated before Dispatch can spawn agents of that type. Dispatch invokes the CLI directly, so any API keys or login state in your shell environment are inherited automatically.
 
@@ -104,9 +104,10 @@ bin/dispatch-dev up --live
 ```
 
 > **Important:** Docker Desktop must be running (not just installed). If you see
-> *"Error: docker compose is not available"*, open Docker.app first.
+> _"Error: docker compose is not available"_, open Docker.app first.
 
 `dispatch-dev` automatically:
+
 - Spins up an isolated Postgres container on a free port
 - Runs database migrations on server start
 - Starts the API server on a free port
@@ -147,24 +148,24 @@ For setting up Dispatch as a persistent service on a dedicated machine, see [doc
 
 Every agent launched by Dispatch gets access to MCP tools via an agent-scoped endpoint. These tools are available automatically — no configuration needed:
 
-| Tool | Description |
-|------|-------------|
-| `dispatch_event` | Report agent status (working, blocked, waiting_user, done, idle) |
-| `dispatch_rename_session` | Update the current session's display name |
-| `dispatch_pin` | Surface key info in the sidebar (URLs, ports, PRs, files) |
-| `dispatch_share` | Upload screenshots and media to the agent's media pane |
-| `dispatch_feedback` | Submit structured review findings (severity, file refs, suggestions) |
-| `dispatch_get_feedback` | Retrieve feedback findings for review |
-| `dispatch_resolve_feedback` | Mark a feedback item as fixed or ignored |
-| `dispatch_launch_persona` | Launch a persona child agent for automated review |
-| `dispatch_list_media` | List media files shared with or by this agent |
-| `dispatch_notify` | Send a Slack notification from the agent (requires webhook configured) |
-| `list_personas` | List available persona reviewers for this project |
-| `create_pr` | Create a GitHub pull request |
-| `get_pr_status` | Check PR CI status and reviews |
-| `get_activity_summary` | Summarize agent activity over a time range |
-| `get_agent_history` | Get detailed agent session history |
-| `get_feedback_summary` | Aggregate persona review feedback for pattern detection |
+| Tool                        | Description                                                            |
+| --------------------------- | ---------------------------------------------------------------------- |
+| `dispatch_event`            | Report agent status (working, blocked, waiting_user, done, idle)       |
+| `dispatch_rename_session`   | Update the current session's display name                              |
+| `dispatch_pin`              | Surface key info in the sidebar (URLs, ports, PRs, files)              |
+| `dispatch_share`            | Upload screenshots and media to the agent's media pane                 |
+| `dispatch_feedback`         | Submit structured review findings (severity, file refs, suggestions)   |
+| `dispatch_get_feedback`     | Retrieve feedback findings for review                                  |
+| `dispatch_resolve_feedback` | Mark a feedback item as fixed or ignored                               |
+| `dispatch_launch_persona`   | Launch a persona child agent for automated review                      |
+| `dispatch_list_media`       | List media files shared with or by this agent                          |
+| `dispatch_notify`           | Send a Slack notification from the agent (requires webhook configured) |
+| `list_personas`             | List available persona reviewers for this project                      |
+| `create_pr`                 | Create a GitHub pull request                                           |
+| `get_pr_status`             | Check PR CI status and reviews                                         |
+| `get_activity_summary`      | Summarize agent activity over a time range                             |
+| `get_agent_history`         | Get detailed agent session history                                     |
+| `get_feedback_summary`      | Aggregate persona review feedback for pattern detection                |
 
 Persona agents additionally get: `review_status`, `get_parent_context`.
 

--- a/apps/server/src/activity-metrics.ts
+++ b/apps/server/src/activity-metrics.ts
@@ -84,8 +84,14 @@ export function computeActivityStats(
     const currentInRange = rangeStartMs === null || t >= rangeStartMs;
     sawInRangeEvent ||= currentInRange;
 
-    if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
-      const segmentStart = rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
+    if (
+      prevType &&
+      prevTime !== null &&
+      prevType !== "done" &&
+      prevType !== "idle"
+    ) {
+      const segmentStart =
+        rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
       const dur = t - segmentStart;
       if (dur > 0) {
         stateDurations[prevType] = (stateDurations[prevType] ?? 0) + dur;
@@ -117,7 +123,9 @@ export function computeActivityStats(
   }
 
   const avg = (arr: number[]) =>
-    arr.length > 0 ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+    arr.length > 0
+      ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length)
+      : 0;
 
   return {
     totalWorkingMs: stateDurations.working ?? 0,
@@ -148,8 +156,14 @@ export function computeDailyStatus(
       continue;
     }
 
-    if (prevType && prevTime !== null && prevType !== "done" && prevType !== "idle") {
-      const segmentStart = rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
+    if (
+      prevType &&
+      prevTime !== null &&
+      prevType !== "done" &&
+      prevType !== "idle"
+    ) {
+      const segmentStart =
+        rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
       const dur = t - segmentStart;
       if (dur > 0) {
         const dayKey = bucketStart(segmentStart, granularity);
@@ -200,7 +214,8 @@ export function computeWorkingTimeByProject(
     }
 
     if (prevType === "working" && prevTime !== null && prevProject) {
-      const segmentStart = rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
+      const segmentStart =
+        rangeStartMs === null ? prevTime : Math.max(prevTime, rangeStartMs);
       const dur = t - segmentStart;
       if (dur > 0) {
         projectMap.set(prevProject, (projectMap.get(prevProject) ?? 0) + dur);

--- a/apps/server/src/agent-type-settings.ts
+++ b/apps/server/src/agent-type-settings.ts
@@ -16,7 +16,9 @@ export function sanitizeEnabledAgentTypes(value: unknown): AgentType[] {
     return [...AGENT_TYPES];
   }
 
-  const unique = value.filter(isAgentType).filter((type, index, types) => types.indexOf(type) === index);
+  const unique = value
+    .filter(isAgentType)
+    .filter((type, index, types) => types.indexOf(type) === index);
   return unique.length > 0 ? unique : [...AGENT_TYPES];
 }
 
@@ -33,7 +35,10 @@ export async function getEnabledAgentTypes(pool: Pool): Promise<AgentType[]> {
   }
 }
 
-export async function setEnabledAgentTypes(pool: Pool, agentTypes: AgentType[]): Promise<AgentType[]> {
+export async function setEnabledAgentTypes(
+  pool: Pool,
+  agentTypes: AgentType[]
+): Promise<AgentType[]> {
   const sanitized = sanitizeEnabledAgentTypes(agentTypes);
   await setSetting(pool, ENABLED_AGENT_TYPES_KEY, JSON.stringify(sanitized));
   return sanitized;

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1,5 +1,16 @@
 import { randomUUID } from "node:crypto";
-import { appendFile, copyFile, mkdir, open, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -8,17 +19,44 @@ import type { Pool } from "pg";
 
 import type { AppConfig } from "../config.js";
 import { createAgentMcpToken, createJobMcpToken } from "../auth.js";
-import { createGitWorktree, cleanupGitWorktree } from "../shared/git/worktree.js";
+import {
+  createGitWorktree,
+  cleanupGitWorktree,
+} from "../shared/git/worktree.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { loadRepoHooks } from "../shared/mcp/repo-tools.js";
 import { harvestTokenUsage } from "./token-harvester.js";
 
-type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "archiving" | "error" | "unknown";
+type AgentStatus =
+  | "creating"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "archiving"
+  | "error"
+  | "unknown";
 type AgentType = "codex" | "claude" | "opencode";
-type AgentLatestEventType = "working" | "blocked" | "waiting_user" | "done" | "idle";
+type AgentLatestEventType =
+  | "working"
+  | "blocked"
+  | "waiting_user"
+  | "done"
+  | "idle";
 type SetupPhase = "worktree" | "env" | "deps" | "session" | null;
-type ArchivePhase = "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
-type PinType = "string" | "url" | "port" | "code" | "pr" | "filename" | "markdown";
+type ArchivePhase =
+  | "stopping"
+  | "worktree-check"
+  | "worktree-cleanup"
+  | "finalizing"
+  | null;
+type PinType =
+  | "string"
+  | "url"
+  | "port"
+  | "code"
+  | "pr"
+  | "filename"
+  | "markdown";
 
 export type AgentPin = {
   label: string;
@@ -82,10 +120,13 @@ export type AgentRecord = {
   updatedAt: string;
 };
 
-const CLI_BY_AGENT_TYPE: Record<AgentType, keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">> = {
+const CLI_BY_AGENT_TYPE: Record<
+  AgentType,
+  keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">
+> = {
   codex: "codexBin",
   claude: "claudeBin",
-  opencode: "opencodeBin"
+  opencode: "opencodeBin",
 };
 
 type WorktreeLocation = "sibling" | "nested";
@@ -261,7 +302,13 @@ export type FeedbackSummaryResult = {
   groups: Array<{
     key: string;
     count: number;
-    bySeverity: { critical: number; high: number; medium: number; low: number; info: number };
+    bySeverity: {
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+      info: number;
+    };
     topFindings: Array<{
       description: string;
       count: number;
@@ -300,7 +347,10 @@ export class AgentManager {
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
-  private readonly runtimeCwdCache = new Map<string, { value: string; expiresAt: number }>();
+  private readonly runtimeCwdCache = new Map<
+    string,
+    { value: string; expiresAt: number }
+  >();
   private readonly eventListeners: AgentEventListener[] = [];
   private lastTmuxInventoryAt = 0;
   private lastLogMaintenanceAt = 0;
@@ -317,12 +367,17 @@ export class AgentManager {
   }
 
   async listAgents(): Promise<AgentRecord[]> {
-    const result = await this.pool.query(`${this.baseAgentSelectSql()} ORDER BY created_at DESC`);
+    const result = await this.pool.query(
+      `${this.baseAgentSelectSql()} ORDER BY created_at DESC`
+    );
     return result.rows as AgentRecord[];
   }
 
   async getAgent(id: string): Promise<AgentRecord | null> {
-    const result = await this.pool.query(`${this.baseAgentSelectSql()} AND id = $1`, [id]);
+    const result = await this.pool.query(
+      `${this.baseAgentSelectSql()} AND id = $1`,
+      [id]
+    );
     return (result.rows[0] as AgentRecord | undefined) ?? null;
   }
 
@@ -342,13 +397,17 @@ export class AgentManager {
 
   /** Harvest token usage for an agent, scoped to its CLI session if known. */
   async harvestAgentTokens(agent: AgentRecord): Promise<void> {
-    await harvestTokenUsage(this.pool, {
-      id: agent.id,
-      type: agent.type,
-      cwd: agent.cwd,
-      worktreePath: agent.worktreePath,
-      cliSessionId: agent.cliSessionId ?? undefined,
-    }, this.logger);
+    await harvestTokenUsage(
+      this.pool,
+      {
+        id: agent.id,
+        type: agent.type,
+        cwd: agent.cwd,
+        worktreePath: agent.worktreePath,
+        cliSessionId: agent.cliSessionId ?? undefined,
+      },
+      this.logger
+    );
   }
 
   async createAgent(input: CreateAgentInput): Promise<AgentRecord> {
@@ -372,18 +431,26 @@ export class AgentManager {
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, "-")
         .replace(/^-+|-+$/g, "");
-      worktreeBranchName = input.worktreeBranch?.trim() || `${id}/${slugName || "work"}`;
+      worktreeBranchName =
+        input.worktreeBranch?.trim() || `${id}/${slugName || "work"}`;
       const worktreeLocation = input.worktreeLocation ?? "sibling";
       if (worktreeLocation === "nested") {
-        worktreePathOverride = path.join(originalCwd, ".dispatch", "worktrees",
-          worktreeBranchName.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase());
+        worktreePathOverride = path.join(
+          originalCwd,
+          ".dispatch",
+          "worktrees",
+          worktreeBranchName
+            .replace(/[^a-z0-9]+/gi, "-")
+            .replace(/^-+|-+$/g, "")
+            .toLowerCase()
+        );
       }
     }
 
     // Auto-assign a CLI session ID for Claude agents so we can track which
     // session file belongs to this agent and resume it on restart.
-    const cliSessionId = input.cliSessionId
-      ?? (type === "claude" ? randomUUID() : null);
+    const cliSessionId =
+      input.cliSessionId ?? (type === "claude" ? randomUUID() : null);
 
     // Insert the agent record immediately so the API can return fast.
     // The setup script running in tmux will handle worktree/deps/etc.
@@ -393,9 +460,24 @@ export class AgentManager {
       INSERT INTO agents (id, name, type, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, review_agent_type, cli_session_id, auto_review, base_branch, updated_at)
       VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13, $14, $15, $16, NOW())
       `,
-      [id, name, type, originalCwd, tmuxSession, mediaDir, JSON.stringify(agentArgs), fullAccess, initialSetupPhase,
-        input.persona ?? null, input.parentAgentId ?? null, input.personaContext ?? null, input.reviewAgentType ?? null,
-        cliSessionId, input.autoReview ?? false, input.baseBranch ?? null]
+      [
+        id,
+        name,
+        type,
+        originalCwd,
+        tmuxSession,
+        mediaDir,
+        JSON.stringify(agentArgs),
+        fullAccess,
+        initialSetupPhase,
+        input.persona ?? null,
+        input.parentAgentId ?? null,
+        input.personaContext ?? null,
+        input.reviewAgentType ?? null,
+        cliSessionId,
+        input.autoReview ?? false,
+        input.baseBranch ?? null,
+      ]
     );
 
     if (this.config.agentRuntime === "inert") {
@@ -416,10 +498,16 @@ export class AgentManager {
           worktreePath = result.worktreePath;
           worktreeBranch = result.branchName;
           effectiveCwd = result.worktreePath;
-          this.logger.info({ agentId: id, worktreePath, worktreeBranch }, "Created worktree for inert agent.");
+          this.logger.info(
+            { agentId: id, worktreePath, worktreeBranch },
+            "Created worktree for inert agent."
+          );
           await this.setupWorktree(originalCwd, worktreePath);
         } catch (error) {
-          this.logger.warn({ err: error, agentId: id }, "Worktree creation failed for inert agent.");
+          this.logger.warn(
+            { err: error, agentId: id },
+            "Worktree creation failed for inert agent."
+          );
         }
       }
 
@@ -429,7 +517,7 @@ export class AgentManager {
       );
       await this.setSystemLatestEvent(id, {
         type: "working",
-        message: "Session started."
+        message: "Session started.",
       });
     } else {
       try {
@@ -445,7 +533,10 @@ export class AgentManager {
           cliSessionId ?? undefined,
           false,
           input.jobRunId,
-          this.shouldSuggestSessionRename(name, id, { persona: input.persona, jobRunId: input.jobRunId }),
+          this.shouldSuggestSessionRename(name, id, {
+            persona: input.persona,
+            jobRunId: input.jobRunId,
+          }),
           !input.persona && !input.jobRunId && (input.autoReview ?? false),
           input.initialPrompt
         );
@@ -471,20 +562,42 @@ export class AgentManager {
         await writeFile(setupScriptPath, setupScript, { mode: 0o755 });
 
         // Start tmux running the setup script — the frontend can connect immediately
-        await runCommand("tmux", ["new-session", "-d", "-s", tmuxSession, "-c", originalCwd, `bash ${setupScriptPath}`]);
-        await runCommand("tmux", ["set-option", "-t", tmuxSession, "status", "off"], {
-          allowedExitCodes: [0, 1]
-        });
-        await runCommand("tmux", ["set-option", "-t", tmuxSession, "allow-passthrough", "on"], {
-          allowedExitCodes: [0, 1]
-        });
-        await runCommand("tmux", ["set-option", "-as", "terminal-features", "xterm-256color:sync"], {
-          allowedExitCodes: [0, 1]
-        });
+        await runCommand("tmux", [
+          "new-session",
+          "-d",
+          "-s",
+          tmuxSession,
+          "-c",
+          originalCwd,
+          `bash ${setupScriptPath}`,
+        ]);
+        await runCommand(
+          "tmux",
+          ["set-option", "-t", tmuxSession, "status", "off"],
+          {
+            allowedExitCodes: [0, 1],
+          }
+        );
+        await runCommand(
+          "tmux",
+          ["set-option", "-t", tmuxSession, "allow-passthrough", "on"],
+          {
+            allowedExitCodes: [0, 1],
+          }
+        );
+        await runCommand(
+          "tmux",
+          ["set-option", "-as", "terminal-features", "xterm-256color:sync"],
+          {
+            allowedExitCodes: [0, 1],
+          }
+        );
 
         if (!(await this.hasAgentSession(tmuxSession))) {
           const detail = await this.readSetupLogTail(id);
-          throw new Error(`tmux session exited immediately after launch${detail}`);
+          throw new Error(
+            `tmux session exited immediately after launch${detail}`
+          );
         }
       } catch (error) {
         const message = this.errorMessage(error);
@@ -493,7 +606,7 @@ export class AgentManager {
         await this.setSystemLatestEvent(id, {
           type: "blocked",
           message: `Failed to create agent: ${message}`,
-          metadata: { source: "system", phase: "create" }
+          metadata: { source: "system", phase: "create" },
         });
         throw new AgentError(`Failed to create agent: ${message}`, 500);
       }
@@ -506,11 +619,14 @@ export class AgentManager {
    * Called by the setup script (via API) to report phase transitions and completion.
    * Updates worktree info and transitions the agent to 'running' when setup is done.
    */
-  async completeSetup(id: string, result: {
-    effectiveCwd: string;
-    worktreePath: string | null;
-    worktreeBranch: string | null;
-  }): Promise<AgentRecord> {
+  async completeSetup(
+    id: string,
+    result: {
+      effectiveCwd: string;
+      worktreePath: string | null;
+      worktreeBranch: string | null;
+    }
+  ): Promise<AgentRecord> {
     const agent = await this.getRequiredAgent(id);
     if (agent.status !== "creating") {
       throw new AgentError("Agent is not in creating state.", 409);
@@ -532,7 +648,7 @@ export class AgentManager {
 
     await this.setSystemLatestEvent(id, {
       type: "working",
-      message: "Session started."
+      message: "Session started.",
     });
 
     // Clean up setup script
@@ -546,7 +662,10 @@ export class AgentManager {
     await this.setSetupPhase(id, phase);
   }
 
-  async updateReviewAgentType(id: string, reviewAgentType: AgentType | null): Promise<void> {
+  async updateReviewAgentType(
+    id: string,
+    reviewAgentType: AgentType | null
+  ): Promise<void> {
     const result = await this.pool.query(
       `UPDATE agents SET review_agent_type = $2, updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL`,
       [id, reviewAgentType]
@@ -558,14 +677,15 @@ export class AgentManager {
 
   async startAgent(id: string): Promise<AgentRecord> {
     const agent = await this.getRequiredAgent(id);
-    const tmuxSession = agent.tmuxSession ?? this.toSessionName(agent.id, agent.name);
+    const tmuxSession =
+      agent.tmuxSession ?? this.toSessionName(agent.id, agent.name);
     const hasSession = await this.hasAgentSession(tmuxSession);
 
     if (hasSession) {
       await this.setAgentStatus(id, "running", null, tmuxSession);
       await this.setSystemLatestEvent(id, {
         type: "working",
-        message: "Session attached to existing tmux session."
+        message: "Session attached to existing tmux session.",
       });
       return (await this.getAgent(id)) as AgentRecord;
     }
@@ -608,7 +728,7 @@ export class AgentManager {
       await this.setAgentStatus(id, "running", null, tmuxSession);
       await this.setSystemLatestEvent(id, {
         type: "working",
-        message: shouldResume ? "Session resumed." : "Session started."
+        message: shouldResume ? "Session resumed." : "Session started.",
       });
     } catch (error) {
       const message = this.errorMessage(error);
@@ -616,7 +736,7 @@ export class AgentManager {
       await this.setSystemLatestEvent(id, {
         type: "blocked",
         message: `Failed to start agent: ${message}`,
-        metadata: { source: "system", phase: "start" }
+        metadata: { source: "system", phase: "start" },
       });
       throw new AgentError(`Failed to start agent: ${message}`, 500);
     }
@@ -637,20 +757,32 @@ export class AgentManager {
     if (this.config.agentRuntime === "inert") {
       return {
         mode: "inert",
-        message: "Agent is running in inert mode. No tmux session or CLI process is attached in this environment."
+        message:
+          "Agent is running in inert mode. No tmux session or CLI process is attached in this environment.",
       };
     }
 
     const hasSession = await this.hasAgentSession(agent.tmuxSession);
     if (!hasSession) {
-      await this.setAgentStatus(id, "stopped", "Agent tmux session is no longer running.", agent.tmuxSession);
-      throw new AgentError("Agent session is not available. Start the agent again.", 409);
+      await this.setAgentStatus(
+        id,
+        "stopped",
+        "Agent tmux session is no longer running.",
+        agent.tmuxSession
+      );
+      throw new AgentError(
+        "Agent session is not available. Start the agent again.",
+        409
+      );
     }
 
     return { mode: "tmux", sessionName: agent.tmuxSession };
   }
 
-  async stopAgent(id: string, input: StopAgentInput = {}): Promise<AgentRecord> {
+  async stopAgent(
+    id: string,
+    input: StopAgentInput = {}
+  ): Promise<AgentRecord> {
     const agent = await this.getRequiredAgent(id);
     const tmuxSession = agent.tmuxSession;
     const force = input.force ?? false;
@@ -663,7 +795,10 @@ export class AgentManager {
 
     // Run repo-defined stop hook (best-effort, non-blocking)
     await this.runLifecycleHook("stop", agent).catch((err) =>
-      this.logger.warn({ err, agentId: id }, "Stop hook failed; continuing shutdown")
+      this.logger.warn(
+        { err, agentId: id },
+        "Stop hook failed; continuing shutdown"
+      )
     );
 
     try {
@@ -674,7 +809,7 @@ export class AgentManager {
       await this.setAgentStatus(id, "stopped", null, tmuxSession ?? undefined);
       await this.setSystemLatestEvent(id, {
         type: "idle",
-        message: "Session stopped."
+        message: "Session stopped.",
       });
 
       // Harvest token usage from session logs (fire-and-forget)
@@ -687,7 +822,7 @@ export class AgentManager {
       await this.setSystemLatestEvent(id, {
         type: "blocked",
         message: `Failed to stop agent: ${message}`,
-        metadata: { source: "system", phase: "stop" }
+        metadata: { source: "system", phase: "stop" },
       });
       throw new AgentError(`Failed to stop agent: ${message}`, 500);
     }
@@ -699,7 +834,10 @@ export class AgentManager {
    * Fast, synchronous first phase of archival: validates state and marks agent as archiving.
    * Returns the updated agent record for SSE broadcast.
    */
-  async beginArchive(id: string, cleanupWorktree: WorktreeCleanupMode = "auto"): Promise<AgentRecord> {
+  async beginArchive(
+    id: string,
+    cleanupWorktree: WorktreeCleanupMode = "auto"
+  ): Promise<AgentRecord> {
     // Atomic transition: only one caller can move out of non-archiving state.
     // This prevents TOCTOU races when concurrent DELETE requests hit the same agent.
     const result = await this.pool.query(
@@ -745,16 +883,28 @@ export class AgentManager {
       const t = Date.now();
       try {
         await this.runLifecycleHook("stop", agent).catch((err) =>
-          this.logger.warn({ err, agentId: id }, "Stop hook failed during archive; continuing")
+          this.logger.warn(
+            { err, agentId: id },
+            "Stop hook failed during archive; continuing"
+          )
         );
-        if (agent.tmuxSession && (await this.hasAgentSession(agent.tmuxSession))) {
+        if (
+          agent.tmuxSession &&
+          (await this.hasAgentSession(agent.tmuxSession))
+        ) {
           await this.stopAgentSession(agent.tmuxSession, true);
         }
         this.harvestAgentTokens(agent).catch((err) =>
-          this.logger.warn({ err, agentId: id }, "Token harvest failed during archive")
+          this.logger.warn(
+            { err, agentId: id },
+            "Token harvest failed during archive"
+          )
         );
       } catch (err) {
-        this.logger.warn({ err, agentId: id }, "Stop during archive failed; continuing");
+        this.logger.warn(
+          { err, agentId: id },
+          "Stop during archive failed; continuing"
+        );
       }
       durations.stop = Date.now() - t;
 
@@ -778,12 +928,19 @@ export class AgentManager {
               this.getUnmergedChanges(agent.worktreePath),
               this.getUncommittedChanges(agent.worktreePath),
             ]);
-            const hasChanges = unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
+            const hasChanges =
+              unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
             shouldCleanup = !hasChanges;
             if (hasChanges) {
               const reasons: string[] = [];
-              if (unmerged.hasUnmergedCommits) reasons.push(`${unmerged.changedFiles.length} unmerged file(s)`);
-              if (uncommitted.hasUncommittedChanges) reasons.push(`${uncommitted.uncommittedFiles.length} uncommitted file(s)`);
+              if (unmerged.hasUnmergedCommits)
+                reasons.push(
+                  `${unmerged.changedFiles.length} unmerged file(s)`
+                );
+              if (uncommitted.hasUncommittedChanges)
+                reasons.push(
+                  `${uncommitted.uncommittedFiles.length} uncommitted file(s)`
+                );
               preserveReason = reasons.join(", ");
             }
           } else if (!shouldCleanup && cleanupWorktree === "keep") {
@@ -799,18 +956,29 @@ export class AgentManager {
             await cleanupGitWorktree({
               cwd: agent.worktreePath,
               deleteBranch: true,
-              force: true
+              force: true,
             });
             durations.worktreeCleanup = Date.now() - tCleanup;
-            this.logger.info({ agentId: id, worktreePath: agent.worktreePath }, "Cleaned up agent worktree.");
+            this.logger.info(
+              { agentId: id, worktreePath: agent.worktreePath },
+              "Cleaned up agent worktree."
+            );
           } else {
             this.logger.info(
-              { agentId: id, worktreePath: agent.worktreePath, cleanupWorktree, preserveReason },
+              {
+                agentId: id,
+                worktreePath: agent.worktreePath,
+                cleanupWorktree,
+                preserveReason,
+              },
               `Preserved agent worktree: ${preserveReason}.`
             );
           }
         } catch (error) {
-          this.logger.warn({ err: error, agentId: id }, "Worktree cleanup failed; leaving on disk.");
+          this.logger.warn(
+            { err: error, agentId: id },
+            "Worktree cleanup failed; leaving on disk."
+          );
         }
       }
 
@@ -825,9 +993,14 @@ export class AgentManager {
            FROM agents WHERE id = $1`,
           [id]
         )
-        .catch((err) => this.logger.warn({ err }, "Failed to insert delete event"));
+        .catch((err) =>
+          this.logger.warn({ err }, "Failed to insert delete event")
+        );
 
-      await this.pool.query("UPDATE agents SET deleted_at = NOW(), archive_phase = NULL, archive_cleanup_mode = NULL, updated_at = NOW() WHERE id = $1", [id]);
+      await this.pool.query(
+        "UPDATE agents SET deleted_at = NOW(), archive_phase = NULL, archive_cleanup_mode = NULL, updated_at = NOW() WHERE id = $1",
+        [id]
+      );
       durations.db = Date.now() - tDb;
 
       // Cascade: archive child agents (persona agents spawned by this parent)
@@ -840,7 +1013,10 @@ export class AgentManager {
         try {
           await this.deleteAgentDirect(child.id, true, cleanupWorktree);
         } catch (err) {
-          this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
+          this.logger.warn(
+            { err, childId: child.id, parentId: id },
+            "Failed to cascade-delete child agent"
+          );
         }
       }
       if (children.rows.length > 0) {
@@ -848,17 +1024,28 @@ export class AgentManager {
       }
 
       durations.total = Date.now() - deleteStart;
-      const parts = Object.entries(durations).map(([k, v]) => `${k}=${v}ms`).join(", ");
-      this.logger.info({ agentId: id, durations }, `Archive durations: ${parts}`);
+      const parts = Object.entries(durations)
+        .map(([k, v]) => `${k}=${v}ms`)
+        .join(", ");
+      this.logger.info(
+        { agentId: id, durations },
+        `Archive durations: ${parts}`
+      );
 
       const deletedIds = [id, ...children.rows.map((r) => r.id)];
       callbacks.onComplete(deletedIds);
     } catch (error) {
       this.logger.error({ err: error, agentId: id }, "Archive failed");
       try {
-        await this.setAgentStatus(id, "error", error instanceof Error ? error.message : "Archive failed");
+        await this.setAgentStatus(
+          id,
+          "error",
+          error instanceof Error ? error.message : "Archive failed"
+        );
         await this.setArchivePhase(id, null);
-      } catch { /* best effort */ }
+      } catch {
+        /* best effort */
+      }
       callbacks.onError(error);
     }
   }
@@ -866,14 +1053,23 @@ export class AgentManager {
   /**
    * Synchronous delete for child/cascade agents (no worktree, fast).
    */
-  private async deleteAgentDirect(id: string, force = false, cleanupWorktree: WorktreeCleanupMode = "auto"): Promise<void> {
+  private async deleteAgentDirect(
+    id: string,
+    force = false,
+    cleanupWorktree: WorktreeCleanupMode = "auto"
+  ): Promise<void> {
     const deleteStart = Date.now();
     const durations: Record<string, number> = {};
     const agent = await this.getRequiredAgent(id);
-    const sessionExists = agent.tmuxSession ? await this.hasAgentSession(agent.tmuxSession) : false;
+    const sessionExists = agent.tmuxSession
+      ? await this.hasAgentSession(agent.tmuxSession)
+      : false;
 
     if (agent.status === "running" && sessionExists && !force) {
-      throw new AgentError("Agent is running. Stop it first or use force delete.", 409);
+      throw new AgentError(
+        "Agent is running. Stop it first or use force delete.",
+        409
+      );
     }
 
     if (agent.status !== "stopped") {
@@ -881,7 +1077,10 @@ export class AgentManager {
       try {
         await this.stopAgent(id, { force: true });
       } catch (err) {
-        this.logger.warn({ err, agentId: id }, "Stop during delete failed; continuing with deletion");
+        this.logger.warn(
+          { err, agentId: id },
+          "Stop during delete failed; continuing with deletion"
+        );
       }
       durations.stop = Date.now() - t;
     }
@@ -894,9 +1093,14 @@ export class AgentManager {
          FROM agents WHERE id = $1`,
         [id]
       )
-      .catch((err) => this.logger.warn({ err }, "Failed to insert delete event"));
+      .catch((err) =>
+        this.logger.warn({ err }, "Failed to insert delete event")
+      );
 
-    await this.pool.query("UPDATE agents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1", [id]);
+    await this.pool.query(
+      "UPDATE agents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1",
+      [id]
+    );
     durations.db = Date.now() - tDb;
 
     // Cascade to any children (recursive to handle multi-level nesting)
@@ -908,12 +1112,17 @@ export class AgentManager {
       try {
         await this.deleteAgentDirect(child.id, true, cleanupWorktree);
       } catch (err) {
-        this.logger.warn({ err, childId: child.id, parentId: id }, "Failed to cascade-delete child agent");
+        this.logger.warn(
+          { err, childId: child.id, parentId: id },
+          "Failed to cascade-delete child agent"
+        );
       }
     }
 
     durations.total = Date.now() - deleteStart;
-    const parts = Object.entries(durations).map(([k, v]) => `${k}=${v}ms`).join(", ");
+    const parts = Object.entries(durations)
+      .map(([k, v]) => `${k}=${v}ms`)
+      .join(", ");
     this.logger.info({ agentId: id, durations }, `Archive durations: ${parts}`);
   }
 
@@ -921,7 +1130,15 @@ export class AgentManager {
     const agent = await this.getRequiredAgent(id);
 
     if (!agent.worktreePath) {
-      return { hasWorktree: false, hasUnmergedCommits: false, hasUncommittedChanges: false, worktreePath: null, branchName: null, changedFiles: [], uncommittedFiles: [] };
+      return {
+        hasWorktree: false,
+        hasUnmergedCommits: false,
+        hasUncommittedChanges: false,
+        worktreePath: null,
+        branchName: null,
+        changedFiles: [],
+        uncommittedFiles: [],
+      };
     }
 
     let branchName: string | null = null;
@@ -932,10 +1149,14 @@ export class AgentManager {
 
     try {
       const branchResult = await runCommand(
-        "git", ["-C", agent.worktreePath, "symbolic-ref", "--short", "-q", "HEAD"],
+        "git",
+        ["-C", agent.worktreePath, "symbolic-ref", "--short", "-q", "HEAD"],
         { allowedExitCodes: [0, 1] }
       );
-      branchName = branchResult.exitCode === 0 && branchResult.stdout ? branchResult.stdout : null;
+      branchName =
+        branchResult.exitCode === 0 && branchResult.stdout
+          ? branchResult.stdout
+          : null;
       const [unmerged, uncommitted] = await Promise.all([
         this.getUnmergedChanges(agent.worktreePath),
         this.getUncommittedChanges(agent.worktreePath),
@@ -955,14 +1176,20 @@ export class AgentManager {
       worktreePath: agent.worktreePath,
       branchName,
       changedFiles,
-      uncommittedFiles
+      uncommittedFiles,
     };
   }
 
-  async upsertLatestEvent(id: string, input: AgentLatestEventInput): Promise<AgentRecord> {
+  async upsertLatestEvent(
+    id: string,
+    input: AgentLatestEventInput
+  ): Promise<AgentRecord> {
     const message = input.message.trim();
     if (!message) {
-      throw new AgentError("Latest event message must be a non-empty string.", 400);
+      throw new AgentError(
+        "Latest event message must be a non-empty string.",
+        400
+      );
     }
 
     const result = await this.pool.query(
@@ -990,7 +1217,9 @@ export class AgentManager {
          FROM agents WHERE id = $1`,
         [id, input.type, message, JSON.stringify(input.metadata ?? {})]
       )
-      .catch((err) => this.logger.warn({ err }, "Failed to insert agent event history"));
+      .catch((err) =>
+        this.logger.warn({ err }, "Failed to insert agent event history")
+      );
 
     // Agent could be soft-deleted between the UPDATE and this SELECT in rare races.
     // Guard against null to prevent downstream crashes (e.g. in event listeners).
@@ -1063,12 +1292,21 @@ export class AgentManager {
 
     const reconciled: AgentRecord[] = [];
 
-    for (const row of result.rows as Array<{ id: string; tmuxSession: string | null; status: string; updatedAt: string }>) {
+    for (const row of result.rows as Array<{
+      id: string;
+      tmuxSession: string | null;
+      status: string;
+      updatedAt: string;
+    }>) {
       // Archiving agents are handled separately — only resume if stuck for > 30s
       if (row.status === "archiving") {
-        const stuckSeconds = (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
+        const stuckSeconds =
+          (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
         if (stuckSeconds > 30) {
-          this.logger.info({ id: row.id, stuckSeconds }, "Found agent stuck in archiving state — will be resumed");
+          this.logger.info(
+            { id: row.id, stuckSeconds },
+            "Found agent stuck in archiving state — will be resumed"
+          );
           const agent = await this.getAgent(row.id);
           if (agent) {
             reconciled.push(agent);
@@ -1077,38 +1315,61 @@ export class AgentManager {
         continue;
       }
 
-      const exists = row.tmuxSession ? await this.hasAgentSession(row.tmuxSession) : false;
+      const exists = row.tmuxSession
+        ? await this.hasAgentSession(row.tmuxSession)
+        : false;
 
       if (!exists) {
-        const exitInfo = this.config.agentRuntime === "tmux" && row.tmuxSession
-          ? await this.readExitFile(row.tmuxSession)
-          : null;
+        const exitInfo =
+          this.config.agentRuntime === "tmux" && row.tmuxSession
+            ? await this.readExitFile(row.tmuxSession)
+            : null;
         if (this.config.agentRuntime === "tmux" && row.tmuxSession) {
           await this.captureMissingSessionIncident({
             agentId: row.id,
             tmuxSession: row.tmuxSession,
             status: row.status,
             updatedAt: row.updatedAt,
-            exitInfo
+            exitInfo,
           });
         }
         if (exitInfo !== null) {
-          this.logger.info({ id: row.id, exitCode: exitInfo }, "Agent process exited with code %d", exitInfo);
+          this.logger.info(
+            { id: row.id, exitCode: exitInfo },
+            "Agent process exited with code %d",
+            exitInfo
+          );
         }
         const setupLogTail = await this.readSetupLogTail(row.id);
         const errorDetail = setupLogTail || null;
-        const launchFailed = row.status === "creating" || (exitInfo !== null && exitInfo !== 0);
+        const launchFailed =
+          row.status === "creating" || (exitInfo !== null && exitInfo !== 0);
         const nextStatus: AgentStatus = launchFailed ? "error" : "stopped";
         const baseMessage = launchFailed
-          ? (row.status === "creating"
-            ? (exitInfo !== null ? `Launch failed with exit code ${exitInfo}.` : "Launch failed before the session became ready.")
-            : (exitInfo !== null ? `Session exited with code ${exitInfo}.` : "Session ended unexpectedly."))
+          ? row.status === "creating"
+            ? exitInfo !== null
+              ? `Launch failed with exit code ${exitInfo}.`
+              : "Launch failed before the session became ready."
+            : exitInfo !== null
+              ? `Session exited with code ${exitInfo}.`
+              : "Session ended unexpectedly."
           : "Session ended normally.";
-        await this.setAgentStatus(row.id, nextStatus, errorDetail, row.tmuxSession ?? undefined);
+        await this.setAgentStatus(
+          row.id,
+          nextStatus,
+          errorDetail,
+          row.tmuxSession ?? undefined
+        );
         await this.setSystemLatestEvent(row.id, {
           type: launchFailed ? "blocked" : "idle",
-          message: setupLogTail ? `${baseMessage}\n${setupLogTail}` : baseMessage,
-          metadata: { source: "system", ...(exitInfo !== null ? { exitCode: exitInfo } : {}), launchFailed }
+          message: setupLogTail
+            ? `${baseMessage}\n${setupLogTail}`
+            : baseMessage,
+          metadata: {
+            source: "system",
+            ...(exitInfo !== null ? { exitCode: exitInfo } : {}),
+            launchFailed,
+          },
         });
         const agent = await this.getAgent(row.id);
         if (agent) {
@@ -1116,14 +1377,24 @@ export class AgentManager {
         }
       } else if (row.status === "stopping") {
         const STUCK_STOPPING_TIMEOUT_S = 60;
-        const stuckSeconds = (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
+        const stuckSeconds =
+          (Date.now() - new Date(row.updatedAt).getTime()) / 1000;
         if (stuckSeconds > STUCK_STOPPING_TIMEOUT_S) {
-          this.logger.warn({ id: row.id, stuckSeconds }, "Agent stuck in stopping state, reverting to running");
-          await this.setAgentStatus(row.id, "running", null, row.tmuxSession ?? undefined);
+          this.logger.warn(
+            { id: row.id, stuckSeconds },
+            "Agent stuck in stopping state, reverting to running"
+          );
+          await this.setAgentStatus(
+            row.id,
+            "running",
+            null,
+            row.tmuxSession ?? undefined
+          );
           await this.setSystemLatestEvent(row.id, {
             type: "working",
-            message: "Stop timed out — agent reverted to running. Try force stop.",
-            metadata: { source: "system" }
+            message:
+              "Stop timed out — agent reverted to running. Try force stop.",
+            metadata: { source: "system" },
           });
           const agent = await this.getAgent(row.id);
           if (agent) {
@@ -1141,9 +1412,13 @@ export class AgentManager {
 
     let stdout: string | undefined;
     try {
-      const result = await runCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], {
-        allowedExitCodes: [0, 1]
-      });
+      const result = await runCommand(
+        "tmux",
+        ["list-sessions", "-F", "#{session_name}:#{session_created}"],
+        {
+          allowedExitCodes: [0, 1],
+        }
+      );
       stdout = result.stdout;
     } catch {
       // tmux not running or no sessions
@@ -1190,7 +1465,10 @@ export class AgentManager {
 
       // Agent in terminal state — session is definitely orphaned
       if (status === "stopped" || status === "error") {
-        this.logger.info({ session: session.name, agentId, status }, "Killing orphaned tmux session (agent in terminal state)");
+        this.logger.info(
+          { session: session.name, agentId, status },
+          "Killing orphaned tmux session (agent in terminal state)"
+        );
         toKill.push(session.name);
         continue;
       }
@@ -1199,12 +1477,17 @@ export class AgentManager {
       // server instance using the same tmux namespace. Only clean up
       // sessions that *this* database definitively knows about.
       if (!status) {
-        this.logger.debug({ session: session.name, agentId }, "Ignoring tmux session with no matching DB record");
+        this.logger.debug(
+          { session: session.name, agentId },
+          "Ignoring tmux session with no matching DB record"
+        );
       }
     }
 
     await Promise.all(
-      toKill.map((name) => runCommand("tmux", ["kill-session", "-t", name]).catch(() => {}))
+      toKill.map((name) =>
+        runCommand("tmux", ["kill-session", "-t", name]).catch(() => {})
+      )
     );
   }
 
@@ -1214,7 +1497,10 @@ export class AgentManager {
 
   private async maybeCaptureTmuxInventory(): Promise<void> {
     const now = Date.now();
-    if (now - this.lastTmuxInventoryAt < AgentManager.TMUX_INVENTORY_INTERVAL_MS) {
+    if (
+      now - this.lastTmuxInventoryAt <
+      AgentManager.TMUX_INVENTORY_INTERVAL_MS
+    ) {
       return;
     }
     this.lastTmuxInventoryAt = now;
@@ -1226,13 +1512,22 @@ export class AgentManager {
         source: "reconcile",
         tmux: {
           serverPid: await this.detectTmuxServerPid(),
-          sessions: await this.captureCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], [0, 1]),
+          sessions: await this.captureCommand(
+            "tmux",
+            ["list-sessions", "-F", "#{session_name}:#{session_created}"],
+            [0, 1]
+          ),
           panes: await this.captureCommand(
             "tmux",
-            ["list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}"],
+            [
+              "list-panes",
+              "-a",
+              "-F",
+              "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}",
+            ],
             [0, 1]
-          )
-        }
+          ),
+        },
       };
       await appendFile(
         path.join(this.diagnosticsRoot(), "tmux-inventory.jsonl"),
@@ -1261,79 +1556,140 @@ export class AgentManager {
         agent: input,
         tmux: {
           serverPid: await this.detectTmuxServerPid(),
-          sessions: await this.captureCommand("tmux", ["list-sessions", "-F", "#{session_name}:#{session_created}"], [0, 1]),
+          sessions: await this.captureCommand(
+            "tmux",
+            ["list-sessions", "-F", "#{session_name}:#{session_created}"],
+            [0, 1]
+          ),
           panes: await this.captureCommand(
             "tmux",
-            ["list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}"],
+            [
+              "list-panes",
+              "-a",
+              "-F",
+              "#{session_name}:#{window_name}:#{pane_id}:#{pane_pid}:#{pane_current_command}",
+            ],
             [0, 1]
-          )
+          ),
         },
-        processes: await this.captureCommand("ps", ["-axo", "pid,ppid,pgid,user,command"], [0]),
+        processes: await this.captureCommand(
+          "ps",
+          ["-axo", "pid,ppid,pgid,user,command"],
+          [0]
+        ),
         launchctl: await this.captureCommand(
           "launchctl",
           ["print", `gui/${process.getuid?.() ?? -1}/com.dispatch.server`],
           [0, 113]
-        )
+        ),
       };
       const fileName = `${safeTs}-missing-session-${input.agentId}.json`;
-      await writeFile(path.join(this.diagnosticsRoot(), fileName), JSON.stringify(payload, null, 2), "utf-8");
+      await writeFile(
+        path.join(this.diagnosticsRoot(), fileName),
+        JSON.stringify(payload, null, 2),
+        "utf-8"
+      );
     } catch (error) {
-      this.logger.warn({ err: error, agentId: input.agentId }, "Failed to capture missing tmux session incident.");
+      this.logger.warn(
+        { err: error, agentId: input.agentId },
+        "Failed to capture missing tmux session incident."
+      );
     }
   }
 
   private async maybeMaintenanceLogs(): Promise<void> {
     const now = Date.now();
-    if (now - this.lastLogMaintenanceAt < AgentManager.LOG_MAINTENANCE_INTERVAL_MS) {
+    if (
+      now - this.lastLogMaintenanceAt <
+      AgentManager.LOG_MAINTENANCE_INTERVAL_MS
+    ) {
       return;
     }
     this.lastLogMaintenanceAt = now;
 
     try {
       // Rotate tmux-inventory.jsonl (keep 1 backup)
-      const inventoryPath = path.join(this.diagnosticsRoot(), "tmux-inventory.jsonl");
+      const inventoryPath = path.join(
+        this.diagnosticsRoot(),
+        "tmux-inventory.jsonl"
+      );
       await this.rotateFile(inventoryPath, 1);
 
       // Rotate dispatch.log via copytruncate (keep 3 backups)
-      const serverLogPath = path.join(os.homedir(), ".dispatch", "logs", "dispatch.log");
+      const serverLogPath = path.join(
+        os.homedir(),
+        ".dispatch",
+        "logs",
+        "dispatch.log"
+      );
       await this.copyTruncateFile(serverLogPath, 3);
 
       // Delete old diagnostics JSON files (> 7 days)
-      await this.deleteOldFiles(this.diagnosticsRoot(), /\.json$/, AgentManager.DIAGNOSTICS_MAX_AGE_MS);
+      await this.deleteOldFiles(
+        this.diagnosticsRoot(),
+        /\.json$/,
+        AgentManager.DIAGNOSTICS_MAX_AGE_MS
+      );
 
       // Delete old rotated logs (inventory backups > 7 days, server log backups > 14 days)
-      await this.deleteOldFiles(this.diagnosticsRoot(), /tmux-inventory\.jsonl\.\d+$/, AgentManager.DIAGNOSTICS_MAX_AGE_MS);
-      await this.deleteOldFiles(path.join(os.homedir(), ".dispatch", "logs"), /dispatch\.log\.\d+$/, AgentManager.SERVER_LOG_MAX_AGE_MS);
+      await this.deleteOldFiles(
+        this.diagnosticsRoot(),
+        /tmux-inventory\.jsonl\.\d+$/,
+        AgentManager.DIAGNOSTICS_MAX_AGE_MS
+      );
+      await this.deleteOldFiles(
+        path.join(os.homedir(), ".dispatch", "logs"),
+        /dispatch\.log\.\d+$/,
+        AgentManager.SERVER_LOG_MAX_AGE_MS
+      );
     } catch (error) {
       this.logger.warn({ err: error }, "Log maintenance failed.");
     }
   }
 
   /** Rotate by renaming: file -> file.1, file.1 -> file.2, etc. */
-  private async rotateFile(filePath: string, maxBackups: number): Promise<void> {
+  private async rotateFile(
+    filePath: string,
+    maxBackups: number
+  ): Promise<void> {
     try {
       const s = await stat(filePath);
       if (s.size < AgentManager.MAX_LOG_SIZE_BYTES) return;
-    } catch { return; } // file doesn't exist
+    } catch {
+      return;
+    } // file doesn't exist
 
     // Shift existing backups
     for (let i = maxBackups; i >= 1; i--) {
       const src = i === 1 ? filePath : `${filePath}.${i - 1}`;
       const dst = `${filePath}.${i}`;
-      try { await rename(src, dst); } catch { /* missing, skip */ }
+      try {
+        await rename(src, dst);
+      } catch {
+        /* missing, skip */
+      }
     }
   }
 
   /** Copy then truncate in-place (preserves open file descriptors like launchd's). */
-  private async copyTruncateFile(filePath: string, maxBackups: number): Promise<void> {
+  private async copyTruncateFile(
+    filePath: string,
+    maxBackups: number
+  ): Promise<void> {
     try {
       const s = await stat(filePath);
       if (s.size < AgentManager.MAX_LOG_SIZE_BYTES) return;
-    } catch { return; }
+    } catch {
+      return;
+    }
 
     // Shift existing backups
     for (let i = maxBackups; i >= 2; i--) {
-      try { await rename(`${filePath}.${i - 1}`, `${filePath}.${i}`); } catch { /* missing */ }
+      try {
+        await rename(`${filePath}.${i - 1}`, `${filePath}.${i}`);
+      } catch {
+        /* missing */
+      }
     }
 
     // Copy current to .1, then truncate in place.
@@ -1348,9 +1704,17 @@ export class AgentManager {
   }
 
   /** Delete files matching a pattern that are older than maxAgeMs. */
-  private async deleteOldFiles(dir: string, pattern: RegExp, maxAgeMs: number): Promise<void> {
+  private async deleteOldFiles(
+    dir: string,
+    pattern: RegExp,
+    maxAgeMs: number
+  ): Promise<void> {
     let entries: string[];
-    try { entries = await readdir(dir); } catch { return; }
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
 
     const now = Date.now();
     for (const entry of entries) {
@@ -1361,12 +1725,18 @@ export class AgentManager {
         if (now - s.mtimeMs > maxAgeMs) {
           await unlink(filePath);
         }
-      } catch { /* already gone or inaccessible */ }
+      } catch {
+        /* already gone or inaccessible */
+      }
     }
   }
 
   private async detectTmuxServerPid(): Promise<number | null> {
-    const processes = await this.captureCommand("ps", ["-axo", "pid=,comm="], [0]);
+    const processes = await this.captureCommand(
+      "ps",
+      ["-axo", "pid=,comm="],
+      [0]
+    );
     if (processes.exitCode !== 0) {
       return null;
     }
@@ -1393,7 +1763,7 @@ export class AgentManager {
       return {
         exitCode: -1,
         stdout: "",
-        stderr: this.errorMessage(error)
+        stderr: this.errorMessage(error),
       };
     }
   }
@@ -1422,20 +1792,30 @@ export class AgentManager {
       // (claude, codex, opencode) may cd internally without updating the shell.
       const agentCwd = await this.resolveAgentProcessCwd(session);
       if (agentCwd) {
-        this.runtimeCwdCache.set(cacheKey, { value: agentCwd, expiresAt: now + 10_000 });
+        this.runtimeCwdCache.set(cacheKey, {
+          value: agentCwd,
+          expiresAt: now + 10_000,
+        });
         return agentCwd;
       }
 
       // Fall back to tmux pane_current_path (the shell's CWD).
-      const result = await runCommand("tmux", ["display-message", "-p", "-t", session, "#{pane_current_path}"], {
-        allowedExitCodes: [0, 1],
-        timeoutMs: 800
-      });
+      const result = await runCommand(
+        "tmux",
+        ["display-message", "-p", "-t", session, "#{pane_current_path}"],
+        {
+          allowedExitCodes: [0, 1],
+          timeoutMs: 800,
+        }
+      );
       const cwd = result.stdout.trim();
       if (result.exitCode !== 0 || !cwd) {
         return fallback;
       }
-      this.runtimeCwdCache.set(cacheKey, { value: cwd, expiresAt: now + 10_000 });
+      this.runtimeCwdCache.set(cacheKey, {
+        value: cwd,
+        expiresAt: now + 10_000,
+      });
       return cwd;
     } catch {
       return fallback;
@@ -1447,11 +1827,14 @@ export class AgentManager {
    * inside a tmux pane. The CLI process may have cd'd into a worktree
    * internally, which tmux's pane_current_path won't reflect.
    */
-  private async resolveAgentProcessCwd(session: string): Promise<string | null> {
+  private async resolveAgentProcessCwd(
+    session: string
+  ): Promise<string | null> {
     try {
       // Get the PID of the tmux pane's shell process.
       const pidResult = await runCommand(
-        "tmux", ["display-message", "-p", "-t", session, "#{pane_pid}"],
+        "tmux",
+        ["display-message", "-p", "-t", session, "#{pane_pid}"],
         { allowedExitCodes: [0, 1], timeoutMs: 800 }
       );
       const panePid = pidResult.stdout.trim();
@@ -1461,12 +1844,15 @@ export class AgentManager {
       }
 
       // Find the agent CLI child process (claude, codex, or opencode).
-      const childrenResult = await runCommand(
-        "pgrep", ["-P", panePid],
-        { allowedExitCodes: [0, 1], timeoutMs: 800 }
-      );
+      const childrenResult = await runCommand("pgrep", ["-P", panePid], {
+        allowedExitCodes: [0, 1],
+        timeoutMs: 800,
+      });
       if (childrenResult.exitCode !== 0 || !childrenResult.stdout.trim()) {
-        this.logger.debug({ session, panePid }, "resolveAgentProcessCwd: no children");
+        this.logger.debug(
+          { session, panePid },
+          "resolveAgentProcessCwd: no children"
+        );
         return null;
       }
 
@@ -1475,30 +1861,42 @@ export class AgentManager {
 
       for (const pid of childPids) {
         const commResult = await runCommand(
-          "ps", ["-o", "comm=", "-p", pid.trim()],
+          "ps",
+          ["-o", "comm=", "-p", pid.trim()],
           { allowedExitCodes: [0, 1], timeoutMs: 800 }
         );
         const comm = commResult.stdout.trim();
         // Match agent CLI binaries by basename.
         const basename = comm.split("/").pop() ?? "";
-        if (basename === "claude" || basename === "codex" || basename === "opencode") {
+        if (
+          basename === "claude" ||
+          basename === "codex" ||
+          basename === "opencode"
+        ) {
           agentPid = pid.trim();
           break;
         }
       }
 
       if (!agentPid) {
-        this.logger.debug({ session, panePid }, "resolveAgentProcessCwd: no agent CLI among children");
+        this.logger.debug(
+          { session, panePid },
+          "resolveAgentProcessCwd: no agent CLI among children"
+        );
         return null;
       }
 
       // Read the process's CWD via lsof (works on macOS and Linux).
       const lsofResult = await runCommand(
-        "lsof", ["-a", "-p", agentPid, "-d", "cwd", "-Fn"],
+        "lsof",
+        ["-a", "-p", agentPid, "-d", "cwd", "-Fn"],
         { allowedExitCodes: [0, 1], timeoutMs: 800 }
       );
       if (lsofResult.exitCode !== 0 || !lsofResult.stdout) {
-        this.logger.debug({ session, agentPid }, "resolveAgentProcessCwd: lsof failed");
+        this.logger.debug(
+          { session, agentPid },
+          "resolveAgentProcessCwd: lsof failed"
+        );
         return null;
       }
 
@@ -1506,7 +1904,10 @@ export class AgentManager {
       for (const line of lsofResult.stdout.split("\n")) {
         if (line.startsWith("n/")) {
           const cwd = line.slice(1);
-          this.logger.debug({ session, agentPid, cwd }, "resolveAgentProcessCwd: resolved");
+          this.logger.debug(
+            { session, agentPid, cwd },
+            "resolveAgentProcessCwd: resolved"
+          );
           return cwd;
         }
       }
@@ -1552,21 +1953,41 @@ export class AgentManager {
     const exitFile = `/tmp/dispatch_${sessionName}.exit`;
     const sessionLogFile = `/tmp/dispatch_setup_${agentId}.log`;
     const wrappedCommand = `bash -c 'exec 2> >(tee "${sessionLogFile}" >&2); ${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`;
-    await runCommand("tmux", ["new-session", "-d", "-s", sessionName, "-c", cwd, wrappedCommand]);
-    await runCommand("tmux", ["set-option", "-t", sessionName, "status", "off"], {
-      allowedExitCodes: [0, 1]
-    });
+    await runCommand("tmux", [
+      "new-session",
+      "-d",
+      "-s",
+      sessionName,
+      "-c",
+      cwd,
+      wrappedCommand,
+    ]);
+    await runCommand(
+      "tmux",
+      ["set-option", "-t", sessionName, "status", "off"],
+      {
+        allowedExitCodes: [0, 1],
+      }
+    );
     // Allow DCS passthrough so agent CLIs that wrap escape sequences
     // (e.g. synchronized output) can reach the outer terminal directly.
-    await runCommand("tmux", ["set-option", "-t", sessionName, "allow-passthrough", "on"], {
-      allowedExitCodes: [0, 1]
-    });
+    await runCommand(
+      "tmux",
+      ["set-option", "-t", sessionName, "allow-passthrough", "on"],
+      {
+        allowedExitCodes: [0, 1],
+      }
+    );
     // Advertise synchronized output support so tmux wraps frame rendering
     // in DEC 2026 sequences, reducing terminal flashing.  Set once per session
     // start (not per WebSocket attach) to avoid unbounded array growth.
-    await runCommand("tmux", ["set-option", "-as", "terminal-features", "xterm-256color:sync"], {
-      allowedExitCodes: [0, 1]
-    });
+    await runCommand(
+      "tmux",
+      ["set-option", "-as", "terminal-features", "xterm-256color:sync"],
+      {
+        allowedExitCodes: [0, 1],
+      }
+    );
 
     // Detect fast-fail launches (for example, missing codex executable) so status
     // is not left as "running" with no backing tmux session.
@@ -1591,13 +2012,20 @@ export class AgentManager {
       return sessionName.trim().length > 0;
     }
 
-    const result = await runCommand("tmux", ["has-session", "-t", sessionName], {
-      allowedExitCodes: [0, 1]
-    });
+    const result = await runCommand(
+      "tmux",
+      ["has-session", "-t", sessionName],
+      {
+        allowedExitCodes: [0, 1],
+      }
+    );
     return result.exitCode === 0;
   }
 
-  private async stopAgentSession(sessionName: string, force: boolean): Promise<void> {
+  private async stopAgentSession(
+    sessionName: string,
+    force: boolean
+  ): Promise<void> {
     if (this.config.agentRuntime === "inert") {
       return;
     }
@@ -1612,9 +2040,10 @@ export class AgentManager {
     }
   }
 
-
-
-  private async runLifecycleHook(hookName: "stop", agent: AgentRecord): Promise<void> {
+  private async runLifecycleHook(
+    hookName: "stop",
+    agent: AgentRecord
+  ): Promise<void> {
     const repoRoot = agent.worktreePath ?? agent.cwd;
     if (!repoRoot) return;
 
@@ -1623,7 +2052,10 @@ export class AgentManager {
     if (!hook) return;
 
     const [command, ...args] = hook.command;
-    this.logger.info({ agentId: agent.id, hook: hookName, command: hook.command }, "Running lifecycle hook");
+    this.logger.info(
+      { agentId: agent.id, hook: hookName, command: hook.command },
+      "Running lifecycle hook"
+    );
 
     const result = await runCommand(command, args, {
       cwd: repoRoot,
@@ -1635,7 +2067,12 @@ export class AgentManager {
 
     if (result.exitCode !== 0) {
       this.logger.warn(
-        { agentId: agent.id, hook: hookName, exitCode: result.exitCode, stderr: result.stderr },
+        {
+          agentId: agent.id,
+          hook: hookName,
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+        },
         "Lifecycle hook exited with non-zero code"
       );
     }
@@ -1676,7 +2113,9 @@ export class AgentManager {
           ? " Autonomous Review is enabled. Before emitting done, commit and push your branch, open a draft PR via create_pr (do not override baseBranch — it defaults correctly), then call list_personas and launch 1 relevant reviewer via dispatch_launch_persona. Poll dispatch_get_feedback until all reviews complete. Address critical/high feedback before resolving; medium and below can be resolved with a comment. After addressing each item, call dispatch_resolve_feedback. Do not emit done until all reviews are resolved."
           : "");
 
-    const userLocalBin = process.env.HOME ? path.join(process.env.HOME, ".local/bin") : null;
+    const userLocalBin = process.env.HOME
+      ? path.join(process.env.HOME, ".local/bin")
+      : null;
     const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(
       (entry): entry is string => typeof entry === "string" && entry.length > 0
     );
@@ -1690,13 +2129,15 @@ export class AgentManager {
       `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`,
       // Pin the Bash tool's cwd to the project root (worktree) after every command.
       // Prevents cwd drift back to the original repo root during long conversations.
-      `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`
+      `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`,
     ];
 
     // Forward the clipboard display to agent sessions so CLI tools can read
     // images pasted via the browser clipboard (xclip needs a DISPLAY).
     if (process.platform === "linux" && process.env.DISPATCH_COPY_DISPLAY) {
-      envPrefixParts.push(`DISPATCH_COPY_DISPLAY=${this.shellEscape(process.env.DISPATCH_COPY_DISPLAY)}`);
+      envPrefixParts.push(
+        `DISPATCH_COPY_DISPLAY=${this.shellEscape(process.env.DISPATCH_COPY_DISPLAY)}`
+      );
     }
 
     // When TLS is enabled with a CA cert, tell agent CLI tools to trust it
@@ -1725,7 +2166,7 @@ export class AgentManager {
             codesearch: { "*": "allow" },
             lsp: { "*": "allow" },
             skill: { "*": "allow" },
-            external_directory: { "*": "allow" }
+            external_directory: { "*": "allow" },
           })
         )}`
       );
@@ -1738,20 +2179,23 @@ export class AgentManager {
       ? createJobMcpToken(this.config.authToken, jobRunId, agentId)
       : createAgentMcpToken(this.config.authToken, agentId);
     const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
-    const { passthroughArgs, appendedSystemPrompt } = this.normalizeAgentArgsForType(type, args);
+    const { passthroughArgs, appendedSystemPrompt } =
+      this.normalizeAgentArgsForType(type, args);
 
     if (type === "claude") {
-      const mcpConfig = this.shellEscape(JSON.stringify({
-        mcpServers: {
-          dispatch: {
-            type: "http",
-            url: dispatchMcpUrl,
-            headers: {
-              Authorization: `Bearer ${dispatchMcpToken}`
-            }
-          }
-        }
-      }));
+      const mcpConfig = this.shellEscape(
+        JSON.stringify({
+          mcpServers: {
+            dispatch: {
+              type: "http",
+              url: dispatchMcpUrl,
+              headers: {
+                Authorization: `Bearer ${dispatchMcpToken}`,
+              },
+            },
+          },
+        })
+      );
       const mcpFlag = `--mcp-config ${mcpConfig}`;
       // Elevate guidance to system prompt so it persists through long conversations
       // and isn't buried as an early user message. CLAUDE.md is also auto-loaded by
@@ -1760,9 +2204,13 @@ export class AgentManager {
       // Session tracking: --resume continues an existing session, --session-id starts
       // a new one with a known ID for token attribution and future resume.
       const sessionFlag = cliSessionId
-        ? (resume ? `--resume ${this.shellEscape(cliSessionId)}` : `--session-id ${this.shellEscape(cliSessionId)}`)
+        ? resume
+          ? `--resume ${this.shellEscape(cliSessionId)}`
+          : `--session-id ${this.shellEscape(cliSessionId)}`
         : "";
-      const flags = [mcpFlag, systemFlag, sessionFlag].filter(Boolean).join(" ");
+      const flags = [mcpFlag, systemFlag, sessionFlag]
+        .filter(Boolean)
+        .join(" ");
       // initialPrompt becomes the first user message (positional arg to Claude Code CLI)
       const allArgs = initialPrompt ? [...args, initialPrompt] : args;
       if (allArgs.length === 0) {
@@ -1773,41 +2221,62 @@ export class AgentManager {
     }
 
     if (type === "opencode") {
-      const promptParts = [launchGuidance, appendedSystemPrompt, initialPrompt].filter(Boolean);
+      const promptParts = [
+        launchGuidance,
+        appendedSystemPrompt,
+        initialPrompt,
+      ].filter(Boolean);
       const startupPrompt = promptParts.join("\n\n");
       const promptFlag = `--prompt ${this.shellEscape(startupPrompt)}`;
-      const sessionFlag = (resume && cliSessionId) ? `--session ${this.shellEscape(cliSessionId)}` : "";
+      const sessionFlag =
+        resume && cliSessionId
+          ? `--session ${this.shellEscape(cliSessionId)}`
+          : "";
       const flagParts = [promptFlag, sessionFlag].filter(Boolean).join(" ");
       if (passthroughArgs.length === 0) {
         return `${envPrefix} ${this.shellEscape(cliBin)} ${flagParts}`;
       }
-      const escaped = passthroughArgs.map((arg) => this.shellEscape(arg)).join(" ");
+      const escaped = passthroughArgs
+        .map((arg) => this.shellEscape(arg))
+        .join(" ");
       return `${envPrefix} ${this.shellEscape(cliBin)} ${escaped} ${flagParts}`;
     }
 
     // Codex: positional arg — AGENTS.md is auto-loaded by Codex CLI and provides authority.
     const codexMcpFlags = [
       "-c",
-      this.shellEscape(`mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`),
+      this.shellEscape(
+        `mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`
+      ),
       "-c",
-      this.shellEscape(`mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`)
+      this.shellEscape(
+        `mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`
+      ),
     ].join(" ");
     const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${this.shellEscape(dispatchMcpToken)}`;
     // Codex resume: `codex resume <sessionId>` with MCP flags
     if (resume && cliSessionId) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} resume ${this.shellEscape(cliSessionId)} ${codexMcpFlags}`;
     }
-    const codexPromptParts = [launchGuidance, appendedSystemPrompt, initialPrompt].filter(Boolean);
+    const codexPromptParts = [
+      launchGuidance,
+      appendedSystemPrompt,
+      initialPrompt,
+    ].filter(Boolean);
     const startupPrompt = codexPromptParts.join("\n\n");
     if (passthroughArgs.length === 0) {
       return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(startupPrompt)}`;
     }
-    const escaped = passthroughArgs.map((arg) => this.shellEscape(arg)).join(" ");
+    const escaped = passthroughArgs
+      .map((arg) => this.shellEscape(arg))
+      .join(" ");
     return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(startupPrompt)}`;
   }
 
   private dispatchMcpUrl(agentId: string, jobRunId?: string): string {
-    const path = jobRunId ? `/api/mcp/jobs/${jobRunId}/${agentId}` : `/api/mcp/${agentId}`;
+    const path = jobRunId
+      ? `/api/mcp/jobs/${jobRunId}/${agentId}`
+      : `/api/mcp/${agentId}`;
     return `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}${path}`;
   }
 
@@ -1828,7 +2297,10 @@ export class AgentManager {
 
     for (let index = 0; index < args.length; index += 1) {
       const arg = args[index];
-      if (arg === "--append-system-prompt" && typeof args[index + 1] === "string") {
+      if (
+        arg === "--append-system-prompt" &&
+        typeof args[index + 1] === "string"
+      ) {
         appendedSystemPrompt = args[index + 1] ?? null;
         index += 1;
         continue;
@@ -1843,7 +2315,7 @@ export class AgentManager {
     const cwd = rawCwd.startsWith("~/")
       ? path.join(process.env.HOME ?? "/", rawCwd.slice(2))
       : rawCwd === "~"
-        ? process.env.HOME ?? "/"
+        ? (process.env.HOME ?? "/")
         : rawCwd;
 
     if (!path.isAbsolute(cwd)) {
@@ -1852,7 +2324,10 @@ export class AgentManager {
 
     const directory = await stat(cwd).catch(() => null);
     if (!directory || !directory.isDirectory()) {
-      throw new AgentError("Working directory does not exist or is not a directory.", 400);
+      throw new AgentError(
+        "Working directory does not exist or is not a directory.",
+        400
+      );
     }
 
     return cwd;
@@ -1887,7 +2362,10 @@ export class AgentManager {
     );
 
     if (result.rowCount !== 1) {
-      this.logger.warn({ id, status }, "Agent status update skipped because row was missing.");
+      this.logger.warn(
+        { id, status },
+        "Agent status update skipped because row was missing."
+      );
     }
   }
 
@@ -1916,7 +2394,10 @@ export class AgentManager {
   ): Promise<PersonaReviewRecord> {
     const VALID_STATUSES = ["reviewing"];
     if (!VALID_STATUSES.includes(input.status)) {
-      throw new AgentError(`Invalid review status "${input.status}". Must be one of: ${VALID_STATUSES.join(", ")}`, 400);
+      throw new AgentError(
+        `Invalid review status "${input.status}". Must be one of: ${VALID_STATUSES.join(", ")}`,
+        400
+      );
     }
     const result = await this.pool.query<PersonaReviewRecord>(
       `UPDATE persona_reviews
@@ -1928,17 +2409,26 @@ export class AgentManager {
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [agentId, input.status, input.message ?? null]
     );
-    if (result.rowCount === 0) throw new AgentError("No persona review found for agent.", 404);
+    if (result.rowCount === 0)
+      throw new AgentError("No persona review found for agent.", 404);
     return result.rows[0]!;
   }
 
   async completePersonaReview(
     agentId: string,
-    input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
+    input: {
+      verdict: string;
+      summary: string;
+      filesReviewed?: string[];
+      message?: string;
+    }
   ): Promise<PersonaReviewRecord> {
     const VALID_VERDICTS = ["approve", "request_changes"];
     if (!VALID_VERDICTS.includes(input.verdict)) {
-      throw new AgentError(`verdict must be one of: ${VALID_VERDICTS.join(", ")}`, 400);
+      throw new AgentError(
+        `verdict must be one of: ${VALID_VERDICTS.join(", ")}`,
+        400
+      );
     }
     if (input.summary.length > 10_000) {
       throw new AgentError("summary exceeds 10,000 character limit.", 400);
@@ -1952,7 +2442,10 @@ export class AgentManager {
       }
       for (const filePath of input.filesReviewed) {
         if (filePath.length > 500) {
-          throw new AgentError("Individual file path in filesReviewed exceeds 500 character limit.", 400);
+          throw new AgentError(
+            "Individual file path in filesReviewed exceeds 500 character limit.",
+            400
+          );
         }
       }
     }
@@ -1965,9 +2458,16 @@ export class AgentManager {
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
-      [agentId, input.verdict, input.summary, JSON.stringify(input.filesReviewed ?? []), input.message ?? null]
+      [
+        agentId,
+        input.verdict,
+        input.summary,
+        JSON.stringify(input.filesReviewed ?? []),
+        input.message ?? null,
+      ]
     );
-    if (result.rowCount === 0) throw new AgentError("No persona review found for agent.", 404);
+    if (result.rowCount === 0)
+      throw new AgentError("No persona review found for agent.", 404);
     return result.rows[0]!;
   }
 
@@ -1983,7 +2483,9 @@ export class AgentManager {
     return result.rows[0] ?? null;
   }
 
-  async getPersonaReviewsByParent(parentAgentId: string): Promise<PersonaReviewRecord[]> {
+  async getPersonaReviewsByParent(
+    parentAgentId: string
+  ): Promise<PersonaReviewRecord[]> {
     const result = await this.pool.query<PersonaReviewRecord>(
       `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
               persona, status, message, verdict, summary,
@@ -1996,7 +2498,9 @@ export class AgentManager {
     return result.rows;
   }
 
-  async listRecentPersonaReviews(sinceDays: number): Promise<PersonaReviewRecord[]> {
+  async listRecentPersonaReviews(
+    sinceDays: number
+  ): Promise<PersonaReviewRecord[]> {
     const result = await this.pool.query<PersonaReviewRecord>(
       `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
               persona, status, message, verdict, summary,
@@ -2010,7 +2514,9 @@ export class AgentManager {
     return result.rows;
   }
 
-  async listRecentFeedback(sinceDays: number): Promise<Array<FeedbackRecord & { persona: string }>> {
+  async listRecentFeedback(
+    sinceDays: number
+  ): Promise<Array<FeedbackRecord & { persona: string }>> {
     const result = await this.pool.query<FeedbackRecord & { persona: string }>(
       `SELECT f.id, f.agent_id AS "agentId", a.persona, f.severity, f.file_path AS "filePath",
               f.line_number AS "lineNumber", f.description, f.suggestion,
@@ -2048,15 +2554,22 @@ export class AgentManager {
     const agentParams: unknown[] = [rangeStart, rangeEnd];
     if (params.project) {
       agentParams.push(params.project);
-      agentConditions.push(`COALESCE(git_context->>'repoRoot', cwd) = $${agentParams.length}`);
+      agentConditions.push(
+        `COALESCE(git_context->>'repoRoot', cwd) = $${agentParams.length}`
+      );
     }
     const agentWhere = `WHERE ${agentConditions.join(" AND ")}`;
 
     // Run all three queries in parallel
-    const [workingTimeResult, sessionResult, agentMetaResult] = await Promise.all([
-      // Query 1: Working time per agent per project via SQL window functions
-      this.pool.query<{ agentId: string; projectDir: string; totalWorkingMs: string }>(
-        `WITH boundary AS (
+    const [workingTimeResult, sessionResult, agentMetaResult] =
+      await Promise.all([
+        // Query 1: Working time per agent per project via SQL window functions
+        this.pool.query<{
+          agentId: string;
+          projectDir: string;
+          totalWorkingMs: string;
+        }>(
+          `WITH boundary AS (
           SELECT DISTINCT ON (ae.agent_id)
             ae.agent_id, ae.event_type,
             $1::timestamptz AS effective_at,
@@ -2096,15 +2609,19 @@ export class AgentManager {
         FROM with_next
         WHERE project_dir IS NOT NULL ${wtProjectFilter}
         GROUP BY agent_id, project_dir`,
-        wtParams
-      ),
+          wtParams
+        ),
 
-      // Query 2: Session counts and outcomes by project
-      this.pool.query<{
-        projectDir: string; sessionCount: string; doneCount: string;
-        idleCount: string; blockedCount: string; errorCount: string;
-      }>(
-        `SELECT
+        // Query 2: Session counts and outcomes by project
+        this.pool.query<{
+          projectDir: string;
+          sessionCount: string;
+          doneCount: string;
+          idleCount: string;
+          blockedCount: string;
+          errorCount: string;
+        }>(
+          `SELECT
           COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
           COUNT(*)::int AS "sessionCount",
           COUNT(*) FILTER (WHERE latest_event_type = 'done')::int AS "doneCount",
@@ -2114,33 +2631,45 @@ export class AgentManager {
         FROM agents
         ${agentWhere}
         GROUP BY COALESCE(git_context->>'repoRoot', cwd)`,
-        agentParams
-      ),
+          agentParams
+        ),
 
-      // Query 3: Agent metadata for top agents list
-      this.pool.query<{
-        id: string; name: string; projectDir: string;
-        latestEventType: string | null; latestEventMessage: string | null;
-      }>(
-        `SELECT id, name,
+        // Query 3: Agent metadata for top agents list
+        this.pool.query<{
+          id: string;
+          name: string;
+          projectDir: string;
+          latestEventType: string | null;
+          latestEventMessage: string | null;
+        }>(
+          `SELECT id, name,
           COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
           latest_event_type AS "latestEventType",
           latest_event_message AS "latestEventMessage"
         FROM agents
         ${agentWhere}`,
-        agentParams
-      ),
-    ]);
+          agentParams
+        ),
+      ]);
 
     // Aggregate working time by project and by agent
-    const projectWorkingTime = new Map<string, { totalWorkingMs: number; agents: Set<string> }>();
-    const workingTimeByAgent = new Map<string, { project: string; totalWorkingMs: number }>();
+    const projectWorkingTime = new Map<
+      string,
+      { totalWorkingMs: number; agents: Set<string> }
+    >();
+    const workingTimeByAgent = new Map<
+      string,
+      { project: string; totalWorkingMs: number }
+    >();
 
     for (const row of workingTimeResult.rows) {
       const ms = Number(row.totalWorkingMs);
 
       // Per-project aggregation
-      const proj = projectWorkingTime.get(row.projectDir) ?? { totalWorkingMs: 0, agents: new Set() };
+      const proj = projectWorkingTime.get(row.projectDir) ?? {
+        totalWorkingMs: 0,
+        agents: new Set(),
+      };
       proj.totalWorkingMs += ms;
       proj.agents.add(row.agentId);
       projectWorkingTime.set(row.projectDir, proj);
@@ -2150,15 +2679,23 @@ export class AgentManager {
       if (agent) {
         agent.totalWorkingMs += ms;
       } else {
-        workingTimeByAgent.set(row.agentId, { project: row.projectDir, totalWorkingMs: ms });
+        workingTimeByAgent.set(row.agentId, {
+          project: row.projectDir,
+          totalWorkingMs: ms,
+        });
       }
     }
 
     // Index session data by project
-    const sessionsByProject = new Map(sessionResult.rows.map((r) => [r.projectDir, r]));
+    const sessionsByProject = new Map(
+      sessionResult.rows.map((r) => [r.projectDir, r])
+    );
 
     // Merge project-level data
-    const allProjectDirs = new Set([...projectWorkingTime.keys(), ...sessionsByProject.keys()]);
+    const allProjectDirs = new Set([
+      ...projectWorkingTime.keys(),
+      ...sessionsByProject.keys(),
+    ]);
     const projects = [...allProjectDirs]
       .map((dir) => {
         const working = projectWorkingTime.get(dir);
@@ -2218,10 +2755,7 @@ export class AgentManager {
     includeReviews: boolean;
     includeChildren: boolean;
   }): Promise<AgentHistoryResult> {
-    const conditions: string[] = [
-      "created_at >= $1",
-      "created_at <= $2",
-    ];
+    const conditions: string[] = ["created_at >= $1", "created_at <= $2"];
     const queryParams: unknown[] = [params.start, params.end];
 
     if (!params.includeChildren) {
@@ -2229,7 +2763,9 @@ export class AgentManager {
     }
     if (params.project) {
       queryParams.push(params.project);
-      conditions.push(`COALESCE(git_context->>'repoRoot', cwd) = $${queryParams.length}`);
+      conditions.push(
+        `COALESCE(git_context->>'repoRoot', cwd) = $${queryParams.length}`
+      );
     }
 
     const whereClause = `WHERE ${conditions.join(" AND ")}`;
@@ -2241,12 +2777,19 @@ export class AgentManager {
         queryParams
       ),
       this.pool.query<{
-        id: string; name: string; type: string; status: string;
-        projectDir: string; createdAt: string;
-        latestEventType: string | null; latestEventMessage: string | null;
-        pins: AgentPin[]; gitContext: AgentGitContext | null;
+        id: string;
+        name: string;
+        type: string;
+        status: string;
+        projectDir: string;
+        createdAt: string;
+        latestEventType: string | null;
+        latestEventMessage: string | null;
+        pins: AgentPin[];
+        gitContext: AgentGitContext | null;
         worktreeBranch: string | null;
-        persona: string | null; parentAgentId: string | null;
+        persona: string | null;
+        parentAgentId: string | null;
       }>(
         `SELECT id, name, type, status,
           COALESCE(git_context->>'repoRoot', cwd) AS "projectDir",
@@ -2276,10 +2819,14 @@ export class AgentManager {
     // Fetch related data in parallel
     const [eventsRows, feedbackRows, reviewsRows] = await Promise.all([
       params.includeEvents && agentIds.length > 0
-        ? this.pool.query<{
-            agentId: string; type: string; message: string; createdAt: string;
-          }>(
-            `SELECT agent_id AS "agentId", event_type AS type, message,
+        ? this.pool
+            .query<{
+              agentId: string;
+              type: string;
+              message: string;
+              createdAt: string;
+            }>(
+              `SELECT agent_id AS "agentId", event_type AS type, message,
                     created_at AS "createdAt"
              FROM (
                SELECT *, ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at ASC) AS rn
@@ -2288,72 +2835,112 @@ export class AgentManager {
              ) ranked
              WHERE rn <= 200
              ORDER BY agent_id, created_at ASC`,
-            [agentIds]
-          ).then((r) => r.rows)
+              [agentIds]
+            )
+            .then((r) => r.rows)
         : [],
       params.includeFeedback && parentAgentIds.length > 0
-        ? this.pool.query<{
-            parentAgentId: string; id: number; persona: string; severity: string;
-            description: string; filePath: string | null; suggestion: string | null;
-            status: string;
-          }>(
-            `SELECT a.parent_agent_id AS "parentAgentId",
+        ? this.pool
+            .query<{
+              parentAgentId: string;
+              id: number;
+              persona: string;
+              severity: string;
+              description: string;
+              filePath: string | null;
+              suggestion: string | null;
+              status: string;
+            }>(
+              `SELECT a.parent_agent_id AS "parentAgentId",
                     f.id, a.persona, f.severity, f.description,
                     f.file_path AS "filePath", f.suggestion, f.status
              FROM agent_feedback f
              JOIN agents a ON a.id = f.agent_id
              WHERE a.parent_agent_id = ANY($1)
              ORDER BY f.created_at ASC`,
-            [parentAgentIds]
-          ).then((r) => r.rows)
+              [parentAgentIds]
+            )
+            .then((r) => r.rows)
         : [],
       params.includeReviews && parentAgentIds.length > 0
-        ? this.pool.query<{
-            parentAgentId: string; persona: string; status: string;
-            verdict: string | null; summary: string | null;
-            filesReviewed: string[] | null;
-          }>(
-            `SELECT parent_agent_id AS "parentAgentId", persona, status,
+        ? this.pool
+            .query<{
+              parentAgentId: string;
+              persona: string;
+              status: string;
+              verdict: string | null;
+              summary: string | null;
+              filesReviewed: string[] | null;
+            }>(
+              `SELECT parent_agent_id AS "parentAgentId", persona, status,
                     verdict, summary, files_reviewed AS "filesReviewed"
              FROM persona_reviews
              WHERE parent_agent_id = ANY($1)
              ORDER BY created_at ASC`,
-            [parentAgentIds]
-          ).then((r) => r.rows)
+              [parentAgentIds]
+            )
+            .then((r) => r.rows)
         : [],
     ]);
 
     // Group related data by agent ID
-    const eventsByAgent = new Map<string, Array<{ type: string; message: string; createdAt: string }>>();
+    const eventsByAgent = new Map<
+      string,
+      Array<{ type: string; message: string; createdAt: string }>
+    >();
     for (const row of eventsRows) {
       const list = eventsByAgent.get(row.agentId) ?? [];
-      list.push({ type: row.type, message: row.message, createdAt: row.createdAt });
+      list.push({
+        type: row.type,
+        message: row.message,
+        createdAt: row.createdAt,
+      });
       eventsByAgent.set(row.agentId, list);
     }
 
-    const feedbackByParent = new Map<string, Array<{
-      id: number; persona: string; severity: string; description: string;
-      filePath: string | null; suggestion: string | null; status: string;
-    }>>();
+    const feedbackByParent = new Map<
+      string,
+      Array<{
+        id: number;
+        persona: string;
+        severity: string;
+        description: string;
+        filePath: string | null;
+        suggestion: string | null;
+        status: string;
+      }>
+    >();
     for (const row of feedbackRows) {
       const list = feedbackByParent.get(row.parentAgentId) ?? [];
       list.push({
-        id: row.id, persona: row.persona, severity: row.severity,
-        description: row.description, filePath: row.filePath,
-        suggestion: row.suggestion, status: row.status,
+        id: row.id,
+        persona: row.persona,
+        severity: row.severity,
+        description: row.description,
+        filePath: row.filePath,
+        suggestion: row.suggestion,
+        status: row.status,
       });
       feedbackByParent.set(row.parentAgentId, list);
     }
 
-    const reviewsByParent = new Map<string, Array<{
-      persona: string; status: string; verdict: string | null;
-      summary: string | null; filesReviewed: string[] | null;
-    }>>();
+    const reviewsByParent = new Map<
+      string,
+      Array<{
+        persona: string;
+        status: string;
+        verdict: string | null;
+        summary: string | null;
+        filesReviewed: string[] | null;
+      }>
+    >();
     for (const row of reviewsRows) {
       const list = reviewsByParent.get(row.parentAgentId) ?? [];
       list.push({
-        persona: row.persona, status: row.status,
-        verdict: row.verdict, summary: row.summary,
+        persona: row.persona,
+        status: row.status,
+        verdict: row.verdict,
+        summary: row.summary,
         filesReviewed: row.filesReviewed,
       });
       reviewsByParent.set(row.parentAgentId, list);
@@ -2368,13 +2955,26 @@ export class AgentManager {
       createdAt: a.createdAt,
       latestEventType: a.latestEventType,
       latestEventMessage: a.latestEventMessage,
-      pins: (a.pins ?? []).map((p) => ({ label: p.label, value: p.value, type: p.type })),
+      pins: (a.pins ?? []).map((p) => ({
+        label: p.label,
+        value: p.value,
+        type: p.type,
+      })),
       git: a.gitContext
-        ? { branch: a.gitContext.branch ?? null, worktreeBranch: a.worktreeBranch }
+        ? {
+            branch: a.gitContext.branch ?? null,
+            worktreeBranch: a.worktreeBranch,
+          }
         : null,
-      ...(params.includeEvents ? { events: eventsByAgent.get(a.id) ?? [] } : {}),
-      ...(params.includeFeedback ? { feedback: feedbackByParent.get(a.id) ?? [] } : {}),
-      ...(params.includeReviews ? { reviews: reviewsByParent.get(a.id) ?? [] } : {}),
+      ...(params.includeEvents
+        ? { events: eventsByAgent.get(a.id) ?? [] }
+        : {}),
+      ...(params.includeFeedback
+        ? { feedback: feedbackByParent.get(a.id) ?? [] }
+        : {}),
+      ...(params.includeReviews
+        ? { reviews: reviewsByParent.get(a.id) ?? [] }
+        : {}),
     }));
 
     return { agents, total, hasMore: params.offset + params.limit < total };
@@ -2410,8 +3010,12 @@ export class AgentManager {
     // Fetch feedback rows and verdict aggregates in parallel
     const [feedbackResult, verdictResult] = await Promise.all([
       this.pool.query<{
-        persona: string; severity: string; description: string;
-        filePath: string | null; status: string; projectRoot: string;
+        persona: string;
+        severity: string;
+        description: string;
+        filePath: string | null;
+        status: string;
+        projectRoot: string;
       }>(
         `SELECT a.persona, f.severity, f.description,
                 f.file_path AS "filePath", f.status,
@@ -2424,7 +3028,11 @@ export class AgentManager {
         feedbackParams
       ),
 
-      this.pool.query<{ total: string; approved: string; changesRequested: string }>(
+      this.pool.query<{
+        total: string;
+        approved: string;
+        changesRequested: string;
+      }>(
         `SELECT
           COUNT(*)::int AS total,
           COUNT(*) FILTER (WHERE pr.verdict = 'approve')::int AS approved,
@@ -2442,8 +3050,10 @@ export class AgentManager {
     const bySeverity = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
     const byStatus = { open: 0, fixed: 0, ignored: 0, dismissed: 0 };
     for (const row of rows) {
-      if (row.severity in bySeverity) bySeverity[row.severity as keyof typeof bySeverity]++;
-      if (row.status in byStatus) byStatus[row.status as keyof typeof byStatus]++;
+      if (row.severity in bySeverity)
+        bySeverity[row.severity as keyof typeof bySeverity]++;
+      if (row.status in byStatus)
+        byStatus[row.status as keyof typeof byStatus]++;
     }
 
     // Group by requested dimension
@@ -2463,9 +3073,10 @@ export class AgentManager {
             break;
           }
           const root = row.projectRoot;
-          const relative = root && row.filePath.startsWith(root)
-            ? row.filePath.slice(root.length + 1)
-            : row.filePath;
+          const relative =
+            root && row.filePath.startsWith(root)
+              ? row.filePath.slice(root.length + 1)
+              : row.filePath;
           // Extract directory (drop the filename)
           const lastSlash = relative.lastIndexOf("/");
           key = lastSlash > 0 ? relative.slice(0, lastSlash) : ".";
@@ -2481,10 +3092,14 @@ export class AgentManager {
     const groups = [...groupMap.entries()]
       .map(([key, items]) => {
         const groupSev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
-        const descCounts = new Map<string, { count: number; severity: string; filePath: string | null }>();
+        const descCounts = new Map<
+          string,
+          { count: number; severity: string; filePath: string | null }
+        >();
 
         for (const item of items) {
-          if (item.severity in groupSev) groupSev[item.severity as keyof typeof groupSev]++;
+          if (item.severity in groupSev)
+            groupSev[item.severity as keyof typeof groupSev]++;
           const existing = descCounts.get(item.description);
           if (existing) {
             existing.count++;
@@ -2529,8 +3144,20 @@ export class AgentManager {
 
   // --- Media ---
 
-  async listMedia(agentId: string): Promise<Array<{ fileName: string; description: string | null; source: string; createdAt: string }>> {
-    const result = await this.pool.query<{ fileName: string; description: string | null; source: string; createdAt: string }>(
+  async listMedia(agentId: string): Promise<
+    Array<{
+      fileName: string;
+      description: string | null;
+      source: string;
+      createdAt: string;
+    }>
+  > {
+    const result = await this.pool.query<{
+      fileName: string;
+      description: string | null;
+      source: string;
+      createdAt: string;
+    }>(
       `SELECT file_name AS "fileName", description, source, created_at AS "createdAt"
        FROM media WHERE agent_id = $1 ORDER BY created_at`,
       [agentId]
@@ -2589,7 +3216,13 @@ export class AgentManager {
     parentAgentId: string,
     persona?: string,
     limit = 100
-  ): Promise<{ personas: Array<{ persona: string; agentId: string; feedback: FeedbackRecord[] }> }> {
+  ): Promise<{
+    personas: Array<{
+      persona: string;
+      agentId: string;
+      feedback: FeedbackRecord[];
+    }>;
+  }> {
     const params: unknown[] = [parentAgentId];
     let whereClause = "WHERE a.parent_agent_id = $1";
     if (persona) {
@@ -2609,11 +3242,18 @@ export class AgentManager {
       params
     );
 
-    const grouped = new Map<string, { persona: string; agentId: string; feedback: FeedbackRecord[] }>();
+    const grouped = new Map<
+      string,
+      { persona: string; agentId: string; feedback: FeedbackRecord[] }
+    >();
     for (const row of result.rows) {
       const key = row.agentId;
       if (!grouped.has(key)) {
-        grouped.set(key, { persona: row.persona, agentId: row.agentId, feedback: [] });
+        grouped.set(key, {
+          persona: row.persona,
+          agentId: row.agentId,
+          feedback: [],
+        });
       }
       const { persona: _p, ...feedbackRecord } = row;
       grouped.get(key)!.feedback.push(feedbackRecord);
@@ -2769,13 +3409,18 @@ export class AgentManager {
       const log = await readFile(logPath, "utf-8");
       const tail = log.trim().split("\n").slice(-20).join("\n");
       if (tail) return `\n\nSetup log (last 20 lines):\n${tail}`;
-    } catch { /* no log file */ }
+    } catch {
+      /* no log file */
+    }
     return "";
   }
 
   private async readExitFile(sessionName: string): Promise<number | null> {
     try {
-      const content = await readFile(`/tmp/dispatch_${sessionName}.exit`, "utf-8");
+      const content = await readFile(
+        `/tmp/dispatch_${sessionName}.exit`,
+        "utf-8"
+      );
       const match = content.trim().match(/^EXIT:(\d+)$/);
       return match ? Number(match[1]) : null;
     } catch {
@@ -2794,7 +3439,10 @@ export class AgentManager {
     );
   }
 
-  private async setArchivePhase(id: string, phase: ArchivePhase): Promise<void> {
+  private async setArchivePhase(
+    id: string,
+    phase: ArchivePhase
+  ): Promise<void> {
     await this.pool.query(
       `UPDATE agents SET archive_phase = $2, updated_at = NOW() WHERE id = $1`,
       [id, phase]
@@ -2837,7 +3485,11 @@ export class AgentManager {
       `-d '{"phase":"${phase}"}' > /dev/null 2>&1 || true`;
 
     // Helper function for the completion callback
-    const curlComplete = (cwdVar: string, worktreePathVar: string, worktreeBranchVar: string) =>
+    const curlComplete = (
+      cwdVar: string,
+      worktreePathVar: string,
+      worktreeBranchVar: string
+    ) =>
       `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/complete" ` +
       `-H "Content-Type: application/json" ` +
       `-H "Authorization: Bearer ${authToken}" ` +
@@ -2881,13 +3533,11 @@ export class AgentManager {
         `# --- Worktree creation ---`,
         `phase "Creating git worktree"`,
         `info "Branch: ${worktreeBranchName}"`,
-        ``,
+        ``
       );
 
       // Determine worktree path arg
-      const wtPathArg = worktreePathOverride
-        ? `"${worktreePathOverride}"`
-        : "";
+      const wtPathArg = worktreePathOverride ? `"${worktreePathOverride}"` : "";
 
       // We need to compute the worktree path. Use git worktree add directly.
       const effectiveBaseBranch = params.baseBranch || "main";
@@ -2906,13 +3556,11 @@ export class AgentManager {
         `  git -C "$REPO_ROOT" rev-parse --verify "$BASE_REF" > /dev/null 2>&1 || {`,
         `    BASE_REF="${effectiveBaseBranch}"`,
         `  }`,
-        ``,
+        ``
       );
 
       if (worktreePathOverride) {
-        lines.push(
-          `  WT_PATH="${worktreePathOverride}"`,
-        );
+        lines.push(`  WT_PATH="${worktreePathOverride}"`);
       } else {
         // Default sibling path: <repoRoot>/../<basename>-<slugified-branch>
         const sluggedBranch = worktreeBranchName
@@ -2921,7 +3569,7 @@ export class AgentManager {
           .toLowerCase();
         lines.push(
           `  REPO_BASENAME=$(basename "$REPO_ROOT")`,
-          `  WT_PATH="$(dirname "$REPO_ROOT")/\${REPO_BASENAME}-${sluggedBranch}"`,
+          `  WT_PATH="$(dirname "$REPO_ROOT")/\${REPO_BASENAME}-${sluggedBranch}"`
         );
       }
 
@@ -2970,7 +3618,7 @@ export class AgentManager {
         `    warn "Worktree creation failed — using original directory"`,
         `  fi`,
         `fi`,
-        ``,
+        ``
       );
     }
 
@@ -2982,8 +3630,8 @@ export class AgentManager {
       ``,
       `# Notify server that setup is complete`,
       `cd "$EFFECTIVE_CWD"`,
-      `${curlComplete('$EFFECTIVE_CWD', '$WORKTREE_PATH', '$WORKTREE_BRANCH')}`,
-      ``,
+      `${curlComplete("$EFFECTIVE_CWD", "$WORKTREE_PATH", "$WORKTREE_BRANCH")}`,
+      ``
     );
 
     // Opencode: write opencode.json with the Dispatch MCP server config.
@@ -3003,13 +3651,13 @@ export class AgentManager {
         `MCP_ENTRY=${this.shellEscape(mcpEntry)}`,
         `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcp = { ...(cfg.mcp ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$OPENCODE_CFG" "$MCP_ENTRY"`,
         `ok "Configured dispatch MCP in opencode.json"`,
-        ``,
+        ``
       );
     }
 
     lines.push(
       `# exec replaces this shell with the agent CLI — seamless transition`,
-      `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`,
+      `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`
     );
 
     return lines.join("\n") + "\n";
@@ -3020,21 +3668,30 @@ export class AgentManager {
     return value.replaceAll("'", "'\\''");
   }
 
-  private async setSystemLatestEvent(id: string, input: AgentLatestEventInput): Promise<void> {
+  private async setSystemLatestEvent(
+    id: string,
+    input: AgentLatestEventInput
+  ): Promise<void> {
     try {
       await this.upsertLatestEvent(id, {
         ...input,
         metadata: {
           ...(input.metadata ?? {}),
-          source: "system"
-        }
+          source: "system",
+        },
       });
     } catch (error) {
-      this.logger.warn({ err: error, id, eventType: input.type }, "Failed to upsert system latest event.");
+      this.logger.warn(
+        { err: error, id, eventType: input.type },
+        "Failed to upsert system latest event."
+      );
     }
   }
 
-  private async setupWorktree(originalCwd: string, worktreePath: string): Promise<void> {
+  private async setupWorktree(
+    originalCwd: string,
+    worktreePath: string
+  ): Promise<void> {
     // Copy .env if it exists
     const envSource = path.join(originalCwd, ".env");
     const envDest = path.join(worktreePath, ".env");
@@ -3050,19 +3707,31 @@ export class AgentManager {
       ["pnpm-lock.yaml", "pnpm", ["install"]],
       ["yarn.lock", "yarn", ["install"]],
       ["package-lock.json", "npm", ["install"]],
-      ["bun.lockb", "bun", ["install"]]
+      ["bun.lockb", "bun", ["install"]],
     ];
 
     for (const [lockfile, bin, args] of lockfileMap) {
       const lockPath = path.join(worktreePath, lockfile);
       const exists = await stat(lockPath).catch(() => null);
       if (exists) {
-        this.logger.info({ worktreePath, packageManager: bin }, "Installing dependencies in worktree.");
+        this.logger.info(
+          { worktreePath, packageManager: bin },
+          "Installing dependencies in worktree."
+        );
         try {
-          await runCommand(bin, args, { cwd: worktreePath, timeoutMs: 120_000 });
-          this.logger.info({ worktreePath, packageManager: bin }, "Dependency install complete.");
+          await runCommand(bin, args, {
+            cwd: worktreePath,
+            timeoutMs: 120_000,
+          });
+          this.logger.info(
+            { worktreePath, packageManager: bin },
+            "Dependency install complete."
+          );
         } catch (error) {
-          this.logger.warn({ err: error, worktreePath, packageManager: bin }, "Dependency install failed.");
+          this.logger.warn(
+            { err: error, worktreePath, packageManager: bin },
+            "Dependency install failed."
+          );
         }
         break;
       }
@@ -3077,14 +3746,17 @@ export class AgentManager {
     return unmerged.hasUnmergedCommits || uncommitted.hasUncommittedChanges;
   }
 
-  private async getUnmergedChanges(worktreePath: string): Promise<{ hasUnmergedCommits: boolean; changedFiles: string[] }> {
+  private async getUnmergedChanges(
+    worktreePath: string
+  ): Promise<{ hasUnmergedCommits: boolean; changedFiles: string[] }> {
     try {
       // Discover the upstream tracking branch (set at worktree creation time).
       // Falls back to origin/main for older worktrees that don't have one.
       let upstreamRef: string | null = null;
       try {
         const upstream = await runCommand(
-          "git", ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+          "git",
+          ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
           { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
         );
         if (upstream.exitCode === 0 && upstream.stdout) {
@@ -3100,14 +3772,18 @@ export class AgentManager {
         : "main";
 
       await runCommand(
-        "git", ["-C", worktreePath, "fetch", "origin", remoteBranch, "--quiet"],
+        "git",
+        ["-C", worktreePath, "fetch", "origin", remoteBranch, "--quiet"],
         { allowedExitCodes: [0, 1, 128], timeoutMs: 15_000 }
       );
 
       // Resolve the base ref: prefer upstream, fall back to origin/main → main
-      const baseRef = (upstreamRef ? await this.resolveRef(worktreePath, upstreamRef) : null)
-        ?? await this.resolveRef(worktreePath, "origin/main")
-        ?? await this.resolveRef(worktreePath, "main");
+      const baseRef =
+        (upstreamRef
+          ? await this.resolveRef(worktreePath, upstreamRef)
+          : null) ??
+        (await this.resolveRef(worktreePath, "origin/main")) ??
+        (await this.resolveRef(worktreePath, "main"));
       if (!baseRef) {
         return { hasUnmergedCommits: false, changedFiles: [] };
       }
@@ -3116,13 +3792,15 @@ export class AgentManager {
       // identical to main's tree, everything on this branch is already in main
       // (handles squash-merges, rebases, and main moving forward with releases).
       const mergeTree = await runCommand(
-        "git", ["-C", worktreePath, "merge-tree", "--write-tree", baseRef, "HEAD"],
+        "git",
+        ["-C", worktreePath, "merge-tree", "--write-tree", baseRef, "HEAD"],
         { allowedExitCodes: [0, 1], timeoutMs: 10_000 }
       );
       // merge-tree outputs the tree hash on the first line (exit 1 = conflicts)
       const resultTree = mergeTree.stdout.trim().split("\n")[0];
       const mainTree = await runCommand(
-        "git", ["-C", worktreePath, "rev-parse", `${baseRef}^{tree}`],
+        "git",
+        ["-C", worktreePath, "rev-parse", `${baseRef}^{tree}`],
         { allowedExitCodes: [0], timeoutMs: 5_000 }
       );
 
@@ -3132,7 +3810,15 @@ export class AgentManager {
 
       // Trees differ — find which files the branch would actually change
       const fileDiff = await runCommand(
-        "git", ["-C", worktreePath, "diff", "--name-only", mainTree.stdout.trim(), resultTree],
+        "git",
+        [
+          "-C",
+          worktreePath,
+          "diff",
+          "--name-only",
+          mainTree.stdout.trim(),
+          resultTree,
+        ],
         { allowedExitCodes: [0], timeoutMs: 10_000 }
       );
       const changedFiles = fileDiff.stdout.trim().split("\n").filter(Boolean);
@@ -3143,24 +3829,34 @@ export class AgentManager {
     }
   }
 
-  private async getUncommittedChanges(worktreePath: string): Promise<{ hasUncommittedChanges: boolean; uncommittedFiles: string[] }> {
+  private async getUncommittedChanges(
+    worktreePath: string
+  ): Promise<{ hasUncommittedChanges: boolean; uncommittedFiles: string[] }> {
     try {
       // Detect staged + unstaged modifications and untracked files
       const status = await runCommand(
-        "git", ["-C", worktreePath, "status", "--porcelain"],
+        "git",
+        ["-C", worktreePath, "status", "--porcelain"],
         { allowedExitCodes: [0], timeoutMs: 10_000 }
       );
       const uncommittedFiles = status.stdout.trim().split("\n").filter(Boolean);
 
-      return { hasUncommittedChanges: uncommittedFiles.length > 0, uncommittedFiles };
+      return {
+        hasUncommittedChanges: uncommittedFiles.length > 0,
+        uncommittedFiles,
+      };
     } catch {
       return { hasUncommittedChanges: false, uncommittedFiles: [] };
     }
   }
 
-  private async resolveRef(worktreePath: string, ref: string): Promise<string | null> {
+  private async resolveRef(
+    worktreePath: string,
+    ref: string
+  ): Promise<string | null> {
     const result = await runCommand(
-      "git", ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
+      "git",
+      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
       { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
     );
     return result.exitCode === 0 && result.stdout.trim() ? ref : null;

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -23,12 +23,17 @@ type SessionTokenSummary = {
   sessionEnd: string | null;
 };
 
-type HarvestAgent = Pick<AgentRecord, "id" | "type" | "cwd" | "worktreePath"> & {
+type HarvestAgent = Pick<
+  AgentRecord,
+  "id" | "type" | "cwd" | "worktreePath"
+> & {
   /** When set, only harvest this specific session file instead of all files in the project dir. */
   cliSessionId?: string;
 };
 
-type HarvestLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
+type HarvestLogger = {
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+};
 
 const UPSERT_SQL = `INSERT INTO agent_token_usage
   (agent_id, session_id, model, input_tokens, cache_creation_tokens, cache_read_tokens,
@@ -69,7 +74,9 @@ export async function discoverSessionFiles(dir: string): Promise<string[]> {
     .map((f) => path.join(dir, f));
 }
 
-async function parseClaudeSessionTokenUsage(filePath: string): Promise<SessionTokenSummary> {
+async function parseClaudeSessionTokenUsage(
+  filePath: string
+): Promise<SessionTokenSummary> {
   const sessionId = path.basename(filePath, ".jsonl");
   const totals = new Map<string, ModelTokenTotals>();
   let sessionStart: string | null = null;
@@ -104,7 +111,13 @@ async function parseClaudeSessionTokenUsage(filePath: string): Promise<SessionTo
 
     let bucket = totals.get(model);
     if (!bucket) {
-      bucket = { inputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, outputTokens: 0, messageCount: 0 };
+      bucket = {
+        inputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        outputTokens: 0,
+        messageCount: 0,
+      };
       totals.set(model, bucket);
     }
 
@@ -131,7 +144,9 @@ async function harvestClaudeTokenUsage(
   // When the agent has a known CLI session ID, only harvest that specific file.
   // This ensures agents sharing the same cwd don't claim each other's sessions.
   if (agent.cliSessionId) {
-    files = files.filter((f) => path.basename(f, ".jsonl") === agent.cliSessionId);
+    files = files.filter(
+      (f) => path.basename(f, ".jsonl") === agent.cliSessionId
+    );
     if (files.length === 0) return;
   }
 
@@ -156,7 +171,10 @@ async function harvestClaudeTokenUsage(
         ]);
       }
     } catch (err) {
-      logger?.warn({ err, file }, "Failed to parse Claude session file for token usage");
+      logger?.warn(
+        { err, file },
+        "Failed to parse Claude session file for token usage"
+      );
     }
   }
 }
@@ -183,7 +201,9 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
   async function walk(dir: string): Promise<void> {
     let entries: import("node:fs").Dirent[];
     try {
-      entries = await readdir(dir, { withFileTypes: true }) as import("node:fs").Dirent[];
+      entries = (await readdir(dir, {
+        withFileTypes: true,
+      })) as import("node:fs").Dirent[];
     } catch {
       return;
     }
@@ -209,7 +229,12 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
 async function parseCodexRolloutForAgent(
   filePath: string,
   agentId: string
-): Promise<{ usage: CodexTokenUsage; model: string; sessionStart: string | null; sessionEnd: string | null } | null> {
+): Promise<{
+  usage: CodexTokenUsage;
+  model: string;
+  sessionStart: string | null;
+  sessionEnd: string | null;
+} | null> {
   let matched = false;
   let lastUsage: CodexTokenUsage | null = null;
   let model = "unknown";
@@ -282,7 +307,8 @@ async function harvestCodexTokenUsage(
       const sessionId = path.basename(file, ".jsonl");
 
       // Normalize to additive model: cached_input_tokens is a subset of input_tokens
-      const nonCachedInput = usage.input_tokens - (usage.cached_input_tokens ?? 0);
+      const nonCachedInput =
+        usage.input_tokens - (usage.cached_input_tokens ?? 0);
       const cachedInput = usage.cached_input_tokens ?? 0;
 
       await pool.query(UPSERT_SQL, [
@@ -298,7 +324,10 @@ async function harvestCodexTokenUsage(
         sessionEnd,
       ]);
     } catch (err) {
-      logger?.warn({ err, file }, "Failed to parse Codex rollout for token usage");
+      logger?.warn(
+        { err, file },
+        "Failed to parse Codex rollout for token usage"
+      );
     }
   }
 }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -15,11 +15,18 @@ function hashToken(token: string): string {
 
 function createMcpScopeToken(secret: string, scope: string): string {
   const payload = Buffer.from(scope, "utf-8").toString("base64url");
-  const signature = crypto.createHmac("sha256", secret).update(scope).digest("base64url");
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(scope)
+    .digest("base64url");
   return `${payload}.${signature}`;
 }
 
-function validateMcpScopeToken(secret: string, token: string, expectedScope: string): boolean {
+function validateMcpScopeToken(
+  secret: string,
+  token: string,
+  expectedScope: string
+): boolean {
   const expected = createMcpScopeToken(secret, expectedScope);
   const actualBuffer = Buffer.from(token, "utf-8");
   const expectedBuffer = Buffer.from(expected, "utf-8");
@@ -36,7 +43,10 @@ export async function setPassword(pool: Pool, password: string): Promise<void> {
   await setSetting(pool, "password_hash", hash);
 }
 
-export async function verifyPassword(pool: Pool, password: string): Promise<boolean> {
+export async function verifyPassword(
+  pool: Pool,
+  password: string
+): Promise<boolean> {
   const hash = await getSetting(pool, "password_hash");
   if (!hash) return false;
   return bcrypt.compare(password, hash);
@@ -44,15 +54,20 @@ export async function verifyPassword(pool: Pool, password: string): Promise<bool
 
 export async function createSession(pool: Pool): Promise<string> {
   const token = crypto.randomUUID();
-  const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
-  await pool.query(
-    "INSERT INTO sessions (token, expires_at) VALUES ($1, $2)",
-    [hashToken(token), expiresAt]
+  const expiresAt = new Date(
+    Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000
   );
+  await pool.query("INSERT INTO sessions (token, expires_at) VALUES ($1, $2)", [
+    hashToken(token),
+    expiresAt,
+  ]);
   return token;
 }
 
-export async function validateSession(pool: Pool, token: string): Promise<boolean> {
+export async function validateSession(
+  pool: Pool,
+  token: string
+): Promise<boolean> {
   const hashed = hashToken(token);
   // Single query checks both hashed and legacy plaintext tokens to avoid timing side-channel
   const result = await pool.query(
@@ -64,13 +79,19 @@ export async function validateSession(pool: Pool, token: string): Promise<boolea
   // Upgrade legacy plaintext token to hashed in-place
   const matched = result.rows[0].token as string;
   if (matched !== hashed) {
-    await pool.query("UPDATE sessions SET token = $1 WHERE token = $2", [hashed, matched]);
+    await pool.query("UPDATE sessions SET token = $1 WHERE token = $2", [
+      hashed,
+      matched,
+    ]);
   }
   return true;
 }
 
 export async function deleteSession(pool: Pool, token: string): Promise<void> {
-  await pool.query("DELETE FROM sessions WHERE token = $1 OR token = $2", [hashToken(token), token]);
+  await pool.query("DELETE FROM sessions WHERE token = $1 OR token = $2", [
+    hashToken(token),
+    token,
+  ]);
 }
 
 export async function deleteAllSessions(pool: Pool): Promise<void> {
@@ -110,10 +131,17 @@ export function isMcpRoute(url: string): boolean {
 }
 
 export function isScopedMcpRoute(url: string): boolean {
-  return /^\/api\/mcp\/[^/]+$/.test(url) || /^\/api\/mcp\/jobs\/[^/]+\/[^/]+$/.test(url);
+  return (
+    /^\/api\/mcp\/[^/]+$/.test(url) ||
+    /^\/api\/mcp\/jobs\/[^/]+\/[^/]+$/.test(url)
+  );
 }
 
-export function shouldAcceptApiBearerToken(url: string, token: string, serverAuthToken: string): boolean {
+export function shouldAcceptApiBearerToken(
+  url: string,
+  token: string,
+  serverAuthToken: string
+): boolean {
   return token === serverAuthToken;
 }
 
@@ -121,15 +149,28 @@ export function createAgentMcpToken(secret: string, agentId: string): string {
   return createMcpScopeToken(secret, `agent:${agentId}`);
 }
 
-export function validateAgentMcpToken(secret: string, token: string, agentId: string): boolean {
+export function validateAgentMcpToken(
+  secret: string,
+  token: string,
+  agentId: string
+): boolean {
   return validateMcpScopeToken(secret, token, `agent:${agentId}`);
 }
 
-export function createJobMcpToken(secret: string, runId: string, agentId: string): string {
+export function createJobMcpToken(
+  secret: string,
+  runId: string,
+  agentId: string
+): string {
   return createMcpScopeToken(secret, `job:${runId}:${agentId}`);
 }
 
-export function validateJobMcpToken(secret: string, token: string, runId: string, agentId: string): boolean {
+export function validateJobMcpToken(
+  secret: string,
+  token: string,
+  runId: string,
+  agentId: string
+): boolean {
   return validateMcpScopeToken(secret, token, `job:${runId}:${agentId}`);
 }
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -27,7 +27,9 @@ export type AppConfig = {
 };
 
 function expandHome(p: string): string {
-  return p.startsWith("~/") ? path.join(process.env.HOME ?? "/tmp", p.slice(2)) : p;
+  return p.startsWith("~/")
+    ? path.join(process.env.HOME ?? "/tmp", p.slice(2))
+    : p;
 }
 
 function loadTls(): TlsConfig | null {
@@ -48,7 +50,9 @@ function resolveAgentRuntime(): "tmux" | "inert" {
   if (env === "tmux") return "tmux";
   if (env === "inert") return "inert";
   if (env) {
-    console.warn(`Unknown DISPATCH_AGENT_RUNTIME="${env}", falling back to auto-detection`);
+    console.warn(
+      `Unknown DISPATCH_AGENT_RUNTIME="${env}", falling back to auto-detection`
+    );
   }
   // No explicit setting — default to tmux if it's available on PATH
   try {
@@ -56,7 +60,9 @@ function resolveAgentRuntime(): "tmux" | "inert" {
     console.log("Agent runtime auto-detected: tmux");
     return "tmux";
   } catch {
-    console.warn("tmux not found on PATH — agent runtime set to inert (agents will not execute)");
+    console.warn(
+      "tmux not found on PATH — agent runtime set to inert (agents will not execute)"
+    );
     return "inert";
   }
 }
@@ -66,18 +72,17 @@ export function loadConfig(): AppConfig {
     host: process.env.DISPATCH_HOST ?? process.env.HOST ?? "127.0.0.1",
     port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 6767),
     databaseUrl:
-      process.env.DATABASE_URL ?? "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
+      process.env.DATABASE_URL ??
+      "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
     authToken: "", // resolved from DB in start() via getOrCreateAuthToken()
-    mediaRoot: process.env.MEDIA_ROOT ?? path.join(process.env.HOME ?? "/tmp", ".dispatch", "media"),
+    mediaRoot:
+      process.env.MEDIA_ROOT ??
+      path.join(process.env.HOME ?? "/tmp", ".dispatch", "media"),
     dispatchBinDir: path.resolve(__dirname, "..", "..", "..", "bin"),
     codexBin:
-      process.env.DISPATCH_CODEX_BIN ??
-      process.env.CODEX_BIN ??
-      "codex",
+      process.env.DISPATCH_CODEX_BIN ?? process.env.CODEX_BIN ?? "codex",
     claudeBin:
-      process.env.DISPATCH_CLAUDE_BIN ??
-      process.env.CLAUDE_BIN ??
-      "claude",
+      process.env.DISPATCH_CLAUDE_BIN ?? process.env.CLAUDE_BIN ?? "claude",
     opencodeBin:
       process.env.DISPATCH_OPENCODE_BIN ??
       process.env.OPENCODE_BIN ??
@@ -99,7 +104,7 @@ function validateConfig(config: AppConfig): void {
   if (config.host === "0.0.0.0") {
     console.warn(
       `${WARN_PREFIX} Server is binding to 0.0.0.0 (all interfaces). ` +
-        `Ensure a password is set or use DISPATCH_HOST=127.0.0.1 to restrict to localhost.`,
+        `Ensure a password is set or use DISPATCH_HOST=127.0.0.1 to restrict to localhost.`
     );
   }
 
@@ -107,22 +112,23 @@ function validateConfig(config: AppConfig): void {
     const dbUrl = new URL(config.databaseUrl);
     const isDefaultUser = dbUrl.username === "dispatch";
     const isDefaultPass = dbUrl.password === "dispatch";
-    const isLocalhost = ["127.0.0.1", "localhost", "::1"].includes(dbUrl.hostname);
+    const isLocalhost = ["127.0.0.1", "localhost", "::1"].includes(
+      dbUrl.hostname
+    );
     if (isDefaultUser && isDefaultPass && !isLocalhost) {
       console.warn(
         `${WARN_PREFIX} Default database credentials (dispatch:dispatch) used with non-localhost host. ` +
-          `Set a strong password via DATABASE_URL.`,
+          `Set a strong password via DATABASE_URL.`
       );
     } else if (isDefaultUser && isDefaultPass) {
       console.warn(
         `${WARN_PREFIX} Default database credentials (dispatch:dispatch) detected. ` +
-          `Consider setting a unique password in DATABASE_URL for production use.`,
+          `Consider setting a unique password in DATABASE_URL for production use.`
       );
     }
   } catch {
     // URL parsing failed — not our problem to warn about here
   }
-
 }
 
 export function assertSafeDatabaseConfig(

--- a/apps/server/src/db/client.ts
+++ b/apps/server/src/db/client.ts
@@ -17,7 +17,7 @@ export function createPool(config: AppConfig): Pool {
   const pool = new Pool({
     connectionString: config.databaseUrl,
     max: 10,
-    idleTimeoutMillis: 30_000
+    idleTimeoutMillis: 30_000,
   });
   // Prevent unhandled 'error' events on idle clients from crashing the process.
   // Connection errors during shutdown (e.g. pg_terminate_backend in tests) are

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -26,7 +26,7 @@ export async function runMigrations(
   const opts: MigrationOptions =
     typeof optionsOrUrl === "string"
       ? { databaseUrl: optionsOrUrl }
-      : optionsOrUrl ?? {};
+      : (optionsOrUrl ?? {});
 
   const url = opts.databaseUrl ?? loadConfig().databaseUrl;
 
@@ -47,7 +47,9 @@ export async function runMigrations(
 
     console.log("Migrations completed.");
   } finally {
-    await lockClient.query("SELECT pg_advisory_unlock($1)", [MIGRATION_LOCK_ID]).catch(() => null);
+    await lockClient
+      .query("SELECT pg_advisory_unlock($1)", [MIGRATION_LOCK_ID])
+      .catch(() => null);
     await lockClient.end().catch(() => null);
   }
 }

--- a/apps/server/src/db/settings.ts
+++ b/apps/server/src/db/settings.ts
@@ -1,7 +1,10 @@
 import type { Pool } from "pg";
 
 /** Read a single value from the settings table. Returns null if unset. */
-export async function getSetting(pool: Pool, key: string): Promise<string | null> {
+export async function getSetting(
+  pool: Pool,
+  key: string
+): Promise<string | null> {
   const result = await pool.query<{ value: string }>(
     "SELECT value FROM settings WHERE key = $1",
     [key]
@@ -10,7 +13,11 @@ export async function getSetting(pool: Pool, key: string): Promise<string | null
 }
 
 /** Upsert a value in the settings table. */
-export async function setSetting(pool: Pool, key: string, value: string): Promise<void> {
+export async function setSetting(
+  pool: Pool,
+  key: string,
+  value: string
+): Promise<void> {
   await pool.query(
     `INSERT INTO settings (key, value, updated_at)
      VALUES ($1, $2, NOW())

--- a/apps/server/src/focus-tracker.ts
+++ b/apps/server/src/focus-tracker.ts
@@ -59,7 +59,8 @@ export class FocusTracker {
     if (this.webNotifyPermission !== "granted") return false;
     // Expire stale permission reports — if the client stopped sending
     // heartbeats, assume permission is no longer available.
-    if (Date.now() - this.webNotifyPermissionUpdatedAt > FOCUS_TTL_MS) return false;
+    if (Date.now() - this.webNotifyPermissionUpdatedAt > FOCUS_TTL_MS)
+      return false;
     return true;
   }
 }

--- a/apps/server/src/jobs/report.ts
+++ b/apps/server/src/jobs/report.ts
@@ -27,7 +27,10 @@ export type JobReport = {
   tasks: JobReportTask[];
 };
 
-export function validateTerminalJobReport(value: unknown, expectedStatus: "completed" | "failed"): JobReport {
+export function validateTerminalJobReport(
+  value: unknown,
+  expectedStatus: "completed" | "failed"
+): JobReport {
   const report = validateJobReport(value);
   if (report.status !== expectedStatus) {
     throw new Error(`report.status must be "${expectedStatus}".`);
@@ -48,26 +51,38 @@ export function validateJobReport(value: unknown): JobReport {
   if (!isRecord(value)) throw new Error("report must be an object.");
   const status = value.status;
   if (status !== "completed" && status !== "failed" && status !== "running") {
-    throw new Error('report.status must be one of: "completed", "failed", "running".');
+    throw new Error(
+      'report.status must be one of: "completed", "failed", "running".'
+    );
   }
   const summary = readNonEmptyString(value.summary, "report.summary");
-  if (summary.length > MAX_SUMMARY_LENGTH) throw new Error(`report.summary exceeds ${MAX_SUMMARY_LENGTH} character limit.`);
-  if (!Array.isArray(value.tasks)) throw new Error("report.tasks must be an array.");
-  if (value.tasks.length > MAX_TASKS) throw new Error(`report.tasks exceeds ${MAX_TASKS} task limit.`);
+  if (summary.length > MAX_SUMMARY_LENGTH)
+    throw new Error(
+      `report.summary exceeds ${MAX_SUMMARY_LENGTH} character limit.`
+    );
+  if (!Array.isArray(value.tasks))
+    throw new Error("report.tasks must be an array.");
+  if (value.tasks.length > MAX_TASKS)
+    throw new Error(`report.tasks exceeds ${MAX_TASKS} task limit.`);
   const tasks = value.tasks.map((task, index) => validateTask(task, index));
   const report: JobReport = { status, summary, tasks };
   const serialized = JSON.stringify(report);
   if (Buffer.byteLength(serialized, "utf-8") > MAX_REPORT_BYTES) {
-    throw new Error(`Report exceeds ${MAX_REPORT_BYTES / 1_000_000}MB size limit.`);
+    throw new Error(
+      `Report exceeds ${MAX_REPORT_BYTES / 1_000_000}MB size limit.`
+    );
   }
   return report;
 }
 
-export function appendJobLog(report: JobReport | null, input: {
-  task: string;
-  message: string;
-  level: "debug" | "info" | "warn" | "error";
-}): JobReport {
+export function appendJobLog(
+  report: JobReport | null,
+  input: {
+    task: string;
+    message: string;
+    level: "debug" | "info" | "warn" | "error";
+  }
+): JobReport {
   const taskName = input.task.trim();
   const message = input.message.trim();
   if (!taskName) throw new Error("task must be a non-empty string.");
@@ -77,14 +92,20 @@ export function appendJobLog(report: JobReport | null, input: {
     ? {
         status: report.status,
         summary: report.summary,
-        tasks: report.tasks.map((task) => ({ ...task, errors: task.errors ? [...task.errors] : undefined, logs: task.logs ? [...task.logs] : undefined }))
+        tasks: report.tasks.map((task) => ({
+          ...task,
+          errors: task.errors ? [...task.errors] : undefined,
+          logs: task.logs ? [...task.logs] : undefined,
+        })),
       }
     : { status: "running", summary: "Job is running.", tasks: [] };
 
   let task = next.tasks.find((candidate) => candidate.name === taskName);
   if (!task) {
     if (next.tasks.length >= MAX_TASKS) {
-      throw new Error(`Cannot add task "${taskName}": report already has ${MAX_TASKS} tasks.`);
+      throw new Error(
+        `Cannot add task "${taskName}": report already has ${MAX_TASKS} tasks.`
+      );
     }
     task = { name: taskName, status: "success", summary: "", logs: [] };
     next.tasks.push(task);
@@ -95,58 +116,112 @@ export function appendJobLog(report: JobReport | null, input: {
     {
       message: message.slice(0, MAX_LOG_MESSAGE_LENGTH),
       level: input.level,
-      createdAt: new Date().toISOString()
-    }
+      createdAt: new Date().toISOString(),
+    },
   ];
   // Keep only the most recent entries if we exceed the cap
-  task.logs = logs.length > MAX_LOGS_PER_TASK ? logs.slice(-MAX_LOGS_PER_TASK) : logs;
+  task.logs =
+    logs.length > MAX_LOGS_PER_TASK ? logs.slice(-MAX_LOGS_PER_TASK) : logs;
   return next;
 }
 
 function validateTask(value: unknown, index: number): JobReportTask {
-  if (!isRecord(value)) throw new Error(`report.tasks[${index}] must be an object.`);
+  if (!isRecord(value))
+    throw new Error(`report.tasks[${index}] must be an object.`);
   const status = value.status;
   if (status !== "success" && status !== "skipped" && status !== "error") {
-    throw new Error(`report.tasks[${index}].status must be one of: "success", "skipped", "error".`);
+    throw new Error(
+      `report.tasks[${index}].status must be one of: "success", "skipped", "error".`
+    );
   }
   const name = readNonEmptyString(value.name, `report.tasks[${index}].name`);
-  if (name.length > MAX_TASK_NAME_LENGTH) throw new Error(`report.tasks[${index}].name exceeds ${MAX_TASK_NAME_LENGTH} character limit.`);
-  const summary = typeof value.summary === "string" ? value.summary.slice(0, MAX_SUMMARY_LENGTH) : "";
+  if (name.length > MAX_TASK_NAME_LENGTH)
+    throw new Error(
+      `report.tasks[${index}].name exceeds ${MAX_TASK_NAME_LENGTH} character limit.`
+    );
+  const summary =
+    typeof value.summary === "string"
+      ? value.summary.slice(0, MAX_SUMMARY_LENGTH)
+      : "";
   const task: JobReportTask = { name, status, summary };
   if (value.errors !== undefined) {
-    if (!Array.isArray(value.errors)) throw new Error(`report.tasks[${index}].errors must be an array.`);
-    if (value.errors.length > MAX_ERRORS_PER_TASK) throw new Error(`report.tasks[${index}].errors exceeds ${MAX_ERRORS_PER_TASK} error limit.`);
-    task.errors = value.errors.map((error, errorIndex) => validateTaskError(error, index, errorIndex));
+    if (!Array.isArray(value.errors))
+      throw new Error(`report.tasks[${index}].errors must be an array.`);
+    if (value.errors.length > MAX_ERRORS_PER_TASK)
+      throw new Error(
+        `report.tasks[${index}].errors exceeds ${MAX_ERRORS_PER_TASK} error limit.`
+      );
+    task.errors = value.errors.map((error, errorIndex) =>
+      validateTaskError(error, index, errorIndex)
+    );
   }
   if (value.logs !== undefined) {
-    if (!Array.isArray(value.logs)) throw new Error(`report.tasks[${index}].logs must be an array.`);
-    if (value.logs.length > MAX_LOGS_PER_TASK) throw new Error(`report.tasks[${index}].logs exceeds ${MAX_LOGS_PER_TASK} log limit.`);
-    task.logs = value.logs.map((log, logIndex) => validateTaskLog(log, index, logIndex));
+    if (!Array.isArray(value.logs))
+      throw new Error(`report.tasks[${index}].logs must be an array.`);
+    if (value.logs.length > MAX_LOGS_PER_TASK)
+      throw new Error(
+        `report.tasks[${index}].logs exceeds ${MAX_LOGS_PER_TASK} log limit.`
+      );
+    task.logs = value.logs.map((log, logIndex) =>
+      validateTaskLog(log, index, logIndex)
+    );
   }
   return task;
 }
 
-function validateTaskError(value: unknown, taskIndex: number, errorIndex: number): JobReportError {
-  if (!isRecord(value)) throw new Error(`report.tasks[${taskIndex}].errors[${errorIndex}] must be an object.`);
-  const message = readNonEmptyString(value.message, `report.tasks[${taskIndex}].errors[${errorIndex}].message`);
+function validateTaskError(
+  value: unknown,
+  taskIndex: number,
+  errorIndex: number
+): JobReportError {
+  if (!isRecord(value))
+    throw new Error(
+      `report.tasks[${taskIndex}].errors[${errorIndex}] must be an object.`
+    );
+  const message = readNonEmptyString(
+    value.message,
+    `report.tasks[${taskIndex}].errors[${errorIndex}].message`
+  );
   const error: JobReportError = {
-    message: message.slice(0, MAX_ERROR_MESSAGE_LENGTH)
+    message: message.slice(0, MAX_ERROR_MESSAGE_LENGTH),
   };
-  if (typeof value.recoverable === "boolean") error.recoverable = value.recoverable;
-  if (typeof value.action === "string") error.action = value.action.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+  if (typeof value.recoverable === "boolean")
+    error.recoverable = value.recoverable;
+  if (typeof value.action === "string")
+    error.action = value.action.slice(0, MAX_ERROR_MESSAGE_LENGTH);
   return error;
 }
 
-function validateTaskLog(value: unknown, taskIndex: number, logIndex: number): JobReportLog {
-  if (!isRecord(value)) throw new Error(`report.tasks[${taskIndex}].logs[${logIndex}] must be an object.`);
+function validateTaskLog(
+  value: unknown,
+  taskIndex: number,
+  logIndex: number
+): JobReportLog {
+  if (!isRecord(value))
+    throw new Error(
+      `report.tasks[${taskIndex}].logs[${logIndex}] must be an object.`
+    );
   const level = value.level;
-  if (level !== "debug" && level !== "info" && level !== "warn" && level !== "error") {
-    throw new Error(`report.tasks[${taskIndex}].logs[${logIndex}].level must be one of: "debug", "info", "warn", "error".`);
+  if (
+    level !== "debug" &&
+    level !== "info" &&
+    level !== "warn" &&
+    level !== "error"
+  ) {
+    throw new Error(
+      `report.tasks[${taskIndex}].logs[${logIndex}].level must be one of: "debug", "info", "warn", "error".`
+    );
   }
   return {
-    message: readNonEmptyString(value.message, `report.tasks[${taskIndex}].logs[${logIndex}].message`),
+    message: readNonEmptyString(
+      value.message,
+      `report.tasks[${taskIndex}].logs[${logIndex}].message`
+    ),
     level,
-    createdAt: typeof value.createdAt === "string" ? value.createdAt : new Date().toISOString()
+    createdAt:
+      typeof value.createdAt === "string"
+        ? value.createdAt
+        : new Date().toISOString(),
   };
 }
 

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -7,8 +7,19 @@ import { Cron } from "croner";
 import type { AgentManager } from "../agents/manager.js";
 import type { AppConfig } from "../config.js";
 import { runCommand } from "../shared/lib/run-command.js";
-import { JobStore, type JobAgentType, type JobRecord, type JobRunConfig, type JobRunRecord, type JobWithLatestRun } from "./store.js";
-import { getNextRun, validateCronExpression, validateCronInterval } from "./cron.js";
+import {
+  JobStore,
+  type JobAgentType,
+  type JobRecord,
+  type JobRunConfig,
+  type JobRunRecord,
+  type JobWithLatestRun,
+} from "./store.js";
+import {
+  getNextRun,
+  validateCronExpression,
+  validateCronInterval,
+} from "./cron.js";
 
 export type JobRunCallback = (run: JobRunRecord) => void;
 
@@ -44,8 +55,17 @@ export type RunJobResult = {
 
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_NEEDS_INPUT_TIMEOUT_MS = 24 * 60 * 60 * 1000;
-const TERMINAL_STATUSES = new Set<JobRunRecord["status"]>(["completed", "failed", "timed_out", "crashed"]);
-const ACTIVE_RUN_STATUSES = new Set<JobRunRecord["status"]>(["started", "running", "needs_input"]);
+const TERMINAL_STATUSES = new Set<JobRunRecord["status"]>([
+  "completed",
+  "failed",
+  "timed_out",
+  "crashed",
+]);
+const ACTIVE_RUN_STATUSES = new Set<JobRunRecord["status"]>([
+  "started",
+  "running",
+  "needs_input",
+]);
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 
@@ -75,7 +95,10 @@ export class JobService {
       try {
         cb(run);
       } catch (err) {
-        this.logger.warn({ err, runId: run.id }, "onRunStateChange callback error");
+        this.logger.warn(
+          { err, runId: run.id },
+          "onRunStateChange callback error"
+        );
       }
     }
   }
@@ -84,18 +107,25 @@ export class JobService {
     const job = await this.getJobOrThrow(input.directory, input.name);
 
     if (!job.prompt) {
-      throw new Error(`Job "${job.name}" has no prompt configured. Add a prompt in the job settings.`);
+      throw new Error(
+        `Job "${job.name}" has no prompt configured. Add a prompt in the job settings.`
+      );
     }
 
     // Pre-check for user-friendly error message. The DB unique index
     // (idx_job_runs_one_active_per_job) is the real guard against concurrent races.
     const activeRun = await this.store.findActiveRun(job.id);
     if (activeRun) {
-      throw new Error(`Job "${job.name}" already has active run ${activeRun.id} (${activeRun.status}).`);
+      throw new Error(
+        `Job "${job.name}" already has active run ${activeRun.id} (${activeRun.status}).`
+      );
     }
 
     // Everything below reads from the DB record only
-    let run = await this.store.createRun(job.id, buildRunConfig(job, input.triggerSource ?? "manual"));
+    let run = await this.store.createRun(
+      job.id,
+      buildRunConfig(job, input.triggerSource ?? "manual")
+    );
     this.emitRunStateChange(run);
     const prompt = buildJobPrompt(job, run.id);
 
@@ -108,7 +138,7 @@ export class JobService {
         fullAccess: job.fullAccess,
         useWorktree: job.useWorktree,
         worktreeBranch: job.branchName ?? undefined,
-        jobRunId: run.id
+        jobRunId: run.id,
       });
       run = await this.store.attachAgent(run.id, agent.id);
       this.emitRunStateChange(run);
@@ -121,11 +151,15 @@ export class JobService {
         runId: run.id,
         agentId: agent.id,
         status: run.status,
-        report: run.report
+        report: run.report,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const crashed = await this.markCrashed(run, `Job failed to start: ${message}`, "spawn-agent");
+      const crashed = await this.markCrashed(
+        run,
+        `Job failed to start: ${message}`,
+        "spawn-agent"
+      );
       throw new Error(`Job run ${crashed.id} failed to start: ${message}`);
     }
   }
@@ -145,21 +179,30 @@ export class JobService {
     return await this.store.getLatestRunForAgent(agentId);
   }
 
-  async completeRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+  async completeRunForAgent(
+    agentId: string,
+    report: unknown
+  ): Promise<JobRunRecord> {
     const run = await this.store.completeRunForAgent(agentId, report);
     this.monitors.delete(run.id);
     this.emitRunStateChange(run);
     return run;
   }
 
-  async failRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
+  async failRunForAgent(
+    agentId: string,
+    report: unknown
+  ): Promise<JobRunRecord> {
     const run = await this.store.failRunForAgent(agentId, report);
     this.monitors.delete(run.id);
     this.emitRunStateChange(run);
     return run;
   }
 
-  async markNeedsInputForAgent(agentId: string, question: string): Promise<JobRunRecord> {
+  async markNeedsInputForAgent(
+    agentId: string,
+    question: string
+  ): Promise<JobRunRecord> {
     const run = await this.store.markNeedsInputForAgent(agentId, question);
     this.emitRunStateChange(run);
     return run;
@@ -167,7 +210,11 @@ export class JobService {
 
   async logForAgent(
     agentId: string,
-    input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+    input: {
+      task: string;
+      message: string;
+      level: "debug" | "info" | "warn" | "error";
+    }
   ): Promise<JobRunRecord> {
     return await this.store.logForAgent(agentId, input);
   }
@@ -176,10 +223,14 @@ export class JobService {
     const displayName = input.displayName?.trim() || input.name;
     const schedule = input.schedule === "" ? null : (input.schedule ?? null);
     if (schedule && !validateCronExpression(schedule)) {
-      throw new Error(`Job "${displayName}" has an invalid cron expression: "${schedule}"`);
+      throw new Error(
+        `Job "${displayName}" has an invalid cron expression: "${schedule}"`
+      );
     }
     if (input.enabled && !schedule) {
-      throw new Error(`Job "${displayName}" needs a schedule before it can be enabled.`);
+      throw new Error(
+        `Job "${displayName}" needs a schedule before it can be enabled.`
+      );
     }
 
     const job = await this.store.createJob({
@@ -188,7 +239,8 @@ export class JobService {
       prompt: input.prompt ?? null,
       schedule,
       timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-      needsInputTimeoutMs: input.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
+      needsInputTimeoutMs:
+        input.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
       agentType: input.agentType ?? "claude",
       useWorktree: input.useWorktree ?? false,
       branchName: input.branchName ?? null,
@@ -207,28 +259,39 @@ export class JobService {
     const existing = await this.getJobOrThrow(input.directory, input.name);
 
     const schedule = input.schedule === "" ? null : input.schedule;
-    const nextSchedule = input.schedule === undefined ? existing.schedule : schedule;
+    const nextSchedule =
+      input.schedule === undefined ? existing.schedule : schedule;
     if (nextSchedule && !validateCronExpression(nextSchedule)) {
-      throw new Error(`Job "${input.displayName ?? existing.name}" has an invalid cron expression: "${nextSchedule}"`);
+      throw new Error(
+        `Job "${input.displayName ?? existing.name}" has an invalid cron expression: "${nextSchedule}"`
+      );
     }
     if (input.enabled && !nextSchedule) {
-      throw new Error(`Job "${input.displayName ?? existing.name}" needs a schedule before it can be enabled.`);
+      throw new Error(
+        `Job "${input.displayName ?? existing.name}" needs a schedule before it can be enabled.`
+      );
     }
 
     const config: Parameters<JobStore["updateJobConfig"]>[1] = {};
     const displayName = normalizeOptionalString(input.displayName);
     const branchName = normalizeNullableString(input.branchName);
     if (displayName !== undefined && displayName !== existing.name) {
-      const conflict = await this.store.getJobByDirectoryAndName(input.directory, displayName);
+      const conflict = await this.store.getJobByDirectoryAndName(
+        input.directory,
+        displayName
+      );
       if (conflict) {
-        throw new Error(`A job named "${displayName}" already exists in directory "${input.directory}".`);
+        throw new Error(
+          `A job named "${displayName}" already exists in directory "${input.directory}".`
+        );
       }
       config.name = displayName;
     }
     if (input.prompt !== undefined) config.prompt = input.prompt;
     if (input.schedule !== undefined) config.schedule = schedule;
     if (input.timeoutMs !== undefined) config.timeoutMs = input.timeoutMs;
-    if (input.needsInputTimeoutMs !== undefined) config.needsInputTimeoutMs = input.needsInputTimeoutMs;
+    if (input.needsInputTimeoutMs !== undefined)
+      config.needsInputTimeoutMs = input.needsInputTimeoutMs;
     if (input.agentType !== undefined) config.agentType = input.agentType;
     if (input.useWorktree !== undefined) config.useWorktree = input.useWorktree;
     if (branchName !== undefined) config.branchName = branchName;
@@ -241,18 +304,26 @@ export class JobService {
     } else {
       this.stopScheduler(updated.id);
     }
-    this.logger.info({ jobId: updated.id, name: updated.name }, "Job configuration updated");
+    this.logger.info(
+      { jobId: updated.id, name: updated.name },
+      "Job configuration updated"
+    );
     return updated;
   }
 
-  async enableJob(input: { name: string; directory: string }): Promise<JobRecord> {
+  async enableJob(input: {
+    name: string;
+    directory: string;
+  }): Promise<JobRecord> {
     const job = await this.getJobOrThrow(input.directory, input.name);
     const schedule = job.schedule;
     if (!schedule) {
       throw new Error(`Job "${job.name}" has no schedule configured.`);
     }
     if (!validateCronExpression(schedule)) {
-      throw new Error(`Job "${job.name}" has an invalid cron expression: "${schedule}"`);
+      throw new Error(
+        `Job "${job.name}" has an invalid cron expression: "${schedule}"`
+      );
     }
     const intervalError = validateCronInterval(schedule);
     if (intervalError) {
@@ -260,31 +331,50 @@ export class JobService {
     }
     const updated = await this.store.setEnabled(job.id, true);
     this.scheduleJob(updated);
-    this.logger.info({ jobId: updated.id, name: updated.name, schedule }, "Job enabled with in-process scheduler");
+    this.logger.info(
+      { jobId: updated.id, name: updated.name, schedule },
+      "Job enabled with in-process scheduler"
+    );
     return updated;
   }
 
-  async disableJob(input: { name: string; directory: string }): Promise<JobRecord> {
+  async disableJob(input: {
+    name: string;
+    directory: string;
+  }): Promise<JobRecord> {
     const job = await this.getJobOrThrow(input.directory, input.name);
     const updated = await this.store.setEnabled(job.id, false);
     this.stopScheduler(updated.id);
-    this.logger.info({ jobId: updated.id, name: updated.name }, "Job disabled, scheduler stopped");
+    this.logger.info(
+      { jobId: updated.id, name: updated.name },
+      "Job disabled, scheduler stopped"
+    );
     return updated;
   }
 
-  async removeJob(input: { name: string; directory: string }): Promise<JobRecord> {
+  async removeJob(input: {
+    name: string;
+    directory: string;
+  }): Promise<JobRecord> {
     const job = await this.getJobOrThrow(input.directory, input.name);
     const activeRun = await this.store.findActiveRun(job.id);
     if (activeRun) {
-      throw new Error(`Job "${job.name}" has active run ${activeRun.id} (${activeRun.status}). Stop or complete the run before removing it.`);
+      throw new Error(
+        `Job "${job.name}" has active run ${activeRun.id} (${activeRun.status}). Stop or complete the run before removing it.`
+      );
     }
     this.stopScheduler(job.id);
     const removed = await this.store.deleteJob(job.id);
-    this.logger.info({ jobId: removed.id, name: removed.name }, "Job removed from configuration");
+    this.logger.info(
+      { jobId: removed.id, name: removed.name },
+      "Job removed from configuration"
+    );
     return removed;
   }
 
-  async listJobs(): Promise<Array<JobWithLatestRun & { nextRun: string | null }>> {
+  async listJobs(): Promise<
+    Array<JobWithLatestRun & { nextRun: string | null }>
+  > {
     const jobs = await this.store.listJobs();
     return jobs.map((job) => {
       let nextRun: string | null = null;
@@ -296,7 +386,11 @@ export class JobService {
     });
   }
 
-  async listRunsForJob(input: { name: string; directory: string; limit?: number }): Promise<{
+  async listRunsForJob(input: {
+    name: string;
+    directory: string;
+    limit?: number;
+  }): Promise<{
     job: JobRecord;
     runs: JobRunRecord[];
   }> {
@@ -306,8 +400,21 @@ export class JobService {
   }
 
   async getStats(): Promise<{
-    stats: { totalRuns: number; successCount: number; failureCount: number; avgDurationMs: number | null; daily: Array<{ day: string; completed: number; failed: number }> };
-    recentRuns: Array<{ id: string; jobId: string; status: string; startedAt: string; durationMs: number | null; jobName: string }>;
+    stats: {
+      totalRuns: number;
+      successCount: number;
+      failureCount: number;
+      avgDurationMs: number | null;
+      daily: Array<{ day: string; completed: number; failed: number }>;
+    };
+    recentRuns: Array<{
+      id: string;
+      jobId: string;
+      status: string;
+      startedAt: string;
+      durationMs: number | null;
+      jobName: string;
+    }>;
   }> {
     const [stats, recentRuns] = await Promise.all([
       this.store.getRunStats(7),
@@ -317,7 +424,10 @@ export class JobService {
   }
 
   /** Look up a job by name + directory, or throw if not found. */
-  private async getJobOrThrow(directory: string, name: string): Promise<JobRecord> {
+  private async getJobOrThrow(
+    directory: string,
+    name: string
+  ): Promise<JobRecord> {
     const job = await this.store.getJobByDirectoryAndName(directory, name);
     if (!job) {
       throw new Error(`Job "${name}" not found in directory "${directory}".`);
@@ -333,7 +443,10 @@ export class JobService {
         this.scheduleJob(job);
       }
     }
-    this.logger.info({ count: this.schedulers.size }, "Started in-process schedulers for enabled jobs");
+    this.logger.info(
+      { count: this.schedulers.size },
+      "Started in-process schedulers for enabled jobs"
+    );
   }
 
   /** Stop all in-process schedulers and signal monitors to exit. Called on server shutdown. */
@@ -364,14 +477,22 @@ export class JobService {
           );
           return;
         }
-        await this.runJob({ name: current.name, directory: current.directory, wait: false, triggerSource: "scheduled" });
+        await this.runJob({
+          name: current.name,
+          directory: current.directory,
+          wait: false,
+          triggerSource: "scheduled",
+        });
       } catch (err) {
         this.logger.error({ err, jobId }, "Scheduled job run failed");
       }
     });
 
     this.schedulers.set(jobId, cronJob);
-    this.logger.info({ jobId, name: job.name, schedule: job.schedule }, "In-process scheduler started");
+    this.logger.info(
+      { jobId, name: job.name, schedule: job.schedule },
+      "In-process scheduler started"
+    );
   }
 
   private stopScheduler(jobId: string): void {
@@ -389,7 +510,10 @@ export class JobService {
         this.logger.warn({ err: error, runId }, "Job monitor failed.");
         const run = await this.store.getRun(runId);
         if (run && ACTIVE_RUN_STATUSES.has(run.status)) {
-          return await this.markCrashed(run, error instanceof Error ? error.message : String(error));
+          return await this.markCrashed(
+            run,
+            error instanceof Error ? error.message : String(error)
+          );
         }
         if (run) return run;
         throw error;
@@ -417,13 +541,28 @@ export class JobService {
       const startedAt = new Date(current.startedAt).getTime();
       const statusUpdatedAt = new Date(current.statusUpdatedAt).getTime();
       if (now - startedAt >= current.config.timeoutMs) {
-        return await this.markTimedOut(current, "Job execution timeout elapsed before the agent reported completion.");
+        return await this.markTimedOut(
+          current,
+          "Job execution timeout elapsed before the agent reported completion."
+        );
       }
-      if (current.status === "needs_input" && now - statusUpdatedAt >= current.config.needsInputTimeoutMs) {
-        return await this.markTimedOut(current, "Job timed out waiting for human input.");
+      if (
+        current.status === "needs_input" &&
+        now - statusUpdatedAt >= current.config.needsInputTimeoutMs
+      ) {
+        return await this.markTimedOut(
+          current,
+          "Job timed out waiting for human input."
+        );
       }
-      if (current.agentId && await this.agentSessionCrashed(current.agentId)) {
-        return await this.markCrashed(current, "Agent session ended before reporting a terminal job state.");
+      if (
+        current.agentId &&
+        (await this.agentSessionCrashed(current.agentId))
+      ) {
+        return await this.markCrashed(
+          current,
+          "Agent session ended before reporting a terminal job state."
+        );
       }
       await sleep(2_000);
       const refreshed = await this.store.getRun(runId);
@@ -432,7 +571,10 @@ export class JobService {
     }
 
     if (!TERMINAL_STATUSES.has(current.status)) {
-      this.logger.warn({ runId, status: current.status }, "Job monitor stopped on unexpected status.");
+      this.logger.warn(
+        { runId, status: current.status },
+        "Job monitor stopped on unexpected status."
+      );
     }
     return current;
   }
@@ -443,11 +585,18 @@ export class JobService {
     if (agent.status === "error" || agent.status === "stopped") return true;
     if (this.config.agentRuntime === "inert") return false;
     if (!agent.tmuxSession) return false;
-    const tmux = await runCommand("tmux", ["has-session", "-t", agent.tmuxSession], { allowedExitCodes: [0, 1] });
+    const tmux = await runCommand(
+      "tmux",
+      ["has-session", "-t", agent.tmuxSession],
+      { allowedExitCodes: [0, 1] }
+    );
     return tmux.exitCode !== 0;
   }
 
-  private async markTimedOut(run: JobRunRecord, message: string): Promise<JobRunRecord> {
+  private async markTimedOut(
+    run: JobRunRecord,
+    message: string
+  ): Promise<JobRunRecord> {
     const updated = await this.store.markTimedOut(run.id, {
       status: "failed",
       summary: message,
@@ -456,16 +605,28 @@ export class JobService {
           name: "guardrails",
           status: "error",
           summary: "The job runner timed out the execution.",
-          errors: [{ message, recoverable: true, action: "Inspect the agent session and rerun when ready." }]
-        }
-      ]
+          errors: [
+            {
+              message,
+              recoverable: true,
+              action: "Inspect the agent session and rerun when ready.",
+            },
+          ],
+        },
+      ],
     });
     this.emitRunStateChange(updated);
     return updated;
   }
 
-  private async markCrashed(run: JobRunRecord, message: string, taskName = "guardrails"): Promise<JobRunRecord> {
-    const diagnostics = run.agentId ? await this.readAgentDiagnostics(run.agentId) : "";
+  private async markCrashed(
+    run: JobRunRecord,
+    message: string,
+    taskName = "guardrails"
+  ): Promise<JobRunRecord> {
+    const diagnostics = run.agentId
+      ? await this.readAgentDiagnostics(run.agentId)
+      : "";
     const fullMessage = diagnostics ? `${message}\n\n${diagnostics}` : message;
     this.logger.warn({ runId: run.id, agentId: run.agentId }, message);
     const updated = await this.store.markCrashed(run.id, {
@@ -476,9 +637,15 @@ export class JobService {
           name: taskName,
           status: "error",
           summary: "The job runner detected an agent crash.",
-          errors: [{ message: fullMessage, recoverable: true, action: "Review the agent terminal logs and rerun the job." }]
-        }
-      ]
+          errors: [
+            {
+              message: fullMessage,
+              recoverable: true,
+              action: "Review the agent terminal logs and rerun the job.",
+            },
+          ],
+        },
+      ],
     });
     this.emitRunStateChange(updated);
     return updated;
@@ -486,16 +653,27 @@ export class JobService {
 
   private async readAgentDiagnostics(agentId: string): Promise<string> {
     const sections: string[] = [];
-    const setupLog = await readFile(`/tmp/dispatch_setup_${agentId}.log`, "utf8").catch(() => "");
+    const setupLog = await readFile(
+      `/tmp/dispatch_setup_${agentId}.log`,
+      "utf8"
+    ).catch(() => "");
     if (setupLog.trim()) {
-      sections.push(`Setup log tail:\n${setupLog.trim().split("\n").slice(-20).join("\n")}`);
+      sections.push(
+        `Setup log tail:\n${setupLog.trim().split("\n").slice(-20).join("\n")}`
+      );
     }
 
     const agent = await this.agentManager.getAgent(agentId);
     if (agent?.tmuxSession) {
-      const pane = await runCommand("tmux", ["capture-pane", "-pt", agent.tmuxSession], { allowedExitCodes: [0, 1] });
+      const pane = await runCommand(
+        "tmux",
+        ["capture-pane", "-pt", agent.tmuxSession],
+        { allowedExitCodes: [0, 1] }
+      );
       if (pane.exitCode === 0 && pane.stdout.trim()) {
-        sections.push(`Terminal pane tail:\n${pane.stdout.trim().split("\n").slice(-40).join("\n")}`);
+        sections.push(
+          `Terminal pane tail:\n${pane.stdout.trim().split("\n").slice(-40).join("\n")}`
+        );
       }
     }
 
@@ -503,7 +681,11 @@ export class JobService {
   }
 }
 
-function buildAgentArgs(agentType: JobRecord["agentType"], prompt: string, fullAccess: boolean): string[] {
+function buildAgentArgs(
+  agentType: JobRecord["agentType"],
+  prompt: string,
+  fullAccess: boolean
+): string[] {
   const args = ["--append-system-prompt", prompt];
   const fullAccessArg =
     agentType === "claude"
@@ -520,13 +702,17 @@ function buildAgentArgs(agentType: JobRecord["agentType"], prompt: string, fullA
   return args;
 }
 
-function buildRunConfig(job: JobRecord, triggerSource: "manual" | "scheduled"): JobRunConfig {
+function buildRunConfig(
+  job: JobRecord,
+  triggerSource: "manual" | "scheduled"
+): JobRunConfig {
   return {
     directory: job.directory,
     name: job.name,
     schedule: job.schedule,
     timeoutMs: job.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    needsInputTimeoutMs: job.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
+    needsInputTimeoutMs:
+      job.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
     notify: job.notify ?? { onComplete: [], onError: [], onNeedsInput: [] },
     triggerSource,
   };
@@ -543,7 +729,7 @@ function buildJobPrompt(job: JobRecord, runId: string): string {
     "Terminal completed/failed states must include a structured report with status, summary, and tasks.",
     "Use repo tools when they are relevant to the job.",
     "\nJob prompt:",
-    job.prompt!
+    job.prompt!,
   ].join("\n");
 }
 
@@ -555,12 +741,16 @@ function sanitizeAgentName(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 60);
 }
 
-function normalizeOptionalString(value: string | undefined): string | undefined {
+function normalizeOptionalString(
+  value: string | undefined
+): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
 }
 
-function normalizeNullableString(value: string | null | undefined): string | null | undefined {
+function normalizeNullableString(
+  value: string | null | undefined
+): string | null | undefined {
   if (value === undefined) return undefined;
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 
 import type { Pool } from "pg";
 
-import { appendJobLog, validateJobReport, validateTerminalJobReport, type JobReport } from "./report.js";
+import {
+  appendJobLog,
+  validateJobReport,
+  validateTerminalJobReport,
+  type JobReport,
+} from "./report.js";
 
 export type JobNotifyConfig = {
   onComplete: string[];
@@ -11,7 +16,14 @@ export type JobNotifyConfig = {
   onNeedsInput: string[];
 };
 
-export type JobRunStatus = "started" | "running" | "completed" | "failed" | "needs_input" | "timed_out" | "crashed";
+export type JobRunStatus =
+  | "started"
+  | "running"
+  | "completed"
+  | "failed"
+  | "needs_input"
+  | "timed_out"
+  | "crashed";
 export type JobAgentType = "claude" | "codex" | "opencode";
 
 export type JobRecord = {
@@ -47,7 +59,11 @@ export type JobRunRecord = {
   createdAt: string;
 };
 
-const ACTIVE_RUN_STATUSES: JobRunStatus[] = ["started", "running", "needs_input"];
+const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
+  "started",
+  "running",
+  "needs_input",
+];
 
 export type JobWithLatestRun = JobRecord & {
   lastRunId: string | null;
@@ -123,7 +139,9 @@ export class JobStore {
       return mapJob(result.rows[0]);
     } catch (error) {
       if (isUniqueViolation(error)) {
-        throw new Error(`A job named "${input.name}" already exists in directory "${input.directory}".`);
+        throw new Error(
+          `A job named "${input.name}" already exists in directory "${input.directory}".`
+        );
       }
       throw error;
     }
@@ -158,7 +176,9 @@ export class JobStore {
     } catch (error) {
       if (isUniqueViolation(error)) {
         const activeRun = await this.findActiveRun(jobId);
-        throw new Error(`Job already has active run ${activeRun?.id ?? "unknown"}.`);
+        throw new Error(
+          `Job already has active run ${activeRun?.id ?? "unknown"}.`
+        );
       }
       throw error;
     }
@@ -178,15 +198,32 @@ export class JobStore {
     return mapRun(result.rows[0]);
   }
 
-  async completeRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
-    return this.setTerminalRunForAgent(agentId, "completed", validateTerminalJobReport(report, "completed"));
+  async completeRunForAgent(
+    agentId: string,
+    report: unknown
+  ): Promise<JobRunRecord> {
+    return this.setTerminalRunForAgent(
+      agentId,
+      "completed",
+      validateTerminalJobReport(report, "completed")
+    );
   }
 
-  async failRunForAgent(agentId: string, report: unknown): Promise<JobRunRecord> {
-    return this.setTerminalRunForAgent(agentId, "failed", validateTerminalJobReport(report, "failed"));
+  async failRunForAgent(
+    agentId: string,
+    report: unknown
+  ): Promise<JobRunRecord> {
+    return this.setTerminalRunForAgent(
+      agentId,
+      "failed",
+      validateTerminalJobReport(report, "failed")
+    );
   }
 
-  async markNeedsInputForAgent(agentId: string, question: string): Promise<JobRunRecord> {
+  async markNeedsInputForAgent(
+    agentId: string,
+    question: string
+  ): Promise<JobRunRecord> {
     const trimmed = question.trim();
     if (!trimmed) throw new Error("question must be a non-empty string.");
     const result = await this.pool.query(
@@ -202,15 +239,19 @@ export class JobStore {
       `,
       [agentId, trimmed, ACTIVE_RUN_STATUSES]
     );
-    if (!result.rows[0]) throw new Error(`No active job run found for agent ${agentId}.`);
+    if (!result.rows[0])
+      throw new Error(`No active job run found for agent ${agentId}.`);
     return mapRun(result.rows[0]);
   }
 
-  async logForAgent(agentId: string, input: {
-    task: string;
-    message: string;
-    level: "debug" | "info" | "warn" | "error";
-  }): Promise<JobRunRecord> {
+  async logForAgent(
+    agentId: string,
+    input: {
+      task: string;
+      message: string;
+      level: "debug" | "info" | "warn" | "error";
+    }
+  ): Promise<JobRunRecord> {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
@@ -259,7 +300,10 @@ export class JobStore {
   }
 
   async getRun(runId: string): Promise<JobRunRecord | null> {
-    const result = await this.pool.query(`SELECT ${this.runColumns()} FROM job_runs WHERE id = $1`, [runId]);
+    const result = await this.pool.query(
+      `SELECT ${this.runColumns()} FROM job_runs WHERE id = $1`,
+      [runId]
+    );
     return result.rows[0] ? mapRun(result.rows[0]) : null;
   }
 
@@ -353,14 +397,16 @@ export class JobStore {
     return result.rows.map((row) => mapRun(row));
   }
 
-  async listRecentRuns(limit = 10): Promise<Array<{
-    id: string;
-    jobId: string;
-    status: JobRunStatus;
-    startedAt: string;
-    durationMs: number | null;
-    jobName: string;
-  }>> {
+  async listRecentRuns(limit = 10): Promise<
+    Array<{
+      id: string;
+      jobId: string;
+      status: JobRunStatus;
+      startedAt: string;
+      durationMs: number | null;
+      jobName: string;
+    }>
+  > {
     const result = await this.pool.query(
       `
       SELECT
@@ -443,7 +489,10 @@ export class JobStore {
     return result.rows[0] ? mapJob(result.rows[0]) : null;
   }
 
-  async getJobByDirectoryAndName(directory: string, name: string): Promise<JobRecord | null> {
+  async getJobByDirectoryAndName(
+    directory: string,
+    name: string
+  ): Promise<JobRecord | null> {
     const result = await this.pool.query(
       `SELECT ${this.jobColumns()} FROM jobs WHERE directory = $1 AND name = $2`,
       [path.resolve(directory), name]
@@ -465,7 +514,10 @@ export class JobStore {
     return mapJob(result.rows[0]);
   }
 
-  async updateJobConfig(jobId: string, input: JobConfigUpdate): Promise<JobRecord> {
+  async updateJobConfig(
+    jobId: string,
+    input: JobConfigUpdate
+  ): Promise<JobRecord> {
     try {
       const result = await this.pool.query(
         `
@@ -505,7 +557,9 @@ export class JobStore {
       return mapJob(result.rows[0]);
     } catch (error) {
       if (isUniqueViolation(error)) {
-        throw new Error(`A job named "${input.name}" already exists in this directory.`);
+        throw new Error(
+          `A job named "${input.name}" already exists in this directory.`
+        );
       }
       throw error;
     }
@@ -555,7 +609,9 @@ export class JobStore {
     if (!result.rows[0]) {
       const existing = await this.getRun(runId);
       if (!existing) throw new Error(`Job run ${runId} not found.`);
-      throw new Error(`Job run ${runId} is no longer active (${existing.status}).`);
+      throw new Error(
+        `Job run ${runId} is no longer active (${existing.status}).`
+      );
     }
     return mapRun(result.rows[0]);
   }
@@ -611,5 +667,10 @@ function mapJobWithLatestRun(row: Record<string, unknown>): JobWithLatestRun {
 }
 
 function isUniqueViolation(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "23505";
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "23505"
+  );
 }

--- a/apps/server/src/notifications/job-notifier.ts
+++ b/apps/server/src/notifications/job-notifier.ts
@@ -58,7 +58,10 @@ export class JobNotifier {
         if (channel === "slack") {
           await this.sendSlackNotification(run, event);
         } else {
-          this.log.debug({ channel, runId: run.id }, "Unknown notification channel, skipping");
+          this.log.debug(
+            { channel, runId: run.id },
+            "Unknown notification channel, skipping"
+          );
         }
       }
     } catch (err) {
@@ -79,18 +82,27 @@ export class JobNotifier {
     }
   }
 
-  private async sendSlackNotification(run: JobRunRecord, event: JobEvent): Promise<void> {
+  private async sendSlackNotification(
+    run: JobRunRecord,
+    event: JobEvent
+  ): Promise<void> {
     const webhookUrl = await this.getCachedWebhookUrl();
     if (!webhookUrl) {
-      this.log.debug({ runId: run.id }, "No Slack webhook configured, skipping job notification");
+      this.log.debug(
+        { runId: run.id },
+        "No Slack webhook configured, skipping job notification"
+      );
       return;
     }
 
     const cfg = EVENT_CONFIG[event];
     const jobName = escapeSlackMrkdwn(run.config.name);
     const directory = run.config.directory;
-    const summary = escapeSlackMrkdwn(run.report?.summary ?? run.pendingQuestion ?? "");
-    const duration = run.durationMs != null ? this.formatDuration(run.durationMs) : null;
+    const summary = escapeSlackMrkdwn(
+      run.report?.summary ?? run.pendingQuestion ?? ""
+    );
+    const duration =
+      run.durationMs != null ? this.formatDuration(run.durationMs) : null;
 
     const statusLabel = run.status === "timed_out" ? "timed out" : run.status;
 
@@ -127,7 +139,10 @@ export class JobNotifier {
 
     if (!res.ok) {
       const body = await res.text();
-      this.log.warn({ status: res.status, body }, "Slack webhook returned error for job notification");
+      this.log.warn(
+        { status: res.status, body },
+        "Slack webhook returned error for job notification"
+      );
     }
   }
 
@@ -136,7 +151,10 @@ export class JobNotifier {
       return this.cachedWebhook.url;
     }
     const url = await getSetting(this.pool, SETTING_WEBHOOK_URL);
-    this.cachedWebhook = { url: url ?? null, expiresAt: Date.now() + CACHE_TTL_MS };
+    this.cachedWebhook = {
+      url: url ?? null,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    };
     return this.cachedWebhook.url;
   }
 
@@ -155,5 +173,8 @@ export class JobNotifier {
 
 /** Escape characters that Slack interprets as mrkdwn or link syntax. */
 function escapeSlackMrkdwn(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -12,13 +12,23 @@ type SlackBlock =
 const NOTIFY_EVENT_TYPES = ["done", "waiting_user", "blocked"] as const;
 type NotifyEventType = (typeof NOTIFY_EVENT_TYPES)[number];
 
-const EVENT_CONFIG: Record<NotifyEventType, { emoji: string; verb: string; color: string }> = {
+const EVENT_CONFIG: Record<
+  NotifyEventType,
+  { emoji: string; verb: string; color: string }
+> = {
   done: { emoji: "\u2705", verb: "finished", color: "#22c55e" },
-  waiting_user: { emoji: "\ud83d\udfe1", verb: "needs your input", color: "#f59e0b" },
+  waiting_user: {
+    emoji: "\ud83d\udfe1",
+    verb: "needs your input",
+    color: "#f59e0b",
+  },
   blocked: { emoji: "\ud83d\udd34", verb: "is blocked", color: "#ef4444" },
 };
 
-const LEVEL_CONFIG: Record<NonNullable<NotifyInput["level"]>, { emoji: string; color: string }> = {
+const LEVEL_CONFIG: Record<
+  NonNullable<NotifyInput["level"]>,
+  { emoji: string; color: string }
+> = {
   info: { emoji: "\u2139\ufe0f", color: "#3b82f6" },
   success: { emoji: "\u2705", color: "#22c55e" },
   warning: { emoji: "\u26a0\ufe0f", color: "#f59e0b" },
@@ -55,7 +65,10 @@ type CachedSettings = {
 export function isValidSlackWebhookUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:" && parsed.href.startsWith(SLACK_WEBHOOK_PREFIX);
+    return (
+      parsed.protocol === "https:" &&
+      parsed.href.startsWith(SLACK_WEBHOOK_PREFIX)
+    );
   } catch {
     return false;
   }
@@ -94,7 +107,9 @@ export class SlackNotifier {
       await deleteSetting(this.pool, SETTING_WEBHOOK_URL);
     } else {
       if (!isValidSlackWebhookUrl(url)) {
-        throw new Error("Invalid webhook URL: must start with https://hooks.slack.com/");
+        throw new Error(
+          "Invalid webhook URL: must start with https://hooks.slack.com/"
+        );
       }
       await setSetting(this.pool, SETTING_WEBHOOK_URL, url);
     }
@@ -115,13 +130,19 @@ export class SlackNotifier {
     webNotifyEnabled: boolean;
     webNotifyEvents: NotifyEventType[];
   }> {
-    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] = await Promise.all([
-      this.getWebhookUrl(),
-      this.getNotifyEvents(),
-      this.getWebNotifyEnabled(),
-      this.getWebNotifyEvents(),
-    ]);
-    return { webhookUrl: webhookUrl ?? "", notifyEvents, webNotifyEnabled, webNotifyEvents };
+    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] =
+      await Promise.all([
+        this.getWebhookUrl(),
+        this.getNotifyEvents(),
+        this.getWebNotifyEnabled(),
+        this.getWebNotifyEvents(),
+      ]);
+    return {
+      webhookUrl: webhookUrl ?? "",
+      notifyEvents,
+      webNotifyEnabled,
+      webNotifyEvents,
+    };
   }
 
   async getWebNotifyEnabled(): Promise<boolean> {
@@ -155,13 +176,15 @@ export class SlackNotifier {
   } | null> {
     const event = agent.latestEvent;
     if (!event) return null;
-    if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return null;
+    if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType))
+      return null;
 
     if (this.isFocused?.(agent.id)) return null;
 
     const settings = await this.getCachedSettings();
     if (!settings.webNotifyEnabled) return null;
-    if (!settings.webNotifyEvents.includes(event.type as NotifyEventType)) return null;
+    if (!settings.webNotifyEvents.includes(event.type as NotifyEventType))
+      return null;
 
     return {
       agentId: agent.id,
@@ -183,24 +206,36 @@ export class SlackNotifier {
 
     try {
       if (this.isFocused?.(agent.id)) {
-        this.log.debug({ agentId: agent.id }, "Skipping notification — user is focused on agent");
+        this.log.debug(
+          { agentId: agent.id },
+          "Skipping notification — user is focused on agent"
+        );
         return;
       }
 
       const settings = await this.getCachedSettings();
       if (!settings.webhookUrl) return;
-      if (!settings.notifyEvents.includes(event.type as NotifyEventType)) return;
+      if (!settings.notifyEvents.includes(event.type as NotifyEventType))
+        return;
 
       const cfg = EVENT_CONFIG[event.type as NotifyEventType];
       await this.sendSlackMessage(settings.webhookUrl, agent, event, cfg);
     } catch (err) {
-      this.log.warn({ err, agentId: agent.id }, "Failed to send Slack notification");
+      this.log.warn(
+        { err, agentId: agent.id },
+        "Failed to send Slack notification"
+      );
     }
   }
 
-  async sendTestMessage(webhookUrl: string): Promise<{ ok: boolean; error?: string }> {
+  async sendTestMessage(
+    webhookUrl: string
+  ): Promise<{ ok: boolean; error?: string }> {
     if (!isValidSlackWebhookUrl(webhookUrl)) {
-      return { ok: false, error: "Invalid webhook URL: must start with https://hooks.slack.com/" };
+      return {
+        ok: false,
+        error: "Invalid webhook URL: must start with https://hooks.slack.com/",
+      };
     }
     try {
       const res = await this.postToSlack(webhookUrl, {
@@ -223,7 +258,10 @@ export class SlackNotifier {
       }
       return { ok: true };
     } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      };
     }
   }
 
@@ -231,15 +269,24 @@ export class SlackNotifier {
    * Agent-initiated notification via the dispatch_notify MCP tool.
    * Bypasses focus filtering by default (agents explicitly chose to notify).
    */
-  async sendNotification(agent: AgentRecord, input: NotifyInput): Promise<NotifyResult> {
+  async sendNotification(
+    agent: AgentRecord,
+    input: NotifyInput
+  ): Promise<NotifyResult> {
     // Rate limit check
     if (this.isRateLimited(agent.id)) {
-      return { sent: false, reason: "Rate limited — max 5 notifications per minute per agent." };
+      return {
+        sent: false,
+        reason: "Rate limited — max 5 notifications per minute per agent.",
+      };
     }
 
     // Respect focus if explicitly requested
     if (input.respectFocus && this.isFocused?.(agent.id)) {
-      return { sent: false, reason: "Notification suppressed — user is focused on this agent." };
+      return {
+        sent: false,
+        reason: "Notification suppressed — user is focused on this agent.",
+      };
     }
 
     const settings = await this.getCachedSettings();
@@ -255,7 +302,9 @@ export class SlackNotifier {
       // Sanitize agent-provided content to prevent broadcast mentions
       // (<!channel>, <!here>, <!everyone>). Regular mrkdwn links are allowed.
       const safeMessage = sanitizeSlackMrkdwn(input.message);
-      const safeTitle = input.title ? sanitizeSlackMrkdwn(input.title) : undefined;
+      const safeTitle = input.title
+        ? sanitizeSlackMrkdwn(input.title)
+        : undefined;
 
       const blocks: SlackBlock[] = [];
 
@@ -293,14 +342,23 @@ export class SlackNotifier {
 
       if (!res.ok) {
         const body = await res.text();
-        this.log.warn({ status: res.status, body }, "Slack webhook returned error for dispatch_notify");
+        this.log.warn(
+          { status: res.status, body },
+          "Slack webhook returned error for dispatch_notify"
+        );
         return { sent: false, reason: `Slack returned ${res.status}: ${body}` };
       }
 
       return { sent: true };
     } catch (err) {
-      this.log.warn({ err, agentId: agent.id }, "Failed to send agent-initiated notification");
-      return { sent: false, reason: err instanceof Error ? err.message : "Unknown error" };
+      this.log.warn(
+        { err, agentId: agent.id },
+        "Failed to send agent-initiated notification"
+      );
+      return {
+        sent: false,
+        reason: err instanceof Error ? err.message : "Unknown error",
+      };
     }
   }
 
@@ -352,13 +410,20 @@ export class SlackNotifier {
     if (this.cachedSettings && Date.now() < this.cachedSettings.expiresAt) {
       return this.cachedSettings;
     }
-    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] = await Promise.all([
-      this.getWebhookUrl(),
-      this.getNotifyEvents(),
-      this.getWebNotifyEnabled(),
-      this.getWebNotifyEvents(),
-    ]);
-    this.cachedSettings = { webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents, expiresAt: Date.now() + CACHE_TTL_MS };
+    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] =
+      await Promise.all([
+        this.getWebhookUrl(),
+        this.getNotifyEvents(),
+        this.getWebNotifyEnabled(),
+        this.getWebNotifyEvents(),
+      ]);
+    this.cachedSettings = {
+      webhookUrl,
+      notifyEvents,
+      webNotifyEnabled,
+      webNotifyEvents,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    };
     return this.cachedSettings;
   }
 
@@ -366,7 +431,10 @@ export class SlackNotifier {
     this.cachedSettings = null;
   }
 
-  private async postToSlack(webhookUrl: string, payload: Record<string, unknown>): Promise<Response> {
+  private async postToSlack(
+    webhookUrl: string,
+    payload: Record<string, unknown>
+  ): Promise<Response> {
     return fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -384,7 +452,9 @@ export class SlackNotifier {
     const agentName = sanitizeSlackMrkdwn(agent.name || agent.id.slice(0, 8));
     const branch = agent.gitContext?.branch;
     const elapsed = this.formatElapsed(agent.createdAt);
-    const agentType = agent.type ? agent.type.charAt(0).toUpperCase() + agent.type.slice(1) : "Agent";
+    const agentType = agent.type
+      ? agent.type.charAt(0).toUpperCase() + agent.type.slice(1)
+      : "Agent";
 
     const blocks: SlackBlock[] = [
       {
@@ -415,7 +485,10 @@ export class SlackNotifier {
 
     if (!res.ok) {
       const body = await res.text();
-      this.log.warn({ status: res.status, body }, "Slack webhook returned error");
+      this.log.warn(
+        { status: res.status, body },
+        "Slack webhook returned error"
+      );
     }
   }
 
@@ -426,6 +499,8 @@ export class SlackNotifier {
     if (mins < 60) return `running ${mins}m`;
     const hours = Math.floor(mins / 60);
     const remainMins = mins % 60;
-    return remainMins > 0 ? `running ${hours}h ${remainMins}m` : `running ${hours}h`;
+    return remainMins > 0
+      ? `running ${hours}h ${remainMins}m`
+      : `running ${hours}h`;
   }
 }

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -23,7 +23,10 @@ type PersonaFrontmatter = {
 const PERSONAS_DIR = ".dispatch/personas";
 const MAX_DIFF_BYTES = 50 * 1024;
 
-export function parseFrontmatter(content: string): { frontmatter: PersonaFrontmatter; body: string } {
+export function parseFrontmatter(content: string): {
+  frontmatter: PersonaFrontmatter;
+  body: string;
+} {
   const trimmed = content.trimStart();
   if (!trimmed.startsWith("---")) {
     return { frontmatter: {}, body: content };
@@ -51,7 +54,9 @@ export function parseFrontmatter(content: string): { frontmatter: PersonaFrontma
   return { frontmatter: frontmatter as PersonaFrontmatter, body };
 }
 
-export async function loadPersonas(repoRoot: string): Promise<PersonaDefinition[]> {
+export async function loadPersonas(
+  repoRoot: string
+): Promise<PersonaDefinition[]> {
   const dir = path.join(repoRoot, PERSONAS_DIR);
   let entries: string[];
   try {

--- a/apps/server/src/personas/review-diff.ts
+++ b/apps/server/src/personas/review-diff.ts
@@ -31,11 +31,14 @@ export async function buildPersonaReviewDiff(
   }
 
   try {
-    const [committedResult, uncommittedResult, untrackedResult] = await Promise.all([
-      runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd }),
-      runCommand("git", ["diff", "HEAD"], { cwd }),
-      runCommand("git", ["ls-files", "--others", "--exclude-standard"], { cwd }),
-    ]);
+    const [committedResult, uncommittedResult, untrackedResult] =
+      await Promise.all([
+        runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd }),
+        runCommand("git", ["diff", "HEAD"], { cwd }),
+        runCommand("git", ["ls-files", "--others", "--exclude-standard"], {
+          cwd,
+        }),
+      ]);
 
     const committedDiff = trimTrailingWhitespace(committedResult.stdout);
     const uncommittedDiff = trimTrailingWhitespace(uncommittedResult.stdout);
@@ -53,7 +56,9 @@ export async function buildPersonaReviewDiff(
     }
 
     if (committedDiff) {
-      sections.push(`### Committed changes since ${baseBranch}\n${committedDiff}`);
+      sections.push(
+        `### Committed changes since ${baseBranch}\n${committedDiff}`
+      );
     }
 
     if (uncommittedDiff) {
@@ -61,7 +66,9 @@ export async function buildPersonaReviewDiff(
     }
 
     if (untrackedFiles.length > 0) {
-      sections.push(`### Untracked files\n${untrackedFiles.map((file) => `- ${file}`).join("\n")}`);
+      sections.push(
+        `### Untracked files\n${untrackedFiles.map((file) => `- ${file}`).join("\n")}`
+      );
     }
 
     if (sections.length === 0) {

--- a/apps/server/src/pins.ts
+++ b/apps/server/src/pins.ts
@@ -1,19 +1,35 @@
-const VALID_PIN_TYPES = ["string", "url", "port", "code", "pr", "filename", "markdown"] as const;
+const VALID_PIN_TYPES = [
+  "string",
+  "url",
+  "port",
+  "code",
+  "pr",
+  "filename",
+  "markdown",
+] as const;
 const MAX_MARKDOWN_LENGTH = 2000;
 const MAX_MARKDOWN_CODE_BLOCK_LINES = 20;
 
-function stripFencedCodeBlocks(value: string): { sanitized: string; codeBlocks: string[] } {
+function stripFencedCodeBlocks(value: string): {
+  sanitized: string;
+  codeBlocks: string[];
+} {
   const codeBlocks: string[] = [];
-  const sanitized = value.replace(/```[^\n]*\n([\s\S]*?)```/g, (_match, body: string) => {
-    codeBlocks.push(body);
-    return "";
-  });
+  const sanitized = value.replace(
+    /```[^\n]*\n([\s\S]*?)```/g,
+    (_match, body: string) => {
+      codeBlocks.push(body);
+      return "";
+    }
+  );
   return { sanitized, codeBlocks };
 }
 
 function validateMarkdownPinValue(value: string): void {
   if (value.length > MAX_MARKDOWN_LENGTH) {
-    throw new Error(`Markdown pins must be ${MAX_MARKDOWN_LENGTH} characters or fewer.`);
+    throw new Error(
+      `Markdown pins must be ${MAX_MARKDOWN_LENGTH} characters or fewer.`
+    );
   }
 
   const { sanitized, codeBlocks } = stripFencedCodeBlocks(value);
@@ -21,15 +37,23 @@ function validateMarkdownPinValue(value: string): void {
   for (const block of codeBlocks) {
     const lineCount = block.replace(/\n$/, "").split("\n").length;
     if (lineCount > MAX_MARKDOWN_CODE_BLOCK_LINES) {
-      throw new Error(`Markdown pin code blocks must be ${MAX_MARKDOWN_CODE_BLOCK_LINES} lines or fewer.`);
+      throw new Error(
+        `Markdown pin code blocks must be ${MAX_MARKDOWN_CODE_BLOCK_LINES} lines or fewer.`
+      );
     }
   }
 
   const disallowedPatterns: Array<[RegExp, string]> = [
     [/!\[[^\]]*]\((?:[^()\\]|\\.)+\)/, "Markdown pins do not support images."],
     [/\[[^\]]+]\((?:[^()\\]|\\.)+\)/, "Markdown pins do not support links."],
-    [/\[[^\]]+]\[[^\]]*]/, "Markdown pins do not support reference-style links."],
-    [/^\s*\[[^\]]+]:\s*\S+/m, "Markdown pins do not support reference-style links."],
+    [
+      /\[[^\]]+]\[[^\]]*]/,
+      "Markdown pins do not support reference-style links.",
+    ],
+    [
+      /^\s*\[[^\]]+]:\s*\S+/m,
+      "Markdown pins do not support reference-style links.",
+    ],
     [/<\/?[A-Za-z][^>]*>/, "Markdown pins do not support raw HTML."],
     [/^\s{0,3}#{1,6}\s/m, "Markdown pins do not support headings."],
     [/^\s{0,3}>\s/m, "Markdown pins do not support blockquotes."],
@@ -37,7 +61,10 @@ function validateMarkdownPinValue(value: string): void {
     [/^(?: {2,}|\t+)[-*+]\s/m, "Markdown pins do not support nested lists."],
     [/^(?: {2,}|\t+)\d+\.\s/m, "Markdown pins do not support nested lists."],
     [/^\s*\|.+\|\s*$/m, "Markdown pins do not support tables."],
-    [/^\s*\|?\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*\|?\s*$/m, "Markdown pins do not support tables."],
+    [
+      /^\s*\|?\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*\|?\s*$/m,
+      "Markdown pins do not support tables.",
+    ],
   ];
 
   for (const [pattern, message] of disallowedPatterns) {
@@ -66,7 +93,10 @@ export function validatePinValue(type: PinType, value: string): void {
   }
 
   if (type === "port") {
-    const parts = value.split(/[\s,]+/).map((part) => part.trim()).filter(Boolean);
+    const parts = value
+      .split(/[\s,]+/)
+      .map((part) => part.trim())
+      .filter(Boolean);
     if (parts.length === 0) {
       throw new Error("Port pins must include at least one integer.");
     }

--- a/apps/server/src/release-store.ts
+++ b/apps/server/src/release-store.ts
@@ -31,5 +31,9 @@ export async function readReleaseStore(): Promise<ReleaseRecord | null> {
 
 export async function writeReleaseStore(record: ReleaseRecord): Promise<void> {
   await mkdir(path.dirname(RELEASE_STORE_PATH), { recursive: true });
-  await writeFile(RELEASE_STORE_PATH, JSON.stringify(record, null, 2) + "\n", "utf-8");
+  await writeFile(
+    RELEASE_STORE_PATH,
+    JSON.stringify(record, null, 2) + "\n",
+    "utf-8"
+  );
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,7 +1,16 @@
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 
@@ -28,16 +37,24 @@ try {
 } catch {
   console.error(
     "\n✗ Failed to load node-pty native module.\n" +
-    "  This usually means the native addon was not compiled during install.\n" +
-    "  Fix: run 'pnpm rebuild node-pty' in the server directory, or ensure\n" +
-    "  'node-pty' is listed in pnpm.onlyBuiltDependencies in package.json.\n"
+      "  This usually means the native addon was not compiled during install.\n" +
+      "  Fix: run 'pnpm rebuild node-pty' in the server directory, or ensure\n" +
+      "  'node-pty' is listed in pnpm.onlyBuiltDependencies in package.json.\n"
   );
   process.exit(1);
 }
 
 import { AgentError, AgentManager } from "./agents/manager.js";
-import type { AgentGitContext, AgentRecord, FeedbackRecord } from "./agents/manager.js";
-import { loadPersonas, loadPersonaBySlug, assemblePersonaPrompt } from "./personas/loader.js";
+import type {
+  AgentGitContext,
+  AgentRecord,
+  FeedbackRecord,
+} from "./agents/manager.js";
+import {
+  loadPersonas,
+  loadPersonaBySlug,
+  assemblePersonaPrompt,
+} from "./personas/loader.js";
 import { buildPersonaReviewDiff } from "./personas/review-diff.js";
 import {
   isPasswordSet,
@@ -54,7 +71,7 @@ import {
   isScopedMcpRoute,
   shouldAcceptApiBearerToken,
   validateAgentMcpToken,
-  validateJobMcpToken
+  validateJobMcpToken,
 } from "./auth.js";
 import { loadConfig } from "./config.js";
 import { createPool } from "./db/client.js";
@@ -64,11 +81,20 @@ import { runCommand } from "./shared/lib/run-command.js";
 import { handleMcpRequest } from "./shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
-import { SlackNotifier, isValidSlackWebhookUrl, type NotifyInput, type NotifyResult } from "./notifications/slack.js";
+import {
+  SlackNotifier,
+  isValidSlackWebhookUrl,
+  type NotifyInput,
+  type NotifyResult,
+} from "./notifications/slack.js";
 import { JobNotifier } from "./notifications/job-notifier.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
-import { AGENT_TYPES, getEnabledAgentTypes, setEnabledAgentTypes } from "./agent-type-settings.js";
+import {
+  AGENT_TYPES,
+  getEnabledAgentTypes,
+  setEnabledAgentTypes,
+} from "./agent-type-settings.js";
 import { isPinType, validatePinValue } from "./pins.js";
 import { JobService } from "./jobs/service.js";
 import { randomUUID } from "node:crypto";
@@ -94,7 +120,12 @@ const terminalTokenStore = new TerminalTokenStore(60_000);
 const jobService = new JobService(pool, agentManager, app.log, config);
 const jobNotifier = new JobNotifier(pool, app.log);
 const AGENT_INITIAL_PROMPT_MAX_CHARS = 16_000;
-const JOB_TERMINAL_STATUSES = new Set(["completed", "failed", "timed_out", "crashed"]);
+const JOB_TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "timed_out",
+  "crashed",
+]);
 jobService.onRunStateChange((run) => {
   uiEventBroker.publish({ type: "job.changed" });
   void jobNotifier.onJobRunStateChange(run).catch((err) => {
@@ -104,7 +135,10 @@ jobService.onRunStateChange((run) => {
   // needs_input is excluded — user may need to interact with the agent.
   if (JOB_TERMINAL_STATUSES.has(run.status) && run.agentId) {
     void autoArchiveJobAgent(run.agentId).catch((err) => {
-      app.log.warn({ err, agentId: run.agentId }, "Auto-archive of job agent failed");
+      app.log.warn(
+        { err, agentId: run.agentId },
+        "Auto-archive of job agent failed"
+      );
     });
   }
 });
@@ -130,7 +164,11 @@ agentManager.onLatestEvent((agent) => {
       // 2. An SSE client is connected (app is open)
       // 3. The browser has notification permission granted (reported via focus heartbeat)
       const webPayload = await slackNotifier.shouldWebNotify(agent);
-      if (webPayload && uiEventBroker.hasConnectedClient() && focusTracker.hasWebNotifyPermission()) {
+      if (
+        webPayload &&
+        uiEventBroker.hasConnectedClient() &&
+        focusTracker.hasWebNotifyPermission()
+      ) {
         uiEventBroker.publish({ type: "notification", ...webPayload });
       } else {
         await sendSlackNotification();
@@ -147,11 +185,17 @@ async function autoArchiveJobAgent(agentId: string): Promise<void> {
   if (archivingAgentIds.has(agentId)) return;
   try {
     const agent = await agentManager.beginArchive(agentId, "auto");
-    uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(agent),
+    });
     archivingAgentIds.add(agentId);
     const archivePromise = agentManager.executeArchive(agentId, {
       onPhaseChange: (updated) => {
-        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
+        uiEventBroker.publish({
+          type: "agent.upsert",
+          agent: withStreamFlag(updated),
+        });
       },
       onComplete: (deletedIds) => {
         for (const deletedId of deletedIds) {
@@ -171,7 +215,13 @@ async function autoArchiveJobAgent(agentId: string): Promise<void> {
   }
 }
 
-const AGENT_LATEST_EVENT_TYPES = ["working", "blocked", "waiting_user", "done", "idle"] as const;
+const AGENT_LATEST_EVENT_TYPES = [
+  "working",
+  "blocked",
+  "waiting_user",
+  "done",
+  "idle",
+] as const;
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
@@ -184,10 +234,24 @@ type UiEvent =
   | { type: "media.seen"; agentId: string; keys: string[] }
   | { type: "stream.started"; agentId: string }
   | { type: "stream.stopped"; agentId: string }
-  | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
-  | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
+  | {
+      type: "feedback.created";
+      agentId: string;
+      feedback: import("./agents/manager.js").FeedbackRecord;
+    }
+  | {
+      type: "feedback.updated";
+      agentId: string;
+      feedback: import("./agents/manager.js").FeedbackRecord;
+    }
   | { type: "job.changed" }
-  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
+  | {
+      type: "notification";
+      agentId: string;
+      agentName: string;
+      eventType: string;
+      message: string;
+    };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -273,16 +337,23 @@ type ActivityQuery = {
   granularity: ActivityGranularity;
 };
 
-const VALID_GRANULARITIES = new Set<ActivityGranularity>(["hour", "day", "week", "month"]);
+const VALID_GRANULARITIES = new Set<ActivityGranularity>([
+  "hour",
+  "day",
+  "week",
+  "month",
+]);
 const FALLBACK_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
 const VALID_TIMEZONES = new Set(Intl.supportedValuesOf("timeZone"));
 
 function parseActivityQuery(query: Record<string, unknown>): ActivityQuery {
   const startStr = typeof query.start === "string" ? query.start : "";
   const endStr = typeof query.end === "string" ? query.end : "";
-  const rawTz = typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
+  const rawTz =
+    typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
   const tz = VALID_TIMEZONES.has(rawTz) ? rawTz : FALLBACK_TZ;
-  const gran = typeof query.granularity === "string" ? query.granularity : "day";
+  const gran =
+    typeof query.granularity === "string" ? query.granularity : "day";
 
   const start = startStr ? new Date(startStr) : null;
   const end = endStr ? new Date(endStr) : null;
@@ -318,7 +389,11 @@ function timeRangeClause(
   };
 }
 
-function dateTruncTz(granularity: ActivityGranularity, column: string, tz: string): string {
+function dateTruncTz(
+  granularity: ActivityGranularity,
+  column: string,
+  tz: string
+): string {
   const escaped = tz.replace(/'/g, "''");
   const trunc = `date_trunc('${granularity}', ${column} AT TIME ZONE '${escaped}')`;
   if (granularity === "hour") {
@@ -328,7 +403,12 @@ function dateTruncTz(granularity: ActivityGranularity, column: string, tz: strin
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function escapeLike(s: string): string {
@@ -379,7 +459,13 @@ const gitRefreshAgentDiagnostics = new Map<
     lastStartedAt: number | null;
     lastCompletedAt: number | null;
     lastDurationMs: number | null;
-    lastResult: "updated" | "unchanged" | "probe_error" | "failed" | "skipped" | null;
+    lastResult:
+      | "updated"
+      | "unchanged"
+      | "probe_error"
+      | "failed"
+      | "skipped"
+      | null;
     lastError: string | null;
   }
 >();
@@ -392,7 +478,7 @@ const gitRefreshCounters = {
   probeErrors: 0,
   failed: 0,
   timedOut: 0,
-  skipped: 0
+  skipped: 0,
 };
 let gitContextRefreshTimer: NodeJS.Timeout | null = null;
 
@@ -404,7 +490,9 @@ const __dirname = path.dirname(__filename);
 const appRootDir = path.resolve(__dirname, "..");
 const repoRootDir = path.resolve(appRootDir, "../..");
 if (!existsSync(path.join(repoRootDir, "pnpm-workspace.yaml"))) {
-  throw new Error(`repoRootDir "${repoRootDir}" does not contain pnpm-workspace.yaml — monorepo layout may have changed`);
+  throw new Error(
+    `repoRootDir "${repoRootDir}" does not contain pnpm-workspace.yaml — monorepo layout may have changed`
+  );
 }
 const releaseNotesFile = path.join(repoRootDir, "release-notes", "current.md");
 const webDistDir = path.resolve(repoRootDir, "apps/web/dist");
@@ -414,15 +502,28 @@ const staticDir = existsSync(webDistDir) ? webDistDir : legacyPublicDir;
 // ---------------------------------------------------------------------------
 // Icon color templating — rewrite index.html and manifest for active color
 // ---------------------------------------------------------------------------
-const VALID_ICON_COLORS = ["teal", "blue", "purple", "red", "orange", "amber", "pink", "cyan"] as const;
-type IconColor = typeof VALID_ICON_COLORS[number];
+const VALID_ICON_COLORS = [
+  "teal",
+  "blue",
+  "purple",
+  "red",
+  "orange",
+  "amber",
+  "pink",
+  "cyan",
+] as const;
+type IconColor = (typeof VALID_ICON_COLORS)[number];
 const DEFAULT_ICON_COLOR: IconColor = "teal";
 const ICON_COLOR_KEY = "icon_color";
 
 const indexHtmlPath = path.join(staticDir, "index.html");
 const manifestPath = path.join(staticDir, "manifest.webmanifest");
-const indexHtmlTemplate = existsSync(indexHtmlPath) ? readFileSync(indexHtmlPath, "utf-8") : "";
-const manifestTemplate = existsSync(manifestPath) ? readFileSync(manifestPath, "utf-8") : "";
+const indexHtmlTemplate = existsSync(indexHtmlPath)
+  ? readFileSync(indexHtmlPath, "utf-8")
+  : "";
+const manifestTemplate = existsSync(manifestPath)
+  ? readFileSync(manifestPath, "utf-8")
+  : "";
 
 let cachedIconColor: IconColor = DEFAULT_ICON_COLOR;
 let cachedIndexHtml: string = indexHtmlTemplate;
@@ -434,12 +535,20 @@ function rewriteForColor(color: IconColor): void {
     cachedIndexHtml = indexHtmlTemplate;
     cachedManifest = manifestTemplate;
   } else {
-    cachedIndexHtml = indexHtmlTemplate.replaceAll("/icons/teal/", `/icons/${color}/`);
-    cachedManifest = manifestTemplate.replaceAll("/icons/teal/", `/icons/${color}/`);
+    cachedIndexHtml = indexHtmlTemplate.replaceAll(
+      "/icons/teal/",
+      `/icons/${color}/`
+    );
+    cachedManifest = manifestTemplate.replaceAll(
+      "/icons/teal/",
+      `/icons/${color}/`
+    );
   }
 }
 
-function withStreamFlag<T extends AgentRecord>(agent: T): T & { hasStream: boolean } {
+function withStreamFlag<T extends AgentRecord>(
+  agent: T
+): T & { hasStream: boolean } {
   return { ...agent, hasStream: streamManager.hasStream(agent.id) };
 }
 
@@ -461,7 +570,9 @@ async function getAppVersionInfo(): Promise<{
 
   let version: string | null = null;
   try {
-    const packageJson = JSON.parse(await readFile(path.join(appRootDir, "package.json"), "utf8")) as {
+    const packageJson = JSON.parse(
+      await readFile(path.join(appRootDir, "package.json"), "utf8")
+    ) as {
       version?: unknown;
     };
     if (typeof packageJson.version === "string" && packageJson.version.trim()) {
@@ -485,14 +596,16 @@ async function getAppVersionInfo(): Promise<{
   const releaseNotes = await readFile(releaseNotesFile, "utf8")
     .then((raw) => raw.trim() || null)
     .catch(() => null);
-  const releaseUrl = releaseTag ? `https://github.com/${await getGitHubRepo()}/releases/tag/${releaseTag}` : null;
+  const releaseUrl = releaseTag
+    ? `https://github.com/${await getGitHubRepo()}/releases/tag/${releaseTag}`
+    : null;
 
   return {
     releaseTag,
     version,
     gitSha,
     releaseNotes,
-    releaseUrl
+    releaseUrl,
   };
 }
 
@@ -502,7 +615,15 @@ async function getAppVersionInfo(): Promise<{
 
 const RELEASE_VERSION_TYPES = ["patch", "minor", "major"] as const;
 type ReleaseVersionType = (typeof RELEASE_VERSION_TYPES)[number];
-type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
+type ReleasePhase =
+  | "preflight"
+  | "triggering"
+  | "watching"
+  | "fetching"
+  | "deploying"
+  | "restarting"
+  | "done"
+  | "failed";
 type ReleaseJobType = "create" | "update";
 
 type ReleaseJob = {
@@ -528,7 +649,9 @@ type ReleaseStreamEvent =
 let activeReleaseJob: ReleaseJob | null = null;
 const releaseStreamClients = new Set<NodeJS.WritableStream>();
 
-const serverDir = process.env.DISPATCH_SERVER_DIR ?? path.join(os.homedir(), ".dispatch", "server");
+const serverDir =
+  process.env.DISPATCH_SERVER_DIR ??
+  path.join(os.homedir(), ".dispatch", "server");
 
 function broadcastReleaseEvent(event: ReleaseStreamEvent): void {
   const payload = `data: ${JSON.stringify(event)}\n\n`;
@@ -563,7 +686,11 @@ function rewindReleaseLog(job: ReleaseJob, count: number): void {
   }
 }
 
-function setReleasePhase(job: ReleaseJob, phase: ReleasePhase, error?: string): void {
+function setReleasePhase(
+  job: ReleaseJob,
+  phase: ReleasePhase,
+  error?: string
+): void {
   job.phase = phase;
   broadcastReleaseEvent({ type: "phase", phase, error });
 }
@@ -579,14 +706,17 @@ function streamProcess(
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: { ...process.env, ...options.env },
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
-    const processor = new ReleaseLogStreamProcessor({
-      append: (line) => appendReleaseLog(job, line),
-      replace: (line) => replaceReleaseLog(job, line),
-      rewind: (count) => rewindReleaseLog(job, count)
-    }, onLine);
+    const processor = new ReleaseLogStreamProcessor(
+      {
+        append: (line) => appendReleaseLog(job, line),
+        replace: (line) => replaceReleaseLog(job, line),
+        rewind: (count) => rewindReleaseLog(job, count),
+      },
+      onLine
+    );
 
     const processChunk = (chunk: Buffer): void => {
       processor.push(chunk);
@@ -609,7 +739,13 @@ function streamProcess(
 
 async function getGitHubRepo(): Promise<string> {
   try {
-    const result = await runCommand("git", ["-C", serverDir, "remote", "get-url", "origin"]);
+    const result = await runCommand("git", [
+      "-C",
+      serverDir,
+      "remote",
+      "get-url",
+      "origin",
+    ]);
     const url = result.stdout;
     const match = url.match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?$/);
     if (match?.[1]) {
@@ -630,9 +766,13 @@ async function checkIsAdmin(): Promise<boolean> {
     await runCommand("gh", ["--version"]);
     const repo = await getGitHubRepo();
     const result = await runCommand("gh", [
-      "repo", "view", repo,
-      "--json", "viewerPermission",
-      "--jq", ".viewerPermission"
+      "repo",
+      "view",
+      repo,
+      "--json",
+      "viewerPermission",
+      "--jq",
+      ".viewerPermission",
     ]);
     cachedIsAdmin = result.stdout.trim() === "ADMIN";
   } catch {
@@ -662,13 +802,19 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-async function fetchReleaseMetadata(tag: string): Promise<GitHubReleaseMetadata | null> {
+async function fetchReleaseMetadata(
+  tag: string
+): Promise<GitHubReleaseMetadata | null> {
   try {
     const repo = await getGitHubRepo();
     const result = await runCommand("gh", [
-      "release", "view", tag,
-      "--repo", repo,
-      "--json", "tagName,publishedAt,url,body"
+      "release",
+      "view",
+      tag,
+      "--repo",
+      repo,
+      "--json",
+      "tagName,publishedAt,url,body",
     ]);
     const data = JSON.parse(result.stdout) as {
       tagName: string;
@@ -680,14 +826,16 @@ async function fetchReleaseMetadata(tag: string): Promise<GitHubReleaseMetadata 
       tag: data.tagName,
       publishedAt: data.publishedAt,
       url: data.url,
-      body: typeof data.body === "string" ? data.body.trim() : null
+      body: typeof data.body === "string" ? data.body.trim() : null,
     };
   } catch {
     return null;
   }
 }
 
-async function fetchLatestReleaseMetadata(tag: string): Promise<GitHubReleaseMetadata | null> {
+async function fetchLatestReleaseMetadata(
+  tag: string
+): Promise<GitHubReleaseMetadata | null> {
   return fetchReleaseMetadata(tag);
 }
 
@@ -696,7 +844,10 @@ async function fetchLatestReleaseMetadata(tag: string): Promise<GitHubReleaseMet
  * Returns true on success, false if the artifact isn't available (caller falls
  * back to building from source).
  */
-async function deployFromArtifact(job: ReleaseJob, tag: string): Promise<boolean> {
+async function deployFromArtifact(
+  job: ReleaseJob,
+  tag: string
+): Promise<boolean> {
   // Need gh CLI to download release assets
   try {
     await runCommand("gh", ["--version"]);
@@ -709,7 +860,10 @@ async function deployFromArtifact(job: ReleaseJob, tag: string): Promise<boolean
   try {
     repo = await getGitHubRepo();
   } catch {
-    appendReleaseLog(job, "could not resolve GitHub repo, skipping artifact download");
+    appendReleaseLog(
+      job,
+      "could not resolve GitHub repo, skipping artifact download"
+    );
     return false;
   }
 
@@ -721,10 +875,15 @@ async function deployFromArtifact(job: ReleaseJob, tag: string): Promise<boolean
     appendReleaseLog(job, `==> downloading release artifact for ${tag}`);
     try {
       await runCommand("gh", [
-        "release", "download", tag,
-        "--pattern", "dispatch-release.tar.gz",
-        "--output", tarball,
-        "--repo", repo
+        "release",
+        "download",
+        tag,
+        "--pattern",
+        "dispatch-release.tar.gz",
+        "--output",
+        tarball,
+        "--repo",
+        repo,
       ]);
     } catch {
       appendReleaseLog(job, "no release artifact found for this tag");
@@ -749,12 +908,26 @@ async function deployFromArtifact(job: ReleaseJob, tag: string): Promise<boolean
     }
 
     appendReleaseLog(job, "==> extracting pre-built artifact");
-    await runCommand("tar", ["xzf", tarball, "--no-same-owner", "-C", serverDir]);
+    await runCommand("tar", [
+      "xzf",
+      tarball,
+      "--no-same-owner",
+      "-C",
+      serverDir,
+    ]);
 
     appendReleaseLog(job, "==> installing dependencies (native modules only)");
-    await streamProcess("pnpm", ["install", "--frozen-lockfile"], { cwd: serverDir }, job);
+    await streamProcess(
+      "pnpm",
+      ["install", "--frozen-lockfile"],
+      { cwd: serverDir },
+      job
+    );
 
-    appendReleaseLog(job, "==> deployed from pre-built artifact (no build needed)");
+    appendReleaseLog(
+      job,
+      "==> deployed from pre-built artifact (no build needed)"
+    );
     return true;
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
@@ -776,7 +949,12 @@ async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
     await runCommand("git", ["-C", serverDir, "checkout", tag]);
 
     appendReleaseLog(job, "==> installing dependencies");
-    await streamProcess("pnpm", ["install", "--frozen-lockfile"], { cwd: serverDir }, job);
+    await streamProcess(
+      "pnpm",
+      ["install", "--frozen-lockfile"],
+      { cwd: serverDir },
+      job
+    );
 
     appendReleaseLog(job, "==> building from source");
     await streamProcess("pnpm", ["run", "build"], { cwd: serverDir }, job);
@@ -798,13 +976,13 @@ async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
   if (process.platform === "linux") {
     spawn("systemctl", ["--user", "restart", "dispatch"], {
       detached: true,
-      stdio: "ignore"
+      stdio: "ignore",
     }).unref();
   } else {
     const uid = process.getuid?.() ?? 501;
     spawn("launchctl", ["kill", "SIGKILL", `gui/${uid}/com.dispatch.server`], {
       detached: true,
-      stdio: "ignore"
+      stdio: "ignore",
     }).unref();
   }
 }
@@ -841,23 +1019,34 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
     try {
       await runCommand("gh", ["--version"]);
     } catch {
-      throw new Error("GitHub CLI (gh) is not available. Install it from https://cli.github.com");
+      throw new Error(
+        "GitHub CLI (gh) is not available. Install it from https://cli.github.com"
+      );
     }
 
     const repo = await getGitHubRepo();
 
     // Trigger workflow
     setReleasePhase(job, "triggering");
-    appendReleaseLog(job, `==> triggering release workflow (version: ${job.versionType})`);
+    appendReleaseLog(
+      job,
+      `==> triggering release workflow (version: ${job.versionType})`
+    );
 
     try {
       await runCommand("gh", [
-        "workflow", "run", "release.yml",
-        "--repo", repo,
-        "--field", `version=${job.versionType}`
+        "workflow",
+        "run",
+        "release.yml",
+        "--repo",
+        repo,
+        "--field",
+        `version=${job.versionType}`,
       ]);
     } catch (err) {
-      throw new Error(`Failed to trigger workflow: ${err instanceof Error ? err.message : String(err)}`);
+      throw new Error(
+        `Failed to trigger workflow: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
 
     // Give GitHub a moment to register the run
@@ -865,12 +1054,18 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
 
     // Get the run ID
     const runIdResult = await runCommand("gh", [
-      "run", "list",
-      "--repo", repo,
-      "--workflow", "release.yml",
-      "--limit", "1",
-      "--json", "databaseId",
-      "--jq", ".[0].databaseId"
+      "run",
+      "list",
+      "--repo",
+      repo,
+      "--workflow",
+      "release.yml",
+      "--limit",
+      "1",
+      "--json",
+      "databaseId",
+      "--jq",
+      ".[0].databaseId",
     ]);
     const runId = runIdResult.stdout.trim();
     if (!runId) {
@@ -886,17 +1081,30 @@ async function runReleaseJob(job: ReleaseJob): Promise<void> {
     // Watch the workflow
     setReleasePhase(job, "watching");
     try {
-      await streamProcess("gh", ["run", "watch", runId, "--repo", repo], { env: { GH_FORCE_TTY: "120" } }, job);
+      await streamProcess(
+        "gh",
+        ["run", "watch", runId, "--repo", repo],
+        { env: { GH_FORCE_TTY: "120" } },
+        job
+      );
     } catch {
       throw new Error(`GitHub Actions workflow failed. See ${runUrl}`);
     }
 
     // Fetch tags and find the latest
     await runCommand("git", ["-C", serverDir, "fetch", "--tags", "--quiet"]);
-    const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
-    const tag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? "";
+    const tagsResult = await runCommand("git", [
+      "-C",
+      serverDir,
+      "tag",
+      "--sort=-version:refname",
+    ]);
+    const tag =
+      tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? "";
     if (!tag) {
-      throw new Error("Could not determine release tag after workflow completed");
+      throw new Error(
+        "Could not determine release tag after workflow completed"
+      );
     }
 
     job.tag = tag;
@@ -946,7 +1154,10 @@ function resolveTilde(raw: string): string {
   if (raw === "~") return os.homedir();
   return raw;
 }
-const directoryField = z.string().min(1, "Job directory is required.").transform(resolveTilde);
+const directoryField = z
+  .string()
+  .min(1, "Job directory is required.")
+  .transform(resolveTilde);
 const RunJobBodySchema = z.object({
   name: z.string().min(1, "Job name is required."),
   directory: directoryField,
@@ -977,29 +1188,45 @@ const JobHistoryParamsSchema = z.object({
 async function registerRoutes() {
   const cookieSecret = await getOrCreateCookieSecret(pool);
   await app.register(fastifyCookie, { secret: cookieSecret });
-  await app.register(fastifyMultipart, { limits: { fileSize: 20 * 1024 * 1024 } });
+  await app.register(fastifyMultipart, {
+    limits: { fileSize: 20 * 1024 * 1024 },
+  });
   await app.register(fastifyWebsocket);
   await app.register(fastifyRateLimit, { global: false });
 
   // Initialize icon color from DB before serving any requests
   const storedIconColor = await getSetting(pool, ICON_COLOR_KEY);
-  if (storedIconColor && (VALID_ICON_COLORS as readonly string[]).includes(storedIconColor)) {
+  if (
+    storedIconColor &&
+    (VALID_ICON_COLORS as readonly string[]).includes(storedIconColor)
+  ) {
     rewriteForColor(storedIconColor as IconColor);
   }
 
   // Serve templated index.html and manifest before static files so they take priority
-  const noCacheHeaders = { "Cache-Control": "no-cache, no-store, must-revalidate" };
+  const noCacheHeaders = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+  };
 
   app.get("/", async (_, reply) => {
-    return reply.type("text/html").headers(noCacheHeaders).send(cachedIndexHtml);
+    return reply
+      .type("text/html")
+      .headers(noCacheHeaders)
+      .send(cachedIndexHtml);
   });
 
   app.get("/index.html", async (_, reply) => {
-    return reply.type("text/html").headers(noCacheHeaders).send(cachedIndexHtml);
+    return reply
+      .type("text/html")
+      .headers(noCacheHeaders)
+      .send(cachedIndexHtml);
   });
 
   app.get("/manifest.webmanifest", async (_, reply) => {
-    return reply.type("application/manifest+json").headers(noCacheHeaders).send(cachedManifest);
+    return reply
+      .type("application/manifest+json")
+      .headers(noCacheHeaders)
+      .send(cachedManifest);
   });
 
   await app.register(fastifyStatic, {
@@ -1010,14 +1237,17 @@ async function registerRoutes() {
       if (base === "sw.js") {
         res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
       }
-    }
+    },
   });
 
   // SPA fallback — serve templated index.html for client-side routes
   app.setNotFoundHandler(async (request, reply) => {
     const url = request.url.split("?")[0];
     if (!url.startsWith("/api/") && !path.extname(url)) {
-      return reply.type("text/html").headers(noCacheHeaders).send(cachedIndexHtml);
+      return reply
+        .type("text/html")
+        .headers(noCacheHeaders)
+        .send(cachedIndexHtml);
     }
     return reply.code(404).send({ error: "Not found" });
   });
@@ -1055,7 +1285,11 @@ async function registerRoutes() {
     const signed = request.cookies[SESSION_COOKIE];
     if (signed) {
       const unsigned = request.unsignCookie(signed);
-      if (unsigned.valid && unsigned.value && await validateSession(pool, unsigned.value)) {
+      if (
+        unsigned.valid &&
+        unsigned.value &&
+        (await validateSession(pool, unsigned.value))
+      ) {
         return;
       }
     }
@@ -1085,49 +1319,57 @@ async function registerRoutes() {
     return { passwordSet: hasPassword, authenticated };
   });
 
-  app.post("/api/v1/auth/setup", { config: { rateLimit: { max: 3, timeWindow: "1 minute" } } }, async (request, reply) => {
-    if (await isPasswordSetCached()) {
-      return reply.code(400).send({ error: "Password is already set." });
+  app.post(
+    "/api/v1/auth/setup",
+    { config: { rateLimit: { max: 3, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      if (await isPasswordSetCached()) {
+        return reply.code(400).send({ error: "Password is already set." });
+      }
+      const parsed = SetupBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues[0].message });
+      }
+      const { password } = parsed.data;
+      await setPassword(pool, password);
+      invalidatePasswordSetCache();
+      const token = await createSession(pool);
+      reply.setCookie(SESSION_COOKIE, token, {
+        path: "/",
+        httpOnly: true,
+        signed: true,
+        sameSite: "lax",
+        secure: config.tls !== null,
+        maxAge: SESSION_MAX_AGE_S,
+      });
+      return { ok: true };
     }
-    const parsed = SetupBodySchema.safeParse(request.body);
-    if (!parsed.success) {
-      return reply.code(400).send({ error: parsed.error.issues[0].message });
-    }
-    const { password } = parsed.data;
-    await setPassword(pool, password);
-    invalidatePasswordSetCache();
-    const token = await createSession(pool);
-    reply.setCookie(SESSION_COOKIE, token, {
-      path: "/",
-      httpOnly: true,
-      signed: true,
-      sameSite: "lax",
-      secure: config.tls !== null,
-      maxAge: SESSION_MAX_AGE_S
-    });
-    return { ok: true };
-  });
+  );
 
-  app.post("/api/v1/auth/login", { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } }, async (request, reply) => {
-    const parsed = LoginBodySchema.safeParse(request.body);
-    if (!parsed.success) {
-      return reply.code(400).send({ error: parsed.error.issues[0].message });
+  app.post(
+    "/api/v1/auth/login",
+    { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      const parsed = LoginBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues[0].message });
+      }
+      const { password } = parsed.data;
+      if (!(await verifyPassword(pool, password))) {
+        return reply.code(401).send({ error: "Invalid password." });
+      }
+      const token = await createSession(pool);
+      reply.setCookie(SESSION_COOKIE, token, {
+        path: "/",
+        httpOnly: true,
+        signed: true,
+        sameSite: "lax",
+        secure: config.tls !== null,
+        maxAge: SESSION_MAX_AGE_S,
+      });
+      return { ok: true };
     }
-    const { password } = parsed.data;
-    if (!(await verifyPassword(pool, password))) {
-      return reply.code(401).send({ error: "Invalid password." });
-    }
-    const token = await createSession(pool);
-    reply.setCookie(SESSION_COOKIE, token, {
-      path: "/",
-      httpOnly: true,
-      signed: true,
-      sameSite: "lax",
-      secure: config.tls !== null,
-      maxAge: SESSION_MAX_AGE_S
-    });
-    return { ok: true };
-  });
+  );
 
   app.post("/api/v1/auth/logout", async (request, reply) => {
     const signed = request.cookies[SESSION_COOKIE];
@@ -1141,29 +1383,35 @@ async function registerRoutes() {
     return { ok: true };
   });
 
-  app.post("/api/v1/auth/change-password", { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } }, async (request, reply) => {
-    const parsed = ChangePasswordBodySchema.safeParse(request.body);
-    if (!parsed.success) {
-      return reply.code(400).send({ error: parsed.error.issues[0].message });
+  app.post(
+    "/api/v1/auth/change-password",
+    { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      const parsed = ChangePasswordBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues[0].message });
+      }
+      const { currentPassword, newPassword } = parsed.data;
+      const changed = await changePassword(pool, currentPassword, newPassword);
+      if (!changed) {
+        return reply
+          .code(401)
+          .send({ error: "Current password is incorrect." });
+      }
+      await deleteAllSessions(pool);
+      const token = await createSession(pool);
+      reply.setCookie(SESSION_COOKIE, token, {
+        path: "/",
+        httpOnly: true,
+        signed: true,
+        sameSite: "lax",
+        secure: config.tls !== null,
+        maxAge: SESSION_MAX_AGE_S,
+      });
+      invalidatePasswordSetCache();
+      return { ok: true };
     }
-    const { currentPassword, newPassword } = parsed.data;
-    const changed = await changePassword(pool, currentPassword, newPassword);
-    if (!changed) {
-      return reply.code(401).send({ error: "Current password is incorrect." });
-    }
-    await deleteAllSessions(pool);
-    const token = await createSession(pool);
-    reply.setCookie(SESSION_COOKIE, token, {
-      path: "/",
-      httpOnly: true,
-      signed: true,
-      sameSite: "lax",
-      secure: config.tls !== null,
-      maxAge: SESSION_MAX_AGE_S,
-    });
-    invalidatePasswordSetCache();
-    return { ok: true };
-  });
+  );
 
   // ---------------------------------------------------------------------------
   // Jobs routes
@@ -1298,8 +1546,13 @@ async function registerRoutes() {
     const runId = params.runId ?? "";
     const agentId = params.agentId ?? "";
     const bearerToken = getBearerToken(request);
-    if (bearerToken && !validateJobMcpToken(config.authToken, bearerToken, runId, agentId)) {
-      return reply.code(403).send({ error: "Invalid MCP token for the requested job agent route." });
+    if (
+      bearerToken &&
+      !validateJobMcpToken(config.authToken, bearerToken, runId, agentId)
+    ) {
+      return reply.code(403).send({
+        error: "Invalid MCP token for the requested job agent route.",
+      });
     }
     const agent = await agentManager.getAgent(agentId);
     if (!agent) {
@@ -1307,7 +1560,9 @@ async function registerRoutes() {
     }
     const run = await jobService.getActiveRunForAgent(agentId);
     if (!run || run.id !== runId || run.agentId !== agentId) {
-      return reply.code(404).send({ error: "Active job run not found for agent." });
+      return reply
+        .code(404)
+        .send({ error: "Active job run not found for agent." });
     }
 
     let repoRoot: string | null = null;
@@ -1333,10 +1588,17 @@ async function registerRoutes() {
         log: mcpJobLog,
         listAgents: async () => {
           const agents = await agentManager.listAgents();
-          return agents.map((a) => ({ id: a.id, name: a.name, status: a.status, cwd: a.cwd }));
+          return agents.map((a) => ({
+            id: a.id,
+            name: a.name,
+            status: a.status,
+            cwd: a.cwd,
+          }));
         },
-        listRecentPersonaReviews: (sinceDays: number) => agentManager.listRecentPersonaReviews(sinceDays),
-        listRecentFeedback: (sinceDays: number) => agentManager.listRecentFeedback(sinceDays),
+        listRecentPersonaReviews: (sinceDays: number) =>
+          agentManager.listRecentPersonaReviews(sinceDays),
+        listRecentFeedback: (sinceDays: number) =>
+          agentManager.listRecentFeedback(sinceDays),
         getActivitySummary: (params) => agentManager.getActivitySummary(params),
         getAgentHistory: (params) => agentManager.getAgentHistory(params),
         getFeedbackSummary: (params) => agentManager.getFeedbackSummary(params),
@@ -1348,8 +1610,13 @@ async function registerRoutes() {
     const params = request.params as { agentId?: string };
     const agentId = params.agentId ?? "";
     const bearerToken = getBearerToken(request);
-    if (bearerToken && !validateAgentMcpToken(config.authToken, bearerToken, agentId)) {
-      return reply.code(403).send({ error: "Invalid MCP token for the requested agent route." });
+    if (
+      bearerToken &&
+      !validateAgentMcpToken(config.authToken, bearerToken, agentId)
+    ) {
+      return reply
+        .code(403)
+        .send({ error: "Invalid MCP token for the requested agent route." });
     }
     const agent = await agentManager.getAgent(agentId);
     if (!agent) {
@@ -1357,7 +1624,9 @@ async function registerRoutes() {
     }
     const activeJobRun = await jobService.getActiveRunForAgent(agentId);
     if (activeJobRun) {
-      return reply.code(403).send({ error: "Job agents must use the job-scoped MCP route." });
+      return reply
+        .code(403)
+        .send({ error: "Job agents must use the job-scoped MCP route." });
     }
 
     let repoRoot: string | null = null;
@@ -1395,9 +1664,18 @@ async function registerRoutes() {
       getParentContext: mcpGetParentContext,
       updateReviewStatus: mcpUpdateReviewStatus,
       completeReview: mcpCompleteReview,
-      getActivitySummary: (params) => agentManager.getActivitySummary(params) as Promise<Record<string, unknown>>,
-      getAgentHistory: (params) => agentManager.getAgentHistory(params) as Promise<Record<string, unknown>>,
-      getFeedbackSummary: (params) => agentManager.getFeedbackSummary(params) as Promise<Record<string, unknown>>,
+      getActivitySummary: (params) =>
+        agentManager.getActivitySummary(params) as Promise<
+          Record<string, unknown>
+        >,
+      getAgentHistory: (params) =>
+        agentManager.getAgentHistory(params) as Promise<
+          Record<string, unknown>
+        >,
+      getFeedbackSummary: (params) =>
+        agentManager.getFeedbackSummary(params) as Promise<
+          Record<string, unknown>
+        >,
     });
   });
 
@@ -1436,7 +1714,14 @@ async function registerRoutes() {
 
   app.get("/api/v1/release/info", async (_, reply) => {
     try {
-      await runCommand("git", ["-C", serverDir, "fetch", "origin", "--tags", "--quiet"]);
+      await runCommand("git", [
+        "-C",
+        serverDir,
+        "fetch",
+        "origin",
+        "--tags",
+        "--quiet",
+      ]);
 
       // Current deployed tag from store (fast)
       const record = await readReleaseStore();
@@ -1457,12 +1742,18 @@ async function registerRoutes() {
       try {
         const repo = await getGitHubRepo();
         const ghResult = await runCommand("gh", [
-          "release", "list",
-          "--repo", repo,
-          "--limit", "10",
-          "--json", "tagName,isPrerelease"
+          "release",
+          "list",
+          "--repo",
+          repo,
+          "--limit",
+          "10",
+          "--json",
+          "tagName,isPrerelease",
         ]);
-        const allReleases = parseGhJson<Array<{ tagName: string; isPrerelease: boolean }>>(ghResult.stdout);
+        const allReleases = parseGhJson<
+          Array<{ tagName: string; isPrerelease: boolean }>
+        >(ghResult.stdout);
         absoluteLatestTag = allReleases[0]?.tagName ?? null;
         if (channel === "stable") {
           latestTag = allReleases.find((r) => !r.isPrerelease)?.tagName ?? null;
@@ -1471,16 +1762,30 @@ async function registerRoutes() {
         }
       } catch {
         // Fallback to git tags (sees all releases regardless of channel)
-        const tagsResult = await runCommand("git", ["-C", serverDir, "tag", "--sort=-version:refname"]);
-        const fallbackTag = tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
+        const tagsResult = await runCommand("git", [
+          "-C",
+          serverDir,
+          "tag",
+          "--sort=-version:refname",
+        ]);
+        const fallbackTag =
+          tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
         latestTag = fallbackTag;
         absoluteLatestTag = fallbackTag;
       }
 
-      const updateAvailable = !!(currentTag && latestTag && compareSemver(latestTag, currentTag) > 0);
+      const updateAvailable = !!(
+        currentTag &&
+        latestTag &&
+        compareSemver(latestTag, currentTag) > 0
+      );
 
       // Try to enrich with GitHub Release metadata
-      let latestRelease: { tag: string; publishedAt: string; url: string } | null = null;
+      let latestRelease: {
+        tag: string;
+        publishedAt: string;
+        url: string;
+      } | null = null;
       if (latestTag && updateAvailable) {
         latestRelease = await fetchLatestReleaseMetadata(latestTag);
       }
@@ -1495,25 +1800,31 @@ async function registerRoutes() {
       const compareTag = absoluteLatestTag ?? currentTag;
       if (isAdmin && compareTag) {
         const refCheck = await runCommand(
-          "git", ["-C", serverDir, "rev-parse", "--verify", compareTag],
+          "git",
+          ["-C", serverDir, "rev-parse", "--verify", compareTag],
           { allowedExitCodes: [0, 128] }
         );
         if (refCheck.exitCode !== 0) {
           refMissing = true;
         } else {
           const countResult = await runCommand("git", [
-            "-C", serverDir,
-            "rev-list", `${compareTag}..origin/main`, "--count"
+            "-C",
+            serverDir,
+            "rev-list",
+            `${compareTag}..origin/main`,
+            "--count",
           ]);
           unreleasedCount = Number(countResult.stdout) || 0;
 
           if (unreleasedCount > 0) {
             const logResult = await runCommand("git", [
-              "-C", serverDir,
-              "log", `${compareTag}..origin/main`,
+              "-C",
+              serverDir,
+              "log",
+              `${compareTag}..origin/main`,
               "--no-merges",
               "--format=%H\t%s",
-              "--max-count=20"
+              "--max-count=20",
             ]);
             commits = logResult.stdout
               .split("\n")
@@ -1522,7 +1833,7 @@ async function registerRoutes() {
                 const tab = line.indexOf("\t");
                 return {
                   sha: line.slice(0, tab).slice(0, 7),
-                  subject: line.slice(tab + 1)
+                  subject: line.slice(tab + 1),
                 };
               });
           }
@@ -1538,7 +1849,7 @@ async function registerRoutes() {
         latestRelease,
         unreleasedCount,
         commits,
-        refMissing
+        refMissing,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -1560,8 +1871,13 @@ async function registerRoutes() {
 
   app.post("/api/v1/release/channel", async (request, reply) => {
     const body = request.body as { channel?: unknown } | undefined;
-    if (!body?.channel || !VALID_CHANNELS.includes(body.channel as ReleaseChannel)) {
-      return reply.code(400).send({ error: `channel must be one of: ${VALID_CHANNELS.join(", ")}` });
+    if (
+      !body?.channel ||
+      !VALID_CHANNELS.includes(body.channel as ReleaseChannel)
+    ) {
+      return reply.code(400).send({
+        error: `channel must be one of: ${VALID_CHANNELS.join(", ")}`,
+      });
     }
     await setSetting(pool, RELEASE_CHANNEL_KEY, body.channel as string);
     return { channel: body.channel };
@@ -1583,16 +1899,25 @@ async function registerRoutes() {
     }
 
     const body = request.body as { tag?: unknown } | undefined;
-    if (!body?.tag || typeof body.tag !== "string" || !/^v\d+\.\d+\.\d+$/.test(body.tag)) {
-      return reply.code(400).send({ error: "tag is required and must be a semver tag (e.g. v0.11.18)" });
+    if (
+      !body?.tag ||
+      typeof body.tag !== "string" ||
+      !/^v\d+\.\d+\.\d+$/.test(body.tag)
+    ) {
+      return reply.code(400).send({
+        error: "tag is required and must be a semver tag (e.g. v0.11.18)",
+      });
     }
 
     try {
       const repo = await getGitHubRepo();
       await runCommand("gh", [
-        "release", "edit", body.tag,
-        "--repo", repo,
-        "--prerelease=false"
+        "release",
+        "edit",
+        body.tag,
+        "--repo",
+        repo,
+        "--prerelease=false",
       ]);
       return { ok: true, tag: body.tag };
     } catch (err) {
@@ -1607,23 +1932,29 @@ async function registerRoutes() {
     try {
       const repo = await getGitHubRepo();
       const result = await runCommand("gh", [
-        "release", "list",
-        "--repo", repo,
-        "--limit", "10",
-        "--json", "tagName,publishedAt,isPrerelease"
+        "release",
+        "list",
+        "--repo",
+        repo,
+        "--limit",
+        "10",
+        "--json",
+        "tagName,publishedAt,isPrerelease",
       ]);
-      const releases = parseGhJson<Array<{
-        tagName: string;
-        publishedAt: string;
-        isPrerelease: boolean;
-      }>>(result.stdout);
+      const releases = parseGhJson<
+        Array<{
+          tagName: string;
+          publishedAt: string;
+          isPrerelease: boolean;
+        }>
+      >(result.stdout);
       return {
         releases: releases.map((r) => ({
           tag: r.tagName,
           publishedAt: r.publishedAt,
           isPrerelease: r.isPrerelease,
-          url: `https://github.com/${repo}/releases/tag/${r.tagName}`
-        }))
+          url: `https://github.com/${repo}/releases/tag/${r.tagName}`,
+        })),
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -1634,22 +1965,36 @@ async function registerRoutes() {
   app.post("/api/v1/release", async (request, reply) => {
     const body = request.body as { versionType?: unknown } | undefined;
 
-    if (!body?.versionType || !RELEASE_VERSION_TYPES.includes(body.versionType as ReleaseVersionType)) {
-      return reply.code(400).send({ error: `versionType must be one of: ${RELEASE_VERSION_TYPES.join(", ")}` });
+    if (
+      !body?.versionType ||
+      !RELEASE_VERSION_TYPES.includes(body.versionType as ReleaseVersionType)
+    ) {
+      return reply.code(400).send({
+        error: `versionType must be one of: ${RELEASE_VERSION_TYPES.join(", ")}`,
+      });
     }
 
     const versionType = body.versionType as ReleaseVersionType;
 
     // Only one release at a time
-    if (activeReleaseJob && activeReleaseJob.phase !== "done" && activeReleaseJob.phase !== "failed") {
-      return reply.code(409).send({ error: "A release is already in progress." });
+    if (
+      activeReleaseJob &&
+      activeReleaseJob.phase !== "done" &&
+      activeReleaseJob.phase !== "failed"
+    ) {
+      return reply
+        .code(409)
+        .send({ error: "A release is already in progress." });
     }
 
     // Quick pre-flight: check gh CLI before spawning the job
     try {
       await runCommand("gh", ["--version"]);
     } catch {
-      return reply.code(422).send({ error: "GitHub CLI (gh) is not available. Install it from https://cli.github.com" });
+      return reply.code(422).send({
+        error:
+          "GitHub CLI (gh) is not available. Install it from https://cli.github.com",
+      });
     }
 
     const job: ReleaseJob = {
@@ -1660,7 +2005,7 @@ async function registerRoutes() {
       log: [],
       runUrl: null,
       tag: null,
-      error: null
+      error: null,
     };
     activeReleaseJob = job;
 
@@ -1673,15 +2018,27 @@ async function registerRoutes() {
   app.post("/api/v1/release/update", async (request, reply) => {
     const body = request.body as { tag?: unknown } | undefined;
 
-    if (!body?.tag || typeof body.tag !== "string" || !/^v\d+\.\d+\.\d+$/.test(body.tag)) {
-      return reply.code(400).send({ error: "tag is required and must be a semver tag (e.g. v0.2.31)" });
+    if (
+      !body?.tag ||
+      typeof body.tag !== "string" ||
+      !/^v\d+\.\d+\.\d+$/.test(body.tag)
+    ) {
+      return reply.code(400).send({
+        error: "tag is required and must be a semver tag (e.g. v0.2.31)",
+      });
     }
 
     const tag = body.tag as string;
 
     // Only one release/update at a time
-    if (activeReleaseJob && activeReleaseJob.phase !== "done" && activeReleaseJob.phase !== "failed") {
-      return reply.code(409).send({ error: "A release or update is already in progress." });
+    if (
+      activeReleaseJob &&
+      activeReleaseJob.phase !== "done" &&
+      activeReleaseJob.phase !== "failed"
+    ) {
+      return reply
+        .code(409)
+        .send({ error: "A release or update is already in progress." });
     }
 
     const job: ReleaseJob = {
@@ -1692,7 +2049,7 @@ async function registerRoutes() {
       log: [],
       runUrl: null,
       tag,
-      error: null
+      error: null,
     };
     activeReleaseJob = job;
 
@@ -1717,7 +2074,10 @@ async function registerRoutes() {
     }, 20_000);
 
     // Send current job snapshot
-    const snapshot: ReleaseStreamEvent = { type: "snapshot", job: activeReleaseJob };
+    const snapshot: ReleaseStreamEvent = {
+      type: "snapshot",
+      job: activeReleaseJob,
+    };
     stream.write(`data: ${JSON.stringify(snapshot)}\n\n`);
 
     stream.on("close", () => {
@@ -1734,7 +2094,7 @@ async function registerRoutes() {
     return {
       status: "ok",
       db: "ok",
-      now: result.rows[0]?.now
+      now: result.rows[0]?.now,
     };
   });
 
@@ -1744,7 +2104,9 @@ async function registerRoutes() {
   app.post("/api/v1/clipboard/image", async (request, reply) => {
     const data = await request.file();
     if (!data) {
-      return reply.code(400).send({ error: "An image file field is required." });
+      return reply
+        .code(400)
+        .send({ error: "An image file field is required." });
     }
     const mime = data.mimetype;
     if (!mime.startsWith("image/")) {
@@ -1752,7 +2114,8 @@ async function registerRoutes() {
     }
 
     const buffer = await data.toBuffer();
-    const ext = mime === "image/png" ? "png" : mime === "image/jpeg" ? "jpg" : "png";
+    const ext =
+      mime === "image/png" ? "png" : mime === "image/jpeg" ? "jpg" : "png";
     const tmpPath = `/tmp/dispatch-clipboard-${Date.now()}.${ext}`;
     await writeFile(tmpPath, buffer);
 
@@ -1762,28 +2125,43 @@ async function registerRoutes() {
         await new Promise<void>((resolve, reject) => {
           const proc = spawn("osascript", [
             "-e",
-            `set the clipboard to (read (POSIX file "${tmpPath}") as «class ${pasteboardClass}»)`
+            `set the clipboard to (read (POSIX file "${tmpPath}") as «class ${pasteboardClass}»)`,
           ]);
-          proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`osascript exited ${code}`)));
+          proc.on("close", (code) =>
+            code === 0
+              ? resolve()
+              : reject(new Error(`osascript exited ${code}`))
+          );
           proc.on("error", reject);
         });
       } else {
         const display = process.env.DISPATCH_COPY_DISPLAY;
         if (!display) {
-          return reply.code(500).send({ error: "DISPATCH_COPY_DISPLAY is not set. Clipboard image paste on Linux requires Xvfb and xclip." });
+          return reply.code(500).send({
+            error:
+              "DISPATCH_COPY_DISPLAY is not set. Clipboard image paste on Linux requires Xvfb and xclip.",
+          });
         }
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn("xclip", ["-selection", "clipboard", "-t", mime, "-i", tmpPath], {
-            env: { ...process.env, DISPLAY: display }
-          });
-          proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(`xclip exited ${code}`)));
+          const proc = spawn(
+            "xclip",
+            ["-selection", "clipboard", "-t", mime, "-i", tmpPath],
+            {
+              env: { ...process.env, DISPLAY: display },
+            }
+          );
+          proc.on("close", (code) =>
+            code === 0 ? resolve() : reject(new Error(`xclip exited ${code}`))
+          );
           proc.on("error", reject);
         });
       }
       return reply.code(200).send({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return reply.code(500).send({ error: `Failed to write to clipboard: ${message}` });
+      return reply
+        .code(500)
+        .send({ error: `Failed to write to clipboard: ${message}` });
     } finally {
       await unlink(tmpPath).catch(() => {});
     }
@@ -1791,7 +2169,7 @@ async function registerRoutes() {
 
   app.get("/api/v1/system/defaults", async () => {
     return {
-      homeDir: os.homedir()
+      homeDir: os.homedir(),
     };
   });
 
@@ -1804,11 +2182,18 @@ async function registerRoutes() {
   app.get("/api/v1/system/path-info", async (request, reply) => {
     const query = request.query as { path?: unknown };
     if (typeof query?.path !== "string" || !query.path.trim()) {
-      return reply.code(400).send({ error: "path query parameter is required." });
+      return reply
+        .code(400)
+        .send({ error: "path query parameter is required." });
     }
     const resolved = resolveTildePath(query.path.trim());
     if (!path.isAbsolute(resolved)) {
-      return { exists: false, isDirectory: false, isGitRepo: false, resolvedPath: resolved };
+      return {
+        exists: false,
+        isDirectory: false,
+        isGitRepo: false,
+        resolvedPath: resolved,
+      };
     }
     try {
       const info = await stat(resolved).catch(() => null);
@@ -1816,22 +2201,33 @@ async function registerRoutes() {
       const isDirectory = exists && info.isDirectory();
       let isGitRepo = false;
       if (isDirectory) {
-        const result = await runCommand("git", ["-C", resolved, "rev-parse", "--is-inside-work-tree"], {
-          timeoutMs: 3_000,
-          allowedExitCodes: [0, 1, 128],
-        });
+        const result = await runCommand(
+          "git",
+          ["-C", resolved, "rev-parse", "--is-inside-work-tree"],
+          {
+            timeoutMs: 3_000,
+            allowedExitCodes: [0, 1, 128],
+          }
+        );
         isGitRepo = result.exitCode === 0 && result.stdout.trim() === "true";
       }
       return { exists, isDirectory, isGitRepo, resolvedPath: resolved };
     } catch {
-      return { exists: false, isDirectory: false, isGitRepo: false, resolvedPath: resolved };
+      return {
+        exists: false,
+        isDirectory: false,
+        isGitRepo: false,
+        resolvedPath: resolved,
+      };
     }
   });
 
   app.get("/api/v1/system/path-completions", async (request, reply) => {
     const query = request.query as { prefix?: unknown };
     if (typeof query?.prefix !== "string" || !query.prefix.trim()) {
-      return reply.code(400).send({ error: "prefix query parameter is required." });
+      return reply
+        .code(400)
+        .send({ error: "prefix query parameter is required." });
     }
     const raw = query.prefix.trim();
     const resolved = resolveTildePath(raw);
@@ -1852,7 +2248,8 @@ async function registerRoutes() {
         .filter((entry) => {
           if (!entry.isDirectory()) return false;
           // Skip hidden dirs unless the partial starts with "."
-          if (entry.name.startsWith(".") && !searchPartial.startsWith(".")) return false;
+          if (entry.name.startsWith(".") && !searchPartial.startsWith("."))
+            return false;
           return entry.name.toLowerCase().startsWith(searchPartial);
         })
         .sort((a, b) => a.name.localeCompare(b.name))
@@ -1877,16 +2274,28 @@ async function registerRoutes() {
   app.get("/api/v1/git/branches", async (request, reply) => {
     const query = request.query as { cwd?: unknown };
     if (typeof query?.cwd !== "string" || !query.cwd.trim()) {
-      return reply.code(400).send({ error: "cwd query parameter is required." });
+      return reply
+        .code(400)
+        .send({ error: "cwd query parameter is required." });
     }
     try {
       const rawCwd = query.cwd.trim();
-      const cwd = rawCwd.startsWith("~/") ? path.join(os.homedir(), rawCwd.slice(2)) : rawCwd === "~" ? os.homedir() : rawCwd;
-      const result = await runCommand("git", ["-C", cwd, "ls-remote", "--heads", "origin"], {
-        timeoutMs: 15_000,
-      });
+      const cwd = rawCwd.startsWith("~/")
+        ? path.join(os.homedir(), rawCwd.slice(2))
+        : rawCwd === "~"
+          ? os.homedir()
+          : rawCwd;
+      const result = await runCommand(
+        "git",
+        ["-C", cwd, "ls-remote", "--heads", "origin"],
+        {
+          timeoutMs: 15_000,
+        }
+      );
       if (result.exitCode !== 0) {
-        return reply.code(500).send({ error: "Failed to list remote branches." });
+        return reply
+          .code(500)
+          .send({ error: "Failed to list remote branches." });
       }
       const branches = result.stdout
         .split("\n")
@@ -1914,24 +2323,40 @@ async function registerRoutes() {
   app.get("/api/v1/agents/settings", async () => {
     const raw = await getSetting(pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation: WorktreeLocation =
-      raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw) ? (raw as WorktreeLocation) : "sibling";
+      raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw)
+        ? (raw as WorktreeLocation)
+        : "sibling";
     const instanceName = (await getSetting(pool, INSTANCE_NAME_KEY)) ?? "";
     return { worktreeLocation, iconColor: cachedIconColor, instanceName };
   });
 
   app.post("/api/v1/agents/settings", async (request, reply) => {
-    const body = request.body as { worktreeLocation?: unknown; iconColor?: unknown; instanceName?: unknown };
+    const body = request.body as {
+      worktreeLocation?: unknown;
+      iconColor?: unknown;
+      instanceName?: unknown;
+    };
 
     if (body.worktreeLocation !== undefined) {
-      if (typeof body.worktreeLocation !== "string" || !(VALID_WORKTREE_LOCATIONS as string[]).includes(body.worktreeLocation)) {
-        return reply.code(400).send({ error: `worktreeLocation must be "sibling" or "nested".` });
+      if (
+        typeof body.worktreeLocation !== "string" ||
+        !(VALID_WORKTREE_LOCATIONS as string[]).includes(body.worktreeLocation)
+      ) {
+        return reply
+          .code(400)
+          .send({ error: `worktreeLocation must be "sibling" or "nested".` });
       }
       await setSetting(pool, WORKTREE_LOCATION_KEY, body.worktreeLocation);
     }
 
     if (body.iconColor !== undefined) {
-      if (typeof body.iconColor !== "string" || !(VALID_ICON_COLORS as readonly string[]).includes(body.iconColor)) {
-        return reply.code(400).send({ error: `iconColor must be one of: ${VALID_ICON_COLORS.join(", ")}` });
+      if (
+        typeof body.iconColor !== "string" ||
+        !(VALID_ICON_COLORS as readonly string[]).includes(body.iconColor)
+      ) {
+        return reply.code(400).send({
+          error: `iconColor must be one of: ${VALID_ICON_COLORS.join(", ")}`,
+        });
       }
       await setSetting(pool, ICON_COLOR_KEY, body.iconColor);
       rewriteForColor(body.iconColor as IconColor);
@@ -1939,7 +2364,9 @@ async function registerRoutes() {
 
     if (body.instanceName !== undefined) {
       if (typeof body.instanceName !== "string") {
-        return reply.code(400).send({ error: "instanceName must be a string." });
+        return reply
+          .code(400)
+          .send({ error: "instanceName must be a string." });
       }
       const trimmed = body.instanceName.trim().slice(0, 100);
       if (trimmed) {
@@ -1951,7 +2378,9 @@ async function registerRoutes() {
 
     const raw = await getSetting(pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation: WorktreeLocation =
-      raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw) ? (raw as WorktreeLocation) : "sibling";
+      raw && (VALID_WORKTREE_LOCATIONS as string[]).includes(raw)
+        ? (raw as WorktreeLocation)
+        : "sibling";
     const instanceName = (await getSetting(pool, INSTANCE_NAME_KEY)) ?? "";
     return { worktreeLocation, iconColor: cachedIconColor, instanceName };
   });
@@ -1974,28 +2403,36 @@ async function registerRoutes() {
         return reply.code(400).send({ error: "webhookUrl must be a string." });
       }
       if (body.webhookUrl && !isValidSlackWebhookUrl(body.webhookUrl)) {
-        return reply.code(400).send({ error: "webhookUrl must start with https://hooks.slack.com/" });
+        return reply.code(400).send({
+          error: "webhookUrl must start with https://hooks.slack.com/",
+        });
       }
       await slackNotifier.setWebhookUrl(body.webhookUrl);
     }
 
     if (body?.notifyEvents !== undefined) {
       if (!Array.isArray(body.notifyEvents)) {
-        return reply.code(400).send({ error: "notifyEvents must be an array." });
+        return reply
+          .code(400)
+          .send({ error: "notifyEvents must be an array." });
       }
       await slackNotifier.setNotifyEvents(body.notifyEvents as string[]);
     }
 
     if (body?.webNotifyEnabled !== undefined) {
       if (typeof body.webNotifyEnabled !== "boolean") {
-        return reply.code(400).send({ error: "webNotifyEnabled must be a boolean." });
+        return reply
+          .code(400)
+          .send({ error: "webNotifyEnabled must be a boolean." });
       }
       await slackNotifier.setWebNotifyEnabled(body.webNotifyEnabled);
     }
 
     if (body?.webNotifyEvents !== undefined) {
       if (!Array.isArray(body.webNotifyEvents)) {
-        return reply.code(400).send({ error: "webNotifyEvents must be an array." });
+        return reply
+          .code(400)
+          .send({ error: "webNotifyEvents must be an array." });
       }
       await slackNotifier.setWebNotifyEvents(body.webNotifyEvents as string[]);
     }
@@ -2005,19 +2442,26 @@ async function registerRoutes() {
 
   app.post("/api/v1/notifications/test", async (request, reply) => {
     const body = request.body as { webhookUrl?: unknown } | null;
-    const url = typeof body?.webhookUrl === "string" ? body.webhookUrl : await slackNotifier.getWebhookUrl();
+    const url =
+      typeof body?.webhookUrl === "string"
+        ? body.webhookUrl
+        : await slackNotifier.getWebhookUrl();
     if (!url) {
-      return reply.code(400).send({ error: "No webhook URL provided or configured." });
+      return reply
+        .code(400)
+        .send({ error: "No webhook URL provided or configured." });
     }
     if (!isValidSlackWebhookUrl(url)) {
-      return reply.code(400).send({ error: "webhookUrl must start with https://hooks.slack.com/" });
+      return reply
+        .code(400)
+        .send({ error: "webhookUrl must start with https://hooks.slack.com/" });
     }
     return slackNotifier.sendTestMessage(url);
   });
 
   app.get("/api/v1/app/settings/agent-types", async () => {
     return {
-      enabledAgentTypes: await getEnabledAgentTypes(pool)
+      enabledAgentTypes: await getEnabledAgentTypes(pool),
     };
   });
 
@@ -2025,25 +2469,33 @@ async function registerRoutes() {
     const body = request.body as { enabledAgentTypes?: unknown } | null;
 
     if (!Array.isArray(body?.enabledAgentTypes)) {
-      return reply.code(400).send({ error: "enabledAgentTypes must be an array." });
+      return reply
+        .code(400)
+        .send({ error: "enabledAgentTypes must be an array." });
     }
 
     const uniqueTypes = body.enabledAgentTypes
-      .filter((value): value is typeof AGENT_TYPES[number] => typeof value === "string" && AGENT_TYPES.includes(value as typeof AGENT_TYPES[number]))
+      .filter(
+        (value): value is (typeof AGENT_TYPES)[number] =>
+          typeof value === "string" &&
+          AGENT_TYPES.includes(value as (typeof AGENT_TYPES)[number])
+      )
       .filter((value, index, values) => values.indexOf(value) === index);
 
     if (uniqueTypes.length === 0) {
-      return reply.code(400).send({ error: "At least one agent type must remain enabled." });
+      return reply
+        .code(400)
+        .send({ error: "At least one agent type must remain enabled." });
     }
 
     if (uniqueTypes.length !== body.enabledAgentTypes.length) {
-      return reply
-        .code(400)
-        .send({ error: `enabledAgentTypes must only include ${AGENT_TYPES.join(", ")}.` });
+      return reply.code(400).send({
+        error: `enabledAgentTypes must only include ${AGENT_TYPES.join(", ")}.`,
+      });
     }
 
     return {
-      enabledAgentTypes: await setEnabledAgentTypes(pool, uniqueTypes)
+      enabledAgentTypes: await setEnabledAgentTypes(pool, uniqueTypes),
     };
   });
 
@@ -2060,17 +2512,21 @@ async function registerRoutes() {
 
   app.get("/api/v1/diagnostics/git-context", async () => {
     const now = Date.now();
-    const pendingAges = Array.from(pendingGitRefreshEnqueuedAt.values()).map((queuedAt) =>
-      Math.max(0, now - queuedAt)
+    const pendingAges = Array.from(pendingGitRefreshEnqueuedAt.values()).map(
+      (queuedAt) => Math.max(0, now - queuedAt)
     );
-    const oldestPendingAgeMs = pendingAges.length > 0 ? Math.max(...pendingAges) : null;
+    const oldestPendingAgeMs =
+      pendingAges.length > 0 ? Math.max(...pendingAges) : null;
 
     const durations = [...gitRefreshDurationsMs].sort((a, b) => a - b);
     const p50DurationMs = percentile(durations, 0.5);
     const p95DurationMs = percentile(durations, 0.95);
-    const maxDurationMs = durations.length > 0 ? durations[durations.length - 1] : null;
+    const maxDurationMs =
+      durations.length > 0 ? durations[durations.length - 1] : null;
     const lastDurationMs =
-      gitRefreshDurationsMs.length > 0 ? gitRefreshDurationsMs[gitRefreshDurationsMs.length - 1] : null;
+      gitRefreshDurationsMs.length > 0
+        ? gitRefreshDurationsMs[gitRefreshDurationsMs.length - 1]
+        : null;
 
     const agents = Array.from(gitRefreshAgentDiagnostics.entries())
       .map(([agentId, diag]) => ({
@@ -2082,7 +2538,7 @@ async function registerRoutes() {
         lastCompletedAt: toIso(diag.lastCompletedAt),
         lastDurationMs: diag.lastDurationMs,
         lastResult: diag.lastResult,
-        lastError: diag.lastError
+        lastError: diag.lastError,
       }))
       .sort((a, b) => a.agentId.localeCompare(b.agentId));
 
@@ -2090,12 +2546,12 @@ async function registerRoutes() {
       config: {
         intervalMs: GIT_CONTEXT_REFRESH_INTERVAL_MS,
         concurrency: GIT_CONTEXT_REFRESH_CONCURRENCY,
-        probeTimeoutMs: PROBE_COMMAND_TIMEOUT_MS
+        probeTimeoutMs: PROBE_COMMAND_TIMEOUT_MS,
       },
       queue: {
         pending: pendingGitRefreshAgentIds.size,
         active: activeGitRefreshAgentIds.size,
-        oldestPendingAgeMs
+        oldestPendingAgeMs,
       },
       counters: gitRefreshCounters,
       durationsMs: {
@@ -2103,9 +2559,9 @@ async function registerRoutes() {
         p50: p50DurationMs,
         p95: p95DurationMs,
         max: maxDurationMs,
-        last: lastDurationMs
+        last: lastDurationMs,
       },
-      agents
+      agents,
     };
   });
 
@@ -2113,8 +2569,12 @@ async function registerRoutes() {
 
   app.get("/api/v1/activity/heatmap", async (request) => {
     const query = request.query as Record<string, unknown>;
-    const days = Math.min(Math.max(parseInt((query.days as string) ?? "365", 10) || 365, 1), 730);
-    const rawTz = typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
+    const days = Math.min(
+      Math.max(parseInt((query.days as string) ?? "365", 10) || 365, 1),
+      730
+    );
+    const rawTz =
+      typeof query.tz === "string" && query.tz ? query.tz : FALLBACK_TZ;
     const tz = VALID_TIMEZONES.has(rawTz) ? rawTz : FALLBACK_TZ;
 
     const result = await pool.query<{ day: string; count: number }>(
@@ -2233,7 +2693,10 @@ async function registerRoutes() {
 
   app.get("/api/v1/activity/token-stats", async (request) => {
     const aq = parseActivityQuery(request.query as Record<string, unknown>);
-    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
+    const tokenFilter = timeRangeClause(
+      aq,
+      "COALESCE(session_start, harvested_at)"
+    );
     const result = await pool.query<{
       total_input: number;
       total_cache_creation: number;
@@ -2253,19 +2716,24 @@ async function registerRoutes() {
        ${tokenFilter.clause}`,
       tokenFilter.params
     );
-    return result.rows[0] ?? {
-      total_input: 0,
-      total_cache_creation: 0,
-      total_cache_read: 0,
-      total_output: 0,
-      total_messages: 0,
-      total_sessions: 0,
-    };
+    return (
+      result.rows[0] ?? {
+        total_input: 0,
+        total_cache_creation: 0,
+        total_cache_read: 0,
+        total_output: 0,
+        total_messages: 0,
+        total_sessions: 0,
+      }
+    );
   });
 
   app.get("/api/v1/activity/token-daily", async (request) => {
     const aq = parseActivityQuery(request.query as Record<string, unknown>);
-    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
+    const tokenFilter = timeRangeClause(
+      aq,
+      "COALESCE(session_start, harvested_at)"
+    );
 
     const result = await pool.query<{
       day: string;
@@ -2292,7 +2760,10 @@ async function registerRoutes() {
 
   app.get("/api/v1/activity/token-by-project", async (request) => {
     const aq = parseActivityQuery(request.query as Record<string, unknown>);
-    const tokenFilter = timeRangeClause(aq, "COALESCE(t.session_start, t.harvested_at)");
+    const tokenFilter = timeRangeClause(
+      aq,
+      "COALESCE(t.session_start, t.harvested_at)"
+    );
     const result = await pool.query<{
       project_dir: string;
       total_input: number;
@@ -2317,7 +2788,10 @@ async function registerRoutes() {
 
   app.get("/api/v1/activity/token-by-model", async (request) => {
     const aq = parseActivityQuery(request.query as Record<string, unknown>);
-    const tokenFilter = timeRangeClause(aq, "COALESCE(session_start, harvested_at)");
+    const tokenFilter = timeRangeClause(
+      aq,
+      "COALESCE(session_start, harvested_at)"
+    );
     const result = await pool.query<{
       model: string;
       total_input: number;
@@ -2367,15 +2841,21 @@ async function registerRoutes() {
   app.get("/api/v1/history/agents", async (request) => {
     const query = request.query as Record<string, unknown>;
     const aq = parseActivityQuery(query);
-    const limit = Math.min(Math.max(parseInt(String(query.limit ?? "50"), 10) || 50, 1), 100);
+    const limit = Math.min(
+      Math.max(parseInt(String(query.limit ?? "50"), 10) || 50, 1),
+      100
+    );
     const offset = Math.max(parseInt(String(query.offset ?? "0"), 10) || 0, 0);
     const search = typeof query.search === "string" ? query.search.trim() : "";
     const type = typeof query.type === "string" ? query.type : "";
     const project = typeof query.project === "string" ? query.project : "";
-    const sortCol = typeof query.sort === "string" && ["created_at", "name", "updated_at"].includes(query.sort)
-      ? query.sort
-      : "created_at";
-    const order = typeof query.order === "string" && query.order === "asc" ? "ASC" : "DESC";
+    const sortCol =
+      typeof query.sort === "string" &&
+      ["created_at", "name", "updated_at"].includes(query.sort)
+        ? query.sort
+        : "created_at";
+    const order =
+      typeof query.order === "string" && query.order === "asc" ? "ASC" : "DESC";
 
     const conditions: string[] = ["a.parent_agent_id IS NULL"];
     const params: unknown[] = [];
@@ -2390,7 +2870,9 @@ async function registerRoutes() {
     }
     if (project) {
       params.push(project);
-      conditions.push(`COALESCE(a.git_context->>'repoRoot', a.cwd) = $${params.length}`);
+      conditions.push(
+        `COALESCE(a.git_context->>'repoRoot', a.cwd) = $${params.length}`
+      );
     }
 
     const dateRange = timeRangeClause(aq, "a.created_at", params.length);
@@ -2401,8 +2883,12 @@ async function registerRoutes() {
       conditions.push(rangeConditions);
     }
 
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-    const sortSql = sortCol === "name" ? `a.name ${order}, a.created_at DESC` : `a.${sortCol} ${order}`;
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const sortSql =
+      sortCol === "name"
+        ? `a.name ${order}, a.created_at DESC`
+        : `a.${sortCol} ${order}`;
     const listParams = [...params, limit, offset];
 
     const [countResult, agentsResult] = await Promise.all([
@@ -2458,7 +2944,9 @@ async function registerRoutes() {
     const childrenByParent = new Map<string, ChildAgent[]>();
 
     if (parentIds.length > 0) {
-      const childResult = await pool.query<ChildAgent & { parentAgentId: string }>(
+      const childResult = await pool.query<
+        ChildAgent & { parentAgentId: string }
+      >(
         `SELECT
           a.id,
           a.name,
@@ -2478,7 +2966,10 @@ async function registerRoutes() {
       for (const child of childResult.rows) {
         const pid = child.parentAgentId;
         let list = childrenByParent.get(pid);
-        if (!list) { list = []; childrenByParent.set(pid, list); }
+        if (!list) {
+          list = [];
+          childrenByParent.set(pid, list);
+        }
         list.push({
           id: child.id,
           name: child.name,
@@ -2490,15 +2981,17 @@ async function registerRoutes() {
       }
     }
 
-    const agents = agentsResult.rows.map((agent: { id: string; totalTokens: number }) => {
-      const children = childrenByParent.get(agent.id) ?? [];
-      const childTokens = children.reduce((sum, c) => sum + c.totalTokens, 0);
-      return {
-        ...agent,
-        children,
-        groupTotalTokens: agent.totalTokens + childTokens,
-      };
-    });
+    const agents = agentsResult.rows.map(
+      (agent: { id: string; totalTokens: number }) => {
+        const children = childrenByParent.get(agent.id) ?? [];
+        const childTokens = children.reduce((sum, c) => sum + c.totalTokens, 0);
+        return {
+          ...agent,
+          children,
+          groupTotalTokens: agent.totalTokens + childTokens,
+        };
+      }
+    );
 
     return { agents, total: countResult.rows[0]?.total ?? 0, limit, offset };
   });
@@ -2530,8 +3023,20 @@ async function registerRoutes() {
       return reply.code(404).send({ error: "Agent not found" });
     }
 
-    const [eventsResult, tokenResult, tokenByModelResult, mediaResult, feedbackResult] = await Promise.all([
-      pool.query<{ id: number; event_type: string; message: string; metadata: Record<string, unknown>; created_at: string }>(
+    const [
+      eventsResult,
+      tokenResult,
+      tokenByModelResult,
+      mediaResult,
+      feedbackResult,
+    ] = await Promise.all([
+      pool.query<{
+        id: number;
+        event_type: string;
+        message: string;
+        metadata: Record<string, unknown>;
+        created_at: string;
+      }>(
         `SELECT id, event_type, message, metadata, created_at
          FROM agent_events WHERE agent_id = $1 ORDER BY created_at ASC`,
         [id]
@@ -2552,7 +3057,11 @@ async function registerRoutes() {
          FROM agent_token_usage WHERE agent_id = $1`,
         [id]
       ),
-      pool.query<{ model: string; input_tokens: number; output_tokens: number }>(
+      pool.query<{
+        model: string;
+        input_tokens: number;
+        output_tokens: number;
+      }>(
         `SELECT model,
           SUM(input_tokens + cache_creation_tokens + cache_read_tokens) AS input_tokens,
           SUM(output_tokens) AS output_tokens
@@ -2560,7 +3069,13 @@ async function registerRoutes() {
          GROUP BY model ORDER BY (SUM(input_tokens + cache_creation_tokens + cache_read_tokens) + SUM(output_tokens)) DESC`,
         [id]
       ),
-      pool.query<{ file_name: string; source: string; size_bytes: number; description: string | null; created_at: string }>(
+      pool.query<{
+        file_name: string;
+        source: string;
+        size_bytes: number;
+        description: string | null;
+        created_at: string;
+      }>(
         `SELECT file_name, source, size_bytes, description, created_at
          FROM media WHERE agent_id = $1 ORDER BY created_at`,
         [id]
@@ -2629,16 +3144,17 @@ async function registerRoutes() {
 
     const idFilter = ids.length > 0 ? new Set(ids) : null;
     const agents = await agentManager.listAgents();
-    const targets = idFilter ? agents.filter((agent) => idFilter.has(agent.id)) : agents;
+    const targets = idFilter
+      ? agents.filter((agent) => idFilter.has(agent.id))
+      : agents;
 
     const contexts = targets.map((agent) => ({
       id: agent.id,
-      gitContext: agent.gitContext
+      gitContext: agent.gitContext,
     }));
 
     return { contexts };
   });
-
 
   app.get("/api/v1/events", async (_request, reply) => {
     reply.raw.setHeader("Content-Type", "text/event-stream");
@@ -2667,7 +3183,10 @@ async function registerRoutes() {
   });
 
   app.post("/api/v1/focus", async (request, reply) => {
-    const body = request.body as { agentId?: unknown; webNotifyPermission?: unknown };
+    const body = request.body as {
+      agentId?: unknown;
+      webNotifyPermission?: unknown;
+    };
     const agentId = body?.agentId;
 
     // Track browser notification permission state from the client
@@ -2686,7 +3205,9 @@ async function registerRoutes() {
     }
 
     if (typeof agentId !== "string" || !agentId.trim()) {
-      return reply.code(400).send({ error: "agentId must be a non-empty string or null." });
+      return reply
+        .code(400)
+        .send({ error: "agentId must be a non-empty string or null." });
     }
 
     focusTracker.setFocused(agentId.trim());
@@ -2709,19 +3230,26 @@ async function registerRoutes() {
     const id = params.id ?? "";
     const body = request.body as { reviewAgentType?: unknown } | null;
 
-    let reviewAgentType: typeof AGENT_TYPES[number] | null;
+    let reviewAgentType: (typeof AGENT_TYPES)[number] | null;
     if (body?.reviewAgentType === null || body?.reviewAgentType === undefined) {
       reviewAgentType = null;
-    } else if (typeof body.reviewAgentType === "string" && AGENT_TYPES.includes(body.reviewAgentType as typeof AGENT_TYPES[number])) {
-      reviewAgentType = body.reviewAgentType as typeof AGENT_TYPES[number];
+    } else if (
+      typeof body.reviewAgentType === "string" &&
+      AGENT_TYPES.includes(body.reviewAgentType as (typeof AGENT_TYPES)[number])
+    ) {
+      reviewAgentType = body.reviewAgentType as (typeof AGENT_TYPES)[number];
     } else {
-      return reply.code(400).send({ error: `reviewAgentType must be null or one of ${AGENT_TYPES.join(", ")}.` });
+      return reply.code(400).send({
+        error: `reviewAgentType must be null or one of ${AGENT_TYPES.join(", ")}.`,
+      });
     }
 
     if (reviewAgentType) {
       const enabledAgentTypes = await getEnabledAgentTypes(pool);
       if (!enabledAgentTypes.includes(reviewAgentType)) {
-        return reply.code(400).send({ error: `${reviewAgentType} agents are disabled in settings.` });
+        return reply.code(400).send({
+          error: `${reviewAgentType} agents are disabled in settings.`,
+        });
       }
     }
 
@@ -2731,7 +3259,10 @@ async function registerRoutes() {
       if (!agent) {
         return reply.code(404).send({ error: "Agent not found." });
       }
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
       return { agent: withStreamFlag(agent) };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -2752,28 +3283,37 @@ async function registerRoutes() {
 
     if (!isAgentLatestEventType(type)) {
       return reply.code(400).send({
-        error: `type must be one of: ${AGENT_LATEST_EVENT_TYPES.join(", ")}.`
+        error: `type must be one of: ${AGENT_LATEST_EVENT_TYPES.join(", ")}.`,
       });
     }
 
     if (typeof message !== "string" || !message.trim()) {
-      return reply.code(400).send({ error: "message must be a non-empty string." });
+      return reply
+        .code(400)
+        .send({ error: "message must be a non-empty string." });
     }
 
     if (
       metadata !== undefined &&
-      (metadata === null || typeof metadata !== "object" || Array.isArray(metadata))
+      (metadata === null ||
+        typeof metadata !== "object" ||
+        Array.isArray(metadata))
     ) {
-      return reply.code(400).send({ error: "metadata must be an object when provided." });
+      return reply
+        .code(400)
+        .send({ error: "metadata must be an object when provided." });
     }
 
     const agent = await agentManager.upsertLatestEvent(id, {
       type,
       message: message.trim(),
-      metadata: metadata as Record<string, unknown> | undefined
+      metadata: metadata as Record<string, unknown> | undefined,
     });
 
-    uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(agent),
+    });
     return { agent };
   });
 
@@ -2781,7 +3321,9 @@ async function registerRoutes() {
     const params = request.params as { id?: string };
     const id = params.id ?? "";
     // Include deleted agents so historical media lists still work
-    const agentExists = await pool.query("SELECT 1 FROM agents WHERE id = $1", [id]);
+    const agentExists = await pool.query("SELECT 1 FROM agents WHERE id = $1", [
+      id,
+    ]);
     if (agentExists.rows.length === 0) {
       return reply.code(404).send({ error: "Agent not found." });
     }
@@ -2791,8 +3333,8 @@ async function registerRoutes() {
     return {
       files: files.map((file) => ({
         ...file,
-        seen: seenKeys.has(toMediaKey(file))
-      }))
+        seen: seenKeys.has(toMediaKey(file)),
+      })),
     };
   });
 
@@ -2814,7 +3356,10 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "Invalid media file name." });
     }
 
-    const filePath = path.join(resolveMediaDir(agentRow.rows[0].id, agentRow.rows[0].media_dir), file);
+    const filePath = path.join(
+      resolveMediaDir(agentRow.rows[0].id, agentRow.rows[0].media_dir),
+      file
+    );
     const fileStat = await stat(filePath).catch(() => null);
     if (!fileStat || !fileStat.isFile()) {
       return reply.code(404).send({ error: "Media file not found." });
@@ -2841,14 +3386,25 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "Invalid file name." });
     }
     if (!isMediaFile(fileName)) {
-      return reply.code(400).send({ error: "Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc)." });
+      return reply.code(400).send({
+        error:
+          "Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc).",
+      });
     }
 
     const isText = isTextFile(fileName);
-    const sourceField = (data.fields.source as { value?: string } | undefined)?.value ?? (isText ? "text" : "screenshot");
+    const sourceField =
+      (data.fields.source as { value?: string } | undefined)?.value ??
+      (isText ? "text" : "screenshot");
     const validSources = ["screenshot", "stream", "simulator", "text", "user"];
-    const source = validSources.includes(sourceField) ? sourceField : (isText ? "text" : "screenshot");
-    const description = (data.fields.description as { value?: string } | undefined)?.value ?? null;
+    const source = validSources.includes(sourceField)
+      ? sourceField
+      : isText
+        ? "text"
+        : "screenshot";
+    const description =
+      (data.fields.description as { value?: string } | undefined)?.value ??
+      null;
 
     const mediaDir = resolveMediaDir(agent.id, agent.mediaDir);
     await mkdir(mediaDir, { recursive: true });
@@ -2856,7 +3412,11 @@ async function registerRoutes() {
     const buffer = await data.toBuffer();
 
     // Timestamp filenames to prevent collisions (matches mcpShareMedia pattern)
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-")
+      .replace("T", "-")
+      .replace("Z", "");
     const ext = path.extname(fileName);
     const base = path.basename(fileName, ext);
     const timestampedFileName = `${base}-${timestamp}${ext}`;
@@ -2878,7 +3438,7 @@ async function registerRoutes() {
       source,
       sizeBytes: buffer.length,
       createdAt: row.created_at.toISOString(),
-      url: `/api/v1/agents/${id}/media/${encodeURIComponent(timestampedFileName)}`
+      url: `/api/v1/agents/${id}/media/${encodeURIComponent(timestampedFileName)}`,
     };
 
     uiEventBroker.publish({ type: "media.changed", agentId: id });
@@ -2894,15 +3454,18 @@ async function registerRoutes() {
     }
 
     const body = request.body as { keys?: unknown } | undefined;
-    if (!Array.isArray(body?.keys) || !body.keys.every((key) => typeof key === "string")) {
-      return reply.code(400).send({ error: "keys must be an array of strings." });
+    if (
+      !Array.isArray(body?.keys) ||
+      !body.keys.every((key) => typeof key === "string")
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "keys must be an array of strings." });
     }
 
     const keys = Array.from(
       new Set(
-        body.keys
-          .map((key) => key.trim())
-          .filter((key) => isValidMediaKey(key))
+        body.keys.map((key) => key.trim()).filter((key) => isValidMediaKey(key))
       )
     );
 
@@ -2923,30 +3486,46 @@ async function registerRoutes() {
       return reply.code(404).send({ error: "Agent not found." });
     }
 
-    const body = request.body as { type?: unknown; port?: unknown; description?: unknown };
+    const body = request.body as {
+      type?: unknown;
+      port?: unknown;
+      description?: unknown;
+    };
     if (body?.type === "stop") {
-      const description = typeof body.description === "string" ? body.description : null;
+      const description =
+        typeof body.description === "string" ? body.description : null;
       streamManager.stopStream(id, description);
       return { ok: true };
     }
 
     if (body?.type === "playwright") {
-      if (typeof body.port !== "number" || !Number.isFinite(body.port) || body.port < 1) {
-        return reply.code(400).send({ error: "port must be a positive number." });
+      if (
+        typeof body.port !== "number" ||
+        !Number.isFinite(body.port) ||
+        body.port < 1
+      ) {
+        return reply
+          .code(400)
+          .send({ error: "port must be a positive number." });
       }
       if (streamManager.hasStream(id)) {
-        return reply.code(409).send({ error: "Stream already active for this agent." });
+        return reply
+          .code(409)
+          .send({ error: "Stream already active for this agent." });
       }
       try {
         await streamManager.startStream(id, body.port);
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to start stream.";
+        const message =
+          error instanceof Error ? error.message : "Failed to start stream.";
         return reply.code(502).send({ error: message });
       }
       return { ok: true };
     }
 
-    return reply.code(400).send({ error: "type must be 'playwright' or 'stop'." });
+    return reply
+      .code(400)
+      .send({ error: "type must be 'playwright' or 'stop'." });
   });
 
   app.get("/api/v1/agents/:id/stream", async (request, reply) => {
@@ -2957,7 +3536,9 @@ async function registerRoutes() {
       return reply.code(404).send({ error: "Agent not found." });
     }
     if (!streamManager.hasStream(id)) {
-      return reply.code(404).send({ error: "No active stream for this agent." });
+      return reply
+        .code(404)
+        .send({ error: "No active stream for this agent." });
     }
 
     reply.hijack();
@@ -2965,7 +3546,7 @@ async function registerRoutes() {
     raw.writeHead(200, {
       "Content-Type": "multipart/x-mixed-replace; boundary=frame",
       "Cache-Control": "no-cache, no-transform",
-      "Connection": "keep-alive",
+      Connection: "keep-alive",
       "X-Accel-Buffering": "no",
     });
     raw.flushHeaders();
@@ -3028,57 +3609,100 @@ async function registerRoutes() {
     };
 
     if (typeof body?.cwd !== "string") {
-      return reply.code(400).send({ error: "Body must include cwd as a string." });
+      return reply
+        .code(400)
+        .send({ error: "Body must include cwd as a string." });
     }
 
     const providedAgentArgs = body.agentArgs ?? body.codexArgs;
     const agentArgsValid =
       providedAgentArgs === undefined ||
-      (Array.isArray(providedAgentArgs) && providedAgentArgs.every((item) => typeof item === "string"));
+      (Array.isArray(providedAgentArgs) &&
+        providedAgentArgs.every((item) => typeof item === "string"));
 
     if (!agentArgsValid) {
-      return reply.code(400).send({ error: "agentArgs must be an array of strings." });
+      return reply
+        .code(400)
+        .send({ error: "agentArgs must be an array of strings." });
     }
 
-    if (body.type !== undefined && body.type !== "codex" && body.type !== "claude" && body.type !== "opencode") {
-      return reply.code(400).send({ error: "type must be codex, claude, or opencode when provided." });
+    if (
+      body.type !== undefined &&
+      body.type !== "codex" &&
+      body.type !== "claude" &&
+      body.type !== "opencode"
+    ) {
+      return reply.code(400).send({
+        error: "type must be codex, claude, or opencode when provided.",
+      });
     }
 
     if (body.fullAccess !== undefined && typeof body.fullAccess !== "boolean") {
-      return reply.code(400).send({ error: "fullAccess must be a boolean when provided." });
+      return reply
+        .code(400)
+        .send({ error: "fullAccess must be a boolean when provided." });
     }
 
-    if (body.useWorktree !== undefined && typeof body.useWorktree !== "boolean") {
-      return reply.code(400).send({ error: "useWorktree must be a boolean when provided." });
+    if (
+      body.useWorktree !== undefined &&
+      typeof body.useWorktree !== "boolean"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "useWorktree must be a boolean when provided." });
     }
 
     if (body.autoReview !== undefined && typeof body.autoReview !== "boolean") {
-      return reply.code(400).send({ error: "autoReview must be a boolean when provided." });
+      return reply
+        .code(400)
+        .send({ error: "autoReview must be a boolean when provided." });
     }
 
-    if (body.worktreeBranch !== undefined && typeof body.worktreeBranch !== "string") {
-      return reply.code(400).send({ error: "worktreeBranch must be a string when provided." });
+    if (
+      body.worktreeBranch !== undefined &&
+      typeof body.worktreeBranch !== "string"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "worktreeBranch must be a string when provided." });
     }
 
     if (body.baseBranch !== undefined && typeof body.baseBranch !== "string") {
-      return reply.code(400).send({ error: "baseBranch must be a string when provided." });
+      return reply
+        .code(400)
+        .send({ error: "baseBranch must be a string when provided." });
     }
 
-    if (body.initialPrompt !== undefined && typeof body.initialPrompt !== "string") {
-      return reply.code(400).send({ error: "initialPrompt must be a string when provided." });
+    if (
+      body.initialPrompt !== undefined &&
+      typeof body.initialPrompt !== "string"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "initialPrompt must be a string when provided." });
     }
 
-    if (typeof body.initialPrompt === "string" && body.initialPrompt.trim().length > AGENT_INITIAL_PROMPT_MAX_CHARS) {
+    if (
+      typeof body.initialPrompt === "string" &&
+      body.initialPrompt.trim().length > AGENT_INITIAL_PROMPT_MAX_CHARS
+    ) {
       return reply.code(400).send({
-        error: `initialPrompt must be at most ${AGENT_INITIAL_PROMPT_MAX_CHARS} characters when provided.`
+        error: `initialPrompt must be at most ${AGENT_INITIAL_PROMPT_MAX_CHARS} characters when provided.`,
       });
     }
 
     const agentArgs = providedAgentArgs as string[] | undefined;
-    const agentType = body.type === "claude" ? "claude" : body.type === "opencode" ? "opencode" : "codex";
+    const agentType =
+      body.type === "claude"
+        ? "claude"
+        : body.type === "opencode"
+          ? "opencode"
+          : "codex";
     const enabledAgentTypes = await getEnabledAgentTypes(pool);
     if (!enabledAgentTypes.includes(agentType)) {
-      return reply.code(400).send({ error: `${agentType} agents are disabled in settings.` });
+      return reply
+        .code(400)
+        .send({ error: `${agentType} agents are disabled in settings.` });
     }
 
     const fullAccessArg =
@@ -3095,7 +3719,8 @@ async function registerRoutes() {
     try {
       const worktreeLocationRaw = await getSetting(pool, WORKTREE_LOCATION_KEY);
       const worktreeLocation: WorktreeLocation =
-        worktreeLocationRaw && (VALID_WORKTREE_LOCATIONS as string[]).includes(worktreeLocationRaw)
+        worktreeLocationRaw &&
+        (VALID_WORKTREE_LOCATIONS as string[]).includes(worktreeLocationRaw)
           ? (worktreeLocationRaw as WorktreeLocation)
           : "sibling";
 
@@ -3105,18 +3730,35 @@ async function registerRoutes() {
         cwd: body.cwd,
         agentArgs: resolvedAgentArgs,
         fullAccess: body.fullAccess === true,
-        useWorktree: typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
-        worktreeBranch: typeof body.worktreeBranch === "string" ? body.worktreeBranch : undefined,
-        baseBranch: typeof body.baseBranch === "string" ? body.baseBranch : undefined,
+        useWorktree:
+          typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
+        worktreeBranch:
+          typeof body.worktreeBranch === "string"
+            ? body.worktreeBranch
+            : undefined,
+        baseBranch:
+          typeof body.baseBranch === "string" ? body.baseBranch : undefined,
         worktreeLocation,
         persona: typeof body.persona === "string" ? body.persona : undefined,
-        parentAgentId: typeof body.parentAgentId === "string" ? body.parentAgentId : undefined,
-        personaContext: typeof body.personaContext === "string" ? body.personaContext : undefined,
+        parentAgentId:
+          typeof body.parentAgentId === "string"
+            ? body.parentAgentId
+            : undefined,
+        personaContext:
+          typeof body.personaContext === "string"
+            ? body.personaContext
+            : undefined,
         autoReview: body.autoReview === true,
-        initialPrompt: typeof body.initialPrompt === "string" ? body.initialPrompt.trim() || undefined : undefined,
+        initialPrompt:
+          typeof body.initialPrompt === "string"
+            ? body.initialPrompt.trim() || undefined
+            : undefined,
       });
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
       return reply.code(201).send({ agent });
     } catch (error) {
       return handleAgentError(reply, error);
@@ -3131,14 +3773,22 @@ async function registerRoutes() {
 
     const validPhases = ["worktree", "env", "deps", "session"];
     if (typeof body?.phase !== "string" || !validPhases.includes(body.phase)) {
-      return reply.code(400).send({ error: "phase must be one of: worktree, env, deps, session" });
+      return reply
+        .code(400)
+        .send({ error: "phase must be one of: worktree, env, deps, session" });
     }
 
     try {
-      await agentManager.updateSetupPhase(id, body.phase as "worktree" | "env" | "deps" | "session");
+      await agentManager.updateSetupPhase(
+        id,
+        body.phase as "worktree" | "env" | "deps" | "session"
+      );
       const agent = await agentManager.getAgent(id);
       if (agent) {
-        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+        uiEventBroker.publish({
+          type: "agent.upsert",
+          agent: withStreamFlag(agent),
+        });
       }
       return { ok: true };
     } catch (error) {
@@ -3162,11 +3812,16 @@ async function registerRoutes() {
     try {
       const agent = await agentManager.completeSetup(id, {
         effectiveCwd: body.effectiveCwd,
-        worktreePath: typeof body.worktreePath === "string" ? body.worktreePath : null,
-        worktreeBranch: typeof body.worktreeBranch === "string" ? body.worktreeBranch : null,
+        worktreePath:
+          typeof body.worktreePath === "string" ? body.worktreePath : null,
+        worktreeBranch:
+          typeof body.worktreeBranch === "string" ? body.worktreeBranch : null,
       });
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
       return { ok: true };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -3180,7 +3835,10 @@ async function registerRoutes() {
     try {
       const agent = await agentManager.startAgent(id);
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
       return { agent };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -3192,16 +3850,26 @@ async function registerRoutes() {
     const body = request.body as { force?: unknown } | undefined;
     const id = params.id ?? "";
 
-    app.log.info({ agentId: id, force: body?.force ?? false }, "Stop agent requested");
+    app.log.info(
+      { agentId: id, force: body?.force ?? false },
+      "Stop agent requested"
+    );
 
     if (body?.force !== undefined && typeof body.force !== "boolean") {
-      return reply.code(400).send({ error: "force must be a boolean when provided." });
+      return reply
+        .code(400)
+        .send({ error: "force must be a boolean when provided." });
     }
 
     try {
-      const agent = await agentManager.stopAgent(id, { force: body?.force as boolean | undefined });
+      const agent = await agentManager.stopAgent(id, {
+        force: body?.force as boolean | undefined,
+      });
       queueGitContextRefresh([agent.id]);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
       return { agent };
     } catch (error) {
       return handleAgentError(reply, error);
@@ -3231,7 +3899,8 @@ async function registerRoutes() {
     const validCleanupModes = ["auto", "keep", "force"] as const;
     type CleanupMode = (typeof validCleanupModes)[number];
     const cleanupWorktree: CleanupMode =
-      typeof query.cleanupWorktree === "string" && (validCleanupModes as readonly string[]).includes(query.cleanupWorktree)
+      typeof query.cleanupWorktree === "string" &&
+      (validCleanupModes as readonly string[]).includes(query.cleanupWorktree)
         ? (query.cleanupWorktree as CleanupMode)
         : "auto";
 
@@ -3239,14 +3908,20 @@ async function registerRoutes() {
       // Fast synchronous phase: mark agent as archiving and return immediately.
       // cleanupWorktree is persisted so reconciliation can honor it if the server restarts.
       const agent = await agentManager.beginArchive(params.id, cleanupWorktree);
-      uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
 
       // Fire-and-forget: run cleanup in background (tracked for graceful shutdown + dedup)
       const agentId = params.id;
       archivingAgentIds.add(agentId);
       const archivePromise = agentManager.executeArchive(agentId, {
         onPhaseChange: (updated) => {
-          uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
+          uiEventBroker.publish({
+            type: "agent.upsert",
+            agent: withStreamFlag(updated),
+          });
         },
         onComplete: (deletedIds) => {
           for (const deletedId of deletedIds) {
@@ -3255,12 +3930,15 @@ async function registerRoutes() {
             pendingGitRefreshEnqueuedAt.delete(deletedId);
             activeGitRefreshAgentIds.delete(deletedId);
             gitRefreshAgentDiagnostics.delete(deletedId);
-            uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
+            uiEventBroker.publish({
+              type: "agent.deleted",
+              agentId: deletedId,
+            });
           }
         },
         onError: (error) => {
           app.log.error({ err: error, agentId }, "Background archive failed");
-        }
+        },
       });
       activeArchives.add(archivePromise);
       archivePromise.finally(() => {
@@ -3279,7 +3957,9 @@ async function registerRoutes() {
   app.get("/api/v1/personas", async (request, reply) => {
     const query = request.query as { cwd?: unknown };
     if (typeof query.cwd !== "string") {
-      return reply.code(400).send({ error: "cwd query parameter is required." });
+      return reply
+        .code(400)
+        .send({ error: "cwd query parameter is required." });
     }
     try {
       // Try worktree root first (uncommitted persona files live here), then repo root
@@ -3313,34 +3993,59 @@ async function registerRoutes() {
     }
   });
 
-  app.patch("/api/v1/agents/:id/feedback/:feedbackId", async (request, reply) => {
-    const params = request.params as { id?: string; feedbackId?: string };
-    const body = request.body as { status?: unknown };
-    const feedbackId = parseInt(params.feedbackId ?? "", 10);
+  app.patch(
+    "/api/v1/agents/:id/feedback/:feedbackId",
+    async (request, reply) => {
+      const params = request.params as { id?: string; feedbackId?: string };
+      const body = request.body as { status?: unknown };
+      const feedbackId = parseInt(params.feedbackId ?? "", 10);
 
-    if (isNaN(feedbackId)) {
-      return reply.code(400).send({ error: "Invalid feedback id." });
-    }
+      if (isNaN(feedbackId)) {
+        return reply.code(400).send({ error: "Invalid feedback id." });
+      }
 
-    const validStatuses = ["open", "dismissed", "forwarded", "fixed", "ignored"] as const;
-    if (typeof body?.status !== "string" || !(validStatuses as readonly string[]).includes(body.status)) {
-      return reply.code(400).send({ error: "status must be one of: open, dismissed, forwarded, fixed, ignored" });
-    }
+      const validStatuses = [
+        "open",
+        "dismissed",
+        "forwarded",
+        "fixed",
+        "ignored",
+      ] as const;
+      if (
+        typeof body?.status !== "string" ||
+        !(validStatuses as readonly string[]).includes(body.status)
+      ) {
+        return reply.code(400).send({
+          error:
+            "status must be one of: open, dismissed, forwarded, fixed, ignored",
+        });
+      }
 
-    try {
-      const agentId = params.id ?? "";
-      const updated = await agentManager.updateFeedbackStatus(
-        feedbackId,
-        agentId,
-        body.status as "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
-      );
-      if (!updated) return reply.code(404).send({ error: "Feedback not found." });
-      uiEventBroker.publish({ type: "feedback.updated", agentId, feedback: updated });
-      return { feedback: updated };
-    } catch (error) {
-      return handleAgentError(reply, error);
+      try {
+        const agentId = params.id ?? "";
+        const updated = await agentManager.updateFeedbackStatus(
+          feedbackId,
+          agentId,
+          body.status as
+            | "open"
+            | "dismissed"
+            | "forwarded"
+            | "fixed"
+            | "ignored"
+        );
+        if (!updated)
+          return reply.code(404).send({ error: "Feedback not found." });
+        uiEventBroker.publish({
+          type: "feedback.updated",
+          agentId,
+          feedback: updated,
+        });
+        return { feedback: updated };
+      } catch (error) {
+        return handleAgentError(reply, error);
+      }
     }
-  });
+  );
 
   app.post("/api/v1/agents/:id/terminal/token", async (request, reply) => {
     const params = request.params as { id?: string };
@@ -3351,21 +4056,24 @@ async function registerRoutes() {
       if (access.mode === "inert") {
         return {
           mode: "inert" as const,
-          message: access.message
+          message: access.message,
         };
       }
       const token = terminalTokenStore.issue(id);
       return {
         mode: "tmux" as const,
         token,
-        wsUrl: `/api/v1/agents/${id}/terminal/ws?token=${token}`
+        wsUrl: `/api/v1/agents/${id}/terminal/ws?token=${token}`,
       };
     } catch (error) {
       // Keep UI state in sync when terminal access lookup corrected a stale running status.
       const refreshed = await agentManager.getAgent(id);
       if (refreshed) {
         queueGitContextRefresh([refreshed.id]);
-        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(refreshed) });
+        uiEventBroker.publish({
+          type: "agent.upsert",
+          agent: withStreamFlag(refreshed),
+        });
       }
       return handleAgentError(reply, error);
     }
@@ -3377,12 +4085,21 @@ async function registerRoutes() {
     async (connection, request) => {
       const socket = connection.socket;
       const params = request.params as { id?: string };
-      const query = request.query as { token?: string; cols?: string; rows?: string };
+      const query = request.query as {
+        token?: string;
+        cols?: string;
+        rows?: string;
+      };
       const agentId = params.id ?? "";
       const token = query.token ?? "";
 
       if (!terminalTokenStore.consume(agentId, token)) {
-        socket.send(JSON.stringify({ type: "error", message: "Invalid or expired terminal token." }));
+        socket.send(
+          JSON.stringify({
+            type: "error",
+            message: "Invalid or expired terminal token.",
+          })
+        );
         socket.close(1008, "invalid token");
         return;
       }
@@ -3394,11 +4111,16 @@ async function registerRoutes() {
           throw new Error(access.message);
         }
         tmuxSession = access.sessionName;
-        await runCommand("tmux", ["set-option", "-t", tmuxSession, "mouse", "on"], {
-          allowedExitCodes: [0]
-        });
+        await runCommand(
+          "tmux",
+          ["set-option", "-t", tmuxSession, "mouse", "on"],
+          {
+            allowedExitCodes: [0],
+          }
+        );
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Terminal attach failed.";
+        const message =
+          error instanceof Error ? error.message : "Terminal attach failed.";
         socket.send(JSON.stringify({ type: "error", message }));
         socket.close(1011, "attach failed");
         return;
@@ -3406,11 +4128,15 @@ async function registerRoutes() {
 
       const cols = Number(query.cols ?? 140);
       const rows = Number(query.rows ?? 42);
-      const ptyProcess = pty.spawn("tmux", ["attach-session", "-t", tmuxSession], {
-        name: "xterm-256color",
-        cols: Number.isFinite(cols) ? cols : 140,
-        rows: Number.isFinite(rows) ? rows : 42
-      });
+      const ptyProcess = pty.spawn(
+        "tmux",
+        ["attach-session", "-t", tmuxSession],
+        {
+          name: "xterm-256color",
+          cols: Number.isFinite(cols) ? cols : 140,
+          rows: Number.isFinite(rows) ? rows : 42,
+        }
+      );
 
       const sendJson = (payload: unknown): void => {
         if (socket.readyState === socket.OPEN) {
@@ -3461,7 +4187,6 @@ async function registerRoutes() {
       });
     }
   );
-
 }
 
 async function waitForDatabase(maxAttempts = 15, delayMs = 2000) {
@@ -3479,9 +4204,13 @@ async function waitForDatabase(maxAttempts = 15, delayMs = 2000) {
 
 let routesRegistered = false;
 
-export async function initializeApp(options?: { runMigrations?: boolean; reconcileState?: boolean }): Promise<typeof app> {
+export async function initializeApp(options?: {
+  runMigrations?: boolean;
+  reconcileState?: boolean;
+}): Promise<typeof app> {
   await waitForDatabase();
-  const shouldRunMigrations = options?.runMigrations ?? process.env.SKIP_MIGRATIONS !== "1";
+  const shouldRunMigrations =
+    options?.runMigrations ?? process.env.SKIP_MIGRATIONS !== "1";
   if (!shouldRunMigrations) {
     app.log.warn("SKIP_MIGRATIONS=1 — skipping database migrations");
   } else {
@@ -3517,9 +4246,11 @@ export async function start() {
   const protocol = config.tls ? "https" : "http";
   await app.listen({
     host: config.host,
-    port: config.port
+    port: config.port,
   });
-  app.log.info(`Dispatch listening on ${protocol}://${config.host}:${config.port}`);
+  app.log.info(
+    `Dispatch listening on ${protocol}://${config.host}:${config.port}`
+  );
 }
 
 export { app, shutdown };
@@ -3533,13 +4264,18 @@ function handleAgentError(reply: FastifyReply, error: unknown) {
   return reply.code(500).send({ error: message });
 }
 
-
 function ensureGitRefreshAgentDiagnostics(agentId: string): {
   lastQueuedAt: number | null;
   lastStartedAt: number | null;
   lastCompletedAt: number | null;
   lastDurationMs: number | null;
-  lastResult: "updated" | "unchanged" | "probe_error" | "failed" | "skipped" | null;
+  lastResult:
+    | "updated"
+    | "unchanged"
+    | "probe_error"
+    | "failed"
+    | "skipped"
+    | null;
   lastError: string | null;
 } {
   const existing = gitRefreshAgentDiagnostics.get(agentId);
@@ -3552,7 +4288,7 @@ function ensureGitRefreshAgentDiagnostics(agentId: string): {
     lastCompletedAt: null,
     lastDurationMs: null,
     lastResult: null,
-    lastError: null
+    lastError: null,
   };
   gitRefreshAgentDiagnostics.set(agentId, created);
   return created;
@@ -3682,9 +4418,12 @@ let sessionCleanupTimer: NodeJS.Timeout | null = null;
 
 function startSessionCleanupTimer(): void {
   if (sessionCleanupTimer) return;
-  sessionCleanupTimer = setInterval(() => {
-    void cleanExpiredSessions(pool).catch(() => null);
-  }, 60 * 60 * 1000); // every hour
+  sessionCleanupTimer = setInterval(
+    () => {
+      void cleanExpiredSessions(pool).catch(() => null);
+    },
+    60 * 60 * 1000
+  ); // every hour
 }
 
 function stopSessionCleanupTimer(): void {
@@ -3703,13 +4442,21 @@ async function runAgentStatusReconciliation(): Promise<void> {
           continue;
         }
         // Resume interrupted archive
-        console.log(`[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`);
-        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+        console.log(
+          `[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`
+        );
+        uiEventBroker.publish({
+          type: "agent.upsert",
+          agent: withStreamFlag(agent),
+        });
         // Cleanup mode is persisted on the agent record by beginArchive
         archivingAgentIds.add(agent.id);
         const archivePromise = agentManager.executeArchive(agent.id, {
           onPhaseChange: (updated) => {
-            uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(updated) });
+            uiEventBroker.publish({
+              type: "agent.upsert",
+              agent: withStreamFlag(updated),
+            });
           },
           onComplete: (deletedIds) => {
             for (const deletedId of deletedIds) {
@@ -3718,12 +4465,18 @@ async function runAgentStatusReconciliation(): Promise<void> {
               pendingGitRefreshEnqueuedAt.delete(deletedId);
               activeGitRefreshAgentIds.delete(deletedId);
               gitRefreshAgentDiagnostics.delete(deletedId);
-              uiEventBroker.publish({ type: "agent.deleted", agentId: deletedId });
+              uiEventBroker.publish({
+                type: "agent.deleted",
+                agentId: deletedId,
+              });
             }
           },
           onError: (error) => {
-            app.log.error({ err: error, agentId: agent.id }, "Resumed archive failed");
-          }
+            app.log.error(
+              { err: error, agentId: agent.id },
+              "Resumed archive failed"
+            );
+          },
         });
         activeArchives.add(archivePromise);
         archivePromise.finally(() => {
@@ -3731,8 +4484,13 @@ async function runAgentStatusReconciliation(): Promise<void> {
           archivingAgentIds.delete(agent.id);
         });
       } else {
-        console.log(`[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`);
-        uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
+        console.log(
+          `[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`
+        );
+        uiEventBroker.publish({
+          type: "agent.upsert",
+          agent: withStreamFlag(agent),
+        });
       }
     }
   } catch (error) {
@@ -3754,7 +4512,9 @@ async function drainGitContextRefreshQueue(): Promise<void> {
     activeGitRefreshAgentIds.size < GIT_CONTEXT_REFRESH_CONCURRENCY &&
     pendingGitRefreshAgentIds.size > 0
   ) {
-    const nextAgentId = pendingGitRefreshAgentIds.values().next().value as string | undefined;
+    const nextAgentId = pendingGitRefreshAgentIds.values().next().value as
+      | string
+      | undefined;
     if (!nextAgentId) {
       return;
     }
@@ -3778,7 +4538,10 @@ async function drainGitContextRefreshQueue(): Promise<void> {
       .catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         recordGitRefreshCompletion(nextAgentId, startedAt, "failed", message);
-        app.log.warn({ err: error, agentId: nextAgentId }, "Git context refresh failed.");
+        app.log.warn(
+          { err: error, agentId: nextAgentId },
+          "Git context refresh failed."
+        );
       })
       .finally(() => {
         activeGitRefreshAgentIds.delete(nextAgentId);
@@ -3807,7 +4570,8 @@ async function refreshAgentGitContext(
 
   const nextContext = probe.value;
   const shouldPublish =
-    agent.gitContextStale || !areGitContextsEqual(agent.gitContext, nextContext);
+    agent.gitContextStale ||
+    !areGitContextsEqual(agent.gitContext, nextContext);
 
   await persistAgentGitContext(agentId, nextContext, false);
   if (!shouldPublish) {
@@ -3816,7 +4580,10 @@ async function refreshAgentGitContext(
 
   const refreshed = await agentManager.getAgent(agentId);
   if (refreshed) {
-    uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(refreshed) });
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(refreshed),
+    });
   }
   return "updated";
 }
@@ -3863,7 +4630,9 @@ async function resolveAgentGitCwd(agent: AgentRecord): Promise<string> {
 
 async function probeGitContext(
   cwd: string
-): Promise<{ status: "ok"; value: AgentGitContext | null } | { status: "error" }> {
+): Promise<
+  { status: "ok"; value: AgentGitContext | null } | { status: "error" }
+> {
   try {
     const inside = await runCommand(
       "git",
@@ -3879,22 +4648,26 @@ async function probeGitContext(
       (
         await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
           allowedExitCodes: [0],
-          timeoutMs: PROBE_COMMAND_TIMEOUT_MS
+          timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
         })
       ).stdout
     );
 
     let branch = (
-      await runCommand("git", ["-C", cwd, "symbolic-ref", "--short", "-q", "HEAD"], {
-        allowedExitCodes: [0, 1],
-        timeoutMs: PROBE_COMMAND_TIMEOUT_MS
-      })
+      await runCommand(
+        "git",
+        ["-C", cwd, "symbolic-ref", "--short", "-q", "HEAD"],
+        {
+          allowedExitCodes: [0, 1],
+          timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
+        }
+      )
     ).stdout;
     if (!branch) {
       branch = (
         await runCommand("git", ["-C", cwd, "rev-parse", "--short", "HEAD"], {
           allowedExitCodes: [0],
-          timeoutMs: PROBE_COMMAND_TIMEOUT_MS
+          timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
         })
       ).stdout;
     }
@@ -3906,8 +4679,8 @@ async function probeGitContext(
         branch,
         worktreePath: checkoutRoot,
         worktreeName: path.basename(checkoutRoot),
-        isWorktree: checkoutRoot !== repoRoot
-      }
+        isWorktree: checkoutRoot !== repoRoot,
+      },
     };
   } catch {
     return { status: "error" };
@@ -3933,7 +4706,10 @@ async function resolveRepoRoot(cwd: string): Promise<string> {
     ["-C", cwd, "rev-parse", "--git-common-dir"],
     { allowedExitCodes: [0, 128], timeoutMs: PROBE_COMMAND_TIMEOUT_MS }
   );
-  if (fallbackCommonDirResult.exitCode === 0 && fallbackCommonDirResult.stdout) {
+  if (
+    fallbackCommonDirResult.exitCode === 0 &&
+    fallbackCommonDirResult.stdout
+  ) {
     const commonDir = fallbackCommonDirResult.stdout;
     const absoluteCommonDir = normalizePath(
       path.isAbsolute(commonDir) ? commonDir : path.resolve(cwd, commonDir)
@@ -3947,7 +4723,7 @@ async function resolveRepoRoot(cwd: string): Promise<string> {
     (
       await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
         allowedExitCodes: [0],
-        timeoutMs: PROBE_COMMAND_TIMEOUT_MS
+        timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
       })
     ).stdout
   );
@@ -3958,20 +4734,24 @@ async function resolveWorktreeRoot(cwd: string): Promise<string> {
     (
       await runCommand("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
         allowedExitCodes: [0],
-        timeoutMs: PROBE_COMMAND_TIMEOUT_MS
+        timeoutMs: PROBE_COMMAND_TIMEOUT_MS,
       })
     ).stdout
   );
 }
 
-function mcpMethodNotAllowed(): { jsonrpc: "2.0"; error: { code: number; message: string }; id: null } {
+function mcpMethodNotAllowed(): {
+  jsonrpc: "2.0";
+  error: { code: number; message: string };
+  id: null;
+} {
   return {
     jsonrpc: "2.0",
     error: {
       code: -32000,
-      message: "Method not allowed."
+      message: "Method not allowed.",
     },
-    id: null
+    id: null,
   };
 }
 
@@ -3998,7 +4778,7 @@ function decodeClientMessage(
     if (parsed.type === "input" && typeof parsed.data === "string") {
       return {
         type: "input",
-        data: parsed.data
+        data: parsed.data,
       };
     }
 
@@ -4010,7 +4790,7 @@ function decodeClientMessage(
       return {
         type: "resize",
         cols: parsed.cols,
-        rows: parsed.rows
+        rows: parsed.rows,
       };
     }
 
@@ -4020,9 +4800,16 @@ function decodeClientMessage(
   }
 }
 
-async function listMediaFiles(
-  agentId: string
-): Promise<Array<{ name: string; source: string; size: number; updatedAt: string; url: string; description: string | null }>> {
+async function listMediaFiles(agentId: string): Promise<
+  Array<{
+    name: string;
+    source: string;
+    size: number;
+    updatedAt: string;
+    url: string;
+    description: string | null;
+  }>
+> {
   const result = await pool.query<{
     file_name: string;
     source: string;
@@ -4044,7 +4831,7 @@ async function listMediaFiles(
     size: row.size_bytes,
     updatedAt: row.effective_updated_at.toISOString(),
     url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(row.file_name)}`,
-    description: row.description ?? null
+    description: row.description ?? null,
   }));
 }
 
@@ -4060,7 +4847,10 @@ function isValidMediaKey(key: string): boolean {
   return !/[\u0000-\u001F]/.test(key);
 }
 
-async function loadSeenMediaKeys(agentId: string, keys: string[]): Promise<Set<string>> {
+async function loadSeenMediaKeys(
+  agentId: string,
+  keys: string[]
+): Promise<Set<string>> {
   if (keys.length === 0) {
     return new Set();
   }
@@ -4077,7 +4867,10 @@ async function loadSeenMediaKeys(agentId: string, keys: string[]): Promise<Set<s
   return new Set(result.rows.map((row) => row.mediaKey));
 }
 
-async function markSeenMediaKeys(agentId: string, keys: string[]): Promise<void> {
+async function markSeenMediaKeys(
+  agentId: string,
+  keys: string[]
+): Promise<void> {
   if (keys.length === 0) {
     return;
   }
@@ -4095,11 +4888,50 @@ async function markSeenMediaKeys(agentId: string, keys: string[]): Promise<void>
 }
 
 const TEXT_EXTENSIONS = new Set([
-  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
-  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
-  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
-  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
-  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
+  ".txt",
+  ".md",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".csv",
+  ".log",
+  ".xml",
+  ".html",
+  ".css",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".py",
+  ".go",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".diff",
+  ".patch",
+  ".env",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".swift",
+  ".kt",
+  ".java",
+  ".c",
+  ".cpp",
+  ".h",
+  ".hpp",
+  ".rb",
+  ".php",
+  ".lua",
+  ".zig",
+  ".nim",
+  ".r",
+  ".m",
+  ".ex",
+  ".exs",
+  ".erl",
+  ".hs",
 ]);
 
 function isTextFile(name: string): boolean {
@@ -4115,7 +4947,11 @@ function isDocumentFile(name: string): boolean {
 }
 
 function isMediaFile(name: string): boolean {
-  return /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name) || isTextFile(name) || isDocumentFile(name);
+  return (
+    /\.(png|jpg|jpeg|gif|webp|mp4)$/i.test(name) ||
+    isTextFile(name) ||
+    isDocumentFile(name)
+  );
 }
 
 function mimeType(name: string): string {
@@ -4201,7 +5037,10 @@ async function cleanupAppResources(): Promise<void> {
 
   // Wait for in-flight archives to finish so clean shutdowns don't leave agents stuck in "archiving"
   if (activeArchives.size > 0) {
-    app.log.info({ count: activeArchives.size }, "Waiting for in-flight archives to complete…");
+    app.log.info(
+      { count: activeArchives.size },
+      "Waiting for in-flight archives to complete…"
+    );
     const ARCHIVE_DRAIN_TIMEOUT_MS = 10_000;
     await Promise.race([
       Promise.allSettled(activeArchives),
@@ -4219,7 +5058,10 @@ async function shutdown(code: number): Promise<void> {
 }
 
 function isAgentLatestEventType(value: unknown): value is AgentLatestEventType {
-  return typeof value === "string" && AGENT_LATEST_EVENT_TYPES.includes(value as AgentLatestEventType);
+  return (
+    typeof value === "string" &&
+    AGENT_LATEST_EVENT_TYPES.includes(value as AgentLatestEventType)
+  );
 }
 
 async function mcpUpsertEvent(
@@ -4227,12 +5069,14 @@ async function mcpUpsertEvent(
   event: { type: string; message: string; metadata?: Record<string, unknown> }
 ): Promise<void> {
   if (!isAgentLatestEventType(event.type)) {
-    throw new Error(`type must be one of: ${AGENT_LATEST_EVENT_TYPES.join(", ")}.`);
+    throw new Error(
+      `type must be one of: ${AGENT_LATEST_EVENT_TYPES.join(", ")}.`
+    );
   }
   const agent = await agentManager.upsertLatestEvent(agentId, {
     type: event.type,
     message: event.message.trim(),
-    metadata: event.metadata
+    metadata: event.metadata,
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }
@@ -4251,7 +5095,11 @@ async function mcpSubmitFeedback(
   feedback: import("./agents/manager.js").FeedbackInput
 ): Promise<FeedbackRecord> {
   const record = await agentManager.submitFeedback(agentId, feedback);
-  uiEventBroker.publish({ type: "feedback.created", agentId, feedback: record });
+  uiEventBroker.publish({
+    type: "feedback.created",
+    agentId,
+    feedback: record,
+  });
   return record;
 }
 
@@ -4259,7 +5107,11 @@ async function mcpGetFeedback(
   agentId: string,
   opts: { persona?: string; limit?: number }
 ) {
-  return agentManager.listFeedbackByParentGrouped(agentId, opts.persona, opts.limit);
+  return agentManager.listFeedbackByParentGrouped(
+    agentId,
+    opts.persona,
+    opts.limit
+  );
 }
 
 async function mcpResolveFeedback(
@@ -4267,9 +5119,20 @@ async function mcpResolveFeedback(
   feedbackId: number,
   status: "fixed" | "ignored"
 ): Promise<import("./agents/manager.js").FeedbackRecord> {
-  const record = await agentManager.updateFeedbackStatusByParent(feedbackId, agentId, status);
-  if (!record) throw new Error(`Feedback #${feedbackId} not found or not owned by a child of this agent.`);
-  uiEventBroker.publish({ type: "feedback.updated", agentId: record.agentId, feedback: record });
+  const record = await agentManager.updateFeedbackStatusByParent(
+    feedbackId,
+    agentId,
+    status
+  );
+  if (!record)
+    throw new Error(
+      `Feedback #${feedbackId} not found or not owned by a child of this agent.`
+    );
+  uiEventBroker.publish({
+    type: "feedback.updated",
+    agentId: record.agentId,
+    feedback: record,
+  });
   return record;
 }
 
@@ -4284,15 +5147,12 @@ async function mcpUpsertPin(
   const agent = await agentManager.upsertPin(agentId, {
     label: pin.label,
     value: pin.value,
-    type: pin.type
+    type: pin.type,
   });
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }
 
-async function mcpDeletePin(
-  agentId: string,
-  label: string
-): Promise<void> {
+async function mcpDeletePin(agentId: string, label: string): Promise<void> {
   const agent = await agentManager.deletePin(agentId, label);
   uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agent) });
 }
@@ -4307,21 +5167,42 @@ async function mcpUpdateReviewStatus(
     agentManager.getAgent(agentId),
     agentManager.getAgent(review.parentAgentId),
   ]);
-  if (child) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(child) });
-  if (parent) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(parent) });
+  if (child)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(child),
+    });
+  if (parent)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(parent),
+    });
 }
 
 async function mcpCompleteReview(
   agentId: string,
-  input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
+  input: {
+    verdict: string;
+    summary: string;
+    filesReviewed?: string[];
+    message?: string;
+  }
 ): Promise<void> {
   const review = await agentManager.completePersonaReview(agentId, input);
   const [child, parent] = await Promise.all([
     agentManager.getAgent(agentId),
     agentManager.getAgent(review.parentAgentId),
   ]);
-  if (child) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(child) });
-  if (parent) uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(parent) });
+  if (child)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(child),
+    });
+  if (parent)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(parent),
+    });
 }
 
 async function mcpGetParentContext(
@@ -4333,7 +5214,7 @@ async function mcpGetParentContext(
   const pins = (parent.pins ?? []).map((p) => ({
     label: p.label,
     value: p.value,
-    type: p.type
+    type: p.type,
   }));
 
   const media = await agentManager.listMedia(parentAgentId);
@@ -4344,8 +5225,8 @@ async function mcpGetParentContext(
       fileName: m.fileName,
       description: m.description,
       source: m.source,
-      createdAt: m.createdAt
-    }))
+      createdAt: m.createdAt,
+    })),
   };
 }
 
@@ -4358,7 +5239,9 @@ async function mcpRenameSession(
   return { id: agent.id, name: agent.name };
 }
 
-function getBearerToken(request: { headers: Record<string, unknown> }): string | null {
+function getBearerToken(request: {
+  headers: Record<string, unknown>;
+}): string | null {
   const authHeader = request.headers.authorization;
   if (typeof authHeader !== "string" || !authHeader.startsWith("Bearer ")) {
     return null;
@@ -4366,24 +5249,37 @@ function getBearerToken(request: { headers: Record<string, unknown> }): string |
   return authHeader.slice(7);
 }
 
-async function mcpJobComplete(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {
+async function mcpJobComplete(
+  agentId: string,
+  report: unknown
+): Promise<{ runId: string; status: string }> {
   const run = await jobService.completeRunForAgent(agentId, report);
   return { runId: run.id, status: run.status };
 }
 
-async function mcpJobFailed(agentId: string, report: unknown): Promise<{ runId: string; status: string }> {
+async function mcpJobFailed(
+  agentId: string,
+  report: unknown
+): Promise<{ runId: string; status: string }> {
   const run = await jobService.failRunForAgent(agentId, report);
   return { runId: run.id, status: run.status };
 }
 
-async function mcpJobNeedsInput(agentId: string, question: string): Promise<{ runId: string; status: string }> {
+async function mcpJobNeedsInput(
+  agentId: string,
+  question: string
+): Promise<{ runId: string; status: string }> {
   const run = await jobService.markNeedsInputForAgent(agentId, question);
   return { runId: run.id, status: run.status };
 }
 
 async function mcpJobLog(
   agentId: string,
-  input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+  input: {
+    task: string;
+    message: string;
+    level: "debug" | "info" | "warn" | "error";
+  }
 ): Promise<{ runId: string; status: string }> {
   const run = await jobService.logForAgent(agentId, input);
   return { runId: run.id, status: run.status };
@@ -4393,17 +5289,30 @@ async function mcpListPersonas(
   agentCwd: string
 ): Promise<Array<{ slug: string; name: string; description: string }>> {
   const personas = await loadPersonas(agentCwd);
-  return personas.map(({ slug, name, description }) => ({ slug, name, description }));
+  return personas.map(({ slug, name, description }) => ({
+    slug,
+    name,
+    description,
+  }));
 }
 
 async function mcpLaunchPersona(
   agentId: string,
-  opts: { persona: string; context: string; agentType?: typeof AGENT_TYPES[number] }
+  opts: {
+    persona: string;
+    context: string;
+    agentType?: (typeof AGENT_TYPES)[number];
+  }
 ): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
   const parent = await agentManager.getAgent(agentId);
   if (!parent) throw new Error("Parent agent not found.");
 
-  const personaAgentType = opts.agentType ?? parent.reviewAgentType ?? (parent.type === "claude" || parent.type === "opencode" ? parent.type : "codex");
+  const personaAgentType =
+    opts.agentType ??
+    parent.reviewAgentType ??
+    (parent.type === "claude" || parent.type === "opencode"
+      ? parent.type
+      : "codex");
   if (!AGENT_TYPES.includes(personaAgentType)) {
     throw new Error(`Unsupported persona agent type "${personaAgentType}".`);
   }
@@ -4437,7 +5346,9 @@ async function mcpLaunchPersona(
     } catch {}
   }
   if (!persona) {
-    throw new Error(`Persona "${opts.persona}" not found in .dispatch/personas/.`);
+    throw new Error(
+      `Persona "${opts.persona}" not found in .dispatch/personas/.`
+    );
   }
 
   const diff = await buildPersonaReviewDiff(parentCwd, runCommand);
@@ -4448,9 +5359,11 @@ async function mcpLaunchPersona(
   const personaArgs: string[] = [`--append-system-prompt`, prompt];
   if (parent.fullAccess) {
     const fullAccessArg =
-      personaAgentType === "claude" ? CLAUDE_FULL_ACCESS_ARG
-      : personaAgentType === "codex" ? CODEX_FULL_ACCESS_ARG
-      : null;
+      personaAgentType === "claude"
+        ? CLAUDE_FULL_ACCESS_ARG
+        : personaAgentType === "codex"
+          ? CODEX_FULL_ACCESS_ARG
+          : null;
     if (fullAccessArg) personaArgs.push(fullAccessArg);
   }
 
@@ -4483,16 +5396,26 @@ async function mcpLaunchPersona(
   const agentWithReview = await agentManager.getAgent(agent.id);
 
   queueGitContextRefresh([agent.id]);
-  uiEventBroker.publish({ type: "agent.upsert", agent: withStreamFlag(agentWithReview ?? agent) });
+  uiEventBroker.publish({
+    type: "agent.upsert",
+    agent: withStreamFlag(agentWithReview ?? agent),
+  });
 
   // Send initial prompt to the persona agent after it starts up
   if (agent.tmuxSession) {
     const tmuxSession = agent.tmuxSession;
-    const initialMessage = "Begin your review now. Follow your system prompt instructions.";
+    const initialMessage =
+      "Begin your review now. Follow your system prompt instructions.";
     setTimeout(async () => {
       try {
         const { runCommand: run } = await import("./shared/lib/run-command.js");
-        await run("tmux", ["send-keys", "-t", tmuxSession, "-l", initialMessage]);
+        await run("tmux", [
+          "send-keys",
+          "-t",
+          tmuxSession,
+          "-l",
+          initialMessage,
+        ]);
         await run("tmux", ["send-keys", "-t", tmuxSession, "Enter"]);
       } catch {}
     }, 10_000);
@@ -4503,18 +5426,36 @@ async function mcpLaunchPersona(
 
 async function mcpShareMedia(
   agentId: string,
-  opts: { filePath: string; description: string; source?: string; name?: string; update?: string }
-): Promise<{ fileName: string; url: string; sizeBytes: number; source: string; description: string }> {
+  opts: {
+    filePath: string;
+    description: string;
+    source?: string;
+    name?: string;
+    update?: string;
+  }
+): Promise<{
+  fileName: string;
+  url: string;
+  sizeBytes: number;
+  source: string;
+  description: string;
+}> {
   const agent = await agentManager.getAgent(agentId);
   if (!agent) throw new Error("Agent not found.");
 
   if (!isMediaFile(opts.filePath)) {
-    throw new Error("Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc).");
+    throw new Error(
+      "Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc)."
+    );
   }
 
   const isText = isTextFile(opts.filePath);
   const validSources = ["screenshot", "stream", "simulator", "text"];
-  const source = isText ? "text" : (opts.source && validSources.includes(opts.source) ? opts.source : "screenshot");
+  const source = isText
+    ? "text"
+    : opts.source && validSources.includes(opts.source)
+      ? opts.source
+      : "screenshot";
 
   const buffer = await readFile(opts.filePath);
   const mediaDir = resolveMediaDir(agentId, agent.mediaDir);
@@ -4527,7 +5468,9 @@ async function mcpShareMedia(
       [agentId, opts.update]
     );
     if (existing.rows.length === 0) {
-      throw new Error(`No media file found with the given fileName for this agent.`);
+      throw new Error(
+        `No media file found with the given fileName for this agent.`
+      );
     }
 
     const fileName = existing.rows[0].file_name;
@@ -4552,16 +5495,23 @@ async function mcpShareMedia(
       url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(fileName)}`,
       sizeBytes: buffer.length,
       source,
-      description: opts.description
+      description: opts.description,
     };
   }
 
   // Create new media file
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, "-")
+    .replace("T", "-")
+    .replace("Z", "");
   const baseName = opts.name ?? path.basename(opts.filePath);
   const ext0 = path.extname(baseName).toLowerCase();
-  const fallbackExt = ext0 === ".mp4" ? ".mp4" : isText ? (ext0 || ".txt") : ".png";
-  const safeName = baseName.replace(/ /g, "-").replace(/[^A-Za-z0-9._-]/g, "") || `shared-${timestamp}${fallbackExt}`;
+  const fallbackExt =
+    ext0 === ".mp4" ? ".mp4" : isText ? ext0 || ".txt" : ".png";
+  const safeName =
+    baseName.replace(/ /g, "-").replace(/[^A-Za-z0-9._-]/g, "") ||
+    `shared-${timestamp}${fallbackExt}`;
   const ext = path.extname(safeName);
   const base = path.basename(safeName, ext);
   const fileName = `${base}-${timestamp}${ext}`;
@@ -4581,14 +5531,23 @@ async function mcpShareMedia(
     url: `/api/v1/agents/${agentId}/media/${encodeURIComponent(fileName)}`,
     sizeBytes: buffer.length,
     source,
-    description: opts.description
+    description: opts.description,
   };
 }
 
 async function mcpListMedia(
   agentId: string,
   opts: { source?: string }
-): Promise<Array<{ fileName: string; filePath: string; source: string; description: string | null; sizeBytes: number; createdAt: string }>> {
+): Promise<
+  Array<{
+    fileName: string;
+    filePath: string;
+    source: string;
+    description: string | null;
+    sizeBytes: number;
+    createdAt: string;
+  }>
+> {
   const agent = await agentManager.getAgent(agentId);
   if (!agent) throw new Error("Agent not found.");
 
@@ -4597,7 +5556,9 @@ async function mcpListMedia(
   const whereClause = opts.source
     ? `WHERE agent_id = $1 AND source = $2`
     : `WHERE agent_id = $1`;
-  const params: (string | number)[] = opts.source ? [agentId, opts.source] : [agentId];
+  const params: (string | number)[] = opts.source
+    ? [agentId, opts.source]
+    : [agentId];
 
   const result = await pool.query<{
     file_name: string;

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -72,13 +72,24 @@ export async function createGitWorktree(
 
   const repoRoot = await resolveRepoRoot(cwd, commandRunner);
   const baseBranch = normalizeRefName(input.baseBranch, "main", "baseBranch");
-  const branchName = normalizeRefName(input.branchName, slugify(name), "branchName");
+  const branchName = normalizeRefName(
+    input.branchName,
+    slugify(name),
+    "branchName"
+  );
   const worktreePath = input.worktreePath?.trim()
     ? path.resolve(input.worktreePath)
-    : path.resolve(repoRoot, "..", `${path.basename(repoRoot)}-${slugify(branchName)}`);
+    : path.resolve(
+        repoRoot,
+        "..",
+        `${path.basename(repoRoot)}-${slugify(branchName)}`
+      );
 
   if (normalizePath(worktreePath) === normalizePath(repoRoot)) {
-    throw new GitWorktreeError("worktree path must differ from the repository root.", 400);
+    throw new GitWorktreeError(
+      "worktree path must differ from the repository root.",
+      400
+    );
   }
 
   await ensurePathDoesNotExist(worktreePath);
@@ -87,7 +98,14 @@ export async function createGitWorktree(
   const baseRef = updateBase ? `origin/${baseBranch}` : baseBranch;
 
   if (updateBase) {
-    await commandRunner("git", ["-C", repoRoot, "fetch", "origin", baseBranch, "--quiet"]);
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "fetch",
+      "origin",
+      baseBranch,
+      "--quiet",
+    ]);
     await ensureGitRefExists(repoRoot, baseRef, commandRunner);
   } else {
     await ensureGitRefExists(repoRoot, baseRef, commandRunner);
@@ -98,18 +116,22 @@ export async function createGitWorktree(
   await ensureBranchDoesNotExist(repoRoot, branchName, commandRunner);
 
   await commandRunner("git", [
-    "-C", repoRoot,
-    "worktree", "add",
-    "-b", branchName,
+    "-C",
+    repoRoot,
+    "worktree",
+    "add",
+    "-b",
+    branchName,
     worktreePath,
-    baseRef
+    baseRef,
   ]);
 
   // Set upstream tracking so archival checks know which branch to compare against
-  await commandRunner("git", [
-    "-C", worktreePath,
-    "branch", "--set-upstream-to", baseRef, branchName
-  ], { allowedExitCodes: [0, 1, 128] });
+  await commandRunner(
+    "git",
+    ["-C", worktreePath, "branch", "--set-upstream-to", baseRef, branchName],
+    { allowedExitCodes: [0, 1, 128] }
+  );
 
   return {
     repoRoot,
@@ -118,7 +140,7 @@ export async function createGitWorktree(
     branchName,
     baseBranch,
     baseRef,
-    baseSha
+    baseSha,
   };
 }
 
@@ -137,7 +159,10 @@ export async function cleanupGitWorktree(
   const normalizedRepoRoot = normalizePath(repoRoot);
 
   if (normalizedWorktreePath === normalizedRepoRoot) {
-    throw new GitWorktreeError("cleanup-worktree only removes linked worktrees, not the primary checkout.", 400);
+    throw new GitWorktreeError(
+      "cleanup-worktree only removes linked worktrees, not the primary checkout.",
+      400
+    );
   }
 
   const baseBranch = normalizeRefName(input.baseBranch, "main", "baseBranch");
@@ -146,8 +171,22 @@ export async function cleanupGitWorktree(
   let updatedBaseBranch = false;
   if (input.updateBaseBranch ?? false) {
     await ensurePrimaryCheckoutCanUpdate(repoRoot, baseBranch, commandRunner);
-    await commandRunner("git", ["-C", repoRoot, "fetch", "origin", baseBranch, "--quiet"]);
-    await commandRunner("git", ["-C", repoRoot, "pull", "--ff-only", "origin", baseBranch]);
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "fetch",
+      "origin",
+      baseBranch,
+      "--quiet",
+    ]);
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "pull",
+      "--ff-only",
+      "origin",
+      baseBranch,
+    ]);
     updatedBaseBranch = true;
   }
 
@@ -162,10 +201,11 @@ export async function cleanupGitWorktree(
   if ((input.deleteBranch ?? false) && branchName) {
     await ensureBranchExists(repoRoot, branchName, commandRunner);
     await commandRunner("git", [
-      "-C", repoRoot,
+      "-C",
+      repoRoot,
       "branch",
       input.force ? "-D" : "--delete",
-      branchName
+      branchName,
     ]);
     deletedBranch = true;
   }
@@ -177,42 +217,70 @@ export async function cleanupGitWorktree(
     branchName,
     baseBranch,
     updatedBaseBranch,
-    deletedBranch
+    deletedBranch,
   };
 }
 
-async function resolveRepoRoot(cwd: string, commandRunner: CommandRunner): Promise<string> {
+async function resolveRepoRoot(
+  cwd: string,
+  commandRunner: CommandRunner
+): Promise<string> {
   try {
     return normalizePath(
       (
-        await commandRunner("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
-          allowedExitCodes: [0]
-        })
+        await commandRunner(
+          "git",
+          ["-C", cwd, "rev-parse", "--show-toplevel"],
+          {
+            allowedExitCodes: [0],
+          }
+        )
       ).stdout
     );
   } catch {
-    throw new GitWorktreeError("No git repository found for the provided working directory.", 404);
+    throw new GitWorktreeError(
+      "No git repository found for the provided working directory.",
+      404
+    );
   }
 }
 
-async function resolveCurrentCheckoutRoot(cwd: string, commandRunner: CommandRunner): Promise<string> {
+async function resolveCurrentCheckoutRoot(
+  cwd: string,
+  commandRunner: CommandRunner
+): Promise<string> {
   return await resolveRepoRoot(cwd, commandRunner);
 }
 
-async function resolveCommonRepoRoot(cwd: string, commandRunner: CommandRunner): Promise<string> {
+async function resolveCommonRepoRoot(
+  cwd: string,
+  commandRunner: CommandRunner
+): Promise<string> {
   const commonDir = (
-    await commandRunner("git", ["-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"])
+    await commandRunner("git", [
+      "-C",
+      cwd,
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir",
+    ])
   ).stdout;
 
   const absoluteCommonDir = normalizePath(commonDir);
   if (path.basename(absoluteCommonDir) !== ".git") {
-    throw new GitWorktreeError("Unable to resolve the repository root for this worktree.", 500);
+    throw new GitWorktreeError(
+      "Unable to resolve the repository root for this worktree.",
+      500
+    );
   }
 
   return normalizePath(path.dirname(absoluteCommonDir));
 }
 
-async function resolveCurrentBranch(cwd: string, commandRunner: CommandRunner): Promise<string | null> {
+async function resolveCurrentBranch(
+  cwd: string,
+  commandRunner: CommandRunner
+): Promise<string | null> {
   const result = await commandRunner(
     "git",
     ["-C", cwd, "symbolic-ref", "--short", "-q", "HEAD"],
@@ -222,15 +290,23 @@ async function resolveCurrentBranch(cwd: string, commandRunner: CommandRunner): 
   return result.exitCode === 0 && result.stdout ? result.stdout : null;
 }
 
-async function resolveGitRef(repoRoot: string, ref: string, commandRunner: CommandRunner): Promise<string> {
+async function resolveGitRef(
+  repoRoot: string,
+  ref: string,
+  commandRunner: CommandRunner
+): Promise<string> {
   return (
     await commandRunner("git", ["-C", repoRoot, "rev-parse", "--verify", ref], {
-      allowedExitCodes: [0]
+      allowedExitCodes: [0],
     })
   ).stdout;
 }
 
-async function ensureGitRefExists(repoRoot: string, ref: string, commandRunner: CommandRunner): Promise<void> {
+async function ensureGitRefExists(
+  repoRoot: string,
+  ref: string,
+  commandRunner: CommandRunner
+): Promise<void> {
   const result = await commandRunner(
     "git",
     ["-C", repoRoot, "rev-parse", "--verify", ref],
@@ -238,39 +314,80 @@ async function ensureGitRefExists(repoRoot: string, ref: string, commandRunner: 
   );
 
   if (result.exitCode !== 0) {
-    throw new GitWorktreeError(`Git ref "${ref}" was not found in ${repoRoot}.`, 404);
+    throw new GitWorktreeError(
+      `Git ref "${ref}" was not found in ${repoRoot}.`,
+      404
+    );
   }
 }
 
-async function ensureBranchDoesNotExist(repoRoot: string, branchName: string, commandRunner: CommandRunner): Promise<void> {
+async function ensureBranchDoesNotExist(
+  repoRoot: string,
+  branchName: string,
+  commandRunner: CommandRunner
+): Promise<void> {
   const localBranch = await commandRunner(
     "git",
-    ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+    [
+      "-C",
+      repoRoot,
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/heads/${branchName}`,
+    ],
     { allowedExitCodes: [0, 1] }
   );
   if (localBranch.exitCode === 0) {
-    throw new GitWorktreeError(`Local branch "${branchName}" already exists.`, 409);
+    throw new GitWorktreeError(
+      `Local branch "${branchName}" already exists.`,
+      409
+    );
   }
 
   const remoteBranch = await commandRunner(
     "git",
-    ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`],
+    [
+      "-C",
+      repoRoot,
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/remotes/origin/${branchName}`,
+    ],
     { allowedExitCodes: [0, 1] }
   );
   if (remoteBranch.exitCode === 0) {
-    throw new GitWorktreeError(`Remote branch "origin/${branchName}" already exists.`, 409);
+    throw new GitWorktreeError(
+      `Remote branch "origin/${branchName}" already exists.`,
+      409
+    );
   }
 }
 
-async function ensureBranchExists(repoRoot: string, branchName: string, commandRunner: CommandRunner): Promise<void> {
+async function ensureBranchExists(
+  repoRoot: string,
+  branchName: string,
+  commandRunner: CommandRunner
+): Promise<void> {
   const result = await commandRunner(
     "git",
-    ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+    [
+      "-C",
+      repoRoot,
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/heads/${branchName}`,
+    ],
     { allowedExitCodes: [0, 1] }
   );
 
   if (result.exitCode !== 0) {
-    throw new GitWorktreeError(`Local branch "${branchName}" no longer exists.`, 404);
+    throw new GitWorktreeError(
+      `Local branch "${branchName}" no longer exists.`,
+      404
+    );
   }
 }
 
@@ -287,7 +404,12 @@ async function ensurePrimaryCheckoutCanUpdate(
     );
   }
 
-  const status = await commandRunner("git", ["-C", repoRoot, "status", "--porcelain"]);
+  const status = await commandRunner("git", [
+    "-C",
+    repoRoot,
+    "status",
+    "--porcelain",
+  ]);
   if (status.stdout) {
     throw new GitWorktreeError(
       `Primary checkout at ${repoRoot} has uncommitted changes. Refusing to update "${baseBranch}".`,
@@ -299,7 +421,10 @@ async function ensurePrimaryCheckoutCanUpdate(
 async function ensurePathDoesNotExist(targetPath: string): Promise<void> {
   try {
     await access(targetPath);
-    throw new GitWorktreeError(`Target worktree path already exists: ${targetPath}`, 409);
+    throw new GitWorktreeError(
+      `Target worktree path already exists: ${targetPath}`,
+      409
+    );
   } catch (error) {
     if (error instanceof GitWorktreeError) {
       throw error;
@@ -307,14 +432,21 @@ async function ensurePathDoesNotExist(targetPath: string): Promise<void> {
   }
 }
 
-function normalizeRefName(value: string | undefined, fallback: string, fieldName: string): string {
+function normalizeRefName(
+  value: string | undefined,
+  fallback: string,
+  fieldName: string
+): string {
   const normalized = (value?.trim() || fallback).trim();
   if (!normalized) {
     throw new GitWorktreeError(`${fieldName} must not be empty.`, 400);
   }
 
   if (/\s/.test(normalized)) {
-    throw new GitWorktreeError(`${fieldName} must not contain whitespace.`, 400);
+    throw new GitWorktreeError(
+      `${fieldName} must not contain whitespace.`,
+      400
+    );
   }
 
   return normalized;
@@ -328,7 +460,10 @@ function slugify(value: string): string {
     .replace(/-{2,}/g, "-");
 
   if (!slug) {
-    throw new GitWorktreeError("Unable to derive a valid worktree name from the provided input.", 400);
+    throw new GitWorktreeError(
+      "Unable to derive a valid worktree name from the provided input.",
+      400
+    );
   }
 
   return slug;

--- a/apps/server/src/shared/github/pr.ts
+++ b/apps/server/src/shared/github/pr.ts
@@ -42,7 +42,11 @@ export type GetPrStatusResult = {
   autoMergeEnabled: boolean;
   headRefName: string;
   baseRefName: string;
-  statusSummary: Array<{ name: string; status: string; conclusion: string | null }>;
+  statusSummary: Array<{
+    name: string;
+    status: string;
+    conclusion: string | null;
+  }>;
 };
 
 export class GitHubPrError extends Error {
@@ -61,14 +65,17 @@ export async function createPr(
 ): Promise<CreatePrResult> {
   const cwd = requireString(input.cwd, "cwd");
   const repoRoot = await resolveRepoRoot(cwd, commandRunner);
-  const baseBranch = (input.baseBranch?.trim() || "main");
+  const baseBranch = input.baseBranch?.trim() || "main";
   const branchName = await resolveCurrentBranch(repoRoot, commandRunner);
 
   if (!branchName) {
     throw new GitHubPrError("Current checkout is in detached HEAD state.", 409);
   }
   if (branchName === baseBranch) {
-    throw new GitHubPrError(`Current branch is already "${baseBranch}". Create the PR from a feature branch instead.`, 409);
+    throw new GitHubPrError(
+      `Current branch is already "${baseBranch}". Create the PR from a feature branch instead.`,
+      409
+    );
   }
 
   await ensureBaseBranchHasDiff(repoRoot, baseBranch, commandRunner);
@@ -89,10 +96,16 @@ export async function createPr(
   }
 
   if (!args.includes("--title") && !args.includes("--fill")) {
-    throw new GitHubPrError("create_pr requires title or fillFromCommits to avoid interactive gh prompts.", 400);
+    throw new GitHubPrError(
+      "create_pr requires title or fillFromCommits to avoid interactive gh prompts.",
+      400
+    );
   }
   if (!args.includes("--body") && !args.includes("--fill")) {
-    throw new GitHubPrError("create_pr requires body or fillFromCommits to avoid interactive gh prompts.", 400);
+    throw new GitHubPrError(
+      "create_pr requires body or fillFromCommits to avoid interactive gh prompts.",
+      400
+    );
   }
 
   const createResult = await commandRunner("gh", args, { cwd: repoRoot });
@@ -101,7 +114,10 @@ export async function createPr(
     throw new GitHubPrError("gh pr create did not return a PR URL.", 500);
   }
 
-  const status = await getPrStatus({ cwd: repoRoot, prNumber: undefined }, commandRunner);
+  const status = await getPrStatus(
+    { cwd: repoRoot, prNumber: undefined },
+    commandRunner
+  );
   return {
     repoRoot,
     branchName,
@@ -109,7 +125,7 @@ export async function createPr(
     prNumber: status.number,
     url,
     title: status.title,
-    isDraft: status.isDraft
+    isDraft: status.isDraft,
   };
 }
 
@@ -121,9 +137,10 @@ export async function getPrStatus(
   const repoRoot = await resolveRepoRoot(cwd, commandRunner);
 
   const args = [
-    "pr", "view",
+    "pr",
+    "view",
     "--json",
-    "number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup"
+    "number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup",
   ];
   if (input.prNumber) {
     args.splice(2, 0, String(input.prNumber));
@@ -141,24 +158,36 @@ export async function getPrStatus(
     reviewDecision: optionalStringField(parsed.reviewDecision),
     mergeStateStatus: optionalStringField(parsed.mergeStateStatus),
     mergeable: optionalStringField(parsed.mergeable),
-    autoMergeEnabled: parsed.autoMergeRequest !== null && parsed.autoMergeRequest !== undefined,
+    autoMergeEnabled:
+      parsed.autoMergeRequest !== null && parsed.autoMergeRequest !== undefined,
     headRefName: stringField(parsed.headRefName, "headRefName"),
     baseRefName: stringField(parsed.baseRefName, "baseRefName"),
-    statusSummary: parseStatusCheckRollup(parsed.statusCheckRollup)
+    statusSummary: parseStatusCheckRollup(parsed.statusCheckRollup),
   };
 }
 
-async function resolveRepoRoot(cwd: string, commandRunner: CommandRunner): Promise<string> {
+async function resolveRepoRoot(
+  cwd: string,
+  commandRunner: CommandRunner
+): Promise<string> {
   try {
     return (
-      await commandRunner("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { allowedExitCodes: [0] })
+      await commandRunner("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+        allowedExitCodes: [0],
+      })
     ).stdout;
   } catch {
-    throw new GitHubPrError("No git repository found for the provided working directory.", 404);
+    throw new GitHubPrError(
+      "No git repository found for the provided working directory.",
+      404
+    );
   }
 }
 
-async function resolveCurrentBranch(repoRoot: string, commandRunner: CommandRunner): Promise<string | null> {
+async function resolveCurrentBranch(
+  repoRoot: string,
+  commandRunner: CommandRunner
+): Promise<string | null> {
   const result = await commandRunner(
     "git",
     ["-C", repoRoot, "symbolic-ref", "--short", "-q", "HEAD"],
@@ -168,25 +197,63 @@ async function resolveCurrentBranch(repoRoot: string, commandRunner: CommandRunn
   return result.exitCode === 0 && result.stdout ? result.stdout : null;
 }
 
-async function ensureBaseBranchHasDiff(repoRoot: string, baseBranch: string, commandRunner: CommandRunner): Promise<void> {
-  await commandRunner("git", ["-C", repoRoot, "fetch", "origin", baseBranch, "--quiet"]);
+async function ensureBaseBranchHasDiff(
+  repoRoot: string,
+  baseBranch: string,
+  commandRunner: CommandRunner
+): Promise<void> {
+  await commandRunner("git", [
+    "-C",
+    repoRoot,
+    "fetch",
+    "origin",
+    baseBranch,
+    "--quiet",
+  ]);
   const diffCount = (
-    await commandRunner("git", ["-C", repoRoot, "rev-list", "--count", `origin/${baseBranch}..HEAD`])
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "rev-list",
+      "--count",
+      `origin/${baseBranch}..HEAD`,
+    ])
   ).stdout;
   if (Number(diffCount) <= 0) {
-    throw new GitHubPrError(`Current branch has no commits ahead of origin/${baseBranch}.`, 409);
+    throw new GitHubPrError(
+      `Current branch has no commits ahead of origin/${baseBranch}.`,
+      409
+    );
   }
 }
 
-async function ensureRemoteBranch(repoRoot: string, branchName: string, commandRunner: CommandRunner): Promise<void> {
+async function ensureRemoteBranch(
+  repoRoot: string,
+  branchName: string,
+  commandRunner: CommandRunner
+): Promise<void> {
   const hasUpstream = await commandRunner(
     "git",
-    ["-C", repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    [
+      "-C",
+      repoRoot,
+      "rev-parse",
+      "--abbrev-ref",
+      "--symbolic-full-name",
+      "@{upstream}",
+    ],
     { allowedExitCodes: [0, 128] }
   );
 
   if (hasUpstream.exitCode !== 0 || !hasUpstream.stdout) {
-    await commandRunner("git", ["-C", repoRoot, "push", "--set-upstream", "origin", branchName]);
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "push",
+      "--set-upstream",
+      "origin",
+      branchName,
+    ]);
     return;
   }
 
@@ -202,10 +269,12 @@ function requireString(value: string | undefined, fieldName: string): string {
 }
 
 function firstNonEmptyLine(value: string): string | null {
-  return value
-    .split("\n")
-    .map((line) => line.trim())
-    .find((line) => line.length > 0) ?? null;
+  return (
+    value
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? null
+  );
 }
 
 function stringField(value: unknown, fieldName: string): string {
@@ -233,7 +302,9 @@ function numberField(value: unknown, fieldName: string): number {
   return value;
 }
 
-function parseStatusCheckRollup(value: unknown): Array<{ name: string; status: string; conclusion: string | null }> {
+function parseStatusCheckRollup(
+  value: unknown
+): Array<{ name: string; status: string; conclusion: string | null }> {
   if (!Array.isArray(value)) {
     return [];
   }
@@ -244,13 +315,16 @@ function parseStatusCheckRollup(value: unknown): Array<{ name: string; status: s
     }
 
     const record = item as Record<string, unknown>;
-    const name = typeof record.name === "string"
-      ? record.name
-      : typeof record.context === "string"
-        ? record.context
-        : "unknown";
-    const status = typeof record.status === "string" ? record.status : "UNKNOWN";
-    const conclusion = typeof record.conclusion === "string" ? record.conclusion : null;
+    const name =
+      typeof record.name === "string"
+        ? record.name
+        : typeof record.context === "string"
+          ? record.context
+          : "unknown";
+    const status =
+      typeof record.status === "string" ? record.status : "UNKNOWN";
+    const conclusion =
+      typeof record.conclusion === "string" ? record.conclusion : null;
     return [{ name, status, conclusion }];
   });
 }

--- a/apps/server/src/shared/lib/run-command.ts
+++ b/apps/server/src/shared/lib/run-command.ts
@@ -22,7 +22,7 @@ export async function runCommand(
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env ? { ...process.env, ...options.env } : process.env,
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     let settled = false;
@@ -95,7 +95,7 @@ export async function runCommand(
       succeed({
         exitCode,
         stdout: stdout.trim(),
-        stderr: stderr.trim()
+        stderr: stderr.trim(),
       });
     });
   });

--- a/apps/server/src/shared/mcp/repo-tools.ts
+++ b/apps/server/src/shared/mcp/repo-tools.ts
@@ -9,13 +9,11 @@ const REPO_TOOL_MANIFEST_PATH = path.join(".dispatch", "tools.json");
 const hooksCache = new Map<string, { mtime: number; hooks: RepoHooks }>();
 const REPO_TOOL_PREFIX = "repo_";
 const BUILTIN_TOOL_NAMES = new Set([
-
   "create_pr",
-
 
   "get_pr_status",
   "dispatch_event",
-  "dispatch_share"
+  "dispatch_share",
 ]);
 
 type RepoToolFile = {
@@ -64,11 +62,19 @@ export type RepoToolDefinition = {
   description: string;
   params?: RepoToolParam[];
   scope?: RepoToolScope[];
-  run: (context: { agentId: string; repoRoot: string; params?: Record<string, unknown> }) => Promise<RepoToolResult>;
+  run: (context: {
+    agentId: string;
+    repoRoot: string;
+    params?: Record<string, unknown>;
+  }) => Promise<RepoToolResult>;
 };
 
-export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinition[]> {
-  const config = await readRepoToolFile(path.join(repoRoot, REPO_TOOL_MANIFEST_PATH));
+export async function loadRepoTools(
+  repoRoot: string
+): Promise<RepoToolDefinition[]> {
+  const config = await readRepoToolFile(
+    path.join(repoRoot, REPO_TOOL_MANIFEST_PATH)
+  );
   const rawTools = Array.isArray(config?.tools) ? config.tools : [];
 
   return rawTools.map((rawTool, index) => {
@@ -89,7 +95,11 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
             if (value === undefined || value === null) continue;
             if (param.type === "boolean" && value === true) {
               args.push(param.flag);
-            } else if (param.type === "string" && typeof value === "string" && value) {
+            } else if (
+              param.type === "string" &&
+              typeof value === "string" &&
+              value
+            ) {
               args.push(param.flag, value);
             }
           }
@@ -102,7 +112,7 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           },
           // Allow all exit codes — the agent decides how to handle failures.
           // Throwing on non-zero hides useful diagnostic output (stderr, partial stdout).
-          allowedExitCodes: Array.from({ length: 256 }, (_, i) => i)
+          allowedExitCodes: Array.from({ length: 256 }, (_, i) => i),
         });
 
         return {
@@ -112,14 +122,17 @@ export async function loadRepoTools(repoRoot: string): Promise<RepoToolDefinitio
           exitCode: result.exitCode,
           stdout: result.stdout,
           stderr: result.stderr,
-          message: result.stdout || `Ran ${prefixedName} in ${currentRepoRoot}.`
+          message:
+            result.stdout || `Ran ${prefixedName} in ${currentRepoRoot}.`,
         };
-      }
+      },
     };
   });
 }
 
-async function readRepoToolFile(filePath: string): Promise<RepoToolFile | null> {
+async function readRepoToolFile(
+  filePath: string
+): Promise<RepoToolFile | null> {
   try {
     return JSON.parse(await readFile(filePath, "utf8")) as RepoToolFile;
   } catch {
@@ -134,10 +147,13 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
 
   const rawTool = value as Record<string, unknown>;
   const rawName = typeof rawTool.name === "string" ? rawTool.name.trim() : "";
-  const description = typeof rawTool.description === "string" ? rawTool.description.trim() : "";
-  const command = Array.isArray(rawTool.command) && rawTool.command.every((part) => typeof part === "string")
-    ? rawTool.command.map((part) => part.trim()).filter(Boolean)
-    : [];
+  const description =
+    typeof rawTool.description === "string" ? rawTool.description.trim() : "";
+  const command =
+    Array.isArray(rawTool.command) &&
+    rawTool.command.every((part) => typeof part === "string")
+      ? rawTool.command.map((part) => part.trim()).filter(Boolean)
+      : [];
 
   if (!rawName) {
     throw new Error(`Repo tool at index ${index} must have a non-empty name.`);
@@ -146,13 +162,17 @@ function parseRepoTool(value: unknown, index: number): RepoToolConfig {
   const name = rawName.replaceAll(".", "_");
   const prefixedName = `${REPO_TOOL_PREFIX}${name}`;
   if (BUILTIN_TOOL_NAMES.has(prefixedName)) {
-    throw new Error(`Repo tool "${name}" collides with a built-in Dispatch MCP tool when prefixed as "${prefixedName}".`);
+    throw new Error(
+      `Repo tool "${name}" collides with a built-in Dispatch MCP tool when prefixed as "${prefixedName}".`
+    );
   }
   if (!description) {
     throw new Error(`Repo tool "${name}" must include a description.`);
   }
   if (command.length === 0) {
-    throw new Error(`Repo tool "${name}" must include a non-empty command array.`);
+    throw new Error(
+      `Repo tool "${name}" must include a non-empty command array.`
+    );
   }
 
   const params = parseRepoToolParams(rawTool.params);
@@ -178,7 +198,11 @@ export async function loadRepoHooks(repoRoot: string): Promise<RepoHooks> {
   }
 
   const config = await readRepoToolFile(manifestPath);
-  if (!config?.hooks || typeof config.hooks !== "object" || Array.isArray(config.hooks)) {
+  if (
+    !config?.hooks ||
+    typeof config.hooks !== "object" ||
+    Array.isArray(config.hooks)
+  ) {
     const empty = {};
     hooksCache.set(manifestPath, { mtime, hooks: empty });
     return empty;
@@ -200,15 +224,18 @@ function parseHookDefinition(value: unknown, name: string): RepoHookDefinition {
     throw new Error(`Invalid hook definition for "${name}".`);
   }
   const raw = value as Record<string, unknown>;
-  const command = Array.isArray(raw.command) && raw.command.every((part) => typeof part === "string")
-    ? raw.command.map((part) => (part as string).trim()).filter(Boolean)
-    : [];
+  const command =
+    Array.isArray(raw.command) &&
+    raw.command.every((part) => typeof part === "string")
+      ? raw.command.map((part) => (part as string).trim()).filter(Boolean)
+      : [];
 
   if (command.length === 0) {
     throw new Error(`Hook "${name}" must include a non-empty command array.`);
   }
 
-  const description = typeof raw.description === "string" ? raw.description.trim() : undefined;
+  const description =
+    typeof raw.description === "string" ? raw.description.trim() : undefined;
 
   return { command, ...(description ? { description } : {}) };
 }
@@ -237,10 +264,13 @@ function parseRepoToolParams(raw: unknown): RepoToolParam[] | undefined {
     const name = typeof p.name === "string" ? p.name.trim() : "";
     const type = p.type === "string" || p.type === "boolean" ? p.type : "";
     const flag = typeof p.flag === "string" ? p.flag.trim() : "";
-    const description = typeof p.description === "string" ? p.description.trim() : "";
+    const description =
+      typeof p.description === "string" ? p.description.trim() : "";
 
     if (!name || !type || !flag) {
-      throw new Error(`Param at index ${i} must have name, type (string|boolean), and flag.`);
+      throw new Error(
+        `Param at index ${i} must have name, type (string|boolean), and flag.`
+      );
     }
     return { name, type, flag, description };
   });

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -4,15 +4,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as z from "zod/v4";
 
-import {
-  createPr,
-
-  getPrStatus,
-  GitHubPrError,
-} from "../github/pr.js";
-import {
-  GitWorktreeError,
-} from "../git/worktree.js";
+import { createPr, getPrStatus, GitHubPrError } from "../github/pr.js";
+import { GitWorktreeError } from "../git/worktree.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 
 export type McpAgent = {
@@ -63,34 +56,79 @@ export type GetFeedbackResult = {
 };
 
 export type JobTools = {
-  complete: (agentId: string, report: unknown) => Promise<{ runId: string; status: string }>;
-  failed: (agentId: string, report: unknown) => Promise<{ runId: string; status: string }>;
-  needsInput: (agentId: string, question: string) => Promise<{ runId: string; status: string }>;
+  complete: (
+    agentId: string,
+    report: unknown
+  ) => Promise<{ runId: string; status: string }>;
+  failed: (
+    agentId: string,
+    report: unknown
+  ) => Promise<{ runId: string; status: string }>;
+  needsInput: (
+    agentId: string,
+    question: string
+  ) => Promise<{ runId: string; status: string }>;
   log: (
     agentId: string,
-    input: { task: string; message: string; level: "debug" | "info" | "warn" | "error" }
+    input: {
+      task: string;
+      message: string;
+      level: "debug" | "info" | "warn" | "error";
+    }
   ) => Promise<{ runId: string; status: string }>;
-  listAgents: () => Promise<Array<{ id: string; name: string; status: string; cwd: string }>>;
-  listRecentPersonaReviews: (sinceDays: number) => Promise<Array<{
-    id: number; agentId: string; parentAgentId: string; persona: string;
-    status: string; message: string | null; verdict: string | null;
-    summary: string | null; filesReviewed: string[] | null;
-    createdAt: string; updatedAt: string;
-  }>>;
-  listRecentFeedback: (sinceDays: number) => Promise<Array<{
-    id: number; agentId: string; persona: string; severity: string;
-    filePath: string | null; lineNumber: number | null;
-    description: string; suggestion: string | null;
-    mediaRef: string | null; status: string; createdAt: string;
-  }>>;
-  getActivitySummary: (params: { start: Date; end: Date; project?: string }) => Promise<Record<string, unknown>>;
+  listAgents: () => Promise<
+    Array<{ id: string; name: string; status: string; cwd: string }>
+  >;
+  listRecentPersonaReviews: (sinceDays: number) => Promise<
+    Array<{
+      id: number;
+      agentId: string;
+      parentAgentId: string;
+      persona: string;
+      status: string;
+      message: string | null;
+      verdict: string | null;
+      summary: string | null;
+      filesReviewed: string[] | null;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
+  listRecentFeedback: (sinceDays: number) => Promise<
+    Array<{
+      id: number;
+      agentId: string;
+      persona: string;
+      severity: string;
+      filePath: string | null;
+      lineNumber: number | null;
+      description: string;
+      suggestion: string | null;
+      mediaRef: string | null;
+      status: string;
+      createdAt: string;
+    }>
+  >;
+  getActivitySummary: (params: {
+    start: Date;
+    end: Date;
+    project?: string;
+  }) => Promise<Record<string, unknown>>;
   getAgentHistory: (params: {
-    start: Date; end: Date; project?: string; limit: number; offset: number;
-    includeEvents: boolean; includeFeedback: boolean;
-    includeReviews: boolean; includeChildren: boolean;
+    start: Date;
+    end: Date;
+    project?: string;
+    limit: number;
+    offset: number;
+    includeEvents: boolean;
+    includeFeedback: boolean;
+    includeReviews: boolean;
+    includeChildren: boolean;
   }) => Promise<Record<string, unknown>>;
   getFeedbackSummary: (params: {
-    start: Date; end: Date; project?: string;
+    start: Date;
+    end: Date;
+    project?: string;
     groupBy: "persona" | "severity" | "directory";
   }) => Promise<Record<string, unknown>>;
 };
@@ -169,7 +207,12 @@ export type ReviewCompletion = {
 
 export type ParentContextResult = {
   pins: Array<{ label: string; value: string; type: string }>;
-  media: Array<{ fileName: string; description: string | null; source: string; createdAt: string }>;
+  media: Array<{
+    fileName: string;
+    description: string | null;
+    source: string;
+    createdAt: string;
+  }>;
 };
 
 export type NotifyInput = {
@@ -188,10 +231,7 @@ export type McpRequestContext = {
   agent: McpAgent | null;
   repoRoot: string | null;
   worktreeRoot: string | null;
-  sendNotify?: (
-    agentId: string,
-    input: NotifyInput
-  ) => Promise<NotifyResult>;
+  sendNotify?: (agentId: string, input: NotifyInput) => Promise<NotifyResult>;
   upsertEvent?: (
     agentId: string,
     event: { type: string; message: string; metadata?: Record<string, unknown> }
@@ -202,12 +242,27 @@ export type McpRequestContext = {
   ) => Promise<{ id: string; name: string }>;
   shareMedia?: (
     agentId: string,
-    opts: { filePath: string; description: string; source?: string; name?: string; update?: string }
+    opts: {
+      filePath: string;
+      description: string;
+      source?: string;
+      name?: string;
+      update?: string;
+    }
   ) => Promise<MediaResult>;
   listMedia?: (
     agentId: string,
     opts: { source?: string }
-  ) => Promise<Array<{ fileName: string; filePath: string; source: string; description: string | null; sizeBytes: number; createdAt: string }>>;
+  ) => Promise<
+    Array<{
+      fileName: string;
+      filePath: string;
+      source: string;
+      description: string | null;
+      sizeBytes: number;
+      createdAt: string;
+    }>
+  >;
   submitFeedback?: (
     agentId: string,
     feedback: FeedbackInput
@@ -217,7 +272,11 @@ export type McpRequestContext = {
   ) => Promise<Array<{ slug: string; name: string; description: string }>>;
   launchPersona?: (
     agentId: string,
-    opts: { persona: string; context: string; agentType?: LaunchPersonaAgentType }
+    opts: {
+      persona: string;
+      context: string;
+      agentType?: LaunchPersonaAgentType;
+    }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
   getFeedback?: (
     agentId: string,
@@ -232,34 +291,43 @@ export type McpRequestContext = {
     agentId: string,
     pin: { label: string; value: string; type: string }
   ) => Promise<void>;
-  deletePin?: (
-    agentId: string,
-    label: string
-  ) => Promise<void>;
-  getParentContext?: (
-    parentAgentId: string
-  ) => Promise<ParentContextResult>;
+  deletePin?: (agentId: string, label: string) => Promise<void>;
+  getParentContext?: (parentAgentId: string) => Promise<ParentContextResult>;
   updateReviewStatus?: (
     agentId: string,
     input: { status: string; message?: string }
   ) => Promise<void>;
   completeReview?: (
     agentId: string,
-    input: { verdict: string; summary: string; filesReviewed?: string[]; message?: string }
-  ) => Promise<void>;
-  getActivitySummary?: (
-    params: { start: Date; end: Date; project?: string }
-  ) => Promise<Record<string, unknown>>;
-  getAgentHistory?: (
-    params: {
-      start: Date; end: Date; project?: string; limit: number; offset: number;
-      includeEvents: boolean; includeFeedback: boolean;
-      includeReviews: boolean; includeChildren: boolean;
+    input: {
+      verdict: string;
+      summary: string;
+      filesReviewed?: string[];
+      message?: string;
     }
-  ) => Promise<Record<string, unknown>>;
-  getFeedbackSummary?: (
-    params: { start: Date; end: Date; project?: string; groupBy: "persona" | "severity" | "directory" }
-  ) => Promise<Record<string, unknown>>;
+  ) => Promise<void>;
+  getActivitySummary?: (params: {
+    start: Date;
+    end: Date;
+    project?: string;
+  }) => Promise<Record<string, unknown>>;
+  getAgentHistory?: (params: {
+    start: Date;
+    end: Date;
+    project?: string;
+    limit: number;
+    offset: number;
+    includeEvents: boolean;
+    includeFeedback: boolean;
+    includeReviews: boolean;
+    includeChildren: boolean;
+  }) => Promise<Record<string, unknown>>;
+  getFeedbackSummary?: (params: {
+    start: Date;
+    end: Date;
+    project?: string;
+    groupBy: "persona" | "severity" | "directory";
+  }) => Promise<Record<string, unknown>>;
   jobTools?: JobTools;
   toolScope?: "agent" | "reviewer" | "job";
 };
@@ -268,11 +336,15 @@ export async function handleMcpRequest(
   req: IncomingMessage,
   res: ServerResponse,
   parsedBody?: unknown,
-  context: McpRequestContext = { agent: null, repoRoot: null, worktreeRoot: null }
+  context: McpRequestContext = {
+    agent: null,
+    repoRoot: null,
+    worktreeRoot: null,
+  }
 ): Promise<void> {
   const server = await createDispatchMcpServer(context);
   const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined
+    sessionIdGenerator: undefined,
   });
   res.once("close", () => {
     void transport.close();
@@ -283,17 +355,27 @@ export async function handleMcpRequest(
   await transport.handleRequest(req, res, parsedBody);
 }
 
-async function createDispatchMcpServer(context: McpRequestContext): Promise<McpServer> {
+async function createDispatchMcpServer(
+  context: McpRequestContext
+): Promise<McpServer> {
   const server = new McpServer({
     name: "dispatch",
-    version: "0.0.0"
+    version: "0.0.0",
   });
   const defaultCwd = context.agent?.cwd ?? undefined;
-  const agentType: AgentType = context.agent?.persona ? "persona" : context.jobTools ? "job" : "agent";
+  const agentType: AgentType = context.agent?.persona
+    ? "persona"
+    : context.jobTools
+      ? "job"
+      : "agent";
   const allowed = TOOL_SETS[agentType];
 
   // ── review_status (persona) ───────────────────────────────────────
-  if (allowed.has("review_status") && context.updateReviewStatus && context.completeReview) {
+  if (
+    allowed.has("review_status") &&
+    context.updateReviewStatus &&
+    context.completeReview
+  ) {
     const agentId = context.agent!.id;
     const updateReviewStatus = context.updateReviewStatus;
     const completeReview = context.completeReview;
@@ -305,8 +387,14 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           "Report review progress. Call with status 'reviewing' while actively reviewing code or testing. " +
           "Call with status 'complete' when the review is finished — include a verdict and summary.",
         inputSchema: {
-          status: z.enum(["reviewing", "complete"]).describe("Current review status."),
-          message: z.string().describe("Short description of current activity or final summary."),
+          status: z
+            .enum(["reviewing", "complete"])
+            .describe("Current review status."),
+          message: z
+            .string()
+            .describe(
+              "Short description of current activity or final summary."
+            ),
           verdict: z
             .enum(["approve", "request_changes"])
             .optional()
@@ -314,39 +402,50 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           summary: z
             .string()
             .optional()
-            .describe("Summary of the review findings. Required when status is 'complete'."),
+            .describe(
+              "Summary of the review findings. Required when status is 'complete'."
+            ),
           filesReviewed: z
             .array(z.string())
             .optional()
-            .describe("List of file paths that were reviewed.")
-        }
+            .describe("List of file paths that were reviewed."),
+        },
       },
       async (args) => {
         try {
           if (args.status === "complete") {
             if (!args.verdict) {
-              return toToolError(new Error("verdict is required when status is 'complete'."));
+              return toToolError(
+                new Error("verdict is required when status is 'complete'.")
+              );
             }
             if (!args.summary) {
-              return toToolError(new Error("summary is required when status is 'complete'."));
+              return toToolError(
+                new Error("summary is required when status is 'complete'.")
+              );
             }
             await completeReview(agentId, {
               verdict: args.verdict,
               summary: args.summary,
               filesReviewed: args.filesReviewed,
-              message: args.message
+              message: args.message,
             });
             return {
-              content: [{ type: "text", text: `Review complete: ${args.verdict}. ${args.summary}` }]
+              content: [
+                {
+                  type: "text",
+                  text: `Review complete: ${args.verdict}. ${args.summary}`,
+                },
+              ],
             };
           }
 
           await updateReviewStatus(agentId, {
             status: "reviewing",
-            message: args.message
+            message: args.message,
           });
           return {
-            content: [{ type: "text", text: `Reviewing: ${args.message}` }]
+            content: [{ type: "text", text: `Reviewing: ${args.message}` }],
           };
         } catch (error) {
           return toToolError(error);
@@ -356,7 +455,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   // ── get_parent_context (persona) ────────────────────────────────────
-  if (allowed.has("get_parent_context") && context.agent?.parentAgentId && context.getParentContext) {
+  if (
+    allowed.has("get_parent_context") &&
+    context.agent?.parentAgentId &&
+    context.getParentContext
+  ) {
     const parentAgentId = context.agent.parentAgentId;
     const getParentContext = context.getParentContext;
 
@@ -366,7 +469,7 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Retrieve the parent agent's pins and shared media. Use this to discover dev server URLs, " +
           "key files, screenshots, and other context the parent agent has surfaced.",
-        inputSchema: {}
+        inputSchema: {},
       },
       async () => {
         try {
@@ -383,12 +486,14 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           if (result.media.length > 0) {
             parts.push("\nShared media:");
             for (const m of result.media) {
-              parts.push(`  ${m.fileName}: ${m.description ?? "(no description)"}`);
+              parts.push(
+                `  ${m.fileName}: ${m.description ?? "(no description)"}`
+              );
             }
           }
           return {
             content: [{ type: "text", text: parts.join("\n") }],
-            structuredContent: result
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);
@@ -406,23 +511,40 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       {
         description: "Create a GitHub pull request for the current branch.",
         inputSchema: {
-          cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
-          baseBranch: z.string().default(defaultBaseBranch).describe("Base branch to target."),
+          cwd: cwdSchema(
+            defaultCwd,
+            "Absolute path inside the git repository."
+          ),
+          baseBranch: z
+            .string()
+            .default(defaultBaseBranch)
+            .describe("Base branch to target."),
           title: z.string().optional().describe("Explicit PR title."),
           body: z.string().optional().describe("Explicit PR body."),
-          draft: z.boolean().default(false).describe("Create the PR as a draft."),
-          fillFromCommits: z.boolean().default(false).describe("Let gh derive title/body from commits.")
-        }
+          draft: z
+            .boolean()
+            .default(false)
+            .describe("Create the PR as a draft."),
+          fillFromCommits: z
+            .boolean()
+            .default(false)
+            .describe("Let gh derive title/body from commits."),
+        },
       },
       async (args) => {
         try {
           const result = await createPr({
             ...args,
-            cwd: resolveCwd(args.cwd, defaultCwd)
+            cwd: resolveCwd(args.cwd, defaultCwd),
           });
           return {
-            content: [{ type: "text", text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.` }],
-            structuredContent: result
+            content: [
+              {
+                type: "text",
+                text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.`,
+              },
+            ],
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);
@@ -438,19 +560,34 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       {
         description: "Fetch status details for a pull request.",
         inputSchema: {
-          cwd: cwdSchema(defaultCwd, "Absolute path inside the git repository."),
-          prNumber: z.number().int().positive().optional().describe("Specific PR number. Defaults to the PR for the current branch.")
-        }
+          cwd: cwdSchema(
+            defaultCwd,
+            "Absolute path inside the git repository."
+          ),
+          prNumber: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Specific PR number. Defaults to the PR for the current branch."
+            ),
+        },
       },
       async (args) => {
         try {
           const result = await getPrStatus({
             ...args,
-            cwd: resolveCwd(args.cwd, defaultCwd)
+            cwd: resolveCwd(args.cwd, defaultCwd),
           });
           return {
-            content: [{ type: "text", text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.` }],
-            structuredContent: result
+            content: [
+              {
+                type: "text",
+                text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.`,
+              },
+            ],
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);
@@ -471,23 +608,32 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Report agent status to Dispatch. Must be called at the start of each turn (working), when stuck and unable to proceed (blocked), waiting for user input (waiting_user), and before the final response (done or idle).",
         inputSchema: {
-          type: z.enum(["working", "blocked", "waiting_user", "done", "idle"]).describe("The status event type."),
-          message: z.string().describe("A short description of what is happening."),
+          type: z
+            .enum(["working", "blocked", "waiting_user", "done", "idle"])
+            .describe("The status event type."),
+          message: z
+            .string()
+            .describe("A short description of what is happening."),
           metadata: z
             .record(z.string(), z.unknown())
             .optional()
-            .describe("Optional metadata object.")
-        }
+            .describe("Optional metadata object."),
+        },
       },
       async (args) => {
         try {
           await upsertEvent(agentId, {
             type: args.type,
             message: args.message,
-            metadata: args.metadata as Record<string, unknown> | undefined
+            metadata: args.metadata as Record<string, unknown> | undefined,
           });
           return {
-            content: [{ type: "text", text: `Updated ${agentId}: ${args.type} - ${args.message}` }]
+            content: [
+              {
+                type: "text",
+                text: `Updated ${agentId}: ${args.type} - ${args.message}`,
+              },
+            ],
           };
         } catch (error) {
           return toToolError(error);
@@ -497,7 +643,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   // ── dispatch_rename_session ───────────────────────────────────────
-  if (allowed.has("dispatch_rename_session") && context.agent && context.renameSession) {
+  if (
+    allowed.has("dispatch_rename_session") &&
+    context.agent &&
+    context.renameSession
+  ) {
     const agentId = context.agent.id;
     const renameSession = context.renameSession;
 
@@ -507,15 +657,21 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Update the current session's display name. Use this to rename a default-generated session to a short goal or topic, or when the user explicitly asks for a rename.",
         inputSchema: {
-          name: z.string().min(1).max(120).describe("New session display name.")
-        }
+          name: z
+            .string()
+            .min(1)
+            .max(120)
+            .describe("New session display name."),
+        },
       },
       async (args) => {
         try {
           const result = await renameSession(agentId, args.name);
           return {
-            content: [{ type: "text", text: `Renamed session to \"${result.name}\".` }],
-            structuredContent: result
+            content: [
+              { type: "text", text: `Renamed session to \"${result.name}\".` },
+            ],
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);
@@ -538,13 +694,32 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           "Requires a Slack webhook to be configured in Dispatch settings. " +
           "Rate limited to 5 messages per minute.",
         inputSchema: {
-          message: z.string().max(3000).describe("The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc). Max 3000 characters."),
-          title: z.string().max(150).optional().describe("Optional title displayed above the message. Defaults to 'Notification from <agent>'. Max 150 characters."),
-          level: z.enum(["info", "success", "warning", "error"]).default("info")
-            .describe("Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."),
-          respectFocus: z.boolean().default(false)
-            .describe("When true, the notification is suppressed if the user is actively viewing this agent in Dispatch. Default false — notifications are always sent."),
-        }
+          message: z
+            .string()
+            .max(3000)
+            .describe(
+              "The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc). Max 3000 characters."
+            ),
+          title: z
+            .string()
+            .max(150)
+            .optional()
+            .describe(
+              "Optional title displayed above the message. Defaults to 'Notification from <agent>'. Max 150 characters."
+            ),
+          level: z
+            .enum(["info", "success", "warning", "error"])
+            .default("info")
+            .describe(
+              "Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."
+            ),
+          respectFocus: z
+            .boolean()
+            .default(false)
+            .describe(
+              "When true, the notification is suppressed if the user is actively viewing this agent in Dispatch. Default false — notifications are always sent."
+            ),
+        },
       },
       async (args) => {
         try {
@@ -555,9 +730,14 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             respectFocus: args.respectFocus,
           });
           return {
-            content: [{ type: "text", text: result.sent
-              ? "Notification sent to Slack."
-              : `Notification not sent: ${result.reason}` }]
+            content: [
+              {
+                type: "text",
+                text: result.sent
+                  ? "Notification sent to Slack."
+                  : `Notification not sent: ${result.reason}`,
+              },
+            ],
           };
         } catch (error) {
           return toToolError(error);
@@ -570,7 +750,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   if (allowed.has("dispatch_share")) registerShareTool(server, context);
 
   // ── dispatch_list_media ──────────────────────────────────────────
-  if (allowed.has("dispatch_list_media") && context.agent && context.listMedia) {
+  if (
+    allowed.has("dispatch_list_media") &&
+    context.agent &&
+    context.listMedia
+  ) {
     const agentId = context.agent.id;
     const listMedia = context.listMedia;
 
@@ -592,7 +776,9 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         try {
           const items = await listMedia(agentId, { source: args.source });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(items, null, 2) }],
+            content: [
+              { type: "text" as const, text: JSON.stringify(items, null, 2) },
+            ],
           };
         } catch (error) {
           return toToolError(error);
@@ -613,17 +799,24 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       {
         description:
           "List the persona reviewers available for this project. Returns each persona's slug, name, and description. Use this to decide which personas to launch via dispatch_launch_persona.",
-        inputSchema: {}
+        inputSchema: {},
       },
       async () => {
         if (!personaRoot) {
-          return { content: [{ type: "text", text: JSON.stringify({ personas: [] }, null, 2) }], structuredContent: { personas: [] } };
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ personas: [] }, null, 2) },
+            ],
+            structuredContent: { personas: [] },
+          };
         }
         try {
           const personas = await listPersonas(personaRoot);
           return {
-            content: [{ type: "text", text: JSON.stringify({ personas }, null, 2) }],
-            structuredContent: { personas }
+            content: [
+              { type: "text", text: JSON.stringify({ personas }, null, 2) },
+            ],
+            structuredContent: { personas },
           };
         } catch (error) {
           return toToolError(error);
@@ -633,7 +826,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   // ── dispatch_launch_persona ───────────────────────────────────────
-  if (allowed.has("dispatch_launch_persona") && context.agent && context.launchPersona) {
+  if (
+    allowed.has("dispatch_launch_persona") &&
+    context.agent &&
+    context.launchPersona
+  ) {
     const agentId = context.agent.id;
     const launchPersona = context.launchPersona;
 
@@ -643,25 +840,39 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files.",
         inputSchema: {
-          persona: z.string().describe("Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."),
-          context: z.string().max(100_000).describe("Briefing for the persona — describe what you built, key files changed, and areas that need attention."),
-          agentType: z.enum(LAUNCH_PERSONA_AGENT_TYPES).optional().describe("Optional agent runtime override for the persona launch.")
-        }
+          persona: z
+            .string()
+            .describe(
+              "Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."
+            ),
+          context: z
+            .string()
+            .max(100_000)
+            .describe(
+              "Briefing for the persona — describe what you built, key files changed, and areas that need attention."
+            ),
+          agentType: z
+            .enum(LAUNCH_PERSONA_AGENT_TYPES)
+            .optional()
+            .describe(
+              "Optional agent runtime override for the persona launch."
+            ),
+        },
       },
       async (args) => {
         try {
           const result = await launchPersona(agentId, {
             persona: args.persona,
             context: args.context,
-            agentType: args.agentType
+            agentType: args.agentType,
           });
           return {
             content: [
               {
                 type: "text",
-                text: `Launched persona "${result.persona}" as agent ${result.agentId}.`
-              }
-            ]
+                text: `Launched persona "${result.persona}" as agent ${result.agentId}.`,
+              },
+            ],
           };
         } catch (error) {
           return toToolError(error);
@@ -671,7 +882,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   // ── dispatch_get_feedback ───────────────────────────────────────────
-  if (allowed.has("dispatch_get_feedback") && context.agent && context.getFeedback) {
+  if (
+    allowed.has("dispatch_get_feedback") &&
+    context.agent &&
+    context.getFeedback
+  ) {
     const agentId = context.agent.id;
     const getFeedback = context.getFeedback;
 
@@ -684,26 +899,37 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
           persona: z
             .string()
             .optional()
-            .describe("Filter to a specific persona by name. If omitted, returns feedback from all child personas."),
+            .describe(
+              "Filter to a specific persona by name. If omitted, returns feedback from all child personas."
+            ),
           limit: z
             .number()
             .int()
             .positive()
             .max(100)
             .default(100)
-            .describe("Maximum number of feedback items to return. Defaults and caps at 100.")
-        }
+            .describe(
+              "Maximum number of feedback items to return. Defaults and caps at 100."
+            ),
+        },
       },
       async (args) => {
         try {
-          const result = await getFeedback(agentId, { persona: args.persona, limit: args.limit });
-          const totalItems = result.personas.reduce((sum, p) => sum + p.feedback.length, 0);
-          const summary = result.personas.length === 0
-            ? "No persona feedback found."
-            : `Found ${totalItems} feedback item(s) from ${result.personas.length} persona(s).`;
+          const result = await getFeedback(agentId, {
+            persona: args.persona,
+            limit: args.limit,
+          });
+          const totalItems = result.personas.reduce(
+            (sum, p) => sum + p.feedback.length,
+            0
+          );
+          const summary =
+            result.personas.length === 0
+              ? "No persona feedback found."
+              : `Found ${totalItems} feedback item(s) from ${result.personas.length} persona(s).`;
           return {
             content: [{ type: "text", text: summary }],
-            structuredContent: result
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);
@@ -713,7 +939,11 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   }
 
   // ── dispatch_resolve_feedback ───────────────────────────────────────
-  if (allowed.has("dispatch_resolve_feedback") && context.agent && context.resolveFeedback) {
+  if (
+    allowed.has("dispatch_resolve_feedback") &&
+    context.agent &&
+    context.resolveFeedback
+  ) {
     const agentId = context.agent.id;
     const resolveFeedback = context.resolveFeedback;
 
@@ -730,14 +960,25 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
             .describe("The ID of the feedback item to resolve."),
           status: z
             .enum(["fixed", "ignored"])
-            .describe("Resolution status: 'fixed' if addressed, 'ignored' if not applicable.")
-        }
+            .describe(
+              "Resolution status: 'fixed' if addressed, 'ignored' if not applicable."
+            ),
+        },
       },
       async (args) => {
         try {
-          const result = await resolveFeedback(agentId, args.feedbackId, args.status);
+          const result = await resolveFeedback(
+            agentId,
+            args.feedbackId,
+            args.status
+          );
           return {
-            content: [{ type: "text", text: `Feedback #${result.id} marked as ${result.status}.` }]
+            content: [
+              {
+                type: "text",
+                text: `Feedback #${result.id} marked as ${result.status}.`,
+              },
+            ],
           };
         } catch (error) {
           return toToolError(error);
@@ -749,9 +990,12 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   // ── Summary / analytics tools (available to both agents and jobs) ──
 
   // Resolve the callback: prefer context-level, fall back to jobTools
-  const getActivitySummary = context.getActivitySummary ?? context.jobTools?.getActivitySummary;
-  const getAgentHistory = context.getAgentHistory ?? context.jobTools?.getAgentHistory;
-  const getFeedbackSummary = context.getFeedbackSummary ?? context.jobTools?.getFeedbackSummary;
+  const getActivitySummary =
+    context.getActivitySummary ?? context.jobTools?.getActivitySummary;
+  const getAgentHistory =
+    context.getAgentHistory ?? context.jobTools?.getAgentHistory;
+  const getFeedbackSummary =
+    context.getFeedbackSummary ?? context.jobTools?.getFeedbackSummary;
 
   if (allowed.has("get_activity_summary") && getActivitySummary) {
     const fn = getActivitySummary;
@@ -761,19 +1005,36 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Get a high-level summary of agent activity in Dispatch over a time range — working time, session counts, outcomes, and top agents by project. Use this for activity digests and dashboards.",
         inputSchema: {
-          start: z.string().datetime({ offset: true }).optional()
-            .describe("Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."),
-          end: z.string().datetime({ offset: true }).optional()
-            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
-          project: z.string().optional()
-            .describe("Filter to a specific project directory (exact match). If omitted, returns all projects."),
+          start: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."
+            ),
+          end: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "End of time range (ISO 8601 with timezone). Defaults to now."
+            ),
+          project: z
+            .string()
+            .optional()
+            .describe(
+              "Filter to a specific project directory (exact match). If omitted, returns all projects."
+            ),
         },
       },
       async (args) => {
         try {
           const end = args.end ? new Date(args.end) : new Date();
-          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 7 * 86_400_000);
-          if (start >= end) return toToolError(new Error("start must be before end"));
+          const start = args.start
+            ? new Date(args.start)
+            : new Date(end.getTime() - 7 * 86_400_000);
+          if (start >= end)
+            return toToolError(new Error("start must be before end"));
           const result = await fn({ start, end, project: args.project });
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -794,31 +1055,71 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Get detailed agent session history — what agents worked on, their event timelines, feedback received, and persona review results. Use for deeper investigation after get_activity_summary or for building narrative summaries.",
         inputSchema: {
-          start: z.string().datetime({ offset: true }).optional()
-            .describe("Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."),
-          end: z.string().datetime({ offset: true }).optional()
-            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
-          project: z.string().optional()
+          start: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "Start of time range (ISO 8601 with timezone). Defaults to 7 days ago."
+            ),
+          end: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "End of time range (ISO 8601 with timezone). Defaults to now."
+            ),
+          project: z
+            .string()
+            .optional()
             .describe("Filter to a specific project directory (exact match)."),
-          limit: z.number().int().min(1).max(50).default(20)
-            .describe("Max number of agent sessions to return (default 20, max 50)."),
-          offset: z.number().int().min(0).default(0)
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(50)
+            .default(20)
+            .describe(
+              "Max number of agent sessions to return (default 20, max 50)."
+            ),
+          offset: z
+            .number()
+            .int()
+            .min(0)
+            .default(0)
             .describe("Pagination offset."),
-          include_events: z.boolean().default(false)
-            .describe("Include the event timeline for each agent session (capped at 200 per agent). Can be verbose."),
-          include_feedback: z.boolean().default(true)
+          include_events: z
+            .boolean()
+            .default(false)
+            .describe(
+              "Include the event timeline for each agent session (capped at 200 per agent). Can be verbose."
+            ),
+          include_feedback: z
+            .boolean()
+            .default(true)
             .describe("Include feedback findings for each agent session."),
-          include_reviews: z.boolean().default(true)
-            .describe("Include persona review summaries for each agent session."),
-          include_children: z.boolean().default(false)
-            .describe("Include child/persona agents as standalone entries (default: nested under parent)."),
+          include_reviews: z
+            .boolean()
+            .default(true)
+            .describe(
+              "Include persona review summaries for each agent session."
+            ),
+          include_children: z
+            .boolean()
+            .default(false)
+            .describe(
+              "Include child/persona agents as standalone entries (default: nested under parent)."
+            ),
         },
       },
       async (args) => {
         try {
           const end = args.end ? new Date(args.end) : new Date();
-          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 7 * 86_400_000);
-          if (start >= end) return toToolError(new Error("start must be before end"));
+          const start = args.start
+            ? new Date(args.start)
+            : new Date(end.getTime() - 7 * 86_400_000);
+          if (start >= end)
+            return toToolError(new Error("start must be before end"));
           const result = await fn({
             start,
             end,
@@ -849,21 +1150,38 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
         description:
           "Aggregate persona review feedback to surface patterns — recurring issue types, hot spots in the codebase, and severity trends. Use for feedback pattern tracking and coaching check-ins.",
         inputSchema: {
-          start: z.string().datetime({ offset: true }).optional()
-            .describe("Start of time range (ISO 8601 with timezone). Defaults to 14 days ago."),
-          end: z.string().datetime({ offset: true }).optional()
-            .describe("End of time range (ISO 8601 with timezone). Defaults to now."),
-          project: z.string().optional()
+          start: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "Start of time range (ISO 8601 with timezone). Defaults to 14 days ago."
+            ),
+          end: z
+            .string()
+            .datetime({ offset: true })
+            .optional()
+            .describe(
+              "End of time range (ISO 8601 with timezone). Defaults to now."
+            ),
+          project: z
+            .string()
+            .optional()
             .describe("Filter to a specific project directory (exact match)."),
-          group_by: z.enum(["persona", "severity", "directory"]).default("persona")
+          group_by: z
+            .enum(["persona", "severity", "directory"])
+            .default("persona")
             .describe("Primary grouping for the summary."),
         },
       },
       async (args) => {
         try {
           const end = args.end ? new Date(args.end) : new Date();
-          const start = args.start ? new Date(args.start) : new Date(end.getTime() - 14 * 86_400_000);
-          if (start >= end) return toToolError(new Error("start must be before end"));
+          const start = args.start
+            ? new Date(args.start)
+            : new Date(end.getTime() - 14 * 86_400_000);
+          if (start >= end)
+            return toToolError(new Error("start must be before end"));
           const result = await fn({
             start,
             end,
@@ -888,30 +1206,47 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     const reportSchema = z.object({
       status: z.enum(["completed", "failed"]),
       summary: z.string().min(1),
-      tasks: z.array(z.object({
-        name: z.string().min(1),
-        status: z.enum(["success", "skipped", "error"]),
-        summary: z.string(),
-        errors: z.array(z.object({
-          message: z.string().min(1),
-          recoverable: z.boolean().optional(),
-          action: z.string().optional()
-        })).optional()
-      }))
+      tasks: z.array(
+        z.object({
+          name: z.string().min(1),
+          status: z.enum(["success", "skipped", "error"]),
+          summary: z.string(),
+          errors: z
+            .array(
+              z.object({
+                message: z.string().min(1),
+                recoverable: z.boolean().optional(),
+                action: z.string().optional(),
+              })
+            )
+            .optional(),
+        })
+      ),
     });
 
     server.registerTool(
       "job_complete",
       {
-        description: "Submit the terminal structured report for a successful Dispatch job run.",
+        description:
+          "Submit the terminal structured report for a successful Dispatch job run.",
         inputSchema: {
-          report: reportSchema.describe("Structured job report. report.status must be completed.")
-        }
+          report: reportSchema.describe(
+            "Structured job report. report.status must be completed."
+          ),
+        },
       },
       async (args) => {
         try {
           const result = await jobTools.complete(agentId, args.report);
-          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Job run ${result.runId} marked ${result.status}.`,
+              },
+            ],
+            structuredContent: result,
+          };
         } catch (error) {
           return toToolError(error);
         }
@@ -921,15 +1256,26 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     server.registerTool(
       "job_failed",
       {
-        description: "Submit the terminal structured report for a failed Dispatch job run.",
+        description:
+          "Submit the terminal structured report for a failed Dispatch job run.",
         inputSchema: {
-          report: reportSchema.describe("Structured job report. report.status must be failed.")
-        }
+          report: reportSchema.describe(
+            "Structured job report. report.status must be failed."
+          ),
+        },
       },
       async (args) => {
         try {
           const result = await jobTools.failed(agentId, args.report);
-          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Job run ${result.runId} marked ${result.status}.`,
+              },
+            ],
+            structuredContent: result,
+          };
         } catch (error) {
           return toToolError(error);
         }
@@ -941,13 +1287,24 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
       {
         description: "Pause a Dispatch job run when human input is required.",
         inputSchema: {
-          question: z.string().min(1).describe("The question or decision needed from a human.")
-        }
+          question: z
+            .string()
+            .min(1)
+            .describe("The question or decision needed from a human."),
+        },
       },
       async (args) => {
         try {
           const result = await jobTools.needsInput(agentId, args.question);
-          return { content: [{ type: "text", text: `Job run ${result.runId} marked ${result.status}.` }], structuredContent: result };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Job run ${result.runId} marked ${result.status}.`,
+              },
+            ],
+            structuredContent: result,
+          };
         } catch (error) {
           return toToolError(error);
         }
@@ -957,17 +1314,32 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     server.registerTool(
       "job_log",
       {
-        description: "Append structured progress for a task within the active Dispatch job run.",
+        description:
+          "Append structured progress for a task within the active Dispatch job run.",
         inputSchema: {
-          task: z.string().min(1).describe("Task name this log entry belongs to."),
+          task: z
+            .string()
+            .min(1)
+            .describe("Task name this log entry belongs to."),
           message: z.string().min(1).describe("Progress message."),
-          level: z.enum(["debug", "info", "warn", "error"]).default("info").describe("Log severity.")
-        }
+          level: z
+            .enum(["debug", "info", "warn", "error"])
+            .default("info")
+            .describe("Log severity."),
+        },
       },
       async (args) => {
         try {
           const result = await jobTools.log(agentId, args);
-          return { content: [{ type: "text", text: `Logged progress for job run ${result.runId}.` }], structuredContent: result };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Logged progress for job run ${result.runId}.`,
+              },
+            ],
+            structuredContent: result,
+          };
         } catch (error) {
           return toToolError(error);
         }
@@ -977,15 +1349,18 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     server.registerTool(
       "list_agents",
       {
-        description: "List all agents from this Dispatch server with their IDs, names, and statuses.",
-        inputSchema: {}
+        description:
+          "List all agents from this Dispatch server with their IDs, names, and statuses.",
+        inputSchema: {},
       },
       async () => {
         try {
           const agents = await jobTools.listAgents();
           return {
-            content: [{ type: "text", text: JSON.stringify({ agents }, null, 2) }],
-            structuredContent: { agents }
+            content: [
+              { type: "text", text: JSON.stringify({ agents }, null, 2) },
+            ],
+            structuredContent: { agents },
           };
         } catch (error) {
           return toToolError(error);
@@ -996,17 +1371,35 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     server.registerTool(
       "list_recent_persona_reviews",
       {
-        description: "List persona reviews from the last N days. Returns review metadata including persona type, status, verdict, and summary.",
+        description:
+          "List persona reviews from the last N days. Returns review metadata including persona type, status, verdict, and summary.",
         inputSchema: {
-          since_days: z.number().int().min(1).max(90).default(7).describe("Number of days to look back (default 7, max 90).")
-        }
+          since_days: z
+            .number()
+            .int()
+            .min(1)
+            .max(90)
+            .default(7)
+            .describe("Number of days to look back (default 7, max 90)."),
+        },
       },
       async (args) => {
         try {
-          const reviews = await jobTools.listRecentPersonaReviews(args.since_days);
+          const reviews = await jobTools.listRecentPersonaReviews(
+            args.since_days
+          );
           return {
-            content: [{ type: "text", text: JSON.stringify({ reviews, count: reviews.length }, null, 2) }],
-            structuredContent: { reviews, count: reviews.length }
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  { reviews, count: reviews.length },
+                  null,
+                  2
+                ),
+              },
+            ],
+            structuredContent: { reviews, count: reviews.length },
           };
         } catch (error) {
           return toToolError(error);
@@ -1017,17 +1410,33 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
     server.registerTool(
       "list_recent_feedback",
       {
-        description: "List feedback items submitted by persona agents in the last N days. Includes persona type, severity, description, status, and file location.",
+        description:
+          "List feedback items submitted by persona agents in the last N days. Includes persona type, severity, description, status, and file location.",
         inputSchema: {
-          since_days: z.number().int().min(1).max(90).default(7).describe("Number of days to look back (default 7, max 90).")
-        }
+          since_days: z
+            .number()
+            .int()
+            .min(1)
+            .max(90)
+            .default(7)
+            .describe("Number of days to look back (default 7, max 90)."),
+        },
       },
       async (args) => {
         try {
           const feedback = await jobTools.listRecentFeedback(args.since_days);
           return {
-            content: [{ type: "text", text: JSON.stringify({ feedback, count: feedback.length }, null, 2) }],
-            structuredContent: { feedback, count: feedback.length }
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  { feedback, count: feedback.length },
+                  null,
+                  2
+                ),
+              },
+            ],
+            structuredContent: { feedback, count: feedback.length },
           };
         } catch (error) {
           return toToolError(error);
@@ -1040,25 +1449,27 @@ async function createDispatchMcpServer(context: McpRequestContext): Promise<McpS
   if (context.agent && toolsRoot) {
     const allRepoTools = await loadRepoTools(toolsRoot);
     const scope = context.toolScope ?? "agent";
-    const repoTools = allRepoTools.filter((tool) => !tool.scope || tool.scope.includes(scope));
+    const repoTools = allRepoTools.filter(
+      (tool) => !tool.scope || tool.scope.includes(scope)
+    );
     for (const tool of repoTools) {
       const inputSchema = buildParamSchema(tool.params);
       server.registerTool(
         tool.name,
         {
           description: tool.description,
-          inputSchema
+          inputSchema,
         },
         async (args) => {
           try {
             const result = await tool.run({
               agentId: context.agent!.id,
               repoRoot: toolsRoot,
-              params: args as Record<string, unknown>
+              params: args as Record<string, unknown>,
             });
             return {
               content: [{ type: "text", text: result.message }],
-              structuredContent: result
+              structuredContent: result,
             };
           } catch (error) {
             return toToolError(error);
@@ -1086,7 +1497,12 @@ function registerPinTool(server: McpServer, context: McpRequestContext): void {
         "Pin a key-value pair to the Dispatch UI for this agent. Pins are displayed in the sidebar so users can quickly find important info. To update a pin, set it again with the same label. To remove a pin, pass delete: true. " +
         "Good things to pin: dev server URLs (url), PR links (pr), key files changed (filename), test/build result summaries (string), DB migration names (string), relevant doc or issue links (url), architecture decisions or assumptions (string), short structured summaries (markdown), the specific blocking question when in waiting_user state (string).",
       inputSchema: {
-        label: z.string().max(100).describe("Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."),
+        label: z
+          .string()
+          .max(100)
+          .describe(
+            "Display label for the pin (e.g. 'API Server', 'Vite Dev', 'DB Port')."
+          ),
         value: z
           .string()
           .max(2000)
@@ -1095,31 +1511,37 @@ function registerPinTool(server: McpServer, context: McpRequestContext): void {
         type: z
           .enum(["string", "url", "port", "code", "pr", "filename", "markdown"])
           .default("string")
-          .describe("Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. 'markdown' renders constrained markdown for short summaries. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."),
+          .describe(
+            "Value type. 'url' renders as a clickable link. 'port' renders as a monospace badge. 'code' renders as a monospace badge. 'pr' renders as a pull request link with a PR icon. 'filename' renders with a file icon in monospace. 'markdown' renders constrained markdown for short summaries. For list-like types (filename, url, string, port), separate multiple values with commas or newlines."
+          ),
         delete: z
           .boolean()
           .default(false)
-          .describe("Set to true to remove the pin with this label.")
-      }
+          .describe("Set to true to remove the pin with this label."),
+      },
     },
     async (args) => {
       try {
         if (args.delete) {
           await deletePin(agentId, args.label);
           return {
-            content: [{ type: "text", text: `Removed pin "${args.label}".` }]
+            content: [{ type: "text", text: `Removed pin "${args.label}".` }],
           };
         }
         if (!args.value) {
-          return toToolError(new Error("value is required when not deleting a pin."));
+          return toToolError(
+            new Error("value is required when not deleting a pin.")
+          );
         }
         await upsertPin(agentId, {
           label: args.label,
           value: args.value,
-          type: args.type ?? "string"
+          type: args.type ?? "string",
         });
         return {
-          content: [{ type: "text", text: `Pinned "${args.label}": ${args.value}` }]
+          content: [
+            { type: "text", text: `Pinned "${args.label}": ${args.value}` },
+          ],
         };
       } catch (error) {
         return toToolError(error);
@@ -1128,7 +1550,10 @@ function registerPinTool(server: McpServer, context: McpRequestContext): void {
   );
 }
 
-function registerShareTool(server: McpServer, context: McpRequestContext): void {
+function registerShareTool(
+  server: McpServer,
+  context: McpRequestContext
+): void {
   if (!context.agent || !context.shareMedia) return;
   const agentId = context.agent.id;
   const shareMedia = context.shareMedia;
@@ -1142,29 +1567,43 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
         filePath: z
           .string()
           .optional()
-          .describe("Absolute path to the file to upload. Not required when source is 'simulator' or when content is provided."),
+          .describe(
+            "Absolute path to the file to upload. Not required when source is 'simulator' or when content is provided."
+          ),
         content: z
           .string()
           .optional()
-          .describe("Text content to share directly (max 32KB). Requires name param with a file extension (e.g. 'snippet.ts'). Use this for text snippets instead of writing to a temp file."),
-        description: z.string().describe("A short description of the shared media."),
+          .describe(
+            "Text content to share directly (max 32KB). Requires name param with a file extension (e.g. 'snippet.ts'). Use this for text snippets instead of writing to a temp file."
+          ),
+        description: z
+          .string()
+          .describe("A short description of the shared media."),
         source: z
           .enum(["screenshot", "simulator", "text"])
           .default("screenshot")
-          .describe("The source type of the media. Automatically set to 'text' when sharing text files."),
+          .describe(
+            "The source type of the media. Automatically set to 'text' when sharing text files."
+          ),
         name: z
           .string()
           .optional()
-          .describe("Preferred file name for the upload. Required when using content param. Derived from the file path if omitted."),
+          .describe(
+            "Preferred file name for the upload. Required when using content param. Derived from the file path if omitted."
+          ),
         simulatorUdid: z
           .string()
           .optional()
-          .describe("Simulator UDID for simulator screenshots. Defaults to 'booted'."),
+          .describe(
+            "Simulator UDID for simulator screenshots. Defaults to 'booted'."
+          ),
         update: z
           .string()
           .optional()
-          .describe("fileName of an existing shared media file to update (returned from a previous dispatch_share call). When set, the file content is replaced instead of creating a new file.")
-      }
+          .describe(
+            "fileName of an existing shared media file to update (returned from a previous dispatch_share call). When set, the file content is replaced instead of creating a new file."
+          ),
+      },
     },
     async (args) => {
       try {
@@ -1173,10 +1612,18 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
         if (args.content !== undefined) {
           const MAX_CONTENT_BYTES = 32 * 1024;
           if (Buffer.byteLength(args.content, "utf-8") > MAX_CONTENT_BYTES) {
-            return toToolError(new Error("content exceeds 32KB limit. Write to a file and use filePath instead."));
+            return toToolError(
+              new Error(
+                "content exceeds 32KB limit. Write to a file and use filePath instead."
+              )
+            );
           }
           if (!args.name) {
-            return toToolError(new Error("name is required when using content param (e.g. 'snippet.ts')."));
+            return toToolError(
+              new Error(
+                "name is required when using content param (e.g. 'snippet.ts')."
+              )
+            );
           }
           const { writeFile: writeFileTmp } = await import("node:fs/promises");
           const tmpDir = process.env.TMPDIR ?? "/tmp";
@@ -1199,12 +1646,23 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
             .replace("T", "-")
             .replace("Z", "");
           const tmpPath = `${process.env.TMPDIR ?? "/tmp"}/sim-${timestamp}.png`;
-          await execFileAsync("xcrun", ["simctl", "io", udid, "screenshot", "--type=png", tmpPath]);
+          await execFileAsync("xcrun", [
+            "simctl",
+            "io",
+            udid,
+            "screenshot",
+            "--type=png",
+            tmpPath,
+          ]);
           filePath = tmpPath;
         }
 
         if (!filePath) {
-          return toToolError(new Error("filePath is required when source is not 'simulator' and content is not provided."));
+          return toToolError(
+            new Error(
+              "filePath is required when source is not 'simulator' and content is not provided."
+            )
+          );
         }
 
         const result = await shareMedia(agentId, {
@@ -1212,17 +1670,17 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
           description: args.description,
           source: args.source,
           name: args.name,
-          update: args.update
+          update: args.update,
         });
 
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(result)
-            }
+              text: JSON.stringify(result),
+            },
           ],
-          structuredContent: result
+          structuredContent: result,
         };
       } catch (error) {
         return toToolError(error);
@@ -1231,7 +1689,10 @@ function registerShareTool(server: McpServer, context: McpRequestContext): void 
   );
 }
 
-function registerFeedbackTool(server: McpServer, context: McpRequestContext): void {
+function registerFeedbackTool(
+  server: McpServer,
+  context: McpRequestContext
+): void {
   if (!context.agent || !context.submitFeedback) return;
   const agentId = context.agent.id;
   const submitFeedback = context.submitFeedback;
@@ -1249,12 +1710,13 @@ function registerFeedbackTool(server: McpServer, context: McpRequestContext): vo
         filePath: z
           .string()
           .optional()
-          .describe("File path relative to repo root where the issue was found."),
-        lineNumber: z
-          .number()
-          .optional()
-          .describe("Line number in the file."),
-        description: z.string().describe("What was found — the issue or observation."),
+          .describe(
+            "File path relative to repo root where the issue was found."
+          ),
+        lineNumber: z.number().optional().describe("Line number in the file."),
+        description: z
+          .string()
+          .describe("What was found — the issue or observation."),
         suggestion: z
           .string()
           .optional()
@@ -1262,8 +1724,10 @@ function registerFeedbackTool(server: McpServer, context: McpRequestContext): vo
         mediaRef: z
           .string()
           .optional()
-          .describe("Filename of a previously shared media file (from dispatch_share) to attach.")
-      }
+          .describe(
+            "Filename of a previously shared media file (from dispatch_share) to attach."
+          ),
+      },
     },
     async (args) => {
       try {
@@ -1273,10 +1737,12 @@ function registerFeedbackTool(server: McpServer, context: McpRequestContext): vo
           lineNumber: args.lineNumber,
           description: args.description,
           suggestion: args.suggestion,
-          mediaRef: args.mediaRef
+          mediaRef: args.mediaRef,
         });
         return {
-          content: [{ type: "text", text: `Feedback #${result.id} submitted.` }]
+          content: [
+            { type: "text", text: `Feedback #${result.id} submitted.` },
+          ],
         };
       } catch (error) {
         return toToolError(error);
@@ -1285,14 +1751,22 @@ function registerFeedbackTool(server: McpServer, context: McpRequestContext): vo
   );
 }
 
-function cwdSchema(defaultCwd: string | undefined, description: string): z.ZodType<string | undefined> {
+function cwdSchema(
+  defaultCwd: string | undefined,
+  description: string
+): z.ZodType<string | undefined> {
   const suffix = defaultCwd
     ? ` Defaults to the agent working directory (${defaultCwd}) when omitted on agent-scoped MCP routes.`
     : "";
-  return defaultCwd ? z.string().optional().describe(`${description}${suffix}`) : z.string().describe(description);
+  return defaultCwd
+    ? z.string().optional().describe(`${description}${suffix}`)
+    : z.string().describe(description);
 }
 
-function resolveCwd(value: string | undefined, defaultCwd: string | undefined): string {
+function resolveCwd(
+  value: string | undefined,
+  defaultCwd: string | undefined
+): string {
   const cwd = value?.trim() || defaultCwd?.trim();
   if (!cwd) {
     throw new Error("cwd is required.");
@@ -1313,20 +1787,24 @@ function buildParamSchema(params?: RepoToolParam[]): Record<string, z.ZodType> {
   return schema;
 }
 
-function toToolError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  const message = error instanceof GitWorktreeError || error instanceof GitHubPrError
-    ? error.message
-    : error instanceof Error
+function toToolError(error: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  const message =
+    error instanceof GitWorktreeError || error instanceof GitHubPrError
       ? error.message
-      : String(error);
+      : error instanceof Error
+        ? error.message
+        : String(error);
 
   return {
     content: [
       {
         type: "text",
-        text: message
-      }
+        text: message,
+      },
     ],
-    isError: true
+    isError: true,
   };
 }

--- a/apps/server/src/stream-manager.ts
+++ b/apps/server/src/stream-manager.ts
@@ -7,7 +7,11 @@ type StreamSession = {
 };
 
 type OnStateChange = (agentId: string, event: "started" | "stopped") => void;
-type OnStreamEnd = (agentId: string, lastFrame: Buffer, description: string | null) => void;
+type OnStreamEnd = (
+  agentId: string,
+  lastFrame: Buffer,
+  description: string | null
+) => void;
 
 const MJPEG_BOUNDARY = "frame";
 const FRAME_REFRESH_INTERVAL_MS = 1000;
@@ -30,7 +34,9 @@ export class StreamManager {
     // Discover CDP target URL
     const response = await fetch(`http://127.0.0.1:${port}/json`);
     if (!response.ok) {
-      throw new Error(`Failed to discover CDP targets on port ${port}: ${response.status}`);
+      throw new Error(
+        `Failed to discover CDP targets on port ${port}: ${response.status}`
+      );
     }
 
     const targets = (await response.json()) as Array<{
@@ -62,7 +68,12 @@ export class StreamManager {
         JSON.stringify({
           id: cdpId++,
           method: "Page.startScreencast",
-          params: { format: "jpeg", quality: 60, maxWidth: 1280, maxHeight: 800 },
+          params: {
+            format: "jpeg",
+            quality: 60,
+            maxWidth: 1280,
+            maxHeight: 800,
+          },
         })
       );
       // Re-push the last cached frame periodically so viewers that connect
@@ -174,7 +185,10 @@ export class StreamManager {
 
     // Send the cached frame immediately so the viewer doesn't see a blank screen
     if (session.lastFrame) {
-      this.writeFrameToViewers({ viewers: new Set([stream]) } as StreamSession, session.lastFrame);
+      this.writeFrameToViewers(
+        { viewers: new Set([stream]) } as StreamSession,
+        session.lastFrame
+      );
     }
 
     return () => {
@@ -201,7 +215,10 @@ export class StreamManager {
     this.writeFrameToViewers(session, jpegBuffer);
   }
 
-  private writeFrameToViewers(session: StreamSession, jpegBuffer: Buffer): void {
+  private writeFrameToViewers(
+    session: StreamSession,
+    jpegBuffer: Buffer
+  ): void {
     const header =
       `--${MJPEG_BOUNDARY}\r\n` +
       `Content-Type: image/jpeg\r\n` +
@@ -215,7 +232,10 @@ export class StreamManager {
 
     for (const viewer of session.viewers) {
       try {
-        const v = viewer as NodeJS.WritableStream & { writable?: boolean; flush?: () => void };
+        const v = viewer as NodeJS.WritableStream & {
+          writable?: boolean;
+          flush?: () => void;
+        };
         if (v.writable !== false) {
           v.write(frameChunk);
           if (typeof v.flush === "function") {

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -10,9 +10,13 @@ export class TmuxTerminal {
   }
 
   async hasSession(): Promise<boolean> {
-    const result = await runCommand("tmux", ["has-session", "-t", this.sessionName], {
-      allowedExitCodes: [0, 1]
-    });
+    const result = await runCommand(
+      "tmux",
+      ["has-session", "-t", this.sessionName],
+      {
+        allowedExitCodes: [0, 1],
+      }
+    );
 
     return result.exitCode === 0;
   }
@@ -26,14 +30,20 @@ export class TmuxTerminal {
       "-S",
       `-${lines}`,
       "-E",
-      "-1"
+      "-1",
     ]);
 
     return result.stdout;
   }
 
   async sendCommand(commandLine: string): Promise<void> {
-    await runCommand("tmux", ["send-keys", "-t", this.sessionName, "-l", commandLine]);
+    await runCommand("tmux", [
+      "send-keys",
+      "-t",
+      this.sessionName,
+      "-l",
+      commandLine,
+    ]);
     await runCommand("tmux", ["send-keys", "-t", this.sessionName, "Enter"]);
   }
 

--- a/apps/server/src/terminal/token-store.ts
+++ b/apps/server/src/terminal/token-store.ts
@@ -18,7 +18,7 @@ export class TerminalTokenStore {
     const token = randomUUID().replaceAll("-", "");
     this.records.set(token, {
       agentId,
-      expiresAtMs: Date.now() + this.ttlMs
+      expiresAtMs: Date.now() + this.ttlMs,
     });
     return token;
   }

--- a/apps/server/test/activity-metrics.test.ts
+++ b/apps/server/test/activity-metrics.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { computeActivityStats, computeDailyStatus, type ActivityEventRow } from "../src/activity-metrics.js";
+import {
+  computeActivityStats,
+  computeDailyStatus,
+  type ActivityEventRow,
+} from "../src/activity-metrics.js";
 
-function row(agent_id: string, event_type: string, created_at: string): ActivityEventRow {
+function row(
+  agent_id: string,
+  event_type: string,
+  created_at: string
+): ActivityEventRow {
   return { agent_id, event_type, created_at: new Date(created_at) };
 }
 

--- a/apps/server/test/agent-type-settings.test.ts
+++ b/apps/server/test/agent-type-settings.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { AGENT_TYPES, sanitizeEnabledAgentTypes } from "../src/agent-type-settings.js";
+import {
+  AGENT_TYPES,
+  sanitizeEnabledAgentTypes,
+} from "../src/agent-type-settings.js";
 
 describe("sanitizeEnabledAgentTypes", () => {
   it("returns defaults when the value is not an array", () => {
@@ -8,10 +11,9 @@ describe("sanitizeEnabledAgentTypes", () => {
   });
 
   it("filters unknown values and removes duplicates", () => {
-    expect(sanitizeEnabledAgentTypes(["codex", "claude", "codex", "unknown"])).toEqual([
-      "codex",
-      "claude",
-    ]);
+    expect(
+      sanitizeEnabledAgentTypes(["codex", "claude", "codex", "unknown"])
+    ).toEqual(["codex", "claude"]);
   });
 
   it("falls back to defaults when the array has no valid types", () => {

--- a/apps/server/test/auth.test.ts
+++ b/apps/server/test/auth.test.ts
@@ -36,7 +36,9 @@ afterAll(async () => {
 beforeEach(async () => {
   // Clean state between tests
   await pool.query("DELETE FROM sessions");
-  await pool.query("DELETE FROM settings WHERE key LIKE 'password_%' OR key = 'auth_token' OR key = 'cookie_secret'");
+  await pool.query(
+    "DELETE FROM settings WHERE key LIKE 'password_%' OR key = 'auth_token' OR key = 'cookie_secret'"
+  );
 });
 
 describe("password management", () => {
@@ -109,7 +111,10 @@ describe("session management", () => {
     // Manually insert an expired session
     const crypto = await import("node:crypto");
     const expiredToken = crypto.randomUUID();
-    const hashed = crypto.createHash("sha256").update(expiredToken).digest("hex");
+    const hashed = crypto
+      .createHash("sha256")
+      .update(expiredToken)
+      .digest("hex");
     await pool.query(
       "INSERT INTO sessions (token, expires_at) VALUES ($1, NOW() - INTERVAL '1 day')",
       [hashed]
@@ -157,31 +162,57 @@ describe("auth token and cookie secret", () => {
     const secret = await getOrCreateAuthToken(pool);
     const token = createJobMcpToken(secret, "run_123", "agt_123456abcdef");
 
-    expect(validateJobMcpToken(secret, token, "run_123", "agt_123456abcdef")).toBe(true);
-    expect(validateJobMcpToken(secret, token, "run_other", "agt_123456abcdef")).toBe(false);
-    expect(validateJobMcpToken(secret, token, "run_123", "agt_otheragent")).toBe(false);
+    expect(
+      validateJobMcpToken(secret, token, "run_123", "agt_123456abcdef")
+    ).toBe(true);
+    expect(
+      validateJobMcpToken(secret, token, "run_other", "agt_123456abcdef")
+    ).toBe(false);
+    expect(
+      validateJobMcpToken(secret, token, "run_123", "agt_otheragent")
+    ).toBe(false);
   });
 
   it("does not let scoped MCP bearer tokens through the global auth gate", async () => {
     const secret = await getOrCreateAuthToken(pool);
     const agentToken = createAgentMcpToken(secret, "agt_123456abcdef");
 
-    expect(shouldAcceptApiBearerToken("/api/mcp", agentToken, secret)).toBe(false);
-    expect(shouldAcceptApiBearerToken("/api/mcp/agt_123456abcdef", agentToken, secret)).toBe(false);
-    expect(shouldAcceptApiBearerToken("/api/mcp/jobs/run_123/agt_123456abcdef", agentToken, secret)).toBe(false);
-    expect(shouldAcceptApiBearerToken("/api/v1/agents", agentToken, secret)).toBe(false);
+    expect(shouldAcceptApiBearerToken("/api/mcp", agentToken, secret)).toBe(
+      false
+    );
+    expect(
+      shouldAcceptApiBearerToken(
+        "/api/mcp/agt_123456abcdef",
+        agentToken,
+        secret
+      )
+    ).toBe(false);
+    expect(
+      shouldAcceptApiBearerToken(
+        "/api/mcp/jobs/run_123/agt_123456abcdef",
+        agentToken,
+        secret
+      )
+    ).toBe(false);
+    expect(
+      shouldAcceptApiBearerToken("/api/v1/agents", agentToken, secret)
+    ).toBe(false);
   });
 
   it("identifies only agent and job MCP routes as scoped routes", () => {
     expect(isScopedMcpRoute("/api/mcp")).toBe(false);
     expect(isScopedMcpRoute("/api/mcp/agt_123456abcdef")).toBe(true);
-    expect(isScopedMcpRoute("/api/mcp/jobs/run_123/agt_123456abcdef")).toBe(true);
+    expect(isScopedMcpRoute("/api/mcp/jobs/run_123/agt_123456abcdef")).toBe(
+      true
+    );
     expect(isScopedMcpRoute("/api/v1/agents")).toBe(false);
   });
 
   it("still accepts the raw server auth token on non-MCP routes", async () => {
     const secret = await getOrCreateAuthToken(pool);
 
-    expect(shouldAcceptApiBearerToken("/api/v1/agents", secret, secret)).toBe(true);
+    expect(shouldAcceptApiBearerToken("/api/v1/agents", secret, secret)).toBe(
+      true
+    );
   });
 });

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { assertSafeDatabaseConfig, assertSafePortConfig } from "../src/config.js";
+import {
+  assertSafeDatabaseConfig,
+  assertSafePortConfig,
+} from "../src/config.js";
 
 describe("database safety config", () => {
   it("refuses the production database from a Dispatch agent context", () => {
@@ -15,7 +18,10 @@ describe("database safety config", () => {
   it("allows isolated dispatch-dev databases from a Dispatch agent context", () => {
     expect(() =>
       assertSafeDatabaseConfig(
-        { databaseUrl: "postgres://dispatch:dispatch@127.0.0.1:5433/dispatch_agt_test" },
+        {
+          databaseUrl:
+            "postgres://dispatch:dispatch@127.0.0.1:5433/dispatch_agt_test",
+        },
         { DISPATCH_AGENT_ID: "agt_test" }
       )
     ).not.toThrow();
@@ -45,8 +51,6 @@ describe("port safety config", () => {
   });
 
   it("allows production port outside agent context", () => {
-    expect(() =>
-      assertSafePortConfig({ port: 6767 }, {})
-    ).not.toThrow();
+    expect(() => assertSafePortConfig({ port: 6767 }, {})).not.toThrow();
   });
 });

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -1,10 +1,25 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
 import type { Pool } from "pg";
 
 import { setupTestDb, teardownTestDb, runTestMigrations } from "./setup.js";
@@ -21,7 +36,8 @@ vi.mock("../../src/shared/lib/run-command.js", () => ({
 }));
 
 // We need to dynamically import AgentManager AFTER the mock is in place
-const { AgentManager, AgentError } = await import("../../src/agents/manager.js");
+const { AgentManager, AgentError } =
+  await import("../../src/agents/manager.js");
 const { createAgentMcpToken } = await import("../../src/auth.js");
 const execFileAsync = promisify(execFile);
 
@@ -81,18 +97,23 @@ beforeEach(async () => {
   await pool.query("DELETE FROM agents");
 
   const { runCommand } = await import("../../src/shared/lib/run-command.js");
-  vi.mocked(runCommand).mockImplementation(async (_cmd: string, args: string[]) => {
-    if (args[0] === "has-session") {
+  vi.mocked(runCommand).mockImplementation(
+    async (_cmd: string, args: string[]) => {
+      if (args[0] === "has-session") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
       return { exitCode: 0, stdout: "", stderr: "" };
     }
-    return { exitCode: 0, stdout: "", stderr: "" };
-  });
+  );
 });
 
 describe("AgentManager", () => {
   describe("createAgent", () => {
     it("should create an agent and return it", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       expect(agent.id).toMatch(/^agt_/);
       expect(agent.status).toBe("creating");
@@ -105,27 +126,47 @@ describe("AgentManager", () => {
     });
 
     it("should use a custom name when provided", async () => {
-      const agent = await manager.createAgent({ name: "my-agent", cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        name: "my-agent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.name).toBe("my-agent");
     });
 
     it("should generate a default name from ID suffix", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.name).toMatch(/^agent-/);
     });
 
     it("should support claude agent type", async () => {
-      const agent = await manager.createAgent({ type: "claude", cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        type: "claude",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.type).toBe("claude");
     });
 
     it("should support opencode agent type", async () => {
-      const agent = await manager.createAgent({ type: "opencode", cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        type: "opencode",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.type).toBe("opencode");
     });
 
     it("should persist reviewAgentType when provided", async () => {
-      const agent = await manager.createAgent({ type: "codex", reviewAgentType: "claude", cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        type: "codex",
+        reviewAgentType: "claude",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.reviewAgentType).toBe("claude");
     });
 
@@ -182,9 +223,9 @@ describe("AgentManager", () => {
     });
 
     it("should reject non-absolute paths", async () => {
-      await expect(manager.createAgent({ cwd: "relative/path" })).rejects.toThrow(
-        "absolute path"
-      );
+      await expect(
+        manager.createAgent({ cwd: "relative/path" })
+      ).rejects.toThrow("absolute path");
     });
 
     it("should reject non-existent directories", async () => {
@@ -194,42 +235,75 @@ describe("AgentManager", () => {
     });
 
     it("should create inert agents without invoking tmux", async () => {
-      const { runCommand } = await import("../../src/shared/lib/run-command.js");
+      const { runCommand } =
+        await import("../../src/shared/lib/run-command.js");
       const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
       vi.mocked(runCommand).mockClear();
 
-      const agent = await inertManager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await inertManager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       expect(agent.status).toBe("running");
       expect(vi.mocked(runCommand)).not.toHaveBeenCalled();
     });
 
     it("should inject an agent-scoped MCP URL into Codex launches", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "codex", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        useWorktree: false,
+      });
 
       // The setup script should contain the MCP configuration
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("mcp_servers.dispatch.url=");
       expect(setupScript).toContain(`/api/mcp/${agent.id}`);
-      expect(setupScript).toContain("mcp_servers.dispatch.bearer_token_env_var=");
+      expect(setupScript).toContain(
+        "mcp_servers.dispatch.bearer_token_env_var="
+      );
       expect(setupScript).toContain("DISPATCH_AUTH_TOKEN=");
-      expect(setupScript).toContain("do not start repo work or infer a task from branch/worktree context alone");
+      expect(setupScript).toContain(
+        "do not start repo work or infer a task from branch/worktree context alone"
+      );
       expect(setupScript).toContain("dispatch_rename_session");
       expect(setupScript).toContain("short topic/goal/feature name");
-      expect(setupScript).toContain("stable label for the task, not as a live status update");
+      expect(setupScript).toContain(
+        "stable label for the task, not as a live status update"
+      );
     });
 
     it("should skip rename guidance when the user provided a custom name", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "codex", name: "bug bash", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        name: "bug bash",
+        useWorktree: false,
+      });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("dispatch_rename_session");
     });
 
     it("should skip rename guidance for custom names that resemble the default pattern", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "codex", name: "agent-foobar", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        name: "agent-foobar",
+        useWorktree: false,
+      });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("dispatch_rename_session");
     });
 
@@ -242,7 +316,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("dispatch_rename_session");
     });
 
@@ -251,28 +328,50 @@ describe("AgentManager", () => {
         cwd: "/tmp",
         type: "codex",
         useWorktree: false,
-        agentArgs: ["--append-system-prompt", "Persona review instructions", "--model", "gpt-5"],
+        agentArgs: [
+          "--append-system-prompt",
+          "Persona review instructions",
+          "--model",
+          "gpt-5",
+        ],
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("Persona review instructions");
       expect(setupScript).toContain("--model");
       expect(setupScript).not.toContain("--append-system-prompt");
     });
 
     it("should inject an agent-scoped MCP URL into Claude launches", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "claude", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        useWorktree: false,
+      });
 
       // The setup script should contain the MCP configuration
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("--mcp-config");
       expect(setupScript).toContain(`/api/mcp/${agent.id}`);
     });
 
     it("should inject an agent-scoped MCP config into OpenCode launches without inline JSON quoting bugs", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "opencode", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "opencode",
+        useWorktree: false,
+      });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain(`MCP_ENTRY='{"type":"remote"`);
       expect(setupScript).toContain(`node --input-type=module -e`);
       expect(setupScript).toContain(`/api/mcp/${agent.id}`);
@@ -280,7 +379,9 @@ describe("AgentManager", () => {
     });
 
     it("should execute the generated OpenCode MCP config merge script", async () => {
-      const tempDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-opencode-config-"));
+      const tempDir = await mkdtemp(
+        path.join(os.tmpdir(), "dispatch-opencode-config-")
+      );
       try {
         await writeFile(
           path.join(tempDir, "opencode.json"),
@@ -292,22 +393,39 @@ describe("AgentManager", () => {
           })
         );
 
-        const agent = await manager.createAgent({ cwd: "/tmp", type: "opencode", useWorktree: false });
-        const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+        const agent = await manager.createAgent({
+          cwd: "/tmp",
+          type: "opencode",
+          useWorktree: false,
+        });
+        const setupScript = await readFile(
+          `/tmp/dispatch_setup_${agent.id}.sh`,
+          "utf-8"
+        );
         const configBlock = setupScript.match(
           /# --- Configure opencode MCP ---\n(?<block>[\s\S]*?)\n# exec replaces this shell/
         )?.groups?.block;
         expect(configBlock).toBeTruthy();
 
-        await execFileAsync("bash", ["-c", `set -euo pipefail\nok() { :; }\nEFFECTIVE_CWD=${JSON.stringify(tempDir)}\n${configBlock}`]);
+        await execFileAsync("bash", [
+          "-c",
+          `set -euo pipefail\nok() { :; }\nEFFECTIVE_CWD=${JSON.stringify(tempDir)}\n${configBlock}`,
+        ]);
 
-        const config = JSON.parse(await readFile(path.join(tempDir, "opencode.json"), "utf-8"));
+        const config = JSON.parse(
+          await readFile(path.join(tempDir, "opencode.json"), "utf-8")
+        );
         expect(config.theme).toBe("system");
-        expect(config.mcp.existing).toEqual({ type: "local", command: ["echo", "ok"] });
+        expect(config.mcp.existing).toEqual({
+          type: "local",
+          command: ["echo", "ok"],
+        });
         expect(config.mcp.dispatch).toEqual({
           type: "remote",
           url: `http://127.0.0.1:6767/api/mcp/${agent.id}`,
-          headers: { Authorization: `Bearer ${createAgentMcpToken("test-token", agent.id)}` },
+          headers: {
+            Authorization: `Bearer ${createAgentMcpToken("test-token", agent.id)}`,
+          },
         });
       } finally {
         await rm(tempDir, { recursive: true, force: true });
@@ -322,7 +440,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("Autonomous Review is enabled");
       expect(setupScript).toContain("list_personas");
       expect(setupScript).toContain("dispatch_launch_persona");
@@ -339,7 +460,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("open a draft PR via create_pr");
       expect(setupScript).toContain("do not override baseBranch");
     });
@@ -352,7 +476,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("Autonomous Review is enabled");
     });
 
@@ -365,7 +492,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("Autonomous Review is enabled");
     });
 
@@ -377,7 +507,10 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("Autonomous Review is enabled");
       expect(setupScript).toContain("list_personas");
     });
@@ -391,16 +524,26 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("Autonomous Review is enabled");
       expect(setupScript).toContain("Dispatch job startup rules");
     });
 
     it("should generate a setup script with worktree steps when useWorktree is true", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "claude", useWorktree: true });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        useWorktree: true,
+      });
 
       expect(agent.setupPhase).toBe("worktree");
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).toContain("Creating git worktree");
       expect(setupScript).toContain("Copying environment files");
       expect(setupScript).toContain("Installing dependencies");
@@ -410,17 +553,27 @@ describe("AgentManager", () => {
     });
 
     it("should skip worktree steps in setup script when useWorktree is false", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", type: "claude", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "claude",
+        useWorktree: false,
+      });
 
       expect(agent.setupPhase).toBe("session");
-      const setupScript = await readFile(`/tmp/dispatch_setup_${agent.id}.sh`, "utf-8");
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
       expect(setupScript).not.toContain("Creating git worktree");
       expect(setupScript).toContain("Starting agent session");
       expect(setupScript).toContain("exec bash");
     });
 
     it("should complete setup and transition to running", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.status).toBe("creating");
 
       const updated = await manager.completeSetup(agent.id, {
@@ -444,8 +597,16 @@ describe("AgentManager", () => {
     });
 
     it("should list created agents in descending order", async () => {
-      await manager.createAgent({ name: "first", cwd: "/tmp", useWorktree: false });
-      await manager.createAgent({ name: "second", cwd: "/tmp", useWorktree: false });
+      await manager.createAgent({
+        name: "first",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+      await manager.createAgent({
+        name: "second",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const agents = await manager.listAgents();
       expect(agents.length).toBe(2);
@@ -454,7 +615,11 @@ describe("AgentManager", () => {
     });
 
     it("should fetch a single agent by ID", async () => {
-      const created = await manager.createAgent({ name: "fetch-me", cwd: "/tmp", useWorktree: false });
+      const created = await manager.createAgent({
+        name: "fetch-me",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const fetched = await manager.getAgent(created.id);
 
       expect(fetched).not.toBeNull();
@@ -463,7 +628,11 @@ describe("AgentManager", () => {
     });
 
     it("should round-trip autoReview through getAgent", async () => {
-      const created = await manager.createAgent({ cwd: "/tmp", autoReview: true, useWorktree: false });
+      const created = await manager.createAgent({
+        cwd: "/tmp",
+        autoReview: true,
+        useWorktree: false,
+      });
       const fetched = await manager.getAgent(created.id);
 
       expect(fetched).not.toBeNull();
@@ -471,8 +640,18 @@ describe("AgentManager", () => {
     });
 
     it("should include autoReview in listAgents results", async () => {
-      await manager.createAgent({ name: "review-on", cwd: "/tmp", autoReview: true, useWorktree: false });
-      await manager.createAgent({ name: "review-off", cwd: "/tmp", autoReview: false, useWorktree: false });
+      await manager.createAgent({
+        name: "review-on",
+        cwd: "/tmp",
+        autoReview: true,
+        useWorktree: false,
+      });
+      await manager.createAgent({
+        name: "review-off",
+        cwd: "/tmp",
+        autoReview: false,
+        useWorktree: false,
+      });
 
       const agents = await manager.listAgents();
       const reviewOn = agents.find((a) => a.name === "review-on");
@@ -483,21 +662,35 @@ describe("AgentManager", () => {
     });
 
     it("should rename an agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
-      const renamed = await manager.renameAgent(agent.id, "Investigate flaky e2e");
+      const renamed = await manager.renameAgent(
+        agent.id,
+        "Investigate flaky e2e"
+      );
 
       expect(renamed.name).toBe("Investigate flaky e2e");
     });
 
     it("should reject empty agent names when renaming", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
-      await expect(manager.renameAgent(agent.id, "   ")).rejects.toThrow("Agent name must not be empty.");
+      await expect(manager.renameAgent(agent.id, "   ")).rejects.toThrow(
+        "Agent name must not be empty."
+      );
     });
 
     it("should update reviewAgentType", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       await manager.updateReviewAgentType(agent.id, "opencode");
       const updated = await manager.getAgent(agent.id);
@@ -520,7 +713,10 @@ describe("AgentManager", () => {
 
   describe("upsertLatestEvent", () => {
     it("should persist an event on an agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const updated = await manager.upsertLatestEvent(agent.id, {
         type: "working",
@@ -534,7 +730,10 @@ describe("AgentManager", () => {
     });
 
     it("should overwrite a previous event", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       await manager.upsertLatestEvent(agent.id, {
         type: "working",
@@ -551,7 +750,10 @@ describe("AgentManager", () => {
     });
 
     it("should store metadata", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const updated = await manager.upsertLatestEvent(agent.id, {
         type: "blocked",
@@ -566,7 +768,10 @@ describe("AgentManager", () => {
     });
 
     it("should reject empty message", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       await expect(
         manager.upsertLatestEvent(agent.id, { type: "working", message: "  " })
@@ -589,7 +794,10 @@ describe("AgentManager", () => {
 
   describe("archiveAgent", () => {
     /** Helper: run the full beginArchive + executeArchive flow and wait for completion. */
-    async function archiveAgent(id: string, cleanupWorktree: "auto" | "keep" | "force" = "auto"): Promise<void> {
+    async function archiveAgent(
+      id: string,
+      cleanupWorktree: "auto" | "keep" | "force" = "auto"
+    ): Promise<void> {
       await manager.beginArchive(id, cleanupWorktree);
       await new Promise<void>((resolve, reject) => {
         void manager.executeArchive(id, {
@@ -601,7 +809,10 @@ describe("AgentManager", () => {
     }
 
     it("should soft-delete an agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       // Stop first so beginArchive doesn't need force
       await manager.stopAgent(agent.id, { force: true });
@@ -612,13 +823,19 @@ describe("AgentManager", () => {
       expect(fetched).toBeNull();
 
       // But the row still exists in the database with deleted_at set
-      const row = await pool.query("SELECT deleted_at FROM agents WHERE id = $1", [agent.id]);
+      const row = await pool.query(
+        "SELECT deleted_at FROM agents WHERE id = $1",
+        [agent.id]
+      );
       expect(row.rowCount).toBe(1);
       expect(row.rows[0].deleted_at).not.toBeNull();
     });
 
     it("should exclude soft-deleted agents from listAgents", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.stopAgent(agent.id, { force: true });
       await archiveAgent(agent.id);
 
@@ -627,7 +844,10 @@ describe("AgentManager", () => {
     });
 
     it("should preserve media rows after soft delete", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       // Insert media directly
       await pool.query(
@@ -642,8 +862,14 @@ describe("AgentManager", () => {
       await archiveAgent(agent.id);
 
       // Media rows are preserved since soft delete doesn't trigger CASCADE
-      const media = await pool.query("SELECT * FROM media WHERE agent_id = $1", [agent.id]);
-      const seen = await pool.query("SELECT * FROM media_seen WHERE agent_id = $1", [agent.id]);
+      const media = await pool.query(
+        "SELECT * FROM media WHERE agent_id = $1",
+        [agent.id]
+      );
+      const seen = await pool.query(
+        "SELECT * FROM media_seen WHERE agent_id = $1",
+        [agent.id]
+      );
       expect(media.rowCount).toBe(1);
       expect(seen.rowCount).toBe(1);
     });
@@ -659,7 +885,10 @@ describe("AgentManager", () => {
     });
 
     it("should set status to archiving during beginArchive", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.stopAgent(agent.id, { force: true });
 
       const archiving = await manager.beginArchive(agent.id);
@@ -668,7 +897,10 @@ describe("AgentManager", () => {
     });
 
     it("should reject archiving an already-archiving agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.stopAgent(agent.id, { force: true });
       await manager.beginArchive(agent.id);
 
@@ -684,7 +916,10 @@ describe("AgentManager", () => {
 
   describe("stopAgent", () => {
     it("should stop an agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       expect(agent.status).toBe("creating");
 
       const stopped = await manager.stopAgent(agent.id, { force: true });
@@ -692,7 +927,10 @@ describe("AgentManager", () => {
     });
 
     it("should be a no-op for already stopped agent", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.stopAgent(agent.id, { force: true });
 
       const result = await manager.stopAgent(agent.id);
@@ -700,7 +938,8 @@ describe("AgentManager", () => {
     });
 
     it("should stop inert agents without invoking tmux", async () => {
-      const { runCommand } = await import("../../src/shared/lib/run-command.js");
+      const { runCommand } =
+        await import("../../src/shared/lib/run-command.js");
       const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
       const agent = await inertManager.createAgent({ cwd: "/tmp" });
       vi.mocked(runCommand).mockClear();
@@ -714,7 +953,10 @@ describe("AgentManager", () => {
 
   describe("reconcileAgents", () => {
     it("should mark agents as stopped when tmux session is gone", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.completeSetup(agent.id, {
         effectiveCwd: "/tmp",
         worktreePath: null,
@@ -722,7 +964,8 @@ describe("AgentManager", () => {
       });
 
       // Now make tmux report no session
-      const { runCommand } = await import("../../src/shared/lib/run-command.js");
+      const { runCommand } =
+        await import("../../src/shared/lib/run-command.js");
       const mockRunCommand = vi.mocked(runCommand);
       mockRunCommand.mockImplementation(async (_cmd, args) => {
         if (args[0] === "has-session") {
@@ -747,11 +990,18 @@ describe("AgentManager", () => {
     });
 
     it("should surface startup crashes as blocked errors with setup details", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await writeFile(`/tmp/dispatch_${agent.tmuxSession}.exit`, "EXIT:2");
-      await writeFile(`/tmp/dispatch_setup_${agent.id}.log`, "error: unexpected argument '--append-system-prompt' found\n");
+      await writeFile(
+        `/tmp/dispatch_setup_${agent.id}.log`,
+        "error: unexpected argument '--append-system-prompt' found\n"
+      );
 
-      const { runCommand } = await import("../../src/shared/lib/run-command.js");
+      const { runCommand } =
+        await import("../../src/shared/lib/run-command.js");
       const mockRunCommand = vi.mocked(runCommand);
       mockRunCommand.mockImplementation(async (_cmd, args) => {
         if (args[0] === "has-session") {
@@ -775,21 +1025,32 @@ describe("AgentManager", () => {
       expect(reconciled!.status).toBe("error");
       expect(reconciled!.latestEvent?.type).toBe("blocked");
       expect(reconciled!.latestEvent?.message).toContain("Launch failed");
-      expect(reconciled!.latestEvent?.message).toContain("unexpected argument '--append-system-prompt'");
-      expect(reconciled!.lastError).toContain("unexpected argument '--append-system-prompt'");
+      expect(reconciled!.latestEvent?.message).toContain(
+        "unexpected argument '--append-system-prompt'"
+      );
+      expect(reconciled!.lastError).toContain(
+        "unexpected argument '--append-system-prompt'"
+      );
     });
 
     it("should not classify a clean exit as an error from generic stderr text", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       await manager.completeSetup(agent.id, {
         effectiveCwd: "/tmp",
         worktreePath: null,
-        worktreeBranch: null
+        worktreeBranch: null,
       });
       await writeFile(`/tmp/dispatch_${agent.tmuxSession}.exit`, "EXIT:0");
-      await writeFile(`/tmp/dispatch_setup_${agent.id}.log`, "warning: previous command printed an error banner\n");
+      await writeFile(
+        `/tmp/dispatch_setup_${agent.id}.log`,
+        "warning: previous command printed an error banner\n"
+      );
 
-      const { runCommand } = await import("../../src/shared/lib/run-command.js");
+      const { runCommand } =
+        await import("../../src/shared/lib/run-command.js");
       const mockRunCommand = vi.mocked(runCommand);
       mockRunCommand.mockImplementation(async (_cmd, args) => {
         if (args[0] === "has-session") {
@@ -812,19 +1073,27 @@ describe("AgentManager", () => {
       const reconciled = await manager.getAgent(agent.id);
       expect(reconciled!.status).toBe("stopped");
       expect(reconciled!.latestEvent?.type).toBe("idle");
-      expect(reconciled!.latestEvent?.message).toContain("Session ended normally.");
+      expect(reconciled!.latestEvent?.message).toContain(
+        "Session ended normally."
+      );
       expect(reconciled!.latestEvent?.message).toContain("error banner");
     });
 
     it("should capture a missing-session diagnostic snapshot", async () => {
-      const tempHome = await mkdtemp(path.join(os.tmpdir(), "dispatch-agent-manager-home-"));
+      const tempHome = await mkdtemp(
+        path.join(os.tmpdir(), "dispatch-agent-manager-home-")
+      );
       const previousHome = process.env.HOME;
       process.env.HOME = tempHome;
 
       try {
-        const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+        const agent = await manager.createAgent({
+          cwd: "/tmp",
+          useWorktree: false,
+        });
 
-        const { runCommand } = await import("../../src/shared/lib/run-command.js");
+        const { runCommand } =
+          await import("../../src/shared/lib/run-command.js");
         const mockRunCommand = vi.mocked(runCommand);
         mockRunCommand.mockClear();
         mockRunCommand.mockImplementation(async (_cmd, args) => {
@@ -841,7 +1110,11 @@ describe("AgentManager", () => {
             return { exitCode: 0, stdout: "", stderr: "" };
           }
           if (_cmd === "ps") {
-            return { exitCode: 0, stdout: "  PID  PPID  PGID USER COMMAND\n", stderr: "" };
+            return {
+              exitCode: 0,
+              stdout: "  PID  PPID  PGID USER COMMAND\n",
+              stderr: "",
+            };
           }
           if (_cmd === "launchctl") {
             return { exitCode: 0, stdout: "launchctl snapshot", stderr: "" };
@@ -853,13 +1126,22 @@ describe("AgentManager", () => {
 
         const diagnosticsDir = path.join(tempHome, ".dispatch", "diagnostics");
         const files = await readdir(diagnosticsDir);
-        const incidentFile = files.find((file) => file.includes(`missing-session-${agent.id}.json`));
+        const incidentFile = files.find((file) =>
+          file.includes(`missing-session-${agent.id}.json`)
+        );
         expect(incidentFile).toBeTruthy();
 
-        const incidentRaw = await readFile(path.join(diagnosticsDir, incidentFile!), "utf-8");
+        const incidentRaw = await readFile(
+          path.join(diagnosticsDir, incidentFile!),
+          "utf-8"
+        );
         const incident = JSON.parse(incidentRaw) as {
           incident: string;
-          agent: { agentId: string; tmuxSession: string; exitInfo: number | null };
+          agent: {
+            agentId: string;
+            tmuxSession: string;
+            exitInfo: number | null;
+          };
           tmux: { sessions: { exitCode: number; stderr: string } };
           launchctl: { stdout: string };
         };
@@ -880,8 +1162,16 @@ describe("AgentManager", () => {
   describe("listFeedbackByParentGrouped", () => {
     it("should only return feedback from the requested parent's children", async () => {
       // Create two parent agents
-      const parentA = await manager.createAgent({ name: "parent-a", cwd: "/tmp", useWorktree: false });
-      const parentB = await manager.createAgent({ name: "parent-b", cwd: "/tmp", useWorktree: false });
+      const parentA = await manager.createAgent({
+        name: "parent-a",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+      const parentB = await manager.createAgent({
+        name: "parent-b",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       // Create persona children for each parent
       const childA = await manager.createAgent({
@@ -918,7 +1208,9 @@ describe("AgentManager", () => {
       expect(resultA.personas[0].persona).toBe("security-review");
       expect(resultA.personas[0].agentId).toBe(childA.id);
       expect(resultA.personas[0].feedback).toHaveLength(1);
-      expect(resultA.personas[0].feedback[0].description).toBe("SQL injection in login handler");
+      expect(resultA.personas[0].feedback[0].description).toBe(
+        "SQL injection in login handler"
+      );
 
       // Parent B should only see child B's feedback
       const resultB = await manager.listFeedbackByParentGrouped(parentB.id);
@@ -926,18 +1218,28 @@ describe("AgentManager", () => {
       expect(resultB.personas[0].persona).toBe("ux-review");
       expect(resultB.personas[0].agentId).toBe(childB.id);
       expect(resultB.personas[0].feedback).toHaveLength(1);
-      expect(resultB.personas[0].feedback[0].description).toBe("Button color contrast");
+      expect(resultB.personas[0].feedback[0].description).toBe(
+        "Button color contrast"
+      );
     });
 
     it("should return empty personas array when agent has no children", async () => {
-      const parent = await manager.createAgent({ name: "lonely-parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "lonely-parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const result = await manager.listFeedbackByParentGrouped(parent.id);
       expect(result.personas).toHaveLength(0);
     });
 
     it("should filter by persona name", async () => {
-      const parent = await manager.createAgent({ name: "multi-parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "multi-parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const secChild = await manager.createAgent({
         name: "sec-child",
@@ -957,14 +1259,21 @@ describe("AgentManager", () => {
       await manager.submitFeedback(secChild.id, { description: "sec finding" });
       await manager.submitFeedback(uxChild.id, { description: "ux finding" });
 
-      const filtered = await manager.listFeedbackByParentGrouped(parent.id, "security-review");
+      const filtered = await manager.listFeedbackByParentGrouped(
+        parent.id,
+        "security-review"
+      );
       expect(filtered.personas).toHaveLength(1);
       expect(filtered.personas[0].persona).toBe("security-review");
       expect(filtered.personas[0].feedback[0].description).toBe("sec finding");
     });
 
     it("should group multiple feedback items under the same persona", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const child = await manager.createAgent({
         name: "child",
         cwd: "/tmp",
@@ -973,8 +1282,14 @@ describe("AgentManager", () => {
         parentAgentId: parent.id,
       });
 
-      await manager.submitFeedback(child.id, { severity: "critical", description: "finding 1" });
-      await manager.submitFeedback(child.id, { severity: "low", description: "finding 2" });
+      await manager.submitFeedback(child.id, {
+        severity: "critical",
+        description: "finding 1",
+      });
+      await manager.submitFeedback(child.id, {
+        severity: "low",
+        description: "finding 2",
+      });
 
       const result = await manager.listFeedbackByParentGrouped(parent.id);
       expect(result.personas).toHaveLength(1);
@@ -986,7 +1301,11 @@ describe("AgentManager", () => {
 
   describe("updateFeedbackStatusByParent", () => {
     it("should allow a parent to resolve its child's feedback", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const child = await manager.createAgent({
         name: "child",
         cwd: "/tmp",
@@ -1000,15 +1319,27 @@ describe("AgentManager", () => {
         description: "XSS vulnerability",
       });
 
-      const updated = await manager.updateFeedbackStatusByParent(feedback.id, parent.id, "fixed");
+      const updated = await manager.updateFeedbackStatusByParent(
+        feedback.id,
+        parent.id,
+        "fixed"
+      );
       expect(updated).not.toBeNull();
       expect(updated!.id).toBe(feedback.id);
       expect(updated!.status).toBe("fixed");
     });
 
     it("should return null when parent does not own the child", async () => {
-      const parentA = await manager.createAgent({ name: "parent-a", cwd: "/tmp", useWorktree: false });
-      const parentB = await manager.createAgent({ name: "parent-b", cwd: "/tmp", useWorktree: false });
+      const parentA = await manager.createAgent({
+        name: "parent-a",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+      const parentB = await manager.createAgent({
+        name: "parent-b",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const child = await manager.createAgent({
         name: "child",
         cwd: "/tmp",
@@ -1017,23 +1348,41 @@ describe("AgentManager", () => {
         parentAgentId: parentA.id,
       });
 
-      const feedback = await manager.submitFeedback(child.id, { description: "finding" });
+      const feedback = await manager.submitFeedback(child.id, {
+        description: "finding",
+      });
 
-      const result = await manager.updateFeedbackStatusByParent(feedback.id, parentB.id, "ignored");
+      const result = await manager.updateFeedbackStatusByParent(
+        feedback.id,
+        parentB.id,
+        "ignored"
+      );
       expect(result).toBeNull();
     });
 
     it("should return null for non-existent feedback id", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
-      const result = await manager.updateFeedbackStatusByParent(99999, parent.id, "fixed");
+      const result = await manager.updateFeedbackStatusByParent(
+        99999,
+        parent.id,
+        "fixed"
+      );
       expect(result).toBeNull();
     });
   });
 
   describe("listRecentPersonaReviews", () => {
     it("should return reviews created within the time window", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const child = await manager.createAgent({
         cwd: "/tmp",
         useWorktree: false,
@@ -1068,7 +1417,11 @@ describe("AgentManager", () => {
 
   describe("listRecentFeedback", () => {
     it("should return feedback with persona info within the time window", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const child = await manager.createAgent({
         cwd: "/tmp",
         useWorktree: false,
@@ -1115,13 +1468,20 @@ describe("AgentManager", () => {
     });
 
     it("should default cliSessionId to null", async () => {
-      const agent = await manager.createAgent({ cwd: "/tmp", useWorktree: false });
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       expect(agent.cliSessionId).toBeNull();
     });
 
     it("should persist cliSessionId for persona agents", async () => {
-      const parent = await manager.createAgent({ name: "parent", cwd: "/tmp", useWorktree: false });
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       const persona = await manager.createAgent({
         name: "sec-review",
         cwd: "/tmp",
@@ -1133,7 +1493,9 @@ describe("AgentManager", () => {
 
       // Re-fetch to verify persistence
       const fetched = await manager.getAgent(persona.id);
-      expect(fetched!.cliSessionId).toBe("11111111-2222-3333-4444-555555555555");
+      expect(fetched!.cliSessionId).toBe(
+        "11111111-2222-3333-4444-555555555555"
+      );
       expect(fetched!.parentAgentId).toBe(parent.id);
     });
   });
@@ -1150,7 +1512,8 @@ describe("AgentManager", () => {
     });
 
     it("should harvest only the persona's session for a persona agent", async () => {
-      const { cwdToClaudeProjectDir } = await import("../../src/agents/token-harvester.js");
+      const { cwdToClaudeProjectDir } =
+        await import("../../src/agents/token-harvester.js");
       const { mkdir, writeFile } = await import("node:fs/promises");
 
       const projectDir = cwdToClaudeProjectDir(tmpDir);
@@ -1162,12 +1525,21 @@ describe("AgentManager", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-04-01T10:00:00.000Z",
         });
 
-      await writeFile(path.join(projectDir, `${parentSessionId}.jsonl`), makeEntry(1000) + "\n");
-      await writeFile(path.join(projectDir, `${personaSessionId}.jsonl`), makeEntry(200) + "\n");
+      await writeFile(
+        path.join(projectDir, `${parentSessionId}.jsonl`),
+        makeEntry(1000) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, `${personaSessionId}.jsonl`),
+        makeEntry(200) + "\n"
+      );
 
       // Create parent + persona agents sharing the same cwd
       const parent = await manager.createAgent({
@@ -1207,7 +1579,8 @@ describe("AgentManager", () => {
     });
 
     it("should exclude persona sessions when harvesting the parent agent", async () => {
-      const { cwdToClaudeProjectDir } = await import("../../src/agents/token-harvester.js");
+      const { cwdToClaudeProjectDir } =
+        await import("../../src/agents/token-harvester.js");
       const { mkdir, writeFile } = await import("node:fs/promises");
 
       const projectDir = cwdToClaudeProjectDir(tmpDir);
@@ -1218,7 +1591,10 @@ describe("AgentManager", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-04-01T10:00:00.000Z",
         });
 
@@ -1231,8 +1607,14 @@ describe("AgentManager", () => {
       });
 
       // Create session files using the parent's auto-generated session ID
-      await writeFile(path.join(projectDir, `${parent.cliSessionId}.jsonl`), makeEntry(800) + "\n");
-      await writeFile(path.join(projectDir, `${personaSessionId}.jsonl`), makeEntry(150) + "\n");
+      await writeFile(
+        path.join(projectDir, `${parent.cliSessionId}.jsonl`),
+        makeEntry(800) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, `${personaSessionId}.jsonl`),
+        makeEntry(150) + "\n"
+      );
 
       await manager.createAgent({
         name: "persona-child",
@@ -1264,7 +1646,8 @@ describe("AgentManager", () => {
     });
 
     it("should handle parent with multiple personas — each only gets its own session", async () => {
-      const { cwdToClaudeProjectDir } = await import("../../src/agents/token-harvester.js");
+      const { cwdToClaudeProjectDir } =
+        await import("../../src/agents/token-harvester.js");
       const { mkdir, writeFile } = await import("node:fs/promises");
 
       const projectDir = cwdToClaudeProjectDir(tmpDir);
@@ -1276,7 +1659,10 @@ describe("AgentManager", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-04-01T10:00:00.000Z",
         });
 
@@ -1287,9 +1673,18 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
 
-      await writeFile(path.join(projectDir, `${parent.cliSessionId}.jsonl`), makeEntry(500) + "\n");
-      await writeFile(path.join(projectDir, `${persona1SessionId}.jsonl`), makeEntry(100) + "\n");
-      await writeFile(path.join(projectDir, `${persona2SessionId}.jsonl`), makeEntry(75) + "\n");
+      await writeFile(
+        path.join(projectDir, `${parent.cliSessionId}.jsonl`),
+        makeEntry(500) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, `${persona1SessionId}.jsonl`),
+        makeEntry(100) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, `${persona2SessionId}.jsonl`),
+        makeEntry(75) + "\n"
+      );
 
       await manager.createAgent({
         name: "sec-persona",
@@ -1324,7 +1719,8 @@ describe("AgentManager", () => {
     });
 
     it("should harvest only the agent's own session file", async () => {
-      const { cwdToClaudeProjectDir } = await import("../../src/agents/token-harvester.js");
+      const { cwdToClaudeProjectDir } =
+        await import("../../src/agents/token-harvester.js");
       const { mkdir, writeFile } = await import("node:fs/promises");
 
       const projectDir = cwdToClaudeProjectDir(tmpDir);
@@ -1333,7 +1729,10 @@ describe("AgentManager", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-04-01T10:00:00.000Z",
         });
 
@@ -1345,8 +1744,14 @@ describe("AgentManager", () => {
       });
 
       // Create the agent's session file and an unrelated one
-      await writeFile(path.join(projectDir, `${agent.cliSessionId}.jsonl`), makeEntry(300) + "\n");
-      await writeFile(path.join(projectDir, "unrelated-session.jsonl"), makeEntry(400) + "\n");
+      await writeFile(
+        path.join(projectDir, `${agent.cliSessionId}.jsonl`),
+        makeEntry(300) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, "unrelated-session.jsonl"),
+        makeEntry(400) + "\n"
+      );
 
       await manager.harvestAgentTokens(agent);
 
@@ -1367,7 +1772,8 @@ describe("AgentManager", () => {
     });
 
     it("should ignore unrelated and persona sessions in the same project dir", async () => {
-      const { cwdToClaudeProjectDir } = await import("../../src/agents/token-harvester.js");
+      const { cwdToClaudeProjectDir } =
+        await import("../../src/agents/token-harvester.js");
       const { mkdir, writeFile } = await import("node:fs/promises");
 
       const projectDir = cwdToClaudeProjectDir(tmpDir);
@@ -1378,7 +1784,10 @@ describe("AgentManager", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-04-01T10:00:00.000Z",
         });
 
@@ -1390,9 +1799,18 @@ describe("AgentManager", () => {
       });
 
       // Create parent's session, a persona session, and an unrelated old session
-      await writeFile(path.join(projectDir, `${parent.cliSessionId}.jsonl`), makeEntry(300) + "\n");
-      await writeFile(path.join(projectDir, `${personaSessionId}.jsonl`), makeEntry(50) + "\n");
-      await writeFile(path.join(projectDir, "old-unrelated.jsonl"), makeEntry(999) + "\n");
+      await writeFile(
+        path.join(projectDir, `${parent.cliSessionId}.jsonl`),
+        makeEntry(300) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, `${personaSessionId}.jsonl`),
+        makeEntry(50) + "\n"
+      );
+      await writeFile(
+        path.join(projectDir, "old-unrelated.jsonl"),
+        makeEntry(999) + "\n"
+      );
 
       await manager.createAgent({
         name: "persona",

--- a/apps/server/test/db/migration-repair.test.ts
+++ b/apps/server/test/db/migration-repair.test.ts
@@ -33,7 +33,9 @@ describe("migration drift repair", () => {
       `SELECT column_name FROM information_schema.columns
        WHERE table_name = 'jobs'`
     );
-    const colNames = cols.rows.map((r: { column_name: string }) => r.column_name);
+    const colNames = cols.rows.map(
+      (r: { column_name: string }) => r.column_name
+    );
 
     expect(colNames).toContain("schedule");
     expect(colNames).toContain("timeout_ms");
@@ -41,7 +43,9 @@ describe("migration drift repair", () => {
     expect(colNames).toContain("notify");
     expect(colNames).toContain("prompt");
 
-    const applied = await pool.query(`SELECT name FROM pgmigrations ORDER BY run_on`);
+    const applied = await pool.query(
+      `SELECT name FROM pgmigrations ORDER BY run_on`
+    );
     const appliedNames = applied.rows.map((r: { name: string }) => r.name);
     expect(appliedNames).toContain("0006_jobs-schedule-repair");
   });

--- a/apps/server/test/db/migrations.test.ts
+++ b/apps/server/test/db/migrations.test.ts
@@ -28,7 +28,9 @@ describe("migrations", () => {
       `SELECT table_name FROM information_schema.tables
        WHERE table_schema = 'public' ORDER BY table_name`
     );
-    const tableNames = tables.rows.map((r: { table_name: string }) => r.table_name);
+    const tableNames = tables.rows.map(
+      (r: { table_name: string }) => r.table_name
+    );
     expect(tableNames).toContain("agents");
     expect(tableNames).toContain("media");
     expect(tableNames).toContain("media_seen");
@@ -48,18 +50,41 @@ describe("migrations", () => {
       `SELECT column_name FROM information_schema.columns
        WHERE table_name = 'agents' ORDER BY ordinal_position`
     );
-    const colNames = cols.rows.map((r: { column_name: string }) => r.column_name);
+    const colNames = cols.rows.map(
+      (r: { column_name: string }) => r.column_name
+    );
 
     const expected = [
-      "id", "name", "type", "status", "cwd",
-      "tmux_session", "simulator_udid", "media_dir",
-      "codex_args", "full_access", "last_error", "created_at", "updated_at",
-      "latest_event_type", "latest_event_message",
-      "latest_event_metadata", "latest_event_updated_at",
-      "git_context", "git_context_stale", "git_context_updated_at",
-      "worktree_path", "worktree_branch", "setup_phase", "deleted_at",
-      "persona", "parent_agent_id", "persona_context",
-      "pins", "archive_phase", "archive_cleanup_mode",
+      "id",
+      "name",
+      "type",
+      "status",
+      "cwd",
+      "tmux_session",
+      "simulator_udid",
+      "media_dir",
+      "codex_args",
+      "full_access",
+      "last_error",
+      "created_at",
+      "updated_at",
+      "latest_event_type",
+      "latest_event_message",
+      "latest_event_metadata",
+      "latest_event_updated_at",
+      "git_context",
+      "git_context_stale",
+      "git_context_updated_at",
+      "worktree_path",
+      "worktree_branch",
+      "setup_phase",
+      "deleted_at",
+      "persona",
+      "parent_agent_id",
+      "persona_context",
+      "pins",
+      "archive_phase",
+      "archive_cleanup_mode",
     ];
 
     for (const col of expected) {
@@ -83,8 +108,12 @@ describe("migrations", () => {
     await pool.query(`DELETE FROM agents WHERE id = 'test-cascade'`);
 
     // Child rows should be gone
-    const media = await pool.query(`SELECT * FROM media WHERE agent_id = 'test-cascade'`);
-    const seen = await pool.query(`SELECT * FROM media_seen WHERE agent_id = 'test-cascade'`);
+    const media = await pool.query(
+      `SELECT * FROM media WHERE agent_id = 'test-cascade'`
+    );
+    const seen = await pool.query(
+      `SELECT * FROM media_seen WHERE agent_id = 'test-cascade'`
+    );
     expect(media.rowCount).toBe(0);
     expect(seen.rowCount).toBe(0);
   });

--- a/apps/server/test/db/summary-tools.test.ts
+++ b/apps/server/test/db/summary-tools.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
 import type { Pool } from "pg";
 
 import { setupTestDb, teardownTestDb, runTestMigrations } from "./setup.js";
@@ -106,7 +114,13 @@ async function insertEvent(
   await pool.query(
     `INSERT INTO agent_events (agent_id, event_type, message, created_at, project_dir)
      VALUES ($1, $2, $3, $4, $5)`,
-    [agentId, eventType, `Agent ${eventType}`, createdAt, opts.projectDir ?? "/projects/test"]
+    [
+      agentId,
+      eventType,
+      `Agent ${eventType}`,
+      createdAt,
+      opts.projectDir ?? "/projects/test",
+    ]
   );
 }
 
@@ -211,9 +225,21 @@ describe("getActivitySummary", () => {
     const gitB = { repoRoot: "/projects/beta" };
 
     const created = hoursAgo(2);
-    await insertAgent("a1", { gitContext: gitA, latestEventType: "done", createdAt: created });
-    await insertAgent("a2", { gitContext: gitA, latestEventType: "done", createdAt: created });
-    await insertAgent("a3", { gitContext: gitB, latestEventType: "blocked", createdAt: created });
+    await insertAgent("a1", {
+      gitContext: gitA,
+      latestEventType: "done",
+      createdAt: created,
+    });
+    await insertAgent("a2", {
+      gitContext: gitA,
+      latestEventType: "done",
+      createdAt: created,
+    });
+    await insertAgent("a3", {
+      gitContext: gitB,
+      latestEventType: "blocked",
+      createdAt: created,
+    });
     // error agent with no latest event — insert directly to avoid default
     await pool.query(
       `INSERT INTO agents (id, name, type, status, cwd, created_at, updated_at, git_context, pins)
@@ -228,7 +254,9 @@ describe("getActivitySummary", () => {
 
     expect(result.projects.length).toBeGreaterThanOrEqual(2);
 
-    const alpha = result.projects.find((p) => p.directory === "/projects/alpha");
+    const alpha = result.projects.find(
+      (p) => p.directory === "/projects/alpha"
+    );
     const beta = result.projects.find((p) => p.directory === "/projects/beta");
 
     expect(alpha).toBeDefined();
@@ -593,8 +621,14 @@ describe("getFeedbackSummary", () => {
 
   it("groups by persona", async () => {
     await insertAgent("parent");
-    await insertAgent("sec-rev", { persona: "security-review", parentAgentId: "parent" });
-    await insertAgent("ux-rev", { persona: "ux-review", parentAgentId: "parent" });
+    await insertAgent("sec-rev", {
+      persona: "security-review",
+      parentAgentId: "parent",
+    });
+    await insertAgent("ux-rev", {
+      persona: "ux-review",
+      parentAgentId: "parent",
+    });
 
     await insertFeedback("sec-rev", { description: "SQL injection" });
     await insertFeedback("sec-rev", { description: "XSS risk" });
@@ -645,8 +679,12 @@ describe("getFeedbackSummary", () => {
       cwd: "/projects/test",
     });
 
-    await insertFeedback("rev", { filePath: "/projects/test/src/auth/login.ts" });
-    await insertFeedback("rev", { filePath: "/projects/test/src/auth/token.ts" });
+    await insertFeedback("rev", {
+      filePath: "/projects/test/src/auth/login.ts",
+    });
+    await insertFeedback("rev", {
+      filePath: "/projects/test/src/auth/token.ts",
+    });
     await insertFeedback("rev", { filePath: "/projects/test/src/db/query.ts" });
 
     const result = await manager.getFeedbackSummary({
@@ -669,10 +707,22 @@ describe("getFeedbackSummary", () => {
     await insertAgent("rev", { persona: "sec", parentAgentId: "parent" });
 
     // Same description repeated 3 times
-    await insertFeedback("rev", { description: "Unused import", severity: "low" });
-    await insertFeedback("rev", { description: "Unused import", severity: "low" });
-    await insertFeedback("rev", { description: "Unused import", severity: "low" });
-    await insertFeedback("rev", { description: "Missing error handling", severity: "high" });
+    await insertFeedback("rev", {
+      description: "Unused import",
+      severity: "low",
+    });
+    await insertFeedback("rev", {
+      description: "Unused import",
+      severity: "low",
+    });
+    await insertFeedback("rev", {
+      description: "Unused import",
+      severity: "low",
+    });
+    await insertFeedback("rev", {
+      description: "Missing error handling",
+      severity: "high",
+    });
 
     const result = await manager.getFeedbackSummary({
       start: daysAgo(7),
@@ -717,8 +767,16 @@ describe("getFeedbackSummary", () => {
 
     await insertAgent("p1", { gitContext: gitA });
     await insertAgent("p2", { gitContext: gitB });
-    await insertAgent("r1", { persona: "sec", parentAgentId: "p1", cwd: "/projects/alpha" });
-    await insertAgent("r2", { persona: "sec", parentAgentId: "p2", cwd: "/projects/beta" });
+    await insertAgent("r1", {
+      persona: "sec",
+      parentAgentId: "p1",
+      cwd: "/projects/alpha",
+    });
+    await insertAgent("r2", {
+      persona: "sec",
+      parentAgentId: "p2",
+      cwd: "/projects/beta",
+    });
 
     await insertFeedback("r1", { description: "Alpha finding" });
     await insertFeedback("r2", { description: "Beta finding" });
@@ -760,9 +818,13 @@ describe("getFeedbackSummary", () => {
   it("includes feedback and review verdicts for archived parent agents", async () => {
     await insertAgent("parent");
     await insertAgent("reviewer", { persona: "sec", parentAgentId: "parent" });
-    await insertFeedback("reviewer", { description: "Archived parent finding" });
+    await insertFeedback("reviewer", {
+      description: "Archived parent finding",
+    });
     await insertReview("reviewer", "parent", "sec", { verdict: "approve" });
-    await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'parent'");
+    await pool.query(
+      "UPDATE agents SET deleted_at = NOW() WHERE id = 'parent'"
+    );
 
     const result = await manager.getFeedbackSummary({
       start: daysAgo(7),
@@ -772,7 +834,9 @@ describe("getFeedbackSummary", () => {
 
     expect(result.totalFindings).toBe(1);
     expect(result.groups).toHaveLength(1);
-    expect(result.groups[0].topFindings[0].description).toBe("Archived parent finding");
+    expect(result.groups[0].topFindings[0].description).toBe(
+      "Archived parent finding"
+    );
     expect(result.reviewVerdicts.total).toBe(1);
     expect(result.reviewVerdicts.approved).toBe(1);
   });

--- a/apps/server/test/db/upgrade.test.ts
+++ b/apps/server/test/db/upgrade.test.ts
@@ -33,26 +33,32 @@ afterAll(async () => {
   await teardownTestDb();
 });
 
-describe.skipIf(!hasMigrationsToTest)("upgrade: applying latest migration preserves existing data", () => {
-  it("should apply all migrations except the last", async () => {
-    const countBeforeLast = migrationFiles.length - 1;
+describe.skipIf(!hasMigrationsToTest)(
+  "upgrade: applying latest migration preserves existing data",
+  () => {
+    it("should apply all migrations except the last", async () => {
+      const countBeforeLast = migrationFiles.length - 1;
 
-    await runMigrations({
-      databaseUrl: getTestDatabaseUrl(),
-      count: countBeforeLast,
+      await runMigrations({
+        databaseUrl: getTestDatabaseUrl(),
+        count: countBeforeLast,
+      });
+
+      // Verify the last migration has NOT been applied
+      const applied = await pool.query(
+        `SELECT name FROM pgmigrations ORDER BY run_on`
+      );
+      const appliedNames = applied.rows.map((r: { name: string }) => r.name);
+      expect(appliedNames).toHaveLength(countBeforeLast);
+
+      const lastMigrationName = migrationFiles[
+        migrationFiles.length - 1
+      ].replace(/\.[^.]+$/, "");
+      expect(appliedNames).not.toContain(lastMigrationName);
     });
 
-    // Verify the last migration has NOT been applied
-    const applied = await pool.query(`SELECT name FROM pgmigrations ORDER BY run_on`);
-    const appliedNames = applied.rows.map((r: { name: string }) => r.name);
-    expect(appliedNames).toHaveLength(countBeforeLast);
-
-    const lastMigrationName = migrationFiles[migrationFiles.length - 1].replace(/\.[^.]+$/, "");
-    expect(appliedNames).not.toContain(lastMigrationName);
-  });
-
-  it("should seed representative data", async () => {
-    await pool.query(`
+    it("should seed representative data", async () => {
+      await pool.query(`
       INSERT INTO agents (id, name, type, status, cwd, full_access, codex_args, pins)
       VALUES
         ('agent-1', 'My Agent', 'claude-code', 'running', '/home/user/project', true,
@@ -61,7 +67,7 @@ describe.skipIf(!hasMigrationsToTest)("upgrade: applying latest migration preser
         ('agent-2', 'Helper', 'codex', 'stopped', '/tmp/work', false, '[]'::jsonb, '[]'::jsonb)
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO media (agent_id, file_name, source, size_bytes, description)
       VALUES
         ('agent-1', 'screenshot-001.png', 'screenshot', 204800, 'Login page'),
@@ -69,136 +75,159 @@ describe.skipIf(!hasMigrationsToTest)("upgrade: applying latest migration preser
         ('agent-2', 'output.png', 'screenshot', 51200, 'Final result')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO media_seen (agent_id, media_key)
       VALUES ('agent-1', 'screenshot-001.png')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO settings (key, value) VALUES ('worktreeLocation', 'sibling')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO sessions (token, expires_at)
       VALUES ('test-session-token', NOW() + INTERVAL '24 hours')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO agent_events (agent_id, event_type, message, metadata, agent_type, agent_name, project_dir)
       VALUES
         ('agent-1', 'working', 'Reading files', '{"phase":"research"}'::jsonb, 'claude-code', 'My Agent', '/home/user/project'),
         ('agent-1', 'done', 'Task complete', '{}'::jsonb, 'claude-code', 'My Agent', '/home/user/project')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO agent_token_usage (agent_id, session_id, model, input_tokens, output_tokens, cache_read_tokens, message_count, session_start)
       VALUES ('agent-1', 'sess-abc', 'claude-opus-4-6', 15000, 3000, 5000, 12, NOW() - INTERVAL '1 hour')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO agent_feedback (agent_id, severity, file_path, line_number, description, suggestion, status)
       VALUES ('agent-1', 'warning', 'src/index.ts', 42, 'Unused import', 'Remove the import', 'open')
     `);
 
-    await pool.query(`
+      await pool.query(`
       INSERT INTO simulator_reservations (udid, agent_id, status)
       VALUES ('UDID-1234', 'agent-1', 'reserved')
     `);
-  });
+    });
 
-  it("should apply the latest migration without errors", async () => {
-    // Run remaining migrations (just the last one)
-    await runMigrations(getTestDatabaseUrl());
+    it("should apply the latest migration without errors", async () => {
+      // Run remaining migrations (just the last one)
+      await runMigrations(getTestDatabaseUrl());
 
-    // All migrations should now be applied
-    const applied = await pool.query(`SELECT name FROM pgmigrations ORDER BY run_on`);
-    expect(applied.rows).toHaveLength(migrationFiles.length);
-  });
+      // All migrations should now be applied
+      const applied = await pool.query(
+        `SELECT name FROM pgmigrations ORDER BY run_on`
+      );
+      expect(applied.rows).toHaveLength(migrationFiles.length);
+    });
 
-  it("should preserve agents with all fields intact", async () => {
-    const agents = await pool.query(`SELECT * FROM agents ORDER BY id`);
-    expect(agents.rowCount).toBe(2);
+    it("should preserve agents with all fields intact", async () => {
+      const agents = await pool.query(`SELECT * FROM agents ORDER BY id`);
+      expect(agents.rowCount).toBe(2);
 
-    const agent1 = agents.rows[0];
-    expect(agent1.id).toBe("agent-1");
-    expect(agent1.name).toBe("My Agent");
-    expect(agent1.type).toBe("claude-code");
-    expect(agent1.status).toBe("running");
-    expect(agent1.full_access).toBe(true);
-    expect(agent1.codex_args).toEqual(["--model", "opus"]);
-    expect(agent1.pins).toEqual([{ label: "API", value: "http://localhost:3000", type: "url" }]);
+      const agent1 = agents.rows[0];
+      expect(agent1.id).toBe("agent-1");
+      expect(agent1.name).toBe("My Agent");
+      expect(agent1.type).toBe("claude-code");
+      expect(agent1.status).toBe("running");
+      expect(agent1.full_access).toBe(true);
+      expect(agent1.codex_args).toEqual(["--model", "opus"]);
+      expect(agent1.pins).toEqual([
+        { label: "API", value: "http://localhost:3000", type: "url" },
+      ]);
 
-    const agent2 = agents.rows[1];
-    expect(agent2.id).toBe("agent-2");
-    expect(agent2.type).toBe("codex");
-    expect(agent2.status).toBe("stopped");
-  });
+      const agent2 = agents.rows[1];
+      expect(agent2.id).toBe("agent-2");
+      expect(agent2.type).toBe("codex");
+      expect(agent2.status).toBe("stopped");
+    });
 
-  it("should preserve media with descriptions", async () => {
-    const media = await pool.query(`SELECT * FROM media ORDER BY file_name`);
-    expect(media.rowCount).toBe(3);
-    expect(media.rows[0].description).toBe("Final result");
-    expect(media.rows[1].description).toBe("Login page");
-    expect(media.rows[2].description).toBeNull();
-  });
+    it("should preserve media with descriptions", async () => {
+      const media = await pool.query(`SELECT * FROM media ORDER BY file_name`);
+      expect(media.rowCount).toBe(3);
+      expect(media.rows[0].description).toBe("Final result");
+      expect(media.rows[1].description).toBe("Login page");
+      expect(media.rows[2].description).toBeNull();
+    });
 
-  it("should preserve media_seen records", async () => {
-    const seen = await pool.query(`SELECT * FROM media_seen`);
-    expect(seen.rowCount).toBe(1);
-    expect(seen.rows[0].agent_id).toBe("agent-1");
-  });
+    it("should preserve media_seen records", async () => {
+      const seen = await pool.query(`SELECT * FROM media_seen`);
+      expect(seen.rowCount).toBe(1);
+      expect(seen.rows[0].agent_id).toBe("agent-1");
+    });
 
-  it("should preserve settings", async () => {
-    const settings = await pool.query(`SELECT * FROM settings WHERE key = 'worktreeLocation'`);
-    expect(settings.rowCount).toBe(1);
-    expect(settings.rows[0].value).toBe("sibling");
-  });
+    it("should preserve settings", async () => {
+      const settings = await pool.query(
+        `SELECT * FROM settings WHERE key = 'worktreeLocation'`
+      );
+      expect(settings.rowCount).toBe(1);
+      expect(settings.rows[0].value).toBe("sibling");
+    });
 
-  it("should preserve sessions", async () => {
-    const sessions = await pool.query(`SELECT * FROM sessions WHERE token = 'test-session-token'`);
-    expect(sessions.rowCount).toBe(1);
-  });
+    it("should preserve sessions", async () => {
+      const sessions = await pool.query(
+        `SELECT * FROM sessions WHERE token = 'test-session-token'`
+      );
+      expect(sessions.rowCount).toBe(1);
+    });
 
-  it("should preserve agent events", async () => {
-    const events = await pool.query(`SELECT * FROM agent_events ORDER BY id`);
-    expect(events.rowCount).toBe(2);
-    expect(events.rows[0].event_type).toBe("working");
-    expect(events.rows[0].agent_type).toBe("claude-code");
-    expect(events.rows[0].project_dir).toBe("/home/user/project");
-  });
+    it("should preserve agent events", async () => {
+      const events = await pool.query(`SELECT * FROM agent_events ORDER BY id`);
+      expect(events.rowCount).toBe(2);
+      expect(events.rows[0].event_type).toBe("working");
+      expect(events.rows[0].agent_type).toBe("claude-code");
+      expect(events.rows[0].project_dir).toBe("/home/user/project");
+    });
 
-  it("should preserve token usage records", async () => {
-    const usage = await pool.query(`SELECT * FROM agent_token_usage WHERE agent_id = 'agent-1'`);
-    expect(usage.rowCount).toBe(1);
-    expect(usage.rows[0].model).toBe("claude-opus-4-6");
-    expect(usage.rows[0].input_tokens).toBe(15000);
-    expect(usage.rows[0].output_tokens).toBe(3000);
-  });
+    it("should preserve token usage records", async () => {
+      const usage = await pool.query(
+        `SELECT * FROM agent_token_usage WHERE agent_id = 'agent-1'`
+      );
+      expect(usage.rowCount).toBe(1);
+      expect(usage.rows[0].model).toBe("claude-opus-4-6");
+      expect(usage.rows[0].input_tokens).toBe(15000);
+      expect(usage.rows[0].output_tokens).toBe(3000);
+    });
 
-  it("should preserve feedback records", async () => {
-    const feedback = await pool.query(`SELECT * FROM agent_feedback WHERE agent_id = 'agent-1'`);
-    expect(feedback.rowCount).toBe(1);
-    expect(feedback.rows[0].severity).toBe("warning");
-    expect(feedback.rows[0].line_number).toBe(42);
-  });
+    it("should preserve feedback records", async () => {
+      const feedback = await pool.query(
+        `SELECT * FROM agent_feedback WHERE agent_id = 'agent-1'`
+      );
+      expect(feedback.rowCount).toBe(1);
+      expect(feedback.rows[0].severity).toBe("warning");
+      expect(feedback.rows[0].line_number).toBe(42);
+    });
 
-  it("should preserve simulator reservations", async () => {
-    const res = await pool.query(`SELECT * FROM simulator_reservations WHERE udid = 'UDID-1234'`);
-    expect(res.rowCount).toBe(1);
-    expect(res.rows[0].agent_id).toBe("agent-1");
-  });
+    it("should preserve simulator reservations", async () => {
+      const res = await pool.query(
+        `SELECT * FROM simulator_reservations WHERE udid = 'UDID-1234'`
+      );
+      expect(res.rowCount).toBe(1);
+      expect(res.rows[0].agent_id).toBe("agent-1");
+    });
 
-  it("should still enforce cascade deletes after upgrade", async () => {
-    await pool.query(`DELETE FROM agents WHERE id = 'agent-1'`);
+    it("should still enforce cascade deletes after upgrade", async () => {
+      await pool.query(`DELETE FROM agents WHERE id = 'agent-1'`);
 
-    const media = await pool.query(`SELECT * FROM media WHERE agent_id = 'agent-1'`);
-    const seen = await pool.query(`SELECT * FROM media_seen WHERE agent_id = 'agent-1'`);
-    const feedback = await pool.query(`SELECT * FROM agent_feedback WHERE agent_id = 'agent-1'`);
-    const usage = await pool.query(`SELECT * FROM agent_token_usage WHERE agent_id = 'agent-1'`);
+      const media = await pool.query(
+        `SELECT * FROM media WHERE agent_id = 'agent-1'`
+      );
+      const seen = await pool.query(
+        `SELECT * FROM media_seen WHERE agent_id = 'agent-1'`
+      );
+      const feedback = await pool.query(
+        `SELECT * FROM agent_feedback WHERE agent_id = 'agent-1'`
+      );
+      const usage = await pool.query(
+        `SELECT * FROM agent_token_usage WHERE agent_id = 'agent-1'`
+      );
 
-    expect(media.rowCount).toBe(0);
-    expect(seen.rowCount).toBe(0);
-    expect(feedback.rowCount).toBe(0);
-    expect(usage.rowCount).toBe(0);
-  });
-});
+      expect(media.rowCount).toBe(0);
+      expect(seen.rowCount).toBe(0);
+      expect(feedback.rowCount).toBe(0);
+      expect(usage.rowCount).toBe(0);
+    });
+  }
+);

--- a/apps/server/test/dispatch-dev.test.ts
+++ b/apps/server/test/dispatch-dev.test.ts
@@ -21,7 +21,7 @@ function run(args: string, options?: { expectFail?: boolean }): string {
         ...process.env,
         // Clear agent ID so it doesn't leak into suffix
         DISPATCH_AGENT_ID: "",
-      }
+      },
     }).trim();
   } catch (error) {
     if (options?.expectFail) {
@@ -114,7 +114,7 @@ describe("dispatch-dev", () => {
       "DEV_API_PID=99999",
       "DEV_CONTAINER_SUFFIX=",
       "DEV_COMPOSE_PROJECT=",
-      "DEV_NO_DB=1"
+      "DEV_NO_DB=1",
     ].join("\n");
     require("node:fs").writeFileSync(STATE_FILE, fakeState);
 

--- a/apps/server/test/gh-release-fields.test.ts
+++ b/apps/server/test/gh-release-fields.test.ts
@@ -48,7 +48,10 @@ describe.skipIf(!GH_AVAILABLE)("gh release list JSON fields", () => {
 
     // Fields used in GET /api/v1/releases
     for (const field of ["tagName", "publishedAt", "isPrerelease"]) {
-      expect(available, `field "${field}" should be available on gh release list`).toContain(field);
+      expect(
+        available,
+        `field "${field}" should be available on gh release list`
+      ).toContain(field);
     }
   });
 
@@ -58,7 +61,10 @@ describe.skipIf(!GH_AVAILABLE)("gh release list JSON fields", () => {
 
     // Fields used in the channel-aware tag resolution
     for (const field of ["tagName", "isPrerelease"]) {
-      expect(available, `field "${field}" should be available on gh release list`).toContain(field);
+      expect(
+        available,
+        `field "${field}" should be available on gh release list`
+      ).toContain(field);
     }
   });
 

--- a/apps/server/test/git-worktree.test.ts
+++ b/apps/server/test/git-worktree.test.ts
@@ -5,10 +5,11 @@ import path from "node:path";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/shared/lib/run-command.js", () => ({
-  runCommand: vi.fn()
+  runCommand: vi.fn(),
 }));
 
-const { createGitWorktree, cleanupGitWorktree, GitWorktreeError } = await import("../src/shared/git/worktree.js");
+const { createGitWorktree, cleanupGitWorktree, GitWorktreeError } =
+  await import("../src/shared/git/worktree.js");
 const { runCommand } = await import("../src/shared/lib/run-command.js");
 
 describe("git worktree services", () => {
@@ -51,7 +52,7 @@ describe("git worktree services", () => {
 
     const result = await createGitWorktree({
       cwd: path.join(repoRoot, "nested"),
-      name: "Feature Auth Flow"
+      name: "Feature Auth Flow",
     });
 
     expect(result).toEqual({
@@ -61,7 +62,7 @@ describe("git worktree services", () => {
       branchName: "feature-auth-flow",
       baseBranch: "main",
       baseRef: "origin/main",
-      baseSha: "abc123"
+      baseSha: "abc123",
     });
   });
 
@@ -88,12 +89,12 @@ describe("git worktree services", () => {
     await expect(
       createGitWorktree({
         cwd: repoRoot,
-        name: "Existing Branch"
+        name: "Existing Branch",
       })
     ).rejects.toMatchObject({
       name: "GitWorktreeError",
       message: 'Local branch "existing-branch" already exists.',
-      statusCode: 409
+      statusCode: 409,
     });
   });
 
@@ -108,7 +109,11 @@ describe("git worktree services", () => {
         case `-C ${path.join(worktreePath, "nested")} rev-parse --show-toplevel`:
           return { exitCode: 0, stdout: worktreePath, stderr: "" };
         case `-C ${worktreePath} rev-parse --path-format=absolute --git-common-dir`:
-          return { exitCode: 0, stdout: path.join(repoRoot, ".git"), stderr: "" };
+          return {
+            exitCode: 0,
+            stdout: path.join(repoRoot, ".git"),
+            stderr: "",
+          };
         case `-C ${worktreePath} symbolic-ref --short -q HEAD`:
           return { exitCode: 0, stdout: "feature-auth-flow", stderr: "" };
         case `-C ${repoRoot} symbolic-ref --short -q HEAD`:
@@ -133,7 +138,7 @@ describe("git worktree services", () => {
     const result = await cleanupGitWorktree({
       cwd: path.join(worktreePath, "nested"),
       updateBaseBranch: true,
-      deleteBranch: true
+      deleteBranch: true,
     });
 
     expect(result).toEqual({
@@ -143,7 +148,7 @@ describe("git worktree services", () => {
       branchName: "feature-auth-flow",
       baseBranch: "main",
       updatedBaseBranch: true,
-      deletedBranch: true
+      deletedBranch: true,
     });
   });
 
@@ -157,7 +162,11 @@ describe("git worktree services", () => {
         case `-C ${repoRoot} rev-parse --show-toplevel`:
           return { exitCode: 0, stdout: repoRoot, stderr: "" };
         case `-C ${repoRoot} rev-parse --path-format=absolute --git-common-dir`:
-          return { exitCode: 0, stdout: path.join(repoRoot, ".git"), stderr: "" };
+          return {
+            exitCode: 0,
+            stdout: path.join(repoRoot, ".git"),
+            stderr: "",
+          };
         default:
           throw new Error(`Unexpected command: ${key}`);
       }
@@ -167,8 +176,9 @@ describe("git worktree services", () => {
 
     await expect(cleanupPromise).rejects.toBeInstanceOf(GitWorktreeError);
     await expect(cleanupPromise).rejects.toMatchObject({
-      message: "cleanup-worktree only removes linked worktrees, not the primary checkout.",
-      statusCode: 400
+      message:
+        "cleanup-worktree only removes linked worktrees, not the primary checkout.",
+      statusCode: 400,
     });
   });
 });

--- a/apps/server/test/github-pr.test.ts
+++ b/apps/server/test/github-pr.test.ts
@@ -25,7 +25,11 @@ describe("github pr services", () => {
         case `-C ${repoRoot} push --set-upstream origin feature/pr-tools`:
           return { exitCode: 0, stdout: "", stderr: "" };
         case `pr create --base main --head feature/pr-tools --fill`:
-          return { exitCode: 0, stdout: "https://github.com/selfcontained/dispatch/pull/99", stderr: "" };
+          return {
+            exitCode: 0,
+            stdout: "https://github.com/selfcontained/dispatch/pull/99",
+            stderr: "",
+          };
         case `pr view --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
           return {
             exitCode: 0,
@@ -41,21 +45,26 @@ describe("github pr services", () => {
               autoMergeRequest: null,
               headRefName: "feature/pr-tools",
               baseRefName: "main",
-              statusCheckRollup: []
+              statusCheckRollup: [],
             }),
-            stderr: ""
+            stderr: "",
           };
         default:
           throw new Error(`Unexpected command: ${key}`);
       }
     });
 
-    const result = await createPr({
-      cwd: repoRoot,
-      fillFromCommits: true
-    }, runner);
+    const result = await createPr(
+      {
+        cwd: repoRoot,
+        fillFromCommits: true,
+      },
+      runner
+    );
 
-    expect(result.url).toBe("https://github.com/selfcontained/dispatch/pull/99");
+    expect(result.url).toBe(
+      "https://github.com/selfcontained/dispatch/pull/99"
+    );
     expect(result.branchName).toBe("feature/pr-tools");
     expect(result.prNumber).toBe(99);
   });
@@ -74,11 +83,19 @@ describe("github pr services", () => {
         case `-C ${repoRoot} rev-list --count origin/feature/foo..HEAD`:
           return { exitCode: 0, stdout: "1", stderr: "" };
         case `-C ${repoRoot} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`:
-          return { exitCode: 0, stdout: "origin/fix/bug-on-feature", stderr: "" };
+          return {
+            exitCode: 0,
+            stdout: "origin/fix/bug-on-feature",
+            stderr: "",
+          };
         case `-C ${repoRoot} push origin fix/bug-on-feature`:
           return { exitCode: 0, stdout: "", stderr: "" };
         case `pr create --base feature/foo --head fix/bug-on-feature --fill`:
-          return { exitCode: 0, stdout: "https://github.com/selfcontained/dispatch/pull/100", stderr: "" };
+          return {
+            exitCode: 0,
+            stdout: "https://github.com/selfcontained/dispatch/pull/100",
+            stderr: "",
+          };
         case `pr view --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,mergeable,autoMergeRequest,headRefName,baseRefName,statusCheckRollup`:
           return {
             exitCode: 0,
@@ -94,22 +111,27 @@ describe("github pr services", () => {
               autoMergeRequest: null,
               headRefName: "fix/bug-on-feature",
               baseRefName: "feature/foo",
-              statusCheckRollup: []
+              statusCheckRollup: [],
             }),
-            stderr: ""
+            stderr: "",
           };
         default:
           throw new Error(`Unexpected command: ${key}`);
       }
     });
 
-    const result = await createPr({
-      cwd: repoRoot,
-      baseBranch: "feature/foo",
-      fillFromCommits: true
-    }, runner);
+    const result = await createPr(
+      {
+        cwd: repoRoot,
+        baseBranch: "feature/foo",
+        fillFromCommits: true,
+      },
+      runner
+    );
 
-    expect(result.url).toBe("https://github.com/selfcontained/dispatch/pull/100");
+    expect(result.url).toBe(
+      "https://github.com/selfcontained/dispatch/pull/100"
+    );
     expect(result.baseBranch).toBe("feature/foo");
     expect(result.branchName).toBe("fix/bug-on-feature");
   });
@@ -136,7 +158,9 @@ describe("github pr services", () => {
       }
     });
 
-    await expect(createPr({ cwd: repoRoot }, runner)).rejects.toBeInstanceOf(GitHubPrError);
+    await expect(createPr({ cwd: repoRoot }, runner)).rejects.toBeInstanceOf(
+      GitHubPrError
+    );
   });
 
   it("reports PR status details", async () => {
@@ -162,10 +186,10 @@ describe("github pr services", () => {
               headRefName: "feature/pr-tools",
               baseRefName: "main",
               statusCheckRollup: [
-                { context: "ci", status: "COMPLETED", conclusion: "SUCCESS" }
-              ]
+                { context: "ci", status: "COMPLETED", conclusion: "SUCCESS" },
+              ],
             }),
-            stderr: ""
+            stderr: "",
           };
         default:
           throw new Error(`Unexpected command: ${key}`);
@@ -174,7 +198,8 @@ describe("github pr services", () => {
 
     const result = await getPrStatus({ cwd: repoRoot, prNumber: 99 }, runner);
     expect(result.number).toBe(99);
-    expect(result.statusSummary).toEqual([{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS" }]);
+    expect(result.statusSummary).toEqual([
+      { name: "ci", status: "COMPLETED", conclusion: "SUCCESS" },
+    ]);
   });
-
 });

--- a/apps/server/test/jobs/job-notifier.test.ts
+++ b/apps/server/test/jobs/job-notifier.test.ts
@@ -1,4 +1,13 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { Pool } from "pg";
 
 import { JobNotifier } from "../../src/notifications/job-notifier.js";
@@ -68,7 +77,11 @@ afterEach(() => {
 
 describe("JobNotifier", () => {
   it("sends Slack notification on completed run with on_complete: [slack]", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(makeRun());
 
     expect(fetchSpy).toHaveBeenCalledOnce();
@@ -81,7 +94,11 @@ describe("JobNotifier", () => {
   });
 
   it("sends Slack notification on failed run with on_error: [slack]", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(
       makeRun({
         status: "failed",
@@ -95,7 +112,11 @@ describe("JobNotifier", () => {
   });
 
   it("sends Slack notification on needs_input with on_needs_input configured", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(
       makeRun({
         status: "needs_input",
@@ -113,7 +134,11 @@ describe("JobNotifier", () => {
   });
 
   it("does not send notification when no channels configured for event", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(
       makeRun({
         config: {
@@ -135,13 +160,21 @@ describe("JobNotifier", () => {
   });
 
   it("does not send notification for running status", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(makeRun({ status: "running" }));
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("routes timed_out to on_error channels", async () => {
-    await setSetting(pool, "slack_webhook_url", "https://hooks.slack.test/test");
+    await setSetting(
+      pool,
+      "slack_webhook_url",
+      "https://hooks.slack.test/test"
+    );
     await notifier.onJobRunStateChange(makeRun({ status: "timed_out" }));
 
     expect(fetchSpy).toHaveBeenCalledOnce();

--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
 import type { Pool } from "pg";
 
 import { setupTestDb, teardownTestDb, runTestMigrations } from "../db/setup.js";
@@ -32,7 +40,15 @@ const mockConfig = {
   port: 6767,
 } as import("../../src/config.js").AppConfig;
 
-function makeJob(store: JobStore, overrides: { name: string; directory: string; prompt?: string | null; schedule?: string | null }) {
+function makeJob(
+  store: JobStore,
+  overrides: {
+    name: string;
+    directory: string;
+    prompt?: string | null;
+    schedule?: string | null;
+  }
+) {
   return store.createJob({
     name: overrides.name,
     directory: overrides.directory,
@@ -78,7 +94,12 @@ beforeEach(async () => {
 describe("JobService", () => {
   describe("onRunStateChange callbacks", () => {
     it("fires callbacks and handles errors in individual callbacks", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
 
       const events: string[] = [];
       service.onRunStateChange((run) => {
@@ -92,7 +113,10 @@ describe("JobService", () => {
       });
 
       const store = new JobStore(pool);
-      const job = await makeJob(store, { name: "cb-test", directory: "/tmp/test-cb" });
+      const job = await makeJob(store, {
+        name: "cb-test",
+        directory: "/tmp/test-cb",
+      });
 
       // Create a real agent record to satisfy FK constraint
       const agentId = `agt_cb_${Date.now()}`;
@@ -125,7 +149,12 @@ describe("JobService", () => {
 
   describe("scheduler lifecycle", () => {
     it("starts and stops schedulers for enabled jobs", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       const store = new JobStore(pool);
 
       const job = await makeJob(store, {
@@ -143,7 +172,12 @@ describe("JobService", () => {
     });
 
     it("startSchedulers is safe to call with no jobs", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       await service.startSchedulers();
       service.stopAllSchedulers();
     });
@@ -151,7 +185,12 @@ describe("JobService", () => {
 
   describe("reconcileActiveRuns", () => {
     it("starts monitors for active runs without crashing", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       await service.reconcileActiveRuns();
       service.stopAllSchedulers();
     });
@@ -159,7 +198,12 @@ describe("JobService", () => {
 
   describe("listJobs with nextRun", () => {
     it("includes nextRun for enabled jobs with schedule", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       const store = new JobStore(pool);
 
       const job = await makeJob(store, {
@@ -179,7 +223,12 @@ describe("JobService", () => {
     });
 
     it("nextRun is null for disabled jobs", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       const store = new JobStore(pool);
 
       const job = await makeJob(store, {
@@ -200,7 +249,12 @@ describe("JobService", () => {
 
   describe("error paths", () => {
     it("runJob throws when job has no prompt", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       const store = new JobStore(pool);
 
       const job = await makeJob(store, {
@@ -216,9 +270,13 @@ describe("JobService", () => {
       service.stopAllSchedulers();
     });
 
-
     it("removeJob throws when job has active run", async () => {
-      const service = new JobService(pool, mockAgentManager, mockLog, mockConfig);
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
       const store = new JobStore(pool);
 
       const job = await makeJob(store, {
@@ -229,7 +287,10 @@ describe("JobService", () => {
       await store.createRun(job.id, makeRunConfig("active-run-test"));
 
       await expect(
-        service.removeJob({ name: "active-run-test", directory: "/tmp/test-activerun" })
+        service.removeJob({
+          name: "active-run-test",
+          directory: "/tmp/test-activerun",
+        })
       ).rejects.toThrow("has active run");
 
       service.stopAllSchedulers();

--- a/apps/server/test/jobs/store-phase2.test.ts
+++ b/apps/server/test/jobs/store-phase2.test.ts
@@ -90,7 +90,10 @@ describe("JobStore Phase 2 — list, history, enable/disable", () => {
     });
 
     // Create first run and complete it
-    const run1 = await store.createRun(job.id, { ...runConfig, name: "history-test" });
+    const run1 = await store.createRun(job.id, {
+      ...runConfig,
+      name: "history-test",
+    });
     await pool.query(
       `INSERT INTO agents (id, name, status, cwd) VALUES ('agent-hist-1', 'Test', 'running', '/tmp/test-repo')
        ON CONFLICT (id) DO NOTHING`
@@ -103,7 +106,10 @@ describe("JobStore Phase 2 — list, history, enable/disable", () => {
     });
 
     // Create second run
-    const run2 = await store.createRun(job.id, { ...runConfig, name: "history-test" });
+    const run2 = await store.createRun(job.id, {
+      ...runConfig,
+      name: "history-test",
+    });
 
     const runs = await store.listRunsForJob(job.id);
     expect(runs.length).toBe(2);
@@ -134,7 +140,10 @@ describe("JobStore Phase 2 — list, history, enable/disable", () => {
       directory: "/tmp/test-repo",
       prompt: "Find me",
     });
-    const found = await store.getJobByDirectoryAndName("/tmp/test-repo", "find-by-name");
+    const found = await store.getJobByDirectoryAndName(
+      "/tmp/test-repo",
+      "find-by-name"
+    );
     expect(found).toBeDefined();
     expect(found!.name).toBe("find-by-name");
   });
@@ -177,8 +186,8 @@ describe("JobStore Phase 2 — list, history, enable/disable", () => {
 
     expect(updated.name).toBe("Update Test Renamed");
     expect(updated.prompt).toBe("Updated prompt");
-    expect(updated.schedule).toBe("0 3 * * *");     // preserved
-    expect(updated.timeoutMs).toBe(300_000);          // preserved
+    expect(updated.schedule).toBe("0 3 * * *"); // preserved
+    expect(updated.timeoutMs).toBe(300_000); // preserved
   });
 
   it("listRunsForJob respects limit", async () => {

--- a/apps/server/test/jobs/store.test.ts
+++ b/apps/server/test/jobs/store.test.ts
@@ -2,7 +2,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Pool } from "pg";
 
 import { JobStore } from "../../src/jobs/store.js";
-import { getTestDatabaseUrl, runTestMigrations, setupTestDb, teardownTestDb } from "../db/setup.js";
+import {
+  getTestDatabaseUrl,
+  runTestMigrations,
+  setupTestDb,
+  teardownTestDb,
+} from "../db/setup.js";
 
 let pool: Pool;
 let store: JobStore;
@@ -41,49 +46,69 @@ describe("JobStore", () => {
       needsInputTimeoutMs: 1_000,
       notify: { onComplete: [], onError: [], onNeedsInput: [] },
     });
-    await expect(store.createRun(job.id, {
-      directory: "/tmp/repo",
-      name: "janitor",
-      schedule: null,
-      timeoutMs: 1_000,
-      needsInputTimeoutMs: 1_000,
-      notify: { onComplete: [], onError: [], onNeedsInput: [] },
-    })).rejects.toThrow(`Job already has active run ${run.id}.`);
+    await expect(
+      store.createRun(job.id, {
+        directory: "/tmp/repo",
+        name: "janitor",
+        schedule: null,
+        timeoutMs: 1_000,
+        needsInputTimeoutMs: 1_000,
+        notify: { onComplete: [], onError: [], onNeedsInput: [] },
+      })
+    ).rejects.toThrow(`Job already has active run ${run.id}.`);
     await pool.query(
       `INSERT INTO agents (id, name, status, cwd) VALUES ('agent-1', 'Job Agent', 'running', '/tmp/repo')`
     );
 
-    await expect(store.findActiveRun(job.id)).resolves.toMatchObject({ id: run.id, status: "started" });
+    await expect(store.findActiveRun(job.id)).resolves.toMatchObject({
+      id: run.id,
+      status: "started",
+    });
     await store.attachAgent(run.id, "agent-1");
-    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({ id: run.id });
-    await store.logForAgent("agent-1", { task: "clean", message: "started", level: "info" });
+    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({
+      id: run.id,
+    });
+    await store.logForAgent("agent-1", {
+      task: "clean",
+      message: "started",
+      level: "info",
+    });
 
-    await expect(store.completeRunForAgent("agent-1", {
-      status: "failed",
-      summary: "Wrong terminal status",
-      tasks: [{ name: "clean", status: "error", summary: "bad" }]
-    })).rejects.toThrow('report.status must be "completed"');
+    await expect(
+      store.completeRunForAgent("agent-1", {
+        status: "failed",
+        summary: "Wrong terminal status",
+        tasks: [{ name: "clean", status: "error", summary: "bad" }],
+      })
+    ).rejects.toThrow('report.status must be "completed"');
 
     const completed = await store.completeRunForAgent("agent-1", {
       status: "completed",
       summary: "Finished",
-      tasks: [{ name: "clean", status: "success", summary: "ok" }]
+      tasks: [{ name: "clean", status: "success", summary: "ok" }],
     });
     expect(completed.status).toBe("completed");
     expect(completed.report?.summary).toBe("Finished");
     await expect(store.findActiveRun(job.id)).resolves.toBeNull();
-    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({ id: run.id, status: "completed" });
+    await expect(store.getLatestRunForAgent("agent-1")).resolves.toMatchObject({
+      id: run.id,
+      status: "completed",
+    });
 
-    await expect(store.markTimedOut(run.id, {
-      status: "failed",
-      summary: "Late timeout",
-      tasks: [{ name: "guardrails", status: "error", summary: "too late" }]
-    })).rejects.toThrow("is no longer active (completed)");
-    await expect(store.failRunForAgent("agent-1", {
-      status: "failed",
-      summary: "Late failure",
-      tasks: [{ name: "clean", status: "error", summary: "too late" }]
-    })).rejects.toThrow("No active job run found for agent agent-1.");
+    await expect(
+      store.markTimedOut(run.id, {
+        status: "failed",
+        summary: "Late timeout",
+        tasks: [{ name: "guardrails", status: "error", summary: "too late" }],
+      })
+    ).rejects.toThrow("is no longer active (completed)");
+    await expect(
+      store.failRunForAgent("agent-1", {
+        status: "failed",
+        summary: "Late failure",
+        tasks: [{ name: "clean", status: "error", summary: "too late" }],
+      })
+    ).rejects.toThrow("No active job run found for agent agent-1.");
 
     const rerun = await store.createRun(job.id, {
       directory: "/tmp/repo",

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -1,8 +1,21 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { FastifyInstance } from "fastify";
 import type { Pool } from "pg";
 
-import { setupTestDb, teardownTestDb, runTestMigrations, getTestDatabaseUrl } from "./db/setup.js";
+import {
+  setupTestDb,
+  teardownTestDb,
+  runTestMigrations,
+  getTestDatabaseUrl,
+} from "./db/setup.js";
 
 vi.mock("../src/shared/lib/run-command.js", () => ({
   runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
@@ -28,7 +41,10 @@ beforeAll(async () => {
   ({ createAgentMcpToken, createJobMcpToken, createSession } = auth);
 
   const serverModule = await import("../src/server.js");
-  app = await serverModule.initializeApp({ runMigrations: false, reconcileState: false });
+  app = await serverModule.initializeApp({
+    runMigrations: false,
+    reconcileState: false,
+  });
 
   const setupResponse = await app.inject({
     method: "POST",
@@ -58,7 +74,9 @@ beforeEach(async () => {
   await pool.query("DELETE FROM sessions");
   await pool.query("DELETE FROM agents");
   const session = await createSession(pool);
-  const signed = (app as FastifyInstance & { signCookie: (value: string) => string }).signCookie(session);
+  const signed = (
+    app as FastifyInstance & { signCookie: (value: string) => string }
+  ).signCookie(session);
   sessionCookie = `dispatch_session=${signed}`;
 });
 
@@ -72,7 +90,9 @@ describe("MCP auth integration", () => {
     });
 
     expect(response.statusCode).toBe(403);
-    expect(response.json()).toEqual({ error: "Invalid MCP token for the requested agent route." });
+    expect(response.json()).toEqual({
+      error: "Invalid MCP token for the requested agent route.",
+    });
   });
 
   it("rejects invalid scoped job tokens on the real route", async () => {
@@ -84,7 +104,9 @@ describe("MCP auth integration", () => {
     });
 
     expect(response.statusCode).toBe(403);
-    expect(response.json()).toEqual({ error: "Invalid MCP token for the requested job agent route." });
+    expect(response.json()).toEqual({
+      error: "Invalid MCP token for the requested job agent route.",
+    });
   });
 
   it("accepts session-cookie auth on /api/mcp", async () => {
@@ -120,7 +142,9 @@ describe("MCP auth integration", () => {
     const agentResponse = await app.inject({
       method: "POST",
       url: "/api/mcp/agt_123456abcdef",
-      headers: { authorization: `Bearer ${createAgentMcpToken(authToken, "agt_123456abcdef")}` },
+      headers: {
+        authorization: `Bearer ${createAgentMcpToken(authToken, "agt_123456abcdef")}`,
+      },
       payload: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
     });
     expect(agentResponse.statusCode).toBe(404);
@@ -129,7 +153,9 @@ describe("MCP auth integration", () => {
     const jobResponse = await app.inject({
       method: "POST",
       url: "/api/mcp/jobs/run_123/agt_123456abcdef",
-      headers: { authorization: `Bearer ${createJobMcpToken(authToken, "run_123", "agt_123456abcdef")}` },
+      headers: {
+        authorization: `Bearer ${createJobMcpToken(authToken, "run_123", "agt_123456abcdef")}`,
+      },
       payload: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
     });
     expect(jobResponse.statusCode).toBe(404);

--- a/apps/server/test/mcp-auth.test.ts
+++ b/apps/server/test/mcp-auth.test.ts
@@ -42,16 +42,26 @@ async function buildApp(): Promise<FastifyInstance> {
     const { agentId } = request.params as { agentId: string };
     const token = getBearerToken(request.headers.authorization);
     if (token && !validateAgentMcpToken(SERVER_AUTH_TOKEN, token, agentId)) {
-      return reply.code(403).send({ error: "Invalid MCP token for the requested agent route." });
+      return reply
+        .code(403)
+        .send({ error: "Invalid MCP token for the requested agent route." });
     }
     return { ok: true, route: "agent" };
   });
 
   app.post("/api/mcp/jobs/:runId/:agentId", async (request, reply) => {
-    const { runId, agentId } = request.params as { runId: string; agentId: string };
+    const { runId, agentId } = request.params as {
+      runId: string;
+      agentId: string;
+    };
     const token = getBearerToken(request.headers.authorization);
-    if (token && !validateJobMcpToken(SERVER_AUTH_TOKEN, token, runId, agentId)) {
-      return reply.code(403).send({ error: "Invalid MCP token for the requested job agent route." });
+    if (
+      token &&
+      !validateJobMcpToken(SERVER_AUTH_TOKEN, token, runId, agentId)
+    ) {
+      return reply.code(403).send({
+        error: "Invalid MCP token for the requested job agent route.",
+      });
     }
     return { ok: true, route: "job" };
   });

--- a/apps/server/test/pack-release.test.ts
+++ b/apps/server/test/pack-release.test.ts
@@ -31,7 +31,6 @@ function tarList(): string[] {
 // before the build step, so we skip gracefully. The release workflow validates
 // pack-release after building.
 describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
-
   afterAll(() => {
     if (existsSync(OUTPUT)) rmSync(OUTPUT);
   });
@@ -70,7 +69,9 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     const files = tarList();
     expect(files.some((f) => f.startsWith("bin/"))).toBe(true);
     expect(files.some((f) => f.includes("dispatch-server"))).toBe(true);
-    expect(files.some((f) => f.includes("dispatch-launchd-wrapper"))).toBe(true);
+    expect(files.some((f) => f.includes("dispatch-launchd-wrapper"))).toBe(
+      true
+    );
   });
 
   it("includes database migrations", () => {
@@ -97,9 +98,7 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     const files = tarList();
     const tsFiles = files.filter(
       (f) =>
-        f.endsWith(".ts") &&
-        !f.endsWith(".d.ts") &&
-        !f.includes("migrations/")
+        f.endsWith(".ts") && !f.endsWith(".d.ts") && !f.includes("migrations/")
     );
     expect(tsFiles).toEqual([]);
   });
@@ -118,12 +117,15 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     writeFileSync(path.join(tmpDir, "package.json"), "{}");
 
     try {
-      execSync(`${tmpDir}/bin/pack-release --output /tmp/should-not-exist.tar.gz`, {
-        cwd: tmpDir,
-        encoding: "utf8",
-        timeout: 10_000,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      execSync(
+        `${tmpDir}/bin/pack-release --output /tmp/should-not-exist.tar.gz`,
+        {
+          cwd: tmpDir,
+          encoding: "utf8",
+          timeout: 10_000,
+          stdio: ["pipe", "pipe", "pipe"],
+        }
+      );
       expect.fail("should have thrown");
     } catch (error) {
       const err = error as { stderr?: string };

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -68,7 +68,10 @@ description: Also valid
 Body`;
 
     const result = parseFrontmatter(content);
-    expect(result.frontmatter).toEqual({ name: "Valid", description: "Also valid" });
+    expect(result.frontmatter).toEqual({
+      name: "Valid",
+      description: "Also valid",
+    });
   });
 
   it("handles values containing colons", () => {
@@ -97,7 +100,11 @@ describe("assemblePersonaPrompt", () => {
   };
 
   it("appends feedback guidelines, context, and diff", () => {
-    const result = assemblePersonaPrompt(basePersona, "Built a widget", "diff --git a/foo");
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "Built a widget",
+      "diff --git a/foo"
+    );
 
     expect(result).toContain("# You are a Test Reviewer");
     expect(result).toContain("## Feedback Guidelines (from Dispatch)");
@@ -236,7 +243,11 @@ feedbackFormat: checklist
 
   it("can be safely projected to slug/name/description without leaking body", async () => {
     const personas = await loadPersonas(tmpRoot);
-    const projected = personas.map(({ slug, name, description }) => ({ slug, name, description }));
+    const projected = personas.map(({ slug, name, description }) => ({
+      slug,
+      name,
+      description,
+    }));
 
     expect(projected).toHaveLength(2);
     for (const p of projected) {

--- a/apps/server/test/persona-review-diff.test.ts
+++ b/apps/server/test/persona-review-diff.test.ts
@@ -57,7 +57,11 @@ describe("buildPersonaReviewDiff", () => {
       if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
         throw new Error("no origin head");
       }
-      if (key === "diff main...HEAD" || key === "diff HEAD" || key === "ls-files --others --exclude-standard") {
+      if (
+        key === "diff main...HEAD" ||
+        key === "diff HEAD" ||
+        key === "ls-files --others --exclude-standard"
+      ) {
         return { stdout: "" };
       }
       throw new Error(`Unexpected command: ${key}`);
@@ -65,7 +69,9 @@ describe("buildPersonaReviewDiff", () => {
 
     const result = await buildPersonaReviewDiff("/repo", runCommand);
 
-    expect(result).toContain('base branch detection failed; committed diff was generated against "main"');
+    expect(result).toContain(
+      'base branch detection failed; committed diff was generated against "main"'
+    );
   });
 
   it("returns a fallback when no changes are detected", async () => {
@@ -74,7 +80,11 @@ describe("buildPersonaReviewDiff", () => {
       if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
         return { stdout: "origin/main\n" };
       }
-      if (key === "diff main...HEAD" || key === "diff HEAD" || key === "ls-files --others --exclude-standard") {
+      if (
+        key === "diff main...HEAD" ||
+        key === "diff HEAD" ||
+        key === "ls-files --others --exclude-standard"
+      ) {
         return { stdout: "" };
       }
       throw new Error(`Unexpected command: ${key}`);

--- a/apps/server/test/pin-values.test.ts
+++ b/apps/server/test/pin-values.test.ts
@@ -32,21 +32,25 @@ describe("splitPinValues", () => {
   });
 
   it("does not split pr pins", () => {
-    expect(splitPinValues("pr", "Review queue")).toEqual([
-      "Review queue",
-    ]);
+    expect(splitPinValues("pr", "Review queue")).toEqual(["Review queue"]);
   });
 
   it("does not split url pins", () => {
-    expect(splitPinValues("url", "http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins")).toEqual([
-      "http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins",
-    ]);
+    expect(
+      splitPinValues(
+        "url",
+        "http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins"
+      )
+    ).toEqual(["http://127.0.0.1:59470/api/v1/agents?view=full&tab=pins"]);
   });
 
   it("does not split markdown pins", () => {
-    expect(splitPinValues("markdown", "**Status**\n- Ready\n- Branch: `feat/log-rotation`")).toEqual([
-      "**Status**\n- Ready\n- Branch: `feat/log-rotation`",
-    ]);
+    expect(
+      splitPinValues(
+        "markdown",
+        "**Status**\n- Ready\n- Branch: `feat/log-rotation`"
+      )
+    ).toEqual(["**Status**\n- Ready\n- Branch: `feat/log-rotation`"]);
   });
 
   it("preserves the original value when split delimiters produce no tokens", () => {

--- a/apps/server/test/pins.test.ts
+++ b/apps/server/test/pins.test.ts
@@ -12,13 +12,21 @@ describe("pin validation", () => {
   });
 
   it("accepts valid http and https urls", () => {
-    expect(() => validatePinValue("url", "http://localhost:3000")).not.toThrow();
-    expect(() => validatePinValue("url", "https://example.com/path")).not.toThrow();
+    expect(() =>
+      validatePinValue("url", "http://localhost:3000")
+    ).not.toThrow();
+    expect(() =>
+      validatePinValue("url", "https://example.com/path")
+    ).not.toThrow();
   });
 
   it("rejects invalid urls", () => {
-    expect(() => validatePinValue("url", "localhost:3000")).toThrow(/valid http or https URLs/i);
-    expect(() => validatePinValue("url", "ftp://example.com")).toThrow(/valid http or https URLs/i);
+    expect(() => validatePinValue("url", "localhost:3000")).toThrow(
+      /valid http or https URLs/i
+    );
+    expect(() => validatePinValue("url", "ftp://example.com")).toThrow(
+      /valid http or https URLs/i
+    );
   });
 
   it("accepts integer ports in range", () => {
@@ -32,34 +40,57 @@ describe("pin validation", () => {
   it("rejects non-integer or out-of-range ports", () => {
     expect(() => validatePinValue("port", "3000.5")).toThrow(/integers/i);
     expect(() => validatePinValue("port", "abc")).toThrow(/integers/i);
-    expect(() => validatePinValue("port", "localhost:3000")).toThrow(/integers/i);
+    expect(() => validatePinValue("port", "localhost:3000")).toThrow(
+      /integers/i
+    );
     expect(() => validatePinValue("port", "-1")).toThrow(/integers/i);
     expect(() => validatePinValue("port", "65536")).toThrow(/0 and 65535/i);
   });
 
   it("accepts constrained markdown pins", () => {
-    expect(() => validatePinValue("markdown", "**Status**\n- Ready\n- Branch: `feat/log-rotation`\n\n```sh\npnpm run check\n```")).not.toThrow();
+    expect(() =>
+      validatePinValue(
+        "markdown",
+        "**Status**\n- Ready\n- Branch: `feat/log-rotation`\n\n```sh\npnpm run check\n```"
+      )
+    ).not.toThrow();
   });
 
   it("rejects markdown pins with links", () => {
-    expect(() => validatePinValue("markdown", "[Dispatch](https://github.com/selfcontained/dispatch)")).toThrow(/do not support links/i);
+    expect(() =>
+      validatePinValue(
+        "markdown",
+        "[Dispatch](https://github.com/selfcontained/dispatch)"
+      )
+    ).toThrow(/do not support links/i);
   });
 
   it("rejects markdown pins with images", () => {
-    expect(() => validatePinValue("markdown", "![diagram](https://example.com/image.png)")).toThrow(/do not support images/i);
+    expect(() =>
+      validatePinValue("markdown", "![diagram](https://example.com/image.png)")
+    ).toThrow(/do not support images/i);
   });
 
   it("rejects markdown pins with raw html", () => {
-    expect(() => validatePinValue("markdown", "<b>unsafe</b>")).toThrow(/do not support raw HTML/i);
+    expect(() => validatePinValue("markdown", "<b>unsafe</b>")).toThrow(
+      /do not support raw HTML/i
+    );
   });
 
   it("rejects markdown pins with nested lists", () => {
-    expect(() => validatePinValue("markdown", "- top\n  - nested")).toThrow(/do not support nested lists/i);
+    expect(() => validatePinValue("markdown", "- top\n  - nested")).toThrow(
+      /do not support nested lists/i
+    );
   });
 
   it("rejects markdown pins with oversized code blocks", () => {
-    const longBlock = Array.from({ length: 21 }, (_, i) => `line ${i + 1}`).join("\n");
-    expect(() => validatePinValue("markdown", `\`\`\`txt\n${longBlock}\n\`\`\``)).toThrow(/code blocks must be 20 lines or fewer/i);
+    const longBlock = Array.from(
+      { length: 21 },
+      (_, i) => `line ${i + 1}`
+    ).join("\n");
+    expect(() =>
+      validatePinValue("markdown", `\`\`\`txt\n${longBlock}\n\`\`\``)
+    ).toThrow(/code blocks must be 20 lines or fewer/i);
   });
 
   it("does not validate other pin types specially", () => {

--- a/apps/server/test/rate-limit.test.ts
+++ b/apps/server/test/rate-limit.test.ts
@@ -18,13 +18,13 @@ async function buildApp(): Promise<FastifyInstance> {
   app.post(
     "/api/v1/auth/login",
     { config: { rateLimit: { max: 5, timeWindow: "1 minute" } } },
-    async () => ({ ok: true }),
+    async () => ({ ok: true })
   );
 
   app.post(
     "/api/v1/auth/setup",
     { config: { rateLimit: { max: 3, timeWindow: "1 minute" } } },
-    async () => ({ ok: true }),
+    async () => ({ ok: true })
   );
 
   app.get("/api/v1/auth/status", async () => ({ ok: true }));
@@ -37,22 +37,35 @@ describe("rate limiting", () => {
   describe("login endpoint", () => {
     let app: FastifyInstance;
 
-    beforeAll(async () => { app = await buildApp(); });
-    afterAll(async () => { await app.close(); });
+    beforeAll(async () => {
+      app = await buildApp();
+    });
+    afterAll(async () => {
+      await app.close();
+    });
 
     it("allows 5 attempts then returns 429", async () => {
       for (let i = 0; i < 5; i++) {
-        const res = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+        const res = await app.inject({
+          method: "POST",
+          url: "/api/v1/auth/login",
+        });
         expect(res.statusCode).toBe(200);
       }
-      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+      const blocked = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/login",
+      });
       expect(blocked.statusCode).toBe(429);
     });
 
     it("includes rate limit headers", async () => {
       // First request already consumed above, but headers are present on every response.
       // The 429 response from the previous test still counts — just verify headers exist.
-      const res = await app.inject({ method: "POST", url: "/api/v1/auth/login" });
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/login",
+      });
       expect(res.headers["x-ratelimit-limit"]).toBe("5");
     });
   });
@@ -60,20 +73,33 @@ describe("rate limiting", () => {
   describe("setup endpoint", () => {
     let app: FastifyInstance;
 
-    beforeAll(async () => { app = await buildApp(); });
-    afterAll(async () => { await app.close(); });
+    beforeAll(async () => {
+      app = await buildApp();
+    });
+    afterAll(async () => {
+      await app.close();
+    });
 
     it("allows 3 attempts then returns 429", async () => {
       for (let i = 0; i < 3; i++) {
-        const res = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+        const res = await app.inject({
+          method: "POST",
+          url: "/api/v1/auth/setup",
+        });
         expect(res.statusCode).toBe(200);
       }
-      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+      const blocked = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/setup",
+      });
       expect(blocked.statusCode).toBe(429);
     });
 
     it("429 response includes retry-after header", async () => {
-      const blocked = await app.inject({ method: "POST", url: "/api/v1/auth/setup" });
+      const blocked = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/setup",
+      });
       expect(blocked.statusCode).toBe(429);
       expect(blocked.headers["retry-after"]).toBeDefined();
     });
@@ -82,12 +108,19 @@ describe("rate limiting", () => {
   describe("status endpoint", () => {
     let app: FastifyInstance;
 
-    beforeAll(async () => { app = await buildApp(); });
-    afterAll(async () => { await app.close(); });
+    beforeAll(async () => {
+      app = await buildApp();
+    });
+    afterAll(async () => {
+      await app.close();
+    });
 
     it("is not rate limited", async () => {
       for (let i = 0; i < 10; i++) {
-        const res = await app.inject({ method: "GET", url: "/api/v1/auth/status" });
+        const res = await app.inject({
+          method: "GET",
+          url: "/api/v1/auth/status",
+        });
         expect(res.statusCode).toBe(200);
       }
     });

--- a/apps/server/test/release-log-stream.test.ts
+++ b/apps/server/test/release-log-stream.test.ts
@@ -19,7 +19,7 @@ function createHarness() {
       if (count > 0) {
         log.splice(-count);
       }
-    }
+    },
   });
 
   return { log, processor };
@@ -36,7 +36,9 @@ describe("ReleaseLogStreamProcessor", () => {
     processor.push("✓ Set up job\n");
     processor.push("* Install dependencies\n");
     processor.push("* Build\n");
-    processor.push("Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n");
+    processor.push(
+      "Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n"
+    );
 
     processor.push("\x1b[9A\x1b[J");
     processor.push("* main Release · 12345\n");
@@ -46,7 +48,9 @@ describe("ReleaseLogStreamProcessor", () => {
     processor.push("✓ Set up job\n");
     processor.push("✓ Install dependencies\n");
     processor.push("* Build\n");
-    processor.push("Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n");
+    processor.push(
+      "Refreshing run status every 3 seconds. Press Ctrl+C to quit.\n"
+    );
 
     processor.push("\x1b[9A\x1b[J");
     processor.push("✓ main Release · 12345\n");
@@ -67,7 +71,7 @@ describe("ReleaseLogStreamProcessor", () => {
       "✓ Set up job",
       "✓ Install dependencies",
       "✓ Build",
-      ""
+      "",
     ]);
   });
 

--- a/apps/server/test/repo-tools.test.ts
+++ b/apps/server/test/repo-tools.test.ts
@@ -5,39 +5,72 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/shared/lib/run-command.js", () => ({
-  runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "started", stderr: "" }))
+  runCommand: vi.fn(async () => ({
+    exitCode: 0,
+    stdout: "started",
+    stderr: "",
+  })),
 }));
 
-const { loadRepoTools, loadRepoHooks } = await import("../src/shared/mcp/repo-tools.js");
+const { loadRepoTools, loadRepoHooks } =
+  await import("../src/shared/mcp/repo-tools.js");
 const { runCommand } = await import("../src/shared/lib/run-command.js");
 
 const tempDirs: string[] = [];
 
 const DEV_PARAMS = [
-  { name: "cwd", type: "string", flag: "--cwd", description: "Working directory" },
-  { name: "live", type: "boolean", flag: "--live", description: "Enable live mode" }
+  {
+    name: "cwd",
+    type: "string",
+    flag: "--cwd",
+    description: "Working directory",
+  },
+  {
+    name: "live",
+    type: "boolean",
+    flag: "--live",
+    description: "Enable live mode",
+  },
 ];
 
-async function createToolsRepo(tools: unknown[], hooks?: unknown): Promise<string> {
-  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+async function createToolsRepo(
+  tools: unknown[],
+  hooks?: unknown
+): Promise<string> {
+  const repoRoot = await mkdtemp(
+    path.join(os.tmpdir(), "dispatch-repo-tools-")
+  );
   tempDirs.push(repoRoot);
   await mkdir(path.join(repoRoot, ".dispatch"));
   const config: Record<string, unknown> = { tools };
   if (hooks !== undefined) config.hooks = hooks;
-  await writeFile(path.join(repoRoot, ".dispatch", "tools.json"), JSON.stringify(config));
+  await writeFile(
+    path.join(repoRoot, ".dispatch", "tools.json"),
+    JSON.stringify(config)
+  );
   return repoRoot;
 }
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
   vi.mocked(runCommand).mockClear();
-  vi.mocked(runCommand).mockResolvedValue({ exitCode: 0, stdout: "started", stderr: "" });
+  vi.mocked(runCommand).mockResolvedValue({
+    exitCode: 0,
+    stdout: "started",
+    stderr: "",
+  });
 });
 
 describe("loadRepoTools", () => {
   it("auto-prefixes repo tools with repo_ namespace", async () => {
     const repoRoot = await createToolsRepo([
-      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"] }
+      {
+        name: "dev_up",
+        description: "Start the repo dev stack.",
+        command: ["dispatch-dev", "up"],
+      },
     ]);
 
     const [tool] = await loadRepoTools(repoRoot);
@@ -45,23 +78,36 @@ describe("loadRepoTools", () => {
 
     expect(tool.name).toBe("repo_dev_up");
     expect(result.agentId).toBe("agt_test");
-    expect(vi.mocked(runCommand)).toHaveBeenCalledWith("dispatch-dev", ["up"], expect.objectContaining({
-      cwd: repoRoot,
-      env: expect.objectContaining({
-        DISPATCH_AGENT_ID: "agt_test",
+    expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
+      "dispatch-dev",
+      ["up"],
+      expect.objectContaining({
+        cwd: repoRoot,
+        env: expect.objectContaining({
+          DISPATCH_AGENT_ID: "agt_test",
+        }),
       })
-    }));
+    );
   });
 
   it("appends CLI flags from params when provided", async () => {
     const repoRoot = await createToolsRepo([
-      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"], params: DEV_PARAMS }
+      {
+        name: "dev_up",
+        description: "Start the repo dev stack.",
+        command: ["dispatch-dev", "up"],
+        params: DEV_PARAMS,
+      },
     ]);
 
     const [tool] = await loadRepoTools(repoRoot);
     expect(tool.params).toHaveLength(2);
 
-    await tool.run({ agentId: "agt_test", repoRoot, params: { cwd: "/tmp/wt", live: true } });
+    await tool.run({
+      agentId: "agt_test",
+      repoRoot,
+      params: { cwd: "/tmp/wt", live: true },
+    });
     expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
       "dispatch-dev",
       ["up", "--cwd", "/tmp/wt", "--live"],
@@ -71,7 +117,12 @@ describe("loadRepoTools", () => {
 
   it("skips unset or false params", async () => {
     const repoRoot = await createToolsRepo([
-      { name: "dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"], params: DEV_PARAMS }
+      {
+        name: "dev_up",
+        description: "Start the repo dev stack.",
+        command: ["dispatch-dev", "up"],
+        params: DEV_PARAMS,
+      },
     ]);
 
     const [tool] = await loadRepoTools(repoRoot);
@@ -86,7 +137,11 @@ describe("loadRepoTools", () => {
 
   it("sanitizes dots in repo tool names to underscores", async () => {
     const repoRoot = await createToolsRepo([
-      { name: "project.dev_up", description: "Start the repo dev stack.", command: ["dispatch-dev", "up"] }
+      {
+        name: "project.dev_up",
+        description: "Start the repo dev stack.",
+        command: ["dispatch-dev", "up"],
+      },
     ]);
 
     const [tool] = await loadRepoTools(repoRoot);
@@ -97,7 +152,7 @@ describe("loadRepoTools", () => {
 describe("loadRepoHooks", () => {
   it("loads a stop hook from tools.json", async () => {
     const repoRoot = await createToolsRepo([], {
-      stop: { command: ["./bin/dispatch-dev", "down"] }
+      stop: { command: ["./bin/dispatch-dev", "down"] },
     });
 
     const hooks = await loadRepoHooks(repoRoot);
@@ -112,7 +167,9 @@ describe("loadRepoHooks", () => {
   });
 
   it("returns empty object when tools.json does not exist", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-repo-tools-"));
+    const repoRoot = await mkdtemp(
+      path.join(os.tmpdir(), "dispatch-repo-tools-")
+    );
     tempDirs.push(repoRoot);
 
     const hooks = await loadRepoHooks(repoRoot);
@@ -121,18 +178,23 @@ describe("loadRepoHooks", () => {
 
   it("parses optional description field", async () => {
     const repoRoot = await createToolsRepo([], {
-      stop: { command: ["./bin/cleanup"], description: "Clean up resources" }
+      stop: { command: ["./bin/cleanup"], description: "Clean up resources" },
     });
 
     const hooks = await loadRepoHooks(repoRoot);
-    expect(hooks.stop).toEqual({ command: ["./bin/cleanup"], description: "Clean up resources" });
+    expect(hooks.stop).toEqual({
+      command: ["./bin/cleanup"],
+      description: "Clean up resources",
+    });
   });
 
   it("throws on hook with empty command", async () => {
     const repoRoot = await createToolsRepo([], {
-      stop: { command: [] }
+      stop: { command: [] },
     });
 
-    await expect(loadRepoHooks(repoRoot)).rejects.toThrow('Hook "stop" must include a non-empty command array');
+    await expect(loadRepoHooks(repoRoot)).rejects.toThrow(
+      'Hook "stop" must include a non-empty command array'
+    );
   });
 });

--- a/apps/server/test/slack-notifier.test.ts
+++ b/apps/server/test/slack-notifier.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-import { SlackNotifier, isValidSlackWebhookUrl } from "../src/notifications/slack.js";
+import {
+  SlackNotifier,
+  isValidSlackWebhookUrl,
+} from "../src/notifications/slack.js";
 import type { AgentRecord } from "../src/agents/manager.js";
 
 // Stub the DB settings module so SlackNotifier never hits a real DB.
 vi.mock("../src/db/settings.js", () => ({
   getSetting: vi.fn((_pool: unknown, key: string) => {
-    if (key === "slack_webhook_url") return Promise.resolve("https://hooks.slack.com/test");
-    if (key === "slack_notify_events") return Promise.resolve(JSON.stringify(["done", "waiting_user", "blocked"]));
+    if (key === "slack_webhook_url")
+      return Promise.resolve("https://hooks.slack.com/test");
+    if (key === "slack_notify_events")
+      return Promise.resolve(
+        JSON.stringify(["done", "waiting_user", "blocked"])
+      );
     return Promise.resolve(null);
   }),
   setSetting: vi.fn(() => Promise.resolve()),
@@ -65,15 +72,27 @@ const mockLog = {
 
 describe("isValidSlackWebhookUrl", () => {
   it("accepts valid Slack webhook URLs", () => {
-    expect(isValidSlackWebhookUrl("https://hooks.slack.com/services/T00/B00/xxx")).toBe(true);
-    expect(isValidSlackWebhookUrl("https://hooks.slack.com/workflows/T00/B00/xxx")).toBe(true);
+    expect(
+      isValidSlackWebhookUrl("https://hooks.slack.com/services/T00/B00/xxx")
+    ).toBe(true);
+    expect(
+      isValidSlackWebhookUrl("https://hooks.slack.com/workflows/T00/B00/xxx")
+    ).toBe(true);
   });
 
   it("rejects non-Slack URLs", () => {
-    expect(isValidSlackWebhookUrl("https://evil.com/hooks.slack.com/")).toBe(false);
-    expect(isValidSlackWebhookUrl("http://hooks.slack.com/services/T00/B00/xxx")).toBe(false);
-    expect(isValidSlackWebhookUrl("https://hooks.slack.com.evil.com/foo")).toBe(false);
-    expect(isValidSlackWebhookUrl("https://169.254.169.254/latest/meta-data")).toBe(false);
+    expect(isValidSlackWebhookUrl("https://evil.com/hooks.slack.com/")).toBe(
+      false
+    );
+    expect(
+      isValidSlackWebhookUrl("http://hooks.slack.com/services/T00/B00/xxx")
+    ).toBe(false);
+    expect(isValidSlackWebhookUrl("https://hooks.slack.com.evil.com/foo")).toBe(
+      false
+    );
+    expect(
+      isValidSlackWebhookUrl("https://169.254.169.254/latest/meta-data")
+    ).toBe(false);
     expect(isValidSlackWebhookUrl("file:///etc/passwd")).toBe(false);
     expect(isValidSlackWebhookUrl("http://localhost:8080")).toBe(false);
     expect(isValidSlackWebhookUrl("not-a-url")).toBe(false);
@@ -84,7 +103,9 @@ describe("isValidSlackWebhookUrl", () => {
 describe("SlackNotifier webhook URL validation", () => {
   it("rejects invalid URLs in setWebhookUrl", async () => {
     const notifier = new SlackNotifier(null as never, mockLog);
-    await expect(notifier.setWebhookUrl("http://169.254.169.254/")).rejects.toThrow(
+    await expect(
+      notifier.setWebhookUrl("http://169.254.169.254/")
+    ).rejects.toThrow(
       "Invalid webhook URL: must start with https://hooks.slack.com/"
     );
   });
@@ -96,7 +117,9 @@ describe("SlackNotifier webhook URL validation", () => {
 
   it("rejects invalid URLs in sendTestMessage", async () => {
     const notifier = new SlackNotifier(null as never, mockLog);
-    const result = await notifier.sendTestMessage("http://internal-service:8080/");
+    const result = await notifier.sendTestMessage(
+      "http://internal-service:8080/"
+    );
     expect(result).toEqual({
       ok: false,
       error: "Invalid webhook URL: must start with https://hooks.slack.com/",
@@ -161,7 +184,12 @@ describe("SlackNotifier focus suppression", () => {
     // "working" is not in the notify list, so it exits early before the focus check
     await notifier.onAgentEvent(
       makeAgent({
-        latestEvent: { type: "working", message: "doing stuff", updatedAt: new Date().toISOString(), metadata: null },
+        latestEvent: {
+          type: "working",
+          message: "doing stuff",
+          updatedAt: new Date().toISOString(),
+          metadata: null,
+        },
       })
     );
 
@@ -178,14 +206,20 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
 
   it("sends a notification with default level", async () => {
     const notifier = new SlackNotifier(null as never, mockLog);
-    const result = await notifier.sendNotification(makeAgent(), { message: "Hello from agent" });
+    const result = await notifier.sendNotification(makeAgent(), {
+      message: "Hello from agent",
+    });
 
     expect(result).toEqual({ sent: true });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     expect(body.username).toBe("Dispatch");
     expect(body.attachments[0].color).toBe("#3b82f6"); // info blue
-    expect(body.attachments[0].blocks[0].text.text).toContain("Hello from agent");
+    expect(body.attachments[0].blocks[0].text.text).toContain(
+      "Hello from agent"
+    );
   });
 
   it("uses custom title and level", async () => {
@@ -197,7 +231,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     });
 
     expect(result).toEqual({ sent: true });
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     expect(body.attachments[0].color).toBe("#22c55e"); // success green
     expect(body.attachments[0].blocks[0].text.text).toContain("CI Report");
   });
@@ -206,7 +242,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     const notifier = new SlackNotifier(null as never, mockLog);
     notifier.setFocusCheck(() => true); // agent is focused
 
-    const result = await notifier.sendNotification(makeAgent(), { message: "Important update" });
+    const result = await notifier.sendNotification(makeAgent(), {
+      message: "Important update",
+    });
 
     expect(result).toEqual({ sent: true });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -221,7 +259,10 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
       respectFocus: true,
     });
 
-    expect(result).toEqual({ sent: false, reason: "Notification suppressed — user is focused on this agent." });
+    expect(result).toEqual({
+      sent: false,
+      reason: "Notification suppressed — user is focused on this agent.",
+    });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -231,9 +272,14 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     vi.mocked(getSetting).mockResolvedValueOnce(null); // notify events
 
     const notifier = new SlackNotifier(null as never, mockLog);
-    const result = await notifier.sendNotification(makeAgent(), { message: "test" });
+    const result = await notifier.sendNotification(makeAgent(), {
+      message: "test",
+    });
 
-    expect(result).toEqual({ sent: false, reason: "No Slack webhook configured." });
+    expect(result).toEqual({
+      sent: false,
+      reason: "No Slack webhook configured.",
+    });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -243,13 +289,20 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
 
     // Send 5 — should all succeed
     for (let i = 0; i < 5; i++) {
-      const result = await notifier.sendNotification(agent, { message: `msg ${i}` });
+      const result = await notifier.sendNotification(agent, {
+        message: `msg ${i}`,
+      });
       expect(result.sent).toBe(true);
     }
 
     // 6th should be rate limited
-    const result = await notifier.sendNotification(agent, { message: "one too many" });
-    expect(result).toEqual({ sent: false, reason: "Rate limited — max 5 notifications per minute per agent." });
+    const result = await notifier.sendNotification(agent, {
+      message: "one too many",
+    });
+    expect(result).toEqual({
+      sent: false,
+      reason: "Rate limited — max 5 notifications per minute per agent.",
+    });
     expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
 
@@ -261,7 +314,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
 
     await notifier.sendNotification(agent, { message: "branch test" });
 
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     const contextText = body.attachments[0].blocks[1].elements[0].text;
     expect(contextText).toContain("feat/notify");
   });
@@ -273,7 +328,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
       title: "Alert <!everyone>",
     });
 
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     const messageText = body.attachments[0].blocks[0].text.text;
     expect(messageText).not.toContain("<!channel>");
     expect(messageText).not.toContain("<!here>");
@@ -288,7 +345,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
       message: "safe body",
     });
 
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     const sectionText = body.attachments[0].blocks[0].text.text;
     const contextText = body.attachments[0].blocks[1].elements[0].text;
     const fallback = body.attachments[0].fallback;
@@ -305,7 +364,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     const notifier = new SlackNotifier(null as never, mockLog);
     await notifier.onAgentEvent(makeAgent({ name: "<!here>" }));
 
-    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
     const sectionText = body.attachments[0].blocks[0].text.text;
     const fallback = body.attachments[0].fallback;
 
@@ -318,7 +379,9 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
   it("cleans up expired rate limit entries from the map", async () => {
     const notifier = new SlackNotifier(null as never, mockLog);
     const agent = makeAgent();
-    const map = (notifier as unknown as { notifyTimestamps: Map<string, number[]> }).notifyTimestamps;
+    const map = (
+      notifier as unknown as { notifyTimestamps: Map<string, number[]> }
+    ).notifyTimestamps;
 
     // Seed with expired timestamps (>60s ago)
     map.set(agent.id, [Date.now() - 120_000]);
@@ -327,7 +390,10 @@ describe("SlackNotifier.sendNotification (dispatch_notify)", () => {
     // Trigger isRateLimited via sendNotification — expired entries get pruned,
     // and if empty the map entry is deleted entirely
     notifier.setFocusCheck(() => true);
-    await notifier.sendNotification(agent, { message: "trigger cleanup", respectFocus: true });
+    await notifier.sendNotification(agent, {
+      message: "trigger cleanup",
+      respectFocus: true,
+    });
 
     expect(map.has(agent.id)).toBe(false);
   });

--- a/apps/server/test/stream-process.test.ts
+++ b/apps/server/test/stream-process.test.ts
@@ -52,7 +52,7 @@ function streamProcess(
   command: string,
   args: string[],
   options: { cwd?: string },
-  job: FakeJob,
+  job: FakeJob
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -125,8 +125,10 @@ async function main() {
 
   console.log(`\n=== Events emitted (${events.length}) ===`);
   for (const evt of events) {
-    if (evt.type === "log") console.log(`  log:     ${JSON.stringify(evt.line)}`);
-    else if (evt.type === "log.replace") console.log(`  replace: ${JSON.stringify(evt.line)}`);
+    if (evt.type === "log")
+      console.log(`  log:     ${JSON.stringify(evt.line)}`);
+    else if (evt.type === "log.replace")
+      console.log(`  replace: ${JSON.stringify(evt.line)}`);
     else if (evt.type === "log.rewind") console.log(`  rewind:  ${evt.count}`);
   }
 
@@ -137,16 +139,25 @@ async function main() {
   console.log("\n=== Assertions ===");
 
   // Should have exactly 2 rewinds (second and third render)
-  console.assert(rewinds.length === 2, `Expected 2 rewinds, got ${rewinds.length}`);
+  console.assert(
+    rewinds.length === 2,
+    `Expected 2 rewinds, got ${rewinds.length}`
+  );
   console.log(`✓ Rewind events: ${rewinds.length}`);
 
   // Final log should have ~9 lines (the last render), not 27 (3x9)
-  console.assert(finalLogCount <= 12, `Expected ≤12 final log lines, got ${finalLogCount}`);
+  console.assert(
+    finalLogCount <= 12,
+    `Expected ≤12 final log lines, got ${finalLogCount}`
+  );
   console.log(`✓ Final log lines: ${finalLogCount} (would be ~27 without fix)`);
 
   // Should NOT contain duplicate "Refreshing" lines
   const refreshLines = job.log.filter((l) => l.includes("Refreshing"));
-  console.assert(refreshLines.length <= 1, `Expected ≤1 Refreshing lines, got ${refreshLines.length}`);
+  console.assert(
+    refreshLines.length <= 1,
+    `Expected ≤1 Refreshing lines, got ${refreshLines.length}`
+  );
   console.log(`✓ Refreshing lines: ${refreshLines.length}`);
 
   // Final log should end with the completed state

--- a/apps/server/test/token-harvester.test.ts
+++ b/apps/server/test/token-harvester.test.ts
@@ -10,7 +10,12 @@ describe("token-harvester", () => {
     it("encodes a simple path by sanitizing non-alphanumeric path chars", () => {
       const result = cwdToClaudeProjectDir("/home/testuser/dev/apps/dispatch");
       expect(result).toBe(
-        path.join(os.homedir(), ".claude", "projects", "-home-testuser-dev-apps-dispatch")
+        path.join(
+          os.homedir(),
+          ".claude",
+          "projects",
+          "-home-testuser-dev-apps-dispatch"
+        )
       );
     });
 
@@ -94,7 +99,8 @@ describe("token-harvester", () => {
 
       await writeFile(jsonlPath, lines.join("\n") + "\n");
 
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
 
       const upserted: Array<{ params: unknown[] }> = [];
       const mockPool = {
@@ -133,7 +139,9 @@ describe("token-harvester", () => {
       expect(opusCall!.params[7]).toBe(2); // message_count
 
       // Find sonnet upsert
-      const sonnetCall = upserted.find((u) => u.params[2] === "claude-sonnet-4-6");
+      const sonnetCall = upserted.find(
+        (u) => u.params[2] === "claude-sonnet-4-6"
+      );
       expect(sonnetCall).toBeDefined();
       expect(sonnetCall!.params[3]).toBe(50); // input_tokens
       expect(sonnetCall!.params[4]).toBe(10); // cache_creation
@@ -146,7 +154,8 @@ describe("token-harvester", () => {
     });
 
     it("silently returns when project dir does not exist", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
 
       const mockPool = {
         query: vi.fn(),
@@ -163,7 +172,8 @@ describe("token-harvester", () => {
     });
 
     it("skips malformed JSON lines", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
       const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
@@ -210,10 +220,13 @@ describe("token-harvester", () => {
     });
 
     it("uses worktreePath when available", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
-      const worktreeDir = await mkdtemp(path.join(os.tmpdir(), "worktree-test-"));
+      const worktreeDir = await mkdtemp(
+        path.join(os.tmpdir(), "worktree-test-")
+      );
       const fakeProjectDir = cwdToClaudeProjectDir(worktreeDir);
       await mkdir(fakeProjectDir, { recursive: true });
 
@@ -251,7 +264,8 @@ describe("token-harvester", () => {
     });
 
     it("only harvests the agent's own session when cliSessionId is set", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
       const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
@@ -270,8 +284,14 @@ describe("token-harvester", () => {
           timestamp: "2026-03-28T10:00:00.000Z",
         });
 
-      await writeFile(path.join(fakeProjectDir, `${agentSession}.jsonl`), makeEntry(500) + "\n");
-      await writeFile(path.join(fakeProjectDir, `${otherSession}.jsonl`), makeEntry(100) + "\n");
+      await writeFile(
+        path.join(fakeProjectDir, `${agentSession}.jsonl`),
+        makeEntry(500) + "\n"
+      );
+      await writeFile(
+        path.join(fakeProjectDir, `${otherSession}.jsonl`),
+        makeEntry(100) + "\n"
+      );
 
       const upserted: Array<{ params: unknown[] }> = [];
       const mockPool = {
@@ -299,7 +319,8 @@ describe("token-harvester", () => {
     });
 
     it("harvests nothing when cliSessionId does not match any file", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
       const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
@@ -309,12 +330,17 @@ describe("token-harvester", () => {
         path.join(fakeProjectDir, "some-session.jsonl"),
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: 100, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: 100, output_tokens: 10 },
+          },
           timestamp: "2026-03-28T10:00:00.000Z",
         }) + "\n"
       );
 
-      const mockPool = { query: vi.fn(async () => ({ rows: [], rowCount: 0 })) };
+      const mockPool = {
+        query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      };
 
       await harvestTokenUsage(mockPool as any, {
         id: "agt-no-match",
@@ -330,7 +356,8 @@ describe("token-harvester", () => {
     });
 
     it("harvests all sessions when cliSessionId is undefined (legacy agents)", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
       const fakeProjectDir = cwdToClaudeProjectDir(tmpDir);
@@ -339,12 +366,21 @@ describe("token-harvester", () => {
       const makeEntry = (tokens: number) =>
         JSON.stringify({
           type: "assistant",
-          message: { model: "claude-opus-4-6", usage: { input_tokens: tokens, output_tokens: 10 } },
+          message: {
+            model: "claude-opus-4-6",
+            usage: { input_tokens: tokens, output_tokens: 10 },
+          },
           timestamp: "2026-03-28T10:00:00.000Z",
         });
 
-      await writeFile(path.join(fakeProjectDir, "session-a.jsonl"), makeEntry(100) + "\n");
-      await writeFile(path.join(fakeProjectDir, "session-b.jsonl"), makeEntry(200) + "\n");
+      await writeFile(
+        path.join(fakeProjectDir, "session-a.jsonl"),
+        makeEntry(100) + "\n"
+      );
+      await writeFile(
+        path.join(fakeProjectDir, "session-b.jsonl"),
+        makeEntry(200) + "\n"
+      );
 
       const upserted: Array<{ params: unknown[] }> = [];
       const mockPool = {
@@ -370,7 +406,8 @@ describe("token-harvester", () => {
     });
 
     it("skips opencode agents gracefully", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
 
       const mockPool = { query: vi.fn() };
 
@@ -397,11 +434,17 @@ describe("token-harvester", () => {
     });
 
     it("parses Codex rollout token_count events and normalizes cache tokens", async () => {
-      const { harvestTokenUsage } = await import("../src/agents/token-harvester.js");
+      const { harvestTokenUsage } =
+        await import("../src/agents/token-harvester.js");
       const { mkdir } = await import("node:fs/promises");
 
       // Create a fake ~/.codex/sessions/ structure
-      const sessionsDir = path.join(os.homedir(), ".codex", "sessions", "test-harvest");
+      const sessionsDir = path.join(
+        os.homedir(),
+        ".codex",
+        "sessions",
+        "test-harvest"
+      );
       await mkdir(sessionsDir, { recursive: true });
 
       const rolloutFile = path.join(sessionsDir, "rollout-test-codex.jsonl");
@@ -413,7 +456,12 @@ describe("token-harvester", () => {
           payload: {
             type: "message",
             role: "user",
-            content: [{ type: "input_text", text: "[dispatch:agt_codex_test] Say hello" }],
+            content: [
+              {
+                type: "input_text",
+                text: "[dispatch:agt_codex_test] Say hello",
+              },
+            ],
           },
         }),
         JSON.stringify({

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -27,15 +27,21 @@ export default tseslint.config(
       // Upgrade hook dependency warnings to errors so CI catches them
       "react-hooks/exhaustive-deps": "error",
       "react-hooks/rules-of-hooks": "error",
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
       // Empty catch blocks are used intentionally to silence expected errors (e.g. socket.close())
       "no-empty": ["error", { allowEmptyCatch: true }],
       // Allow _-prefixed names to signal intentionally unused destructured values
-      "@typescript-eslint/no-unused-vars": ["error", {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        destructuredArrayIgnorePattern: "^_",
-      }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
     },
   }
 );

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,11 +1,17 @@
 <!doctype html>
-<html lang="en" style="background:#141414;color-scheme:dark">
+<html lang="en" style="background: #141414; color-scheme: dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
     <meta name="theme-color" content="#0B1220" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <meta name="apple-mobile-web-app-title" content="Dispatch" />
     <link rel="icon" type="image/png" href="/icons/teal/favicon.png" />
     <link rel="apple-touch-icon" href="/icons/teal/apple-touch-icon.png" />
@@ -30,7 +36,9 @@
         overflow: hidden;
         background: #141414;
         color: #f5f5f5;
-        transition: background-color 180ms ease, color 180ms ease;
+        transition:
+          background-color 180ms ease,
+          color 180ms ease;
       }
 
       #root {
@@ -39,30 +47,58 @@
       }
     </style>
   </head>
-  <body style="margin:0;background:#141414;color:#f5f5f5">
+  <body style="margin: 0; background: #141414; color: #f5f5f5">
     <script>
       // Apply saved theme before first paint to avoid flash.
-      (function(){
-        var theme = localStorage.getItem('dispatch:theme');
+      (function () {
+        var theme = localStorage.getItem("dispatch:theme");
         var palette = {
-          default: { background: '#141414', foreground: '#f5f5f5', themeColor: '#0B1220' },
-          'cool-navy': { background: '#10131a', foreground: '#f1f3f8', themeColor: '#10131a' },
-          'oled-black': { background: '#000000', foreground: '#f0f0f0', themeColor: '#000000' },
-          'solarized-dark': { background: '#00212b', foreground: '#8ea4a9', themeColor: '#00212b' },
-          light: { background: '#ffffff', foreground: '#171717', themeColor: '#ffffff' },
-          vaporwave: { background: '#12081e', foreground: '#eddcff', themeColor: '#12081e' },
-          mytra: { background: '#020202', foreground: '#d9dde4', themeColor: '#020202' }
+          default: {
+            background: "#141414",
+            foreground: "#f5f5f5",
+            themeColor: "#0B1220",
+          },
+          "cool-navy": {
+            background: "#10131a",
+            foreground: "#f1f3f8",
+            themeColor: "#10131a",
+          },
+          "oled-black": {
+            background: "#000000",
+            foreground: "#f0f0f0",
+            themeColor: "#000000",
+          },
+          "solarized-dark": {
+            background: "#00212b",
+            foreground: "#8ea4a9",
+            themeColor: "#00212b",
+          },
+          light: {
+            background: "#ffffff",
+            foreground: "#171717",
+            themeColor: "#ffffff",
+          },
+          vaporwave: {
+            background: "#12081e",
+            foreground: "#eddcff",
+            themeColor: "#12081e",
+          },
+          mytra: {
+            background: "#020202",
+            foreground: "#d9dde4",
+            themeColor: "#020202",
+          },
         };
         var selected = palette[theme] || palette.default;
-        if (theme && theme !== 'default') {
-          document.documentElement.setAttribute('data-theme', theme);
+        if (theme && theme !== "default") {
+          document.documentElement.setAttribute("data-theme", theme);
         }
         document.documentElement.style.backgroundColor = selected.background;
         document.body.style.backgroundColor = selected.background;
         document.body.style.color = selected.foreground;
         var metaTheme = document.querySelector('meta[name="theme-color"]');
         if (metaTheme) {
-          metaTheme.setAttribute('content', selected.themeColor);
+          metaTheme.setAttribute("content", selected.themeColor);
         }
       })();
     </script>

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {}
-  }
+    autoprefixer: {},
+  },
 };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,21 +2,47 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import "@xterm/xterm/css/xterm.css";
-import { BarChart3, History, PanelLeftOpen, PanelRightOpen } from "lucide-react";
-import { feedbackDetailAtom, expandedAgentIdAtom, fullAccessByCwdAtom, baseBranchByCwdAtom, autoReviewByCwdAtom } from "@/lib/store";
+import {
+  BarChart3,
+  History,
+  PanelLeftOpen,
+  PanelRightOpen,
+} from "lucide-react";
+import {
+  feedbackDetailAtom,
+  expandedAgentIdAtom,
+  fullAccessByCwdAtom,
+  baseBranchByCwdAtom,
+  autoReviewByCwdAtom,
+} from "@/lib/store";
 import { AgentListContent } from "@/components/app/agent-sidebar";
 import { ActivityPane } from "@/components/app/activity-pane";
-import { JobsProvider, JobListContent, JobDetailPane } from "@/components/app/jobs-pane";
-import { SettingsContent, SettingsNavContent, useSettingsState } from "@/components/app/settings-pane";
+import {
+  JobsProvider,
+  JobListContent,
+  JobDetailPane,
+} from "@/components/app/jobs-pane";
+import {
+  SettingsContent,
+  SettingsNavContent,
+  useSettingsState,
+} from "@/components/app/settings-pane";
 import { type NavSection, SidebarShell } from "@/components/app/sidebar-shell";
 import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
 import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
 import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
 import { MediaLightbox } from "@/components/app/media-lightbox";
-import { MediaSidebar, MediaSidebarContent } from "@/components/app/media-sidebar";
+import {
+  MediaSidebar,
+  MediaSidebarContent,
+} from "@/components/app/media-sidebar";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
 import { TerminalPane } from "@/components/app/terminal-pane";
-import { type FeedbackDetailState, FeedbackDetailPanel, ReviewSummaryPanel } from "@/components/app/feedback-panel";
+import {
+  type FeedbackDetailState,
+  FeedbackDetailPanel,
+  ReviewSummaryPanel,
+} from "@/components/app/feedback-panel";
 import {
   type Agent,
   type AgentVisualState,
@@ -38,7 +64,12 @@ import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { useTemporaryState } from "@/hooks/use-temporary-state";
-import { AGENT_TYPES, type AgentType, isAgentType, sanitizeEnabledAgentTypes } from "@/lib/agent-types";
+import {
+  AGENT_TYPES,
+  type AgentType,
+  isAgentType,
+  sanitizeEnabledAgentTypes,
+} from "@/lib/agent-types";
 import { Button } from "@/components/ui/button";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -71,7 +102,9 @@ function readCwdHistory(): string[] {
     const raw = window.localStorage.getItem(CWD_HISTORY_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0)
+      : [];
   } catch {
     return [];
   }
@@ -92,7 +125,9 @@ function removeCwdFromHistory(cwd: string): string[] {
   return current;
 }
 
-function isFullAccessEnabled(agent: Pick<Agent, "fullAccess" | "agentArgs">): boolean {
+function isFullAccessEnabled(
+  agent: Pick<Agent, "fullAccess" | "agentArgs">
+): boolean {
   return (
     agent.fullAccess ||
     agent.agentArgs.includes(CODEX_FULL_ACCESS_ARG) ||
@@ -112,17 +147,30 @@ export function DashboardLayout(): JSX.Element {
   const settingsSection = settingsOpen ? pathSegments[1] : undefined;
   const settingsSubsection = settingsOpen ? pathSegments[2] : undefined;
   const activityOpen = pathSegments[0] === "activity";
-  const activityTab = activityOpen ? (pathSegments[1] as "metrics" | "history" | undefined) : undefined;
+  const activityTab = activityOpen
+    ? (pathSegments[1] as "metrics" | "history" | undefined)
+    : undefined;
   const jobsOpen = pathSegments[0] === "jobs";
 
   useEffect(() => {
     if (!legacyDocsOpen) return;
-    navigate(legacyDocsSection ? `/settings/help/${legacyDocsSection}` : "/settings/help", { replace: true });
+    navigate(
+      legacyDocsSection
+        ? `/settings/help/${legacyDocsSection}`
+        : "/settings/help",
+      { replace: true }
+    );
   }, [legacyDocsOpen, legacyDocsSection, navigate]);
 
   // ── Theme & Branding ──────────────────────────────────────────────────
   const { theme, setTheme } = useTheme();
-  const { iconColor, setIconColor, isLoading: isIconColorSaving, error: iconColorError, clearError: clearIconColorError } = useIconColor();
+  const {
+    iconColor,
+    setIconColor,
+    isLoading: isIconColorSaving,
+    error: iconColorError,
+    clearError: clearIconColorError,
+  } = useIconColor();
   const { instanceName } = useInstanceName();
 
   // ── Page title ───────────────────────────────────────────────────────
@@ -160,18 +208,32 @@ export function DashboardLayout(): JSX.Element {
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createCwd, setCreateCwd] = useState(() => readLastUsedCwd());
-  const [createCwdInitialized, setCreateCwdInitialized] = useState(() => readLastUsedCwd().trim().length > 0);
-  const [enabledAgentTypes, setEnabledAgentTypes] = useState<AgentType[]>([...AGENT_TYPES]);
-  const [lastUsedAgentType, setLastUsedAgentType] = useState<AgentType | null>(() => readLastUsedAgentType());
+  const [createCwdInitialized, setCreateCwdInitialized] = useState(
+    () => readLastUsedCwd().trim().length > 0
+  );
+  const [enabledAgentTypes, setEnabledAgentTypes] = useState<AgentType[]>([
+    ...AGENT_TYPES,
+  ]);
+  const [lastUsedAgentType, setLastUsedAgentType] = useState<AgentType | null>(
+    () => readLastUsedAgentType()
+  );
   const [createType, setCreateType] = useState<AgentType>("codex");
-  const [createFullAccess, setCreateFullAccess] = useAtom(fullAccessByCwdAtom(createCwd));
-  const [createAutoReview, setCreateAutoReview] = useAtom(autoReviewByCwdAtom(createCwd));
-  const [createBaseBranch, setCreateBaseBranch] = useAtom(baseBranchByCwdAtom(createCwd));
+  const [createFullAccess, setCreateFullAccess] = useAtom(
+    fullAccessByCwdAtom(createCwd)
+  );
+  const [createAutoReview, setCreateAutoReview] = useAtom(
+    autoReviewByCwdAtom(createCwd)
+  );
+  const [createBaseBranch, setCreateBaseBranch] = useAtom(
+    baseBranchByCwdAtom(createCwd)
+  );
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
   const [createInitialPrompt, setCreateInitialPrompt] = useState("");
   const [creating, setCreating] = useState(false);
-  const [cwdHistory, setCwdHistory] = useState<string[]>(() => readCwdHistory());
+  const [cwdHistory, setCwdHistory] = useState<string[]>(() =>
+    readCwdHistory()
+  );
 
   // ── Delete dialog state ───────────────────────────────────────────────
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -182,17 +244,23 @@ export function DashboardLayout(): JSX.Element {
   // ── Misc UI state ────────────────────────────────────────────────────
   const [feedbackDetail, setFeedbackDetail] = useAtom(feedbackDetailAtom);
   // Keep last feedback detail alive during close transition so content fades out.
-  const feedbackDetailStaleRef = useRef<NonNullable<FeedbackDetailState> | null>(null);
+  const feedbackDetailStaleRef =
+    useRef<NonNullable<FeedbackDetailState> | null>(null);
   if (feedbackDetail) feedbackDetailStaleRef.current = feedbackDetail;
-  const feedbackDetailRendered = feedbackDetail ?? feedbackDetailStaleRef.current;
+  const feedbackDetailRendered =
+    feedbackDetail ?? feedbackDetailStaleRef.current;
   const [expandedAgentId, setExpandedAgentId] = useAtom(expandedAgentIdAtom);
 
   // ── Agent selection ────────────────────────────────────────────────────
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
   // ── Agents ────────────────────────────────────────────────────────────
-  const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<string | null>(null);
-  const [sharedConnState, setSharedConnState] = useState<"disconnected" | "reconnecting" | "connected">("disconnected");
+  const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<
+    string | null
+  >(null);
+  const [sharedConnState, setSharedConnState] = useState<
+    "disconnected" | "reconnecting" | "connected"
+  >("disconnected");
 
   const {
     agents,
@@ -210,11 +278,12 @@ export function DashboardLayout(): JSX.Element {
 
   selectedAgentIdRef.current = validatedSelectedAgentId;
 
-  const focusedAgentId = sharedConnState === "connected" || sharedConnState === "reconnecting"
-    ? (sharedConnectedAgentId ?? validatedSelectedAgentId)
-    : null;
+  const focusedAgentId =
+    sharedConnState === "connected" || sharedConnState === "reconnecting"
+      ? (sharedConnectedAgentId ?? validatedSelectedAgentId)
+      : null;
   const focusedAgent = focusedAgentId
-    ? agents.find((agent) => agent.id === focusedAgentId) ?? null
+    ? (agents.find((agent) => agent.id === focusedAgentId) ?? null)
     : null;
 
   const {
@@ -230,8 +299,12 @@ export function DashboardLayout(): JSX.Element {
     markSeenInCache,
   } = useMedia(focusedAgentId, mediaPanelOpen);
 
-  const focusedAgentHasStream = focusedAgentId ? streamingAgentIds.has(focusedAgentId) : false;
-  const focusedAgentStreamUrl = focusedAgentId ? `/api/v1/agents/${focusedAgentId}/stream` : null;
+  const focusedAgentHasStream = focusedAgentId
+    ? streamingAgentIds.has(focusedAgentId)
+    : false;
+  const focusedAgentStreamUrl = focusedAgentId
+    ? `/api/v1/agents/${focusedAgentId}/stream`
+    : null;
 
   const uploadFile = useCallback(async (agentId: string, file: File) => {
     const form = new FormData();
@@ -243,14 +316,19 @@ export function DashboardLayout(): JSX.Element {
       body: form,
     });
     if (!res.ok) {
-      const body = await res.json().catch(() => null) as { error?: string } | null;
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
       throw new Error(body?.error ?? `Upload failed (${res.status})`);
     }
   }, []);
 
-  const ensureAuxExpanded = useCallback((agentId: string) => {
-    setExpandedAgentId(agentId);
-  }, [setExpandedAgentId]);
+  const ensureAuxExpanded = useCallback(
+    (agentId: string) => {
+      setExpandedAgentId(agentId);
+    },
+    [setExpandedAgentId]
+  );
 
   // ── Terminal ──────────────────────────────────────────────────────────
   const {
@@ -300,7 +378,13 @@ export function DashboardLayout(): JSX.Element {
   useAgentFocus(focusedAgentId, "authenticated");
 
   // ── SSE ───────────────────────────────────────────────────────────────
-  useSSE("authenticated", connectedAgentIdRef, selectedAgentIdRef, setStreamingAgentIds, markSeenInCache);
+  useSSE(
+    "authenticated",
+    connectedAgentIdRef,
+    selectedAgentIdRef,
+    setStreamingAgentIds,
+    markSeenInCache
+  );
 
   // Return focus to the terminal when either sidebar closes.
   const prevLeftOpenRef = useRef(leftPanelOpen);
@@ -325,7 +409,10 @@ export function DashboardLayout(): JSX.Element {
   useEffect(() => {
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as HTMLElement;
-      if (!target.closest("[data-radix-popper-content-wrapper]") && !target.closest("[data-agent-control='true']")) {
+      if (
+        !target.closest("[data-radix-popper-content-wrapper]") &&
+        !target.closest("[data-agent-control='true']")
+      ) {
         setOverflowAgentId(null);
       }
     };
@@ -335,7 +422,8 @@ export function DashboardLayout(): JSX.Element {
 
   // ── Persist last-used CWD ─────────────────────────────────────────────
   useEffect(() => {
-    const lastUsedCwd = agentProjectRoot(connectedAgent) || agentProjectRoot(selectedAgent);
+    const lastUsedCwd =
+      agentProjectRoot(connectedAgent) || agentProjectRoot(selectedAgent);
     if (lastUsedCwd) {
       window.localStorage.setItem(LAST_USED_CWD_KEY, lastUsedCwd);
     }
@@ -355,16 +443,22 @@ export function DashboardLayout(): JSX.Element {
         if (cancelled) return;
         setCreateCwdInitialized(true);
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [createCwdInitialized]);
 
   useEffect(() => {
     let cancelled = false;
 
-    void api<{ enabledAgentTypes: AgentType[] }>("/api/v1/app/settings/agent-types")
+    void api<{ enabledAgentTypes: AgentType[] }>(
+      "/api/v1/app/settings/agent-types"
+    )
       .then((payload) => {
         if (cancelled) return;
-        setEnabledAgentTypes(sanitizeEnabledAgentTypes(payload.enabledAgentTypes));
+        setEnabledAgentTypes(
+          sanitizeEnabledAgentTypes(payload.enabledAgentTypes)
+        );
       })
       .catch(() => {
         if (cancelled) return;
@@ -387,22 +481,30 @@ export function DashboardLayout(): JSX.Element {
   const hasActiveAgent = Boolean(validatedSelectedAgentId);
   // ── Agent action callbacks ────────────────────────────────────────────
   const resolveCreateDefaultCwd = useCallback((): string => {
-    const activeCwd = agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
+    const activeCwd =
+      agentProjectRoot(selectedAgent) || agentProjectRoot(connectedAgent);
     if (activeCwd) return activeCwd;
     const latestAgentCwd = agentProjectRoot(agents[0]);
     if (latestAgentCwd) return latestAgentCwd;
     return readLastUsedCwd();
   }, [agents, connectedAgent, selectedAgent]);
 
-  const openCreateDialog = useCallback((typeOverride?: AgentType) => {
-    setCreateCwd(resolveCreateDefaultCwd());
-    if (typeOverride && enabledAgentTypes.includes(typeOverride)) {
-      setCreateType(typeOverride);
-    } else {
-      setCreateType((current) => (enabledAgentTypes.includes(current) ? current : enabledAgentTypes[0] ?? "codex"));
-    }
-    setCreateOpen(true);
-  }, [enabledAgentTypes, resolveCreateDefaultCwd]);
+  const openCreateDialog = useCallback(
+    (typeOverride?: AgentType) => {
+      setCreateCwd(resolveCreateDefaultCwd());
+      if (typeOverride && enabledAgentTypes.includes(typeOverride)) {
+        setCreateType(typeOverride);
+      } else {
+        setCreateType((current) =>
+          enabledAgentTypes.includes(current)
+            ? current
+            : (enabledAgentTypes[0] ?? "codex")
+        );
+      }
+      setCreateOpen(true);
+    },
+    [enabledAgentTypes, resolveCreateDefaultCwd]
+  );
 
   const toggleAgentDetails = useCallback(
     (agentId: string) => {
@@ -465,15 +567,19 @@ export function DashboardLayout(): JSX.Element {
       if (connectedAgentId === agent.id) {
         detachTerminal();
       }
-      setExpandedAgentId((current) => current === agent.id ? null : current);
-      setFeedbackDetail((prev) => prev?.parentAgentId === agent.id ? null : prev);
+      setExpandedAgentId((current) => (current === agent.id ? null : current));
+      setFeedbackDetail((prev) =>
+        prev?.parentAgentId === agent.id ? null : prev
+      );
       const params = new URLSearchParams();
       if (cleanupWorktree) {
         params.set("cleanupWorktree", cleanupWorktree);
       }
       const qs = params.toString();
       // Backend handles stopping + cleanup asynchronously; returns 202 immediately
-      await api(`/api/v1/agents/${agent.id}${qs ? `?${qs}` : ""}`, { method: "DELETE" });
+      await api(`/api/v1/agents/${agent.id}${qs ? `?${qs}` : ""}`, {
+        method: "DELETE",
+      });
     },
     [connectedAgentId, detachTerminal, setExpandedAgentId, setFeedbackDetail]
   );
@@ -500,7 +606,8 @@ export function DashboardLayout(): JSX.Element {
             autoReview: createAutoReview,
             useWorktree: createUseWorktree,
             worktreeBranch: createWorktreeBranch.trim() || undefined,
-            baseBranch: createBaseBranch !== "main" ? createBaseBranch : undefined,
+            baseBranch:
+              createBaseBranch !== "main" ? createBaseBranch : undefined,
             initialPrompt: createInitialPrompt.trim() || undefined,
           }),
         });
@@ -518,12 +625,28 @@ export function DashboardLayout(): JSX.Element {
         ensureAuxExpanded(payload.agent.id);
         refreshMedia(payload.agent.id);
         // Small delay to let tmux session start before connecting
-        setTimeout(() => void ensureTerminalConnected(true, true, payload.agent.id), 300);
+        setTimeout(
+          () => void ensureTerminalConnected(true, true, payload.agent.id),
+          300
+        );
       } finally {
         setCreating(false);
       }
     },
-    [createAutoReview, createBaseBranch, createCwd, createFullAccess, createInitialPrompt, createName, createType, createUseWorktree, createWorktreeBranch, ensureAuxExpanded, ensureTerminalConnected, refreshMedia]
+    [
+      createAutoReview,
+      createBaseBranch,
+      createCwd,
+      createFullAccess,
+      createInitialPrompt,
+      createName,
+      createType,
+      createUseWorktree,
+      createWorktreeBranch,
+      ensureAuxExpanded,
+      ensureTerminalConnected,
+      refreshMedia,
+    ]
   );
 
   const borderForAgentState = (state: AgentVisualState): string => {
@@ -537,7 +660,10 @@ export function DashboardLayout(): JSX.Element {
     return "bg-status-waiting";
   };
 
-  const [pulsingNavItem, setPulsingNavItem] = useTemporaryState<string | null>(null, 260);
+  const [pulsingNavItem, setPulsingNavItem] = useTemporaryState<string | null>(
+    null,
+    260
+  );
   const [pendingNavPulse, setPendingNavPulse] = useState<string | null>(null);
 
   const currentNavItem = (() => {
@@ -570,429 +696,535 @@ export function DashboardLayout(): JSX.Element {
     setPendingNavPulse(null);
   }, [currentNavItem, pendingNavPulse, setPulsingNavItem]);
 
-  const triggerNavAnimation = useCallback((navItem: string) => {
-    if (navItem === currentNavItem) {
-      setPulsingNavItem(navItem);
-      return;
-    }
-    setPendingNavPulse(navItem);
-  }, [currentNavItem, setPulsingNavItem]);
+  const triggerNavAnimation = useCallback(
+    (navItem: string) => {
+      if (navItem === currentNavItem) {
+        setPulsingNavItem(navItem);
+        return;
+      }
+      setPendingNavPulse(navItem);
+    },
+    [currentNavItem, setPulsingNavItem]
+  );
 
   // ── Navigation callbacks ────────────────────────────────────────────
-  const handleSidebarNavigate = useCallback((section: NavSection) => {
-    if (section === "agents") navigate("/");
-    else if (section === "jobs") navigate("/jobs");
-    else if (section === "activity") navigate("/activity");
-    else if (section === "settings") navigate("/settings");
-  }, [navigate]);
+  const handleSidebarNavigate = useCallback(
+    (section: NavSection) => {
+      if (section === "agents") navigate("/");
+      else if (section === "jobs") navigate("/jobs");
+      else if (section === "activity") navigate("/activity");
+      else if (section === "settings") navigate("/settings");
+    },
+    [navigate]
+  );
 
   // ── Settings state ────────────────────────────────────────────────────
-  const { activeSection: settingsActiveSection, setActiveSectionState: setSettingsActiveSection, isAdmin, sections: settingsSections } = useSettingsState(settingsOpen, settingsSection);
+  const {
+    activeSection: settingsActiveSection,
+    setActiveSectionState: setSettingsActiveSection,
+    isAdmin,
+    sections: settingsSections,
+  } = useSettingsState(settingsOpen, settingsSection);
 
-  const handleSettingsSectionChange = useCallback((section: string | null) => {
-    if (section) {
-      setSettingsActiveSection(section as Parameters<typeof setSettingsActiveSection>[0]);
-      navigate(`/settings/${section}`, { replace: true });
-      if (isMobile) setMobileLeftOpen(false);
-    }
-  }, [isMobile, navigate, setMobileLeftOpen, setSettingsActiveSection]);
+  const handleSettingsSectionChange = useCallback(
+    (section: string | null) => {
+      if (section) {
+        setSettingsActiveSection(
+          section as Parameters<typeof setSettingsActiveSection>[0]
+        );
+        navigate(`/settings/${section}`, { replace: true });
+        if (isMobile) setMobileLeftOpen(false);
+      }
+    },
+    [isMobile, navigate, setMobileLeftOpen, setSettingsActiveSection]
+  );
 
   // ── Sidebar content helper for closing on mobile actions ────────────
-  const mobileCloseAndAction = useCallback(<T extends unknown[]>(fn: (...args: T) => void) => {
-    return (...args: T) => {
-      if (isMobile) setMobileLeftOpen(false);
-      fn(...args);
-    };
-  }, [isMobile, setMobileLeftOpen]);
+  const mobileCloseAndAction = useCallback(
+    <T extends unknown[]>(fn: (...args: T) => void) => {
+      return (...args: T) => {
+        if (isMobile) setMobileLeftOpen(false);
+        fn(...args);
+      };
+    },
+    [isMobile, setMobileLeftOpen]
+  );
 
   const isAgentsView = currentNavItem === "agents";
 
   // ── Render ────────────────────────────────────────────────────────────
   return (
-    <JobsProvider open={jobsOpen} agents={agents} onOpenAgent={attachToAgent} enabledAgentTypes={enabledAgentTypes}>
-    <div className="h-full min-h-0 overflow-hidden bg-background text-foreground">
-      <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
-        {/* ── Unified sidebar (desktop: inline, mobile: slide-over) ─── */}
-        <GlassSidebar
-          open={isMobile ? mobileLeftOpen : leftOpen}
-          onOpenChange={(open) => {
-            if (isMobile) {
-              if (open) setMobileMediaOpen(false);
-              setMobileLeftOpen(open);
-            } else {
-              setLeftOpen(open);
-            }
-          }}
-          side="left"
-          width={320}
-          mobile={isMobile}
-          label="Navigation sidebar"
-        >
-          <SidebarShell
-            activeSection={currentNavItem as NavSection}
-            onNavigate={(section) => {
-              handleSidebarNavigate(section);
-            }}
-            onRequestClose={isMobile ? () => setMobileLeftOpen(false) : () => setLeftOpen(false)}
-            closeButtonIcon={isMobile ? "x" : "chevron"}
-            pulsingNavItem={pulsingNavItem}
-            triggerNavAnimation={triggerNavAnimation}
-          >
-            {currentNavItem === "agents" && (
-              <AgentListContent
-                agents={agents}
-                selectedAgentId={validatedSelectedAgentId}
-                expandedAgentId={expandedAgentId}
-                overflowAgentId={overflowAgentId}
-                onOpenCreateDialog={isMobile ? mobileCloseAndAction(openCreateDialog) : openCreateDialog}
-                enabledAgentTypes={enabledAgentTypes}
-                lastUsedAgentType={lastUsedAgentType}
-                setOverflowAgentId={setOverflowAgentId}
-                setDeleteTarget={setDeleteTarget}
-                setDeleteConfirmOpen={isMobile ? mobileCloseAndAction(setDeleteConfirmOpen) : setDeleteConfirmOpen}
-                setStopTarget={setStopTarget}
-                setStopConfirmOpen={isMobile ? mobileCloseAndAction(setStopConfirmOpen) : setStopConfirmOpen}
-                agentVisualState={agentVisualState}
-                borderForAgentState={borderForAgentState}
-                toggleAgentDetails={toggleAgentDetails}
-                isFullAccessEnabled={isFullAccessEnabled}
-                detachTerminal={detachAndClearSelection}
-                attachToAgent={attachToAgent}
-                startAgent={startAgent}
-                sendTerminalInput={sendTerminalInput}
-                connectedAgentId={connectedAgentId}
-                onOpenFeedbackDetail={setFeedbackDetail}
-                feedbackDetailState={feedbackDetail}
-                onRequestClose={isMobile ? () => setMobileLeftOpen(false) : undefined}
-                closeOnSessionAction={isMobile}
-              />
-            )}
-            {currentNavItem === "jobs" && <JobListContent onItemSelect={isMobile ? () => setMobileLeftOpen(false) : undefined} />}
-            {currentNavItem === "settings" && (
-              <SettingsNavContent
-                activeSection={settingsActiveSection}
-                activeSubsection={settingsSubsection}
-                sections={settingsSections}
-                onSectionChange={handleSettingsSectionChange}
-                onSubsectionChange={(subsection) => {
-                  navigate(`/settings/help/${subsection}`, { replace: true });
-                  if (isMobile) setMobileLeftOpen(false);
-                }}
-                apiState={apiState}
-                dbState={dbState}
-                serviceDotClass={serviceDotClass}
-              />
-            )}
-            {currentNavItem === "activity" && (
-              <div className="flex h-full min-h-0 flex-col">
-                <div className="mt-2 flex h-14 items-center border-b border-border px-3">
-                  <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Activity</div>
-                </div>
-                <nav className="min-h-0 flex-1 overflow-y-auto py-2">
-                  <button
-                    type="button"
-                    onClick={() => { if (isMobile) setMobileLeftOpen(false); navigate("/activity/metrics", { replace: true }); }}
-                    className={cn(
-                      "flex w-full items-center gap-2.5 px-4 py-2.5 text-left text-sm transition-colors",
-                      (activityTab ?? "metrics") === "metrics"
-                        ? "bg-muted text-foreground"
-                        : "text-muted-foreground hover:text-foreground"
-                    )}
-                  >
-                    <BarChart3 className="h-3.5 w-3.5 shrink-0" />
-                    Metrics
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => { if (isMobile) setMobileLeftOpen(false); navigate("/activity/history", { replace: true }); }}
-                    className={cn(
-                      "flex w-full items-center gap-2.5 px-4 py-2.5 text-left text-sm transition-colors",
-                      activityTab === "history"
-                        ? "bg-muted text-foreground"
-                        : "text-muted-foreground hover:text-foreground"
-                    )}
-                  >
-                    <History className="h-3.5 w-3.5 shrink-0" />
-                    History
-                  </button>
-                </nav>
-              </div>
-            )}
-          </SidebarShell>
-        </GlassSidebar>
-
-        {/* ── Main content area ──────────────────────────────────────── */}
-        <main
-          className={cn("min-h-0 min-w-0 flex-1 overflow-hidden", mediaOpen && !isMobile && isAgentsView && "border-r-2 border-border")}
-        >
-          <div
-            className={cn(
-              "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",
-              !isAgentsView
-                ? "grid-rows-[minmax(0,1fr)]"
-                : isMobile
-                ? "grid-rows-[minmax(0,1fr)_auto]"
-                : feedbackDetail
-                  ? "grid-rows-[minmax(0,1fr)_minmax(0,1fr)]"
-                  : "grid-rows-[minmax(0,1fr)_0fr]"
-            )}
-            onTransitionEnd={(e) => {
-              if (e.propertyName === "grid-template-rows" && !feedbackDetail) {
-                feedbackDetailStaleRef.current = null;
+    <JobsProvider
+      open={jobsOpen}
+      agents={agents}
+      onOpenAgent={attachToAgent}
+      enabledAgentTypes={enabledAgentTypes}
+    >
+      <div className="h-full min-h-0 overflow-hidden bg-background text-foreground">
+        <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
+          {/* ── Unified sidebar (desktop: inline, mobile: slide-over) ─── */}
+          <GlassSidebar
+            open={isMobile ? mobileLeftOpen : leftOpen}
+            onOpenChange={(open) => {
+              if (isMobile) {
+                if (open) setMobileMediaOpen(false);
+                setMobileLeftOpen(open);
+              } else {
+                setLeftOpen(open);
               }
             }}
+            side="left"
+            width={320}
+            mobile={isMobile}
+            label="Navigation sidebar"
           >
-            {/* Open sidebar button — shown on all views when sidebar is collapsed */}
-            {!leftPanelOpen ? (
-              <div className="pointer-events-none absolute left-3 top-3 z-10">
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="pointer-events-auto"
-                  onClick={() => handleSetLeftPanelOpen(true)}
-                  title="Open sidebar"
-                >
-                  <PanelRightOpen className="h-4 w-4" />
-                </Button>
-              </div>
-            ) : null}
-
-            {/* Agents view — terminal */}
-            {isAgentsView && (
-              <div className="relative min-h-0 min-w-0 pb-14 pt-14">
-                {focusedAgent?.name ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
-                    <div
-                      data-testid="current-session-name"
-                      className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
-                    >
-                      {focusedAgent.name}
+            <SidebarShell
+              activeSection={currentNavItem as NavSection}
+              onNavigate={(section) => {
+                handleSidebarNavigate(section);
+              }}
+              onRequestClose={
+                isMobile
+                  ? () => setMobileLeftOpen(false)
+                  : () => setLeftOpen(false)
+              }
+              closeButtonIcon={isMobile ? "x" : "chevron"}
+              pulsingNavItem={pulsingNavItem}
+              triggerNavAnimation={triggerNavAnimation}
+            >
+              {currentNavItem === "agents" && (
+                <AgentListContent
+                  agents={agents}
+                  selectedAgentId={validatedSelectedAgentId}
+                  expandedAgentId={expandedAgentId}
+                  overflowAgentId={overflowAgentId}
+                  onOpenCreateDialog={
+                    isMobile
+                      ? mobileCloseAndAction(openCreateDialog)
+                      : openCreateDialog
+                  }
+                  enabledAgentTypes={enabledAgentTypes}
+                  lastUsedAgentType={lastUsedAgentType}
+                  setOverflowAgentId={setOverflowAgentId}
+                  setDeleteTarget={setDeleteTarget}
+                  setDeleteConfirmOpen={
+                    isMobile
+                      ? mobileCloseAndAction(setDeleteConfirmOpen)
+                      : setDeleteConfirmOpen
+                  }
+                  setStopTarget={setStopTarget}
+                  setStopConfirmOpen={
+                    isMobile
+                      ? mobileCloseAndAction(setStopConfirmOpen)
+                      : setStopConfirmOpen
+                  }
+                  agentVisualState={agentVisualState}
+                  borderForAgentState={borderForAgentState}
+                  toggleAgentDetails={toggleAgentDetails}
+                  isFullAccessEnabled={isFullAccessEnabled}
+                  detachTerminal={detachAndClearSelection}
+                  attachToAgent={attachToAgent}
+                  startAgent={startAgent}
+                  sendTerminalInput={sendTerminalInput}
+                  connectedAgentId={connectedAgentId}
+                  onOpenFeedbackDetail={setFeedbackDetail}
+                  feedbackDetailState={feedbackDetail}
+                  onRequestClose={
+                    isMobile ? () => setMobileLeftOpen(false) : undefined
+                  }
+                  closeOnSessionAction={isMobile}
+                />
+              )}
+              {currentNavItem === "jobs" && (
+                <JobListContent
+                  onItemSelect={
+                    isMobile ? () => setMobileLeftOpen(false) : undefined
+                  }
+                />
+              )}
+              {currentNavItem === "settings" && (
+                <SettingsNavContent
+                  activeSection={settingsActiveSection}
+                  activeSubsection={settingsSubsection}
+                  sections={settingsSections}
+                  onSectionChange={handleSettingsSectionChange}
+                  onSubsectionChange={(subsection) => {
+                    navigate(`/settings/help/${subsection}`, { replace: true });
+                    if (isMobile) setMobileLeftOpen(false);
+                  }}
+                  apiState={apiState}
+                  dbState={dbState}
+                  serviceDotClass={serviceDotClass}
+                />
+              )}
+              {currentNavItem === "activity" && (
+                <div className="flex h-full min-h-0 flex-col">
+                  <div className="mt-2 flex h-14 items-center border-b border-border px-3">
+                    <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                      Activity
                     </div>
                   </div>
-                ) : null}
-                {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
-                  <div className="pointer-events-none absolute right-3 top-3 z-10">
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="pointer-events-auto relative"
-                      onClick={() => handleSetMediaPanelOpen(true)}
-                      title="Open media sidebar"
-                      data-testid="toggle-media-sidebar"
+                  <nav className="min-h-0 flex-1 overflow-y-auto py-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (isMobile) setMobileLeftOpen(false);
+                        navigate("/activity/metrics", { replace: true });
+                      }}
+                      className={cn(
+                        "flex w-full items-center gap-2.5 px-4 py-2.5 text-left text-sm transition-colors",
+                        (activityTab ?? "metrics") === "metrics"
+                          ? "bg-muted text-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
                     >
-                      <PanelLeftOpen className="h-4 w-4" />
-                      {unseenMediaCount > 0 ? (
-                        <span className="absolute -right-1.5 -top-1.5 min-w-5 rounded-full border border-border bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
-                          {unseenMediaCount}
-                        </span>
-                      ) : null}
-                    </Button>
-                  </div>
-                ) : null}
-                {connState === "reconnecting" ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
-                    <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
-                  </div>
-                ) : null}
-                <AgentsWorkspace onUnmount={handleAgentsWorkspaceUnmount}>
-                  <TerminalPane
-                    isAttached={isAttached}
-                    connState={connState}
-                    statusMessage={statusMessage}
-                    terminalMode={terminalMode}
-                    terminalPlaceholderMessage={terminalPlaceholderMessage}
-                    terminalHostRef={terminalHostRef}
-                    archivePhase={selectedAgent?.status === "archiving" ? selectedAgent.archivePhase : null}
-                  />
-                </AgentsWorkspace>
-              </div>
-            )}
+                      <BarChart3 className="h-3.5 w-3.5 shrink-0" />
+                      Metrics
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (isMobile) setMobileLeftOpen(false);
+                        navigate("/activity/history", { replace: true });
+                      }}
+                      className={cn(
+                        "flex w-full items-center gap-2.5 px-4 py-2.5 text-left text-sm transition-colors",
+                        activityTab === "history"
+                          ? "bg-muted text-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      <History className="h-3.5 w-3.5 shrink-0" />
+                      History
+                    </button>
+                  </nav>
+                </div>
+              )}
+            </SidebarShell>
+          </GlassSidebar>
 
-            {/* Jobs view */}
-            {jobsOpen && (
-              <div className={cn("min-h-0 min-w-0", !leftPanelOpen && "pt-14")}>
-                <JobDetailPane />
-              </div>
+          {/* ── Main content area ──────────────────────────────────────── */}
+          <main
+            className={cn(
+              "min-h-0 min-w-0 flex-1 overflow-hidden",
+              mediaOpen &&
+                !isMobile &&
+                isAgentsView &&
+                "border-r-2 border-border"
             )}
+          >
+            <div
+              className={cn(
+                "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",
+                !isAgentsView
+                  ? "grid-rows-[minmax(0,1fr)]"
+                  : isMobile
+                    ? "grid-rows-[minmax(0,1fr)_auto]"
+                    : feedbackDetail
+                      ? "grid-rows-[minmax(0,1fr)_minmax(0,1fr)]"
+                      : "grid-rows-[minmax(0,1fr)_0fr]"
+              )}
+              onTransitionEnd={(e) => {
+                if (
+                  e.propertyName === "grid-template-rows" &&
+                  !feedbackDetail
+                ) {
+                  feedbackDetailStaleRef.current = null;
+                }
+              }}
+            >
+              {/* Open sidebar button — shown on all views when sidebar is collapsed */}
+              {!leftPanelOpen ? (
+                <div className="pointer-events-none absolute left-3 top-3 z-10">
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="pointer-events-auto"
+                    onClick={() => handleSetLeftPanelOpen(true)}
+                    title="Open sidebar"
+                  >
+                    <PanelRightOpen className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : null}
 
-            {/* Activity view */}
-            {activityOpen && (
-              <div className={cn("min-h-0 min-w-0 flex-1 overflow-hidden", !leftPanelOpen && "pt-14")}>
-                <ActivityPane
-                  open={true}
-                  initialTab={activityTab}
-                />
-              </div>
-            )}
-
-            {/* Settings view */}
-            {settingsOpen && (
-              <div className={cn("min-h-0 min-w-0 flex-1 overflow-hidden", !leftPanelOpen && "pt-14")}>
-              <SettingsContent
-                activeSection={settingsActiveSection}
-                onLogout={handleLogout}
-                theme={theme}
-                setTheme={setTheme}
-                iconColor={iconColor}
-                setIconColor={setIconColor}
-                isIconColorSaving={isIconColorSaving}
-                iconColorError={iconColorError}
-                clearIconColorError={clearIconColorError}
-                enabledAgentTypes={enabledAgentTypes}
-                onEnabledAgentTypesChange={setEnabledAgentTypes}
-                initialSubsection={settingsSubsection}
-                onSubsectionChange={(subsection) => {
-                  if (settingsSection !== "help") return;
-                  navigate(subsection ? `/settings/help/${subsection}` : "/settings/help", { replace: true });
-                }}
-                isAdmin={isAdmin}
-              />
-              </div>
-            )}
-
-            {/* Feedback panel — agents view only */}
-            {!isMobile && isAgentsView ? (
-              <div className={cn("min-h-0 overflow-hidden transition-opacity duration-300", feedbackDetail ? "opacity-100" : "opacity-0")}>
-                {feedbackDetailRendered ? (
-                  "summaryAgentId" in feedbackDetailRendered ? (
-                    (() => {
-                      const summaryAgent = agents.find((a) => a.id === feedbackDetailRendered.summaryAgentId);
-                      return summaryAgent ? (
-                        <ReviewSummaryPanel
-                          key={`summary-${feedbackDetailRendered.summaryAgentId}`}
-                          parentAgentId={feedbackDetailRendered.parentAgentId}
-                          agent={summaryAgent}
-                          onClose={() => setFeedbackDetail(null)}
-                        />
-                      ) : null;
-                    })()
-                  ) : (
-                    <FeedbackDetailPanel
-                      key={feedbackDetailRendered.parentAgentId}
-                      parentAgentId={feedbackDetailRendered.parentAgentId}
-                      itemId={feedbackDetailRendered.itemId}
-                      isConnected={connectedAgentId === feedbackDetailRendered.parentAgentId}
-                      sendTerminalInput={sendTerminalInput}
-                      onClose={() => setFeedbackDetail(null)}
-                      onNavigate={(itemId) => setFeedbackDetail((prev) => prev ? { ...prev, itemId } : null)}
+              {/* Agents view — terminal */}
+              {isAgentsView && (
+                <div className="relative min-h-0 min-w-0 pb-14 pt-14">
+                  {focusedAgent?.name ? (
+                    <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
+                      <div
+                        data-testid="current-session-name"
+                        className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
+                      >
+                        {focusedAgent.name}
+                      </div>
+                    </div>
+                  ) : null}
+                  {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
+                    <div className="pointer-events-none absolute right-3 top-3 z-10">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="pointer-events-auto relative"
+                        onClick={() => handleSetMediaPanelOpen(true)}
+                        title="Open media sidebar"
+                        data-testid="toggle-media-sidebar"
+                      >
+                        <PanelLeftOpen className="h-4 w-4" />
+                        {unseenMediaCount > 0 ? (
+                          <span className="absolute -right-1.5 -top-1.5 min-w-5 rounded-full border border-border bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+                            {unseenMediaCount}
+                          </span>
+                        ) : null}
+                      </Button>
+                    </div>
+                  ) : null}
+                  {connState === "reconnecting" ? (
+                    <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
+                      <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
+                    </div>
+                  ) : null}
+                  <AgentsWorkspace onUnmount={handleAgentsWorkspaceUnmount}>
+                    <TerminalPane
+                      isAttached={isAttached}
+                      connState={connState}
+                      statusMessage={statusMessage}
+                      terminalMode={terminalMode}
+                      terminalPlaceholderMessage={terminalPlaceholderMessage}
+                      terminalHostRef={terminalHostRef}
+                      archivePhase={
+                        selectedAgent?.status === "archiving"
+                          ? selectedAgent.archivePhase
+                          : null
+                      }
                     />
-                  )
-                ) : null}
-              </div>
-            ) : null}
+                  </AgentsWorkspace>
+                </div>
+              )}
 
-            {isMobile && isAgentsView ? <MobileTerminalToolbar onSendInput={sendTerminalInput} ctrlPendingRef={ctrlPendingRef} /> : null}
-          </div>
-        </main>
+              {/* Jobs view */}
+              {jobsOpen && (
+                <div
+                  className={cn("min-h-0 min-w-0", !leftPanelOpen && "pt-14")}
+                >
+                  <JobDetailPane />
+                </div>
+              )}
 
-        {/* ── Media sidebar (right, desktop only, agents view only) ── */}
-        {isAgentsView ? (
-        <div className="hidden shrink-0 md:block">
-          <MediaSidebar
-            mediaOpen={mediaOpen && hasActiveAgent}
-            mediaFiles={mediaFiles}
-            selectedAgentId={focusedAgentId}
-            selectedAgentName={focusedAgent?.name ?? null}
-            selectedAgentWorkspaceRoot={focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null}
-            selectedAgentPins={focusedAgent?.pins ?? []}
-            animatingMediaKeys={animatingMediaKeys}
-            unseenMediaCount={unseenMediaCount}
-            mediaViewportRef={mediaViewportRef}
-            setMediaOpen={setMediaOpen}
-            hasStream={focusedAgentHasStream}
-            streamUrl={focusedAgentStreamUrl}
-            openLightbox={openLightbox}
-            onUploadFile={uploadFile}
-          />
+              {/* Activity view */}
+              {activityOpen && (
+                <div
+                  className={cn(
+                    "min-h-0 min-w-0 flex-1 overflow-hidden",
+                    !leftPanelOpen && "pt-14"
+                  )}
+                >
+                  <ActivityPane open={true} initialTab={activityTab} />
+                </div>
+              )}
+
+              {/* Settings view */}
+              {settingsOpen && (
+                <div
+                  className={cn(
+                    "min-h-0 min-w-0 flex-1 overflow-hidden",
+                    !leftPanelOpen && "pt-14"
+                  )}
+                >
+                  <SettingsContent
+                    activeSection={settingsActiveSection}
+                    onLogout={handleLogout}
+                    theme={theme}
+                    setTheme={setTheme}
+                    iconColor={iconColor}
+                    setIconColor={setIconColor}
+                    isIconColorSaving={isIconColorSaving}
+                    iconColorError={iconColorError}
+                    clearIconColorError={clearIconColorError}
+                    enabledAgentTypes={enabledAgentTypes}
+                    onEnabledAgentTypesChange={setEnabledAgentTypes}
+                    initialSubsection={settingsSubsection}
+                    onSubsectionChange={(subsection) => {
+                      if (settingsSection !== "help") return;
+                      navigate(
+                        subsection
+                          ? `/settings/help/${subsection}`
+                          : "/settings/help",
+                        { replace: true }
+                      );
+                    }}
+                    isAdmin={isAdmin}
+                  />
+                </div>
+              )}
+
+              {/* Feedback panel — agents view only */}
+              {!isMobile && isAgentsView ? (
+                <div
+                  className={cn(
+                    "min-h-0 overflow-hidden transition-opacity duration-300",
+                    feedbackDetail ? "opacity-100" : "opacity-0"
+                  )}
+                >
+                  {feedbackDetailRendered ? (
+                    "summaryAgentId" in feedbackDetailRendered ? (
+                      (() => {
+                        const summaryAgent = agents.find(
+                          (a) => a.id === feedbackDetailRendered.summaryAgentId
+                        );
+                        return summaryAgent ? (
+                          <ReviewSummaryPanel
+                            key={`summary-${feedbackDetailRendered.summaryAgentId}`}
+                            parentAgentId={feedbackDetailRendered.parentAgentId}
+                            agent={summaryAgent}
+                            onClose={() => setFeedbackDetail(null)}
+                          />
+                        ) : null;
+                      })()
+                    ) : (
+                      <FeedbackDetailPanel
+                        key={feedbackDetailRendered.parentAgentId}
+                        parentAgentId={feedbackDetailRendered.parentAgentId}
+                        itemId={feedbackDetailRendered.itemId}
+                        isConnected={
+                          connectedAgentId ===
+                          feedbackDetailRendered.parentAgentId
+                        }
+                        sendTerminalInput={sendTerminalInput}
+                        onClose={() => setFeedbackDetail(null)}
+                        onNavigate={(itemId) =>
+                          setFeedbackDetail((prev) =>
+                            prev ? { ...prev, itemId } : null
+                          )
+                        }
+                      />
+                    )
+                  ) : null}
+                </div>
+              ) : null}
+
+              {isMobile && isAgentsView ? (
+                <MobileTerminalToolbar
+                  onSendInput={sendTerminalInput}
+                  ctrlPendingRef={ctrlPendingRef}
+                />
+              ) : null}
+            </div>
+          </main>
+
+          {/* ── Media sidebar (right, desktop only, agents view only) ── */}
+          {isAgentsView ? (
+            <div className="hidden shrink-0 md:block">
+              <MediaSidebar
+                mediaOpen={mediaOpen && hasActiveAgent}
+                mediaFiles={mediaFiles}
+                selectedAgentId={focusedAgentId}
+                selectedAgentName={focusedAgent?.name ?? null}
+                selectedAgentWorkspaceRoot={
+                  focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null
+                }
+                selectedAgentPins={focusedAgent?.pins ?? []}
+                animatingMediaKeys={animatingMediaKeys}
+                unseenMediaCount={unseenMediaCount}
+                mediaViewportRef={mediaViewportRef}
+                setMediaOpen={setMediaOpen}
+                hasStream={focusedAgentHasStream}
+                streamUrl={focusedAgentStreamUrl}
+                openLightbox={openLightbox}
+                onUploadFile={uploadFile}
+              />
+            </div>
+          ) : null}
         </div>
+
+        {/* ── Mobile media slide-over ──────────────────────────────────── */}
+        {isMobile && isAgentsView ? (
+          <GlassSidebar
+            open={mobileMediaOpen}
+            onOpenChange={(open) => {
+              if (open) setMobileLeftOpen(false);
+              setMobileMediaOpen(open);
+            }}
+            side="right"
+            mobile={true}
+            label="Media sidebar"
+          >
+            <MediaSidebarContent
+              mediaFiles={mediaFiles}
+              selectedAgentId={focusedAgentId}
+              selectedAgentName={focusedAgent?.name ?? null}
+              selectedAgentWorkspaceRoot={
+                focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null
+              }
+              selectedAgentPins={focusedAgent?.pins ?? []}
+              animatingMediaKeys={animatingMediaKeys}
+              unseenMediaCount={unseenMediaCount}
+              mediaViewportRef={mediaViewportRef}
+              hasStream={focusedAgentHasStream}
+              streamUrl={focusedAgentStreamUrl}
+              openLightbox={openLightbox}
+              onRequestClose={() => setMobileMediaOpen(false)}
+              onUploadFile={uploadFile}
+            />
+          </GlassSidebar>
         ) : null}
+
+        <CreateAgentDialog
+          open={createOpen}
+          createName={createName}
+          createType={createType}
+          createCwd={createCwd}
+          createFullAccess={createFullAccess}
+          createAutoReview={createAutoReview}
+          createUseWorktree={createUseWorktree}
+          createWorktreeBranch={createWorktreeBranch}
+          createBaseBranch={createBaseBranch}
+          creating={creating}
+          cwdHistory={cwdHistory}
+          enabledAgentTypes={enabledAgentTypes}
+          initialPrompt={createInitialPrompt}
+          setOpen={setCreateOpen}
+          setCreateName={setCreateName}
+          setCreateType={setCreateType}
+          setCreateCwd={setCreateCwd}
+          setCreateFullAccess={setCreateFullAccess}
+          setCreateAutoReview={setCreateAutoReview}
+          setCreateUseWorktree={setCreateUseWorktree}
+          setCreateWorktreeBranch={setCreateWorktreeBranch}
+          setCreateBaseBranch={setCreateBaseBranch}
+          setInitialPrompt={setCreateInitialPrompt}
+          onSubmit={handleCreateAgent}
+          onRemoveCwdHistory={handleRemoveCwdHistory}
+        />
+
+        <DeleteAgentDialog
+          open={deleteConfirmOpen}
+          deleteTarget={deleteTarget}
+          setOpen={setDeleteConfirmOpen}
+          setDeleteTarget={setDeleteTarget}
+          onDelete={deleteAgent}
+        />
+
+        <StopAgentDialog
+          open={stopConfirmOpen}
+          stopTarget={stopTarget}
+          setOpen={setStopConfirmOpen}
+          setStopTarget={setStopTarget}
+          onStop={stopAgent}
+        />
+
+        <MediaLightbox
+          item={lightboxItem}
+          currentIndex={lightboxIndex}
+          totalItems={mediaFiles.length}
+          setLightboxIndex={setLightboxIndex}
+        />
+
+        <div className="sr-only" aria-live="polite">
+          {statusMessage}
+        </div>
       </div>
-
-      {/* ── Mobile media slide-over ──────────────────────────────────── */}
-      {isMobile && isAgentsView ? (
-        <GlassSidebar
-          open={mobileMediaOpen}
-          onOpenChange={(open) => {
-            if (open) setMobileLeftOpen(false);
-            setMobileMediaOpen(open);
-          }}
-          side="right"
-          mobile={true}
-          label="Media sidebar"
-        >
-          <MediaSidebarContent
-            mediaFiles={mediaFiles}
-            selectedAgentId={focusedAgentId}
-            selectedAgentName={focusedAgent?.name ?? null}
-            selectedAgentWorkspaceRoot={focusedAgent?.worktreePath ?? focusedAgent?.cwd ?? null}
-            selectedAgentPins={focusedAgent?.pins ?? []}
-            animatingMediaKeys={animatingMediaKeys}
-            unseenMediaCount={unseenMediaCount}
-            mediaViewportRef={mediaViewportRef}
-            hasStream={focusedAgentHasStream}
-            streamUrl={focusedAgentStreamUrl}
-            openLightbox={openLightbox}
-            onRequestClose={() => setMobileMediaOpen(false)}
-            onUploadFile={uploadFile}
-          />
-        </GlassSidebar>
-      ) : null}
-
-      <CreateAgentDialog
-        open={createOpen}
-        createName={createName}
-        createType={createType}
-        createCwd={createCwd}
-        createFullAccess={createFullAccess}
-        createAutoReview={createAutoReview}
-        createUseWorktree={createUseWorktree}
-        createWorktreeBranch={createWorktreeBranch}
-        createBaseBranch={createBaseBranch}
-        creating={creating}
-        cwdHistory={cwdHistory}
-        enabledAgentTypes={enabledAgentTypes}
-        initialPrompt={createInitialPrompt}
-        setOpen={setCreateOpen}
-        setCreateName={setCreateName}
-        setCreateType={setCreateType}
-        setCreateCwd={setCreateCwd}
-        setCreateFullAccess={setCreateFullAccess}
-        setCreateAutoReview={setCreateAutoReview}
-        setCreateUseWorktree={setCreateUseWorktree}
-        setCreateWorktreeBranch={setCreateWorktreeBranch}
-        setCreateBaseBranch={setCreateBaseBranch}
-        setInitialPrompt={setCreateInitialPrompt}
-        onSubmit={handleCreateAgent}
-        onRemoveCwdHistory={handleRemoveCwdHistory}
-      />
-
-      <DeleteAgentDialog
-        open={deleteConfirmOpen}
-        deleteTarget={deleteTarget}
-        setOpen={setDeleteConfirmOpen}
-        setDeleteTarget={setDeleteTarget}
-        onDelete={deleteAgent}
-      />
-
-      <StopAgentDialog
-        open={stopConfirmOpen}
-        stopTarget={stopTarget}
-        setOpen={setStopConfirmOpen}
-        setStopTarget={setStopTarget}
-        onStop={stopAgent}
-      />
-
-      <MediaLightbox
-        item={lightboxItem}
-        currentIndex={lightboxIndex}
-        totalItems={mediaFiles.length}
-        setLightboxIndex={setLightboxIndex}
-      />
-
-      <div className="sr-only" aria-live="polite">
-        {statusMessage}
-      </div>
-    </div>
     </JobsProvider>
   );
 }

--- a/apps/web/src/components/app/activity-pane.tsx
+++ b/apps/web/src/components/app/activity-pane.tsx
@@ -1,7 +1,11 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { CalendarIcon } from "lucide-react";
 import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { AgentHistoryTab } from "@/components/app/agent-history-tab";
 import {
@@ -31,7 +35,11 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart";
 import { cn } from "@/lib/utils";
-import { formatDuration, formatTokenCount, shortProjectName } from "@/lib/format";
+import {
+  formatDuration,
+  formatTokenCount,
+  shortProjectName,
+} from "@/lib/format";
 import { StatCard } from "@/components/app/stat-card";
 import {
   ACTIVITY_RANGES,
@@ -72,7 +80,10 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-function formatBucketLabel(iso: string, granularity: ActivityGranularity): string {
+function formatBucketLabel(
+  iso: string,
+  granularity: ActivityGranularity
+): string {
   if (granularity === "hour") {
     // iso is like "2026-04-14 09:00"
     const hourStr = iso.split(" ")[1] ?? "00:00";
@@ -109,8 +120,18 @@ const chartConfig: ChartConfig = {
 
 const DAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 const MONTH_NAMES = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
 ];
 
 function intensityClass(count: number, max: number): string {
@@ -124,9 +145,11 @@ function intensityClass(count: number, max: number): string {
 
 type HeatmapCell = { date: string; count: number; label: string };
 
-function buildHeatmapGrid(
-  data: Array<{ day: string; count: number }>
-): { cells: HeatmapCell[][]; months: Array<{ label: string; col: number }>; max: number } {
+function buildHeatmapGrid(data: Array<{ day: string; count: number }>): {
+  cells: HeatmapCell[][];
+  months: Array<{ label: string; col: number }>;
+  max: number;
+} {
   const countMap = new Map<string, number>();
   let max = 0;
   for (const d of data) {
@@ -167,11 +190,16 @@ function buildHeatmapGrid(
         week.push({
           date: iso,
           count,
-          label: inFuture ? dateLabel : `${dateLabel}: ${count} event${count !== 1 ? "s" : ""}`,
+          label: inFuture
+            ? dateLabel
+            : `${dateLabel}: ${count} event${count !== 1 ? "s" : ""}`,
         });
 
         if (cursor.getMonth() !== lastMonth && dow <= 3) {
-          months.push({ label: MONTH_NAMES[cursor.getMonth()], col: cols.length });
+          months.push({
+            label: MONTH_NAMES[cursor.getMonth()],
+            col: cols.length,
+          });
           lastMonth = cursor.getMonth();
         }
       }
@@ -226,7 +254,9 @@ function Heatmap({ data }: { data: Array<{ day: string; count: number }> }) {
                     title={cell.label}
                     className={cn(
                       "h-[11px] w-[11px] rounded-[2px] transition-colors",
-                      cell.date ? intensityClass(cell.count, max) : "bg-transparent"
+                      cell.date
+                        ? intensityClass(cell.count, max)
+                        : "bg-transparent"
                     )}
                   />
                 ))}
@@ -277,17 +307,31 @@ function formatHour(hour: number): string {
   return `${normalized}${suffix}`;
 }
 
-function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: ActivityRange }) {
+function ActiveHoursGrid({
+  data,
+  range,
+}: {
+  data: ActiveHoursCell[];
+  range: ActivityRange;
+}) {
   const cellMap = useMemo(
     () => new Map(data.map((cell) => [`${cell.dayOfWeek}:${cell.hour}`, cell])),
     [data]
   );
   const max = Math.max(...data.map((cell) => cell.avgPerWeek), 0.01);
-  const cadenceLabel = range === "daily" ? "events" : range === "7d" ? "events" : "avg events / week";
+  const cadenceLabel =
+    range === "daily"
+      ? "events"
+      : range === "7d"
+        ? "events"
+        : "avg events / week";
 
   return (
     <div className="space-y-3">
-      <ScrollArea style={{ maxWidth: "calc(100vw - 24px)" }} className="max-w-full">
+      <ScrollArea
+        style={{ maxWidth: "calc(100vw - 24px)" }}
+        className="max-w-full"
+      >
         <div className="grid w-max grid-cols-[56px_repeat(24,28px)] gap-x-1.5 gap-y-2 pb-2">
           <div />
           {Array.from({ length: 24 }, (_, hour) => (
@@ -319,7 +363,11 @@ function ActiveHoursGrid({ data, range }: { data: ActiveHoursCell[]; range: Acti
                   <div
                     key={`${dayOfWeek}-${hour}`}
                     title={title}
-                    data-testid={dayOfWeek === 1 && hour === 9 ? "active-hours-cell-sample" : undefined}
+                    data-testid={
+                      dayOfWeek === 1 && hour === 9
+                        ? "active-hours-cell-sample"
+                        : undefined
+                    }
                     className={cn(
                       "h-5 rounded-[6px] border border-border/40 transition-colors",
                       activeHoursIntensity(cell.avgPerWeek, max)
@@ -359,7 +407,11 @@ function fillGaps<T extends { day: string }>(
   if (granularity === "hour") {
     // Fill all 24 hours for the selected day
     const dataMap = new Map(data.map((d) => [d.day, d]));
-    const datePrefix = dailyDate ?? (data.length > 0 ? data[0].day.split(" ")[0] : new Date().toISOString().slice(0, 10));
+    const datePrefix =
+      dailyDate ??
+      (data.length > 0
+        ? data[0].day.split(" ")[0]
+        : new Date().toISOString().slice(0, 10));
     const filled: T[] = [];
     for (let h = 0; h < 24; h++) {
       const key = `${datePrefix} ${String(h).padStart(2, "0")}:00`;
@@ -392,7 +444,12 @@ function DailyStackedBarChart({
   dailyDate?: string;
 }) {
   const chartData = useMemo(() => {
-    const filled = fillGaps<DailyStatusEntry>(rawData, granularity, (day) => ({ day }), dailyDate);
+    const filled = fillGaps<DailyStatusEntry>(
+      rawData,
+      granularity,
+      (day) => ({ day }),
+      dailyDate
+    );
     return filled.map((d) => ({
       day: d.day,
       label: formatBucketLabel(d.day, granularity),
@@ -411,7 +468,10 @@ function DailyStackedBarChart({
   }
 
   return (
-    <ChartContainer config={chartConfig} className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full">
+    <ChartContainer
+      config={chartConfig}
+      className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full"
+    >
       <BarChart data={chartData} barCategoryGap="20%">
         <CartesianGrid vertical={false} />
         <XAxis
@@ -445,7 +505,9 @@ function DailyStackedBarChart({
             />
           }
         />
-        <ChartLegend content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />} />
+        <ChartLegend
+          content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />}
+        />
         {STATUS_ORDER.map((key) => (
           <Bar
             key={key}
@@ -463,7 +525,8 @@ function DailyStackedBarChart({
 // ── Token helpers ──────────────────────────────────────────────────
 
 function cacheHitRate(stats: TokenStats): number {
-  const totalInput = stats.total_input + stats.total_cache_creation + stats.total_cache_read;
+  const totalInput =
+    stats.total_input + stats.total_cache_creation + stats.total_cache_read;
   if (totalInput === 0) return 0;
   return Math.round((stats.total_cache_read / totalInput) * 100);
 }
@@ -479,7 +542,12 @@ function shortModelName(model: string): string {
 
 // ── Token daily chart ─────────────────────────────────────────────
 
-const TOKEN_ORDER = ["input_tokens", "cache_read_tokens", "cache_creation_tokens", "output_tokens"];
+const TOKEN_ORDER = [
+  "input_tokens",
+  "cache_read_tokens",
+  "cache_creation_tokens",
+  "output_tokens",
+];
 
 const tokenChartConfig: ChartConfig = {
   input_tokens: { label: "Input", color: "hsl(var(--chart-1))" },
@@ -511,7 +579,9 @@ function DailyTokenChart({
 }) {
   const chartData = useMemo(() => {
     const filled = fillGaps(rawData, granularity, EMPTY_TOKEN_ENTRY, dailyDate);
-    const agentsMap = new Map(agentsCreatedData?.map((d) => [d.day, d.count]) ?? []);
+    const agentsMap = new Map(
+      agentsCreatedData?.map((d) => [d.day, d.count]) ?? []
+    );
     return filled.map((d) => ({
       ...d,
       label: formatBucketLabel(d.day, granularity),
@@ -530,7 +600,10 @@ function DailyTokenChart({
   }
 
   return (
-    <ChartContainer config={tokenChartConfig} className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full">
+    <ChartContainer
+      config={tokenChartConfig}
+      className="aspect-[1.5/1] sm:aspect-[2.5/1] w-full"
+    >
       <ComposedChart data={chartData} barCategoryGap="20%">
         <CartesianGrid vertical={false} />
         <XAxis
@@ -541,25 +614,35 @@ function DailyTokenChart({
           interval="preserveStartEnd"
         />
         <YAxis yAxisId="tokens" hide />
-        {hasAgentsLine && (
-          <YAxis yAxisId="agents" orientation="right" hide />
-        )}
+        {hasAgentsLine && <YAxis yAxisId="agents" orientation="right" hide />}
         <ChartTooltip
           content={({ active, payload, label: tooltipLabel }) => {
             if (!active || !payload?.length) return null;
-            const tokenEntries = payload.filter((p) => p.dataKey !== "agents_created");
-            const total = tokenEntries.reduce((sum, p) => sum + (typeof p.value === "number" ? p.value : 0), 0);
+            const tokenEntries = payload.filter(
+              (p) => p.dataKey !== "agents_created"
+            );
+            const total = tokenEntries.reduce(
+              (sum, p) => sum + (typeof p.value === "number" ? p.value : 0),
+              0
+            );
             return (
               <div className="rounded-lg border bg-card px-3 py-2 text-xs shadow-md">
                 <div className="mb-1.5 font-medium">{tooltipLabel}</div>
                 {payload.map((p) => (
-                  <div key={String(p.dataKey)} className="flex items-center gap-2 py-0.5">
+                  <div
+                    key={String(p.dataKey)}
+                    className="flex items-center gap-2 py-0.5"
+                  >
                     <div
                       className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-                      style={{ backgroundColor: tokenChartConfig[p.dataKey as string]?.color }}
+                      style={{
+                        backgroundColor:
+                          tokenChartConfig[p.dataKey as string]?.color,
+                      }}
                     />
                     <span className="flex-1 text-muted-foreground">
-                      {tokenChartConfig[p.dataKey as string]?.label ?? String(p.dataKey)}
+                      {tokenChartConfig[p.dataKey as string]?.label ??
+                        String(p.dataKey)}
                     </span>
                     <span className="font-mono font-medium text-foreground tabular-nums">
                       {p.dataKey === "agents_created"
@@ -571,7 +654,9 @@ function DailyTokenChart({
                 {tokenEntries.length > 1 && (
                   <div className="mt-1.5 flex items-center gap-2 border-t border-border pt-1.5">
                     <div className="h-2.5 w-2.5 shrink-0" />
-                    <span className="flex-1 font-medium text-foreground">Total</span>
+                    <span className="flex-1 font-medium text-foreground">
+                      Total
+                    </span>
                     <span className="font-mono font-medium text-foreground tabular-nums">
                       {formatTokenCount(total)}
                     </span>
@@ -581,7 +666,9 @@ function DailyTokenChart({
             );
           }}
         />
-        <ChartLegend content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />} />
+        <ChartLegend
+          content={<ChartLegendContent className="flex-wrap gap-2 sm:gap-4" />}
+        />
         {TOKEN_ORDER.map((key) => (
           <Bar
             key={key}
@@ -628,7 +715,8 @@ function HorizontalBar({
       <div className="flex items-center justify-between text-xs">
         <span className="truncate text-foreground">{label}</span>
         <span className="ml-2 shrink-0 font-mono text-muted-foreground tabular-nums">
-          {formatTokenCount(value)}{sub ? ` ${sub}` : ""}
+          {formatTokenCount(value)}
+          {sub ? ` ${sub}` : ""}
         </span>
       </div>
       <div className="h-2 w-full rounded-full bg-muted/60">
@@ -645,12 +733,24 @@ function HorizontalBar({
 
 function ModelBreakdown({ data }: { data: TokenByModel[] }) {
   if (data.length === 0) return null;
-  const max = Math.max(...data.map((m) => m.total_input + m.total_cache_creation + m.total_cache_read + m.total_output));
+  const max = Math.max(
+    ...data.map(
+      (m) =>
+        m.total_input +
+        m.total_cache_creation +
+        m.total_cache_read +
+        m.total_output
+    )
+  );
 
   return (
     <div className="space-y-3">
       {data.map((m) => {
-        const total = m.total_input + m.total_cache_creation + m.total_cache_read + m.total_output;
+        const total =
+          m.total_input +
+          m.total_cache_creation +
+          m.total_cache_read +
+          m.total_output;
         return (
           <HorizontalBar
             key={m.model}
@@ -677,8 +777,12 @@ function ProjectBreakdown({
 }) {
   if (data.length === 0) return null;
   const max = Math.max(...data.map((p) => p.total_input + p.total_output));
-  const wtMap = new Map(workingTime?.map((w) => [w.project_dir, w.working_time_ms]) ?? []);
-  const maxWt = Math.max(...(workingTime?.map((w) => w.working_time_ms) ?? [0]));
+  const wtMap = new Map(
+    workingTime?.map((w) => [w.project_dir, w.working_time_ms]) ?? []
+  );
+  const maxWt = Math.max(
+    ...(workingTime?.map((w) => w.working_time_ms) ?? [0])
+  );
 
   return (
     <div className="space-y-4">
@@ -696,7 +800,9 @@ function ProjectBreakdown({
             {wt != null && wt > 0 && (
               <div className="pl-0">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="text-transparent">{shortProjectName(p.project_dir)}</span>
+                  <span className="text-transparent">
+                    {shortProjectName(p.project_dir)}
+                  </span>
                   <span className="ml-2 shrink-0 font-mono text-muted-foreground tabular-nums">
                     {formatDuration(wt)} working
                   </span>
@@ -731,11 +837,13 @@ function DatePickerPopover({
   // Scoped to this component so it only applies while the date picker is mounted.
   useEffect(() => {
     const style = document.createElement("style");
-    style.textContent = "[data-radix-popper-content-wrapper]{z-index:80!important}";
+    style.textContent =
+      "[data-radix-popper-content-wrapper]{z-index:80!important}";
     document.head.appendChild(style);
-    return () => { style.remove(); };
+    return () => {
+      style.remove();
+    };
   }, []);
-
 
   return (
     <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
@@ -759,7 +867,9 @@ function DatePickerPopover({
           selected={new Date(dailyDate + "T00:00:00")}
           onSelect={(date) => {
             if (date) {
-              onDateChange(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`);
+              onDateChange(
+                `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`
+              );
               setCalendarOpen(false);
             }
           }}
@@ -773,7 +883,10 @@ function DatePickerPopover({
 // ── Main pane ───────────────────────────────────────────────────────
 
 /** Activity content for the main content area. */
-export function ActivityPane({ open, initialTab }: ActivityPaneProps): JSX.Element {
+export function ActivityPane({
+  open,
+  initialTab,
+}: ActivityPaneProps): JSX.Element {
   const [range, setRange] = useState<ActivityRange>("7d");
   const [dailyDate, setDailyDate] = useState<string>(() => {
     const d = new Date();
@@ -799,14 +912,25 @@ export function ActivityPane({ open, initialTab }: ActivityPaneProps): JSX.Eleme
   const { data: tokenByModel } = useTokenByModel(range, dailyDateParam);
   const { data: tokenByProject } = useTokenByProject(range, dailyDateParam);
   const { data: agentsCreated } = useAgentsCreated(range, dailyDateParam);
-  const { data: workingTimeByProject } = useWorkingTimeByProject(range, dailyDateParam);
+  const { data: workingTimeByProject } = useWorkingTimeByProject(
+    range,
+    dailyDateParam
+  );
 
-  const hasData = stats && (stats.totalWorkingMs > 0 || stats.avgBlockedMs > 0 || stats.avgWaitingMs > 0);
+  const hasData =
+    stats &&
+    (stats.totalWorkingMs > 0 ||
+      stats.avgBlockedMs > 0 ||
+      stats.avgWaitingMs > 0);
   const totalTokens = tokenStats
-    ? tokenStats.total_input + tokenStats.total_cache_creation + tokenStats.total_cache_read + tokenStats.total_output
+    ? tokenStats.total_input +
+      tokenStats.total_cache_creation +
+      tokenStats.total_cache_read +
+      tokenStats.total_output
     : 0;
   const hasTokenData = totalTokens > 0;
-  const hasActiveHourData = activeHours?.some((cell) => cell.count > 0) ?? false;
+  const hasActiveHourData =
+    activeHours?.some((cell) => cell.count > 0) ?? false;
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
@@ -816,9 +940,15 @@ export function ActivityPane({ open, initialTab }: ActivityPaneProps): JSX.Eleme
           {tab === "metrics" && (
             <>
               {isDaily && (
-                <DatePickerPopover dailyDate={dailyDate} onDateChange={setDailyDate} />
+                <DatePickerPopover
+                  dailyDate={dailyDate}
+                  onDateChange={setDailyDate}
+                />
               )}
-              <Select value={range} onValueChange={(value) => setRange(value as ActivityRange)}>
+              <Select
+                value={range}
+                onValueChange={(value) => setRange(value as ActivityRange)}
+              >
                 <SelectTrigger
                   className="h-8 w-[132px] bg-muted/30 text-xs"
                   data-testid="activity-range-select"
@@ -847,78 +977,175 @@ export function ActivityPane({ open, initialTab }: ActivityPaneProps): JSX.Eleme
       )}
 
       {/* Metrics tab body */}
-      {tab === "metrics" && <ScrollArea className="flex-1">
-        <div className="mx-auto max-w-5xl min-w-0 overflow-hidden space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
-          {hasTokenData && tokenStats && (
-            <div className="flex flex-wrap gap-2 sm:gap-3">
-              <StatCard label="Total tokens" value={formatTokenCount(totalTokens)} sub={`${formatTokenCount(tokenStats.total_output)} output`} />
-              <StatCard label="Cache hit rate" value={`${cacheHitRate(tokenStats)}%`} sub="of input from cache" />
-              <StatCard label="Avg tokens / session" value={tokenStats.total_sessions > 0 ? formatTokenCount(Math.round(totalTokens / tokenStats.total_sessions)) : "—"} />
-              <StatCard label="Sessions" value={tokenStats.total_sessions} sub={`${tokenStats.total_messages} messages`} />
-              {agentsCreated && agentsCreated.total > 0 && <StatCard label="Agents created" value={agentsCreated.total} />}
-            </div>
-          )}
+      {tab === "metrics" && (
+        <ScrollArea className="flex-1">
+          <div className="mx-auto max-w-5xl min-w-0 overflow-hidden space-y-6 px-3 pt-4 pb-12 sm:space-y-8 sm:px-5 sm:pt-6 sm:pb-20 md:px-8">
+            {hasTokenData && tokenStats && (
+              <div className="flex flex-wrap gap-2 sm:gap-3">
+                <StatCard
+                  label="Total tokens"
+                  value={formatTokenCount(totalTokens)}
+                  sub={`${formatTokenCount(tokenStats.total_output)} output`}
+                />
+                <StatCard
+                  label="Cache hit rate"
+                  value={`${cacheHitRate(tokenStats)}%`}
+                  sub="of input from cache"
+                />
+                <StatCard
+                  label="Avg tokens / session"
+                  value={
+                    tokenStats.total_sessions > 0
+                      ? formatTokenCount(
+                          Math.round(totalTokens / tokenStats.total_sessions)
+                        )
+                      : "—"
+                  }
+                />
+                <StatCard
+                  label="Sessions"
+                  value={tokenStats.total_sessions}
+                  sub={`${tokenStats.total_messages} messages`}
+                />
+                {agentsCreated && agentsCreated.total > 0 && (
+                  <StatCard
+                    label="Agents created"
+                    value={agentsCreated.total}
+                  />
+                )}
+              </div>
+            )}
 
-          {tokenDaily && tokenDaily.days.length > 0 && (
+            {tokenDaily && tokenDaily.days.length > 0 && (
+              <div>
+                <h2 className="mb-3 text-sm font-medium text-foreground">
+                  Token usage (
+                  {isDaily
+                    ? new Date(dailyDate + "T00:00:00").toLocaleDateString(
+                        undefined,
+                        { month: "short", day: "numeric" }
+                      )
+                    : rangeLabel(range).toLowerCase()}
+                  )
+                </h2>
+                <DailyTokenChart
+                  data={tokenDaily.days}
+                  granularity={tokenDaily.granularity}
+                  agentsCreatedData={agentsCreated?.days}
+                  dailyDate={dailyDateParam}
+                />
+              </div>
+            )}
+
+            {hasTokenData &&
+            (tokenByModel?.length || tokenByProject?.length) ? (
+              <div className="grid gap-6 sm:grid-cols-2">
+                {tokenByModel && tokenByModel.length > 0 && (
+                  <div>
+                    <h2 className="mb-3 text-sm font-medium text-foreground">
+                      Tokens by model
+                    </h2>
+                    <ModelBreakdown data={tokenByModel} />
+                  </div>
+                )}
+                {tokenByProject && tokenByProject.length > 0 && (
+                  <div>
+                    <h2 className="mb-3 text-sm font-medium text-foreground">
+                      By project
+                    </h2>
+                    <ProjectBreakdown
+                      data={tokenByProject}
+                      workingTime={workingTimeByProject}
+                    />
+                  </div>
+                )}
+              </div>
+            ) : null}
+
             <div>
               <h2 className="mb-3 text-sm font-medium text-foreground">
-                Token usage ({isDaily ? new Date(dailyDate + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" }) : rangeLabel(range).toLowerCase()})
+                Activity this year
               </h2>
-              <DailyTokenChart data={tokenDaily.days} granularity={tokenDaily.granularity} agentsCreatedData={agentsCreated?.days} dailyDate={dailyDateParam} />
-            </div>
-          )}
-
-          {hasTokenData && (tokenByModel?.length || tokenByProject?.length) ? (
-            <div className="grid gap-6 sm:grid-cols-2">
-              {tokenByModel && tokenByModel.length > 0 && (
-                <div><h2 className="mb-3 text-sm font-medium text-foreground">Tokens by model</h2><ModelBreakdown data={tokenByModel} /></div>
-              )}
-              {tokenByProject && tokenByProject.length > 0 && (
-                <div><h2 className="mb-3 text-sm font-medium text-foreground">By project</h2><ProjectBreakdown data={tokenByProject} workingTime={workingTimeByProject} /></div>
+              {heatmapData ? (
+                <Heatmap data={heatmapData} />
+              ) : (
+                <div className="h-24 animate-pulse rounded-md bg-muted/30" />
               )}
             </div>
-          ) : null}
 
-          <div>
-            <h2 className="mb-3 text-sm font-medium text-foreground">Activity this year</h2>
-            {heatmapData ? <Heatmap data={heatmapData} /> : <div className="h-24 animate-pulse rounded-md bg-muted/30" />}
+            {activeHours && activeHours.length > 0 && hasActiveHourData && (
+              <div className="min-w-0">
+                <h2 className="mb-1 text-sm font-medium text-foreground">
+                  Active hours
+                </h2>
+                <p className="mb-3 text-xs text-muted-foreground">
+                  {isDaily
+                    ? "Active-state events by weekday and hour for the selected day."
+                    : range === "7d"
+                      ? "Active-state events by weekday and hour for the last 7 days."
+                      : `Average active-state events per week by weekday and hour for ${rangeLabel(range).toLowerCase()}.`}
+                </p>
+                <ActiveHoursGrid data={activeHours} range={range} />
+              </div>
+            )}
+
+            {stats && hasData && (
+              <div className="flex flex-wrap gap-2 sm:gap-3">
+                <StatCard
+                  label="Total working time"
+                  value={formatDuration(stats.totalWorkingMs)}
+                />
+                <StatCard
+                  label="Avg blocked time"
+                  value={formatDuration(stats.avgBlockedMs)}
+                />
+                <StatCard
+                  label="Avg waiting time"
+                  value={formatDuration(stats.avgWaitingMs)}
+                />
+                <StatCard
+                  label="Busiest day"
+                  value={stats.busiestDay ? formatDate(stats.busiestDay) : "—"}
+                  sub={
+                    stats.busiestDayCount > 0
+                      ? `${stats.busiestDayCount} events`
+                      : undefined
+                  }
+                />
+              </div>
+            )}
+
+            {dailyStatus && dailyStatus.days.length > 0 && (
+              <div>
+                <h2 className="mb-3 text-sm font-medium text-foreground">
+                  Status breakdown (
+                  {isDaily
+                    ? new Date(dailyDate + "T00:00:00").toLocaleDateString(
+                        undefined,
+                        { month: "short", day: "numeric" }
+                      )
+                    : rangeLabel(range).toLowerCase()}
+                  )
+                </h2>
+                <DailyStackedBarChart
+                  data={dailyStatus.days}
+                  granularity={dailyStatus.granularity}
+                  dailyDate={dailyDateParam}
+                />
+              </div>
+            )}
+
+            {stats &&
+              !hasData &&
+              (!heatmapData || heatmapData.length === 0) &&
+              !hasTokenData && (
+                <div className="py-12 text-center text-sm text-muted-foreground">
+                  No activity yet. Stats will appear here as agents run.
+                </div>
+              )}
           </div>
-
-          {activeHours && activeHours.length > 0 && hasActiveHourData && (
-            <div className="min-w-0">
-              <h2 className="mb-1 text-sm font-medium text-foreground">Active hours</h2>
-              <p className="mb-3 text-xs text-muted-foreground">
-                {isDaily ? "Active-state events by weekday and hour for the selected day." : range === "7d" ? "Active-state events by weekday and hour for the last 7 days." : `Average active-state events per week by weekday and hour for ${rangeLabel(range).toLowerCase()}.`}
-              </p>
-              <ActiveHoursGrid data={activeHours} range={range} />
-            </div>
-          )}
-
-          {stats && hasData && (
-            <div className="flex flex-wrap gap-2 sm:gap-3">
-              <StatCard label="Total working time" value={formatDuration(stats.totalWorkingMs)} />
-              <StatCard label="Avg blocked time" value={formatDuration(stats.avgBlockedMs)} />
-              <StatCard label="Avg waiting time" value={formatDuration(stats.avgWaitingMs)} />
-              <StatCard label="Busiest day" value={stats.busiestDay ? formatDate(stats.busiestDay) : "—"} sub={stats.busiestDayCount > 0 ? `${stats.busiestDayCount} events` : undefined} />
-            </div>
-          )}
-
-          {dailyStatus && dailyStatus.days.length > 0 && (
-            <div>
-              <h2 className="mb-3 text-sm font-medium text-foreground">
-                Status breakdown ({isDaily ? new Date(dailyDate + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" }) : rangeLabel(range).toLowerCase()})
-              </h2>
-              <DailyStackedBarChart data={dailyStatus.days} granularity={dailyStatus.granularity} dailyDate={dailyDateParam} />
-            </div>
-          )}
-
-          {stats && !hasData && (!heatmapData || heatmapData.length === 0) && !hasTokenData && (
-            <div className="py-12 text-center text-sm text-muted-foreground">
-              No activity yet. Stats will appear here as agents run.
-            </div>
-          )}
-        </div>
-      </ScrollArea>}
+        </ScrollArea>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -11,13 +11,24 @@ import {
 
 import { AgentMeta, FrontTruncatedValue } from "@/components/app/agent-meta";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
-import { latestEventLabel, latestEventColor, formatRelativeTime } from "@/components/app/agent-event-utils";
-import { type FeedbackDetailState, ParentFeedbackPanel } from "@/components/app/feedback-panel";
+import {
+  latestEventLabel,
+  latestEventColor,
+  formatRelativeTime,
+} from "@/components/app/agent-event-utils";
+import {
+  type FeedbackDetailState,
+  ParentFeedbackPanel,
+} from "@/components/app/feedback-panel";
 import { PersonaLauncher } from "@/components/app/persona-launcher";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AnimatePresence, motion } from "framer-motion";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { cn } from "@/lib/utils";
@@ -31,7 +42,9 @@ export type AgentCardProps = {
   agentVisualState: (agent: Agent) => AgentVisualState;
   borderForAgentState: (state: AgentVisualState) => string;
   toggleAgentDetails: (agentId: string) => void;
-  isFullAccessEnabled: (agent: Pick<Agent, "agentArgs" | "fullAccess">) => boolean;
+  isFullAccessEnabled: (
+    agent: Pick<Agent, "agentArgs" | "fullAccess">
+  ) => boolean;
   detachTerminal: () => void;
   attachToAgent: (agent: Agent) => Promise<void>;
   startAgent: (agent: Agent) => Promise<void>;
@@ -94,13 +107,20 @@ export function AgentCard({
         )}
       >
         <div
-          className={cn("flex items-center gap-1.5", !isStopped && "cursor-pointer")}
+          className={cn(
+            "flex items-center gap-1.5",
+            !isStopped && "cursor-pointer"
+          )}
           data-testid={`agent-row-${agent.id}`}
           onClick={(event) => {
             const target = event.target as HTMLElement;
             if (target.closest("[data-agent-control='true']")) return;
             if (isStopped) return;
-            if (connectedAgentId === agent.id) { detachTerminal(); if (isExpanded) toggleAgentDetails(agent.id); return; }
+            if (connectedAgentId === agent.id) {
+              detachTerminal();
+              if (isExpanded) toggleAgentDetails(agent.id);
+              return;
+            }
             if (closeOnSessionAction) onRequestClose?.();
             void attachToAgent(agent);
           }}
@@ -108,7 +128,12 @@ export function AgentCard({
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="min-w-0 flex flex-1 items-center gap-2 text-left text-sm font-semibold">
-                <AgentTypeIcon type={agent.type} eventType={agent.status === "running" ? agent.latestEvent?.type : null} />
+                <AgentTypeIcon
+                  type={agent.type}
+                  eventType={
+                    agent.status === "running" ? agent.latestEvent?.type : null
+                  }
+                />
                 <span className="truncate">{agent.name}</span>
               </div>
             </TooltipTrigger>
@@ -118,7 +143,10 @@ export function AgentCard({
           {needsAttention ? (
             <Badge
               className="border-status-blocked/45 bg-status-blocked/15 text-status-blocked"
-              title={agent.lastError ?? "Agent entered an error state and may need attention."}
+              title={
+                agent.lastError ??
+                "Agent entered an error state and may need attention."
+              }
             >
               Attention
             </Badge>
@@ -149,7 +177,13 @@ export function AgentCard({
                   <Play className="h-3.5 w-3.5" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Resume<br /><span className="text-muted-foreground">Resume agent session</span></TooltipContent>
+              <TooltipContent>
+                Resume
+                <br />
+                <span className="text-muted-foreground">
+                  Resume agent session
+                </span>
+              </TooltipContent>
             </Tooltip>
           ) : agent.status === "archiving" ? null : (
             <Tooltip>
@@ -166,7 +200,13 @@ export function AgentCard({
                   <Pause className="h-3.5 w-3.5" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Pause<br /><span className="text-muted-foreground">Pause agent session</span></TooltipContent>
+              <TooltipContent>
+                Pause
+                <br />
+                <span className="text-muted-foreground">
+                  Pause agent session
+                </span>
+              </TooltipContent>
             </Tooltip>
           )}
 
@@ -178,7 +218,9 @@ export function AgentCard({
                 data-agent-control="true"
                 data-testid={`agent-archive-${agent.id}`}
                 className="ml-auto"
-                disabled={agent.status === "archiving" || agent.status === "creating"}
+                disabled={
+                  agent.status === "archiving" || agent.status === "creating"
+                }
                 onClick={() => {
                   setDeleteTarget(agent);
                   setDeleteConfirmOpen(true);
@@ -187,7 +229,11 @@ export function AgentCard({
                 <Archive className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Archive<br /><span className="text-muted-foreground">Remove agent</span></TooltipContent>
+            <TooltipContent>
+              Archive
+              <br />
+              <span className="text-muted-foreground">Remove agent</span>
+            </TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -199,16 +245,27 @@ export function AgentCard({
                 data-testid={`agent-expand-toggle-${agent.id}`}
                 onClick={() => {
                   // If collapsing while a child persona is connected, detach it
-                  if (isExpanded && connectedAgentId && childAgents.some((c) => c.id === connectedAgentId)) {
+                  if (
+                    isExpanded &&
+                    connectedAgentId &&
+                    childAgents.some((c) => c.id === connectedAgentId)
+                  ) {
                     detachTerminal();
                   }
                   toggleAgentDetails(agent.id);
                 }}
               >
-                <ChevronDown className={cn("h-3.5 w-3.5 transition-transform duration-200", isExpanded && "rotate-180")} />
+                <ChevronDown
+                  className={cn(
+                    "h-3.5 w-3.5 transition-transform duration-200",
+                    isExpanded && "rotate-180"
+                  )}
+                />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isExpanded ? "Hide details" : "Show details"}</TooltipContent>
+            <TooltipContent>
+              {isExpanded ? "Hide details" : "Show details"}
+            </TooltipContent>
           </Tooltip>
         </div>
 
@@ -216,10 +273,15 @@ export function AgentCard({
           <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-status-working">
             <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
             <span className="truncate font-medium">
-              {agent.setupPhase === "worktree" ? "Creating worktree…" :
-               agent.setupPhase === "env" ? "Copying environment…" :
-               agent.setupPhase === "deps" ? "Installing dependencies…" :
-               agent.setupPhase === "session" ? "Starting session…" : "Setting up…"}
+              {agent.setupPhase === "worktree"
+                ? "Creating worktree…"
+                : agent.setupPhase === "env"
+                  ? "Copying environment…"
+                  : agent.setupPhase === "deps"
+                    ? "Installing dependencies…"
+                    : agent.setupPhase === "session"
+                      ? "Starting session…"
+                      : "Setting up…"}
             </span>
           </div>
         ) : null}
@@ -228,10 +290,15 @@ export function AgentCard({
           <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-orange-400">
             <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
             <span className="truncate font-medium">
-              {agent.archivePhase === "stopping" ? "Stopping agent…" :
-               agent.archivePhase === "worktree-check" ? "Checking worktree…" :
-               agent.archivePhase === "worktree-cleanup" ? "Removing worktree…" :
-               agent.archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
+              {agent.archivePhase === "stopping"
+                ? "Stopping agent…"
+                : agent.archivePhase === "worktree-check"
+                  ? "Checking worktree…"
+                  : agent.archivePhase === "worktree-cleanup"
+                    ? "Removing worktree…"
+                    : agent.archivePhase === "finalizing"
+                      ? "Finalizing…"
+                      : "Archiving…"}
             </span>
           </div>
         ) : null}
@@ -240,19 +307,47 @@ export function AgentCard({
           isExpanded ? (
             <div className="mt-1 text-xs text-muted-foreground">
               <div className="flex items-baseline">
-                <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
-                <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-                <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
+                <span
+                  className={cn(
+                    "shrink-0 font-medium",
+                    latestEventColor(agent.latestEvent.type)
+                  )}
+                >
+                  {latestEventLabel(agent.latestEvent.type)}
+                </span>
+                <span className="mx-1.5 shrink-0 text-muted-foreground/70">
+                  •
+                </span>
+                <span className="shrink-0">
+                  {formatRelativeTime(agent.latestEvent.updatedAt)}
+                </span>
               </div>
-              <div className="mt-0.5 leading-relaxed text-muted-foreground">{agent.latestEvent.message}</div>
+              <div className="mt-0.5 leading-relaxed text-muted-foreground">
+                {agent.latestEvent.message}
+              </div>
             </div>
           ) : (
             <div className="mt-1 flex min-w-0 items-baseline text-xs text-muted-foreground">
-              <span className={cn("shrink-0 font-medium", latestEventColor(agent.latestEvent.type))}>{latestEventLabel(agent.latestEvent.type)}</span>
-              <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-              <span className="shrink-0">{formatRelativeTime(agent.latestEvent.updatedAt)}</span>
-              <span className="mx-1.5 shrink-0 text-muted-foreground/70">•</span>
-              <span className="min-w-0 truncate">{agent.latestEvent.message}</span>
+              <span
+                className={cn(
+                  "shrink-0 font-medium",
+                  latestEventColor(agent.latestEvent.type)
+                )}
+              >
+                {latestEventLabel(agent.latestEvent.type)}
+              </span>
+              <span className="mx-1.5 shrink-0 text-muted-foreground/70">
+                •
+              </span>
+              <span className="shrink-0">
+                {formatRelativeTime(agent.latestEvent.updatedAt)}
+              </span>
+              <span className="mx-1.5 shrink-0 text-muted-foreground/70">
+                •
+              </span>
+              <span className="min-w-0 truncate">
+                {agent.latestEvent.message}
+              </span>
             </div>
           )
         ) : null}
@@ -270,40 +365,86 @@ export function AgentCard({
                 <div className="grid gap-2 text-xs text-muted-foreground">
                   {agent.gitContext?.isWorktree ? (
                     <>
-                      <AgentMeta label="Repo" value={agent.gitContext.repoRoot.split("/").pop() ?? agent.gitContext.repoRoot} />
+                      <AgentMeta
+                        label="Repo"
+                        value={
+                          agent.gitContext.repoRoot.split("/").pop() ??
+                          agent.gitContext.repoRoot
+                        }
+                      />
                       <div className="grid gap-1">
-                        <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Branch</div>
+                        <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">
+                          Branch
+                        </div>
                         {agent.gitContext.branch ? (
                           <div className="grid gap-0">
                             <div className="text-muted-foreground">
-                              <FrontTruncatedValue value={sidebarBaseBranch} mono className="text-muted-foreground" tooltipClassName="" tooltipValue={`Base branch: ${sidebarBaseBranch}`} />
+                              <FrontTruncatedValue
+                                value={sidebarBaseBranch}
+                                mono
+                                className="text-muted-foreground"
+                                tooltipClassName=""
+                                tooltipValue={`Base branch: ${sidebarBaseBranch}`}
+                              />
                             </div>
                             <div className="flex items-center gap-1 pl-1">
-                              <span className="shrink-0 font-mono text-[11px] text-muted-foreground/50">└</span>
-                              <FrontTruncatedValue value={agent.gitContext.branch} mono tooltipValue={`Working branch: ${agent.gitContext.branch}`} />
+                              <span className="shrink-0 font-mono text-[11px] text-muted-foreground/50">
+                                └
+                              </span>
+                              <FrontTruncatedValue
+                                value={agent.gitContext.branch}
+                                mono
+                                tooltipValue={`Working branch: ${agent.gitContext.branch}`}
+                              />
                             </div>
                           </div>
                         ) : (
-                          <FrontTruncatedValue value={agent.gitContext.branch} mono />
+                          <FrontTruncatedValue
+                            value={agent.gitContext.branch}
+                            mono
+                          />
                         )}
                       </div>
-                      <AgentMeta label="Worktree" value={agent.cwd} mono truncateStart />
+                      <AgentMeta
+                        label="Worktree"
+                        value={agent.cwd}
+                        mono
+                        truncateStart
+                      />
                     </>
                   ) : (
                     <>
-                      <AgentMeta label="Working dir" value={agent.cwd} mono truncateStart />
+                      <AgentMeta
+                        label="Working dir"
+                        value={agent.cwd}
+                        mono
+                        truncateStart
+                      />
                       {agent.gitContext ? (
-                        <AgentMeta label="Branch" value={agent.gitContext.branch} mono truncateStart />
+                        <AgentMeta
+                          label="Branch"
+                          value={agent.gitContext.branch}
+                          mono
+                          truncateStart
+                        />
                       ) : (
                         <div className="grid gap-1">
-                          <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Git</div>
-                          <div className="text-foreground text-xs">Not a git repository</div>
+                          <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">
+                            Git
+                          </div>
+                          <div className="text-foreground text-xs">
+                            Not a git repository
+                          </div>
                         </div>
                       )}
                     </>
                   )}
                   <div className="flex items-center justify-between">
-                    <div className="text-foreground">{AGENT_TYPE_LABELS[agent.type as AgentType] ?? agent.type ?? "Codex"}</div>
+                    <div className="text-foreground">
+                      {AGENT_TYPE_LABELS[agent.type as AgentType] ??
+                        agent.type ??
+                        "Codex"}
+                    </div>
                     <div
                       className={cn(
                         "inline-flex items-center gap-1 px-1.5 py-0.5 text-foreground text-[11px]",
@@ -311,18 +452,28 @@ export function AgentCard({
                           "border border-status-waiting/45 bg-status-waiting/15 text-status-waiting"
                       )}
                     >
-                      {fullAccessEnabled ? <AlertTriangle className="h-3 w-3" /> : null}
-                      <span>{fullAccessEnabled ? "Full access" : "Sandboxed"}</span>
+                      {fullAccessEnabled ? (
+                        <AlertTriangle className="h-3 w-3" />
+                      ) : null}
+                      <span>
+                        {fullAccessEnabled ? "Full access" : "Sandboxed"}
+                      </span>
                     </div>
                   </div>
-                  {agent.lastError ? <AgentMeta label="Last error" value={agent.lastError} /> : null}
+                  {agent.lastError ? (
+                    <AgentMeta label="Last error" value={agent.lastError} />
+                  ) : null}
                   {agent.persona ? (
                     <div className="flex items-center gap-1.5">
-                      <span className="uppercase tracking-wide text-[10px] text-muted-foreground/80">Persona</span>
+                      <span className="uppercase tracking-wide text-[10px] text-muted-foreground/80">
+                        Persona
+                      </span>
                       <Badge variant="running">{agent.persona}</Badge>
                       {agent.parentAgentId ? (
                         <span className="text-[10px] text-muted-foreground">
-                          from {agents.find((a) => a.id === agent.parentAgentId)?.name ?? agent.parentAgentId.slice(-6)}
+                          from{" "}
+                          {agents.find((a) => a.id === agent.parentAgentId)
+                            ?.name ?? agent.parentAgentId.slice(-6)}
                         </span>
                       ) : null}
                     </div>
@@ -346,7 +497,12 @@ export function AgentCard({
                     onRequestClose={onRequestClose}
                     closeOnSessionAction={closeOnSessionAction}
                     onOpenDetail={onOpenFeedbackDetail}
-                    activeDetailItemId={feedbackDetailState?.parentAgentId === agent.id && "itemId" in feedbackDetailState ? feedbackDetailState.itemId : null}
+                    activeDetailItemId={
+                      feedbackDetailState?.parentAgentId === agent.id &&
+                      "itemId" in feedbackDetailState
+                        ? feedbackDetailState.itemId
+                        : null
+                    }
                     childAgents={childAgents}
                     selectedAgentId={selectedAgentId}
                     agentVisualState={getVisualState}

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -1,5 +1,20 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, CheckCircle2, ChevronDown, ChevronRight, ChevronUp, Search, X } from "lucide-react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Search,
+  X,
+} from "lucide-react";
 import { Bar, BarChart, XAxis, YAxis } from "recharts";
 
 import { Input } from "@/components/ui/input";
@@ -19,7 +34,12 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Markdown } from "@/components/ui/markdown";
 import { cn } from "@/lib/utils";
-import { formatDuration, formatTokenCount, formatRelativeTime, shortProjectName } from "@/lib/format";
+import {
+  formatDuration,
+  formatTokenCount,
+  formatRelativeTime,
+  shortProjectName,
+} from "@/lib/format";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { StatCard } from "@/components/app/stat-card";
 import { MediaLightbox, stripTimestamp } from "@/components/app/media-lightbox";
@@ -42,13 +62,15 @@ import {
 
 function formatTimestamp(iso: string): string {
   const d = new Date(iso);
-  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 function shortModelName(model: string): string {
-  return model
-    .replace(/-\d{8}$/, "")
-    .replace("claude-", "");
+  return model.replace(/-\d{8}$/, "").replace("claude-", "");
 }
 
 const EVENT_TYPE_COLORS: Record<string, string> = {
@@ -94,7 +116,15 @@ function AgentHistoryList({
   }, [search]);
 
   const filters: HistoryFilters = useMemo(
-    () => ({ search: debouncedSearch, type, project, range, sort, order, offset: 0 }),
+    () => ({
+      search: debouncedSearch,
+      type,
+      project,
+      range,
+      sort,
+      order,
+      offset: 0,
+    }),
     [debouncedSearch, type, project, range, sort, order]
   );
 
@@ -125,7 +155,8 @@ function AgentHistoryList({
     [sort]
   );
 
-  const hasActiveFilters = debouncedSearch || type || project || range !== "all";
+  const hasActiveFilters =
+    debouncedSearch || type || project || range !== "all";
 
   return (
     <div className="mx-auto flex h-full max-w-5xl flex-col px-3 sm:px-5 md:px-8">
@@ -150,7 +181,10 @@ function AgentHistoryList({
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <Select value={type || "__all__"} onValueChange={(v) => setType(v === "__all__" ? "" : v)}>
+          <Select
+            value={type || "__all__"}
+            onValueChange={(v) => setType(v === "__all__" ? "" : v)}
+          >
             <SelectTrigger className="h-7 w-[100px] text-[11px]">
               <SelectValue placeholder="All types" />
             </SelectTrigger>
@@ -163,7 +197,10 @@ function AgentHistoryList({
           </Select>
 
           {projects && projects.length > 0 && (
-            <Select value={project || "__all__"} onValueChange={(v) => setProject(v === "__all__" ? "" : v)}>
+            <Select
+              value={project || "__all__"}
+              onValueChange={(v) => setProject(v === "__all__" ? "" : v)}
+            >
               <SelectTrigger className="h-7 max-w-[180px] text-[11px]">
                 <SelectValue placeholder="All projects" />
               </SelectTrigger>
@@ -178,7 +215,10 @@ function AgentHistoryList({
             </Select>
           )}
 
-          <Select value={range} onValueChange={(v) => onRangeChange(v as ActivityRange)}>
+          <Select
+            value={range}
+            onValueChange={(v) => onRangeChange(v as ActivityRange)}
+          >
             <SelectTrigger className="h-7 w-[120px] text-[11px]">
               <SelectValue />
             </SelectTrigger>
@@ -222,16 +262,30 @@ function AgentHistoryList({
                 className="cursor-pointer px-3 py-2 font-medium sm:px-5"
                 onClick={() => toggleSort("name")}
               >
-                Name {sort === "name" && (order === "desc" ? <ChevronDown className="ml-0.5 inline h-3 w-3" /> : <ChevronUp className="ml-0.5 inline h-3 w-3" />)}
+                Name{" "}
+                {sort === "name" &&
+                  (order === "desc" ? (
+                    <ChevronDown className="ml-0.5 inline h-3 w-3" />
+                  ) : (
+                    <ChevronUp className="ml-0.5 inline h-3 w-3" />
+                  ))}
               </th>
-              <th className="hidden px-2 py-2 font-medium sm:table-cell">Project</th>
+              <th className="hidden px-2 py-2 font-medium sm:table-cell">
+                Project
+              </th>
               <th className="px-2 py-2 font-medium">Duration</th>
               <th className="px-2 py-2 font-medium">Tokens</th>
               <th
                 className="cursor-pointer px-2 py-2 pr-3 font-medium sm:pr-5"
                 onClick={() => toggleSort("created_at")}
               >
-                Created {sort === "created_at" && (order === "desc" ? <ChevronDown className="ml-0.5 inline h-3 w-3" /> : <ChevronUp className="ml-0.5 inline h-3 w-3" />)}
+                Created{" "}
+                {sort === "created_at" &&
+                  (order === "desc" ? (
+                    <ChevronDown className="ml-0.5 inline h-3 w-3" />
+                  ) : (
+                    <ChevronUp className="ml-0.5 inline h-3 w-3" />
+                  ))}
               </th>
             </tr>
           </thead>
@@ -261,9 +315,11 @@ function AgentHistoryList({
                             onClick={(e) => toggleExpanded(agent.id, e)}
                             className="flex-shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
                           >
-                            {isExpanded
-                              ? <ChevronDown className="h-3.5 w-3.5" />
-                              : <ChevronRight className="h-3.5 w-3.5" />}
+                            {isExpanded ? (
+                              <ChevronDown className="h-3.5 w-3.5" />
+                            ) : (
+                              <ChevronRight className="h-3.5 w-3.5" />
+                            )}
                           </button>
                         ) : (
                           <span className="w-[18px] flex-shrink-0" />
@@ -280,8 +336,13 @@ function AgentHistoryList({
                       </div>
                     </td>
                     <td className="hidden px-2 py-2.5 text-muted-foreground sm:table-cell">
-                      <span className="truncate" title={agent.gitContext?.repoRoot ?? agent.cwd}>
-                        {shortProjectName(agent.gitContext?.repoRoot ?? agent.cwd)}
+                      <span
+                        className="truncate"
+                        title={agent.gitContext?.repoRoot ?? agent.cwd}
+                      >
+                        {shortProjectName(
+                          agent.gitContext?.repoRoot ?? agent.cwd
+                        )}
                       </span>
                     </td>
                     <td className="px-2 py-2.5 text-muted-foreground">
@@ -290,43 +351,54 @@ function AgentHistoryList({
                     <td className="px-2 py-2.5 text-muted-foreground">
                       {hasChildren ? (
                         <div>
-                          <span>{formatTokenCount(agent.groupTotalTokens)}</span>
+                          <span>
+                            {formatTokenCount(agent.groupTotalTokens)}
+                          </span>
                           <span className="ml-1 text-[10px] text-muted-foreground/60">
                             ({formatTokenCount(agent.totalTokens)})
                           </span>
                         </div>
+                      ) : agent.totalTokens > 0 ? (
+                        formatTokenCount(agent.totalTokens)
                       ) : (
-                        agent.totalTokens > 0 ? formatTokenCount(agent.totalTokens) : "—"
+                        "—"
                       )}
                     </td>
                     <td className="px-2 py-2.5 pr-3 text-muted-foreground sm:pr-5">
                       {formatRelativeTime(agent.createdAt)}
                     </td>
                   </tr>
-                  {hasChildren && isExpanded && agent.children.map((child) => (
-                    <tr
-                      key={child.id}
-                      className="cursor-pointer border-b border-border/30 bg-muted/10 transition-colors hover:bg-muted/30"
-                      onClick={() => onSelect(child.id)}
-                    >
-                      <td colSpan={3} className="py-2 pl-10 pr-3 sm:pl-12 sm:pr-5">
-                        <div className="flex items-center gap-2">
-                          <Badge className="h-4 px-1.5 text-[10px] font-normal">
-                            {child.persona ?? "review"}
-                          </Badge>
-                          <span className="truncate text-muted-foreground">
-                            {child.name}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {child.totalTokens > 0 ? formatTokenCount(child.totalTokens) : "—"}
-                      </td>
-                      <td className="px-2 py-2 pr-3 text-muted-foreground sm:pr-5">
-                        {formatRelativeTime(child.createdAt)}
-                      </td>
-                    </tr>
-                  ))}
+                  {hasChildren &&
+                    isExpanded &&
+                    agent.children.map((child) => (
+                      <tr
+                        key={child.id}
+                        className="cursor-pointer border-b border-border/30 bg-muted/10 transition-colors hover:bg-muted/30"
+                        onClick={() => onSelect(child.id)}
+                      >
+                        <td
+                          colSpan={3}
+                          className="py-2 pl-10 pr-3 sm:pl-12 sm:pr-5"
+                        >
+                          <div className="flex items-center gap-2">
+                            <Badge className="h-4 px-1.5 text-[10px] font-normal">
+                              {child.persona ?? "review"}
+                            </Badge>
+                            <span className="truncate text-muted-foreground">
+                              {child.name}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-2 py-2 text-muted-foreground">
+                          {child.totalTokens > 0
+                            ? formatTokenCount(child.totalTokens)
+                            : "—"}
+                        </td>
+                        <td className="px-2 py-2 pr-3 text-muted-foreground sm:pr-5">
+                          {formatRelativeTime(child.createdAt)}
+                        </td>
+                      </tr>
+                    ))}
                 </Fragment>
               );
             })}
@@ -338,9 +410,7 @@ function AgentHistoryList({
                   className="px-5 py-12 text-center text-sm text-muted-foreground"
                 >
                   No agents found.{" "}
-                  {hasActiveFilters && (
-                    <span>Try adjusting your filters.</span>
-                  )}
+                  {hasActiveFilters && <span>Try adjusting your filters.</span>}
                 </td>
               </tr>
             )}
@@ -350,7 +420,8 @@ function AgentHistoryList({
         {data && data.agents.length < data.total && (
           <div className="py-3 text-center">
             <button className="text-xs text-muted-foreground hover:text-foreground">
-              Showing {data.agents.length} of {data.total} — load more coming soon
+              Showing {data.agents.length} of {data.total} — load more coming
+              soon
             </button>
           </div>
         )}
@@ -392,9 +463,19 @@ function DurationBar({ durations }: { durations: Record<string, number> }) {
             />
           }
         />
-        <Bar dataKey="working" stackId="a" fill="var(--color-working)" radius={[4, 0, 0, 4]} />
+        <Bar
+          dataKey="working"
+          stackId="a"
+          fill="var(--color-working)"
+          radius={[4, 0, 0, 4]}
+        />
         <Bar dataKey="blocked" stackId="a" fill="var(--color-blocked)" />
-        <Bar dataKey="waiting_user" stackId="a" fill="var(--color-waiting_user)" radius={[0, 4, 4, 0]} />
+        <Bar
+          dataKey="waiting_user"
+          stackId="a"
+          fill="var(--color-waiting_user)"
+          radius={[0, 4, 4, 0]}
+        />
       </BarChart>
     </ChartContainer>
   );
@@ -403,7 +484,9 @@ function DurationBar({ durations }: { durations: Record<string, number> }) {
 function EventTimeline({ events }: { events: HistoryEvent[] }) {
   const [expanded, setExpanded] = useState(false);
   const showAll = expanded || events.length <= 10;
-  const visible = showAll ? events : [...events.slice(0, 5), ...events.slice(-5)];
+  const visible = showAll
+    ? events
+    : [...events.slice(0, 5), ...events.slice(-5)];
   const hiddenCount = events.length - 10;
 
   return (
@@ -427,7 +510,8 @@ function EventTimeline({ events }: { events: HistoryEvent[] }) {
                   <div
                     className={cn(
                       "h-2 w-2 shrink-0 rounded-full",
-                      EVENT_TYPE_COLORS[event.event_type] ?? "bg-muted-foreground"
+                      EVENT_TYPE_COLORS[event.event_type] ??
+                        "bg-muted-foreground"
                     )}
                   />
                   {i < visible.length - 1 && (
@@ -442,17 +526,24 @@ function EventTimeline({ events }: { events: HistoryEvent[] }) {
                     <span
                       className={cn(
                         "inline-block rounded px-1 py-0.5 text-[10px] font-medium",
-                        event.event_type === "working" && "bg-status-working/15 text-status-working",
-                        event.event_type === "blocked" && "bg-status-blocked/15 text-status-blocked",
-                        event.event_type === "waiting_user" && "bg-status-waiting/15 text-status-waiting",
-                        event.event_type === "done" && "bg-status-done/15 text-status-done",
-                        event.event_type === "idle" && "bg-muted text-muted-foreground"
+                        event.event_type === "working" &&
+                          "bg-status-working/15 text-status-working",
+                        event.event_type === "blocked" &&
+                          "bg-status-blocked/15 text-status-blocked",
+                        event.event_type === "waiting_user" &&
+                          "bg-status-waiting/15 text-status-waiting",
+                        event.event_type === "done" &&
+                          "bg-status-done/15 text-status-done",
+                        event.event_type === "idle" &&
+                          "bg-muted text-muted-foreground"
                       )}
                     >
                       {EVENT_TYPE_LABELS[event.event_type] ?? event.event_type}
                     </span>
                   </div>
-                  <p className="mt-0.5 text-xs text-foreground">{event.message}</p>
+                  <p className="mt-0.5 text-xs text-foreground">
+                    {event.message}
+                  </p>
                 </div>
               </div>
             </Fragment>
@@ -473,7 +564,10 @@ const SEVERITY_DOT: Record<string, string> = {
   info: "bg-muted-foreground",
 };
 
-const SEVERITY_LABELS: Record<string, { label: string; variant: "error" | "default" }> = {
+const SEVERITY_LABELS: Record<
+  string,
+  { label: string; variant: "error" | "default" }
+> = {
   critical: { label: "Critical", variant: "error" },
   high: { label: "High", variant: "error" },
   medium: { label: "Medium", variant: "default" },
@@ -481,11 +575,12 @@ const SEVERITY_LABELS: Record<string, { label: string; variant: "error" | "defau
   info: { label: "Info", variant: "default" },
 };
 
-const FEEDBACK_STATUS_LABELS: Record<string, { label: string; color: string }> = {
-  fixed: { label: "Fixed", color: "text-green-500" },
-  ignored: { label: "Ignored", color: "text-muted-foreground/60" },
-  dismissed: { label: "Dismissed", color: "text-muted-foreground/60" },
-};
+const FEEDBACK_STATUS_LABELS: Record<string, { label: string; color: string }> =
+  {
+    fixed: { label: "Fixed", color: "text-green-500" },
+    ignored: { label: "Ignored", color: "text-muted-foreground/60" },
+    dismissed: { label: "Dismissed", color: "text-muted-foreground/60" },
+  };
 
 const PERSONA_COLORS = [
   "hsl(var(--chart-1))",
@@ -505,7 +600,10 @@ function FeedbackItemRow({
 }) {
   const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
   const statusLabel = FEEDBACK_STATUS_LABELS[item.status];
-  const isResolved = item.status === "fixed" || item.status === "ignored" || item.status === "dismissed";
+  const isResolved =
+    item.status === "fixed" ||
+    item.status === "ignored" ||
+    item.status === "dismissed";
   const severityInfo = SEVERITY_LABELS[item.severity] ?? SEVERITY_LABELS.info;
 
   return (
@@ -514,17 +612,26 @@ function FeedbackItemRow({
         className="flex w-full min-w-0 items-center gap-1.5 rounded px-1 py-1.5 text-left text-[11px] hover:bg-muted/40 transition-colors"
         onClick={onToggle}
       >
-        <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", isExpanded && "rotate-90")} />
+        <ChevronRight
+          className={cn(
+            "h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform",
+            isExpanded && "rotate-90"
+          )}
+        />
         <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
         <span className="shrink-0 font-mono text-muted-foreground truncate max-w-[100px] sm:max-w-[120px]">
-          {item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
+          {item.filePath
+            ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}`
+            : "—"}
         </span>
         <span className="min-w-0 flex-1 truncate text-foreground">
           {item.description}
         </span>
         {statusLabel ? (
           <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>
-            {item.status === "fixed" && <CheckCircle2 className="mr-0.5 inline h-2.5 w-2.5" />}
+            {item.status === "fixed" && (
+              <CheckCircle2 className="mr-0.5 inline h-2.5 w-2.5" />
+            )}
             {statusLabel.label}
           </span>
         ) : null}
@@ -536,23 +643,34 @@ function FeedbackItemRow({
             <Badge variant={severityInfo.variant}>{severityInfo.label}</Badge>
             {item.filePath ? (
               <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
-                {item.filePath}{item.lineNumber ? `:${item.lineNumber}` : ""}
+                {item.filePath}
+                {item.lineNumber ? `:${item.lineNumber}` : ""}
               </span>
             ) : null}
             {statusLabel ? (
-              <span className={cn("ml-auto text-[11px]", statusLabel.color)}>{statusLabel.label}</span>
+              <span className={cn("ml-auto text-[11px]", statusLabel.color)}>
+                {statusLabel.label}
+              </span>
             ) : null}
           </div>
 
           <div>
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Description</div>
-            <Markdown className="text-sm text-foreground">{item.description}</Markdown>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+              Description
+            </div>
+            <Markdown className="text-sm text-foreground">
+              {item.description}
+            </Markdown>
           </div>
 
           {item.suggestion ? (
             <div>
-              <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Suggestion</div>
-              <Markdown className="text-sm text-muted-foreground">{item.suggestion}</Markdown>
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                Suggestion
+              </div>
+              <Markdown className="text-sm text-muted-foreground">
+                {item.suggestion}
+              </Markdown>
             </div>
           ) : null}
         </div>
@@ -563,7 +681,9 @@ function FeedbackItemRow({
 
 function FeedbackTimeline({ feedback }: { feedback: HistoryFeedbackItem[] }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set()
+  );
 
   // Group by persona
   const groups = useMemo(() => {
@@ -604,15 +724,17 @@ function FeedbackTimeline({ feedback }: { feedback: HistoryFeedbackItem[] }) {
                 className="flex w-full items-center gap-1.5 mb-0.5 py-0.5 text-left hover:bg-muted/40 rounded transition-colors"
                 onClick={() => toggleGroup(persona)}
               >
-                <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isCollapsed && "rotate-90")} />
+                <ChevronRight
+                  className={cn(
+                    "h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform",
+                    !isCollapsed && "rotate-90"
+                  )}
+                />
                 <span
                   className="h-2 w-2 shrink-0 rounded-full"
                   style={{ backgroundColor: color }}
                 />
-                <span
-                  className="text-xs font-medium"
-                  style={{ color }}
-                >
+                <span className="text-xs font-medium" style={{ color }}>
                   {label}
                 </span>
                 <span className="text-[10px] text-muted-foreground/50">
@@ -627,7 +749,9 @@ function FeedbackTimeline({ feedback }: { feedback: HistoryFeedbackItem[] }) {
                     key={item.id}
                     item={item}
                     isExpanded={expandedId === item.id}
-                    onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                    onToggle={() =>
+                      setExpandedId(expandedId === item.id ? null : item.id)
+                    }
                   />
                 ))}
               </div>
@@ -670,7 +794,8 @@ function DetailTabs({
     [media, agentId]
   );
 
-  const lightboxItem = lightboxIndex !== null ? lightboxItems[lightboxIndex] ?? null : null;
+  const lightboxItem =
+    lightboxIndex !== null ? (lightboxItems[lightboxIndex] ?? null) : null;
 
   const tabs: Array<{ key: DetailTab; label: string; count: number }> = [
     { key: "events", label: "Events", count: events.length },
@@ -791,7 +916,10 @@ function AgentHistoryDetail({
   if (isLoading || !data) {
     return (
       <div className="space-y-4 p-5">
-        <button onClick={onBack} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
           <ArrowLeft className="h-3.5 w-3.5" /> Back
         </button>
         <div className="space-y-3">
@@ -824,7 +952,9 @@ function AgentHistoryDetail({
         </button>
         <div className="flex items-center gap-2">
           <AgentTypeIcon type={agent.type} />
-          <h2 className="text-base font-semibold text-foreground">{agent.name}</h2>
+          <h2 className="text-base font-semibold text-foreground">
+            {agent.name}
+          </h2>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           <span>
@@ -861,13 +991,17 @@ function AgentHistoryDetail({
           {agent.gitContext?.worktreePath && agent.gitContext.isWorktree && (
             <div className="flex items-center gap-2">
               <span className="w-16 shrink-0 text-[11px]">Worktree</span>
-              <span className="font-mono text-[11px]">{shortProjectName(agent.gitContext.worktreePath)}</span>
+              <span className="font-mono text-[11px]">
+                {shortProjectName(agent.gitContext.worktreePath)}
+              </span>
             </div>
           )}
           {agent.cwd !== agent.gitContext?.repoRoot && (
             <div className="flex items-center gap-2">
               <span className="w-16 shrink-0 text-[11px]">Directory</span>
-              <span className="font-mono text-[11px]">{shortProjectName(agent.cwd)}</span>
+              <span className="font-mono text-[11px]">
+                {shortProjectName(agent.cwd)}
+              </span>
             </div>
           )}
         </div>
@@ -876,9 +1010,18 @@ function AgentHistoryDetail({
       {/* Stats */}
       <div className="flex flex-wrap gap-2 sm:gap-3">
         <StatCard label="Total duration" value={formatDuration(durationMs)} />
-        <StatCard label="Working" value={formatDuration(stateDurations.working ?? 0)} />
-        <StatCard label="Blocked" value={formatDuration(stateDurations.blocked ?? 0)} />
-        <StatCard label="Waiting" value={formatDuration(stateDurations.waiting_user ?? 0)} />
+        <StatCard
+          label="Working"
+          value={formatDuration(stateDurations.working ?? 0)}
+        />
+        <StatCard
+          label="Blocked"
+          value={formatDuration(stateDurations.blocked ?? 0)}
+        />
+        <StatCard
+          label="Waiting"
+          value={formatDuration(stateDurations.waiting_user ?? 0)}
+        />
         {totalTokens > 0 && (
           <StatCard
             label="Tokens"
@@ -900,7 +1043,9 @@ function AgentHistoryDetail({
       {/* Duration bar */}
       {Object.values(stateDurations).some((v) => v > 0) && (
         <div>
-          <h3 className="mb-2 text-sm font-medium text-foreground">Duration breakdown</h3>
+          <h3 className="mb-2 text-sm font-medium text-foreground">
+            Duration breakdown
+          </h3>
           <DurationBar durations={stateDurations} />
           <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-muted-foreground">
             {["working", "blocked", "waiting_user"].map(
@@ -913,7 +1058,8 @@ function AgentHistoryDetail({
                         EVENT_TYPE_COLORS[key]
                       )}
                     />
-                    {EVENT_TYPE_LABELS[key]}: {formatDuration(stateDurations[key])}
+                    {EVENT_TYPE_LABELS[key]}:{" "}
+                    {formatDuration(stateDurations[key])}
                   </span>
                 )
             )}
@@ -922,7 +1068,12 @@ function AgentHistoryDetail({
       )}
 
       {/* Tabbed: Events / Media */}
-      <DetailTabs events={events} media={media} feedback={feedback} agentId={agentId} />
+      <DetailTabs
+        events={events}
+        media={media}
+        feedback={feedback}
+        agentId={agentId}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/app/agent-meta.tsx
+++ b/apps/web/src/components/app/agent-meta.tsx
@@ -1,5 +1,10 @@
 import { useRef, useState, useLayoutEffect } from "react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type AgentMetaProps = {
@@ -68,13 +73,23 @@ export function FrontTruncatedValue({
         <TooltipTrigger asChild>
           <div
             ref={containerRef}
-            className={cn("text-foreground whitespace-nowrap overflow-hidden", mono && "font-mono text-[11px]", className)}
+            className={cn(
+              "text-foreground whitespace-nowrap overflow-hidden",
+              mono && "font-mono text-[11px]",
+              className
+            )}
             title={tooltipValue ?? value}
           >
             {display}
           </div>
         </TooltipTrigger>
-        <TooltipContent side="right" className={cn("max-w-[360px] break-all text-xs font-mono", tooltipClassName)}>
+        <TooltipContent
+          side="right"
+          className={cn(
+            "max-w-[360px] break-all text-xs font-mono",
+            tooltipClassName
+          )}
+        >
           {tooltipValue ?? value}
         </TooltipContent>
       </Tooltip>
@@ -82,14 +97,29 @@ export function FrontTruncatedValue({
   );
 }
 
-export function AgentMeta({ label, value, mono = false, truncateStart = false }: AgentMetaProps): JSX.Element {
+export function AgentMeta({
+  label,
+  value,
+  mono = false,
+  truncateStart = false,
+}: AgentMetaProps): JSX.Element {
   return (
     <div className="grid gap-1">
-      <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">{label}</div>
+      <div className="uppercase tracking-wide text-[10px] text-muted-foreground/80">
+        {label}
+      </div>
       {truncateStart ? (
         <FrontTruncatedValue value={value} mono={mono} />
       ) : (
-        <div className={cn("text-foreground", mono && "font-mono text-[11px]", "break-all")}>{value}</div>
+        <div
+          className={cn(
+            "text-foreground",
+            mono && "font-mono text-[11px]",
+            "break-all"
+          )}
+        >
+          {value}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -1,13 +1,16 @@
-import {
-  ChevronDown,
-} from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
 import { AgentCard } from "@/components/app/agent-card";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type FeedbackDetailState } from "@/components/app/feedback-panel";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import React from "react";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
@@ -20,7 +23,9 @@ export type AgentListContentProps = {
   onOpenCreateDialog: (type?: AgentType) => void;
   enabledAgentTypes: AgentType[];
   lastUsedAgentType: AgentType | null;
-  setOverflowAgentId: (value: string | null | ((current: string | null) => string | null)) => void;
+  setOverflowAgentId: (
+    value: string | null | ((current: string | null) => string | null)
+  ) => void;
   setDeleteTarget: (agent: Agent | null) => void;
   setDeleteConfirmOpen: (open: boolean) => void;
   setStopTarget: (agent: Agent | null) => void;
@@ -28,7 +33,9 @@ export type AgentListContentProps = {
   agentVisualState: (agent: Agent) => AgentVisualState;
   borderForAgentState: (state: AgentVisualState) => string;
   toggleAgentDetails: (agentId: string) => void;
-  isFullAccessEnabled: (agent: Pick<Agent, "agentArgs" | "fullAccess">) => boolean;
+  isFullAccessEnabled: (
+    agent: Pick<Agent, "agentArgs" | "fullAccess">
+  ) => boolean;
   detachTerminal: () => void;
   attachToAgent: (agent: Agent) => Promise<void>;
   startAgent: (agent: Agent) => Promise<void>;
@@ -67,87 +74,105 @@ export function AgentListContent({
   onRequestClose,
   closeOnSessionAction = false,
 }: AgentListContentProps): JSX.Element {
-  const defaultCreateType: AgentType = lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
-    ? lastUsedAgentType
-    : enabledAgentTypes[0] ?? "codex";
+  const defaultCreateType: AgentType =
+    lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
+      ? lastUsedAgentType
+      : (enabledAgentTypes[0] ?? "codex");
 
   return (
     <div data-testid="agent-sidebar" className="flex h-full min-h-0 flex-col">
       <div className="mt-2 flex h-14 items-center border-b border-border px-3">
-        <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Agents</div>
+        <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Agents
+        </div>
         <div className="ml-auto flex items-center">
-            <Button
-              size="sm"
-              variant="default"
-              className="rounded-r-none border-r-0 bg-muted/35 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
-              onClick={() => onOpenCreateDialog(defaultCreateType)}
-              data-testid="create-agent-button"
-            >
-              <AgentTypeIcon type={defaultCreateType} className="mr-1 h-4 w-4 border-none bg-transparent p-0 text-foreground/80" />
-              Create
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="default"
-                  className="rounded-l-none border-l border-border/80 bg-muted/35 px-1 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
-                  data-testid="create-agent-type-dropdown"
+          <Button
+            size="sm"
+            variant="default"
+            className="rounded-r-none border-r-0 bg-muted/35 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
+            onClick={() => onOpenCreateDialog(defaultCreateType)}
+            data-testid="create-agent-button"
+          >
+            <AgentTypeIcon
+              type={defaultCreateType}
+              className="mr-1 h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
+            />
+            Create
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="sm"
+                variant="default"
+                className="rounded-l-none border-l border-border/80 bg-muted/35 px-1 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
+                data-testid="create-agent-type-dropdown"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {enabledAgentTypes.map((agentType) => (
+                <DropdownMenuItem
+                  key={agentType}
+                  className="text-foreground"
+                  onClick={() => onOpenCreateDialog(agentType)}
+                  data-testid={`create-agent-type-${agentType}`}
                 >
-                  <ChevronDown className="h-3.5 w-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {enabledAgentTypes.map((agentType) => (
-                  <DropdownMenuItem
-                    key={agentType}
-                    className="text-foreground"
-                    onClick={() => onOpenCreateDialog(agentType)}
-                    data-testid={`create-agent-type-${agentType}`}
-                  >
-                    <AgentTypeIcon type={agentType} className="mr-2 h-4 w-4" />
-                    {AGENT_TYPE_LABELS[agentType]}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  <AgentTypeIcon type={agentType} className="mr-2 h-4 w-4" />
+                  {AGENT_TYPE_LABELS[agentType]}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
-      <div data-testid="agent-sidebar-scroll" className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        data-testid="agent-sidebar-scroll"
+        className="min-h-0 flex-1 overflow-y-auto"
+      >
         <TooltipProvider delayDuration={120}>
           {agents.length === 0 ? (
-            <div data-testid="no-agents-message" className="p-4 text-sm text-muted-foreground">No agents yet.</div>
+            <div
+              data-testid="no-agents-message"
+              className="p-4 text-sm text-muted-foreground"
+            >
+              No agents yet.
+            </div>
           ) : (
             <React.Fragment>
-            {agents.filter((a) => !a.parentAgentId).map((agent) => (
-              <AgentCard
-                key={agent.id}
-                agent={agent}
-                agents={agents}
-                childAgents={agents.filter((a) => a.parentAgentId === agent.id)}
-                selectedAgentId={selectedAgentId}
-                expandedAgentId={expandedAgentId}
-                agentVisualState={agentVisualState}
-                borderForAgentState={borderForAgentState}
-                toggleAgentDetails={toggleAgentDetails}
-                isFullAccessEnabled={isFullAccessEnabled}
-                detachTerminal={detachTerminal}
-                attachToAgent={attachToAgent}
-                startAgent={startAgent}
-                setDeleteTarget={setDeleteTarget}
-                setDeleteConfirmOpen={setDeleteConfirmOpen}
-                setStopTarget={setStopTarget}
-                setStopConfirmOpen={setStopConfirmOpen}
-                sendTerminalInput={sendTerminalInput}
-                enabledAgentTypes={enabledAgentTypes}
-                connectedAgentId={connectedAgentId}
-                onOpenFeedbackDetail={onOpenFeedbackDetail}
-                feedbackDetailState={feedbackDetailState}
-                onRequestClose={onRequestClose}
-                closeOnSessionAction={closeOnSessionAction}
-              />
-            ))}
+              {agents
+                .filter((a) => !a.parentAgentId)
+                .map((agent) => (
+                  <AgentCard
+                    key={agent.id}
+                    agent={agent}
+                    agents={agents}
+                    childAgents={agents.filter(
+                      (a) => a.parentAgentId === agent.id
+                    )}
+                    selectedAgentId={selectedAgentId}
+                    expandedAgentId={expandedAgentId}
+                    agentVisualState={agentVisualState}
+                    borderForAgentState={borderForAgentState}
+                    toggleAgentDetails={toggleAgentDetails}
+                    isFullAccessEnabled={isFullAccessEnabled}
+                    detachTerminal={detachTerminal}
+                    attachToAgent={attachToAgent}
+                    startAgent={startAgent}
+                    setDeleteTarget={setDeleteTarget}
+                    setDeleteConfirmOpen={setDeleteConfirmOpen}
+                    setStopTarget={setStopTarget}
+                    setStopConfirmOpen={setStopConfirmOpen}
+                    sendTerminalInput={sendTerminalInput}
+                    enabledAgentTypes={enabledAgentTypes}
+                    connectedAgentId={connectedAgentId}
+                    onOpenFeedbackDetail={onOpenFeedbackDetail}
+                    feedbackDetailState={feedbackDetailState}
+                    onRequestClose={onRequestClose}
+                    closeOnSessionAction={closeOnSessionAction}
+                  />
+                ))}
             </React.Fragment>
           )}
         </TooltipProvider>

--- a/apps/web/src/components/app/agent-type-icon.tsx
+++ b/apps/web/src/components/app/agent-type-icon.tsx
@@ -13,7 +13,8 @@ type AgentTypeIconProps = {
 const eventColorClass: Record<AgentEventType, string> = {
   working: "text-status-working border-status-working/50 bg-status-working/15",
   blocked: "text-status-blocked border-status-blocked/50 bg-status-blocked/15",
-  waiting_user: "text-status-waiting border-status-waiting/50 bg-status-waiting/15",
+  waiting_user:
+    "text-status-waiting border-status-waiting/50 bg-status-waiting/15",
   done: "text-status-done border-status-done/50 bg-status-done/15",
   idle: "",
 };
@@ -21,7 +22,9 @@ const eventColorClass: Record<AgentEventType, string> = {
 const CODEX_LOGO_PATH =
   "M60.8734,57.2556v-14.9432c0-1.2586.4722-2.2029,1.5728-2.8314l30.0443-17.3023c4.0899-2.3593,8.9662-3.4599,13.9988-3.4599,18.8759,0,30.8307,14.6289,30.8307,30.2006,0,1.1007,0,2.3593-.158,3.6178l-31.1446-18.2467c-1.8872-1.1006-3.7754-1.1006-5.6629,0l-39.4812,22.9651ZM131.0276,115.4561v-35.7074c0-2.2028-.9446-3.7756-2.8318-4.8763l-39.481-22.9651,12.8982-7.3934c1.1007-.6285,2.0453-.6285,3.1458,0l30.0441,17.3024c8.6523,5.0341,14.4708,15.7296,14.4708,26.1107,0,11.9539-7.0769,22.965-18.2461,27.527v.0021ZM51.593,83.9964l-12.8982-7.5497c-1.1007-.6285-1.5728-1.5728-1.5728-2.8314v-34.6048c0-16.8303,12.8982-29.5722,30.3585-29.5722,6.607,0,12.7403,2.2029,17.9324,6.1349l-30.987,17.9324c-1.8871,1.1007-2.8314,2.6735-2.8314,4.8764v45.6159l-.0014-.0015ZM79.3562,100.0403l-18.4829-10.3811v-22.0209l18.4829-10.3811,18.4812,10.3811v22.0209l-18.4812,10.3811ZM91.2319,147.8591c-6.607,0-12.7403-2.2031-17.9324-6.1344l30.9866-17.9333c1.8872-1.1005,2.8318-2.6728,2.8318-4.8759v-45.616l13.0564,7.5498c1.1005.6285,1.5723,1.5728,1.5723,2.8314v34.6051c0,16.8297-13.0564,29.5723-30.5147,29.5723v.001ZM53.9522,112.7822l-30.0443-17.3024c-8.652-5.0343-14.471-15.7296-14.471-26.1107,0-12.1119,7.2356-22.9652,18.403-27.5272v35.8634c0,2.2028.9443,3.7756,2.8314,4.8763l39.3248,22.8068-12.8982,7.3938c-1.1007.6287-2.045.6287-3.1456,0ZM52.2229,138.5791c-17.7745,0-30.8306-13.3713-30.8306-29.8871,0-1.2585.1578-2.5169.3143-3.7754l30.987,17.9323c1.8871,1.1005,3.7757,1.1005,5.6628,0l39.4811-22.807v14.9435c0,1.2585-.4721,2.2021-1.5728,2.8308l-30.0443,17.3025c-4.0898,2.359-8.9662,3.4605-13.9989,3.4605h.0014ZM91.2319,157.296c19.0327,0,34.9188-13.5272,38.5383-31.4594,17.6164-4.562,28.9425-21.0779,28.9425-37.908,0-11.0112-4.719-21.7066-13.2133-29.4143.7867-3.3035,1.2595-6.607,1.2595-9.909,0-22.4929-18.2471-39.3247-39.3251-39.3247-4.2461,0-8.3363.6285-12.4262,2.045-7.0792-6.9213-16.8318-11.3254-27.5271-11.3254-19.0331,0-34.9191,13.5268-38.5384,31.4591C11.3255,36.0212,0,52.5373,0,69.3675c0,11.0112,4.7184,21.7065,13.2125,29.4142-.7865,3.3035-1.2586,6.6067-1.2586,9.9092,0,22.4923,18.2466,39.3241,39.3248,39.3241,4.2462,0,8.3362-.6277,12.426-2.0441,7.0776,6.921,16.8302,11.3251,27.5271,11.3251Z";
 
-function normalizeAgentType(type?: string | null): "codex" | "claude" | "opencode" | "unknown" {
+function normalizeAgentType(
+  type?: string | null
+): "codex" | "claude" | "opencode" | "unknown" {
   if (type === "claude") {
     return "claude";
   }
@@ -34,10 +37,18 @@ function normalizeAgentType(type?: string | null): "codex" | "claude" | "opencod
   return "unknown";
 }
 
-export function AgentTypeIcon({ type, className, eventType }: AgentTypeIconProps): JSX.Element {
+export function AgentTypeIcon({
+  type,
+  className,
+  eventType,
+}: AgentTypeIconProps): JSX.Element {
   const normalizedType = normalizeAgentType(type);
   const label =
-    normalizedType === "claude" ? "Claude" : normalizedType === "opencode" ? "OpenCode" : "Codex";
+    normalizedType === "claude"
+      ? "Claude"
+      : normalizedType === "opencode"
+        ? "OpenCode"
+        : "Codex";
   const statusClass = eventType ? eventColorClass[eventType] : "";
   const baseClass = statusClass
     ? "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors duration-300"
@@ -60,8 +71,10 @@ export function AgentTypeIcon({ type, className, eventType }: AgentTypeIconProps
     );
   }
 
-  const logoPath = normalizedType === "claude" ? siClaude.path : CODEX_LOGO_PATH;
-  const viewBox = normalizedType === "claude" ? "0 0 24 24" : "0 0 158.7128 157.296";
+  const logoPath =
+    normalizedType === "claude" ? siClaude.path : CODEX_LOGO_PATH;
+  const viewBox =
+    normalizedType === "claude" ? "0 0 24 24" : "0 0 158.7128 157.296";
 
   return (
     <span

--- a/apps/web/src/components/app/agent-type-settings.tsx
+++ b/apps/web/src/components/app/agent-type-settings.tsx
@@ -3,7 +3,11 @@ import { useCallback, useEffect, useState } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { AGENT_TYPES, AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import {
+  AGENT_TYPES,
+  AGENT_TYPE_LABELS,
+  type AgentType,
+} from "@/lib/agent-types";
 
 type AgentTypeSettingsResponse = {
   enabledAgentTypes: AgentType[];
@@ -38,7 +42,11 @@ export function AgentTypeSettings({
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Failed to load agent type settings.");
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load agent type settings."
+        );
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -62,17 +70,24 @@ export function AgentTypeSettings({
       onChange(next);
 
       try {
-        const data = await api<AgentTypeSettingsResponse>("/api/v1/app/settings/agent-types", {
-          method: "POST",
-          body: JSON.stringify({ enabledAgentTypes: next }),
-        });
+        const data = await api<AgentTypeSettingsResponse>(
+          "/api/v1/app/settings/agent-types",
+          {
+            method: "POST",
+            body: JSON.stringify({ enabledAgentTypes: next }),
+          }
+        );
         setAgentTypes(data.enabledAgentTypes);
         onChange(data.enabledAgentTypes);
       } catch (err) {
         // Revert on failure
         setAgentTypes(agentTypes);
         onChange(agentTypes);
-        setError(err instanceof Error ? err.message : "Failed to save agent type settings.");
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to save agent type settings."
+        );
       }
     },
     [agentTypes, onChange]
@@ -89,7 +104,8 @@ export function AgentTypeSettings({
           Available agent types
         </div>
         <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
-          Choose which agent runtimes can be created from the app. Disabled types are removed from the create-agent dialog.
+          Choose which agent runtimes can be created from the app. Disabled
+          types are removed from the create-agent dialog.
         </p>
       </div>
 
@@ -102,7 +118,9 @@ export function AgentTypeSettings({
               key={agentType}
               className={cn(
                 "flex items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors",
-                disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer hover:bg-muted/50",
+                disabled
+                  ? "cursor-not-allowed opacity-60"
+                  : "cursor-pointer hover:bg-muted/50"
               )}
             >
               <Checkbox
@@ -112,9 +130,13 @@ export function AgentTypeSettings({
                 data-testid={`agent-type-toggle-${agentType}`}
               />
               <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground">{AGENT_TYPE_LABELS[agentType]}</div>
+                <div className="text-sm font-medium text-foreground">
+                  {AGENT_TYPE_LABELS[agentType]}
+                </div>
                 <div className="text-xs text-muted-foreground">
-                  {disabled ? "At least one agent type must stay enabled." : "Available in the create-agent dialog."}
+                  {disabled
+                    ? "At least one agent type must stay enabled."
+                    : "Available in the create-agent dialog."}
                 </div>
               </div>
             </label>

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -38,12 +38,13 @@ export function AppHeader({
     >
       <div className="flex min-w-0 flex-1 items-center">
         {showLeftToggle ? (
-          <div
-            className={cn(
-              "inline-flex items-center gap-1"
-            )}
-          >
-            <Button size="icon" variant="ghost" onClick={() => setLeftOpen(true)} title="Open agent sidebar">
+          <div className={cn("inline-flex items-center gap-1")}>
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={() => setLeftOpen(true)}
+              title="Open agent sidebar"
+            >
               <PanelRightOpen className="h-4 w-4" />
             </Button>
             {!isMobile ? (
@@ -54,7 +55,9 @@ export function AppHeader({
               />
             ) : null}
           </div>
-        ) : <div />}
+        ) : (
+          <div />
+        )}
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-1">

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -1,17 +1,48 @@
-import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, GitBranch, Loader2, ChevronLeft } from "lucide-react";
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Check,
+  ChevronDown,
+  GitBranch,
+  Loader2,
+  ChevronLeft,
+} from "lucide-react";
 
 import { PathInput } from "@/components/app/path-input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandLoading } from "@/components/ui/command";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandLoading,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-function useClickOutside(ref: React.RefObject<HTMLElement | null>, isOpen: boolean, onClose: () => void): void {
+function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void
+): void {
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e: MouseEvent) => {
@@ -42,9 +73,15 @@ type CreateAgentDialogProps = {
   setCreateName: (name: string) => void;
   setCreateType: (value: AgentType) => void;
   setCreateCwd: (cwd: string) => void;
-  setCreateFullAccess: (value: boolean | ((current: boolean) => boolean)) => void;
-  setCreateAutoReview: (value: boolean | ((current: boolean) => boolean)) => void;
-  setCreateUseWorktree: (value: boolean | ((current: boolean) => boolean)) => void;
+  setCreateFullAccess: (
+    value: boolean | ((current: boolean) => boolean)
+  ) => void;
+  setCreateAutoReview: (
+    value: boolean | ((current: boolean) => boolean)
+  ) => void;
+  setCreateUseWorktree: (
+    value: boolean | ((current: boolean) => boolean)
+  ) => void;
   setCreateWorktreeBranch: (value: string) => void;
   setCreateBaseBranch: (value: string) => void;
   setInitialPrompt: (value: string) => void;
@@ -77,9 +114,8 @@ export function CreateAgentDialog({
   setCreateBaseBranch,
   setInitialPrompt,
   onSubmit,
-  onRemoveCwdHistory
+  onRemoveCwdHistory,
 }: CreateAgentDialogProps): JSX.Element {
-
   // --- Step state: "config" is the main form, "prompt" is the initial prompt textarea ---
   const [step, setStep] = useState<"config" | "prompt">("config");
   const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -109,11 +145,16 @@ export function CreateAgentDialog({
   const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [branchesLoading, setBranchesLoading] = useState(false);
-  const [branchesFetchedForCwd, setBranchesFetchedForCwd] = useState<string | null>(null);
+  const [branchesFetchedForCwd, setBranchesFetchedForCwd] = useState<
+    string | null
+  >(null);
   const branchCmdRef = useRef<HTMLDivElement>(null);
   const branchTriggerRef = useRef<HTMLButtonElement>(null);
   const branchInputRef = useRef<HTMLInputElement>(null);
-  const closeBranchDropdown = useCallback(() => setBranchDropdownOpen(false), []);
+  const closeBranchDropdown = useCallback(
+    () => setBranchDropdownOpen(false),
+    []
+  );
   useClickOutside(branchCmdRef, branchDropdownOpen, closeBranchDropdown);
 
   const fetchBranches = useCallback(async () => {
@@ -122,7 +163,9 @@ export function CreateAgentDialog({
     setBranchesLoading(true);
     setRemoteBranches([]);
     try {
-      const result = await api<{ branches: string[] }>(`/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`);
+      const result = await api<{ branches: string[] }>(
+        `/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`
+      );
       setRemoteBranches(result.branches);
       // If the pre-selected branch doesn't exist in the fetched list, fall back to the first available branch
       if (!result.branches.includes(createBaseBranch)) {
@@ -145,7 +188,10 @@ export function CreateAgentDialog({
   }, [fetchBranches, branchesFetchedForCwd, createCwd]);
 
   const allBranches = useMemo(
-    () => remoteBranches.includes("main") ? remoteBranches : ["main", ...remoteBranches],
+    () =>
+      remoteBranches.includes("main")
+        ? remoteBranches
+        : ["main", ...remoteBranches],
     [remoteBranches]
   );
 
@@ -166,10 +212,16 @@ export function CreateAgentDialog({
           <>
             <DialogHeader>
               <DialogTitle>Create Agent</DialogTitle>
-              <DialogDescription>Name, type, and working directory for a new agent session.</DialogDescription>
+              <DialogDescription>
+                Name, type, and working directory for a new agent session.
+              </DialogDescription>
             </DialogHeader>
 
-            <form data-testid="create-agent-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
+            <form
+              data-testid="create-agent-form"
+              className="space-y-3"
+              onSubmit={(event) => void onSubmit(event)}
+            >
               <div className="relative space-y-1" ref={typeCmdRef}>
                 <label className="text-sm text-muted-foreground">Type</label>
                 <button
@@ -180,7 +232,11 @@ export function CreateAgentDialog({
                   aria-expanded={typeDropdownOpen}
                   onClick={() => setTypeDropdownOpen((prev) => !prev)}
                   onKeyDown={(e) => {
-                    if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                    if (
+                      e.key === "ArrowDown" ||
+                      e.key === "Enter" ||
+                      e.key === " "
+                    ) {
                       e.preventDefault();
                       if (!typeDropdownOpen) setTypeDropdownOpen(true);
                     }
@@ -191,11 +247,30 @@ export function CreateAgentDialog({
                   )}
                 >
                   {AGENT_TYPE_LABELS[createType]}
-                  <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", typeDropdownOpen && "rotate-180")} />
+                  <ChevronDown
+                    className={cn(
+                      "h-4 w-4 text-muted-foreground transition-transform",
+                      typeDropdownOpen && "rotate-180"
+                    )}
+                  />
                 </button>
                 {typeDropdownOpen ? (
                   <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-border bg-background shadow-md">
-                    <Command shouldFilter={false} ref={(el) => { if (el) requestAnimationFrame(() => el.focus()); }} onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); setTypeDropdownOpen(false); requestAnimationFrame(() => typeTriggerRef.current?.focus()); } }}>
+                    <Command
+                      shouldFilter={false}
+                      ref={(el) => {
+                        if (el) requestAnimationFrame(() => el.focus());
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          setTypeDropdownOpen(false);
+                          requestAnimationFrame(() =>
+                            typeTriggerRef.current?.focus()
+                          );
+                        }
+                      }}
+                    >
                       <CommandList>
                         <CommandGroup>
                           {enabledAgentTypes.map((agentType) => (
@@ -205,10 +280,19 @@ export function CreateAgentDialog({
                               onSelect={() => {
                                 setCreateType(agentType);
                                 setTypeDropdownOpen(false);
-                                requestAnimationFrame(() => typeTriggerRef.current?.focus());
+                                requestAnimationFrame(() =>
+                                  typeTriggerRef.current?.focus()
+                                );
                               }}
                             >
-                              <Check className={cn("mr-2 h-3 w-3 shrink-0", agentType === createType ? "opacity-100" : "opacity-0")} />
+                              <Check
+                                className={cn(
+                                  "mr-2 h-3 w-3 shrink-0",
+                                  agentType === createType
+                                    ? "opacity-100"
+                                    : "opacity-0"
+                                )}
+                              />
                               {AGENT_TYPE_LABELS[agentType]}
                             </CommandItem>
                           ))}
@@ -229,7 +313,8 @@ export function CreateAgentDialog({
                   data-testid="create-agent-name"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Leave blank and the agent will set its own name based on the task.
+                  Leave blank and the agent will set its own name based on the
+                  task.
                 </p>
               </div>
 
@@ -247,7 +332,9 @@ export function CreateAgentDialog({
                 <label className="flex cursor-pointer items-start gap-3">
                   <Checkbox
                     checked={createUseWorktree}
-                    onCheckedChange={() => setCreateUseWorktree((current) => !current)}
+                    onCheckedChange={() =>
+                      setCreateUseWorktree((current) => !current)
+                    }
                     className="mt-0.5"
                     title="Toggle git worktree"
                     data-testid="create-agent-worktree"
@@ -265,7 +352,9 @@ export function CreateAgentDialog({
                 {createUseWorktree ? (
                   <div className="ml-8 w-[calc(100%-2rem)] space-y-2">
                     <div className="relative" ref={branchCmdRef}>
-                      <label className="mb-1 block text-xs text-muted-foreground">Base branch</label>
+                      <label className="mb-1 block text-xs text-muted-foreground">
+                        Base branch
+                      </label>
                       <button
                         ref={branchTriggerRef}
                         type="button"
@@ -273,9 +362,17 @@ export function CreateAgentDialog({
                         tabIndex={0}
                         aria-expanded={branchDropdownOpen}
                         data-testid="create-agent-base-branch"
-                        onClick={() => branchDropdownOpen ? setBranchDropdownOpen(false) : openBranchDropdown()}
+                        onClick={() =>
+                          branchDropdownOpen
+                            ? setBranchDropdownOpen(false)
+                            : openBranchDropdown()
+                        }
                         onKeyDown={(e) => {
-                          if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                          if (
+                            e.key === "ArrowDown" ||
+                            e.key === "Enter" ||
+                            e.key === " "
+                          ) {
                             e.preventDefault();
                             if (!branchDropdownOpen) openBranchDropdown();
                           }
@@ -289,7 +386,12 @@ export function CreateAgentDialog({
                         {branchesLoading ? (
                           <Loader2 className="ml-2 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                         ) : (
-                          <ChevronDown className={cn("ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform", branchDropdownOpen && "rotate-180")} />
+                          <ChevronDown
+                            className={cn(
+                              "ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                              branchDropdownOpen && "rotate-180"
+                            )}
+                          />
                         )}
                       </button>
                       {branchDropdownOpen ? (
@@ -299,11 +401,17 @@ export function CreateAgentDialog({
                               if (e.key === "Escape") {
                                 e.preventDefault();
                                 setBranchDropdownOpen(false);
-                                requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                                requestAnimationFrame(() =>
+                                  branchTriggerRef.current?.focus()
+                                );
                               }
                             }}
                           >
-                            <CommandInput ref={branchInputRef} placeholder="Search branches..." className="font-mono text-xs" />
+                            <CommandInput
+                              ref={branchInputRef}
+                              placeholder="Search branches..."
+                              className="font-mono text-xs"
+                            />
                             <CommandList>
                               {branchesLoading ? (
                                 <CommandLoading>
@@ -324,10 +432,19 @@ export function CreateAgentDialog({
                                     onSelect={() => {
                                       setCreateBaseBranch(branch);
                                       setBranchDropdownOpen(false);
-                                      requestAnimationFrame(() => branchTriggerRef.current?.focus());
+                                      requestAnimationFrame(() =>
+                                        branchTriggerRef.current?.focus()
+                                      );
                                     }}
                                   >
-                                    <Check className={cn("mr-2 h-3 w-3 shrink-0", branch === createBaseBranch ? "opacity-100" : "opacity-0")} />
+                                    <Check
+                                      className={cn(
+                                        "mr-2 h-3 w-3 shrink-0",
+                                        branch === createBaseBranch
+                                          ? "opacity-100"
+                                          : "opacity-0"
+                                      )}
+                                    />
                                     {branch}
                                   </CommandItem>
                                 ))}
@@ -339,7 +456,9 @@ export function CreateAgentDialog({
                     </div>
                     <Input
                       value={createWorktreeBranch}
-                      onChange={(event) => setCreateWorktreeBranch(event.target.value)}
+                      onChange={(event) =>
+                        setCreateWorktreeBranch(event.target.value)
+                      }
                       placeholder="branch name (auto-generated if empty)"
                       data-testid="create-agent-worktree-branch"
                     />
@@ -350,14 +469,19 @@ export function CreateAgentDialog({
               <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
                 <Checkbox
                   checked={createFullAccess}
-                  onCheckedChange={() => setCreateFullAccess((current) => !current)}
+                  onCheckedChange={() =>
+                    setCreateFullAccess((current) => !current)
+                  }
                   className="mt-0.5"
                   title="Toggle full access"
                 />
                 <span className="space-y-1">
-                  <span className="block text-sm font-medium text-foreground">Start in full access mode</span>
+                  <span className="block text-sm font-medium text-foreground">
+                    Start in full access mode
+                  </span>
                   <span className="block text-xs text-muted-foreground">
-                    Starts the selected agent with its most permissive supported execution mode.
+                    Starts the selected agent with its most permissive supported
+                    execution mode.
                   </span>
                 </span>
               </label>
@@ -365,21 +489,32 @@ export function CreateAgentDialog({
               <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
                 <Checkbox
                   checked={createAutoReview}
-                  onCheckedChange={() => setCreateAutoReview((current) => !current)}
+                  onCheckedChange={() =>
+                    setCreateAutoReview((current) => !current)
+                  }
                   className="mt-0.5"
                   title="Toggle autonomous review"
                   data-testid="create-agent-auto-review"
                 />
                 <span className="space-y-1">
-                  <span className="block text-sm font-medium text-foreground">Autonomous Review</span>
+                  <span className="block text-sm font-medium text-foreground">
+                    Autonomous Review
+                  </span>
                   <span className="block text-xs text-muted-foreground">
-                    Agent will launch one review agent and address feedback before completing.
+                    Agent will launch one review agent and address feedback
+                    before completing.
                   </span>
                 </span>
               </label>
 
               <div className="flex justify-end gap-2 pt-1">
-                <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)} data-testid="create-agent-cancel">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  tabIndex={0}
+                  onClick={() => setOpen(false)}
+                  data-testid="create-agent-cancel"
+                >
                   Cancel
                 </Button>
                 <Button
@@ -392,8 +527,16 @@ export function CreateAgentDialog({
                 >
                   Create with prompt
                 </Button>
-                <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-submit">
-                  {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                <Button
+                  type="submit"
+                  variant="primary"
+                  tabIndex={0}
+                  disabled={creating}
+                  data-testid="create-agent-submit"
+                >
+                  {creating ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : null}
                   Create
                 </Button>
               </div>
@@ -403,10 +546,16 @@ export function CreateAgentDialog({
           <>
             <DialogHeader>
               <DialogTitle>Initial Prompt</DialogTitle>
-              <DialogDescription>This prompt will be sent as the agent's first message.</DialogDescription>
+              <DialogDescription>
+                This prompt will be sent as the agent's first message.
+              </DialogDescription>
             </DialogHeader>
 
-            <form data-testid="create-agent-prompt-form" className="space-y-3" onSubmit={(event) => void onSubmit(event)}>
+            <form
+              data-testid="create-agent-prompt-form"
+              className="space-y-3"
+              onSubmit={(event) => void onSubmit(event)}
+            >
               <textarea
                 ref={promptTextareaRef}
                 value={initialPrompt}
@@ -433,11 +582,24 @@ export function CreateAgentDialog({
                   Back
                 </Button>
                 <div className="flex gap-2">
-                  <Button type="button" variant="ghost" tabIndex={0} onClick={() => setOpen(false)}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    tabIndex={0}
+                    onClick={() => setOpen(false)}
+                  >
                     Cancel
                   </Button>
-                  <Button type="submit" variant="primary" tabIndex={0} disabled={creating} data-testid="create-agent-prompt-submit">
-                    {creating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    tabIndex={0}
+                    disabled={creating}
+                    data-testid="create-agent-prompt-submit"
+                  >
+                    {creating ? (
+                      <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    ) : null}
                     Create
                   </Button>
                 </div>

--- a/apps/web/src/components/app/delete-agent-dialog.tsx
+++ b/apps/web/src/components/app/delete-agent-dialog.tsx
@@ -3,7 +3,13 @@ import { AlertTriangle, Archive, GitBranch, Loader2 } from "lucide-react";
 
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { api } from "@/lib/api";
 
 type WorktreeStatus = {
@@ -31,10 +37,12 @@ export function DeleteAgentDialog({
   deleteTarget,
   setOpen,
   setDeleteTarget,
-  onDelete
+  onDelete,
 }: DeleteAgentDialogProps): JSX.Element {
   const [step, setStep] = useState<DeleteStep>("confirm");
-  const [worktreeStatus, setWorktreeStatus] = useState<WorktreeStatus | null>(null);
+  const [worktreeStatus, setWorktreeStatus] = useState<WorktreeStatus | null>(
+    null
+  );
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -78,7 +86,11 @@ export function DeleteAgentDialog({
     if (!deleteTarget) return;
 
     // If there's a worktree with unmerged commits or uncommitted changes, transition to choice step
-    if (worktreeStatus?.hasWorktree && (worktreeStatus.hasUnmergedCommits || worktreeStatus.hasUncommittedChanges)) {
+    if (
+      worktreeStatus?.hasWorktree &&
+      (worktreeStatus.hasUnmergedCommits ||
+        worktreeStatus.hasUncommittedChanges)
+    ) {
       setStep("worktree-choice");
       return;
     }
@@ -116,8 +128,12 @@ export function DeleteAgentDialog({
   }, [setOpen, setDeleteTarget]);
 
   if (step === "worktree-choice" && worktreeStatus) {
-    const hasUnmerged = worktreeStatus.hasUnmergedCommits && worktreeStatus.changedFiles.length > 0;
-    const hasUncommitted = worktreeStatus.hasUncommittedChanges && worktreeStatus.uncommittedFiles.length > 0;
+    const hasUnmerged =
+      worktreeStatus.hasUnmergedCommits &&
+      worktreeStatus.changedFiles.length > 0;
+    const hasUncommitted =
+      worktreeStatus.hasUncommittedChanges &&
+      worktreeStatus.uncommittedFiles.length > 0;
 
     return (
       <Dialog open={open} onOpenChange={setOpen}>
@@ -132,8 +148,11 @@ export function DeleteAgentDialog({
                 <div className="flex items-start gap-2">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
                   <span>
-                    Branch <code className="rounded bg-muted px-1 py-0.5 text-xs">{worktreeStatus.branchName}</code> has
-                    commits not merged to origin.
+                    Branch{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                      {worktreeStatus.branchName}
+                    </code>{" "}
+                    has commits not merged to origin.
                   </span>
                 </div>
                 <div className="ml-6 max-h-40 overflow-y-auto rounded bg-muted/50 px-2 py-1.5 text-xs font-mono leading-relaxed text-muted-foreground">
@@ -158,11 +177,18 @@ export function DeleteAgentDialog({
               </div>
             )}
 
-            <p className="text-sm text-muted-foreground">The agent will be archived either way.</p>
+            <p className="text-sm text-muted-foreground">
+              The agent will be archived either way.
+            </p>
           </div>
 
           <div className="grid gap-2 pt-1 sm:grid-cols-[auto,minmax(0,1fr),minmax(0,1fr)]">
-            <Button variant="ghost" onClick={close} disabled={deleting} className="w-full sm:w-auto">
+            <Button
+              variant="ghost"
+              onClick={close}
+              disabled={deleting}
+              className="w-full sm:w-auto"
+            >
               Cancel
             </Button>
             <Button
@@ -182,7 +208,9 @@ export function DeleteAgentDialog({
               data-testid="delete-agent-force-worktree"
               className="h-auto w-full min-w-0 whitespace-normal py-2 text-center"
             >
-              {deleting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+              {deleting ? (
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              ) : null}
               Archive and remove worktree
             </Button>
           </div>
@@ -216,7 +244,11 @@ export function DeleteAgentDialog({
             disabled={loading || deleting}
             onClick={() => void handleConfirmDelete()}
           >
-            {loading || deleting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Archive className="mr-1.5 h-4 w-4" />}
+            {loading || deleting ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Archive className="mr-1.5 h-4 w-4" />
+            )}
             Archive
           </Button>
         </div>

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -13,7 +13,14 @@ import {
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-export type DocsSection = "agents" | "tools" | "worktrees" | "personas" | "events" | "media" | "notifications";
+export type DocsSection =
+  | "agents"
+  | "tools"
+  | "worktrees"
+  | "personas"
+  | "events"
+  | "media"
+  | "notifications";
 
 type DocsPaneProps = {
   open: boolean;
@@ -47,11 +54,15 @@ function CodeBlock({ children }: { children: string }) {
 }
 
 function P({ children }: { children: React.ReactNode }) {
-  return <p className="text-sm leading-relaxed text-muted-foreground">{children}</p>;
+  return (
+    <p className="text-sm leading-relaxed text-muted-foreground">{children}</p>
+  );
 }
 
 function H3({ children }: { children: React.ReactNode }) {
-  return <h3 className="text-base font-semibold text-foreground">{children}</h3>;
+  return (
+    <h3 className="text-base font-semibold text-foreground">{children}</h3>
+  );
 }
 
 function Section({ children }: { children: React.ReactNode }) {
@@ -73,33 +84,50 @@ const SECTIONS: SectionDef[] = [
             arrow to pick a specific agent type). Fill in the create form:
           </P>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
-            <li><strong>Type</strong> — choose the CLI: <Code>claude</Code>, <Code>codex</Code>, or <Code>opencode</Code>. Disabled types can be enabled in Settings.</li>
-            <li><strong>Name</strong> — optional display name for the agent.</li>
-            <li><strong>Working directory</strong> — path to the repo. Autocompletes as you type and validates that the directory exists. Recent directories are saved for quick selection.</li>
-            <li><strong>Create git worktree</strong> — checked by default. Creates an isolated worktree so the agent works on its own branch without touching your primary checkout. When enabled, you can pick a base branch and optionally set a custom branch name.</li>
-            <li><strong>Full access mode</strong> — starts the CLI in its most permissive execution mode, so the agent can run commands and edit files without confirmation prompts.</li>
+            <li>
+              <strong>Type</strong> — choose the CLI: <Code>claude</Code>,{" "}
+              <Code>codex</Code>, or <Code>opencode</Code>. Disabled types can
+              be enabled in Settings.
+            </li>
+            <li>
+              <strong>Name</strong> — optional display name for the agent.
+            </li>
+            <li>
+              <strong>Working directory</strong> — path to the repo.
+              Autocompletes as you type and validates that the directory exists.
+              Recent directories are saved for quick selection.
+            </li>
+            <li>
+              <strong>Create git worktree</strong> — checked by default. Creates
+              an isolated worktree so the agent works on its own branch without
+              touching your primary checkout. When enabled, you can pick a base
+              branch and optionally set a custom branch name.
+            </li>
+            <li>
+              <strong>Full access mode</strong> — starts the CLI in its most
+              permissive execution mode, so the agent can run commands and edit
+              files without confirmation prompts.
+            </li>
           </ul>
         </Section>
 
         <Section>
           <H3>Setup phases</H3>
           <P>
-            After creating an agent, the sidebar shows a progress indicator
-            as it moves through setup: creating the worktree, copying
-            environment files, installing dependencies, and starting the
-            session. Once setup completes the agent transitions
-            to <strong>running</strong>.
+            After creating an agent, the sidebar shows a progress indicator as
+            it moves through setup: creating the worktree, copying environment
+            files, installing dependencies, and starting the session. Once setup
+            completes the agent transitions to <strong>running</strong>.
           </P>
         </Section>
 
         <Section>
           <H3>Status indicators</H3>
           <P>
-            Each agent in the sidebar shows a color-coded status from its
-            latest event: blue for <strong>working</strong>, red
-            for <strong>blocked</strong>, yellow
-            for <strong>waiting</strong>, and green
-            for <strong>done</strong>. The sidebar also shows the event
+            Each agent in the sidebar shows a color-coded status from its latest
+            event: blue for <strong>working</strong>, red for{" "}
+            <strong>blocked</strong>, yellow for <strong>waiting</strong>, and
+            green for <strong>done</strong>. The sidebar also shows the event
             message and how long ago it was reported.
           </P>
         </Section>
@@ -107,10 +135,9 @@ const SECTIONS: SectionDef[] = [
         <Section>
           <H3>Starting and stopping</H3>
           <P>
-            Press the play button to resume a stopped agent. Press the
-            stop button to terminate it. Click an agent's name to attach
-            your terminal to its session, or click again to detach without
-            stopping.
+            Press the play button to resume a stopped agent. Press the stop
+            button to terminate it. Click an agent's name to attach your
+            terminal to its session, or click again to detach without stopping.
           </P>
         </Section>
 
@@ -119,8 +146,8 @@ const SECTIONS: SectionDef[] = [
           <P>
             The agent runs inside <Code>tmux</Code>, independent of your
             browser. Closing the tab just detaches your terminal view — the
-            agent keeps working. Open Dispatch again and click the agent to
-            pick up where you left off.
+            agent keeps working. Open Dispatch again and click the agent to pick
+            up where you left off.
           </P>
         </Section>
 
@@ -128,9 +155,9 @@ const SECTIONS: SectionDef[] = [
           <H3>Agent details</H3>
           <P>
             Expand an agent card to see its metadata: working directory or
-            worktree path, git branch, agent type, and whether it's running
-            in full access or sandboxed mode. Persona agents show their
-            role and link to their parent agent.
+            worktree path, git branch, agent type, and whether it's running in
+            full access or sandboxed mode. Persona agents show their role and
+            link to their parent agent.
           </P>
         </Section>
 
@@ -139,8 +166,8 @@ const SECTIONS: SectionDef[] = [
           <P>
             Click the archive button to remove an agent. If the agent has a
             worktree with unmerged commits or uncommitted changes, you'll be
-            asked whether to keep or remove the worktree. Archived agents
-            are preserved in the History section of the Activity page.
+            asked whether to keep or remove the worktree. Archived agents are
+            preserved in the History section of the Activity page.
           </P>
         </Section>
       </>
@@ -154,18 +181,18 @@ const SECTIONS: SectionDef[] = [
     content: (
       <>
         <P>
-          Repos can register custom MCP tools that agents call during a
-          session. Tools are defined in <Code>.dispatch/tools.json</Code> at
-          the repo root.
+          Repos can register custom MCP tools that agents call during a session.
+          Tools are defined in <Code>.dispatch/tools.json</Code> at the repo
+          root.
         </P>
 
         <Section>
           <H3>Defining tools</H3>
           <P>
-            Each tool has a name, a description, and a command to run.
-            Dispatch automatically prefixes tool names with <Code>repo.</Code>{" "}
-            when exposing them to agents. The command executes in the repo root
-            when called.
+            Each tool has a name, a description, and a command to run. Dispatch
+            automatically prefixes tool names with <Code>repo.</Code> when
+            exposing them to agents. The command executes in the repo root when
+            called.
           </P>
           <CodeBlock>{`
 // .dispatch/tools.json
@@ -189,9 +216,9 @@ const SECTIONS: SectionDef[] = [
   ]
 }`}</CodeBlock>
           <P>
-            The tools above would be available to agents
-            as <Code>repo.lint</Code>, <Code>repo.test</Code>,
-            and <Code>repo.db_reset</Code>.
+            The tools above would be available to agents as{" "}
+            <Code>repo.lint</Code>, <Code>repo.test</Code>, and{" "}
+            <Code>repo.db_reset</Code>.
           </P>
         </Section>
 
@@ -225,9 +252,9 @@ const SECTIONS: SectionDef[] = [
 }`}</CodeBlock>
           <P>
             When an agent calls <Code>repo.dev_up</Code> with{" "}
-            <Code>{"{ cwd: \"/path\", live: true }"}</Code>, Dispatch
-            runs <Code>./bin/dev up --cwd /path --live</Code>.
-            Parameters that are omitted or false are skipped.
+            <Code>{'{ cwd: "/path", live: true }'}</Code>, Dispatch runs{" "}
+            <Code>./bin/dev up --cwd /path --live</Code>. Parameters that are
+            omitted or false are skipped.
           </P>
         </Section>
 
@@ -238,24 +265,42 @@ const SECTIONS: SectionDef[] = [
             regardless of repo configuration:
           </P>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li>
+              <Code>create_pr</Code> — open a pull request from the current
+              branch
+            </li>
+            <li>
+              <Code>get_pr_status</Code> — check CI status on a pull request
+            </li>
 
-            <li><Code>create_pr</Code> — open a pull request from the current branch</li>
-            <li><Code>get_pr_status</Code> — check CI status on a pull request</li>
-
-
-            <li><Code>dispatch_event</Code> — report agent status (working, blocked, done)</li>
-            <li><Code>dispatch_share</Code> — publish a screenshot or image to the session's media stream</li>
-            <li><Code>dispatch_feedback</Code> — submit a structured finding with severity, file reference, and suggestion</li>
-            <li><Code>dispatch_get_feedback</Code> — retrieve feedback findings for the current session</li>
-            <li><Code>dispatch_launch_persona</Code> — launch a persona agent as a child of the current session</li>
+            <li>
+              <Code>dispatch_event</Code> — report agent status (working,
+              blocked, done)
+            </li>
+            <li>
+              <Code>dispatch_share</Code> — publish a screenshot or image to the
+              session's media stream
+            </li>
+            <li>
+              <Code>dispatch_feedback</Code> — submit a structured finding with
+              severity, file reference, and suggestion
+            </li>
+            <li>
+              <Code>dispatch_get_feedback</Code> — retrieve feedback findings
+              for the current session
+            </li>
+            <li>
+              <Code>dispatch_launch_persona</Code> — launch a persona agent as a
+              child of the current session
+            </li>
           </ul>
         </Section>
 
         <Section>
           <H3>Lifecycle hooks</H3>
           <P>
-            Repos can define lifecycle hooks
-            in <Code>.dispatch/tools.json</Code> that run automatically at key
+            Repos can define lifecycle hooks in{" "}
+            <Code>.dispatch/tools.json</Code> that run automatically at key
             moments. Currently the <Code>stop</Code> hook is supported — it runs
             when an agent is stopped or terminated, useful for teardown tasks
             like shutting down dev servers.
@@ -274,25 +319,23 @@ const SECTIONS: SectionDef[] = [
         <Section>
           <H3>Environment</H3>
           <P>
-            Agent sessions run inside tmux (non-login, non-interactive),
-            so standard shell profiles are <strong>not</strong> sourced.
-            If agents need tools like <Code>nvm</Code>, <Code>pyenv</Code>,
-            or tokens like <Code>GH_TOKEN</Code>, add them
-            to <Code>~/.dispatch/env</Code>:
+            Agent sessions run inside tmux (non-login, non-interactive), so
+            standard shell profiles are <strong>not</strong> sourced. If agents
+            need tools like <Code>nvm</Code>, <Code>pyenv</Code>, or tokens like{" "}
+            <Code>GH_TOKEN</Code>, add them to <Code>~/.dispatch/env</Code>:
           </P>
           <CodeBlock>{`# ~/.dispatch/env
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 export GH_TOKEN="ghp_..."`}</CodeBlock>
           <P>
-            Avoid using <Code>exit</Code> in this file — it runs in the
-            setup script's shell and will kill the agent session.
+            Avoid using <Code>exit</Code> in this file — it runs in the setup
+            script's shell and will kill the agent session.
           </P>
           <P>
-            Repo tool commands and hooks also
-            receive <Code>DISPATCH_AGENT_ID</Code> in their environment, so
-            scripts can scope resources (databases, temp directories, ports) per
-            agent.
+            Repo tool commands and hooks also receive{" "}
+            <Code>DISPATCH_AGENT_ID</Code> in their environment, so scripts can
+            scope resources (databases, temp directories, ports) per agent.
           </P>
         </Section>
       </>
@@ -306,35 +349,31 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
     content: (
       <>
         <P>
-          Git worktrees let agents work on changes in isolation without
-          touching the main checkout. Each agent gets its own branch and
-          directory — ideal for parallel tasks or keeping exploratory work
-          separate.
+          Git worktrees let agents work on changes in isolation without touching
+          the main checkout. Each agent gets its own branch and directory —
+          ideal for parallel tasks or keeping exploratory work separate.
         </P>
 
         <Section>
           <H3>Automatic worktree creation</H3>
           <P>
             When creating an agent, the <strong>Create git worktree</strong>{" "}
-            checkbox is enabled by default. Dispatch creates a new branch
-            and linked worktree directory, copies environment files
-            (like <Code>.env</Code>), and starts the agent inside it. You
-            can choose a base branch and optionally set a custom branch name
-            in the create dialog.
+            checkbox is enabled by default. Dispatch creates a new branch and
+            linked worktree directory, copies environment files (like{" "}
+            <Code>.env</Code>), and starts the agent inside it. You can choose a
+            base branch and optionally set a custom branch name in the create
+            dialog.
           </P>
         </Section>
-
-
-
 
         <Section>
           <H3>Worktree location</H3>
           <P>
-            By default, worktrees are created inside the repo
-            at <Code>.dispatch/worktrees/</Code>. You can change this
-            in <strong>Settings</strong> to place them next to the repo
-            instead (as siblings). This is useful if your tooling doesn't
-            work well with nested worktrees.
+            By default, worktrees are created inside the repo at{" "}
+            <Code>.dispatch/worktrees/</Code>. You can change this in{" "}
+            <strong>Settings</strong> to place them next to the repo instead (as
+            siblings). This is useful if your tooling doesn't work well with
+            nested worktrees.
           </P>
         </Section>
 
@@ -342,19 +381,18 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <H3>Cleaning up</H3>
           <P>
             When archiving an agent with a worktree, Dispatch checks for
-            unmerged commits and uncommitted changes. If the worktree is
-            clean, it's removed automatically. If there are outstanding
-            changes, you're asked whether to keep the worktree for manual
-            review or remove it.
+            unmerged commits and uncommitted changes. If the worktree is clean,
+            it's removed automatically. If there are outstanding changes, you're
+            asked whether to keep the worktree for manual review or remove it.
           </P>
         </Section>
 
         <Section>
           <H3>Parallel agents</H3>
           <P>
-            Multiple agents can work in the same repo simultaneously. Each
-            uses its own worktree with a separate branch and directory, so
-            there are no conflicts between concurrent sessions.
+            Multiple agents can work in the same repo simultaneously. Each uses
+            its own worktree with a separate branch and directory, so there are
+            no conflicts between concurrent sessions.
           </P>
         </Section>
       </>
@@ -368,10 +406,10 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
     content: (
       <>
         <P>
-          Personas are reusable agent roles defined per repository. Each
-          persona reviews work from a specific perspective — for example,
-          security, UX, or architecture. A persona agent runs as a child of
-          the agent that launched it and submits structured feedback.
+          Personas are reusable agent roles defined per repository. Each persona
+          reviews work from a specific perspective — for example, security, UX,
+          or architecture. A persona agent runs as a child of the agent that
+          launched it and submits structured feedback.
         </P>
 
         <Section>
@@ -379,23 +417,22 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <P>
             An agent calls the built-in <Code>dispatch_launch_persona</Code>{" "}
             tool, passing the persona name and a context briefing. Dispatch
-            loads the persona definition from the repo, spawns a new child
-            agent with the persona's instructions and a diff of the current
-            branch, and the child reviews the work and submits findings
-            via <Code>dispatch_feedback</Code>.
+            loads the persona definition from the repo, spawns a new child agent
+            with the persona's instructions and a diff of the current branch,
+            and the child reviews the work and submits findings via{" "}
+            <Code>dispatch_feedback</Code>.
           </P>
         </Section>
 
         <Section>
           <H3>Defining personas</H3>
           <P>
-            Each repo defines its own personas as markdown files
-            in <Code>.dispatch/personas/</Code>. The filename (without
-            extension) becomes the persona slug used when launching. Files
-            use YAML frontmatter for metadata and the body contains
-            instructions with <Code>{"{{context}}"}</Code>{" "}
-            and <Code>{"{{diff}}"}</Code> placeholders that Dispatch fills
-            in at launch time.
+            Each repo defines its own personas as markdown files in{" "}
+            <Code>.dispatch/personas/</Code>. The filename (without extension)
+            becomes the persona slug used when launching. Files use YAML
+            frontmatter for metadata and the body contains instructions with{" "}
+            <Code>{"{{context}}"}</Code> and <Code>{"{{diff}}"}</Code>{" "}
+            placeholders that Dispatch fills in at launch time.
           </P>
           <CodeBlock>{`
 # .dispatch/personas/security-review.md
@@ -414,22 +451,22 @@ for vulnerabilities, injection risks, and auth issues.
 ## Diff
 {{diff}}`}</CodeBlock>
           <P>
-            The <Code>name</Code> and <Code>description</Code> fields are
-            shown in the persona picker UI. The <Code>feedbackFormat</Code>{" "}
-            field is optional and defaults to <Code>findings</Code>.
+            The <Code>name</Code> and <Code>description</Code> fields are shown
+            in the persona picker UI. The <Code>feedbackFormat</Code> field is
+            optional and defaults to <Code>findings</Code>.
           </P>
         </Section>
 
         <Section>
           <H3>Feedback findings</H3>
           <P>
-            Persona agents submit findings with
-            the <Code>dispatch_feedback</Code> tool. Each finding includes a
+            Persona agents submit findings with the{" "}
+            <Code>dispatch_feedback</Code> tool. Each finding includes a
             severity (<Code>critical</Code>, <Code>high</Code>,{" "}
-            <Code>medium</Code>, <Code>low</Code>, <Code>info</Code>),
-            a description, and optionally a file path, line number, and
-            suggested fix. Findings appear in the Feedback panel where you can
-            review and resolve them.
+            <Code>medium</Code>, <Code>low</Code>, <Code>info</Code>), a
+            description, and optionally a file path, line number, and suggested
+            fix. Findings appear in the Feedback panel where you can review and
+            resolve them.
           </P>
         </Section>
       </>
@@ -443,19 +480,33 @@ for vulnerabilities, injection risks, and auth issues.
     content: (
       <>
         <P>
-          Agents report their status throughout a task using
-          the <Code>dispatch_event</Code> tool. These events drive the status
+          Agents report their status throughout a task using the{" "}
+          <Code>dispatch_event</Code> tool. These events drive the status
           indicators in the sidebar and enable Slack notifications.
         </P>
 
         <Section>
           <H3>Event types</H3>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
-            <li><Code>working</Code> — actively making progress (reading files, writing code, running tests)</li>
-            <li><Code>blocked</Code> — hit an error or obstacle that needs resolution</li>
-            <li><Code>waiting_user</Code> — needs a decision or approval before continuing</li>
-            <li><Code>done</Code> — task is complete</li>
-            <li><Code>idle</Code> — no meaningful action was taken (e.g. answered an informational question)</li>
+            <li>
+              <Code>working</Code> — actively making progress (reading files,
+              writing code, running tests)
+            </li>
+            <li>
+              <Code>blocked</Code> — hit an error or obstacle that needs
+              resolution
+            </li>
+            <li>
+              <Code>waiting_user</Code> — needs a decision or approval before
+              continuing
+            </li>
+            <li>
+              <Code>done</Code> — task is complete
+            </li>
+            <li>
+              <Code>idle</Code> — no meaningful action was taken (e.g. answered
+              an informational question)
+            </li>
           </ul>
         </Section>
 
@@ -464,19 +515,18 @@ for vulnerabilities, injection risks, and auth issues.
           <P>
             The agent sidebar shows the latest event message and a color-coded
             status indicator for each agent. Events are also stored in the
-            database for activity tracking — the Activity page uses them
-            to build heatmaps, working-time breakdowns, and daily status charts.
+            database for activity tracking — the Activity page uses them to
+            build heatmaps, working-time breakdowns, and daily status charts.
           </P>
         </Section>
 
         <Section>
           <H3>Configuring agent instructions</H3>
           <P>
-            To get agents to report events, add instructions to your
-            repo's <Code>CLAUDE.md</Code> (or equivalent config) telling the
-            agent to call <Code>dispatch_event</Code> at key checkpoints:
-            start of turn, phase transitions, errors, and before the final
-            response.
+            To get agents to report events, add instructions to your repo's{" "}
+            <Code>CLAUDE.md</Code> (or equivalent config) telling the agent to
+            call <Code>dispatch_event</Code> at key checkpoints: start of turn,
+            phase transitions, errors, and before the final response.
           </P>
         </Section>
       </>
@@ -500,17 +550,17 @@ for vulnerabilities, injection risks, and auth issues.
           <P>
             Agents call the <Code>dispatch_share</Code> tool to publish media.
             It accepts a file path or raw text content, along with a
-            description. Supported formats include PNG, JPG, GIF, WebP
-            images, MP4 video, and text files.
+            description. Supported formats include PNG, JPG, GIF, WebP images,
+            MP4 video, and text files.
           </P>
         </Section>
 
         <Section>
           <H3>Simulator screenshots</H3>
           <P>
-            When <Code>dispatch_share</Code> is called
-            with <Code>source: "simulator"</Code>, it automatically captures
-            a screenshot from the iOS Simulator using <Code>xcrun simctl</Code>.
+            When <Code>dispatch_share</Code> is called with{" "}
+            <Code>source: "simulator"</Code>, it automatically captures a
+            screenshot from the iOS Simulator using <Code>xcrun simctl</Code>.
             This is useful for agents validating mobile UI changes.
           </P>
         </Section>
@@ -518,20 +568,20 @@ for vulnerabilities, injection risks, and auth issues.
         <Section>
           <H3>Screen streaming</H3>
           <P>
-            Agents running Playwright can stream their browser session live.
-            The stream appears in the media sidebar as a real-time MJPEG feed
-            via Chrome DevTools Protocol. When the stream ends, the last frame
-            is saved as a screenshot.
+            Agents running Playwright can stream their browser session live. The
+            stream appears in the media sidebar as a real-time MJPEG feed via
+            Chrome DevTools Protocol. When the stream ends, the last frame is
+            saved as a screenshot.
           </P>
         </Section>
 
         <Section>
           <H3>Media sidebar</H3>
           <P>
-            Click any agent's media count badge to open the sidebar. Media
-            items are shown in reverse chronological order. Click an item
-            to open the full-screen lightbox. New items since your last
-            visit are marked with a badge.
+            Click any agent's media count badge to open the sidebar. Media items
+            are shown in reverse chronological order. Click an item to open the
+            full-screen lightbox. New items since your last visit are marked
+            with a badge.
           </P>
         </Section>
       </>
@@ -560,13 +610,17 @@ for vulnerabilities, injection risks, and auth issues.
 
         <Section>
           <H3>Configurable events</H3>
-          <P>
-            You can choose which agent events trigger a notification:
-          </P>
+          <P>You can choose which agent events trigger a notification:</P>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
-            <li><Code>done</Code> — agent finished its task</li>
-            <li><Code>waiting_user</Code> — agent needs your input</li>
-            <li><Code>blocked</Code> — agent hit an error it can't resolve</li>
+            <li>
+              <Code>done</Code> — agent finished its task
+            </li>
+            <li>
+              <Code>waiting_user</Code> — agent needs your input
+            </li>
+            <li>
+              <Code>blocked</Code> — agent hit an error it can't resolve
+            </li>
           </ul>
         </Section>
 
@@ -589,7 +643,10 @@ function isValidDocsSection(value: string | undefined): value is DocsSection {
 }
 
 /** Lightweight section metadata for sidebar nav (avoids importing heavy content JSX). */
-export const DOCS_SECTION_NAV = SECTIONS.map(({ id, label }) => ({ id, label }));
+export const DOCS_SECTION_NAV = SECTIONS.map(({ id, label }) => ({
+  id,
+  label,
+}));
 
 type DocsContentProps = {
   initialSection?: string;
@@ -602,8 +659,12 @@ export function DocsContent({
   onSectionChange: _onSectionChange,
   title = "Docs",
 }: DocsContentProps): JSX.Element {
-  const resolvedInitial = isValidDocsSection(initialSection) ? initialSection : null;
-  const [activeSection, setActiveSectionState] = useState<DocsSection | null>(resolvedInitial);
+  const resolvedInitial = isValidDocsSection(initialSection)
+    ? initialSection
+    : null;
+  const [activeSection, setActiveSectionState] = useState<DocsSection | null>(
+    resolvedInitial
+  );
 
   useEffect(() => {
     if (isValidDocsSection(initialSection)) {
@@ -611,7 +672,8 @@ export function DocsContent({
     }
   }, [initialSection]);
 
-  const active = SECTIONS.find((section) => section.id === activeSection) ?? SECTIONS[0];
+  const active =
+    SECTIONS.find((section) => section.id === activeSection) ?? SECTIONS[0];
 
   return (
     <div className="flex min-h-0 flex-1 items-stretch">
@@ -623,12 +685,12 @@ export function DocsContent({
                 <div className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
                   {title}
                 </div>
-                <h2 className="text-2xl font-semibold tracking-tight">{active.title}</h2>
+                <h2 className="text-2xl font-semibold tracking-tight">
+                  {active.title}
+                </h2>
               </div>
             </div>
-            <div className="grid gap-6">
-              {active.content}
-            </div>
+            <div className="grid gap-6">{active.content}</div>
           </div>
         </ScrollArea>
       </div>
@@ -636,27 +698,44 @@ export function DocsContent({
   );
 }
 
-export function DocsPane({ open, onClose, initialSection, onSectionChange }: DocsPaneProps): JSX.Element {
+export function DocsPane({
+  open,
+  onClose,
+  initialSection,
+  onSectionChange,
+}: DocsPaneProps): JSX.Element {
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={(value) => { if (!value) onClose(); }}>
+    <DialogPrimitive.Root
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) onClose();
+      }}
+    >
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-[70] bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
           data-testid="docs-pane"
           className="fixed inset-0 z-[70] flex flex-col overflow-hidden border border-border bg-card text-foreground shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 md:inset-4 md:rounded-sm"
         >
-          <DialogPrimitive.Title className="sr-only">Dispatch Docs</DialogPrimitive.Title>
+          <DialogPrimitive.Title className="sr-only">
+            Dispatch Docs
+          </DialogPrimitive.Title>
           <DialogPrimitive.Description className="sr-only">
             Product documentation for core Dispatch functionality
           </DialogPrimitive.Description>
           <div className="flex h-12 shrink-0 items-center border-b border-border px-5">
-            <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Docs</span>
+            <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Docs
+            </span>
             <DialogPrimitive.Close className="ml-auto rounded-sm p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
             </DialogPrimitive.Close>
           </div>
-          <DocsContent initialSection={initialSection} onSectionChange={onSectionChange} />
+          <DocsContent
+            initialSection={initialSection}
+            onSectionChange={onSectionChange}
+          />
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -1,15 +1,46 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Ban, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, MessageCircleQuestion, RotateCcw, Wrench, X } from "lucide-react";
+import {
+  Ban,
+  Check,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  MessageCircleQuestion,
+  RotateCcw,
+  Wrench,
+  X,
+} from "lucide-react";
 
 import { FrontTruncatedValue } from "@/components/app/agent-meta";
 import { reviewVerdictLabel } from "@/components/app/agent-event-utils";
-import { PersonaAgentRow, getVerdict, getReviewSummary, getFilesReviewed } from "@/components/app/persona-agent-row";
-import { type Agent, type AgentVisualState, type FeedbackItem } from "@/components/app/types";
+import {
+  PersonaAgentRow,
+  getVerdict,
+  getReviewSummary,
+  getFilesReviewed,
+} from "@/components/app/persona-agent-row";
+import {
+  type Agent,
+  type AgentVisualState,
+  type FeedbackItem,
+} from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useCopyText } from "@/hooks/use-copy";
 import { api } from "@/lib/api";
 import { Markdown } from "@/components/ui/markdown";
@@ -29,7 +60,10 @@ const SEVERITY_DOT: Record<string, string> = {
   info: "bg-muted-foreground",
 };
 
-const SEVERITY_LABELS: Record<string, { label: string; variant: "error" | "default" }> = {
+const SEVERITY_LABELS: Record<
+  string,
+  { label: string; variant: "error" | "default" }
+> = {
   critical: { label: "Critical", variant: "error" },
   high: { label: "High", variant: "error" },
   medium: { label: "Medium", variant: "default" },
@@ -44,7 +78,11 @@ const STATUS_LABELS: Record<string, { label: string; color: string }> = {
 };
 
 const SEVERITY_ORDER: Record<string, number> = {
-  critical: 0, high: 1, medium: 2, low: 3, info: 4,
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
 };
 
 function bySeverity(a: FeedbackItem, b: FeedbackItem): number {
@@ -53,7 +91,10 @@ function bySeverity(a: FeedbackItem, b: FeedbackItem): number {
 
 function formatFeedbackText(item: FeedbackItem): string {
   const parts: string[] = [];
-  if (item.filePath) parts.push(`File: ${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`);
+  if (item.filePath)
+    parts.push(
+      `File: ${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`
+    );
   parts.push(`Severity: ${item.severity}`);
   parts.push(item.description);
   if (item.suggestion) parts.push(`Suggestion: ${item.suggestion}`);
@@ -81,10 +122,14 @@ function FeedbackActions({
   statusLabel: { label: string; color: string } | undefined;
   size?: "sm" | "default";
 }): JSX.Element {
-  const btnClass = size === "sm" ? "h-6 gap-1 px-1.5 text-[10px]" : "h-7 gap-1.5 px-2.5 text-xs";
+  const btnClass =
+    size === "sm"
+      ? "h-6 gap-1 px-1.5 text-[10px]"
+      : "h-7 gap-1.5 px-2.5 text-xs";
   const iconClass = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
   const resolveIconClass = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
-  const resolveBtnClass = size === "sm" ? "h-6 px-1.5 text-[10px]" : "h-7 px-2 text-xs gap-1.5";
+  const resolveBtnClass =
+    size === "sm" ? "h-6 px-1.5 text-[10px]" : "h-7 px-2 text-xs gap-1.5";
 
   return (
     <div className="flex items-center justify-between">
@@ -95,37 +140,62 @@ function FeedbackActions({
               <TooltipTrigger asChild>
                 <span className={cn(!isConnected && "cursor-not-allowed")}>
                   <Button
-                    variant="ghost" size="sm"
-                    className={cn(btnClass, !isConnected && "opacity-40 pointer-events-none")}
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      btnClass,
+                      !isConnected && "opacity-40 pointer-events-none"
+                    )}
                     onClick={() => onForward("wdyt")}
                   >
                     <MessageCircleQuestion className={iconClass} /> WDYT
                   </Button>
                 </span>
               </TooltipTrigger>
-              <TooltipContent>{isConnected ? "Ask what it thinks about this" : "Connect to parent agent to forward feedback"}</TooltipContent>
+              <TooltipContent>
+                {isConnected
+                  ? "Ask what it thinks about this"
+                  : "Connect to parent agent to forward feedback"}
+              </TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className={cn(!isConnected && "cursor-not-allowed")}>
                   <Button
-                    variant="ghost" size="sm"
-                    className={cn(btnClass, !isConnected && "opacity-40 pointer-events-none")}
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      btnClass,
+                      !isConnected && "opacity-40 pointer-events-none"
+                    )}
                     onClick={() => onForward("fix")}
                   >
                     <Wrench className={iconClass} /> Fix
                   </Button>
                 </span>
               </TooltipTrigger>
-              <TooltipContent>{isConnected ? "Tell agent to fix this" : "Connect to parent agent to forward feedback"}</TooltipContent>
+              <TooltipContent>
+                {isConnected
+                  ? "Tell agent to fix this"
+                  : "Connect to parent agent to forward feedback"}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
         ) : null}
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className={btnClass} onClick={onCopy}>
-                {copied ? <Check className={iconClass + " text-green-500"} /> : <Copy className={iconClass} />}
+              <Button
+                variant="ghost"
+                size="sm"
+                className={btnClass}
+                onClick={onCopy}
+              >
+                {copied ? (
+                  <Check className={iconClass + " text-green-500"} />
+                ) : (
+                  <Copy className={iconClass} />
+                )}
               </Button>
             </TooltipTrigger>
             <TooltipContent>Copy to clipboard</TooltipContent>
@@ -137,7 +207,14 @@ function FeedbackActions({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="sm" className={resolveBtnClass + " text-green-500/70 hover:text-green-500"} onClick={() => onUpdateStatus("fixed")}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={
+                    resolveBtnClass + " text-green-500/70 hover:text-green-500"
+                  }
+                  onClick={() => onUpdateStatus("fixed")}
+                >
                   <CheckCircle2 className={resolveIconClass} />
                   {size === "default" ? "Fixed" : null}
                 </Button>
@@ -146,7 +223,15 @@ function FeedbackActions({
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="sm" className={resolveBtnClass + " text-muted-foreground/50 hover:text-muted-foreground"} onClick={() => onUpdateStatus("ignored")}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={
+                    resolveBtnClass +
+                    " text-muted-foreground/50 hover:text-muted-foreground"
+                  }
+                  onClick={() => onUpdateStatus("ignored")}
+                >
                   <Ban className={resolveIconClass} />
                   {size === "default" ? "Ignore" : null}
                 </Button>
@@ -157,9 +242,22 @@ function FeedbackActions({
         ) : (
           <div className="flex items-center gap-1">
             {statusLabel ? (
-              <span className={cn("text-[10px]", size === "default" && "text-sm", statusLabel.color)}>{statusLabel.label}</span>
+              <span
+                className={cn(
+                  "text-[10px]",
+                  size === "default" && "text-sm",
+                  statusLabel.color
+                )}
+              >
+                {statusLabel.label}
+              </span>
             ) : null}
-            <Button variant="ghost" size="sm" className={btnClass} onClick={() => onUpdateStatus("open")}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={btnClass}
+              onClick={() => onUpdateStatus("open")}
+            >
               <RotateCcw className={iconClass} /> Reopen
             </Button>
           </div>
@@ -205,23 +303,35 @@ export function ParentFeedbackPanel({
   const [sheetItemId, setSheetItemId] = useState<number | null>(null);
   const [summaryAgentId, setSummaryAgentId] = useState<string | null>(null);
   const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
-  const [showResolvedAgents, setShowResolvedAgents] = useState<Set<string>>(new Set());
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [showResolvedAgents, setShowResolvedAgents] = useState<Set<string>>(
+    new Set()
+  );
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set()
+  );
   const [copied, copyText] = useCopyText();
 
   const { data: feedback = [] } = useQuery<FeedbackItem[]>({
     queryKey: ["feedback", parentAgentId, "children"],
     queryFn: async () => {
-      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${parentAgentId}/feedback?scope=children`);
+      const result = await api<{ feedback: FeedbackItem[] }>(
+        `/api/v1/agents/${parentAgentId}/feedback?scope=children`
+      );
       return result.feedback;
     },
     staleTime: 0,
   });
 
-  const sheetItem = sheetItemId != null ? feedback.find((f) => f.id === sheetItemId) ?? null : null;
+  const sheetItem =
+    sheetItemId != null
+      ? (feedback.find((f) => f.id === sheetItemId) ?? null)
+      : null;
 
   // Subscribe to agents cache reactively (query is managed by useAgents elsewhere)
-  const { data: allAgents = [] } = useQuery<Agent[]>({ queryKey: ["agents"], enabled: false });
+  const { data: allAgents = [] } = useQuery<Agent[]>({
+    queryKey: ["agents"],
+    enabled: false,
+  });
   const parentAgent = allAgents.find((a) => a.id === parentAgentId);
   const parentCwd = parentAgent?.worktreePath ?? parentAgent?.cwd;
 
@@ -231,7 +341,9 @@ export function ParentFeedbackPanel({
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
     queryKey: ["personas", parentCwd],
     queryFn: async () => {
-      const result = await api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(parentCwd ?? "")}`);
+      const result = await api<{ personas: PersonaSummary[] }>(
+        `/api/v1/personas?cwd=${encodeURIComponent(parentCwd ?? "")}`
+      );
       return result.personas;
     },
     enabled: !!parentCwd,
@@ -244,68 +356,112 @@ export function ParentFeedbackPanel({
     for (const agent of allAgents) {
       if (agent.parentAgentId === parentAgentId && agent.persona) {
         const idx = slugToIndex.get(agent.persona);
-        const colorVar = idx != null ? `var(--chart-${(idx % 4) + 1})` : `var(--chart-1)`;
+        const colorVar =
+          idx != null ? `var(--chart-${(idx % 4) + 1})` : `var(--chart-1)`;
         const persona = personas.find((p) => p.slug === agent.persona);
-        map.set(agent.id, { name: persona?.name ?? agent.persona, color: `hsl(${colorVar})` });
+        map.set(agent.id, {
+          name: persona?.name ?? agent.persona,
+          color: `hsl(${colorVar})`,
+        });
       }
     }
     return map;
   }, [allAgents, parentAgentId, personas]);
 
-  const activeItems = useMemo(() => feedback.filter((f) => f.status === "open" || f.status === "forwarded").sort(bySeverity), [feedback]);
-  const resolvedItems = useMemo(() => feedback.filter((f) => f.status !== "open" && f.status !== "forwarded").sort(bySeverity), [feedback]);
+  const activeItems = useMemo(
+    () =>
+      feedback
+        .filter((f) => f.status === "open" || f.status === "forwarded")
+        .sort(bySeverity),
+    [feedback]
+  );
+  const resolvedItems = useMemo(
+    () =>
+      feedback
+        .filter((f) => f.status !== "open" && f.status !== "forwarded")
+        .sort(bySeverity),
+    [feedback]
+  );
   const activeCount = activeItems.length;
 
-  const sheetIsActive = sheetItem && (sheetItem.status === "open" || sheetItem.status === "forwarded");
+  const sheetIsActive =
+    sheetItem &&
+    (sheetItem.status === "open" || sheetItem.status === "forwarded");
   const sheetNavItems = sheetIsActive ? activeItems : resolvedItems;
-  const sheetIndex = sheetItem ? sheetNavItems.findIndex((f) => f.id === sheetItem.id) : -1;
+  const sheetIndex = sheetItem
+    ? sheetNavItems.findIndex((f) => f.id === sheetItem.id)
+    : -1;
   const prevSheetItem = sheetIndex > 0 ? sheetNavItems[sheetIndex - 1]! : null;
-  const nextSheetItem = sheetIndex >= 0 && sheetIndex < sheetNavItems.length - 1 ? sheetNavItems[sheetIndex + 1]! : null;
+  const nextSheetItem =
+    sheetIndex >= 0 && sheetIndex < sheetNavItems.length - 1
+      ? sheetNavItems[sheetIndex + 1]!
+      : null;
 
-  const updateStatus = useCallback(async (item: FeedbackItem, status: string) => {
-    await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
-      method: "PATCH",
-      body: JSON.stringify({ status }),
-    });
-    const update = (f: FeedbackItem) => f.id === item.id ? { ...f, status: status as FeedbackItem["status"] } : f;
-    queryClient.setQueryData<FeedbackItem[]>(["feedback", parentAgentId, "children"], (old) => old?.map(update));
-  }, [queryClient, parentAgentId]);
+  const updateStatus = useCallback(
+    async (item: FeedbackItem, status: string) => {
+      await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      });
+      const update = (f: FeedbackItem) =>
+        f.id === item.id
+          ? { ...f, status: status as FeedbackItem["status"] }
+          : f;
+      queryClient.setQueryData<FeedbackItem[]>(
+        ["feedback", parentAgentId, "children"],
+        (old) => old?.map(update)
+      );
+    },
+    [queryClient, parentAgentId]
+  );
 
   const dismissUI = useCallback(() => {
     setSheetItemId(null);
     if (closeOnSessionAction) onRequestClose?.();
   }, [closeOnSessionAction, onRequestClose]);
 
-  const forward = useCallback((item: FeedbackItem, mode: "wdyt" | "fix") => {
-    if (sendTerminalInput && isConnected) {
-      const prefix = mode === "fix"
-        ? "Fix the following issue found by the persona reviewer:"
-        : "A persona reviewer flagged the following. What do you think — is this a real concern?";
-      const text = prefix + "\n" + formatFeedbackText(item) + "\r";
-      sendTerminalInput(text);
-      void updateStatus(item, "forwarded");
-    }
-    dismissUI();
-  }, [sendTerminalInput, isConnected, updateStatus, dismissUI]);
+  const forward = useCallback(
+    (item: FeedbackItem, mode: "wdyt" | "fix") => {
+      if (sendTerminalInput && isConnected) {
+        const prefix =
+          mode === "fix"
+            ? "Fix the following issue found by the persona reviewer:"
+            : "A persona reviewer flagged the following. What do you think — is this a real concern?";
+        const text = prefix + "\n" + formatFeedbackText(item) + "\r";
+        sendTerminalInput(text);
+        void updateStatus(item, "forwarded");
+      }
+      dismissUI();
+    },
+    [sendTerminalInput, isConnected, updateStatus, dismissUI]
+  );
 
-  const handleCopy = useCallback((item: FeedbackItem) => {
-    copyText(formatFeedbackText(item));
-    setCopiedItemId(item.id);
-  }, [copyText]);
+  const handleCopy = useCallback(
+    (item: FeedbackItem) => {
+      copyText(formatFeedbackText(item));
+      setCopiedItemId(item.id);
+    },
+    [copyText]
+  );
 
-  const handleResolve = useCallback((item: FeedbackItem, status: string) => {
-    void updateStatus(item, status);
-    // Auto-advance to the next unresolved item within the same persona
-    const samePersona = activeItems.filter((f) => f.agentId === item.agentId);
-    const idx = samePersona.findIndex((f) => f.id === item.id);
-    const remaining = samePersona.filter((f) => f.id !== item.id);
-    const nextId = remaining.length > 0
-      ? remaining[Math.min(Math.max(idx, 0), remaining.length - 1)]!.id
-      : null;
-    setSheetItemId(sheetItemId != null ? nextId : null);
-  }, [updateStatus, activeItems, sheetItemId]);
+  const handleResolve = useCallback(
+    (item: FeedbackItem, status: string) => {
+      void updateStatus(item, status);
+      // Auto-advance to the next unresolved item within the same persona
+      const samePersona = activeItems.filter((f) => f.agentId === item.agentId);
+      const idx = samePersona.findIndex((f) => f.id === item.id);
+      const remaining = samePersona.filter((f) => f.id !== item.id);
+      const nextId =
+        remaining.length > 0
+          ? remaining[Math.min(Math.max(idx, 0), remaining.length - 1)]!.id
+          : null;
+      setSheetItemId(sheetItemId != null ? nextId : null);
+    },
+    [updateStatus, activeItems, sheetItemId]
+  );
 
-  const severityInfo = (sev: string) => SEVERITY_LABELS[sev] ?? SEVERITY_LABELS.info;
+  const severityInfo = (sev: string) =>
+    SEVERITY_LABELS[sev] ?? SEVERITY_LABELS.info;
 
   if (feedback.length === 0 && childAgents.length === 0) return null;
 
@@ -345,7 +501,9 @@ export function ParentFeedbackPanel({
             const agentActive = activeFeedbackByAgent.get(child.id) ?? [];
             const agentResolved = resolvedFeedbackByAgent.get(child.id) ?? [];
             const showingResolved = showResolvedAgents.has(child.id);
-            const items = showingResolved ? [...agentActive, ...agentResolved] : agentActive;
+            const items = showingResolved
+              ? [...agentActive, ...agentResolved]
+              : agentActive;
             const isGroupCollapsed = collapsedGroups.has(child.id);
             const childState = getVisualState?.(child);
             const unresolvedCount = agentActive.length;
@@ -355,17 +513,18 @@ export function ParentFeedbackPanel({
             const canTriage = isConnected && !!sendTerminalInput;
             const childVerdict = getVerdict(child);
             const childSummary = getReviewSummary(child);
-            const handleTriage = unresolvedCount > 0
-              ? () => {
-                  if (!canTriage) return;
-                  const personaName = child.persona ?? child.name;
-                  const verdictContext = childVerdict
-                    ? `\n\nThe reviewer's verdict was: ${reviewVerdictLabel(childVerdict)}.${childSummary ? ` Their summary: "${childSummary}"` : ""}`
-                    : "";
-                  const message = `Review and triage the pending feedback from the "${personaName}" persona.${verdictContext}\n\nUse the dispatch_get_feedback MCP tool to fetch the unresolved items, then address each one: fix the ones that should be fixed and resolve them as you go using dispatch_resolve_feedback. When done, provide a summary report explaining what you addressed and what you chose not to address along with why.`;
-                  sendTerminalInput!(message + "\r");
-                }
-              : undefined;
+            const handleTriage =
+              unresolvedCount > 0
+                ? () => {
+                    if (!canTriage) return;
+                    const personaName = child.persona ?? child.name;
+                    const verdictContext = childVerdict
+                      ? `\n\nThe reviewer's verdict was: ${reviewVerdictLabel(childVerdict)}.${childSummary ? ` Their summary: "${childSummary}"` : ""}`
+                      : "";
+                    const message = `Review and triage the pending feedback from the "${personaName}" persona.${verdictContext}\n\nUse the dispatch_get_feedback MCP tool to fetch the unresolved items, then address each one: fix the ones that should be fixed and resolve them as you go using dispatch_resolve_feedback. When done, provide a summary report explaining what you addressed and what you chose not to address along with why.`;
+                    sendTerminalInput!(message + "\r");
+                  }
+                : undefined;
 
             return (
               <div key={child.id}>
@@ -373,7 +532,12 @@ export function ParentFeedbackPanel({
                   <div
                     className={cn(hasAnyFeedback && "cursor-pointer")}
                     onClick={(e) => {
-                      if ((e.target as HTMLElement).closest("[data-agent-control='true']")) return;
+                      if (
+                        (e.target as HTMLElement).closest(
+                          "[data-agent-control='true']"
+                        )
+                      )
+                        return;
                       if (hasAnyFeedback) {
                         e.stopPropagation();
                         setCollapsedGroups((prev) => {
@@ -402,7 +566,10 @@ export function ParentFeedbackPanel({
                       triageDisabled={!canTriage}
                       onOpenSummary={() => {
                         if (onOpenDetail) {
-                          onOpenDetail({ parentAgentId, summaryAgentId: child.id });
+                          onOpenDetail({
+                            parentAgentId,
+                            summaryAgentId: child.id,
+                          });
                         } else {
                           setSummaryAgentId(child.id);
                         }
@@ -411,79 +578,116 @@ export function ParentFeedbackPanel({
                   </div>
                 ) : null}
                 <AnimatePresence initial={false}>
-                  {!isGroupCollapsed && hasAnyFeedback ? (() => {
-                    return (
-                      <motion.div
-                        key={`feedback-${child.id}`}
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: "auto", opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.2, ease: "easeOut" }}
-                        className="overflow-hidden"
-                      >
-                        <div className="space-y-px ml-4 mt-0.5">
-                          {items.map((item) => {
-                            const isActionable = item.status === "open" || item.status === "forwarded";
-                            const dotColor = SEVERITY_DOT[item.severity] ?? SEVERITY_DOT.info;
-                            const statusLabel = STATUS_LABELS[item.status];
-                            const isSelected = item.id === (activeDetailItemId ?? sheetItemId);
+                  {!isGroupCollapsed && hasAnyFeedback
+                    ? (() => {
+                        return (
+                          <motion.div
+                            key={`feedback-${child.id}`}
+                            initial={{ height: 0, opacity: 0 }}
+                            animate={{ height: "auto", opacity: 1 }}
+                            exit={{ height: 0, opacity: 0 }}
+                            transition={{ duration: 0.2, ease: "easeOut" }}
+                            className="overflow-hidden"
+                          >
+                            <div className="space-y-px ml-4 mt-0.5">
+                              {items.map((item) => {
+                                const isActionable =
+                                  item.status === "open" ||
+                                  item.status === "forwarded";
+                                const dotColor =
+                                  SEVERITY_DOT[item.severity] ??
+                                  SEVERITY_DOT.info;
+                                const statusLabel = STATUS_LABELS[item.status];
+                                const isSelected =
+                                  item.id ===
+                                  (activeDetailItemId ?? sheetItemId);
 
-                            return (
-                              <div key={item.id} className={cn(!isActionable && "opacity-40")}>
+                                return (
+                                  <div
+                                    key={item.id}
+                                    className={cn(
+                                      !isActionable && "opacity-40"
+                                    )}
+                                  >
+                                    <button
+                                      className={cn(
+                                        "flex w-full items-center gap-1.5 px-1 py-2 md:py-1 text-left text-[11px] transition-colors",
+                                        "border-b-2",
+                                        isSelected
+                                          ? "border-primary"
+                                          : "border-transparent hover:bg-muted/40"
+                                      )}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        if (isSelected) {
+                                          if (onOpenDetail) onOpenDetail(null);
+                                          else setSheetItemId(null);
+                                        } else {
+                                          if (onOpenDetail)
+                                            onOpenDetail({
+                                              parentAgentId,
+                                              itemId: item.id,
+                                            });
+                                          else setSheetItemId(item.id);
+                                        }
+                                      }}
+                                    >
+                                      <span
+                                        className={cn(
+                                          "h-1.5 w-1.5 shrink-0 rounded-full",
+                                          dotColor
+                                        )}
+                                      />
+                                      <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
+                                        <FrontTruncatedValue
+                                          value={
+                                            item.filePath
+                                              ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}`
+                                              : "—"
+                                          }
+                                          mono
+                                        />
+                                      </div>
+                                      <span className="min-w-0 flex-1 truncate text-foreground">
+                                        {item.description}
+                                      </span>
+                                      {statusLabel && !isActionable ? (
+                                        <span
+                                          className={cn(
+                                            "shrink-0 text-[9px]",
+                                            statusLabel.color
+                                          )}
+                                        >
+                                          {statusLabel.label}
+                                        </span>
+                                      ) : null}
+                                    </button>
+                                  </div>
+                                );
+                              })}
+                              {resolvedCount > 0 ? (
                                 <button
-                                  className={cn(
-                                    "flex w-full items-center gap-1.5 px-1 py-2 md:py-1 text-left text-[11px] transition-colors",
-                                    "border-b-2",
-                                    isSelected ? "border-primary" : "border-transparent hover:bg-muted/40"
-                                  )}
+                                  className="mt-1 rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground/60 hover:bg-muted/40 hover:text-muted-foreground transition-colors"
                                   onClick={(e) => {
                                     e.stopPropagation();
-                                    if (isSelected) {
-                                      if (onOpenDetail) onOpenDetail(null);
-                                      else setSheetItemId(null);
-                                    } else {
-                                      if (onOpenDetail) onOpenDetail({ parentAgentId, itemId: item.id });
-                                      else setSheetItemId(item.id);
-                                    }
+                                    setShowResolvedAgents((prev) => {
+                                      const next = new Set(prev);
+                                      if (next.has(child.id))
+                                        next.delete(child.id);
+                                      else next.add(child.id);
+                                      return next;
+                                    });
                                   }}
                                 >
-                                  <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotColor)} />
-                                  <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
-                                    <FrontTruncatedValue
-                                      value={item.filePath ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}` : "—"}
-                                      mono
-                                    />
-                                  </div>
-                                  <span className="min-w-0 flex-1 truncate text-foreground">
-                                    {item.description}
-                                  </span>
-                                  {statusLabel && !isActionable ? (
-                                    <span className={cn("shrink-0 text-[9px]", statusLabel.color)}>{statusLabel.label}</span>
-                                  ) : null}
+                                  {showingResolved ? "Hide" : "Show"}{" "}
+                                  {resolvedCount} resolved
                                 </button>
-                              </div>
-                            );
-                          })}
-                          {resolvedCount > 0 ? (
-                            <button
-                              className="mt-1 rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground/60 hover:bg-muted/40 hover:text-muted-foreground transition-colors"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setShowResolvedAgents((prev) => {
-                                  const next = new Set(prev);
-                                  if (next.has(child.id)) next.delete(child.id);
-                                  else next.add(child.id);
-                                  return next;
-                                });
-                              }}
-                            >
-                              {showingResolved ? "Hide" : "Show"} {resolvedCount} resolved
-                            </button>
-                          ) : null}
-                        </div>
-                      </motion.div>
-                    );
-                  })() : null}
+                              ) : null}
+                            </div>
+                          </motion.div>
+                        );
+                      })()
+                    : null}
                 </AnimatePresence>
               </div>
             );
@@ -492,114 +696,165 @@ export function ParentFeedbackPanel({
       </div>
 
       {/* Full feedback detail sheet — only used on mobile (when onOpenDetail is not provided) */}
-      {!onOpenDetail ? <Sheet open={!!sheetItem} onOpenChange={(open) => { if (!open) setSheetItemId(null); }}>
-        <SheetContent side="bottom" hideCloseButton overlayClassName="z-[70]" className="z-[70] flex min-h-[40vh] max-h-[80vh] flex-col overflow-hidden px-6 py-5">
-          {sheetItem ? (
-            <>
-              {/* Nav + close in one container so they share alignment */}
-              <div className="absolute right-4 top-4 flex items-center space-x-8 z-10">
-                <div className="flex items-center gap-1">
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    {sheetIndex + 1}/{sheetNavItems.length}{!sheetIsActive ? " resolved" : ""}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0"
-                    disabled={!prevSheetItem}
-                    onClick={() => prevSheetItem && setSheetItemId(prevSheetItem.id)}
-                  >
-                    <ChevronLeft className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0"
-                    disabled={!nextSheetItem}
-                    onClick={() => nextSheetItem && setSheetItemId(nextSheetItem.id)}
-                  >
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-8 p-0 opacity-70 hover:opacity-100"
-                  onClick={() => setSheetItemId(null)}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-              <SheetHeader className="shrink-0">
-                <div className="flex items-center gap-2 pr-32">
-                  <Badge variant={severityInfo(sheetItem.severity).variant}>
-                    {severityInfo(sheetItem.severity).label}
-                  </Badge>
-                  <SheetTitle className="text-base flex-1">
-                    {sheetItem.filePath
-                      ? `${sheetItem.filePath}${sheetItem.lineNumber ? `:${sheetItem.lineNumber}` : ""}`
-                      : "Feedback"}
-                  </SheetTitle>
-                </div>
-                <SheetDescription className="text-xs text-muted-foreground flex items-center gap-1.5">
-                  {(() => {
-                    const attr = personaAttribution.get(sheetItem.agentId);
-                    if (attr) {
-                      return (
-                        <>
-                          <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
-                          <span style={{ color: attr.color }}>{attr.name}</span>
-                        </>
-                      );
-                    }
-                    return "From persona review";
-                  })()}
-                </SheetDescription>
-              </SheetHeader>
-
-              <div className="mt-4 min-h-0 flex-1 space-y-3 overflow-y-auto">
-                <div>
-                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Description</div>
-                  <Markdown className="text-sm text-foreground">{sheetItem.description}</Markdown>
-                </div>
-
-                {sheetItem.suggestion ? (
-                  <div>
-                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Suggestion</div>
-                    <Markdown className="text-sm text-muted-foreground">{sheetItem.suggestion}</Markdown>
+      {!onOpenDetail ? (
+        <Sheet
+          open={!!sheetItem}
+          onOpenChange={(open) => {
+            if (!open) setSheetItemId(null);
+          }}
+        >
+          <SheetContent
+            side="bottom"
+            hideCloseButton
+            overlayClassName="z-[70]"
+            className="z-[70] flex min-h-[40vh] max-h-[80vh] flex-col overflow-hidden px-6 py-5"
+          >
+            {sheetItem ? (
+              <>
+                {/* Nav + close in one container so they share alignment */}
+                <div className="absolute right-4 top-4 flex items-center space-x-8 z-10">
+                  <div className="flex items-center gap-1">
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {sheetIndex + 1}/{sheetNavItems.length}
+                      {!sheetIsActive ? " resolved" : ""}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      disabled={!prevSheetItem}
+                      onClick={() =>
+                        prevSheetItem && setSheetItemId(prevSheetItem.id)
+                      }
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      disabled={!nextSheetItem}
+                      onClick={() =>
+                        nextSheetItem && setSheetItemId(nextSheetItem.id)
+                      }
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
                   </div>
-                ) : null}
-              </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0 opacity-70 hover:opacity-100"
+                    onClick={() => setSheetItemId(null)}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <SheetHeader className="shrink-0">
+                  <div className="flex items-center gap-2 pr-32">
+                    <Badge variant={severityInfo(sheetItem.severity).variant}>
+                      {severityInfo(sheetItem.severity).label}
+                    </Badge>
+                    <SheetTitle className="text-base flex-1">
+                      {sheetItem.filePath
+                        ? `${sheetItem.filePath}${sheetItem.lineNumber ? `:${sheetItem.lineNumber}` : ""}`
+                        : "Feedback"}
+                    </SheetTitle>
+                  </div>
+                  <SheetDescription className="text-xs text-muted-foreground flex items-center gap-1.5">
+                    {(() => {
+                      const attr = personaAttribution.get(sheetItem.agentId);
+                      if (attr) {
+                        return (
+                          <>
+                            <span
+                              className="h-2 w-2 shrink-0 rounded-full"
+                              style={{ backgroundColor: attr.color }}
+                            />
+                            <span style={{ color: attr.color }}>
+                              {attr.name}
+                            </span>
+                          </>
+                        );
+                      }
+                      return "From persona review";
+                    })()}
+                  </SheetDescription>
+                </SheetHeader>
 
-              <div className="shrink-0 pt-2 border-t border-border">
-                <FeedbackActions
-                  item={sheetItem}
-                  isConnected={isConnected}
-                  onForward={(mode) => forward(sheetItem, mode)}
-                  onCopy={() => handleCopy(sheetItem)}
-                  copied={copied && copiedItemId === sheetItem.id}
-                  onUpdateStatus={(s) => handleResolve(sheetItem, s)}
-                  isActionable={sheetItem.status === "open" || sheetItem.status === "forwarded"}
-                  statusLabel={STATUS_LABELS[sheetItem.status]}
-                  size="default"
-                />
-              </div>
-            </>
-          ) : null}
-        </SheetContent>
-      </Sheet> : null}
+                <div className="mt-4 min-h-0 flex-1 space-y-3 overflow-y-auto">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                      Description
+                    </div>
+                    <Markdown className="text-sm text-foreground">
+                      {sheetItem.description}
+                    </Markdown>
+                  </div>
+
+                  {sheetItem.suggestion ? (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                        Suggestion
+                      </div>
+                      <Markdown className="text-sm text-muted-foreground">
+                        {sheetItem.suggestion}
+                      </Markdown>
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="shrink-0 pt-2 border-t border-border">
+                  <FeedbackActions
+                    item={sheetItem}
+                    isConnected={isConnected}
+                    onForward={(mode) => forward(sheetItem, mode)}
+                    onCopy={() => handleCopy(sheetItem)}
+                    copied={copied && copiedItemId === sheetItem.id}
+                    onUpdateStatus={(s) => handleResolve(sheetItem, s)}
+                    isActionable={
+                      sheetItem.status === "open" ||
+                      sheetItem.status === "forwarded"
+                    }
+                    statusLabel={STATUS_LABELS[sheetItem.status]}
+                    size="default"
+                  />
+                </div>
+              </>
+            ) : null}
+          </SheetContent>
+        </Sheet>
+      ) : null}
 
       {/* Review summary sheet */}
       {(() => {
-        const summaryAgent = summaryAgentId ? childAgents.find((a) => a.id === summaryAgentId) ?? null : null;
+        const summaryAgent = summaryAgentId
+          ? (childAgents.find((a) => a.id === summaryAgentId) ?? null)
+          : null;
         const verdict = summaryAgent ? getVerdict(summaryAgent) : undefined;
-        const summary = summaryAgent ? getReviewSummary(summaryAgent) : undefined;
-        const filesReviewed = summaryAgent ? getFilesReviewed(summaryAgent) : undefined;
-        const attr = summaryAgent ? personaAttribution.get(summaryAgent.id) : undefined;
+        const summary = summaryAgent
+          ? getReviewSummary(summaryAgent)
+          : undefined;
+        const filesReviewed = summaryAgent
+          ? getFilesReviewed(summaryAgent)
+          : undefined;
+        const attr = summaryAgent
+          ? personaAttribution.get(summaryAgent.id)
+          : undefined;
 
         return (
-          <Sheet open={!!summaryAgent} onOpenChange={(open) => { if (!open) setSummaryAgentId(null); }}>
-            <SheetContent side="bottom" hideCloseButton overlayClassName="z-[70]" className="z-[70] flex min-h-[30vh] max-h-[70vh] flex-col overflow-hidden px-6 py-5">
+          <Sheet
+            open={!!summaryAgent}
+            onOpenChange={(open) => {
+              if (!open) setSummaryAgentId(null);
+            }}
+          >
+            <SheetContent
+              side="bottom"
+              hideCloseButton
+              overlayClassName="z-[70]"
+              className="z-[70] flex min-h-[30vh] max-h-[70vh] flex-col overflow-hidden px-6 py-5"
+            >
               {summaryAgent ? (
                 <>
                   <div className="absolute right-4 top-4 z-10">
@@ -615,16 +870,23 @@ export function ParentFeedbackPanel({
                   <SheetHeader className="shrink-0">
                     <div className="flex items-center gap-2 pr-16">
                       {verdict ? (
-                        <Badge variant={verdict === "approve" ? "default" : "error"}>
+                        <Badge
+                          variant={verdict === "approve" ? "default" : "error"}
+                        >
                           {reviewVerdictLabel(verdict)}
                         </Badge>
                       ) : null}
-                      <SheetTitle className="text-base flex-1">Review Summary</SheetTitle>
+                      <SheetTitle className="text-base flex-1">
+                        Review Summary
+                      </SheetTitle>
                     </div>
                     <SheetDescription className="text-xs text-muted-foreground flex items-center gap-1.5">
                       {attr ? (
                         <>
-                          <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
+                          <span
+                            className="h-2 w-2 shrink-0 rounded-full"
+                            style={{ backgroundColor: attr.color }}
+                          />
                           <span style={{ color: attr.color }}>{attr.name}</span>
                         </>
                       ) : (
@@ -636,24 +898,38 @@ export function ParentFeedbackPanel({
                   <div className="mt-4 min-h-0 flex-1 space-y-3 overflow-y-auto">
                     {summary ? (
                       <div>
-                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Summary</div>
-                        <Markdown className="text-sm text-foreground">{summary}</Markdown>
+                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                          Summary
+                        </div>
+                        <Markdown className="text-sm text-foreground">
+                          {summary}
+                        </Markdown>
                       </div>
                     ) : null}
 
                     {filesReviewed && filesReviewed.length > 0 ? (
                       <div>
-                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Files Reviewed</div>
+                        <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                          Files Reviewed
+                        </div>
                         <div className="space-y-0.5">
                           {filesReviewed.map((f) => (
-                            <div key={f} className="font-mono text-xs text-muted-foreground">{f}</div>
+                            <div
+                              key={f}
+                              className="font-mono text-xs text-muted-foreground"
+                            >
+                              {f}
+                            </div>
                           ))}
                         </div>
                       </div>
                     ) : null}
 
-                    {!summary && (!filesReviewed || filesReviewed.length === 0) ? (
-                      <div className="text-sm text-muted-foreground">No summary available.</div>
+                    {!summary &&
+                    (!filesReviewed || filesReviewed.length === 0) ? (
+                      <div className="text-sm text-muted-foreground">
+                        No summary available.
+                      </div>
                     ) : null}
                   </div>
                 </>
@@ -676,13 +952,18 @@ function useFeedbackData(parentAgentId: string) {
   const { data: feedback = [] } = useQuery<FeedbackItem[]>({
     queryKey: ["feedback", parentAgentId, "children"],
     queryFn: async () => {
-      const result = await api<{ feedback: FeedbackItem[] }>(`/api/v1/agents/${parentAgentId}/feedback?scope=children`);
+      const result = await api<{ feedback: FeedbackItem[] }>(
+        `/api/v1/agents/${parentAgentId}/feedback?scope=children`
+      );
       return result.feedback;
     },
     staleTime: 0,
   });
 
-  const { data: allAgents = [] } = useQuery<Agent[]>({ queryKey: ["agents"], enabled: false });
+  const { data: allAgents = [] } = useQuery<Agent[]>({
+    queryKey: ["agents"],
+    enabled: false,
+  });
   const parentAgent = allAgents.find((a) => a.id === parentAgentId);
   const parentCwd = parentAgent?.worktreePath ?? parentAgent?.cwd;
 
@@ -690,7 +971,9 @@ function useFeedbackData(parentAgentId: string) {
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
     queryKey: ["personas", parentCwd],
     queryFn: async () => {
-      const result = await api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(parentCwd ?? "")}`);
+      const result = await api<{ personas: PersonaSummary[] }>(
+        `/api/v1/personas?cwd=${encodeURIComponent(parentCwd ?? "")}`
+      );
       return result.personas;
     },
     enabled: !!parentCwd,
@@ -702,22 +985,35 @@ function useFeedbackData(parentAgentId: string) {
     for (const agent of allAgents) {
       if (agent.parentAgentId === parentAgentId && agent.persona) {
         const idx = slugToIndex.get(agent.persona);
-        const colorVar = idx != null ? `var(--chart-${(idx % 4) + 1})` : `var(--chart-1)`;
+        const colorVar =
+          idx != null ? `var(--chart-${(idx % 4) + 1})` : `var(--chart-1)`;
         const persona = personas.find((p) => p.slug === agent.persona);
-        map.set(agent.id, { name: persona?.name ?? agent.persona, color: `hsl(${colorVar})` });
+        map.set(agent.id, {
+          name: persona?.name ?? agent.persona,
+          color: `hsl(${colorVar})`,
+        });
       }
     }
     return map;
   }, [allAgents, parentAgentId, personas]);
 
-  const updateStatus = useCallback(async (item: FeedbackItem, status: string) => {
-    await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
-      method: "PATCH",
-      body: JSON.stringify({ status }),
-    });
-    const update = (f: FeedbackItem) => f.id === item.id ? { ...f, status: status as FeedbackItem["status"] } : f;
-    queryClient.setQueryData<FeedbackItem[]>(["feedback", parentAgentId, "children"], (old) => old?.map(update));
-  }, [queryClient, parentAgentId]);
+  const updateStatus = useCallback(
+    async (item: FeedbackItem, status: string) => {
+      await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      });
+      const update = (f: FeedbackItem) =>
+        f.id === item.id
+          ? { ...f, status: status as FeedbackItem["status"] }
+          : f;
+      queryClient.setQueryData<FeedbackItem[]>(
+        ["feedback", parentAgentId, "children"],
+        (old) => old?.map(update)
+      );
+    },
+    [queryClient, parentAgentId]
+  );
 
   return { feedback, personaAttribution, updateStatus };
 }
@@ -741,57 +1037,88 @@ export function FeedbackDetailPanel({
   onClose: () => void;
   onNavigate: (itemId: number) => void;
 }): JSX.Element | null {
-  const { feedback, personaAttribution, updateStatus } = useFeedbackData(parentAgentId);
+  const { feedback, personaAttribution, updateStatus } =
+    useFeedbackData(parentAgentId);
   const [copied, copyText] = useCopyText();
   const [copiedItemId, setCopiedItemId] = useState<number | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
-  const activeItems = useMemo(() => feedback.filter((f) => f.status === "open" || f.status === "forwarded").sort(bySeverity), [feedback]);
-  const resolvedItems = useMemo(() => feedback.filter((f) => f.status !== "open" && f.status !== "forwarded").sort(bySeverity), [feedback]);
+  const activeItems = useMemo(
+    () =>
+      feedback
+        .filter((f) => f.status === "open" || f.status === "forwarded")
+        .sort(bySeverity),
+    [feedback]
+  );
+  const resolvedItems = useMemo(
+    () =>
+      feedback
+        .filter((f) => f.status !== "open" && f.status !== "forwarded")
+        .sort(bySeverity),
+    [feedback]
+  );
   const item = feedback.find((f) => f.id === itemId) ?? null;
 
-  const isActiveItem = item && (item.status === "open" || item.status === "forwarded");
+  const isActiveItem =
+    item && (item.status === "open" || item.status === "forwarded");
   const navItems = isActiveItem ? activeItems : resolvedItems;
   const itemIndex = item ? navItems.findIndex((f) => f.id === item.id) : -1;
   const prevItem = itemIndex > 0 ? navItems[itemIndex - 1]! : null;
-  const nextItem = itemIndex >= 0 && itemIndex < navItems.length - 1 ? navItems[itemIndex + 1]! : null;
+  const nextItem =
+    itemIndex >= 0 && itemIndex < navItems.length - 1
+      ? navItems[itemIndex + 1]!
+      : null;
 
   // Auto-focus the panel when it opens
   useEffect(() => {
     panelRef.current?.focus();
   }, [itemId]);
 
-  const forward = useCallback((feedbackItem: FeedbackItem, mode: "wdyt" | "fix") => {
-    if (sendTerminalInput && isConnected) {
-      const prefix = mode === "fix"
-        ? "Fix the following issue found by the persona reviewer:"
-        : "A persona reviewer flagged the following. What do you think — is this a real concern?";
-      const text = prefix + "\n" + formatFeedbackText(feedbackItem) + "\r";
-      sendTerminalInput(text);
-      void updateStatus(feedbackItem, "forwarded");
-    }
-  }, [sendTerminalInput, isConnected, updateStatus]);
+  const forward = useCallback(
+    (feedbackItem: FeedbackItem, mode: "wdyt" | "fix") => {
+      if (sendTerminalInput && isConnected) {
+        const prefix =
+          mode === "fix"
+            ? "Fix the following issue found by the persona reviewer:"
+            : "A persona reviewer flagged the following. What do you think — is this a real concern?";
+        const text = prefix + "\n" + formatFeedbackText(feedbackItem) + "\r";
+        sendTerminalInput(text);
+        void updateStatus(feedbackItem, "forwarded");
+      }
+    },
+    [sendTerminalInput, isConnected, updateStatus]
+  );
 
-  const handleCopy = useCallback((feedbackItem: FeedbackItem) => {
-    copyText(formatFeedbackText(feedbackItem));
-    setCopiedItemId(feedbackItem.id);
-  }, [copyText]);
+  const handleCopy = useCallback(
+    (feedbackItem: FeedbackItem) => {
+      copyText(formatFeedbackText(feedbackItem));
+      setCopiedItemId(feedbackItem.id);
+    },
+    [copyText]
+  );
 
-  const handleResolve = useCallback((feedbackItem: FeedbackItem, status: string) => {
-    void updateStatus(feedbackItem, status);
-    // Advance within the same persona group
-    const samePersona = activeItems.filter((f) => f.agentId === feedbackItem.agentId);
-    const idx = samePersona.findIndex((f) => f.id === feedbackItem.id);
-    const remaining = samePersona.filter((f) => f.id !== feedbackItem.id);
-    if (remaining.length > 0) {
-      onNavigate(remaining[Math.min(Math.max(idx, 0), remaining.length - 1)]!.id);
-    } else if (resolvedItems.length > 0) {
-      // Show first resolved item instead of closing
-      onNavigate(resolvedItems[0]!.id);
-    } else {
-      onClose();
-    }
-  }, [updateStatus, activeItems, resolvedItems, onNavigate, onClose]);
+  const handleResolve = useCallback(
+    (feedbackItem: FeedbackItem, status: string) => {
+      void updateStatus(feedbackItem, status);
+      // Advance within the same persona group
+      const samePersona = activeItems.filter(
+        (f) => f.agentId === feedbackItem.agentId
+      );
+      const idx = samePersona.findIndex((f) => f.id === feedbackItem.id);
+      const remaining = samePersona.filter((f) => f.id !== feedbackItem.id);
+      if (remaining.length > 0) {
+        onNavigate(
+          remaining[Math.min(Math.max(idx, 0), remaining.length - 1)]!.id
+        );
+      } else if (resolvedItems.length > 0) {
+        // Show first resolved item instead of closing
+        onNavigate(resolvedItems[0]!.id);
+      } else {
+        onClose();
+      }
+    },
+    [updateStatus, activeItems, resolvedItems, onNavigate, onClose]
+  );
 
   if (!item) return null;
 
@@ -804,16 +1131,17 @@ export function FeedbackDetailPanel({
       ref={panelRef}
       tabIndex={-1}
       onKeyDown={(e) => {
-        if (e.key === "Escape") { e.stopPropagation(); onClose(); }
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onClose();
+        }
       }}
       className="flex h-full min-h-0 flex-col overflow-hidden border-t border-border bg-card px-6 py-4 outline-none"
     >
       {/* Header row with nav + close */}
       <div className="flex items-center justify-between shrink-0 mb-3">
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          <Badge variant={severityInfo!.variant}>
-            {severityInfo!.label}
-          </Badge>
+          <Badge variant={severityInfo!.variant}>{severityInfo!.label}</Badge>
           <span className="text-base font-semibold truncate">
             {item.filePath
               ? `${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`
@@ -821,14 +1149,18 @@ export function FeedbackDetailPanel({
           </span>
           {attr ? (
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
-              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: attr.color }}
+              />
               <span style={{ color: attr.color }}>{attr.name}</span>
             </span>
           ) : null}
         </div>
         <div className="flex items-center gap-1 shrink-0 ml-4">
           <span className="text-xs text-muted-foreground tabular-nums">
-            {itemIndex + 1}/{navItems.length}{!isActiveItem ? " resolved" : ""}
+            {itemIndex + 1}/{navItems.length}
+            {!isActiveItem ? " resolved" : ""}
           </span>
           <Button
             variant="ghost"
@@ -862,14 +1194,22 @@ export function FeedbackDetailPanel({
       {/* Scrollable content */}
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
         <div>
-          <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Description</div>
-          <Markdown className="text-sm text-foreground">{item.description}</Markdown>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+            Description
+          </div>
+          <Markdown className="text-sm text-foreground">
+            {item.description}
+          </Markdown>
         </div>
 
         {item.suggestion ? (
           <div>
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Suggestion</div>
-            <Markdown className="text-sm text-muted-foreground">{item.suggestion}</Markdown>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+              Suggestion
+            </div>
+            <Markdown className="text-sm text-muted-foreground">
+              {item.suggestion}
+            </Markdown>
           </div>
         ) : null}
       </div>
@@ -904,7 +1244,9 @@ export function ReviewSummaryPanel({
   const { personaAttribution } = useFeedbackData(parentAgentId);
 
   const panelRef = useRef<HTMLDivElement>(null);
-  useEffect(() => { panelRef.current?.focus(); }, [agent.id]);
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, [agent.id]);
 
   const verdict = getVerdict(agent);
   const summary = getReviewSummary(agent);
@@ -916,7 +1258,10 @@ export function ReviewSummaryPanel({
       ref={panelRef}
       tabIndex={-1}
       onKeyDown={(e) => {
-        if (e.key === "Escape") { e.stopPropagation(); onClose(); }
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onClose();
+        }
       }}
       className="flex h-full min-h-0 flex-col overflow-hidden border-t border-border bg-card px-6 py-4 outline-none"
     >
@@ -927,10 +1272,15 @@ export function ReviewSummaryPanel({
               {reviewVerdictLabel(verdict)}
             </Badge>
           ) : null}
-          <span className="text-base font-semibold truncate">Review Summary</span>
+          <span className="text-base font-semibold truncate">
+            Review Summary
+          </span>
           {attr ? (
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
-              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: attr.color }} />
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: attr.color }}
+              />
               <span style={{ color: attr.color }}>{attr.name}</span>
             </span>
           ) : null}
@@ -948,24 +1298,35 @@ export function ReviewSummaryPanel({
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
         {summary ? (
           <div>
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Summary</div>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+              Summary
+            </div>
             <Markdown className="text-sm text-foreground">{summary}</Markdown>
           </div>
         ) : null}
 
         {filesReviewed && filesReviewed.length > 0 ? (
           <div>
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">Files Reviewed</div>
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+              Files Reviewed
+            </div>
             <div className="space-y-0.5">
               {filesReviewed.map((f) => (
-                <div key={f} className="font-mono text-xs text-muted-foreground">{f}</div>
+                <div
+                  key={f}
+                  className="font-mono text-xs text-muted-foreground"
+                >
+                  {f}
+                </div>
               ))}
             </div>
           </div>
         ) : null}
 
         {!summary && (!filesReviewed || filesReviewed.length === 0) ? (
-          <div className="text-sm text-muted-foreground">No summary available.</div>
+          <div className="text-sm text-muted-foreground">
+            No summary available.
+          </div>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -1,6 +1,23 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import cronstrue from "cronstrue";
-import { Activity, AlarmClock, CheckCircle2, ChevronDown, Clock, GitBranch, History, Loader2, LoaderCircle, MessageSquareText, Play, Settings, Terminal, Trash2, X, XCircle } from "lucide-react";
+import {
+  Activity,
+  AlarmClock,
+  CheckCircle2,
+  ChevronDown,
+  Clock,
+  GitBranch,
+  History,
+  Loader2,
+  LoaderCircle,
+  MessageSquareText,
+  Play,
+  Settings,
+  Terminal,
+  Trash2,
+  X,
+  XCircle,
+} from "lucide-react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -11,11 +28,38 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Bar, BarChart, XAxis } from "recharts";
-import { type AddJobConfig, type Job, type JobRun, type JobRunStatus, useJobActions, useJobHistory, useJobs, useJobStats } from "@/hooks/use-jobs";
-import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, type ChartConfig } from "@/components/ui/chart";
+import {
+  type AddJobConfig,
+  type Job,
+  type JobRun,
+  type JobRunStatus,
+  useJobActions,
+  useJobHistory,
+  useJobs,
+  useJobStats,
+} from "@/hooks/use-jobs";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { StatCard } from "@/components/app/stat-card";
 import { formatRelativeTime } from "@/lib/format";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
@@ -38,7 +82,10 @@ type JobsContextValue = {
   tab: DetailTab;
   history: { data?: { runs: JobRun[] }; isLoading: boolean };
   activeRunAgent: Agent | null;
-  jobStats: { data?: import("@/hooks/use-jobs").JobStats | null; isLoading: boolean };
+  jobStats: {
+    data?: import("@/hooks/use-jobs").JobStats | null;
+    isLoading: boolean;
+  };
   routeRunId: string | undefined;
   selectJob: (job: Job) => void;
   openAddJob: () => void;
@@ -68,34 +115,47 @@ function useJobsContext(): JobsContextValue {
 
 type DetailTab = "configure" | "prompt" | "history";
 
-const ACTIVE_RUN_STATUSES: JobRunStatus[] = ["started", "running", "needs_input"];
+const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
+  "started",
+  "running",
+  "needs_input",
+];
 
 function statusClasses(status: JobRunStatus | null): string {
-  if (status === "completed") return "border-status-done/45 bg-status-done/15 text-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed") return "border-status-blocked/45 bg-status-blocked/15 text-status-blocked";
-  if (status === "needs_input") return "border-status-waiting/45 bg-status-waiting/15 text-status-waiting";
-  if (status === "started" || status === "running") return "border-status-working/45 bg-status-working/15 text-status-working";
+  if (status === "completed")
+    return "border-status-done/45 bg-status-done/15 text-status-done";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "border-status-blocked/45 bg-status-blocked/15 text-status-blocked";
+  if (status === "needs_input")
+    return "border-status-waiting/45 bg-status-waiting/15 text-status-waiting";
+  if (status === "started" || status === "running")
+    return "border-status-working/45 bg-status-working/15 text-status-working";
   return "border-border bg-muted/35 text-muted-foreground";
 }
 
 function statusTextColor(status: JobRunStatus | null): string {
   if (status === "completed") return "text-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed") return "text-status-blocked";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "text-status-blocked";
   if (status === "needs_input") return "text-status-waiting";
-  if (status === "started" || status === "running") return "text-status-working";
+  if (status === "started" || status === "running")
+    return "text-status-working";
   return "text-muted-foreground";
 }
 
 function statusIcon(status: JobRunStatus | null): JSX.Element | null {
   if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" />;
-  if (status === "failed" || status === "timed_out" || status === "crashed") return <XCircle className="h-3.5 w-3.5" />;
-  if (status === "started" || status === "running" || status === "needs_input") return <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin" />;
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return <XCircle className="h-3.5 w-3.5" />;
+  if (status === "started" || status === "running" || status === "needs_input")
+    return <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin" />;
   return null;
 }
 
 function statusDotColor(status: JobRunStatus | null): string {
   if (status === "completed") return "bg-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed") return "bg-status-blocked";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "bg-status-blocked";
   if (status === "needs_input") return "bg-status-waiting";
   if (status === "started" || status === "running") return "bg-status-working";
   return "bg-muted-foreground";
@@ -105,7 +165,10 @@ function formatDate(iso: string | null | undefined): string {
   if (!iso) return "Not scheduled";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return "Unknown";
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 function formatDuration(ms: number | null | undefined): string {
@@ -134,9 +197,11 @@ function errorMessage(error: unknown): string {
 
 function cronError(schedule: string, enabled: boolean): string | null {
   const trimmed = schedule.trim();
-  if (!trimmed) return enabled ? "Add a cron schedule before enabling this job." : null;
+  if (!trimmed)
+    return enabled ? "Add a cron schedule before enabling this job." : null;
   const fields = trimmed.split(/\s+/);
-  if (fields.length !== 5) return "Use a 5-field cron expression like */30 * * * *.";
+  if (fields.length !== 5)
+    return "Use a 5-field cron expression like */30 * * * *.";
   return null;
 }
 
@@ -161,23 +226,49 @@ function triggerSourceLabel(run: JobRun): string {
 
 function useActiveRun(job: Job | null, agents: Agent[]) {
   return useMemo(() => {
-    if (!job?.lastRunId || !job.lastRunStatus || !ACTIVE_RUN_STATUSES.includes(job.lastRunStatus)) return null;
-    return agents.find((agent) => agent.name.startsWith(`job-${job.name}-`) || agent.name.endsWith(job.lastRunId!.slice(0, 8))) ?? null;
+    if (
+      !job?.lastRunId ||
+      !job.lastRunStatus ||
+      !ACTIVE_RUN_STATUSES.includes(job.lastRunStatus)
+    )
+      return null;
+    return (
+      agents.find(
+        (agent) =>
+          agent.name.startsWith(`job-${job.name}-`) ||
+          agent.name.endsWith(job.lastRunId!.slice(0, 8))
+      ) ?? null
+    );
   }, [agents, job]);
 }
 
 /** Provider that manages all job state. Wrap around both JobListContent and JobDetailPane. */
-export function JobsProvider({ open, agents, onOpenAgent, enabledAgentTypes, children }: JobsPaneProps & { children: React.ReactNode }): JSX.Element {
+export function JobsProvider({
+  open,
+  agents,
+  onOpenAgent,
+  enabledAgentTypes,
+  children,
+}: JobsPaneProps & { children: React.ReactNode }): JSX.Element {
   const navigate = useNavigate();
-  const { jobId: routeJobId, section: routeSection, runId: routeRunId } = useParams();
+  const {
+    jobId: routeJobId,
+    section: routeSection,
+    runId: routeRunId,
+  } = useParams();
   const { data: jobs = [], isLoading, error } = useJobs(open);
   const { addJob, runNow, setEnabled, updateJob, removeJob } = useJobActions();
   const [isAddingJob, setIsAddingJob] = useState(false);
   const [actionErrorByJobId] = useState<Record<string, string>>({});
   const [justAddedJobId, setJustAddedJobId] = useState<string | null>(null);
   const showOverview = routeJobId === "overview";
-  const selectedJob = showOverview ? null : (jobs.find((job) => job.id === routeJobId) ?? null);
-  const tab: DetailTab = routeSection === "prompt" || routeSection === "history" ? routeSection : "configure";
+  const selectedJob = showOverview
+    ? null
+    : (jobs.find((job) => job.id === routeJobId) ?? null);
+  const tab: DetailTab =
+    routeSection === "prompt" || routeSection === "history"
+      ? routeSection
+      : "configure";
   const history = useJobHistory(selectedJob);
   const activeRunAgent = useActiveRun(selectedJob, agents);
   const jobStats = useJobStats(open && !selectedJob);
@@ -196,12 +287,33 @@ export function JobsProvider({ open, agents, onOpenAgent, enabledAgentTypes, chi
   const showDetailPane = !!selectedJob || showOverview;
 
   const ctx: JobsContextValue = {
-    jobs, isLoading, error, selectedJob, showOverview, showDetailPane, tab,
-    history, activeRunAgent, jobStats, routeRunId,
-    selectJob, openAddJob, actionErrorByJobId, navigate,
-    agents, onOpenAgent, enabledAgentTypes,
-    addJob, runNow, setEnabled, updateJob, removeJob,
-    isAddingJob, setIsAddingJob, justAddedJobId, setJustAddedJobId,
+    jobs,
+    isLoading,
+    error,
+    selectedJob,
+    showOverview,
+    showDetailPane,
+    tab,
+    history,
+    activeRunAgent,
+    jobStats,
+    routeRunId,
+    selectJob,
+    openAddJob,
+    actionErrorByJobId,
+    navigate,
+    agents,
+    onOpenAgent,
+    enabledAgentTypes,
+    addJob,
+    runNow,
+    setEnabled,
+    updateJob,
+    removeJob,
+    isAddingJob,
+    setIsAddingJob,
+    justAddedJobId,
+    setJustAddedJobId,
   };
 
   return (
@@ -224,13 +336,29 @@ export function JobsProvider({ open, agents, onOpenAgent, enabledAgentTypes, chi
 }
 
 /** Job list content for the unified sidebar. */
-export function JobListContent({ onItemSelect }: { onItemSelect?: () => void }): JSX.Element {
-  const { jobs, isLoading, error, selectedJob, showOverview, actionErrorByJobId, selectJob, openAddJob, navigate } = useJobsContext();
+export function JobListContent({
+  onItemSelect,
+}: {
+  onItemSelect?: () => void;
+}): JSX.Element {
+  const {
+    jobs,
+    isLoading,
+    error,
+    selectedJob,
+    showOverview,
+    actionErrorByJobId,
+    selectJob,
+    openAddJob,
+    navigate,
+  } = useJobsContext();
 
   return (
     <div data-testid="jobs-sidebar" className="flex h-full min-h-0 flex-col">
       <div className="mt-2 flex h-14 items-center border-b border-border px-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Jobs</h2>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Jobs
+        </h2>
         <div className="ml-auto flex items-center">
           <Button
             size="sm"
@@ -245,16 +373,28 @@ export function JobListContent({ onItemSelect }: { onItemSelect?: () => void }):
         </div>
       </div>
 
-      <div data-testid="jobs-sidebar-scroll" className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        data-testid="jobs-sidebar-scroll"
+        className="min-h-0 flex-1 overflow-y-auto"
+      >
         {error ? (
-          <div className="m-3 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{error instanceof Error ? error.message : "Failed to load jobs."}</div>
+          <div className="m-3 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+            {error instanceof Error ? error.message : "Failed to load jobs."}
+          </div>
         ) : isLoading ? (
-          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading jobs...</div>
+          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading jobs...
+          </div>
         ) : jobs.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground">
             <div className="rounded-md border border-dashed border-border p-4">
-              <div className="font-medium text-foreground">No jobs added yet.</div>
-              <div className="mt-1 text-xs">Added jobs will appear here with schedule, status, and run controls.</div>
+              <div className="font-medium text-foreground">
+                No jobs added yet.
+              </div>
+              <div className="mt-1 text-xs">
+                Added jobs will appear here with schedule, status, and run
+                controls.
+              </div>
             </div>
           </div>
         ) : (
@@ -264,7 +404,10 @@ export function JobListContent({ onItemSelect }: { onItemSelect?: () => void }):
                 "flex w-full items-center gap-2 border-b border-r-4 border-border border-r-transparent px-3 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/40",
                 showOverview && "border-r-primary bg-muted/60"
               )}
-              onClick={() => { navigate("/jobs/overview"); onItemSelect?.(); }}
+              onClick={() => {
+                navigate("/jobs/overview");
+                onItemSelect?.();
+              }}
             >
               <Activity className="h-3.5 w-3.5" />
               <span>Overview</span>
@@ -277,25 +420,42 @@ export function JobListContent({ onItemSelect }: { onItemSelect?: () => void }):
                   data-testid={`job-row-${job.id}`}
                   className={cn(
                     "w-full cursor-pointer border-b border-r-4 border-border border-r-transparent px-3 py-2 text-left transition-colors hover:bg-muted/40",
-                    selectedJob?.id === job.id && "md:border-r-primary md:bg-muted/60"
+                    selectedJob?.id === job.id &&
+                      "md:border-r-primary md:bg-muted/60"
                   )}
-                  onClick={() => { selectJob(job); onItemSelect?.(); }}
+                  onClick={() => {
+                    selectJob(job);
+                    onItemSelect?.();
+                  }}
                 >
                   <div className="flex items-center gap-2">
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-semibold leading-5">{job.name}</div>
-                      <div className="truncate font-mono text-[11px] text-muted-foreground" title={job.directory}>{shortPath(job.directory)}</div>
+                      <div className="truncate text-sm font-semibold leading-5">
+                        {job.name}
+                      </div>
+                      <div
+                        className="truncate font-mono text-[11px] text-muted-foreground"
+                        title={job.directory}
+                      >
+                        {shortPath(job.directory)}
+                      </div>
                     </div>
                     <Badge className={statusClasses(job.lastRunStatus)}>
-                      <span className="mr-1 hidden sm:inline-flex">{statusIcon(job.lastRunStatus)}</span>
+                      <span className="mr-1 hidden sm:inline-flex">
+                        {statusIcon(job.lastRunStatus)}
+                      </span>
                       {job.lastRunStatus ?? "new"}
                     </Badge>
                   </div>
                   <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
                     <Clock className="h-3.5 w-3.5 shrink-0" />
-                    <span className="truncate">{job.schedule ? `Cron: ${job.schedule}` : "No schedule"}</span>
+                    <span className="truncate">
+                      {job.schedule ? `Cron: ${job.schedule}` : "No schedule"}
+                    </span>
                     <span className="shrink-0 text-muted-foreground/70">•</span>
-                    <span className="shrink-0">{job.enabled ? "enabled" : "disabled"}</span>
+                    <span className="shrink-0">
+                      {job.enabled ? "enabled" : "disabled"}
+                    </span>
                   </div>
                   {actionError ? (
                     <div className="mt-2 rounded border border-status-blocked/30 bg-status-blocked/10 px-2 py-1 text-xs text-status-blocked">
@@ -315,9 +475,23 @@ export function JobListContent({ onItemSelect }: { onItemSelect?: () => void }):
 /** Job detail pane for the main content area. */
 export function JobDetailPane(): JSX.Element {
   const {
-    jobs, selectedJob, tab, history, activeRunAgent, jobStats,
-    routeRunId, navigate, onOpenAgent, enabledAgentTypes,
-    runNow, setEnabled, updateJob, removeJob, justAddedJobId, setJustAddedJobId, selectJob,
+    jobs,
+    selectedJob,
+    tab,
+    history,
+    activeRunAgent,
+    jobStats,
+    routeRunId,
+    navigate,
+    onOpenAgent,
+    enabledAgentTypes,
+    runNow,
+    setEnabled,
+    updateJob,
+    removeJob,
+    justAddedJobId,
+    setJustAddedJobId,
+    selectJob,
   } = useJobsContext();
 
   return (
@@ -330,20 +504,32 @@ export function JobDetailPane(): JSX.Element {
               job={selectedJob}
               tab={tab}
               onTabChange={(nextTab) => {
-                navigate(`/jobs/${selectedJob.id}${nextTab === "configure" ? "" : `/${nextTab}`}`);
+                navigate(
+                  `/jobs/${selectedJob.id}${nextTab === "configure" ? "" : `/${nextTab}`}`
+                );
               }}
               history={history.data?.runs ?? []}
               historyLoading={history.isLoading}
               selectedRunId={routeRunId ?? null}
               onSelectRun={(runId) => {
-                navigate(runId ? `/jobs/${selectedJob.id}/history/${runId}` : `/jobs/${selectedJob.id}/history`);
+                navigate(
+                  runId
+                    ? `/jobs/${selectedJob.id}/history/${runId}`
+                    : `/jobs/${selectedJob.id}/history`
+                );
               }}
               activeRunAgent={activeRunAgent}
               onOpenAgent={onOpenAgent}
-              onRunNow={async (job) => { await runNow.mutateAsync(job); }}
-              onSetEnabled={async (job, enabled) => { await setEnabled.mutateAsync({ job, enabled }); }}
+              onRunNow={async (job) => {
+                await runNow.mutateAsync(job);
+              }}
+              onSetEnabled={async (job, enabled) => {
+                await setEnabled.mutateAsync({ job, enabled });
+              }}
               enabledAgentTypes={enabledAgentTypes}
-              onUpdateJob={async (job) => { await updateJob.mutateAsync(job); }}
+              onUpdateJob={async (job) => {
+                await updateJob.mutateAsync(job);
+              }}
               onRemoveJob={async (job) => {
                 await removeJob.mutateAsync(job);
                 navigate("/jobs");
@@ -361,7 +547,9 @@ export function JobDetailPane(): JSX.Element {
               stats={jobStats.data ?? null}
               statsLoading={jobStats.isLoading}
               onSelectJob={selectJob}
-              onSelectRun={(jobId, runId) => navigate(`/jobs/${jobId}/history/${runId}`)}
+              onSelectRun={(jobId, runId) =>
+                navigate(`/jobs/${jobId}/history/${runId}`)
+              }
             />
           </div>
         )}
@@ -378,7 +566,8 @@ function formatTimeUntil(iso: string): string {
   if (mins < 60) return `in ${mins}m`;
   const hours = Math.floor(mins / 60);
   const remMins = mins % 60;
-  if (hours < 24) return remMins > 0 ? `in ${hours}h ${remMins}m` : `in ${hours}h`;
+  if (hours < 24)
+    return remMins > 0 ? `in ${hours}h ${remMins}m` : `in ${hours}h`;
   const days = Math.floor(hours / 24);
   return `in ${days}d`;
 }
@@ -391,13 +580,28 @@ function formatTimeUntilDate(iso: string): string {
   const tomorrow = new Date(now);
   tomorrow.setDate(tomorrow.getDate() + 1);
   const isTomorrow = date.toDateString() === tomorrow.toDateString();
-  const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
   if (isToday) return `Today at ${time}`;
   if (isTomorrow) return `Tomorrow at ${time}`;
-  return date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+  return date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
-function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
+function JobsOverview({
+  jobs,
+  stats,
+  statsLoading,
+  onSelectJob,
+  onSelectRun,
+}: {
   jobs: Job[];
   stats: import("@/hooks/use-jobs").JobStats | null;
   statsLoading: boolean;
@@ -407,7 +611,10 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
   const upcomingJobs = useMemo(() => {
     return jobs
       .filter((j) => j.nextRun)
-      .sort((a, b) => new Date(a.nextRun!).getTime() - new Date(b.nextRun!).getTime())
+      .sort(
+        (a, b) =>
+          new Date(a.nextRun!).getTime() - new Date(b.nextRun!).getTime()
+      )
       .slice(0, 5);
   }, [jobs]);
 
@@ -415,14 +622,20 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
   const metrics = stats?.stats ?? null;
   const hasAnyData = jobs.length > 0;
 
-  const successRate = metrics && metrics.totalRuns > 0
-    ? Math.round((metrics.successCount / metrics.totalRuns) * 100)
-    : null;
+  const successRate =
+    metrics && metrics.totalRuns > 0
+      ? Math.round((metrics.successCount / metrics.totalRuns) * 100)
+      : null;
 
   const dailyChartData = useMemo(() => {
     if (!metrics?.daily?.length) return [];
     const byDay = new Map(metrics.daily.map((d) => [d.day, d]));
-    const days: Array<{ day: string; label: string; completed: number; failed: number }> = [];
+    const days: Array<{
+      day: string;
+      label: string;
+      completed: number;
+      failed: number;
+    }> = [];
     const now = new Date();
     for (let i = 6; i >= 0; i--) {
       const d = new Date(now);
@@ -445,7 +658,10 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
         <div>
           <AlarmClock className="mx-auto mb-3 h-8 w-8" />
           <div className="font-medium text-foreground">No jobs yet</div>
-          <div className="mt-1 max-w-sm text-sm">Use jobs for recurring maintenance, scheduled checks, and repeatable agent workflows that should run without manual prompting.</div>
+          <div className="mt-1 max-w-sm text-sm">
+            Use jobs for recurring maintenance, scheduled checks, and repeatable
+            agent workflows that should run without manual prompting.
+          </div>
         </div>
       </div>
     );
@@ -465,16 +681,28 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
         {metrics && metrics.totalRuns > 0 && (
           <>
             <div className="flex flex-wrap gap-2 sm:gap-3">
-              <StatCard label="Total Runs" value={metrics.totalRuns} sub="Last 7 days" />
+              <StatCard
+                label="Total Runs"
+                value={metrics.totalRuns}
+                sub="Last 7 days"
+              />
               <StatCard
                 label="Success Rate"
                 value={successRate !== null ? `${successRate}%` : "-"}
                 sub="Last 7 days"
-                variant={successRate !== null && successRate < 80 ? "warning" : undefined}
+                variant={
+                  successRate !== null && successRate < 80
+                    ? "warning"
+                    : undefined
+                }
               />
               <StatCard
                 label="Avg Duration"
-                value={metrics.avgDurationMs ? formatDuration(metrics.avgDurationMs) : "-"}
+                value={
+                  metrics.avgDurationMs
+                    ? formatDuration(metrics.avgDurationMs)
+                    : "-"
+                }
                 sub="Last 7 days"
               />
               <StatCard
@@ -488,7 +716,9 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
             <div className="flex flex-col gap-4 sm:flex-row [&>*]:sm:flex-1 [&>*]:sm:min-w-0">
               {dailyChartData.length > 0 && (
                 <div>
-                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">Daily Runs</h3>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Daily Runs
+                  </h3>
                   <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3">
                     <DailyRunsChart data={dailyChartData} />
                   </div>
@@ -514,10 +744,14 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
                   className="flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
                   onClick={() => onSelectJob(job)}
                 >
-                  <span className="font-medium text-foreground">{job.name}</span>
+                  <span className="font-medium text-foreground">
+                    {job.name}
+                  </span>
                   <span className="flex items-center gap-2 text-xs text-muted-foreground">
                     <span>{formatTimeUntil(job.nextRun!)}</span>
-                    <span className="hidden text-muted-foreground/60 sm:inline">{formatTimeUntilDate(job.nextRun!)}</span>
+                    <span className="hidden text-muted-foreground/60 sm:inline">
+                      {formatTimeUntilDate(job.nextRun!)}
+                    </span>
                   </span>
                 </button>
               ))}
@@ -533,20 +767,36 @@ function JobsOverview({ jobs, stats, statsLoading, onSelectJob, onSelectRun }: {
               Recent Activity
             </div>
             <div className="divide-y divide-border rounded-md border border-border bg-muted/40">
-              {recentRuns.filter((run) => jobs.some((j) => j.id === run.jobId)).slice(0, 8).map((run) => {
-                return (
-                  <button
-                    key={run.id}
-                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
-                    onClick={() => onSelectRun(run.jobId, run.id)}
-                  >
-                    <span className="min-w-0 flex-1 truncate font-medium text-foreground">{run.jobName}</span>
-                    <span className={cn("shrink-0 text-xs capitalize", statusTextColor(run.status))}>{run.status}</span>
-                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatDuration(run.durationMs)}</span>
-                    <span className="shrink-0 text-xs text-muted-foreground/60">{formatRelativeTime(run.startedAt)}</span>
-                  </button>
-                );
-              })}
+              {recentRuns
+                .filter((run) => jobs.some((j) => j.id === run.jobId))
+                .slice(0, 8)
+                .map((run) => {
+                  return (
+                    <button
+                      key={run.id}
+                      className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
+                      onClick={() => onSelectRun(run.jobId, run.id)}
+                    >
+                      <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+                        {run.jobName}
+                      </span>
+                      <span
+                        className={cn(
+                          "shrink-0 text-xs capitalize",
+                          statusTextColor(run.status)
+                        )}
+                      >
+                        {run.status}
+                      </span>
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {formatDuration(run.durationMs)}
+                      </span>
+                      <span className="shrink-0 text-xs text-muted-foreground/60">
+                        {formatRelativeTime(run.startedAt)}
+                      </span>
+                    </button>
+                  );
+                })}
             </div>
           </div>
         )}
@@ -573,21 +823,45 @@ const dailyRunsChartConfig = {
   failed: { label: "Failed", color: "hsl(var(--status-blocked))" },
 } satisfies ChartConfig;
 
-function DailyRunsChart({ data }: { data: Array<{ day: string; label: string; completed: number; failed: number }> }) {
+function DailyRunsChart({
+  data,
+}: {
+  data: Array<{
+    day: string;
+    label: string;
+    completed: number;
+    failed: number;
+  }>;
+}) {
   return (
     <ChartContainer config={dailyRunsChartConfig} className="h-full w-full">
       <BarChart data={data} barCategoryGap="20%">
-        <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={6} tick={{ fontSize: 11 }} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tick={{ fontSize: 11 }}
+        />
         <ChartTooltip
           content={
             <ChartTooltipContent
               indicator="dot"
               formatter={(value, name, item) => (
                 <>
-                  <div className="h-2.5 w-2.5 shrink-0 rounded-[2px]" style={{ backgroundColor: item.color }} />
+                  <div
+                    className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                    style={{ backgroundColor: item.color }}
+                  />
                   <div className="flex flex-1 items-center justify-between gap-4">
-                    <span className="text-muted-foreground">{dailyRunsChartConfig[name as keyof typeof dailyRunsChartConfig]?.label ?? name}</span>
-                    <span className="font-mono font-medium tabular-nums text-foreground">{value as number}</span>
+                    <span className="text-muted-foreground">
+                      {dailyRunsChartConfig[
+                        name as keyof typeof dailyRunsChartConfig
+                      ]?.label ?? name}
+                    </span>
+                    <span className="font-mono font-medium tabular-nums text-foreground">
+                      {value as number}
+                    </span>
                   </div>
                 </>
               )}
@@ -596,8 +870,18 @@ function DailyRunsChart({ data }: { data: Array<{ day: string; label: string; co
           }
         />
         <ChartLegend content={<ChartLegendContent className="gap-2" />} />
-        <Bar dataKey="completed" stackId="runs" fill="var(--color-completed)" radius={0} />
-        <Bar dataKey="failed" stackId="runs" fill="var(--color-failed)" radius={[2, 2, 0, 0]} />
+        <Bar
+          dataKey="completed"
+          stackId="runs"
+          fill="var(--color-completed)"
+          radius={0}
+        />
+        <Bar
+          dataKey="failed"
+          stackId="runs"
+          fill="var(--color-failed)"
+          radius={[2, 2, 0, 0]}
+        />
       </BarChart>
     </ChartContainer>
   );
@@ -605,7 +889,9 @@ function DailyRunsChart({ data }: { data: Array<{ day: string; label: string; co
 
 // ─── Avg Duration Per Job ─────────────────────────────────────────────
 
-function JobAvgDuration({ runs }: {
+function JobAvgDuration({
+  runs,
+}: {
   runs: Array<{ jobName: string; durationMs: number | null }>;
 }) {
   const perJob = useMemo(() => {
@@ -628,20 +914,29 @@ function JobAvgDuration({ runs }: {
 
   return (
     <div>
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">Avg Duration</h3>
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Avg Duration
+      </h3>
       <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-center">
         <div className="flex flex-col gap-3 overflow-y-auto min-h-0">
-        {perJob.jobs.map((job) => (
-          <div key={job.name}>
-            <div className="mb-1 flex items-center justify-between">
-              <span className="truncate text-xs text-muted-foreground">{job.name}</span>
-              <span className="text-xs font-medium tabular-nums text-foreground">{formatDuration(job.avg)}</span>
+          {perJob.jobs.map((job) => (
+            <div key={job.name}>
+              <div className="mb-1 flex items-center justify-between">
+                <span className="truncate text-xs text-muted-foreground">
+                  {job.name}
+                </span>
+                <span className="text-xs font-medium tabular-nums text-foreground">
+                  {formatDuration(job.avg)}
+                </span>
+              </div>
+              <div className="flex h-2 overflow-hidden rounded-sm bg-muted/60">
+                <div
+                  className="bg-chart-1/70 transition-all rounded-sm"
+                  style={{ width: `${(job.avg / perJob.maxAvg) * 100}%` }}
+                />
+              </div>
             </div>
-            <div className="flex h-2 overflow-hidden rounded-sm bg-muted/60">
-              <div className="bg-chart-1/70 transition-all rounded-sm" style={{ width: `${(job.avg / perJob.maxAvg) * 100}%` }} />
-            </div>
-          </div>
-        ))}
+          ))}
         </div>
       </div>
     </div>
@@ -652,17 +947,32 @@ function JobAvgDuration({ runs }: {
 
 const MAX_RUN_CELLS = 16;
 
-function RunHistoryGrid({ runs }: {
-  runs: Array<{ jobId: string; jobName: string; status: JobRunStatus; startedAt: string }>;
+function RunHistoryGrid({
+  runs,
+}: {
+  runs: Array<{
+    jobId: string;
+    jobName: string;
+    status: JobRunStatus;
+    startedAt: string;
+  }>;
 }) {
   const perJob = useMemo(() => {
-    const grouped = new Map<string, Array<{ status: JobRunStatus; startedAt: string }>>();
+    const grouped = new Map<
+      string,
+      Array<{ status: JobRunStatus; startedAt: string }>
+    >();
     for (const run of runs) {
       if (!grouped.has(run.jobName)) grouped.set(run.jobName, []);
-      grouped.get(run.jobName)!.push({ status: run.status, startedAt: run.startedAt });
+      grouped
+        .get(run.jobName)!
+        .push({ status: run.status, startedAt: run.startedAt });
     }
     // Each job's runs are newest-first from the API; take last N then reverse to oldest→newest
-    const result: Array<{ name: string; runs: Array<{ status: JobRunStatus; startedAt: string }> }> = [];
+    const result: Array<{
+      name: string;
+      runs: Array<{ status: JobRunStatus; startedAt: string }>;
+    }> = [];
     for (const [name, jobRuns] of grouped) {
       result.push({ name, runs: jobRuns.slice(0, MAX_RUN_CELLS).reverse() });
     }
@@ -673,27 +983,45 @@ function RunHistoryGrid({ runs }: {
 
   return (
     <div>
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">Run History</h3>
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Run History
+      </h3>
       <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-between">
         <TooltipProvider delayDuration={80}>
           <div className="space-y-2 overflow-y-auto min-h-0 flex-1">
             {perJob.map(({ name, runs: jobRuns }) => (
               <div key={name}>
-                <div className="mb-1 truncate text-[10px] text-muted-foreground">{name}</div>
-                <div className="grid gap-[1px]" style={{ gridTemplateColumns: `repeat(${MAX_RUN_CELLS}, 1fr)` }}>
+                <div className="mb-1 truncate text-[10px] text-muted-foreground">
+                  {name}
+                </div>
+                <div
+                  className="grid gap-[1px]"
+                  style={{
+                    gridTemplateColumns: `repeat(${MAX_RUN_CELLS}, 1fr)`,
+                  }}
+                >
                   {Array.from({ length: MAX_RUN_CELLS }, (_, i) => {
                     const run = i < jobRuns.length ? jobRuns[i] : null;
-                    if (!run) return <div key={i} className="h-4 sm:h-3 bg-muted/30" />;
+                    if (!run)
+                      return <div key={i} className="h-4 sm:h-3 bg-muted/30" />;
                     return (
                       <Tooltip key={i}>
                         <TooltipTrigger asChild>
-                          <div className={cn(
-                            "h-4 sm:h-3",
-                            run.status === "completed" && "bg-status-done/70",
-                            (run.status === "failed" || run.status === "timed_out" || run.status === "crashed") && "bg-status-blocked/70",
-                            (run.status === "running" || run.status === "started") && "bg-status-working/70",
-                            run.status === "needs_input" && "bg-status-waiting/70",
-                          )} />
+                          <div
+                            className={cn(
+                              "h-4 sm:h-3",
+                              run.status === "completed" && "bg-status-done/70",
+                              (run.status === "failed" ||
+                                run.status === "timed_out" ||
+                                run.status === "crashed") &&
+                                "bg-status-blocked/70",
+                              (run.status === "running" ||
+                                run.status === "started") &&
+                                "bg-status-working/70",
+                              run.status === "needs_input" &&
+                                "bg-status-waiting/70"
+                            )}
+                          />
                         </TooltipTrigger>
                         <TooltipContent side="top" className="text-xs">
                           {run.status} — {formatRelativeTime(run.startedAt)}
@@ -707,8 +1035,14 @@ function RunHistoryGrid({ runs }: {
           </div>
         </TooltipProvider>
         <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-          <span className="flex items-center gap-1"><span className="inline-block h-2 w-3 bg-status-done/70" />Completed</span>
-          <span className="flex items-center gap-1"><span className="inline-block h-2 w-3 bg-status-blocked/70" />Failed</span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-3 bg-status-done/70" />
+            Completed
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-3 bg-status-blocked/70" />
+            Failed
+          </span>
         </div>
       </div>
     </div>
@@ -729,10 +1063,19 @@ function AddJobDialog({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
         <DialogPrimitive.Content className="fixed inset-x-2 bottom-2 top-2 z-50 flex max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-lg border border-border bg-card shadow-xl outline-none md:left-1/2 md:top-1/2 md:h-[min(760px,88vh)] md:w-[min(760px,calc(100vw-2rem))] md:-translate-x-1/2 md:-translate-y-1/2">
-          <DialogPrimitive.Title className="sr-only">Add job</DialogPrimitive.Title>
-          <DialogPrimitive.Description className="sr-only">Create a new recurring Dispatch job.</DialogPrimitive.Description>
+          <DialogPrimitive.Title className="sr-only">
+            Add job
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Create a new recurring Dispatch job.
+          </DialogPrimitive.Description>
           <DialogPrimitive.Close asChild>
-            <Button variant="ghost" size="icon" className="absolute right-3 top-3 z-10" aria-label="Close add job">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-3 top-3 z-10"
+              aria-label="Close add job"
+            >
               <X className="h-4 w-4" />
             </Button>
           </DialogPrimitive.Close>
@@ -757,8 +1100,11 @@ function AddJobFlow({
   const [prompt, setPrompt] = useState("");
   const [schedule, setSchedule] = useState("");
   const [timeoutMinutes, setTimeoutMinutes] = useState("30");
-  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] = useState("1440");
-  const [agentType, setAgentType] = useState<AgentType>(enabledAgentTypes[0] ?? "codex");
+  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] =
+    useState("1440");
+  const [agentType, setAgentType] = useState<AgentType>(
+    enabledAgentTypes[0] ?? "codex"
+  );
   const [fullAccess, setFullAccess] = useState(false);
   const [useWorktree, setUseWorktree] = useState(false);
   const [branchName, setBranchName] = useState("");
@@ -766,30 +1112,61 @@ function AddJobFlow({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const scheduleError = cronError(schedule, enableImmediately);
-  const canAdd = !!displayName.trim() && !!directory.trim() && !!prompt.trim() && !scheduleError && !!msFromMinutes(timeoutMinutes) && !!msFromMinutes(needsInputTimeoutMinutes);
+  const canAdd =
+    !!displayName.trim() &&
+    !!directory.trim() &&
+    !!prompt.trim() &&
+    !scheduleError &&
+    !!msFromMinutes(timeoutMinutes) &&
+    !!msFromMinutes(needsInputTimeoutMinutes);
 
   return (
     <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col overflow-hidden p-4 md:p-8">
       <div className="text-lg font-semibold">Create a new job</div>
-      <p className="mt-1 text-sm text-muted-foreground">Define a recurring automation with a prompt and schedule.</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Define a recurring automation with a prompt and schedule.
+      </p>
 
       <ScrollArea className="mt-6 min-h-0 flex-1 pr-1">
         <div className="grid min-w-0 gap-4">
           <div className="min-w-0 rounded-md border border-border bg-background/50 p-4">
             <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
               <span>
-                <span className="block font-medium text-foreground">Enabled</span>
-                <span className="block text-xs text-muted-foreground">Run this job on its schedule after creating it.</span>
+                <span className="block font-medium text-foreground">
+                  Enabled
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Run this job on its schedule after creating it.
+                </span>
               </span>
-              <SwitchToggle checked={enableImmediately} onCheckedChange={setEnableImmediately} ariaLabel="Enable job" />
+              <SwitchToggle
+                checked={enableImmediately}
+                onCheckedChange={setEnableImmediately}
+                ariaLabel="Enable job"
+              />
             </label>
             <div className="mt-4 grid min-w-0 gap-3 md:grid-cols-2">
               <div className="min-w-0 space-y-1 md:col-span-2">
-                <label className="text-sm text-muted-foreground" htmlFor="job-display-name">Name</label>
-                <Input id="job-display-name" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="e.g. Daily cleanup" />
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-display-name"
+                >
+                  Name
+                </label>
+                <Input
+                  id="job-display-name"
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="e.g. Daily cleanup"
+                />
               </div>
               <div className="min-w-0 space-y-1 md:col-span-2">
-                <label className="text-sm text-muted-foreground" htmlFor="job-directory">Working directory</label>
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-directory"
+                >
+                  Working directory
+                </label>
                 <PathInput
                   value={directory}
                   onChange={setDirectory}
@@ -800,20 +1177,46 @@ function AddJobFlow({
                 />
               </div>
               <div className="min-w-0 space-y-1">
-                <label className="text-sm text-muted-foreground" htmlFor="job-schedule">Cron schedule</label>
-                <Input id="job-schedule" value={schedule} onChange={(event) => setSchedule(event.target.value)} placeholder="*/30 * * * *" className="font-mono text-xs" />
-                {scheduleError ? <div className="text-xs text-status-blocked">{scheduleError}</div> : null}
-                {!scheduleError && schedule.trim() ? <div className="text-xs text-muted-foreground">{humanSchedule(schedule)}</div> : null}
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-schedule"
+                >
+                  Cron schedule
+                </label>
+                <Input
+                  id="job-schedule"
+                  value={schedule}
+                  onChange={(event) => setSchedule(event.target.value)}
+                  placeholder="*/30 * * * *"
+                  className="font-mono text-xs"
+                />
+                {scheduleError ? (
+                  <div className="text-xs text-status-blocked">
+                    {scheduleError}
+                  </div>
+                ) : null}
+                {!scheduleError && schedule.trim() ? (
+                  <div className="text-xs text-muted-foreground">
+                    {humanSchedule(schedule)}
+                  </div>
+                ) : null}
               </div>
               <div className="min-w-0 space-y-1">
-                <label className="text-sm text-muted-foreground">Agent type</label>
-                <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentType)}>
+                <label className="text-sm text-muted-foreground">
+                  Agent type
+                </label>
+                <Select
+                  value={agentType}
+                  onValueChange={(value) => setAgentType(value as AgentType)}
+                >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
                     {enabledAgentTypes.map((type) => (
-                      <SelectItem key={type} value={type}>{AGENT_TYPE_LABELS[type]}</SelectItem>
+                      <SelectItem key={type} value={type}>
+                        {AGENT_TYPE_LABELS[type]}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -823,8 +1226,15 @@ function AddJobFlow({
 
           <div className="min-w-0 rounded-md border border-border bg-muted/20 p-4">
             <div className="space-y-1">
-              <label className="text-sm font-medium text-foreground" htmlFor="job-prompt">Prompt</label>
-              <p className="text-xs text-muted-foreground">The instructions the agent will follow when this job runs.</p>
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="job-prompt"
+              >
+                Prompt
+              </label>
+              <p className="text-xs text-muted-foreground">
+                The instructions the agent will follow when this job runs.
+              </p>
             </div>
             <textarea
               id="job-prompt"
@@ -836,29 +1246,66 @@ function AddJobFlow({
           </div>
 
           <div className="min-w-0 rounded-md border border-border bg-background/50 p-4">
-            <button type="button" className="flex w-full items-center justify-between gap-3 text-left" onClick={() => setAdvancedOpen((current) => !current)}>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-3 text-left"
+              onClick={() => setAdvancedOpen((current) => !current)}
+            >
               <div>
                 <div className="text-sm font-medium">Advanced settings</div>
-                <div className="mt-1 text-xs text-muted-foreground">Timeouts, worktree behavior, and permissions.</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Timeouts, worktree behavior, and permissions.
+                </div>
               </div>
-              <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", advancedOpen && "rotate-180")} />
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 text-muted-foreground transition-transform",
+                  advancedOpen && "rotate-180"
+                )}
+              />
             </button>
             <div
               className={cn(
                 "grid min-w-0 overflow-hidden transition-all duration-200 ease-out",
-                advancedOpen ? "mt-4 grid-rows-[1fr] opacity-100" : "mt-0 grid-rows-[0fr] opacity-0",
+                advancedOpen
+                  ? "mt-4 grid-rows-[1fr] opacity-100"
+                  : "mt-0 grid-rows-[0fr] opacity-0"
               )}
               aria-hidden={!advancedOpen}
             >
               <div className="min-h-0">
                 <div className="grid min-w-0 gap-3 md:grid-cols-2">
                   <div className="min-w-0 space-y-1">
-                    <label className="text-sm text-muted-foreground" htmlFor="job-timeout">Run timeout, minutes</label>
-                    <Input id="job-timeout" value={timeoutMinutes} onChange={(event) => setTimeoutMinutes(event.target.value)} inputMode="numeric" />
+                    <label
+                      className="text-sm text-muted-foreground"
+                      htmlFor="job-timeout"
+                    >
+                      Run timeout, minutes
+                    </label>
+                    <Input
+                      id="job-timeout"
+                      value={timeoutMinutes}
+                      onChange={(event) =>
+                        setTimeoutMinutes(event.target.value)
+                      }
+                      inputMode="numeric"
+                    />
                   </div>
                   <div className="min-w-0 space-y-1">
-                    <label className="text-sm text-muted-foreground" htmlFor="job-needs-input-timeout">Wait for input, minutes</label>
-                    <Input id="job-needs-input-timeout" value={needsInputTimeoutMinutes} onChange={(event) => setNeedsInputTimeoutMinutes(event.target.value)} inputMode="numeric" />
+                    <label
+                      className="text-sm text-muted-foreground"
+                      htmlFor="job-needs-input-timeout"
+                    >
+                      Wait for input, minutes
+                    </label>
+                    <Input
+                      id="job-needs-input-timeout"
+                      value={needsInputTimeoutMinutes}
+                      onChange={(event) =>
+                        setNeedsInputTimeoutMinutes(event.target.value)
+                      }
+                      inputMode="numeric"
+                    />
                   </div>
                   <JobWorktreeOption
                     checked={useWorktree}
@@ -866,14 +1313,19 @@ function AddJobFlow({
                     onCheckedChange={setUseWorktree}
                     onBranchNameChange={setBranchName}
                   />
-                  <JobFullAccessOption checked={fullAccess} onCheckedChange={setFullAccess} />
+                  <JobFullAccessOption
+                    checked={fullAccess}
+                    onCheckedChange={setFullAccess}
+                  />
                 </div>
               </div>
             </div>
           </div>
 
           {submitError ? (
-            <div className="rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{submitError}</div>
+            <div className="rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+              {submitError}
+            </div>
           ) : null}
         </div>
       </ScrollArea>
@@ -949,13 +1401,20 @@ function JobDetail({
   justAdded: boolean;
   onDismissAdded: () => void;
 }) {
-  const [detailActionError, setDetailActionError] = useState<string | null>(null);
+  const [detailActionError, setDetailActionError] = useState<string | null>(
+    null
+  );
   return (
     <div className={cn("flex h-full min-h-0 flex-col p-4 md:p-6", className)}>
       <div className="flex flex-wrap items-start gap-3">
         <div className="min-w-0 flex-1">
           <h2 className="truncate text-xl font-semibold">{job.name}</h2>
-          <div className="mt-1 truncate font-mono text-xs text-muted-foreground" title={job.directory}>{shortPath(job.directory)}</div>
+          <div
+            className="mt-1 truncate font-mono text-xs text-muted-foreground"
+            title={job.directory}
+          >
+            {shortPath(job.directory)}
+          </div>
         </div>
         <Button
           size="sm"
@@ -963,7 +1422,9 @@ function JobDetail({
           disabled={isUpdating}
           onClick={() => {
             setDetailActionError(null);
-            void onRunNow(job).catch((error) => setDetailActionError(errorMessage(error)));
+            void onRunNow(job).catch((error) =>
+              setDetailActionError(errorMessage(error))
+            );
           }}
         >
           <Play className="mr-2 h-4 w-4" />
@@ -975,8 +1436,12 @@ function JobDetail({
         <div className="mt-4 rounded-md border border-status-working/40 bg-status-working/10 p-3">
           <div className="flex flex-wrap items-center gap-3">
             <div className="min-w-0 flex-1">
-              <div className="text-sm font-medium text-status-working">Active run is attached to a live agent session.</div>
-              <div className="truncate text-xs text-muted-foreground">{activeRunAgent.name}</div>
+              <div className="text-sm font-medium text-status-working">
+                Active run is attached to a live agent session.
+              </div>
+              <div className="truncate text-xs text-muted-foreground">
+                {activeRunAgent.name}
+              </div>
             </div>
             <Button size="sm" onClick={() => void onOpenAgent(activeRunAgent)}>
               <Terminal className="mr-2 h-4 w-4" />
@@ -988,18 +1453,28 @@ function JobDetail({
 
       {justAdded ? (
         <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-4">
-          <div className="text-sm font-semibold text-status-done">Job added</div>
-          <div className="mt-1 text-sm text-muted-foreground">
-            {job.enabled && job.nextRun ? `Scheduled next run: ${formatDate(job.nextRun)}.` : "This job is saved but not enabled on a schedule yet."}
+          <div className="text-sm font-semibold text-status-done">
+            Job added
           </div>
-          {detailActionError ? <div className="mt-3 rounded border border-status-blocked/30 bg-status-blocked/10 p-2 text-sm text-status-blocked">{detailActionError}</div> : null}
+          <div className="mt-1 text-sm text-muted-foreground">
+            {job.enabled && job.nextRun
+              ? `Scheduled next run: ${formatDate(job.nextRun)}.`
+              : "This job is saved but not enabled on a schedule yet."}
+          </div>
+          {detailActionError ? (
+            <div className="mt-3 rounded border border-status-blocked/30 bg-status-blocked/10 p-2 text-sm text-status-blocked">
+              {detailActionError}
+            </div>
+          ) : null}
           <div className="mt-4 flex flex-wrap gap-2">
             <Button
               size="sm"
               variant="primary"
               onClick={() => {
                 setDetailActionError(null);
-                void onRunNow(job).catch((error) => setDetailActionError(errorMessage(error)));
+                void onRunNow(job).catch((error) =>
+                  setDetailActionError(errorMessage(error))
+                );
               }}
             >
               <Play className="mr-2 h-4 w-4" />
@@ -1012,23 +1487,63 @@ function JobDetail({
                 disabled={!job.schedule}
                 onClick={() => {
                   setDetailActionError(null);
-                  void onSetEnabled(job, true).catch((error) => setDetailActionError(errorMessage(error)));
+                  void onSetEnabled(job, true).catch((error) =>
+                    setDetailActionError(errorMessage(error))
+                  );
                 }}
               >
                 Enable schedule
               </Button>
             ) : null}
-            <Button size="sm" variant="default" onClick={() => { onDismissAdded(); onTabChange("configure"); }}>Edit settings</Button>
-            <Button size="sm" variant="ghost" onClick={() => { onDismissAdded(); onTabChange("history"); }}>View history</Button>
+            <Button
+              size="sm"
+              variant="default"
+              onClick={() => {
+                onDismissAdded();
+                onTabChange("configure");
+              }}
+            >
+              Edit settings
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                onDismissAdded();
+                onTabChange("history");
+              }}
+            >
+              View history
+            </Button>
           </div>
         </div>
       ) : null}
 
       <div className="mt-5 flex flex-wrap items-center gap-2 border-b border-border">
-        <TabButton active={tab === "configure"} onClick={() => onTabChange("configure")} icon={<Settings className="h-4 w-4" />}>Configure</TabButton>
-        <TabButton active={tab === "prompt"} onClick={() => onTabChange("prompt")} icon={<MessageSquareText className="h-4 w-4" />}>Prompt</TabButton>
-        <TabButton active={tab === "history"} onClick={() => onTabChange("history")} icon={<History className="h-4 w-4" />}>History</TabButton>
-        <Badge className={cn("mb-2 self-center", statusClasses(job.lastRunStatus))}>
+        <TabButton
+          active={tab === "configure"}
+          onClick={() => onTabChange("configure")}
+          icon={<Settings className="h-4 w-4" />}
+        >
+          Configure
+        </TabButton>
+        <TabButton
+          active={tab === "prompt"}
+          onClick={() => onTabChange("prompt")}
+          icon={<MessageSquareText className="h-4 w-4" />}
+        >
+          Prompt
+        </TabButton>
+        <TabButton
+          active={tab === "history"}
+          onClick={() => onTabChange("history")}
+          icon={<History className="h-4 w-4" />}
+        >
+          History
+        </TabButton>
+        <Badge
+          className={cn("mb-2 self-center", statusClasses(job.lastRunStatus))}
+        >
           <span className="mr-1">{statusIcon(job.lastRunStatus)}</span>
           {job.lastRunStatus ?? "never run"}
         </Badge>
@@ -1036,26 +1551,57 @@ function JobDetail({
 
       {tab === "history" ? (
         <div className="min-h-0 flex-1">
-          <HistoryTab runs={history} loading={historyLoading} selectedRunId={selectedRunId} onSelectRun={onSelectRun} />
+          <HistoryTab
+            runs={history}
+            loading={historyLoading}
+            selectedRunId={selectedRunId}
+            onSelectRun={onSelectRun}
+          />
         </div>
       ) : tab === "configure" ? (
         <ScrollArea className="min-h-0 flex-1 pr-1">
-          <SettingsTab job={job} enabledAgentTypes={enabledAgentTypes} onUpdateJob={onUpdateJob} onRemoveJob={onRemoveJob} isUpdating={isUpdating} isRemoving={isRemoving} />
+          <SettingsTab
+            job={job}
+            enabledAgentTypes={enabledAgentTypes}
+            onUpdateJob={onUpdateJob}
+            onRemoveJob={onRemoveJob}
+            isUpdating={isUpdating}
+            isRemoving={isRemoving}
+          />
         </ScrollArea>
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-          <PromptTab job={job} onUpdateJob={onUpdateJob} isUpdating={isUpdating} />
+          <PromptTab
+            job={job}
+            onUpdateJob={onUpdateJob}
+            isUpdating={isUpdating}
+          />
         </div>
       )}
     </div>
   );
 }
 
-function TabButton({ active, onClick, icon, children }: { active: boolean; onClick: () => void; icon: React.ReactNode; children: React.ReactNode }) {
+function TabButton({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <button
       type="button"
-      className={cn("flex items-center gap-2 border-b-2 px-3 py-2 text-sm transition-colors", active ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground")}
+      className={cn(
+        "flex items-center gap-2 border-b-2 px-3 py-2 text-sm transition-colors",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground"
+      )}
       onClick={onClick}
     >
       {icon}
@@ -1123,9 +1669,12 @@ function JobFullAccessOption({
         title="Toggle full access"
       />
       <span className="space-y-1">
-        <span className="block text-sm font-medium text-foreground">Run in full access mode</span>
+        <span className="block text-sm font-medium text-foreground">
+          Run in full access mode
+        </span>
         <span className="block text-xs text-muted-foreground">
-          Starts the selected agent with its most permissive supported execution mode.
+          Starts the selected agent with its most permissive supported execution
+          mode.
         </span>
       </span>
     </label>
@@ -1180,8 +1729,12 @@ function SettingsTab({
 }) {
   const [displayName, setDisplayName] = useState(job.name);
   const [schedule, setSchedule] = useState(job.schedule ?? "");
-  const [timeoutMinutes, setTimeoutMinutes] = useState(minutesFromMs(job.timeoutMs));
-  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] = useState(minutesFromMs(job.needsInputTimeoutMs));
+  const [timeoutMinutes, setTimeoutMinutes] = useState(
+    minutesFromMs(job.timeoutMs)
+  );
+  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] = useState(
+    minutesFromMs(job.needsInputTimeoutMs)
+  );
   const [agentType, setAgentType] = useState<AgentType>(job.agentType);
   const [fullAccess, setFullAccess] = useState(job.fullAccess);
   const [useWorktree, setUseWorktree] = useState(job.useWorktree);
@@ -1192,7 +1745,11 @@ function SettingsTab({
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [saved, setSaved] = useState(false);
   const scheduleError = cronError(schedule, enabled);
-  const canSave = !!displayName.trim() && !scheduleError && !!msFromMinutes(timeoutMinutes) && !!msFromMinutes(needsInputTimeoutMinutes);
+  const canSave =
+    !!displayName.trim() &&
+    !scheduleError &&
+    !!msFromMinutes(timeoutMinutes) &&
+    !!msFromMinutes(needsInputTimeoutMinutes);
 
   useEffect(() => {
     setDisplayName(job.name);
@@ -1214,45 +1771,106 @@ function SettingsTab({
     <div className="mt-4 grid gap-4">
       <div className="rounded-md border border-border bg-background/50 p-4">
         <div className="text-sm font-medium">Job configuration</div>
-        <p className="mt-1 text-xs text-muted-foreground">These values are used when the schedule or Run button starts this job.</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          These values are used when the schedule or Run button starts this job.
+        </p>
         <label className="mt-4 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
           <span>
             <span className="block font-medium text-foreground">Enabled</span>
-            <span className="block text-xs text-muted-foreground">Run this job on its saved schedule.</span>
+            <span className="block text-xs text-muted-foreground">
+              Run this job on its saved schedule.
+            </span>
           </span>
-          <SwitchToggle checked={enabled} onCheckedChange={setEnabled} ariaLabel="Enable job" />
+          <SwitchToggle
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            ariaLabel="Enable job"
+          />
         </label>
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           <div className="space-y-1 md:col-span-2">
-            <label className="text-sm text-muted-foreground" htmlFor={`settings-name-${job.id}`}>Name</label>
-            <Input id={`settings-name-${job.id}`} value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
+            <label
+              className="text-sm text-muted-foreground"
+              htmlFor={`settings-name-${job.id}`}
+            >
+              Name
+            </label>
+            <Input
+              id={`settings-name-${job.id}`}
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+            />
           </div>
           <div className="space-y-1">
-            <label className="text-sm text-muted-foreground" htmlFor={`settings-schedule-${job.id}`}>Cron schedule</label>
-            <Input id={`settings-schedule-${job.id}`} value={schedule} onChange={(event) => setSchedule(event.target.value)} placeholder="*/30 * * * *" className="font-mono text-xs" />
-            {scheduleError ? <div className="text-xs text-status-blocked">{scheduleError}</div> : null}
-            {!scheduleError && schedule.trim() ? <div className="text-xs text-muted-foreground">{humanSchedule(schedule)}</div> : null}
+            <label
+              className="text-sm text-muted-foreground"
+              htmlFor={`settings-schedule-${job.id}`}
+            >
+              Cron schedule
+            </label>
+            <Input
+              id={`settings-schedule-${job.id}`}
+              value={schedule}
+              onChange={(event) => setSchedule(event.target.value)}
+              placeholder="*/30 * * * *"
+              className="font-mono text-xs"
+            />
+            {scheduleError ? (
+              <div className="text-xs text-status-blocked">{scheduleError}</div>
+            ) : null}
+            {!scheduleError && schedule.trim() ? (
+              <div className="text-xs text-muted-foreground">
+                {humanSchedule(schedule)}
+              </div>
+            ) : null}
           </div>
           <div className="space-y-1">
             <label className="text-sm text-muted-foreground">Agent type</label>
-            <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentType)}>
+            <Select
+              value={agentType}
+              onValueChange={(value) => setAgentType(value as AgentType)}
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 {enabledAgentTypes.map((type) => (
-                  <SelectItem key={type} value={type}>{AGENT_TYPE_LABELS[type]}</SelectItem>
+                  <SelectItem key={type} value={type}>
+                    {AGENT_TYPE_LABELS[type]}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
           <div className="space-y-1">
-            <label className="text-sm text-muted-foreground" htmlFor={`settings-timeout-${job.id}`}>Run timeout, minutes</label>
-            <Input id={`settings-timeout-${job.id}`} value={timeoutMinutes} onChange={(event) => setTimeoutMinutes(event.target.value)} inputMode="numeric" />
+            <label
+              className="text-sm text-muted-foreground"
+              htmlFor={`settings-timeout-${job.id}`}
+            >
+              Run timeout, minutes
+            </label>
+            <Input
+              id={`settings-timeout-${job.id}`}
+              value={timeoutMinutes}
+              onChange={(event) => setTimeoutMinutes(event.target.value)}
+              inputMode="numeric"
+            />
           </div>
           <div className="space-y-1">
-            <label className="text-sm text-muted-foreground" htmlFor={`settings-needs-input-${job.id}`}>Wait for input, minutes</label>
-            <Input id={`settings-needs-input-${job.id}`} value={needsInputTimeoutMinutes} onChange={(event) => setNeedsInputTimeoutMinutes(event.target.value)} inputMode="numeric" />
+            <label
+              className="text-sm text-muted-foreground"
+              htmlFor={`settings-needs-input-${job.id}`}
+            >
+              Wait for input, minutes
+            </label>
+            <Input
+              id={`settings-needs-input-${job.id}`}
+              value={needsInputTimeoutMinutes}
+              onChange={(event) =>
+                setNeedsInputTimeoutMinutes(event.target.value)
+              }
+              inputMode="numeric"
+            />
           </div>
         </div>
         <div className="mt-4 grid gap-3">
@@ -1262,10 +1880,21 @@ function SettingsTab({
             onCheckedChange={setUseWorktree}
             onBranchNameChange={setBranchName}
           />
-          <JobFullAccessOption checked={fullAccess} onCheckedChange={setFullAccess} />
+          <JobFullAccessOption
+            checked={fullAccess}
+            onCheckedChange={setFullAccess}
+          />
         </div>
-        {saveError ? <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{saveError}</div> : null}
-        {saved ? <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">Settings saved.</div> : null}
+        {saveError ? (
+          <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+            {saveError}
+          </div>
+        ) : null}
+        {saved ? (
+          <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">
+            Settings saved.
+          </div>
+        ) : null}
         <div className="mt-4 flex justify-end">
           <Button
             variant="primary"
@@ -1285,22 +1914,29 @@ function SettingsTab({
                 branchName: useWorktree ? branchName : null,
                 fullAccess,
                 enabled,
-              }).then(() => {
-                setSaved(true);
-              }).catch((error) => {
-                setSaveError(errorMessage(error));
-              });
+              })
+                .then(() => {
+                  setSaved(true);
+                })
+                .catch((error) => {
+                  setSaveError(errorMessage(error));
+                });
             }}
           >
-            {isUpdating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {isUpdating ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Save
           </Button>
         </div>
       </div>
       <div className="rounded-md border border-status-blocked/30 bg-status-blocked/5 p-4">
-        <div className="text-sm font-medium text-status-blocked">Remove job</div>
+        <div className="text-sm font-medium text-status-blocked">
+          Remove job
+        </div>
         <p className="mt-1 text-xs text-muted-foreground">
-          Remove this saved job, schedule, and run history from this Dispatch instance.
+          Remove this saved job, schedule, and run history from this Dispatch
+          instance.
         </p>
         <div className="mt-3 flex flex-wrap justify-end gap-2">
           <Button
@@ -1316,7 +1952,11 @@ function SettingsTab({
             Remove
           </Button>
         </div>
-        {removeError ? <div className="mt-3 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{removeError}</div> : null}
+        {removeError ? (
+          <div className="mt-3 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+            {removeError}
+          </div>
+        ) : null}
       </div>
       <RemoveJobDialog
         open={removeDialogOpen}
@@ -1352,16 +1992,31 @@ function RemoveJobDialog({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
         <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-50 w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-5 shadow-xl outline-none">
-          <DialogPrimitive.Title className="text-base font-semibold">Remove job?</DialogPrimitive.Title>
+          <DialogPrimitive.Title className="text-base font-semibold">
+            Remove job?
+          </DialogPrimitive.Title>
           <DialogPrimitive.Description className="mt-2 text-sm text-muted-foreground">
-            Remove <span className="font-medium text-foreground">{job.name}</span> from this Dispatch instance? This removes its saved schedule and run history.
+            Remove{" "}
+            <span className="font-medium text-foreground">{job.name}</span> from
+            this Dispatch instance? This removes its saved schedule and run
+            history.
           </DialogPrimitive.Description>
           <div className="mt-5 flex justify-end gap-2">
             <DialogPrimitive.Close asChild>
-              <Button variant="ghost" disabled={isRemoving}>Cancel</Button>
+              <Button variant="ghost" disabled={isRemoving}>
+                Cancel
+              </Button>
             </DialogPrimitive.Close>
-            <Button variant="destructive" disabled={isRemoving} onClick={onConfirm}>
-              {isRemoving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+            <Button
+              variant="destructive"
+              disabled={isRemoving}
+              onClick={onConfirm}
+            >
+              {isRemoving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="mr-2 h-4 w-4" />
+              )}
               Remove
             </Button>
           </div>
@@ -1394,8 +2049,15 @@ function PromptTab({
     <div className="mt-4 flex h-full min-h-full flex-col">
       <div className="flex h-full min-h-full flex-1 flex-col rounded-md border border-border bg-background/50 p-4">
         <div className="space-y-1">
-          <label className="text-sm font-medium text-foreground" htmlFor={`prompt-${job.id}`}>Prompt</label>
-          <p className="text-xs text-muted-foreground">The instructions the agent will follow when this job runs.</p>
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor={`prompt-${job.id}`}
+          >
+            Prompt
+          </label>
+          <p className="text-xs text-muted-foreground">
+            The instructions the agent will follow when this job runs.
+          </p>
         </div>
         <textarea
           id={`prompt-${job.id}`}
@@ -1404,8 +2066,16 @@ function PromptTab({
           placeholder="Describe what the agent should do..."
           className="mt-2 h-[max(16rem,calc(100dvh-21rem))] min-h-64 shrink-0 w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
         />
-        {saveError ? <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">{saveError}</div> : null}
-        {saved ? <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">Prompt saved.</div> : null}
+        {saveError ? (
+          <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+            {saveError}
+          </div>
+        ) : null}
+        {saved ? (
+          <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">
+            Prompt saved.
+          </div>
+        ) : null}
         <div className="mt-4 flex justify-end">
           <Button
             variant="primary"
@@ -1417,14 +2087,18 @@ function PromptTab({
                 name: job.name,
                 directory: job.directory,
                 prompt: prompt.trim() || null,
-              }).then(() => {
-                setSaved(true);
-              }).catch((error) => {
-                setSaveError(errorMessage(error));
-              });
+              })
+                .then(() => {
+                  setSaved(true);
+                })
+                .catch((error) => {
+                  setSaveError(errorMessage(error));
+                });
             }}
           >
-            {isUpdating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {isUpdating ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Save prompt
           </Button>
         </div>
@@ -1433,33 +2107,67 @@ function PromptTab({
   );
 }
 
-function HistoryTab({ runs, loading, selectedRunId, onSelectRun }: { runs: JobRun[]; loading: boolean; selectedRunId: string | null; onSelectRun: (runId: string) => void }) {
-  const selectedRun = selectedRunId ? runs.find((run) => run.id === selectedRunId) ?? null : null;
+function HistoryTab({
+  runs,
+  loading,
+  selectedRunId,
+  onSelectRun,
+}: {
+  runs: JobRun[];
+  loading: boolean;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+}) {
+  const selectedRun = selectedRunId
+    ? (runs.find((run) => run.id === selectedRunId) ?? null)
+    : null;
   return (
     <ScrollArea className="mt-4 min-h-0 h-full pr-1">
       {loading ? (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading history...</div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading history...
+        </div>
       ) : runs.length === 0 ? (
         <div className="text-sm text-muted-foreground">No runs yet.</div>
       ) : (
         <div className="flex flex-col">
           {runs.map((run) => {
             const isSelected = selectedRun?.id === run.id;
-            const isActive = run.status === "started" || run.status === "running" || run.status === "needs_input";
+            const isActive =
+              run.status === "started" ||
+              run.status === "running" ||
+              run.status === "needs_input";
             return (
               <div key={run.id}>
                 <button
                   type="button"
                   className={cn(
                     "flex w-full min-w-0 items-center gap-2.5 overflow-hidden py-1.5 text-left text-xs transition-colors hover:text-foreground",
-                    isSelected ? "text-foreground" : "text-muted-foreground",
+                    isSelected ? "text-foreground" : "text-muted-foreground"
                   )}
                   onClick={() => onSelectRun(isSelected ? "" : run.id)}
                 >
-                  <span className={cn("h-2 w-2 shrink-0 rounded-full", statusDotColor(run.status), isActive && "animate-pulse")} />
-                  <span className={cn("shrink-0 font-medium", statusTextColor(run.status))}>{run.status}</span>
-                  <span className="min-w-0 truncate font-mono tabular-nums">{formatDate(run.startedAt)}</span>
-                  <span className="font-mono tabular-nums opacity-50">{formatDuration(run.durationMs)}</span>
+                  <span
+                    className={cn(
+                      "h-2 w-2 shrink-0 rounded-full",
+                      statusDotColor(run.status),
+                      isActive && "animate-pulse"
+                    )}
+                  />
+                  <span
+                    className={cn(
+                      "shrink-0 font-medium",
+                      statusTextColor(run.status)
+                    )}
+                  >
+                    {run.status}
+                  </span>
+                  <span className="min-w-0 truncate font-mono tabular-nums">
+                    {formatDate(run.startedAt)}
+                  </span>
+                  <span className="font-mono tabular-nums opacity-50">
+                    {formatDuration(run.durationMs)}
+                  </span>
                   <span className="opacity-40">{triggerSourceLabel(run)}</span>
                 </button>
                 {isSelected && <RunReport run={run} />}
@@ -1474,32 +2182,64 @@ function HistoryTab({ runs, loading, selectedRunId, onSelectRun }: { runs: JobRu
 
 function RunReport({ run }: { run: JobRun | null }) {
   if (!run) {
-    return <div className="mb-2 ml-4 border-l-2 border-border pl-3 text-xs text-muted-foreground">Select a run.</div>;
+    return (
+      <div className="mb-2 ml-4 border-l-2 border-border pl-3 text-xs text-muted-foreground">
+        Select a run.
+      </div>
+    );
   }
   return (
     <div className="mb-2 ml-[3px] border-l-2 border-border pl-4">
       {run.report?.summary && (
-        <div className="pb-1 text-xs text-muted-foreground">{run.report.summary}</div>
+        <div className="pb-1 text-xs text-muted-foreground">
+          {run.report.summary}
+        </div>
       )}
       {run.report?.tasks.map((task, index) => (
         <div key={`${task.name}-${index}`} className="py-0.5">
           <div className="flex items-center gap-1.5 text-xs">
-            <span className={cn(
-              "h-1.5 w-1.5 shrink-0 rounded-full",
-              task.status === "success" ? "bg-status-done" : task.status === "error" ? "bg-status-blocked" : "bg-muted-foreground",
-            )} />
+            <span
+              className={cn(
+                "h-1.5 w-1.5 shrink-0 rounded-full",
+                task.status === "success"
+                  ? "bg-status-done"
+                  : task.status === "error"
+                    ? "bg-status-blocked"
+                    : "bg-muted-foreground"
+              )}
+            />
             <span className="font-medium">{task.name}</span>
-            {task.status === "error" && <span className="uppercase text-status-blocked">{task.status}</span>}
+            {task.status === "error" && (
+              <span className="uppercase text-status-blocked">
+                {task.status}
+              </span>
+            )}
           </div>
-          {task.summary ? <div className="pl-3.5 text-xs text-muted-foreground/70">{task.summary}</div> : null}
+          {task.summary ? (
+            <div className="pl-3.5 text-xs text-muted-foreground/70">
+              {task.summary}
+            </div>
+          ) : null}
           {task.errors?.map((error, errorIndex) => (
-            <div key={errorIndex} className="pl-3.5 text-xs text-status-blocked">
+            <div
+              key={errorIndex}
+              className="pl-3.5 text-xs text-status-blocked"
+            >
               {error.message}
-              {error.action ? <span className="ml-2 text-muted-foreground">{error.action}</span> : null}
+              {error.action ? (
+                <span className="ml-2 text-muted-foreground">
+                  {error.action}
+                </span>
+              ) : null}
             </div>
           ))}
           {task.logs?.slice(-5).map((log, logIndex) => (
-            <div key={logIndex} className="pl-3.5 font-mono text-[11px] text-muted-foreground/50">[{log.level}] {log.message}</div>
+            <div
+              key={logIndex}
+              className="pl-3.5 font-mono text-[11px] text-muted-foreground/50"
+            >
+              [{log.level}] {log.message}
+            </div>
           ))}
         </div>
       ))}
@@ -1510,7 +2250,9 @@ function RunReport({ run }: { run: JobRun | null }) {
         </div>
       )}
       {run.completedAt && (
-        <div className="pt-1 font-mono text-[11px] text-muted-foreground/50">Completed {formatDate(run.completedAt)}</div>
+        <div className="pt-1 font-mono text-[11px] text-muted-foreground/50">
+          Completed {formatDate(run.completedAt)}
+        </div>
       )}
       {!run.report && !run.pendingQuestion && (
         <div className="text-xs text-muted-foreground">No report yet.</div>

--- a/apps/web/src/components/app/login-page.tsx
+++ b/apps/web/src/components/app/login-page.tsx
@@ -1,6 +1,12 @@
 import { useState, type FormEvent } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useAuthContext } from "@/contexts/auth-context";
@@ -23,7 +29,7 @@ export function LoginPage({ onAuthenticated }: LoginPageProps): JSX.Element {
         method: "POST",
         headers: { "content-type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ password })
+        body: JSON.stringify({ password }),
       });
       if (!res.ok) {
         const body = (await res.json()) as { error?: string };
@@ -56,7 +62,12 @@ export function LoginPage({ onAuthenticated }: LoginPageProps): JSX.Element {
               data-testid="login-password"
             />
             {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" variant="primary" className="w-full" disabled={loading || !password}>
+            <Button
+              type="submit"
+              variant="primary"
+              className="w-full"
+              disabled={loading || !password}
+            >
               {loading ? "Signing in..." : "Sign in"}
             </Button>
           </form>

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronLeft, ChevronRight, Copy, Download, X } from "lucide-react";
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Download,
+  X,
+} from "lucide-react";
 import hljs from "highlight.js/lib/core";
 import typescript from "highlight.js/lib/languages/typescript";
 import javascript from "highlight.js/lib/languages/javascript";
@@ -65,24 +72,94 @@ import { useCopyText } from "@/hooks/use-copy";
 import { cn } from "@/lib/utils";
 
 const EXT_TO_LANG: Record<string, string> = {
-  ".ts": "typescript", ".tsx": "typescript", ".js": "javascript", ".jsx": "javascript",
-  ".py": "python", ".go": "go", ".rs": "rust", ".sh": "bash", ".bash": "bash",
-  ".json": "json", ".yaml": "yaml", ".yml": "yaml", ".toml": "ini",
-  ".html": "xml", ".xml": "xml", ".css": "css", ".sql": "sql",
-  ".md": "markdown", ".swift": "swift", ".kt": "kotlin", ".java": "java",
-  ".c": "c", ".cpp": "cpp", ".h": "c", ".hpp": "cpp",
-  ".rb": "ruby", ".php": "php", ".lua": "lua", ".r": "r",
-  ".ex": "elixir", ".exs": "elixir", ".erl": "erlang", ".hs": "haskell",
-  ".diff": "diff", ".patch": "diff", ".ini": "ini", ".cfg": "ini", ".conf": "ini",
-  ".zig": "zig", ".nim": "nim", ".m": "objectivec",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".py": "python",
+  ".go": "go",
+  ".rs": "rust",
+  ".sh": "bash",
+  ".bash": "bash",
+  ".json": "json",
+  ".yaml": "yaml",
+  ".yml": "yaml",
+  ".toml": "ini",
+  ".html": "xml",
+  ".xml": "xml",
+  ".css": "css",
+  ".sql": "sql",
+  ".md": "markdown",
+  ".swift": "swift",
+  ".kt": "kotlin",
+  ".java": "java",
+  ".c": "c",
+  ".cpp": "cpp",
+  ".h": "c",
+  ".hpp": "cpp",
+  ".rb": "ruby",
+  ".php": "php",
+  ".lua": "lua",
+  ".r": "r",
+  ".ex": "elixir",
+  ".exs": "elixir",
+  ".erl": "erlang",
+  ".hs": "haskell",
+  ".diff": "diff",
+  ".patch": "diff",
+  ".ini": "ini",
+  ".cfg": "ini",
+  ".conf": "ini",
+  ".zig": "zig",
+  ".nim": "nim",
+  ".m": "objectivec",
 };
 
 const TEXT_EXTENSIONS = new Set([
-  ".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".csv", ".log", ".xml",
-  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".rs", ".sh",
-  ".sql", ".diff", ".patch", ".env", ".ini", ".cfg", ".conf", ".swift",
-  ".kt", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".lua",
-  ".zig", ".nim", ".r", ".m", ".ex", ".exs", ".erl", ".hs",
+  ".txt",
+  ".md",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".csv",
+  ".log",
+  ".xml",
+  ".html",
+  ".css",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".py",
+  ".go",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".diff",
+  ".patch",
+  ".env",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".swift",
+  ".kt",
+  ".java",
+  ".c",
+  ".cpp",
+  ".h",
+  ".hpp",
+  ".rb",
+  ".php",
+  ".lua",
+  ".zig",
+  ".nim",
+  ".r",
+  ".m",
+  ".ex",
+  ".exs",
+  ".erl",
+  ".hs",
 ]);
 
 function fileExtension(name: string): string {
@@ -106,7 +183,8 @@ export function stripTimestamp(name: string): string {
   return name.replace(TIMESTAMP_RE, "");
 }
 
-const HAS_CLIPBOARD_WRITE = typeof ClipboardItem !== "undefined" && !!navigator.clipboard?.write;
+const HAS_CLIPBOARD_WRITE =
+  typeof ClipboardItem !== "undefined" && !!navigator.clipboard?.write;
 
 type MediaLightboxItem = {
   src: string;
@@ -126,7 +204,13 @@ type MediaLightboxProps = {
   setLightboxIndex: (nextIndex: number | null) => void;
 };
 
-function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.Element {
+function TextViewer({
+  src,
+  fileName,
+}: {
+  src: string;
+  fileName: string;
+}): JSX.Element {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -139,9 +223,15 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
         if (!res.ok) throw new Error(`Failed to load (${res.status})`);
         return res.text();
       })
-      .then((text) => { if (!cancelled) setContent(text); })
-      .catch((err) => { if (!cancelled) setError(String(err)); });
-    return () => { cancelled = true; };
+      .then((text) => {
+        if (!cancelled) setContent(text);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [src]);
 
   const highlightedHtml = useMemo(() => {
@@ -163,10 +253,15 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   }, [content, fileName]);
 
   const shouldWrapText = isMarkdownFile(fileName);
-  const textWrapClassName = "whitespace-pre-wrap break-words [overflow-wrap:anywhere]";
+  const textWrapClassName =
+    "whitespace-pre-wrap break-words [overflow-wrap:anywhere]";
 
   if (error) {
-    return <div className="grid h-full place-items-center text-sm text-destructive">{error}</div>;
+    return (
+      <div className="grid h-full place-items-center text-sm text-destructive">
+        {error}
+      </div>
+    );
   }
 
   if (content === null) {
@@ -180,22 +275,42 @@ function TextViewer({ src, fileName }: { src: string; fileName: string }): JSX.E
   return (
     <LogStream className="min-h-full overflow-auto p-0">
       {highlightedHtml ? (
-        <pre className={cn("p-4 text-sm leading-relaxed", shouldWrapText && textWrapClassName)}>
+        <pre
+          className={cn(
+            "p-4 text-sm leading-relaxed",
+            shouldWrapText && textWrapClassName
+          )}
+        >
           <code
             className={cn("hljs", shouldWrapText && textWrapClassName)}
             dangerouslySetInnerHTML={{ __html: highlightedHtml }}
           />
         </pre>
       ) : (
-        <pre className={cn("p-4 text-sm leading-relaxed", shouldWrapText && textWrapClassName)}>
-          <code className={cn(shouldWrapText && textWrapClassName)}>{content}</code>
+        <pre
+          className={cn(
+            "p-4 text-sm leading-relaxed",
+            shouldWrapText && textWrapClassName
+          )}
+        >
+          <code className={cn(shouldWrapText && textWrapClassName)}>
+            {content}
+          </code>
         </pre>
       )}
     </LogStream>
   );
 }
 
-function MediaActions({ src, fileName, isText }: { src: string; fileName: string; isText?: boolean }): JSX.Element {
+function MediaActions({
+  src,
+  fileName,
+  isText,
+}: {
+  src: string;
+  fileName: string;
+  isText?: boolean;
+}): JSX.Element {
   const [copied, copyText] = useCopyText();
   const [imageCopied, setImageCopied] = useState(false);
   const imageCopiedTimerRef = useRef<number | null>(null);
@@ -210,20 +325,30 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
     const controller = new AbortController();
     void fetch(src, { signal: controller.signal })
       .then((r) => r.text())
-      .then((t) => { cachedTextRef.current = t; })
+      .then((t) => {
+        cachedTextRef.current = t;
+      })
       .catch(() => {});
     return () => controller.abort();
   }, [src, isText]);
 
   // Clean up the image-copied timer on unmount.
-  useEffect(() => () => {
-    if (imageCopiedTimerRef.current) window.clearTimeout(imageCopiedTimerRef.current);
-  }, []);
+  useEffect(
+    () => () => {
+      if (imageCopiedTimerRef.current)
+        window.clearTimeout(imageCopiedTimerRef.current);
+    },
+    []
+  );
 
   const markImageCopied = useCallback(() => {
     setImageCopied(true);
-    if (imageCopiedTimerRef.current) window.clearTimeout(imageCopiedTimerRef.current);
-    imageCopiedTimerRef.current = window.setTimeout(() => setImageCopied(false), 2000);
+    if (imageCopiedTimerRef.current)
+      window.clearTimeout(imageCopiedTimerRef.current);
+    imageCopiedTimerRef.current = window.setTimeout(
+      () => setImageCopied(false),
+      2000
+    );
   }, []);
 
   const handleCopy = useCallback(() => {
@@ -247,7 +372,10 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
   const showCopy = isText || HAS_CLIPBOARD_WRITE;
 
   return (
-    <div className="flex flex-none items-center gap-1" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="flex flex-none items-center gap-1"
+      onClick={(e) => e.stopPropagation()}
+    >
       <a
         href={src}
         download={displayName}
@@ -261,12 +389,22 @@ function MediaActions({ src, fileName, isText }: { src: string; fileName: string
         <Button
           size="sm"
           variant={showCopied ? "default" : "ghost"}
-          className={showCopied ? "h-7 gap-1.5 px-2 text-xs" : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"}
+          className={
+            showCopied
+              ? "h-7 gap-1.5 px-2 text-xs"
+              : "h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+          }
           onClick={handleCopy}
           title="Copy"
         >
-          {showCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          <span className="hidden sm:inline">{showCopied ? "Copied!" : "Copy"}</span>
+          {showCopied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          <span className="hidden sm:inline">
+            {showCopied ? "Copied!" : "Copy"}
+          </span>
         </Button>
       )}
     </div>
@@ -279,7 +417,7 @@ export function MediaLightbox({
   item,
   currentIndex,
   totalItems,
-  setLightboxIndex
+  setLightboxIndex,
 }: MediaLightboxProps): JSX.Element | null {
   const canGoPrev = currentIndex > 0;
   const canGoNext = currentIndex >= 0 && currentIndex < totalItems - 1;
@@ -291,7 +429,9 @@ export function MediaLightbox({
     if (!meta) return;
     const original = meta.content;
     meta.content = "width=device-width, initial-scale=1.0";
-    return () => { meta.content = original; };
+    return () => {
+      meta.content = original;
+    };
   }, [item]);
 
   useEffect(() => {
@@ -336,9 +476,10 @@ export function MediaLightbox({
   const isVideo = /\.mp4/i.test(item.src);
   const displayName = stripTimestamp(item.file.name);
 
-  const sizeLabel = item.file.size >= 1024 * 1024
-    ? `${(item.file.size / (1024 * 1024)).toFixed(1)} MB`
-    : `${Math.max(1, Math.round(item.file.size / 1024))} KB`;
+  const sizeLabel =
+    item.file.size >= 1024 * 1024
+      ? `${(item.file.size / (1024 * 1024)).toFixed(1)} MB`
+      : `${Math.max(1, Math.round(item.file.size / 1024))} KB`;
 
   return (
     <div
@@ -346,9 +487,15 @@ export function MediaLightbox({
       data-testid="media-lightbox"
     >
       <div className="mx-auto flex w-full max-w-4xl items-center gap-3 overflow-hidden rounded-t-lg border border-b-0 border-border bg-surface px-3 py-2 sm:px-4 sm:py-2.5">
-        <span className="min-w-0 shrink truncate text-xs font-medium text-foreground sm:text-sm">{displayName}</span>
+        <span className="min-w-0 shrink truncate text-xs font-medium text-foreground sm:text-sm">
+          {displayName}
+        </span>
         <div className="ml-auto flex shrink-0 items-center gap-2 sm:gap-3">
-          <MediaActions src={item.src} fileName={item.file.name} isText={isText} />
+          <MediaActions
+            src={item.src}
+            fileName={item.file.name}
+            isText={isText}
+          />
           <div className="mx-0.5 h-5 w-px bg-border" />
           <Button
             aria-label="Previous media item"
@@ -390,11 +537,19 @@ export function MediaLightbox({
       <div
         className={cn(
           "mx-auto min-h-0 w-full max-w-4xl overflow-auto border-x border-border touch-pinch-zoom",
-          isDocument ? "bg-white" : isText ? "bg-[hsl(var(--log-stream-bg))]" : "bg-black"
+          isDocument
+            ? "bg-white"
+            : isText
+              ? "bg-[hsl(var(--log-stream-bg))]"
+              : "bg-black"
         )}
       >
         {isDocument ? (
-          <iframe src={item.src} title={displayName} className="h-full w-full" />
+          <iframe
+            src={item.src}
+            title={displayName}
+            className="h-full w-full"
+          />
         ) : isText ? (
           <TextViewer src={item.src} fileName={item.file.name} />
         ) : isVideo ? (
@@ -413,10 +568,18 @@ export function MediaLightbox({
         )}
       </div>
       <div className="mx-auto flex w-full max-w-4xl items-center gap-2 rounded-b-lg border border-t-0 border-border bg-surface px-2 py-1.5 text-xs text-muted-foreground sm:gap-3 sm:px-4 sm:py-2">
-        {item.caption ? <span className="min-w-0 truncate">{item.caption}</span> : null}
-        {item.file.source ? <span className="flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">{item.file.source === "user" ? "your upload" : item.file.source}</span> : null}
+        {item.caption ? (
+          <span className="min-w-0 truncate">{item.caption}</span>
+        ) : null}
+        {item.file.source ? (
+          <span className="flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+            {item.file.source === "user" ? "your upload" : item.file.source}
+          </span>
+        ) : null}
         <span className="ml-auto flex-none">{sizeLabel}</span>
-        <span className="hidden flex-none sm:inline">{new Date(item.file.updatedAt).toLocaleString()}</span>
+        <span className="hidden flex-none sm:inline">
+          {new Date(item.file.updatedAt).toLocaleString()}
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,17 +1,39 @@
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
-import { Check, ChevronRight, ExternalLink, FileText, Loader2, MonitorPlay, X, Image, File as FileIcon, Video, Upload, User } from "lucide-react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  Check,
+  ChevronRight,
+  ExternalLink,
+  FileText,
+  Loader2,
+  MonitorPlay,
+  X,
+  Image,
+  File as FileIcon,
+  Video,
+  Upload,
+  User,
+} from "lucide-react";
 import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
 import { mediaSidebarTabAtom } from "@/lib/store";
-import { MediaActions, isTextFile, stripTimestamp } from "@/components/app/media-lightbox";
+import {
+  MediaActions,
+  isTextFile,
+  stripTimestamp,
+} from "@/components/app/media-lightbox";
 import { PinsPanel } from "@/components/app/pins-panel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const ACCEPTED_EXTENSIONS =
   ".png,.jpg,.jpeg,.gif,.webp,.mp4,.pdf,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
-
 
 function fileExtension(name: string): string {
   const dot = name.lastIndexOf(".");
@@ -44,8 +66,13 @@ type MediaSidebarContentProps = MediaSidebarSharedProps & {
   className?: string;
 };
 
-
-function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; selectedAgentId: string }): JSX.Element {
+function LiveStreamSection({
+  streamUrl,
+  selectedAgentId,
+}: {
+  streamUrl: string;
+  selectedAgentId: string;
+}): JSX.Element {
   const popOut = useCallback(() => {
     window.open(
       `/api/v1/agents/${selectedAgentId}/stream/viewer`,
@@ -58,9 +85,16 @@ function LiveStreamSection({ streamUrl, selectedAgentId }: { streamUrl: string; 
     <div className="border-b-2 border-border">
       <div className="flex items-center gap-2 px-3 py-2">
         <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-status-blocked" />
-        <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">Live Stream</span>
+        <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">
+          Live Stream
+        </span>
         <div className="ml-auto">
-          <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs" onClick={popOut}>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 gap-1 px-2 text-xs"
+            onClick={popOut}
+          >
             <ExternalLink className="h-3 w-3" />
             Pop out
           </Button>
@@ -88,7 +122,17 @@ function MediaContent({
   hasStream,
   streamUrl,
   onUploadFile,
-}: Pick<MediaSidebarSharedProps, "mediaFiles" | "selectedAgentId" | "animatingMediaKeys" | "mediaViewportRef" | "openLightbox" | "hasStream" | "streamUrl" | "onUploadFile">): JSX.Element {
+}: Pick<
+  MediaSidebarSharedProps,
+  | "mediaFiles"
+  | "selectedAgentId"
+  | "animatingMediaKeys"
+  | "mediaViewportRef"
+  | "openLightbox"
+  | "hasStream"
+  | "streamUrl"
+  | "onUploadFile"
+>): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -105,7 +149,8 @@ function MediaContent({
       try {
         await onUploadFile(selectedAgentId, file);
         setUploadSuccess(true);
-        if (successTimerRef.current) window.clearTimeout(successTimerRef.current);
+        if (successTimerRef.current)
+          window.clearTimeout(successTimerRef.current);
         successTimerRef.current = window.setTimeout(() => {
           setUploadSuccess(false);
           successTimerRef.current = null;
@@ -128,7 +173,10 @@ function MediaContent({
   return (
     <>
       {hasStream && streamUrl && selectedAgentId ? (
-        <LiveStreamSection streamUrl={streamUrl} selectedAgentId={selectedAgentId} />
+        <LiveStreamSection
+          streamUrl={streamUrl}
+          selectedAgentId={selectedAgentId}
+        />
       ) : null}
 
       {/* Upload button bar */}
@@ -149,15 +197,29 @@ function MediaContent({
               disabled={uploading}
               onClick={triggerFilePicker}
             >
-              {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : uploadSuccess ? <Check className="h-3 w-3" /> : <Upload className="h-3 w-3" />}
-              {uploading ? "Uploading…" : uploadSuccess ? "Shared" : "Share file"}
+              {uploading ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : uploadSuccess ? (
+                <Check className="h-3 w-3" />
+              ) : (
+                <Upload className="h-3 w-3" />
+              )}
+              {uploading
+                ? "Uploading…"
+                : uploadSuccess
+                  ? "Shared"
+                  : "Share file"}
             </Button>
             {uploadError ? (
-              <span className="truncate text-xs text-destructive">{uploadError}</span>
+              <span className="truncate text-xs text-destructive">
+                {uploadError}
+              </span>
             ) : null}
           </div>
           {uploadSuccess ? (
-            <p className="mt-1 text-[11px] text-muted-foreground">Tell the agent about the file so it knows to look.</p>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Tell the agent about the file so it knows to look.
+            </p>
           ) : null}
         </div>
       ) : null}
@@ -179,12 +241,18 @@ function MediaContent({
                 {selectedAgentId ? (
                   <>
                     No media yet.{" "}
-                    <button className="underline hover:text-foreground" onClick={triggerFilePicker}>
+                    <button
+                      className="underline hover:text-foreground"
+                      onClick={triggerFilePicker}
+                    >
                       Share a file
                     </button>{" "}
-                    or wait for agents to share screenshots, videos and documents.
+                    or wait for agents to share screenshots, videos and
+                    documents.
                   </>
-                ) : "Focus an agent to view media."}
+                ) : (
+                  "Focus an agent to view media."
+                )}
               </div>
             </div>
           </div>
@@ -206,15 +274,20 @@ function MediaContent({
                 data-media-key={mediaKey}
                 className={cn(
                   "border-b-2 border-border px-3 py-3",
-                  isStream && "border-l-2 border-l-status-blocked/60 bg-status-blocked/5",
+                  isStream &&
+                    "border-l-2 border-l-status-blocked/60 bg-status-blocked/5",
                   animating && "animate-media-in-slow"
                 )}
               >
                 {isStream ? (
                   <div className="mb-2 flex items-center gap-1.5">
                     <MonitorPlay className="h-3.5 w-3.5 text-status-blocked" />
-                    <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">Stream recording</span>
-                    <span className="ml-auto text-xs text-muted-foreground">{new Date(file.updatedAt).toLocaleString()}</span>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-status-blocked">
+                      Stream recording
+                    </span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {new Date(file.updatedAt).toLocaleString()}
+                    </span>
                   </div>
                 ) : (
                   <div className="mb-2 flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -237,16 +310,29 @@ function MediaContent({
                   >
                     <div className="flex items-center gap-2">
                       <FileText className="h-4 w-4 flex-none text-muted-foreground" />
-                      <span className="truncate text-xs font-medium text-foreground">{stripTimestamp(file.name)}</span>
-                      <span className="ml-auto flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{fileExtension(file.name)}</span>
+                      <span className="truncate text-xs font-medium text-foreground">
+                        {stripTimestamp(file.name)}
+                      </span>
+                      <span className="ml-auto flex-none rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        {fileExtension(file.name)}
+                      </span>
                     </div>
                   </button>
                 ) : /\.mp4$/i.test(file.name) ? (
-                  <div className={cn(
-                    "block w-full overflow-hidden border-2 bg-black/60",
-                    unseen ? "media-thumb-unseen" : "media-thumb-seen"
-                  )}>
-                    <video src={cacheBustUrl} controls muted playsInline preload="metadata" className="max-h-[260px] w-full object-contain" />
+                  <div
+                    className={cn(
+                      "block w-full overflow-hidden border-2 bg-black/60",
+                      unseen ? "media-thumb-unseen" : "media-thumb-seen"
+                    )}
+                  >
+                    <video
+                      src={cacheBustUrl}
+                      controls
+                      muted
+                      playsInline
+                      preload="metadata"
+                      className="max-h-[260px] w-full object-contain"
+                    />
                   </div>
                 ) : (
                   <button
@@ -256,14 +342,24 @@ function MediaContent({
                     )}
                     onClick={() => openLightbox(file)}
                   >
-                    <img src={cacheBustUrl} alt={file.description || ""} className="max-h-[260px] w-full object-contain" />
+                    <img
+                      src={cacheBustUrl}
+                      alt={file.description || ""}
+                      className="max-h-[260px] w-full object-contain"
+                    />
                   </button>
                 )}
                 <div className="mt-2 text-xs text-muted-foreground">
                   {file.description ? <div>{file.description}</div> : null}
-                  <div className={`flex items-center justify-between gap-2${file.description ? " mt-1" : ""}`}>
+                  <div
+                    className={`flex items-center justify-between gap-2${file.description ? " mt-1" : ""}`}
+                  >
                     <span>{Math.max(1, Math.round(file.size / 1024))} KB</span>
-                    <MediaActions src={cacheBustUrl} fileName={file.name} isText={isText} />
+                    <MediaActions
+                      src={cacheBustUrl}
+                      fileName={file.name}
+                      isText={isText}
+                    />
                   </div>
                 </div>
               </article>
@@ -290,7 +386,7 @@ export function MediaSidebarContent({
   closeButtonIcon = "x",
   className,
   unseenMediaCount,
-  onUploadFile
+  onUploadFile,
 }: MediaSidebarContentProps & { unseenMediaCount: number }): JSX.Element {
   const [activeTab, setActiveTab] = useAtom(mediaSidebarTabAtom);
   const prevAgentIdRef = useRef(selectedAgentId);
@@ -304,7 +400,13 @@ export function MediaSidebarContent({
   }
 
   return (
-    <aside data-testid="media-sidebar" className={cn("flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground", className)}>
+    <aside
+      data-testid="media-sidebar"
+      className={cn(
+        "flex h-full min-h-0 w-full flex-col border-l-2 border-border bg-card text-foreground",
+        className
+      )}
+    >
       {/* Tab header */}
       <div className="flex min-h-14 items-center pt-[env(safe-area-inset-top)]">
         <div className="flex flex-1">
@@ -349,22 +451,42 @@ export function MediaSidebarContent({
         </div>
         {onRequestClose ? (
           <div className="px-2">
-            <Button size="icon" variant="ghost" onClick={onRequestClose} title="Close sidebar" className="h-7 w-7">
-              {closeButtonIcon === "chevron" ? <ChevronRight className="h-4 w-4" /> : <X className="h-4 w-4" />}
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={onRequestClose}
+              title="Close sidebar"
+              className="h-7 w-7"
+            >
+              {closeButtonIcon === "chevron" ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <X className="h-4 w-4" />
+              )}
             </Button>
           </div>
         ) : null}
       </div>
 
       {/* Tab content — both panels stay mounted so refs (e.g. IntersectionObserver) remain attached */}
-      <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "pins" && "hidden")}>
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col",
+          activeTab !== "pins" && "hidden"
+        )}
+      >
         <PinsPanel
           pins={selectedAgentPins}
           selectedAgentName={selectedAgentName}
           selectedAgentWorkspaceRoot={selectedAgentWorkspaceRoot}
         />
       </div>
-      <div className={cn("flex min-h-0 flex-1 flex-col", activeTab !== "media" && "hidden")}>
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col",
+          activeTab !== "media" && "hidden"
+        )}
+      >
         <MediaContent
           mediaFiles={mediaFiles}
           selectedAgentId={selectedAgentId}
@@ -380,7 +502,12 @@ export function MediaSidebarContent({
   );
 }
 
-export function MediaSidebar({ mediaOpen, setMediaOpen, hasStream, ...props }: MediaSidebarProps): JSX.Element {
+export function MediaSidebar({
+  mediaOpen,
+  setMediaOpen,
+  hasStream,
+  ...props
+}: MediaSidebarProps): JSX.Element {
   // Auto-open the sidebar when a stream starts so the user doesn't miss it
   useEffect(() => {
     if (hasStream) {

--- a/apps/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/apps/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -1,4 +1,10 @@
-import { type MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -7,7 +13,10 @@ type MobileTerminalToolbarProps = {
   ctrlPendingRef: MutableRefObject<boolean>;
 };
 
-export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTerminalToolbarProps): JSX.Element {
+export function MobileTerminalToolbar({
+  onSendInput,
+  ctrlPendingRef,
+}: MobileTerminalToolbarProps): JSX.Element {
   const [inputOpen, setInputOpen] = useState(false);
   const [ctrlActive, setCtrlActive] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -27,14 +36,17 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
     });
   }, [ctrlPendingRef]);
 
-  const sendKey = useCallback((key: string) => {
-    onSendInput(key);
-    // After any toolbar key press, clear ctrl
-    if (ctrlActive) {
-      setCtrlActive(false);
-      ctrlPendingRef.current = false;
-    }
-  }, [ctrlActive, ctrlPendingRef, onSendInput]);
+  const sendKey = useCallback(
+    (key: string) => {
+      onSendInput(key);
+      // After any toolbar key press, clear ctrl
+      if (ctrlActive) {
+        setCtrlActive(false);
+        ctrlPendingRef.current = false;
+      }
+    },
+    [ctrlActive, ctrlPendingRef, onSendInput]
+  );
 
   const openInput = useCallback(() => {
     setInputOpen(true);
@@ -114,7 +126,16 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
             aria-label="Open text input"
             onClick={openInput}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <rect x="2" y="4" width="20" height="16" rx="2" />
               <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M6 16h8" />
             </svg>
@@ -176,7 +197,9 @@ export function MobileTerminalToolbar({ onSendInput, ctrlPendingRef }: MobileTer
             >
               Cancel
             </button>
-            <span className="text-sm font-medium text-foreground">Terminal Input</span>
+            <span className="text-sm font-medium text-foreground">
+              Terminal Input
+            </span>
             <button
               className="text-sm font-medium text-primary"
               onClick={submitInput}

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -17,10 +17,22 @@ type NotificationSettingsResponse = {
   webNotifyEvents: NotifyEventType[];
 };
 
-const EVENT_OPTIONS: Array<{ id: NotifyEventType; label: string; description: string }> = [
+const EVENT_OPTIONS: Array<{
+  id: NotifyEventType;
+  label: string;
+  description: string;
+}> = [
   { id: "done", label: "Done", description: "Agent finished its task" },
-  { id: "waiting_user", label: "Waiting for input", description: "Agent needs your response" },
-  { id: "blocked", label: "Blocked", description: "Agent hit an error or obstacle" },
+  {
+    id: "waiting_user",
+    label: "Waiting for input",
+    description: "Agent needs your response",
+  },
+  {
+    id: "blocked",
+    label: "Blocked",
+    description: "Agent hit an error or obstacle",
+  },
 ];
 
 export function NotificationSettings(): JSX.Element {
@@ -43,9 +55,8 @@ export function NotificationSettings(): JSX.Element {
     "blocked",
   ]);
   const [savedWebEvents, setSavedWebEvents] = useState<NotifyEventType[]>([]);
-  const [browserPermission, setBrowserPermission] = useState<NotificationPermission>(
-    getNotificationPermission()
-  );
+  const [browserPermission, setBrowserPermission] =
+    useState<NotificationPermission>(getNotificationPermission());
 
   // Re-check permission when the user returns to this page (e.g. after
   // changing settings in iOS Settings or browser site settings).
@@ -56,7 +67,8 @@ export function NotificationSettings(): JSX.Element {
       }
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
-    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
   }, []);
 
   const [loading, setLoading] = useState(true);
@@ -147,47 +159,54 @@ export function NotificationSettings(): JSX.Element {
     }
   }, [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents]);
 
-  const persistWebNotificationSettings = useCallback(async (
-    nextEnabled: boolean,
-    nextEvents: NotifyEventType[]
-  ): Promise<boolean> => {
-    const requestId = webSaveRequestIdRef.current + 1;
-    webSaveRequestIdRef.current = requestId;
-    setWebError("");
-    setWebMessage("");
-    setSaving(true);
-    try {
-      const data = await api<NotificationSettingsResponse>(
-        "/api/v1/notifications/settings",
-        {
-          method: "POST",
-          body: JSON.stringify({
-            webNotifyEnabled: nextEnabled,
-            webNotifyEvents: nextEvents,
-          }),
+  const persistWebNotificationSettings = useCallback(
+    async (
+      nextEnabled: boolean,
+      nextEvents: NotifyEventType[]
+    ): Promise<boolean> => {
+      const requestId = webSaveRequestIdRef.current + 1;
+      webSaveRequestIdRef.current = requestId;
+      setWebError("");
+      setWebMessage("");
+      setSaving(true);
+      try {
+        const data = await api<NotificationSettingsResponse>(
+          "/api/v1/notifications/settings",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              webNotifyEnabled: nextEnabled,
+              webNotifyEvents: nextEvents,
+            }),
+          }
+        );
+        if (webSaveRequestIdRef.current !== requestId) {
+          return true;
         }
-      );
-      if (webSaveRequestIdRef.current !== requestId) {
+        setSavedWebEnabled(data.webNotifyEnabled);
+        setSavedWebEvents(data.webNotifyEvents);
+        setWebNotifyEnabled(data.webNotifyEnabled);
+        setWebNotifyEvents(data.webNotifyEvents);
+        setWebMessage("Browser notification settings saved.");
         return true;
+      } catch (err) {
+        if (webSaveRequestIdRef.current !== requestId) {
+          return true;
+        }
+        setWebError(
+          err instanceof Error
+            ? err.message
+            : "Failed to save browser notifications."
+        );
+        return false;
+      } finally {
+        if (webSaveRequestIdRef.current === requestId) {
+          setSaving(false);
+        }
       }
-      setSavedWebEnabled(data.webNotifyEnabled);
-      setSavedWebEvents(data.webNotifyEvents);
-      setWebNotifyEnabled(data.webNotifyEnabled);
-      setWebNotifyEvents(data.webNotifyEvents);
-      setWebMessage("Browser notification settings saved.");
-      return true;
-    } catch (err) {
-      if (webSaveRequestIdRef.current !== requestId) {
-        return true;
-      }
-      setWebError(err instanceof Error ? err.message : "Failed to save browser notifications.");
-      return false;
-    } finally {
-      if (webSaveRequestIdRef.current === requestId) {
-        setSaving(false);
-      }
-    }
-  }, []);
+    },
+    []
+  );
 
   const handleTest = useCallback(async () => {
     setError("");
@@ -221,32 +240,44 @@ export function NotificationSettings(): JSX.Element {
     );
   }, []);
 
-  const toggleWebEvent = useCallback(async (eventType: NotifyEventType) => {
-    const previousEnabled = webNotifyEnabledRef.current;
-    const previousEvents = webNotifyEventsRef.current;
-    const nextEvents = previousEvents.includes(eventType)
-      ? previousEvents.filter((e) => e !== eventType)
-      : [...previousEvents, eventType];
+  const toggleWebEvent = useCallback(
+    async (eventType: NotifyEventType) => {
+      const previousEnabled = webNotifyEnabledRef.current;
+      const previousEvents = webNotifyEventsRef.current;
+      const nextEvents = previousEvents.includes(eventType)
+        ? previousEvents.filter((e) => e !== eventType)
+        : [...previousEvents, eventType];
 
-    setWebNotifyEvents(nextEvents);
-    const saved = await persistWebNotificationSettings(previousEnabled, nextEvents);
-    if (!saved) {
-      setWebNotifyEnabled(savedWebEnabledRef.current);
-      setWebNotifyEvents(savedWebEventsRef.current);
-    }
-  }, [persistWebNotificationSettings]);
+      setWebNotifyEvents(nextEvents);
+      const saved = await persistWebNotificationSettings(
+        previousEnabled,
+        nextEvents
+      );
+      if (!saved) {
+        setWebNotifyEnabled(savedWebEnabledRef.current);
+        setWebNotifyEvents(savedWebEventsRef.current);
+      }
+    },
+    [persistWebNotificationSettings]
+  );
 
-  const toggleWebNotifyEnabled = useCallback(async (checked: boolean) => {
-    const previousEvents = webNotifyEventsRef.current;
-    const nextEnabled = checked;
+  const toggleWebNotifyEnabled = useCallback(
+    async (checked: boolean) => {
+      const previousEvents = webNotifyEventsRef.current;
+      const nextEnabled = checked;
 
-    setWebNotifyEnabled(nextEnabled);
-    const saved = await persistWebNotificationSettings(nextEnabled, previousEvents);
-    if (!saved) {
-      setWebNotifyEnabled(savedWebEnabledRef.current);
-      setWebNotifyEvents(savedWebEventsRef.current);
-    }
-  }, [persistWebNotificationSettings]);
+      setWebNotifyEnabled(nextEnabled);
+      const saved = await persistWebNotificationSettings(
+        nextEnabled,
+        previousEvents
+      );
+      if (!saved) {
+        setWebNotifyEnabled(savedWebEnabledRef.current);
+        setWebNotifyEvents(savedWebEventsRef.current);
+      }
+    },
+    [persistWebNotificationSettings]
+  );
 
   const handleRequestPermission = useCallback(async () => {
     const result = await requestNotificationPermission();
@@ -263,16 +294,17 @@ export function NotificationSettings(): JSX.Element {
   }, []);
 
   if (loading) {
-    return (
-      <div className="p-6 text-sm text-muted-foreground">Loading...</div>
-    );
+    return <div className="p-6 text-sm text-muted-foreground">Loading...</div>;
   }
 
   const notificationsSupported = typeof Notification !== "undefined";
-  const isStandalone = window.matchMedia("(display-mode: standalone)").matches
-    || ("standalone" in navigator && (navigator as { standalone?: boolean }).standalone === true);
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
-    || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const isStandalone =
+    window.matchMedia("(display-mode: standalone)").matches ||
+    ("standalone" in navigator &&
+      (navigator as { standalone?: boolean }).standalone === true);
+  const isIOS =
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 
   return (
     <div className="flex flex-col gap-8 overflow-y-auto p-6">
@@ -283,7 +315,8 @@ export function NotificationSettings(): JSX.Element {
         </h3>
         <p className="mb-3 text-sm text-muted-foreground">
           Get native desktop or mobile notifications when agents need attention.
-          When enabled and the app is open, browser notifications are used instead of Slack.
+          When enabled and the app is open, browser notifications are used
+          instead of Slack.
         </p>
 
         {!notificationsSupported ? (
@@ -300,7 +333,9 @@ export function NotificationSettings(): JSX.Element {
               <div className="flex items-center gap-3 rounded border border-border px-3 py-2.5">
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-foreground">
-                    {browserPermission === "denied" ? "Notifications blocked" : "Permission required"}
+                    {browserPermission === "denied"
+                      ? "Notifications blocked"
+                      : "Permission required"}
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {browserPermission === "denied"
@@ -327,7 +362,9 @@ export function NotificationSettings(): JSX.Element {
               <Checkbox
                 checked={webNotifyEnabled}
                 disabled={browserPermission !== "granted" || saving}
-                onCheckedChange={(checked) => void toggleWebNotifyEnabled(checked === true)}
+                onCheckedChange={(checked) =>
+                  void toggleWebNotifyEnabled(checked === true)
+                }
                 data-testid="web-notify-enabled"
               />
               <div className="min-w-0">
@@ -379,7 +416,9 @@ export function NotificationSettings(): JSX.Element {
                 </div>
               </div>
             )}
-            {webError ? <p className="text-sm text-destructive">{webError}</p> : null}
+            {webError ? (
+              <p className="text-sm text-destructive">{webError}</p>
+            ) : null}
             {webMessage ? (
               <p className="text-sm text-status-working">{webMessage}</p>
             ) : null}
@@ -393,12 +432,19 @@ export function NotificationSettings(): JSX.Element {
           Slack Webhook
         </h3>
         <p className="mb-3 text-sm text-muted-foreground">
-          Receive notifications in Slack when agents finish, need input, or get blocked.
+          Receive notifications in Slack when agents finish, need input, or get
+          blocked.
           {webNotifyEnabled && (
-            <> When browser notifications are active, Slack is used as a fallback for when the app is closed.</>
+            <>
+              {" "}
+              When browser notifications are active, Slack is used as a fallback
+              for when the app is closed.
+            </>
           )}
           {!webNotifyEnabled && (
-            <>{" "}Create an{" "}
+            <>
+              {" "}
+              Create an{" "}
               <a
                 href="https://api.slack.com/messaging/webhooks"
                 target="_blank"
@@ -407,7 +453,8 @@ export function NotificationSettings(): JSX.Element {
               >
                 Incoming Webhook
               </a>{" "}
-              in your Slack workspace and paste the URL below.</>
+              in your Slack workspace and paste the URL below.
+            </>
           )}
         </p>
         <div className="max-w-lg space-y-3">

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, CheckCircle2, ChevronDown, GitBranch, Loader2, X } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  GitBranch,
+  Loader2,
+  X,
+} from "lucide-react";
 
-import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-function useClickOutside(ref: React.RefObject<HTMLElement | null>, isOpen: boolean, onClose: () => void): void {
+function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void
+): void {
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e: MouseEvent) => {
@@ -82,14 +98,23 @@ export function PathInput({
     if (!showValidation) return;
     setValidating(true);
     const timer = setTimeout(() => {
-      api<PathInfo & { resolvedPath: string }>(`/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`)
+      api<PathInfo & { resolvedPath: string }>(
+        `/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`
+      )
         .then((result) => {
-          setPathValidation({ exists: result.exists, isDirectory: result.isDirectory, isGitRepo: result.isGitRepo });
+          setPathValidation({
+            exists: result.exists,
+            isDirectory: result.isDirectory,
+            isGitRepo: result.isGitRepo,
+          });
         })
         .catch(() => setPathValidation(null))
         .finally(() => setValidating(false));
     }, 400);
-    return () => { clearTimeout(timer); setValidating(false); };
+    return () => {
+      clearTimeout(timer);
+      setValidating(false);
+    };
   }, [value, showValidation]);
 
   // Debounced inline ghost completion
@@ -100,7 +125,9 @@ export function PathInput({
       return;
     }
     const timer = setTimeout(() => {
-      api<{ completions: string[] }>(`/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`)
+      api<{ completions: string[] }>(
+        `/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`
+      )
         .then((result) => {
           if (result.completions.length > 0) {
             const best = result.completions[0];
@@ -125,7 +152,10 @@ export function PathInput({
   return (
     <div className={cn("relative", className)}>
       {label ? (
-        <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor={id}>
+        <label
+          className="mb-1.5 block text-xs font-medium text-muted-foreground"
+          htmlFor={id}
+        >
           {label}
         </label>
       ) : null}
@@ -139,7 +169,9 @@ export function PathInput({
               className="pointer-events-none absolute inset-0 flex h-9 items-center overflow-hidden rounded-md border border-transparent px-3 py-2 font-mono text-xs"
             >
               <span className="invisible whitespace-pre">{value}</span>
-              <span className="whitespace-pre text-muted-foreground/40">{ghostSuffix}</span>
+              <span className="whitespace-pre text-muted-foreground/40">
+                {ghostSuffix}
+              </span>
             </div>
           ) : null}
           <Input
@@ -158,7 +190,11 @@ export function PathInput({
                 e.stopPropagation();
                 setDropdownOpen(false);
               }
-              if ((e.key === "Enter" || e.key === "ArrowDown") && !dropdownOpen && history.length > 0) {
+              if (
+                (e.key === "Enter" || e.key === "ArrowDown") &&
+                !dropdownOpen &&
+                history.length > 0
+              ) {
                 e.preventDefault();
                 setDropdownOpen(true);
               }
@@ -185,19 +221,27 @@ export function PathInput({
                 inputRef.current?.focus();
               }}
             >
-              <ChevronDown className={cn("h-4 w-4 transition-transform", dropdownOpen && "rotate-180")} />
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  dropdownOpen && "rotate-180"
+                )}
+              />
             </button>
           ) : null}
         </div>
         {dropdownOpen && sortedHistory.length > 0 ? (
           <div className="absolute left-0 right-0 z-[60] mt-1.5 rounded-md border border-border bg-background p-1 shadow-md">
-            <Command shouldFilter={false} onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                e.preventDefault();
-                setDropdownOpen(false);
-                inputRef.current?.focus();
-              }
-            }}>
+            <Command
+              shouldFilter={false}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setDropdownOpen(false);
+                  inputRef.current?.focus();
+                }
+              }}
+            >
               <CommandList>
                 <CommandGroup heading="Recent">
                   {sortedHistory.map((dir) => (
@@ -247,21 +291,29 @@ export function PathInput({
                 {pathValidation.isGitRepo ? (
                   <>
                     <GitBranch className="h-3 w-3 text-emerald-500" />
-                    <span className="text-emerald-600 dark:text-emerald-400">Git repository</span>
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      Git repository
+                    </span>
                   </>
                 ) : (
-                  <span className="text-emerald-600 dark:text-emerald-400">Valid directory</span>
+                  <span className="text-emerald-600 dark:text-emerald-400">
+                    Valid directory
+                  </span>
                 )}
               </>
             ) : pathValidation.exists ? (
               <>
                 <AlertCircle className="h-3 w-3 text-amber-500" />
-                <span className="text-amber-600 dark:text-amber-400">Not a directory</span>
+                <span className="text-amber-600 dark:text-amber-400">
+                  Not a directory
+                </span>
               </>
             ) : (
               <>
                 <AlertCircle className="h-3 w-3 text-amber-500" />
-                <span className="text-amber-600 dark:text-amber-400">Directory not found</span>
+                <span className="text-amber-600 dark:text-amber-400">
+                  Directory not found
+                </span>
               </>
             )
           ) : null}

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -1,8 +1,23 @@
-import { Check, ChevronRight, Eye, ListChecks, Terminal, X, XCircle } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  Eye,
+  ListChecks,
+  Terminal,
+  X,
+  XCircle,
+} from "lucide-react";
 
-import { reviewVerdictLabel, type ReviewVerdict } from "@/components/app/agent-event-utils";
+import {
+  reviewVerdictLabel,
+  type ReviewVerdict,
+} from "@/components/app/agent-event-utils";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export type PersonaAgentRowProps = {
@@ -23,7 +38,15 @@ export type PersonaAgentRowProps = {
   onOpenSummary?: () => void;
 };
 
-function PersonaStatusIcon({ reviewStatus, verdict, className }: { reviewStatus?: string | null; verdict?: ReviewVerdict; className?: string }): JSX.Element {
+function PersonaStatusIcon({
+  reviewStatus,
+  verdict,
+  className,
+}: {
+  reviewStatus?: string | null;
+  verdict?: ReviewVerdict;
+  className?: string;
+}): JSX.Element {
   // Review complete — show verdict icon
   if (reviewStatus === "complete" && verdict) {
     return <PersonaVerdictIcon verdict={verdict} className={className} />;
@@ -59,17 +82,33 @@ function PersonaStatusIcon({ reviewStatus, verdict, className }: { reviewStatus?
   );
 }
 
-function PersonaVerdictIcon({ verdict, className }: { verdict?: ReviewVerdict; className?: string }): JSX.Element {
+function PersonaVerdictIcon({
+  verdict,
+  className,
+}: {
+  verdict?: ReviewVerdict;
+  className?: string;
+}): JSX.Element {
   if (verdict === "approve") {
     return (
-      <span className={cn("inline-flex shrink-0 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/15 text-emerald-500", className)}>
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/15 text-emerald-500",
+          className
+        )}
+      >
         <Check className="h-3 w-3" />
       </span>
     );
   }
   // request_changes or unknown
   return (
-    <span className={cn("inline-flex shrink-0 items-center justify-center rounded-full border border-orange-500/50 bg-orange-500/15 text-orange-500", className)}>
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full border border-orange-500/50 bg-orange-500/15 text-orange-500",
+        className
+      )}
+    >
       <XCircle className="h-3 w-3" />
     </span>
   );
@@ -128,7 +167,12 @@ export function PersonaAgentRow({
       )}
     >
       {hasFeedback ? (
-        <ChevronRight className={cn("h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform", !isCollapsed && "rotate-90")} />
+        <ChevronRight
+          className={cn(
+            "h-2.5 w-2.5 shrink-0 text-muted-foreground/60 transition-transform",
+            !isCollapsed && "rotate-90"
+          )}
+        />
       ) : null}
       <PersonaStatusIcon
         reviewStatus={reviewStatus}
@@ -137,13 +181,20 @@ export function PersonaAgentRow({
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <span className="truncate text-xs font-medium" style={{ color: `hsl(${colorVar})` }}>
+          <span
+            className="truncate text-xs font-medium"
+            style={{ color: `hsl(${colorVar})` }}
+          >
             {child.persona ?? child.name}
           </span>
           {feedbackCount != null && feedbackCount > 0 ? (
-            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/20 px-1 text-[10px] font-semibold text-primary">{feedbackCount}</span>
+            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/20 px-1 text-[10px] font-semibold text-primary">
+              {feedbackCount}
+            </span>
           ) : resolvedCount != null && resolvedCount > 0 ? (
-            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium text-muted-foreground/60">{resolvedCount}</span>
+            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium text-muted-foreground/60">
+              {resolvedCount}
+            </span>
           ) : null}
         </div>
         <div className="mt-0.5 flex items-center gap-1.5 text-[10px]">
@@ -153,19 +204,31 @@ export function PersonaAgentRow({
                 data-agent-control="true"
                 className={cn(
                   "font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid transition-colors",
-                  verdict === "approve" ? "text-emerald-500 decoration-emerald-500/40 hover:decoration-emerald-500" : "text-orange-500 decoration-orange-500/40 hover:decoration-orange-500"
+                  verdict === "approve"
+                    ? "text-emerald-500 decoration-emerald-500/40 hover:decoration-emerald-500"
+                    : "text-orange-500 decoration-orange-500/40 hover:decoration-orange-500"
                 )}
-                onClick={(e) => { e.stopPropagation(); onOpenSummary(); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenSummary();
+                }}
               >
                 {reviewVerdictLabel(verdict)}
               </button>
             ) : (
-              <span className={cn("font-medium", verdict === "approve" ? "text-emerald-500" : "text-orange-500")}>
+              <span
+                className={cn(
+                  "font-medium",
+                  verdict === "approve" ? "text-emerald-500" : "text-orange-500"
+                )}
+              >
                 {reviewVerdictLabel(verdict)}
               </span>
             )
           ) : isReviewing ? (
-            <span className="font-medium text-status-working">{reviewMessage ?? "Reviewing"}</span>
+            <span className="font-medium text-status-working">
+              {reviewMessage ?? "Reviewing"}
+            </span>
           ) : child.status === "running" ? (
             <span className="font-medium text-muted-foreground">Starting</span>
           ) : null}
@@ -183,18 +246,30 @@ export function PersonaAgentRow({
         {onTriage ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <span data-agent-control="true" className={cn(triageDisabled && "cursor-not-allowed")}>
+              <span
+                data-agent-control="true"
+                className={cn(triageDisabled && "cursor-not-allowed")}
+              >
                 <button
                   aria-label="Auto-triage feedback"
                   disabled={triageDisabled}
-                  className={cn("rounded p-2 transition-colors", triageDisabled ? "text-muted-foreground/25" : "text-muted-foreground/50 hover:text-foreground")}
+                  className={cn(
+                    "rounded p-2 transition-colors",
+                    triageDisabled
+                      ? "text-muted-foreground/25"
+                      : "text-muted-foreground/50 hover:text-foreground"
+                  )}
                   onClick={onTriage}
                 >
                   <ListChecks className="h-3.5 w-3.5" />
                 </button>
               </span>
             </TooltipTrigger>
-            <TooltipContent>{triageDisabled ? "Connect to parent agent to auto-triage" : "Auto-triage feedback"}</TooltipContent>
+            <TooltipContent>
+              {triageDisabled
+                ? "Connect to parent agent to auto-triage"
+                : "Auto-triage feedback"}
+            </TooltipContent>
           </Tooltip>
         ) : null}
         {!childIsStopped ? (

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -36,14 +36,20 @@ export function PersonaLauncher({
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
     queryKey: ["personas", cwd],
     queryFn: async () => {
-      const result = await api<{ personas: PersonaSummary[] }>(`/api/v1/personas?cwd=${encodeURIComponent(cwd)}`);
+      const result = await api<{ personas: PersonaSummary[] }>(
+        `/api/v1/personas?cwd=${encodeURIComponent(cwd)}`
+      );
       return result.personas;
     },
   });
 
   if (personas.length === 0) return null;
 
-  const reviewAgentType = agent.reviewAgentType ?? (agent.type === "claude" || agent.type === "opencode" ? agent.type : "codex");
+  const reviewAgentType =
+    agent.reviewAgentType ??
+    (agent.type === "claude" || agent.type === "opencode"
+      ? agent.type
+      : "codex");
 
   const launchPersona = (slug: string) => {
     if (!sendTerminalInput) return;
@@ -52,13 +58,20 @@ export function PersonaLauncher({
   };
 
   const updateReviewAgentType = async (nextType: AgentType): Promise<void> => {
-    const result = await api<{ agent: Agent }>(`/api/v1/agents/${agent.id}/review-agent-type`, {
-      method: "PATCH",
-      body: JSON.stringify({ reviewAgentType: nextType }),
-    });
-    queryClient.setQueryData<Agent[]>(["agents"], (old) => old?.map((item) => (
-      item.id === result.agent.id ? result.agent : item
-    )) ?? [result.agent]);
+    const result = await api<{ agent: Agent }>(
+      `/api/v1/agents/${agent.id}/review-agent-type`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ reviewAgentType: nextType }),
+      }
+    );
+    queryClient.setQueryData<Agent[]>(
+      ["agents"],
+      (old) =>
+        old?.map((item) =>
+          item.id === result.agent.id ? result.agent : item
+        ) ?? [result.agent]
+    );
   };
 
   return (
@@ -71,7 +84,10 @@ export function PersonaLauncher({
             className="gap-1.5 rounded-r-none border border-border/60 border-r-0 bg-background/50 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             data-testid="launch-reviewer-button"
           >
-            <AgentTypeIcon type={reviewAgentType} className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80" />
+            <AgentTypeIcon
+              type={reviewAgentType}
+              className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
+            />
             Launch Reviewer
           </Button>
         </DropdownMenuTrigger>
@@ -79,16 +95,27 @@ export function PersonaLauncher({
           {personas.map((p, i) => {
             const colorVar = `var(--chart-${(i % 4) + 1})`;
             return (
-              <DropdownMenuItem key={p.slug} className="text-foreground" onClick={() => launchPersona(p.slug)}>
+              <DropdownMenuItem
+                key={p.slug}
+                className="text-foreground"
+                onClick={() => launchPersona(p.slug)}
+              >
                 <div className="flex items-start gap-2.5">
                   <div
                     className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
                     style={{ backgroundColor: `hsl(${colorVar})` }}
                   />
                   <div>
-                    <div className="text-sm font-medium" style={{ color: `hsl(${colorVar})` }}>{p.name}</div>
+                    <div
+                      className="text-sm font-medium"
+                      style={{ color: `hsl(${colorVar})` }}
+                    >
+                      {p.name}
+                    </div>
                     {p.description ? (
-                      <div className="text-xs text-muted-foreground">{p.description}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {p.description}
+                      </div>
                     ) : null}
                   </div>
                 </div>
@@ -114,11 +141,15 @@ export function PersonaLauncher({
             <DropdownMenuItem
               key={agentType}
               className="text-foreground"
-              onClick={() => { void updateReviewAgentType(agentType); }}
+              onClick={() => {
+                void updateReviewAgentType(agentType);
+              }}
               data-testid={`launch-reviewer-type-${agentType}`}
             >
               <span className="flex items-center gap-3">
-                <Check className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`} />
+                <Check
+                  className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
+                />
                 <span>{AGENT_TYPE_LABELS[agentType]}</span>
               </span>
             </DropdownMenuItem>

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -1,10 +1,20 @@
-import { Check, Copy, ExternalLink, FileText, GitPullRequest, Pin } from "lucide-react";
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  FileText,
+  GitPullRequest,
+  Pin,
+} from "lucide-react";
 
 import { FrontTruncatedValue } from "@/components/app/agent-meta";
 import { type AgentPin } from "@/components/app/types";
 import { Markdown } from "@/components/ui/markdown";
 import { useCopyText } from "@/hooks/use-copy";
-import { getSafariExternalHref, isStandaloneIOSApp } from "@/lib/external-links";
+import {
+  getSafariExternalHref,
+  isStandaloneIOSApp,
+} from "@/lib/external-links";
 import { splitPinValues } from "@/lib/pins";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
@@ -17,7 +27,13 @@ function formatPrDisplay(value: string): string {
   return m ? `${m[1]}#${m[2]}` : value;
 }
 
-function CopyButton({ value, title }: { value: string; title?: string }): JSX.Element {
+function CopyButton({
+  value,
+  title,
+}: {
+  value: string;
+  title?: string;
+}): JSX.Element {
   const [copied, copyText] = useCopyText();
 
   return (
@@ -26,19 +42,34 @@ function CopyButton({ value, title }: { value: string; title?: string }): JSX.El
       className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
       title={title ?? "Copy to clipboard"}
     >
-      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+      {copied ? (
+        <Check className="h-3 w-3 text-green-500" />
+      ) : (
+        <Copy className="h-3 w-3" />
+      )}
     </button>
   );
 }
 
-type ResolvedValue = { display: string; tooltip: string; href: string | null; badge: boolean; icon: "pr" | "file" | null };
+type ResolvedValue = {
+  display: string;
+  tooltip: string;
+  href: string | null;
+  badge: boolean;
+  icon: "pr" | "file" | null;
+};
 
-function trimFilenameForDisplay(value: string, workspaceRoot: string | null): { display: string; tooltip: string } {
+function trimFilenameForDisplay(
+  value: string,
+  workspaceRoot: string | null
+): { display: string; tooltip: string } {
   if (!workspaceRoot) {
     return { display: value, tooltip: value };
   }
 
-  const normalizedRoot = workspaceRoot.endsWith("/") ? workspaceRoot.slice(0, -1) : workspaceRoot;
+  const normalizedRoot = workspaceRoot.endsWith("/")
+    ? workspaceRoot.slice(0, -1)
+    : workspaceRoot;
   if (!normalizedRoot) {
     return { display: value, tooltip: value };
   }
@@ -70,13 +101,20 @@ function shouldRenderMarkdownAsPlainText(value: string): boolean {
   return unsupportedPatterns.some((pattern) => pattern.test(sanitized));
 }
 
-function normalizeExternalHref(type: AgentPin["type"], value: string): string | null {
+function normalizeExternalHref(
+  type: AgentPin["type"],
+  value: string
+): string | null {
   if (type !== "url" && type !== "pr") return null;
 
   const trimmed = value.trim();
   if (!trimmed) return null;
 
-  const candidate = SAFE_URL_RE.test(trimmed) ? trimmed : type === "url" ? `http://${trimmed}` : trimmed;
+  const candidate = SAFE_URL_RE.test(trimmed)
+    ? trimmed
+    : type === "url"
+      ? `http://${trimmed}`
+      : trimmed;
 
   try {
     const parsed = new URL(candidate);
@@ -105,36 +143,79 @@ function MarkdownPinBody({ value }: { value: string }): JSX.Element {
             {value}
           </pre>
         ) : (
-          <Markdown variant="pin">
-            {value}
-          </Markdown>
+          <Markdown variant="pin">{value}</Markdown>
         )}
       </div>
     </ScrollArea>
   );
 }
 
-function resolveDisplayValue(type: AgentPin["type"], value: string): ResolvedValue {
+function resolveDisplayValue(
+  type: AgentPin["type"],
+  value: string
+): ResolvedValue {
   const href = normalizeExternalHref(type, value);
   if (type === "pr" && href) {
-    return { display: formatPrDisplay(href), tooltip: value.trim(), href, badge: false, icon: "pr" };
+    return {
+      display: formatPrDisplay(href),
+      tooltip: value.trim(),
+      href,
+      badge: false,
+      icon: "pr",
+    };
   }
   if (type === "pr") {
-    return { display: value, tooltip: value, href: null, badge: false, icon: "pr" };
+    return {
+      display: value,
+      tooltip: value,
+      href: null,
+      badge: false,
+      icon: "pr",
+    };
   }
   if (type === "url" && href) {
-    return { display: value.trim(), tooltip: value.trim(), href, badge: false, icon: null };
+    return {
+      display: value.trim(),
+      tooltip: value.trim(),
+      href,
+      badge: false,
+      icon: null,
+    };
   }
   if (type === "url") {
-    return { display: value, tooltip: value, href: null, badge: false, icon: null };
+    return {
+      display: value,
+      tooltip: value,
+      href: null,
+      badge: false,
+      icon: null,
+    };
   }
   if (type === "filename") {
-    return { display: value, tooltip: value, href: null, badge: true, icon: "file" };
+    return {
+      display: value,
+      tooltip: value,
+      href: null,
+      badge: true,
+      icon: "file",
+    };
   }
   if (type === "port" || type === "code") {
-    return { display: value, tooltip: value, href: null, badge: true, icon: null };
+    return {
+      display: value,
+      tooltip: value,
+      href: null,
+      badge: true,
+      icon: null,
+    };
   }
-  return { display: value, tooltip: value, href: null, badge: false, icon: null };
+  return {
+    display: value,
+    tooltip: value,
+    href: null,
+    badge: false,
+    icon: null,
+  };
 }
 
 function PinValueRow({
@@ -150,16 +231,24 @@ function PinValueRow({
     return <MarkdownPinBody value={value} />;
   }
 
-  const filenameValue = type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : null;
-  const { display, tooltip, href, badge, icon } = resolveDisplayValue(type, filenameValue?.display ?? value);
+  const filenameValue =
+    type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : null;
+  const { display, tooltip, href, badge, icon } = resolveDisplayValue(
+    type,
+    filenameValue?.display ?? value
+  );
   const tooltipValue = filenameValue?.tooltip ?? tooltip;
   const showSafariButton = Boolean(href) && isStandaloneIOSApp();
   const safariHref = href ? getSafariExternalHref(href) : null;
 
   return (
     <div className="flex items-center gap-1.5">
-      {icon === "pr" && <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />}
-      {icon === "file" && <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />}
+      {icon === "pr" && (
+        <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-primary" />
+      )}
+      {icon === "file" && (
+        <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+      )}
       {href ? (
         <a
           href={href}
@@ -215,23 +304,41 @@ function PinValueRow({
   );
 }
 
-function PinItem({ pin, workspaceRoot }: { pin: AgentPin; workspaceRoot: string | null }): JSX.Element {
+function PinItem({
+  pin,
+  workspaceRoot,
+}: {
+  pin: AgentPin;
+  workspaceRoot: string | null;
+}): JSX.Element {
   const values = splitPinValues(pin.type, pin.value);
   const isMulti = values.length > 1;
 
   return (
-    <div className="px-4 py-2.5 border-b border-border last:border-b-0" data-testid="pin-item" data-pin-label={pin.label}>
+    <div
+      className="px-4 py-2.5 border-b border-border last:border-b-0"
+      data-testid="pin-item"
+      data-pin-label={pin.label}
+    >
       <div className="flex items-center gap-1">
         <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
           {pin.label}
         </div>
         <div className="ml-auto">
-          <CopyButton value={pin.value} title={isMulti ? "Copy all" : "Copy to clipboard"} />
+          <CopyButton
+            value={pin.value}
+            title={isMulti ? "Copy all" : "Copy to clipboard"}
+          />
         </div>
       </div>
       <div className="flex flex-col gap-1 mt-1">
         {values.map((v, i) => (
-          <PinValueRow key={i} type={pin.type} value={v} workspaceRoot={workspaceRoot} />
+          <PinValueRow
+            key={i}
+            type={pin.type}
+            value={v}
+            workspaceRoot={workspaceRoot}
+          />
         ))}
       </div>
     </div>
@@ -244,7 +351,11 @@ type PinsPanelProps = {
   selectedAgentWorkspaceRoot: string | null;
 };
 
-export function PinsPanel({ pins, selectedAgentName, selectedAgentWorkspaceRoot }: PinsPanelProps): JSX.Element {
+export function PinsPanel({
+  pins,
+  selectedAgentName,
+  selectedAgentWorkspaceRoot,
+}: PinsPanelProps): JSX.Element {
   if (pins.length === 0) {
     return (
       <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
@@ -261,9 +372,16 @@ export function PinsPanel({ pins, selectedAgentName, selectedAgentWorkspaceRoot 
   }
 
   return (
-    <div data-testid="pins-panel-scroll" className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+    <div
+      data-testid="pins-panel-scroll"
+      className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]"
+    >
       {pins.map((pin) => (
-        <PinItem key={pin.label.toLowerCase()} pin={pin} workspaceRoot={selectedAgentWorkspaceRoot} />
+        <PinItem
+          key={pin.label.toLowerCase()}
+          pin={pin}
+          workspaceRoot={selectedAgentWorkspaceRoot}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
-import { CheckCircle2, ExternalLink, Loader2, ShieldCheck, Sparkles, Zap } from "lucide-react";
+import {
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  ShieldCheck,
+  Sparkles,
+  Zap,
+} from "lucide-react";
 import { OperationTakeover } from "@/components/app/release-manager";
-import type { ReleaseInfo, ReleaseVersionType, UseReleaseStreamResult } from "@/hooks/use-release-stream";
+import type {
+  ReleaseInfo,
+  ReleaseVersionType,
+  UseReleaseStreamResult,
+} from "@/hooks/use-release-stream";
 import { cn } from "@/lib/utils";
 
 type GitHubRelease = {
@@ -11,34 +22,37 @@ type GitHubRelease = {
   url: string;
 };
 
-const VERSION_CONFIG: Record<ReleaseVersionType, {
-  icon: typeof ShieldCheck;
-  color: string;
-  border: string;
-  bg: string;
-  hover: string;
-}> = {
+const VERSION_CONFIG: Record<
+  ReleaseVersionType,
+  {
+    icon: typeof ShieldCheck;
+    color: string;
+    border: string;
+    bg: string;
+    hover: string;
+  }
+> = {
   patch: {
     icon: ShieldCheck,
     color: "text-status-working",
     border: "border-status-working/30",
     bg: "bg-status-working/10",
-    hover: "hover:border-status-working/60 hover:bg-status-working/20"
+    hover: "hover:border-status-working/60 hover:bg-status-working/20",
   },
   minor: {
     icon: Sparkles,
     color: "text-status-done",
     border: "border-status-done/30",
     bg: "bg-status-done/10",
-    hover: "hover:border-status-done/60 hover:bg-status-done/20"
+    hover: "hover:border-status-done/60 hover:bg-status-done/20",
   },
   major: {
     icon: Zap,
     color: "text-violet-400",
     border: "border-violet-500/30",
     bg: "bg-violet-500/10",
-    hover: "hover:border-violet-500/60 hover:bg-violet-500/20"
-  }
+    hover: "hover:border-violet-500/60 hover:bg-violet-500/20",
+  },
 };
 
 const CREATE_PHASES = ["preflight", "triggering", "watching", "done"] as const;
@@ -48,7 +62,7 @@ function formatDate(iso: string): string {
     month: "short",
     day: "numeric",
     hour: "2-digit",
-    minute: "2-digit"
+    minute: "2-digit",
   });
 }
 
@@ -89,7 +103,11 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
       }
       setInfo((await res.json()) as ReleaseInfo);
     } catch (err) {
-      setInfoError(err instanceof Error ? cleanError(err.message) : "Failed to load release info");
+      setInfoError(
+        err instanceof Error
+          ? cleanError(err.message)
+          : "Failed to load release info"
+      );
     } finally {
       setInfoLoading(false);
     }
@@ -103,8 +121,11 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
         const data = (await res.json()) as { releases: GitHubRelease[] };
         setReleases(data.releases);
       }
-    } catch { /* ignore */ }
-    finally { setReleasesLoading(false); }
+    } catch {
+      /* ignore */
+    } finally {
+      setReleasesLoading(false);
+    }
   }, []);
 
   useEffect(() => {
@@ -117,14 +138,23 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
     const res = await fetch("/api/v1/release", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ versionType })
+      body: JSON.stringify({ versionType }),
     });
     if (!res.ok) {
       const err = (await res.json()) as { error?: string };
       setReleaseError(cleanError(err.error ?? "Failed to start release"));
       return;
     }
-    setJob({ jobType: "create", versionType, phase: "preflight", startedAt: new Date().toISOString(), log: [], runUrl: null, tag: null, error: null });
+    setJob({
+      jobType: "create",
+      versionType,
+      phase: "preflight",
+      startedAt: new Date().toISOString(),
+      log: [],
+      runUrl: null,
+      tag: null,
+      error: null,
+    });
     connectStream();
   };
 
@@ -135,16 +165,22 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
       const res = await fetch("/api/v1/release/promote", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tag })
+        body: JSON.stringify({ tag }),
       });
       if (res.ok) {
-        setReleases((prev) => prev.map((r) => r.tag === tag ? { ...r, isPrerelease: false } : r));
+        setReleases((prev) =>
+          prev.map((r) => (r.tag === tag ? { ...r, isPrerelease: false } : r))
+        );
       } else {
         const err = (await res.json()) as { error?: string };
         setPromoteError(cleanError(err.error ?? `Failed to promote ${tag}`));
       }
     } catch (err) {
-      setPromoteError(err instanceof Error ? cleanError(err.message) : `Failed to promote ${tag}`);
+      setPromoteError(
+        err instanceof Error
+          ? cleanError(err.message)
+          : `Failed to promote ${tag}`
+      );
     } finally {
       setPromotingTag(null);
     }
@@ -183,7 +219,9 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
     <div className="flex flex-col gap-6 p-4 md:p-6">
       {/* Unreleased commits */}
       <div>
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Unreleased changes</div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Unreleased changes
+        </div>
 
         {infoLoading && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -202,20 +240,29 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
           <>
             {info.refMissing ? (
               <div className="rounded border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-sm text-status-waiting">
-                Deployed version <span className="font-mono">{info.currentTag ?? "unknown"}</span> not found in origin — commit count unavailable.
+                Deployed version{" "}
+                <span className="font-mono">
+                  {info.currentTag ?? "unknown"}
+                </span>{" "}
+                not found in origin — commit count unavailable.
               </div>
             ) : info.unreleasedCount === 0 ? (
-              <div className="text-sm text-muted-foreground">No unreleased commits on main</div>
+              <div className="text-sm text-muted-foreground">
+                No unreleased commits on main
+              </div>
             ) : (
               <div>
                 <div className="mb-2 text-sm text-muted-foreground">
-                  {info.unreleasedCount} unreleased {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
+                  {info.unreleasedCount} unreleased{" "}
+                  {info.unreleasedCount === 1 ? "commit" : "commits"} on{" "}
                   <span className="font-mono">main</span>
                 </div>
                 <div className="flex flex-col gap-0.5 rounded border border-border bg-muted/20 p-2">
                   {info.commits.map((c) => (
                     <div key={c.sha} className="flex gap-2 py-0.5 text-xs">
-                      <span className="shrink-0 font-mono text-muted-foreground">{c.sha}</span>
+                      <span className="shrink-0 font-mono text-muted-foreground">
+                        {c.sha}
+                      </span>
                       <span className="text-foreground">{c.subject}</span>
                     </div>
                   ))}
@@ -234,7 +281,9 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
       {/* Create release */}
       {info && (info.refMissing || info.unreleasedCount > 0) && (
         <div>
-          <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Create release</div>
+          <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">
+            Create release
+          </div>
 
           {releaseError && (
             <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -243,22 +292,39 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
           )}
 
           <div className="flex flex-col gap-2">
-            {(["patch", "minor", "major"] as ReleaseVersionType[]).map((type) => {
-              const { icon: Icon, color, border, bg, hover } = VERSION_CONFIG[type];
-              return (
-                <button
-                  key={type}
-                  onClick={() => void handleRelease(type)}
-                  className={cn(
-                    "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
-                    border, bg, hover
-                  )}
-                >
-                  <Icon className={cn("h-5 w-5", color)} />
-                  <span className={cn("font-mono text-sm font-bold capitalize", color)}>{type}</span>
-                </button>
-              );
-            })}
+            {(["patch", "minor", "major"] as ReleaseVersionType[]).map(
+              (type) => {
+                const {
+                  icon: Icon,
+                  color,
+                  border,
+                  bg,
+                  hover,
+                } = VERSION_CONFIG[type];
+                return (
+                  <button
+                    key={type}
+                    onClick={() => void handleRelease(type)}
+                    className={cn(
+                      "flex flex-col items-center justify-center gap-2 rounded border py-4 transition-all",
+                      border,
+                      bg,
+                      hover
+                    )}
+                  >
+                    <Icon className={cn("h-5 w-5", color)} />
+                    <span
+                      className={cn(
+                        "font-mono text-sm font-bold capitalize",
+                        color
+                      )}
+                    >
+                      {type}
+                    </span>
+                  </button>
+                );
+              }
+            )}
           </div>
         </div>
       )}
@@ -267,7 +333,9 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
 
       {/* Recent releases */}
       <div>
-        <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Recent releases</div>
+        <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Recent releases
+        </div>
 
         {promoteError && (
           <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -289,13 +357,17 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
                 key={r.tag}
                 className="flex items-center gap-3 rounded border border-border px-3 py-2.5"
               >
-                <span className="font-mono text-sm font-semibold text-foreground">{r.tag}</span>
-                <span className={cn(
-                  "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-                  r.isPrerelease
-                    ? "bg-status-waiting/15 text-status-waiting"
-                    : "bg-green-500/15 text-green-400"
-                )}>
+                <span className="font-mono text-sm font-semibold text-foreground">
+                  {r.tag}
+                </span>
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                    r.isPrerelease
+                      ? "bg-status-waiting/15 text-status-waiting"
+                      : "bg-green-500/15 text-green-400"
+                  )}
+                >
                   {r.isPrerelease ? "pre-release" : "stable"}
                 </span>
                 <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -1,8 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowDownToLine, CheckCircle2, ChevronDown, ChevronRight, ExternalLink, Loader2, RefreshCw, Trash2, XCircle } from "lucide-react";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import {
+  ArrowDownToLine,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { OperationLog, PhaseProgress } from "@/components/app/release-shared";
-import { type ReleaseChannel, type ReleaseInfo, type ReleaseJob, type UseReleaseStreamResult } from "@/hooks/use-release-stream";
+import {
+  type ReleaseChannel,
+  type ReleaseInfo,
+  type ReleaseJob,
+  type UseReleaseStreamResult,
+} from "@/hooks/use-release-stream";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -21,7 +41,7 @@ function formatDate(iso: string): string {
     month: "short",
     day: "numeric",
     hour: "2-digit",
-    minute: "2-digit"
+    minute: "2-digit",
   });
 }
 
@@ -55,12 +75,18 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   useEffect(() => {
     let cancelled = false;
     void api<AppVersionInfo>("/api/v1/app/version")
-      .then((data) => { if (!cancelled) setVersionInfo(data); })
+      .then((data) => {
+        if (!cancelled) setVersionInfo(data);
+      })
       .catch(() => {});
     void api<{ channel: ReleaseChannel }>("/api/v1/release/channel")
-      .then((data) => { if (!cancelled) setChannel(data.channel); })
+      .then((data) => {
+        if (!cancelled) setChannel(data.channel);
+      })
       .catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleChannelChange = useCallback(async (value: ReleaseChannel) => {
@@ -75,7 +101,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
       setInfo(null);
     } catch {
       // revert on error
-      setChannel((prev) => prev === "stable" ? "latest" : "stable");
+      setChannel((prev) => (prev === "stable" ? "latest" : "stable"));
     } finally {
       setChannelSaving(false);
     }
@@ -94,7 +120,11 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
       }
       setInfo((await res.json()) as ReleaseInfo);
     } catch (err) {
-      setInfoError(err instanceof Error ? cleanError(err.message) : "Failed to check for updates");
+      setInfoError(
+        err instanceof Error
+          ? cleanError(err.message)
+          : "Failed to check for updates"
+      );
     } finally {
       setInfoLoading(false);
     }
@@ -105,14 +135,23 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
     const res = await fetch("/api/v1/release/update", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tag })
+      body: JSON.stringify({ tag }),
     });
     if (!res.ok) {
       const err = (await res.json()) as { error?: string };
       setUpdateError(cleanError(err.error ?? "Failed to start update"));
       return;
     }
-    setJob({ jobType: "update", versionType: null, phase: "fetching", startedAt: new Date().toISOString(), log: [], runUrl: null, tag, error: null });
+    setJob({
+      jobType: "update",
+      versionType: null,
+      phase: "fetching",
+      startedAt: new Date().toISOString(),
+      log: [],
+      runUrl: null,
+      tag,
+      error: null,
+    });
     connectStream();
   };
 
@@ -140,9 +179,15 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
 
   // Only show takeover for update jobs
   const updateJob = job?.jobType === "update" ? job : null;
-  const isDone = updateJob?.phase === "done" || (!postRestartPolling && updateJob?.phase === "restarting" && status?.tag === updateJob?.tag);
+  const isDone =
+    updateJob?.phase === "done" ||
+    (!postRestartPolling &&
+      updateJob?.phase === "restarting" &&
+      status?.tag === updateJob?.tag);
   const isFailed = updateJob?.phase === "failed";
-  const isRestarting = updateJob?.phase === "restarting" || (updateJob !== null && postRestartPolling);
+  const isRestarting =
+    updateJob?.phase === "restarting" ||
+    (updateJob !== null && postRestartPolling);
   // Only show takeover for active jobs, not stale done jobs from server memory
   const showTakeover = updateJob !== null && !isDone;
 
@@ -156,7 +201,11 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
         isRestarting={isRestarting}
         postRestartPolling={postRestartPolling}
         status={status}
-        onDismiss={() => { setJob(null); setInfo(null); setUpdateError(null); }}
+        onDismiss={() => {
+          setJob(null);
+          setInfo(null);
+          setUpdateError(null);
+        }}
       />
     );
   }
@@ -165,12 +214,18 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
     <div className="flex flex-col gap-6 p-4 md:p-6">
       {/* Current version */}
       <div>
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Current version</div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Current version
+        </div>
         {status ? (
           <div className="flex items-baseline gap-2">
-            <span className="font-mono text-xl font-bold text-foreground">{status.tag ?? "unknown"}</span>
+            <span className="font-mono text-xl font-bold text-foreground">
+              {status.tag ?? "unknown"}
+            </span>
             {status.deployedAt ? (
-              <span className="text-xs text-muted-foreground">{formatDate(status.deployedAt)}</span>
+              <span className="text-xs text-muted-foreground">
+                {formatDate(status.deployedAt)}
+              </span>
             ) : null}
           </div>
         ) : (
@@ -181,15 +236,21 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
           <div className="mt-3 grid gap-2 rounded border border-border p-3 text-sm">
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground">Release tag</span>
-              <span className="font-mono">{versionInfo.releaseTag ?? "unreleased"}</span>
+              <span className="font-mono">
+                {versionInfo.releaseTag ?? "unreleased"}
+              </span>
             </div>
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground">Package version</span>
-              <span className="font-mono">{versionInfo.version ?? "unknown"}</span>
+              <span className="font-mono">
+                {versionInfo.version ?? "unknown"}
+              </span>
             </div>
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground">Git SHA</span>
-              <span className="font-mono">{versionInfo.gitSha ?? "unavailable"}</span>
+              <span className="font-mono">
+                {versionInfo.gitSha ?? "unavailable"}
+              </span>
             </div>
           </div>
         )}
@@ -202,7 +263,11 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
             onClick={() => setNotesExpanded(!notesExpanded)}
             className="flex items-center gap-1.5 text-[10px] uppercase tracking-widest text-muted-foreground hover:text-foreground transition-colors"
           >
-            {notesExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            {notesExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
             Release notes
             {versionInfo.releaseUrl ? (
               <a
@@ -231,11 +296,18 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
 
       {/* Release channel */}
       <div>
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Release channel</div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Release channel
+        </div>
         <p className="mb-3 text-sm text-muted-foreground">
           Choose which releases this instance follows.
         </p>
-        <div className={cn("inline-flex rounded border border-border", channelSaving && "opacity-50 pointer-events-none")}>
+        <div
+          className={cn(
+            "inline-flex rounded border border-border",
+            channelSaving && "opacity-50 pointer-events-none"
+          )}
+        >
           {(["stable", "latest"] as ReleaseChannel[]).map((ch) => (
             <button
               key={ch}
@@ -286,7 +358,10 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                 <div className="flex items-center gap-2">
                   <ArrowDownToLine className="h-4 w-4 text-blue-400" />
                   <span className="text-sm text-foreground">
-                    <span className="font-mono font-semibold">{info.latestTag}</span> available
+                    <span className="font-mono font-semibold">
+                      {info.latestTag}
+                    </span>{" "}
+                    available
                   </span>
                   {info.latestRelease?.publishedAt && (
                     <span className="text-xs text-muted-foreground">
@@ -334,7 +409,9 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
 
       {/* Reload */}
       <div>
-        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">Reload</div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Reload
+        </div>
         <p className="mb-3 text-sm text-muted-foreground">
           Reload the app to pick up the latest version.
         </p>
@@ -344,7 +421,9 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
             disabled={reloading}
             className="inline-flex items-center gap-2 rounded-l border border-r-0 border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
           >
-            <RefreshCw className={cn("h-3.5 w-3.5", reloading && "animate-spin")} />
+            <RefreshCw
+              className={cn("h-3.5 w-3.5", reloading && "animate-spin")}
+            />
             {reloading ? "Reloading..." : "Reload"}
           </button>
           <DropdownMenu>
@@ -432,7 +511,9 @@ export function OperationTakeover({
               <CheckCircle2 className="h-4 w-4 shrink-0" />
               <span>
                 {job.jobType === "update" ? "Updated to" : "Released"}{" "}
-                <span className="font-mono font-semibold">{job.tag ?? status?.tag}</span>
+                <span className="font-mono font-semibold">
+                  {job.tag ?? status?.tag}
+                </span>
               </span>
             </div>
             <button
@@ -448,7 +529,9 @@ export function OperationTakeover({
           <div className="flex flex-col gap-3">
             <div className="flex items-start gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
               <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{job.error ? cleanError(job.error) : "Operation failed"}</span>
+              <span>
+                {job.error ? cleanError(job.error) : "Operation failed"}
+              </span>
             </div>
             <button
               onClick={onDismiss}
@@ -461,7 +544,12 @@ export function OperationTakeover({
       </div>
 
       {/* Right column — log */}
-      <OperationLog logRef={logRef} job={job} isRestarting={isRestarting} postRestartPolling={postRestartPolling} />
+      <OperationLog
+        logRef={logRef}
+        job={job}
+        isRestarting={isRestarting}
+        postRestartPolling={postRestartPolling}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/app/release-shared.tsx
+++ b/apps/web/src/components/app/release-shared.tsx
@@ -11,7 +11,7 @@ const PHASE_LABELS: Record<ReleasePhase, string> = {
   deploying: "Deploying",
   restarting: "Restarting",
   done: "Complete",
-  failed: "Failed"
+  failed: "Failed",
 };
 
 type PhaseProgressProps = {
@@ -21,40 +21,53 @@ type PhaseProgressProps = {
   isRestarting: boolean;
 };
 
-export function PhaseProgress({ job, phasesOrder, isFailed, isRestarting }: PhaseProgressProps): JSX.Element {
+export function PhaseProgress({
+  job,
+  phasesOrder,
+  isFailed,
+  isRestarting,
+}: PhaseProgressProps): JSX.Element {
   const phaseIndex = phasesOrder.indexOf(job.phase);
 
   return (
     <div>
-      <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">Progress</div>
+      <div className="mb-3 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Progress
+      </div>
       <div className="flex flex-col gap-2">
-        {phasesOrder.filter((p) => p !== "done").map((phase, i) => {
-          const current = phaseIndex === i;
-          const done = phaseIndex > i || job.phase === "done";
-          return (
-            <div key={phase} className="flex items-center gap-3">
-              <div className={cn(
-                "h-2 w-2 rounded-full shrink-0",
-                done && "bg-status-working",
-                current && !isFailed && "animate-pulse bg-status-waiting",
-                current && isFailed && "bg-destructive",
-                !done && !current && "bg-muted"
-              )} />
-              <span className={cn(
-                "text-sm",
-                done && "text-muted-foreground",
-                current && !isFailed && "text-foreground font-medium",
-                current && isFailed && "text-destructive font-medium",
-                !done && !current && "text-muted-foreground/50"
-              )}>
-                {PHASE_LABELS[phase as ReleasePhase] ?? phase}
-              </span>
-              {current && isRestarting && phase === "restarting" && (
-                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-              )}
-            </div>
-          );
-        })}
+        {phasesOrder
+          .filter((p) => p !== "done")
+          .map((phase, i) => {
+            const current = phaseIndex === i;
+            const done = phaseIndex > i || job.phase === "done";
+            return (
+              <div key={phase} className="flex items-center gap-3">
+                <div
+                  className={cn(
+                    "h-2 w-2 rounded-full shrink-0",
+                    done && "bg-status-working",
+                    current && !isFailed && "animate-pulse bg-status-waiting",
+                    current && isFailed && "bg-destructive",
+                    !done && !current && "bg-muted"
+                  )}
+                />
+                <span
+                  className={cn(
+                    "text-sm",
+                    done && "text-muted-foreground",
+                    current && !isFailed && "text-foreground font-medium",
+                    current && isFailed && "text-destructive font-medium",
+                    !done && !current && "text-muted-foreground/50"
+                  )}
+                >
+                  {PHASE_LABELS[phase as ReleasePhase] ?? phase}
+                </span>
+                {current && isRestarting && phase === "restarting" && (
+                  <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                )}
+              </div>
+            );
+          })}
       </div>
     </div>
   );
@@ -67,7 +80,12 @@ type OperationLogProps = {
   postRestartPolling: boolean;
 };
 
-export function OperationLog({ logRef, job, isRestarting, postRestartPolling }: OperationLogProps): JSX.Element {
+export function OperationLog({
+  logRef,
+  job,
+  isRestarting,
+  postRestartPolling,
+}: OperationLogProps): JSX.Element {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col p-2">
       <LogStream viewportRef={logRef}>

--- a/apps/web/src/components/app/security-settings.tsx
+++ b/apps/web/src/components/app/security-settings.tsx
@@ -6,7 +6,9 @@ type SecuritySettingsProps = {
   onLogout: () => void;
 };
 
-export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Element {
+export function SecuritySettings({
+  onLogout,
+}: SecuritySettingsProps): JSX.Element {
   const [passwordSet, setPasswordSet] = useState<boolean | null>(null);
 
   const [newPassword, setNewPassword] = useState("");
@@ -19,7 +21,9 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
   useEffect(() => {
     void (async () => {
       try {
-        const res = await fetch("/api/v1/auth/status", { credentials: "include" });
+        const res = await fetch("/api/v1/auth/status", {
+          credentials: "include",
+        });
         if (res.ok) {
           const data = (await res.json()) as { passwordSet: boolean };
           setPasswordSet(data.passwordSet);
@@ -48,7 +52,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
         method: "POST",
         headers: { "content-type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ password: newPassword })
+        body: JSON.stringify({ password: newPassword }),
       });
       if (!res.ok) {
         const body = (await res.json()) as { error?: string };
@@ -67,7 +71,12 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
 
   const handleChangePassword = async (e: FormEvent) => {
     e.preventDefault();
-    if (!currentPassword || newPassword.length < 8 || newPassword !== confirmPassword) return;
+    if (
+      !currentPassword ||
+      newPassword.length < 8 ||
+      newPassword !== confirmPassword
+    )
+      return;
     setError("");
     setMessage("");
     setLoading(true);
@@ -76,7 +85,7 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
         method: "POST",
         headers: { "content-type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ currentPassword, newPassword })
+        body: JSON.stringify({ currentPassword, newPassword }),
       });
       if (!res.ok) {
         const body = (await res.json()) as { error?: string };
@@ -92,12 +101,11 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
     }
   };
 
-  const mismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+  const mismatch =
+    confirmPassword.length > 0 && newPassword !== confirmPassword;
 
   if (passwordSet === null) {
-    return (
-      <div className="p-6 text-sm text-muted-foreground">Loading...</div>
-    );
+    return <div className="p-6 text-sm text-muted-foreground">Loading...</div>;
   }
 
   return (
@@ -108,10 +116,14 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
         </h3>
         {!passwordSet && (
           <p className="mb-4 text-sm text-muted-foreground">
-            No password is set. Anyone who can reach this server has full access. Set a password to require authentication.
+            No password is set. Anyone who can reach this server has full
+            access. Set a password to require authentication.
           </p>
         )}
-        <form onSubmit={passwordSet ? handleChangePassword : handleSetPassword} className="max-w-sm space-y-3">
+        <form
+          onSubmit={passwordSet ? handleChangePassword : handleSetPassword}
+          className="max-w-sm space-y-3"
+        >
           {passwordSet && (
             <Input
               type="password"
@@ -123,7 +135,11 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
           )}
           <Input
             type="password"
-            placeholder={passwordSet ? "New password (min 8 characters)" : "Password (min 8 characters)"}
+            placeholder={
+              passwordSet
+                ? "New password (min 8 characters)"
+                : "Password (min 8 characters)"
+            }
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
             data-testid="security-new-password"
@@ -135,15 +151,28 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
             onChange={(e) => setConfirmPassword(e.target.value)}
             data-testid="security-confirm-password"
           />
-          {mismatch && <p className="text-sm text-destructive">Passwords do not match.</p>}
+          {mismatch && (
+            <p className="text-sm text-destructive">Passwords do not match.</p>
+          )}
           {error && <p className="text-sm text-destructive">{error}</p>}
           {message && <p className="text-sm text-status-working">{message}</p>}
           <Button
             type="submit"
             variant="primary"
-            disabled={loading || newPassword.length < 8 || newPassword !== confirmPassword || (passwordSet && !currentPassword)}
+            disabled={
+              loading ||
+              newPassword.length < 8 ||
+              newPassword !== confirmPassword ||
+              (passwordSet && !currentPassword)
+            }
           >
-            {loading ? (passwordSet ? "Changing..." : "Setting up...") : (passwordSet ? "Change password" : "Set password")}
+            {loading
+              ? passwordSet
+                ? "Changing..."
+                : "Setting up..."
+              : passwordSet
+                ? "Change password"
+                : "Set password"}
           </Button>
         </form>
       </div>
@@ -153,7 +182,11 @@ export function SecuritySettings({ onLogout }: SecuritySettingsProps): JSX.Eleme
           <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Session
           </h3>
-          <Button variant="destructive" onClick={onLogout} data-testid="logout-button">
+          <Button
+            variant="destructive"
+            onClick={onLogout}
+            data-testid="logout-button"
+          >
             Log out
           </Button>
         </div>

--- a/apps/web/src/components/app/service-status.tsx
+++ b/apps/web/src/components/app/service-status.tsx
@@ -9,15 +9,25 @@ type ServiceStatusProps = {
   dotClass: string;
 };
 
-export function ServiceStatus({ icon, label, value, dotClass }: ServiceStatusProps): JSX.Element {
+export function ServiceStatus({
+  icon,
+  label,
+  value,
+  dotClass,
+}: ServiceStatusProps): JSX.Element {
   return (
     <div
       data-testid={`service-status-${label.toLowerCase()}`}
       className="grid grid-cols-[0.875rem_2rem_0.625rem_minmax(0,1fr)] items-center gap-x-2"
     >
-      <span className="flex h-3.5 w-3.5 items-center justify-center">{icon}</span>
+      <span className="flex h-3.5 w-3.5 items-center justify-center">
+        {icon}
+      </span>
       <span>{label}</span>
-      <span data-testid={`service-dot-${label.toLowerCase()}`} className={cn("h-2.5 w-2.5 rounded-full", dotClass)} />
+      <span
+        data-testid={`service-dot-${label.toLowerCase()}`}
+        className={cn("h-2.5 w-2.5 rounded-full", dotClass)}
+      />
       <span className="hidden truncate uppercase sm:inline">{value}</span>
     </div>
   );

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowDownToLine, Bell, BookOpenText, Database, Package, Server, Settings, Users } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Bell,
+  BookOpenText,
+  Database,
+  Package,
+  Server,
+  Settings,
+  Users,
+} from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { DocsContent, DOCS_SECTION_NAV } from "@/components/app/docs-pane";
@@ -17,20 +26,45 @@ import { type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type SettingsSection = "general" | "agents" | "notifications" | "updates" | "help" | "releases";
+type SettingsSection =
+  | "general"
+  | "agents"
+  | "notifications"
+  | "updates"
+  | "help"
+  | "releases";
 
-const BASE_SECTIONS: Array<{ id: SettingsSection; label: string; icon: typeof ArrowDownToLine }> = [
+const BASE_SECTIONS: Array<{
+  id: SettingsSection;
+  label: string;
+  icon: typeof ArrowDownToLine;
+}> = [
   { id: "general", label: "General", icon: Settings },
   { id: "agents", label: "Agents", icon: Users },
   { id: "notifications", label: "Notifications", icon: Bell },
   { id: "updates", label: "Updates", icon: ArrowDownToLine },
 ];
 
-const RELEASES_SECTION = { id: "releases" as SettingsSection, label: "Releases", icon: Package };
-const HELP_SECTION = { id: "help" as SettingsSection, label: "Help", icon: BookOpenText };
+const RELEASES_SECTION = {
+  id: "releases" as SettingsSection,
+  label: "Releases",
+  icon: Package,
+};
+const HELP_SECTION = {
+  id: "help" as SettingsSection,
+  label: "Help",
+  icon: BookOpenText,
+};
 
 function InstanceNameSettings(): JSX.Element {
-  const { instanceName, setInstanceName, isSaving, saveError, didSave, clearSaveState } = useInstanceName();
+  const {
+    instanceName,
+    setInstanceName,
+    isSaving,
+    saveError,
+    didSave,
+    clearSaveState,
+  } = useInstanceName();
   const [draft, setDraft] = useState(instanceName);
   const inputRef = useRef<HTMLInputElement>(null);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,11 +109,15 @@ function InstanceNameSettings(): JSX.Element {
 
   return (
     <div>
-      <label htmlFor="instance-name" className="mb-1.5 block text-[10px] uppercase tracking-widest text-muted-foreground">
+      <label
+        htmlFor="instance-name"
+        className="mb-1.5 block text-[10px] uppercase tracking-widest text-muted-foreground"
+      >
         Instance name
       </label>
       <p className="mb-3 text-sm text-muted-foreground">
-        Give this Dispatch instance a name to distinguish it from others. Shown in the sidebar and browser tab.
+        Give this Dispatch instance a name to distinguish it from others. Shown
+        in the sidebar and browser tab.
       </p>
       <div className="flex items-center gap-2">
         <input
@@ -87,7 +125,10 @@ function InstanceNameSettings(): JSX.Element {
           ref={inputRef}
           type="text"
           value={draft}
-          onChange={(e) => { setDraft(e.target.value); if (saveError) clearSaveState(); }}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (saveError) clearSaveState();
+          }}
           onBlur={save}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
@@ -100,7 +141,9 @@ function InstanceNameSettings(): JSX.Element {
           maxLength={100}
           className={cn(
             "w-full max-w-sm rounded border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none disabled:opacity-50",
-            saveError ? "border-destructive" : "border-border focus:border-primary/50"
+            saveError
+              ? "border-destructive"
+              : "border-border focus:border-primary/50"
           )}
         />
         {showSaved && !saveError ? (
@@ -108,7 +151,9 @@ function InstanceNameSettings(): JSX.Element {
         ) : null}
       </div>
       {saveError ? (
-        <p className="mt-1.5 text-xs text-destructive">Failed to save. Please try again.</p>
+        <p className="mt-1.5 text-xs text-destructive">
+          Failed to save. Please try again.
+        </p>
       ) : null}
     </div>
   );
@@ -119,7 +164,8 @@ function InstanceNameSettings(): JSX.Element {
 type WorktreeLocation = "sibling" | "nested";
 
 function WorktreeLocationSettings(): JSX.Element {
-  const [worktreeLocation, setWorktreeLocation] = useState<WorktreeLocation>("sibling");
+  const [worktreeLocation, setWorktreeLocation] =
+    useState<WorktreeLocation>("sibling");
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -129,17 +175,22 @@ function WorktreeLocationSettings(): JSX.Element {
         if (!cancelled) setWorktreeLocation(data.worktreeLocation);
       })
       .catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleChange = useCallback(async (value: WorktreeLocation) => {
     setWorktreeLocation(value);
     setSaving(true);
     try {
-      await api<{ worktreeLocation: WorktreeLocation }>("/api/v1/agents/settings", {
-        method: "POST",
-        body: JSON.stringify({ worktreeLocation: value }),
-      });
+      await api<{ worktreeLocation: WorktreeLocation }>(
+        "/api/v1/agents/settings",
+        {
+          method: "POST",
+          body: JSON.stringify({ worktreeLocation: value }),
+        }
+      );
     } catch {
       // revert on error
     } finally {
@@ -147,17 +198,23 @@ function WorktreeLocationSettings(): JSX.Element {
     }
   }, []);
 
-  const options: Array<{ value: WorktreeLocation; label: string; description: string }> = [
+  const options: Array<{
+    value: WorktreeLocation;
+    label: string;
+    description: string;
+  }> = [
     {
       value: "sibling",
       label: "Sibling directories",
-      description: "Worktrees are created next to the repo (e.g. ../repo-branch-name)"
+      description:
+        "Worktrees are created next to the repo (e.g. ../repo-branch-name)",
     },
     {
       value: "nested",
       label: "Inside .dispatch/worktrees",
-      description: "Worktrees are created inside the repo in .dispatch/worktrees/"
-    }
+      description:
+        "Worktrees are created inside the repo in .dispatch/worktrees/",
+    },
   ];
 
   return (
@@ -182,8 +239,12 @@ function WorktreeLocationSettings(): JSX.Element {
             )}
           >
             <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground">{opt.label}</div>
-              <div className="text-xs text-muted-foreground">{opt.description}</div>
+              <div className="text-sm font-medium text-foreground">
+                {opt.label}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {opt.description}
+              </div>
             </div>
           </button>
         ))}
@@ -250,8 +311,12 @@ function AppearanceSettings({
                 ))}
               </div>
               <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground">{t.label}</div>
-                <div className="text-xs text-muted-foreground">{t.description}</div>
+                <div className="text-sm font-medium text-foreground">
+                  {t.label}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {t.description}
+                </div>
               </div>
             </button>
           ))}
@@ -263,9 +328,17 @@ function AppearanceSettings({
           Icon Color
         </div>
         <p className="mb-3 text-sm text-muted-foreground">
-          Pick a color for the app icon to help distinguish multiple Dispatch installations.
+          Pick a color for the app icon to help distinguish multiple Dispatch
+          installations.
         </p>
-        <div className={cn("flex flex-wrap gap-2", isIconColorSaving && "pointer-events-none opacity-60")} role="radiogroup" aria-label="Icon color">
+        <div
+          className={cn(
+            "flex flex-wrap gap-2",
+            isIconColorSaving && "pointer-events-none opacity-60"
+          )}
+          role="radiogroup"
+          aria-label="Icon color"
+        >
           {ICON_COLOR_OPTIONS.map((c) => (
             <button
               key={c.id}
@@ -291,21 +364,33 @@ function AppearanceSettings({
                 alt=""
                 className="h-7 w-7 object-contain"
               />
-              <span className={cn(
-                "text-[10px] leading-none",
-                displayColor === c.id ? "text-foreground" : "text-muted-foreground"
-              )}>{c.label}</span>
+              <span
+                className={cn(
+                  "text-[10px] leading-none",
+                  displayColor === c.id
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                )}
+              >
+                {c.label}
+              </span>
             </button>
           ))}
         </div>
         {iconColorError ? (
           <p className="mt-2 text-xs text-destructive">
             {iconColorError}{" "}
-            <button onClick={clearIconColorError} className="underline hover:no-underline">Dismiss</button>
+            <button
+              onClick={clearIconColorError}
+              className="underline hover:no-underline"
+            >
+              Dismiss
+            </button>
           </p>
         ) : (
           <p className="mt-2 text-xs text-muted-foreground/70">
-            Changing the icon color will reload the page. PWA users may need to reinstall for launcher icons to update.
+            Changing the icon color will reload the page. PWA users may need to
+            reinstall for launcher icons to update.
           </p>
         )}
       </div>
@@ -313,10 +398,19 @@ function AppearanceSettings({
   );
 }
 
-const ALL_VALID_SECTIONS: SettingsSection[] = ["general", "agents", "notifications", "updates", "help", "releases"];
+const ALL_VALID_SECTIONS: SettingsSection[] = [
+  "general",
+  "agents",
+  "notifications",
+  "updates",
+  "help",
+  "releases",
+];
 
 function isValidSection(value: string | undefined): value is SettingsSection {
-  return value !== undefined && ALL_VALID_SECTIONS.includes(value as SettingsSection);
+  return (
+    value !== undefined && ALL_VALID_SECTIONS.includes(value as SettingsSection)
+  );
 }
 
 export type SettingsPaneProps = {
@@ -341,20 +435,29 @@ export type SettingsPaneProps = {
 };
 
 export function useSettingsState(open: boolean, initialSection?: string) {
-  const resolvedInitial = isValidSection(initialSection) ? initialSection : "general";
-  const [activeSection, setActiveSectionState] = useState<SettingsSection | null>(resolvedInitial);
+  const resolvedInitial = isValidSection(initialSection)
+    ? initialSection
+    : "general";
+  const [activeSection, setActiveSectionState] =
+    useState<SettingsSection | null>(resolvedInitial);
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     void api<{ isAdmin: boolean }>("/api/v1/release/admin-check")
-      .then((data) => { if (!cancelled) setIsAdmin(data.isAdmin); })
+      .then((data) => {
+        if (!cancelled) setIsAdmin(data.isAdmin);
+      })
       .catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
-  const sections = isAdmin ? [...BASE_SECTIONS, RELEASES_SECTION, HELP_SECTION] : [...BASE_SECTIONS, HELP_SECTION];
+  const sections = isAdmin
+    ? [...BASE_SECTIONS, RELEASES_SECTION, HELP_SECTION]
+    : [...BASE_SECTIONS, HELP_SECTION];
 
   useEffect(() => {
     if (open && isValidSection(initialSection)) {
@@ -382,7 +485,11 @@ export function SettingsNavContent({
 }: {
   activeSection: SettingsSection | null;
   activeSubsection?: string;
-  sections: Array<{ id: SettingsSection; label: string; icon: typeof Settings }>;
+  sections: Array<{
+    id: SettingsSection;
+    label: string;
+    icon: typeof Settings;
+  }>;
   onSectionChange: (section: SettingsSection) => void;
   onSubsectionChange?: (subsection: string) => void;
   apiState: ServiceState;
@@ -392,7 +499,9 @@ export function SettingsNavContent({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="mt-2 flex h-14 items-center border-b border-border px-3">
-        <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Settings</div>
+        <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Settings
+        </div>
       </div>
       <nav className="min-h-0 flex-1 overflow-y-auto py-2">
         {sections.map(({ id, label, icon: Icon }) => (
@@ -438,8 +547,18 @@ export function SettingsNavContent({
           System
         </div>
         <div className="space-y-2 text-xs text-muted-foreground">
-          <ServiceStatus icon={<Server className="h-3.5 w-3.5" />} label="API" value={apiState} dotClass={serviceDotClass(apiState)} />
-          <ServiceStatus icon={<Database className="h-3.5 w-3.5" />} label="DB" value={dbState} dotClass={serviceDotClass(dbState)} />
+          <ServiceStatus
+            icon={<Server className="h-3.5 w-3.5" />}
+            label="API"
+            value={apiState}
+            dotClass={serviceDotClass(apiState)}
+          />
+          <ServiceStatus
+            icon={<Database className="h-3.5 w-3.5" />}
+            label="DB"
+            value={dbState}
+            dotClass={serviceDotClass(dbState)}
+          />
         </div>
       </div>
     </div>
@@ -486,7 +605,7 @@ export function SettingsContent({
         key={activeSection}
         className={cn(
           "min-h-0 min-w-0 flex-1 overflow-y-auto",
-          activeSection === "help" && "flex overflow-hidden",
+          activeSection === "help" && "flex overflow-hidden"
         )}
       >
         {activeSection === "general" && (
@@ -495,7 +614,15 @@ export function SettingsContent({
               <InstanceNameSettings />
             </div>
             <div className="border-t border-border">
-              <AppearanceSettings theme={theme} setTheme={setTheme} iconColor={iconColor} setIconColor={setIconColor} isIconColorSaving={isIconColorSaving} iconColorError={iconColorError} clearIconColorError={clearIconColorError} />
+              <AppearanceSettings
+                theme={theme}
+                setTheme={setTheme}
+                iconColor={iconColor}
+                setIconColor={setIconColor}
+                isIconColorSaving={isIconColorSaving}
+                iconColorError={iconColorError}
+                clearIconColorError={clearIconColorError}
+              />
             </div>
             <div className="border-t border-border">
               <SecuritySettings onLogout={onLogout} />
@@ -514,7 +641,9 @@ export function SettingsContent({
           </div>
         )}
         {activeSection === "notifications" && <NotificationSettings />}
-        {activeSection === "updates" && <UpdatesSection stream={releaseStream} />}
+        {activeSection === "updates" && (
+          <UpdatesSection stream={releaseStream} />
+        )}
         {activeSection === "help" && (
           <DocsContent
             title="Help & Docs"
@@ -522,7 +651,9 @@ export function SettingsContent({
             onSectionChange={onSubsectionChange}
           />
         )}
-        {activeSection === "releases" && isAdmin && <ReleasesAdmin stream={releaseStream} />}
+        {activeSection === "releases" && isAdmin && (
+          <ReleasesAdmin stream={releaseStream} />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/app/sidebar-shell.tsx
+++ b/apps/web/src/components/app/sidebar-shell.tsx
@@ -9,7 +9,12 @@ import {
 import React from "react";
 
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { cn } from "@/lib/utils";
@@ -35,7 +40,10 @@ export function SidebarNavBar({
       active ? "text-primary hover:text-primary/80" : "text-muted-foreground"
     );
 
-  const triggerNavAnimationForKey = (event: React.KeyboardEvent<HTMLButtonElement>, navItem: string): void => {
+  const triggerNavAnimationForKey = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    navItem: string
+  ): void => {
     if (event.key === "Enter" || event.key === " ") {
       triggerNavAnimation?.(navItem);
     }
@@ -101,29 +109,50 @@ export function SidebarShell({
   const { instanceName } = useInstanceName();
 
   return (
-    <aside data-testid="sidebar-shell" className="flex h-full min-h-0 w-full flex-col text-foreground">
+    <aside
+      data-testid="sidebar-shell"
+      className="flex h-full min-h-0 w-full flex-col text-foreground"
+    >
       <div className="flex min-h-14 items-center px-3 pt-[env(safe-area-inset-top)]">
         <div className="flex items-center gap-2.5">
-          <img src={`/icons/${iconColor}/brand-icon.svg`} alt="" className="h-7 w-7 shrink-0 object-contain" />
+          <img
+            src={`/icons/${iconColor}/brand-icon.svg`}
+            alt=""
+            className="h-7 w-7 shrink-0 object-contain"
+          />
           <div className="flex min-w-0 flex-col justify-center">
-            <div className="text-sm font-bold uppercase tracking-widest text-foreground">Dispatch</div>
+            <div className="text-sm font-bold uppercase tracking-widest text-foreground">
+              Dispatch
+            </div>
             {instanceName ? (
-              <div title={instanceName} className="truncate text-[11px] leading-tight text-muted-foreground">{instanceName}</div>
+              <div
+                title={instanceName}
+                className="truncate text-[11px] leading-tight text-muted-foreground"
+              >
+                {instanceName}
+              </div>
             ) : null}
           </div>
         </div>
         {onRequestClose ? (
           <div className="ml-auto">
-            <Button size="icon" variant="ghost" onClick={onRequestClose} title="Close sidebar">
-              {closeButtonIcon === "chevron" ? <ChevronLeft className="h-4 w-4" /> : <X className="h-4 w-4" />}
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={onRequestClose}
+              title="Close sidebar"
+            >
+              {closeButtonIcon === "chevron" ? (
+                <ChevronLeft className="h-4 w-4" />
+              ) : (
+                <X className="h-4 w-4" />
+              )}
             </Button>
           </div>
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
-        {children}
-      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
 
       <SidebarNavBar
         activeSection={activeSection}

--- a/apps/web/src/components/app/stat-card.tsx
+++ b/apps/web/src/components/app/stat-card.tsx
@@ -14,8 +14,19 @@ export function StatCard({
   return (
     <div className="min-w-[7rem] max-w-[14rem] flex-1 basis-[7rem] rounded-md border border-border bg-muted/40 px-2.5 py-2 sm:px-4 sm:py-3">
       <p className="text-[10px] sm:text-xs text-muted-foreground">{label}</p>
-      <p className={cn("mt-0.5 sm:mt-1 text-lg sm:text-2xl font-semibold", variant === "warning" ? "text-status-blocked" : "text-foreground")}>{value}</p>
-      {sub && <p className="mt-0.5 text-[10px] sm:text-xs text-muted-foreground">{sub}</p>}
+      <p
+        className={cn(
+          "mt-0.5 sm:mt-1 text-lg sm:text-2xl font-semibold",
+          variant === "warning" ? "text-status-blocked" : "text-foreground"
+        )}
+      >
+        {value}
+      </p>
+      {sub && (
+        <p className="mt-0.5 text-[10px] sm:text-xs text-muted-foreground">
+          {sub}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/app/status-footer.tsx
+++ b/apps/web/src/components/app/status-footer.tsx
@@ -12,11 +12,19 @@ type StatusFooterProps = {
 export function StatusFooter({
   apiState,
   dbState,
-  serviceDotClass
+  serviceDotClass,
 }: StatusFooterProps): JSX.Element {
   return (
-    <footer data-testid="status-footer" className="flex h-11 items-center justify-end gap-8 border-t-2 border-border bg-surface px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs">
-      <ServiceStatus icon={<Server className="h-3.5 w-3.5" />} label="API" value={apiState} dotClass={serviceDotClass(apiState)} />
+    <footer
+      data-testid="status-footer"
+      className="flex h-11 items-center justify-end gap-8 border-t-2 border-border bg-surface px-3 pb-[env(safe-area-inset-bottom)] text-[10px] text-muted-foreground sm:text-xs"
+    >
+      <ServiceStatus
+        icon={<Server className="h-3.5 w-3.5" />}
+        label="API"
+        value={apiState}
+        dotClass={serviceDotClass(apiState)}
+      />
       <ServiceStatus
         icon={<Database className="h-3.5 w-3.5" />}
         label="DB"

--- a/apps/web/src/components/app/stop-agent-dialog.tsx
+++ b/apps/web/src/components/app/stop-agent-dialog.tsx
@@ -3,7 +3,13 @@ import { Loader2, Pause } from "lucide-react";
 
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 type StopAgentDialogProps = {
   open: boolean;
@@ -18,7 +24,7 @@ export function StopAgentDialog({
   stopTarget,
   setOpen,
   setStopTarget,
-  onStop
+  onStop,
 }: StopAgentDialogProps): JSX.Element {
   const [stopping, setStopping] = useState(false);
 
@@ -41,7 +47,12 @@ export function StopAgentDialog({
   }, [stopTarget, onStop, setOpen, setStopTarget]);
 
   return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) close(); }}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) close();
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Pause Agent</DialogTitle>
@@ -52,7 +63,12 @@ export function StopAgentDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="flex justify-end gap-2">
-          <Button variant="ghost" data-testid="stop-agent-cancel" onClick={close} disabled={stopping}>
+          <Button
+            variant="ghost"
+            data-testid="stop-agent-cancel"
+            onClick={close}
+            disabled={stopping}
+          >
             Cancel
           </Button>
           <Button
@@ -61,7 +77,11 @@ export function StopAgentDialog({
             disabled={stopping}
             onClick={() => void handleConfirmStop()}
           >
-            {stopping ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Pause className="mr-1.5 h-4 w-4" />}
+            {stopping ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Pause className="mr-1.5 h-4 w-4" />
+            )}
             Pause
           </Button>
         </div>

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -21,7 +21,7 @@ export const TerminalPane = memo(function TerminalPane({
   terminalMode,
   terminalPlaceholderMessage,
   terminalHostRef,
-  archivePhase
+  archivePhase,
 }: TerminalPaneProps): JSX.Element {
   const [showReconnectOverlay, setShowReconnectOverlay] = useState(false);
 
@@ -42,11 +42,16 @@ export const TerminalPane = memo(function TerminalPane({
   const showInertState = terminalMode === "inert" && isAttached;
 
   return (
-    <div data-testid="terminal-pane" className="relative h-full min-h-0 overflow-hidden bg-terminal-bg">
+    <div
+      data-testid="terminal-pane"
+      className="relative h-full min-h-0 overflow-hidden bg-terminal-bg"
+    >
       <div
         className={cn(
           "h-full w-full",
-          (!isAttached || showInertState) && connState !== "reconnecting" && "invisible",
+          (!isAttached || showInertState) &&
+            connState !== "reconnecting" &&
+            "invisible",
           showReconnectOverlay && "blur-[1.5px]"
         )}
       >
@@ -54,7 +59,10 @@ export const TerminalPane = memo(function TerminalPane({
       </div>
 
       {showEmptyState ? (
-        <div data-testid="terminal-empty-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
+        <div
+          data-testid="terminal-empty-state"
+          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+        >
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
             <p className="text-sm">Tap an agent row to focus it.</p>
@@ -63,10 +71,15 @@ export const TerminalPane = memo(function TerminalPane({
       ) : null}
 
       {showInertState ? (
-        <div data-testid="terminal-inert-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
+        <div
+          data-testid="terminal-inert-state"
+          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+        >
           <div className="flex max-w-xl flex-col items-center gap-3 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-9 w-9 text-status-waiting" />
-            <p className="text-base font-medium text-foreground">Agent running in inert mode</p>
+            <p className="text-base font-medium text-foreground">
+              Agent running in inert mode
+            </p>
             <p className="text-sm leading-6 text-muted-foreground">
               {terminalPlaceholderMessage ??
                 "This environment does not launch a real tmux session or CLI process. Agent lifecycle flows are simulated for UI validation."}
@@ -76,20 +89,32 @@ export const TerminalPane = memo(function TerminalPane({
       ) : null}
 
       {archivePhase ? (
-        <div data-testid="terminal-archive-state" className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg">
+        <div
+          data-testid="terminal-archive-state"
+          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+        >
           <div className="flex max-w-md flex-col items-center gap-3 px-6 text-center text-muted-foreground">
             <Archive className="h-9 w-9 text-orange-400" />
-            <p className="text-base font-medium text-foreground">Archiving agent</p>
+            <p className="text-base font-medium text-foreground">
+              Archiving agent
+            </p>
             <div className="flex items-center gap-2 text-sm text-orange-400">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span>
-                {archivePhase === "stopping" ? "Stopping agent…" :
-                 archivePhase === "worktree-check" ? "Checking worktree…" :
-                 archivePhase === "worktree-cleanup" ? "Removing worktree…" :
-                 archivePhase === "finalizing" ? "Finalizing…" : "Archiving…"}
+                {archivePhase === "stopping"
+                  ? "Stopping agent…"
+                  : archivePhase === "worktree-check"
+                    ? "Checking worktree…"
+                    : archivePhase === "worktree-cleanup"
+                      ? "Removing worktree…"
+                      : archivePhase === "finalizing"
+                        ? "Finalizing…"
+                        : "Archiving…"}
               </span>
             </div>
-            <p className="text-xs text-muted-foreground/70">You can switch to another agent while this completes.</p>
+            <p className="text-xs text-muted-foreground/70">
+              You can switch to another agent while this completes.
+            </p>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -1,4 +1,11 @@
-export type AgentStatus = "creating" | "running" | "stopping" | "stopped" | "archiving" | "error" | "unknown";
+export type AgentStatus =
+  | "creating"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "archiving"
+  | "error"
+  | "unknown";
 
 export type AgentPin = {
   label: string;
@@ -18,7 +25,12 @@ export type Agent = {
   agentArgs: string[];
   fullAccess: boolean;
   setupPhase?: "worktree" | "env" | "deps" | "session" | null;
-  archivePhase?: "stopping" | "worktree-check" | "worktree-cleanup" | "finalizing" | null;
+  archivePhase?:
+    | "stopping"
+    | "worktree-check"
+    | "worktree-cleanup"
+    | "finalizing"
+    | null;
   lastError?: string | null;
   latestEvent?: {
     type: "working" | "blocked" | "waiting_user" | "done" | "idle";

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -9,22 +9,31 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "border-border bg-muted text-muted-foreground",
-        running: "border-status-working/40 bg-status-working/15 text-status-working",
-        stopped: "border-status-waiting/35 bg-status-waiting/15 text-status-waiting",
-        error: "border-status-blocked/40 bg-status-blocked/15 text-status-blocked",
-        transitional: "border-status-done/35 bg-status-done/15 text-status-done"
-      }
+        running:
+          "border-status-working/40 bg-status-working/15 text-status-working",
+        stopped:
+          "border-status-waiting/35 bg-status-waiting/15 text-status-waiting",
+        error:
+          "border-status-blocked/40 bg-status-blocked/15 text-status-blocked",
+        transitional:
+          "border-status-done/35 bg-status-done/15 text-status-done",
+      },
     },
     defaultVariants: {
-      variant: "default"
-    }
+      variant: "default",
+    },
   }
 );
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+export interface BadgeProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps): JSX.Element {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
 export { Badge, badgeVariants };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,9 +9,11 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-muted text-foreground hover:bg-muted/80 border border-border",
+        default:
+          "bg-muted text-foreground hover:bg-muted/80 border border-border",
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
         "ghost-primary":
           "text-status-working hover:bg-status-working/15 hover:text-status-working",
@@ -20,23 +22,24 @@ const buttonVariants = cva(
         "ghost-destructive":
           "text-status-blocked hover:bg-status-blocked/15 hover:text-status-blocked",
         "ghost-warning":
-          "text-status-waiting hover:bg-status-waiting/15 hover:text-status-waiting"
+          "text-status-waiting hover:bg-status-waiting/15 hover:text-status-waiting",
       },
       size: {
         default: "h-9 px-3 py-2",
         sm: "h-8 rounded-md px-2.5",
-        icon: "h-8 w-8"
-      }
+        icon: "h-8 w-8",
+      },
     },
     defaultVariants: {
       variant: "default",
-      size: "default"
-    }
+      size: "default",
+    },
   }
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
@@ -44,7 +47,13 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
   }
 );
 Button.displayName = "Button";

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -12,7 +12,8 @@ function Calendar({
       classNames={{
         months: "flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        month_caption: "flex justify-center pt-1 relative items-center text-sm font-medium",
+        month_caption:
+          "flex justify-center pt-1 relative items-center text-sm font-medium",
         caption_label: "text-sm font-medium",
         nav: "flex items-center gap-1",
         button_previous:

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -2,31 +2,59 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("rounded-xl border bg-card text-card-foreground shadow-sm", className)} {...props} />
-  )
-);
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
 Card.displayName = "Card";
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("flex flex-col space-y-1.5 p-4", className)} {...props} />
-);
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-4", className)}
+    {...props}
+  />
+));
 CardHeader.displayName = "CardHeader";
 
-const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => <h3 ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
-);
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
 CardTitle.displayName = "CardTitle";
 
-const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-);
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
 CardDescription.displayName = "CardDescription";
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
-);
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
+));
 CardContent.displayName = "CardContent";
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -165,7 +165,15 @@ function ChartTooltipContent({
     }
 
     return <div className={cn("font-medium", labelClassName)}>{value}</div>;
-  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ]);
 
   if (!active || !payload?.length) {
     return null;

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -16,7 +16,7 @@ export function Checkbox({
         "data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
         "data-[state=unchecked]:border-border data-[state=unchecked]:bg-background",
         "disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
     >
       <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -9,7 +9,10 @@ const Command = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
     ref={ref}
-    className={cn("flex h-full w-full flex-col overflow-hidden rounded-md bg-background text-foreground", className)}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-background text-foreground",
+      className
+    )}
     {...props}
   />
 ));
@@ -49,7 +52,11 @@ const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
-  <CommandPrimitive.Empty ref={ref} className="px-2 py-4 text-center text-xs text-muted-foreground" {...props} />
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="px-2 py-4 text-center text-xs text-muted-foreground"
+    {...props}
+  />
 ));
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -12,7 +12,11 @@ const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay ref={ref} className={cn("fixed inset-0 z-[70] bg-black/70", className)} {...props} />
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-[70] bg-black/70", className)}
+    {...props}
+  />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -34,7 +38,10 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn("flex flex-col space-y-1.5", className)} {...props} />
 );
 
@@ -42,7 +49,11 @@ const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
@@ -50,7 +61,11 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
@@ -63,5 +78,5 @@ export {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogDescription
+  DialogDescription,
 };

--- a/apps/web/src/components/ui/glass-sidebar.tsx
+++ b/apps/web/src/components/ui/glass-sidebar.tsx
@@ -31,11 +31,21 @@ type GlassSidebarProps = {
 };
 
 /** Desktop: inline collapsible panel that animates width */
-function DesktopSidebar({ open, side, width = 320, className, children }: Pick<GlassSidebarProps, "open" | "side" | "width" | "className" | "children">) {
+function DesktopSidebar({
+  open,
+  side,
+  width = 320,
+  className,
+  children,
+}: Pick<
+  GlassSidebarProps,
+  "open" | "side" | "width" | "className" | "children"
+>) {
   const borderSide = side === "left" ? "border-r" : "border-l";
-  const shadowSide = side === "left"
-    ? "shadow-[4px_0_24px_rgba(0,0,0,0.3)]"
-    : "shadow-[-4px_0_24px_rgba(0,0,0,0.3)]";
+  const shadowSide =
+    side === "left"
+      ? "shadow-[4px_0_24px_rgba(0,0,0,0.3)]"
+      : "shadow-[-4px_0_24px_rgba(0,0,0,0.3)]";
 
   return (
     <div
@@ -56,7 +66,14 @@ function DesktopSidebar({ open, side, width = 320, className, children }: Pick<G
 }
 
 /** Mobile: full-screen slide-over with backdrop */
-function MobileSidebar({ open, onOpenChange, side, label, className, children }: Omit<GlassSidebarProps, "width" | "mobile">) {
+function MobileSidebar({
+  open,
+  onOpenChange,
+  side,
+  label,
+  className,
+  children,
+}: Omit<GlassSidebarProps, "width" | "mobile">) {
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -4,19 +4,21 @@ import { cn } from "@/lib/utils";
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
-  return (
-    <input
-      type={type}
-      className={cn(
-        "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        className
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
 Input.displayName = "Input";
 
 export { Input };

--- a/apps/web/src/components/ui/log-stream.tsx
+++ b/apps/web/src/components/ui/log-stream.tsx
@@ -5,7 +5,11 @@ type LogStreamProps = HTMLAttributes<HTMLDivElement> & {
   viewportRef?: Ref<HTMLDivElement>;
 };
 
-export function LogStream({ viewportRef, className, ...props }: LogStreamProps): JSX.Element {
+export function LogStream({
+  viewportRef,
+  className,
+  ...props
+}: LogStreamProps): JSX.Element {
   return (
     <div
       ref={viewportRef}

--- a/apps/web/src/components/ui/markdown.tsx
+++ b/apps/web/src/components/ui/markdown.tsx
@@ -9,7 +9,11 @@ type MarkdownProps = {
   variant?: "default" | "pin";
 };
 
-export function Markdown({ children, className, variant = "default" }: MarkdownProps): JSX.Element {
+export function Markdown({
+  children,
+  className,
+  variant = "default",
+}: MarkdownProps): JSX.Element {
   if (variant === "pin") {
     return (
       <div
@@ -24,10 +28,28 @@ export function Markdown({ children, className, variant = "default" }: MarkdownP
           "[&_table]:my-1 [&_table]:min-w-full [&_table]:border-collapse [&_table]:text-[11px]",
           "[&_th]:border [&_th]:border-border/60 [&_th]:bg-muted/50 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_th]:font-semibold",
           "[&_td]:border [&_td]:border-border/60 [&_td]:px-2 [&_td]:py-1",
-          className,
+          className
         )}
       >
-        <ReactMarkdown remarkPlugins={[remarkGfm]} allowedElements={["p", "ul", "li", "strong", "em", "code", "pre", "table", "thead", "tbody", "tr", "th", "td"]} unwrapDisallowed>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          allowedElements={[
+            "p",
+            "ul",
+            "li",
+            "strong",
+            "em",
+            "code",
+            "pre",
+            "table",
+            "thead",
+            "tbody",
+            "tr",
+            "th",
+            "td",
+          ]}
+          unwrapDisallowed
+        >
           {children}
         </ReactMarkdown>
       </div>
@@ -47,7 +69,7 @@ export function Markdown({ children, className, variant = "default" }: MarkdownP
         "prose-code:before:content-none prose-code:after:content-none",
         "prose-a:text-primary prose-a:underline",
         "prose-li:text-foreground prose-li:marker:text-muted-foreground",
-        className,
+        className
       )}
     >
       <ReactMarkdown>{children}</ReactMarkdown>

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -12,20 +12,25 @@ const PopoverContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
     container?: HTMLElement | null;
   }
->(({ className, align = "center", sideOffset = 4, container, ...props }, ref) => (
-  <PopoverPrimitive.Portal container={container}>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+>(
+  (
+    { className, align = "center", sideOffset = 4, container, ...props },
+    ref
+  ) => (
+    <PopoverPrimitive.Portal container={container}>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent };

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -5,10 +5,18 @@ import { cn } from "@/lib/utils";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & { horizontal?: boolean }
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    horizontal?: boolean;
+  }
 >(({ className, children, horizontal, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root ref={ref} className={cn("relative overflow-hidden", className)} {...props}>
-    <ScrollAreaPrimitive.Viewport className="h-full max-h-[inherit] w-full rounded-[inherit]">{children}</ScrollAreaPrimitive.Viewport>
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full max-h-[inherit] w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
     <ScrollBar orientation="vertical" />
     {horizontal && <ScrollBar orientation="horizontal" />}
     <ScrollAreaPrimitive.Corner />
@@ -25,8 +33,10 @@ const ScrollBar = React.forwardRef<
     orientation={orientation}
     className={cn(
       "flex touch-none select-none transition-colors",
-      orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-[1px]",
-      orientation === "horizontal" && "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -38,7 +38,10 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
@@ -52,13 +55,17 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -83,7 +90,11 @@ const SelectContent = React.forwardRef<
     >
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
-        className={cn("p-1", position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]")}
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
       >
         {children}
       </SelectPrimitive.Viewport>
@@ -97,7 +108,11 @@ const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label ref={ref} className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)} {...props} />
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
@@ -129,7 +144,11 @@ const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
 ));
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
@@ -141,5 +160,5 @@ export {
   SelectLabel,
   SelectSeparator,
   SelectTrigger,
-  SelectValue
+  SelectValue,
 };

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -15,7 +15,10 @@ const SheetOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
-    className={cn("fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out", className)}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out",
+      className
+    )}
     {...props}
     ref={ref}
   />
@@ -32,17 +35,18 @@ const sheetVariants = cva(
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md"
-      }
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
+      },
     },
     defaultVariants: {
-      side: "right"
-    }
+      side: "right",
+    },
   }
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
     VariantProps<typeof sheetVariants> {
   hideCloseButton?: boolean;
   overlayClassName?: string;
@@ -51,31 +55,57 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, hideCloseButton = false, overlayClassName, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay className={overlayClassName} />
-    <DialogPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-      {children}
-      {!hideCloseButton ? (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      ) : null}
-    </DialogPrimitive.Content>
-  </SheetPortal>
-));
+>(
+  (
+    {
+      side = "right",
+      className,
+      children,
+      hideCloseButton = false,
+      overlayClassName,
+      ...props
+    },
+    ref
+  ) => (
+    <SheetPortal>
+      <SheetOverlay className={overlayClassName} />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        {!hideCloseButton ? (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+);
 SheetContent.displayName = DialogPrimitive.Content.displayName;
 
-const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-2 text-left", className)} {...props} />
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-2 text-left", className)}
+    {...props}
+  />
 );
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
 ));
 SheetTitle.displayName = DialogPrimitive.Title.displayName;
 
@@ -83,7 +113,11 @@ const SheetDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
 ));
 SheetDescription.displayName = DialogPrimitive.Description.displayName;
 
@@ -96,5 +130,5 @@ export {
   SheetContent,
   SheetHeader,
   SheetTitle,
-  SheetDescription
+  SheetDescription,
 };

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -14,6 +14,7 @@ export const AuthContextProvider = AuthContext.Provider;
 
 export function useAuthContext(): AuthContextValue {
   const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuthContext must be used within AuthContextProvider");
+  if (!ctx)
+    throw new Error("useAuthContext must be used within AuthContextProvider");
   return ctx;
 }

--- a/apps/web/src/hooks/use-activity.ts
+++ b/apps/web/src/hooks/use-activity.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { buildActiveHours, type ActiveHourEvent, type ActiveHoursCell } from "@/lib/active-hours";
+import {
+  buildActiveHours,
+  type ActiveHourEvent,
+  type ActiveHoursCell,
+} from "@/lib/active-hours";
 
 export type { ActiveHoursCell } from "@/lib/active-hours";
 
@@ -38,7 +42,10 @@ function getGranularity(range: ActivityRange): ActivityGranularity {
   return "month";
 }
 
-export function getRangeBounds(range: ActivityRange, dailyDate?: string): { start: string; end: string } {
+export function getRangeBounds(
+  range: ActivityRange,
+  dailyDate?: string
+): { start: string; end: string } {
   const now = new Date();
   const end = now.toISOString();
 
@@ -54,10 +61,16 @@ export function getRangeBounds(range: ActivityRange, dailyDate?: string): { star
     return { start: yearStart.toISOString(), end };
   }
   if (range === "7d") {
-    return { start: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(), end };
+    return {
+      start: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+      end,
+    };
   }
   if (range === "30d") {
-    return { start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(), end };
+    return {
+      start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      end,
+    };
   }
   // "all" — no bounds
   return { start: "", end: "" };
@@ -112,7 +125,10 @@ export function useActivityHeatmap(days = 365) {
 export function useActivityStats(range: ActivityRange, dailyDate?: string) {
   return useQuery<ActivityStats>({
     queryKey: ["activity", "stats", range, dailyDate],
-    queryFn: () => api<ActivityStats>(`/api/v1/activity/stats?${activityParams(range, dailyDate)}`),
+    queryFn: () =>
+      api<ActivityStats>(
+        `/api/v1/activity/stats?${activityParams(range, dailyDate)}`
+      ),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -168,7 +184,10 @@ export type TokenDailyEntry = {
 export function useTokenStats(range: ActivityRange, dailyDate?: string) {
   return useQuery<TokenStats>({
     queryKey: ["activity", "token-stats", range, dailyDate],
-    queryFn: () => api<TokenStats>(`/api/v1/activity/token-stats?${activityParams(range, dailyDate)}`),
+    queryFn: () =>
+      api<TokenStats>(
+        `/api/v1/activity/token-stats?${activityParams(range, dailyDate)}`
+      ),
     ...ACTIVITY_QUERY_OPTIONS,
   });
 }
@@ -251,7 +270,10 @@ export type WorkingTimeByProject = {
   working_time_ms: number;
 };
 
-export function useWorkingTimeByProject(range: ActivityRange, dailyDate?: string) {
+export function useWorkingTimeByProject(
+  range: ActivityRange,
+  dailyDate?: string
+) {
   return useQuery<WorkingTimeByProject[]>({
     queryKey: ["activity", "working-time-by-project", range, dailyDate],
     queryFn: async () => {

--- a/apps/web/src/hooks/use-agent-focus.ts
+++ b/apps/web/src/hooks/use-agent-focus.ts
@@ -22,7 +22,7 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
  */
 export function useAgentFocus(
   selectedAgentId: string | null,
-  authState: AuthState,
+  authState: AuthState
 ): void {
   const lastReportedRef = useRef<string | null>(null);
 

--- a/apps/web/src/hooks/use-agent-history.ts
+++ b/apps/web/src/hooks/use-agent-history.ts
@@ -138,7 +138,9 @@ export function useHistoryProjects() {
   return useQuery<string[]>({
     queryKey: ["history", "projects"],
     queryFn: async () => {
-      const payload = await api<{ projects: string[] }>("/api/v1/history/projects");
+      const payload = await api<{ projects: string[] }>(
+        "/api/v1/history/projects"
+      );
       return payload.projects;
     },
     ...HISTORY_QUERY_OPTIONS,
@@ -149,7 +151,9 @@ export function useHistoryAgents(filters: HistoryFilters) {
   return useQuery<HistoryAgentsResponse>({
     queryKey: ["history", "agents", filters],
     queryFn: () =>
-      api<HistoryAgentsResponse>(`/api/v1/history/agents?${buildParams(filters)}`),
+      api<HistoryAgentsResponse>(
+        `/api/v1/history/agents?${buildParams(filters)}`
+      ),
     ...HISTORY_QUERY_OPTIONS,
   });
 }

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -12,14 +12,16 @@ export function useAgents(
   connectedAgentId: string | null,
   connState: ConnState,
   enabled: boolean,
-  selectedAgentId: string | null,
+  selectedAgentId: string | null
 ) {
   const queryClient = useQueryClient();
   const connectedAgentIdRef = useRef(connectedAgentId);
   connectedAgentIdRef.current = connectedAgentId;
 
   const [overflowAgentId, setOverflowAgentId] = useState<string | null>(null);
-  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(new Set());
+  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(
+    new Set()
+  );
 
   const { data: agents = [], isSuccess: agentsLoaded } = useQuery<Agent[]>({
     queryKey: ["agents"],
@@ -61,33 +63,37 @@ export function useAgents(
     (agent: Agent): AgentVisualState => {
       if (agent.status === "creating") return "active";
       if (agent.status !== "running") return "stopped";
-      if (connState === "connected" && connectedAgentId === agent.id) return "active";
+      if (connState === "connected" && connectedAgentId === agent.id)
+        return "active";
       return "idle";
     },
     [connState, connectedAgentId]
   );
 
-  return useMemo(() => ({
-    agents,
-    agentsLoaded,
-    validatedSelectedAgentId,
-    selectedAgent,
-    connectedAgent,
-    overflowAgentId,
-    setOverflowAgentId,
-    streamingAgentIds,
-    setStreamingAgentIds,
-    agentVisualState,
-    resortAgents,
-  }), [
-    agents,
-    agentsLoaded,
-    validatedSelectedAgentId,
-    selectedAgent,
-    connectedAgent,
-    overflowAgentId,
-    streamingAgentIds,
-    agentVisualState,
-    resortAgents,
-  ]);
+  return useMemo(
+    () => ({
+      agents,
+      agentsLoaded,
+      validatedSelectedAgentId,
+      selectedAgent,
+      connectedAgent,
+      overflowAgentId,
+      setOverflowAgentId,
+      streamingAgentIds,
+      setStreamingAgentIds,
+      agentVisualState,
+      resortAgents,
+    }),
+    [
+      agents,
+      agentsLoaded,
+      validatedSelectedAgentId,
+      selectedAgent,
+      connectedAgent,
+      overflowAgentId,
+      streamingAgentIds,
+      agentVisualState,
+      resortAgents,
+    ]
+  );
 }

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -52,13 +52,20 @@ export function useAuth(): {
       }
     };
     authEvents.addEventListener("unauthenticated", onUnauthenticated);
-    return () => authEvents.removeEventListener("unauthenticated", onUnauthenticated);
+    return () =>
+      authEvents.removeEventListener("unauthenticated", onUnauthenticated);
   }, []);
 
-  const handleAuthenticated = useCallback(() => setAuthState("authenticated"), []);
+  const handleAuthenticated = useCallback(
+    () => setAuthState("authenticated"),
+    []
+  );
 
   const handleLogout = useCallback(async () => {
-    await fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" });
+    await fetch("/api/v1/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
     setAuthState("needs-login");
     void queryClient.invalidateQueries({ queryKey: ["auth-status"] });
   }, [queryClient]);

--- a/apps/web/src/hooks/use-copy.ts
+++ b/apps/web/src/hooks/use-copy.ts
@@ -38,19 +38,25 @@ export function useCopyText(): [boolean, (text: string) => void] {
     timerRef.current = window.setTimeout(() => setCopied(false), 2000);
   }, []);
 
-  const copyText = useCallback((text: string) => {
-    // Prefer Clipboard API — it works inside focus-trapped dialogs (sheets, modals)
-    // where execCommand fails because the hidden textarea can't receive focus.
-    if (navigator.clipboard?.writeText) {
-      void navigator.clipboard.writeText(text).then(markCopied).catch(() => {
-        // Clipboard API rejected (e.g. non-secure context) — try execCommand
-        if (copyViaExecCommand(text)) markCopied();
-      });
-      return;
-    }
-    // No Clipboard API — fall back to execCommand (iOS Safari non-secure contexts)
-    if (copyViaExecCommand(text)) markCopied();
-  }, [markCopied]);
+  const copyText = useCallback(
+    (text: string) => {
+      // Prefer Clipboard API — it works inside focus-trapped dialogs (sheets, modals)
+      // where execCommand fails because the hidden textarea can't receive focus.
+      if (navigator.clipboard?.writeText) {
+        void navigator.clipboard
+          .writeText(text)
+          .then(markCopied)
+          .catch(() => {
+            // Clipboard API rejected (e.g. non-secure context) — try execCommand
+            if (copyViaExecCommand(text)) markCopied();
+          });
+        return;
+      }
+      // No Clipboard API — fall back to execCommand (iOS Safari non-secure contexts)
+      if (copyViaExecCommand(text)) markCopied();
+    },
+    [markCopied]
+  );
 
   return [copied, copyText];
 }

--- a/apps/web/src/hooks/use-health.ts
+++ b/apps/web/src/hooks/use-health.ts
@@ -1,7 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { type ServiceState } from "@/components/app/types";
 import { api } from "@/lib/api";
-import { recordHealthPollFire, recordHealthPollSkip } from "@/lib/energy-metrics";
+import {
+  recordHealthPollFire,
+  recordHealthPollSkip,
+} from "@/lib/energy-metrics";
 
 type HealthData = { apiState: ServiceState; dbState: ServiceState };
 
@@ -14,7 +17,9 @@ export function useHealth(enabled: boolean): HealthData {
         throw new Error("skipped — tab hidden");
       }
       recordHealthPollFire();
-      const health = await api<{ status: string; db: string }>("/api/v1/health");
+      const health = await api<{ status: string; db: string }>(
+        "/api/v1/health"
+      );
       return {
         apiState: health.status === "ok" ? "ok" : "down",
         dbState: health.db === "ok" ? "ok" : "down",

--- a/apps/web/src/hooks/use-icon-color.ts
+++ b/apps/web/src/hooks/use-icon-color.ts
@@ -1,8 +1,17 @@
 import { useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
-export const ICON_COLORS = ["teal", "blue", "purple", "red", "orange", "amber", "pink", "cyan"] as const;
-export type IconColorId = typeof ICON_COLORS[number];
+export const ICON_COLORS = [
+  "teal",
+  "blue",
+  "purple",
+  "red",
+  "orange",
+  "amber",
+  "pink",
+  "cyan",
+] as const;
+export type IconColorId = (typeof ICON_COLORS)[number];
 
 export type IconColorDefinition = {
   id: IconColorId;
@@ -60,7 +69,7 @@ export function useIconColor(): {
     (id: IconColorId) => {
       mutation.mutate(id);
     },
-    [mutation],
+    [mutation]
   );
 
   const clearError = useCallback(() => {
@@ -71,7 +80,9 @@ export function useIconColor(): {
     iconColor: data?.iconColor ?? "teal",
     setIconColor,
     isLoading: mutation.isPending,
-    error: mutation.isError ? "Failed to save icon color. Please try again." : null,
+    error: mutation.isError
+      ? "Failed to save icon color. Please try again."
+      : null,
     clearError,
   };
 }

--- a/apps/web/src/hooks/use-instance-name.ts
+++ b/apps/web/src/hooks/use-instance-name.ts
@@ -39,7 +39,7 @@ export function useInstanceName(): {
     (name: string) => {
       mutation.mutate(name);
     },
-    [mutation],
+    [mutation]
   );
 
   const clearSaveState = useCallback(() => {

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -2,7 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 
-export type JobRunStatus = "started" | "running" | "completed" | "failed" | "needs_input" | "timed_out" | "crashed";
+export type JobRunStatus =
+  | "started"
+  | "running"
+  | "completed"
+  | "failed"
+  | "needs_input"
+  | "timed_out"
+  | "crashed";
 export type JobAgentType = "claude" | "codex" | "opencode";
 export type JobRunTriggerSource = "manual" | "scheduled";
 
@@ -20,7 +27,11 @@ export type JobReport = {
     status: "success" | "skipped" | "error";
     summary?: string;
     errors?: Array<{ message: string; recoverable?: boolean; action?: string }>;
-    logs?: Array<{ level: "debug" | "info" | "warn" | "error"; message: string; timestamp: string }>;
+    logs?: Array<{
+      level: "debug" | "info" | "warn" | "error";
+      message: string;
+      timestamp: string;
+    }>;
   }>;
 };
 
@@ -99,11 +110,27 @@ export function useJobs(enabled = true) {
 }
 
 export function useJobHistory(job: Job | null) {
-  return useQuery<{ job: Omit<Job, "lastRunId" | "lastRunStatus" | "lastRunStartedAt" | "lastRunCompletedAt" | "lastRunDurationMs" | "lastRunReport" | "nextRun">; runs: JobRun[] }>({
+  return useQuery<{
+    job: Omit<
+      Job,
+      | "lastRunId"
+      | "lastRunStatus"
+      | "lastRunStartedAt"
+      | "lastRunCompletedAt"
+      | "lastRunDurationMs"
+      | "lastRunReport"
+      | "nextRun"
+    >;
+    runs: JobRun[];
+  }>({
     queryKey: ["jobs", job?.directory, job?.name, "history"],
     queryFn: () => {
       if (!job) throw new Error("Job is required.");
-      const params = new URLSearchParams({ name: job.name, directory: job.directory, limit: "50" });
+      const params = new URLSearchParams({
+        name: job.name,
+        directory: job.directory,
+        limit: "50",
+      });
       return api(`/api/v1/jobs/history?${params.toString()}`);
     },
     enabled: !!job,
@@ -119,7 +146,14 @@ export type JobStats = {
     avgDurationMs: number | null;
     daily: Array<{ day: string; completed: number; failed: number }>;
   };
-  recentRuns: Array<{ id: string; jobId: string; status: JobRunStatus; startedAt: string; durationMs: number | null; jobName: string }>;
+  recentRuns: Array<{
+    id: string;
+    jobId: string;
+    status: JobRunStatus;
+    startedAt: string;
+    durationMs: number | null;
+    jobName: string;
+  }>;
 };
 
 export function useJobStats(enabled = true) {
@@ -141,7 +175,11 @@ export function useJobActions() {
     mutationFn: (job: JobIdentity) =>
       api("/api/v1/jobs/run", {
         method: "POST",
-        body: JSON.stringify({ name: job.name, directory: job.directory, wait: false }),
+        body: JSON.stringify({
+          name: job.name,
+          directory: job.directory,
+          wait: false,
+        }),
       }),
     onSuccess: invalidateJobs,
   });

--- a/apps/web/src/hooks/use-layout.ts
+++ b/apps/web/src/hooks/use-layout.ts
@@ -8,7 +8,9 @@ export function useLayout() {
   const [leftOpen, setLeftOpen] = useAtom(leftSidebarOpenAtom);
   const [mediaOpen, setMediaOpen] = useAtom(mediaSidebarOpenAtom);
   const [isMobile, setIsMobile] = useState(() =>
-    typeof window !== "undefined" ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches : false
+    typeof window !== "undefined"
+      ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches
+      : false
   );
   const [mobileLeftOpen, setMobileLeftOpen] = useState(false);
   const [mobileMediaOpen, setMobileMediaOpen] = useState(false);
@@ -57,31 +59,34 @@ export function useLayout() {
     [isMobile, setMediaOpen]
   );
 
-  return useMemo(() => ({
-    isMobile,
-    leftOpen,
-    mediaOpen,
-    leftPanelOpen,
-    mediaPanelOpen,
-    mobileLeftOpen,
-    mobileMediaOpen,
-    setLeftOpen,
-    setMediaOpen,
-    setMobileLeftOpen,
-    setMobileMediaOpen,
-    handleSetLeftPanelOpen,
-    handleSetMediaPanelOpen,
-  }), [
-    isMobile,
-    leftOpen,
-    mediaOpen,
-    leftPanelOpen,
-    mediaPanelOpen,
-    mobileLeftOpen,
-    mobileMediaOpen,
-    setLeftOpen,
-    setMediaOpen,
-    handleSetLeftPanelOpen,
-    handleSetMediaPanelOpen,
-  ]);
+  return useMemo(
+    () => ({
+      isMobile,
+      leftOpen,
+      mediaOpen,
+      leftPanelOpen,
+      mediaPanelOpen,
+      mobileLeftOpen,
+      mobileMediaOpen,
+      setLeftOpen,
+      setMediaOpen,
+      setMobileLeftOpen,
+      setMobileMediaOpen,
+      handleSetLeftPanelOpen,
+      handleSetMediaPanelOpen,
+    }),
+    [
+      isMobile,
+      leftOpen,
+      mediaOpen,
+      leftPanelOpen,
+      mediaPanelOpen,
+      mobileLeftOpen,
+      mobileMediaOpen,
+      setLeftOpen,
+      setMediaOpen,
+      handleSetLeftPanelOpen,
+      handleSetMediaPanelOpen,
+    ]
+  );
 }

--- a/apps/web/src/hooks/use-media.ts
+++ b/apps/web/src/hooks/use-media.ts
@@ -1,21 +1,37 @@
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type MediaFile } from "@/components/app/types";
 import { api } from "@/lib/api";
 
-export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean) {
+export function useMedia(
+  selectedAgentId: string | null,
+  mediaPanelOpen: boolean
+) {
   const queryClient = useQueryClient();
 
-  const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(new Set());
+  const [animatingMediaKeys, setAnimatingMediaKeys] = useState<Set<string>>(
+    new Set()
+  );
   const [lightboxMediaKey, setLightboxMediaKey] = useState<string | null>(null);
   const mediaViewportRef = useRef<HTMLDivElement>(null);
   const previousMediaKeysRef = useRef<Set<string>>(new Set());
   const clearMediaAnimTimerRef = useRef<number | null>(null);
 
-  const { data: mediaFiles = [], refetch: refetchMedia } = useQuery<MediaFile[]>({
+  const { data: mediaFiles = [], refetch: refetchMedia } = useQuery<
+    MediaFile[]
+  >({
     queryKey: ["media", selectedAgentId],
     queryFn: async () => {
-      const payload = await api<{ files: MediaFile[] }>(`/api/v1/agents/${selectedAgentId}/media`);
+      const payload = await api<{ files: MediaFile[] }>(
+        `/api/v1/agents/${selectedAgentId}/media`
+      );
       return payload.files ?? [];
     },
     enabled: !!selectedAgentId,
@@ -104,8 +120,13 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
             const mediaKey = (entry.target as HTMLElement).dataset.mediaKey;
             if (mediaKey) {
               // Check if already seen in current cache data
-              const cached = queryClient.getQueryData<MediaFile[]>(["media", selected]);
-              const file = cached?.find((f) => `${f.name}:${f.updatedAt}` === mediaKey);
+              const cached = queryClient.getQueryData<MediaFile[]>([
+                "media",
+                selected,
+              ]);
+              const file = cached?.find(
+                (f) => `${f.name}:${f.updatedAt}` === mediaKey
+              );
               if (file && !file.seen) {
                 newlySeen.push(mediaKey);
               }
@@ -132,7 +153,13 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     return () => {
       observer.disconnect();
     };
-  }, [markSeenInCache, mediaFiles, mediaPanelOpen, queryClient, selectedAgentId]);
+  }, [
+    markSeenInCache,
+    mediaFiles,
+    mediaPanelOpen,
+    queryClient,
+    selectedAgentId,
+  ]);
 
   const unseenMediaCount = useMemo(() => {
     return mediaFiles.filter((file) => !file.seen).length;
@@ -143,12 +170,13 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
   }, []);
 
   const lightboxItems = useMemo(
-    () => mediaFiles.map((file) => ({
-      key: `${file.name}:${file.updatedAt}`,
-      src: `${file.url}?t=${encodeURIComponent(file.updatedAt)}`,
-      caption: file.description || "",
-      file,
-    })),
+    () =>
+      mediaFiles.map((file) => ({
+        key: `${file.name}:${file.updatedAt}`,
+        src: `${file.url}?t=${encodeURIComponent(file.updatedAt)}`,
+        caption: file.description || "",
+        file,
+      })),
     [mediaFiles]
   );
 
@@ -185,26 +213,29 @@ export function useMedia(selectedAgentId: string | null, mediaPanelOpen: boolean
     [queryClient, selectedAgentId]
   );
 
-  return useMemo(() => ({
-    mediaFiles,
-    animatingMediaKeys,
-    unseenMediaCount,
-    lightboxIndex,
-    lightboxItem,
-    setLightboxIndex,
-    openLightbox,
-    mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
-    refreshMedia,
-    markSeenInCache,
-  }), [
-    mediaFiles,
-    animatingMediaKeys,
-    unseenMediaCount,
-    lightboxIndex,
-    lightboxItem,
-    setLightboxIndex,
-    openLightbox,
-    refreshMedia,
-    markSeenInCache,
-  ]);
+  return useMemo(
+    () => ({
+      mediaFiles,
+      animatingMediaKeys,
+      unseenMediaCount,
+      lightboxIndex,
+      lightboxItem,
+      setLightboxIndex,
+      openLightbox,
+      mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
+      refreshMedia,
+      markSeenInCache,
+    }),
+    [
+      mediaFiles,
+      animatingMediaKeys,
+      unseenMediaCount,
+      lightboxIndex,
+      lightboxItem,
+      setLightboxIndex,
+      openLightbox,
+      refreshMedia,
+      markSeenInCache,
+    ]
+  );
 }

--- a/apps/web/src/hooks/use-release-stream.ts
+++ b/apps/web/src/hooks/use-release-stream.ts
@@ -2,7 +2,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { recordReleaseManagerPollFire } from "@/lib/energy-metrics";
 
 export type ReleaseVersionType = "patch" | "minor" | "major";
-export type ReleasePhase = "preflight" | "triggering" | "watching" | "fetching" | "deploying" | "restarting" | "done" | "failed";
+export type ReleasePhase =
+  | "preflight"
+  | "triggering"
+  | "watching"
+  | "fetching"
+  | "deploying"
+  | "restarting"
+  | "done"
+  | "failed";
 export type ReleaseJobType = "create" | "update";
 
 export type ReleaseChannel = "stable" | "latest";
@@ -65,10 +73,14 @@ export function useReleaseStream(): UseReleaseStreamResult {
     try {
       const res = await fetch("/api/v1/release/status");
       if (res.ok) setStatus((await res.json()) as ReleaseStatus);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, []);
 
-  useEffect(() => { void fetchStatus(); }, [fetchStatus]);
+  useEffect(() => {
+    void fetchStatus();
+  }, [fetchStatus]);
 
   const startHealthPoll = useCallback((expectedTag: string | null) => {
     setPostRestartPolling(true);
@@ -86,11 +98,15 @@ export function useReleaseStream(): UseReleaseStreamResult {
             healthPollRef.current = null;
             setPostRestartPolling(false);
             setStatus(data);
-            setJob((prev) => prev ? { ...prev, phase: "done", tag: data.tag } : prev);
+            setJob((prev) =>
+              prev ? { ...prev, phase: "done", tag: data.tag } : prev
+            );
             setTimeout(() => window.location.reload(), 1500);
           }
         }
-      } catch { /* server still down */ }
+      } catch {
+        /* server still down */
+      }
     }, 2000);
   }, []);
 
@@ -107,7 +123,8 @@ export function useReleaseStream(): UseReleaseStreamResult {
       }
       setJob((prev) => {
         if (!prev) return prev;
-        if (event.type === "log") return { ...prev, log: [...prev.log, event.line] };
+        if (event.type === "log")
+          return { ...prev, log: [...prev.log, event.line] };
         if (event.type === "log.rewind") {
           return { ...prev, log: prev.log.slice(0, -event.count) };
         }
@@ -120,7 +137,12 @@ export function useReleaseStream(): UseReleaseStreamResult {
           }
           return { ...prev, log: updated };
         }
-        if (event.type === "phase") return { ...prev, phase: event.phase, error: event.error ?? prev.error };
+        if (event.type === "phase")
+          return {
+            ...prev,
+            phase: event.phase,
+            error: event.error ?? prev.error,
+          };
         if (event.type === "runUrl") return { ...prev, runUrl: event.url };
         if (event.type === "tag") return { ...prev, tag: event.tag };
         return prev;
@@ -129,7 +151,10 @@ export function useReleaseStream(): UseReleaseStreamResult {
 
     es.onerror = () => {
       setJob((prev) => {
-        if (prev?.jobType === "update" && (prev.phase === "restarting" || prev.phase === "deploying")) {
+        if (
+          prev?.jobType === "update" &&
+          (prev.phase === "restarting" || prev.phase === "deploying")
+        ) {
           startHealthPoll(prev.tag);
           return { ...prev, phase: "restarting" };
         }
@@ -148,5 +173,12 @@ export function useReleaseStream(): UseReleaseStreamResult {
     };
   }, [connectStream]);
 
-  return { status, job, postRestartPolling, connectStream, fetchStatus, setJob };
+  return {
+    status,
+    job,
+    postRestartPolling,
+    connectStream,
+    fetchStatus,
+    setJob,
+  };
 }

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -16,14 +16,20 @@ type UiEvent =
   | { type: "feedback.created"; agentId: string }
   | { type: "feedback.updated"; agentId: string }
   | { type: "job.changed" }
-  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
+  | {
+      type: "notification";
+      agentId: string;
+      agentName: string;
+      eventType: string;
+      message: string;
+    };
 
 export function useSSE(
   authState: AuthState,
   connectedAgentIdRef: React.RefObject<string | null>,
   selectedAgentIdRef: React.RefObject<string | null>,
   setStreamingAgentIds: React.Dispatch<React.SetStateAction<Set<string>>>,
-  markSeenInCache: (agentId: string, keys: Set<string>) => void,
+  markSeenInCache: (agentId: string, keys: Set<string>) => void
 ): void {
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -72,7 +78,10 @@ export function useSSE(
         }
 
         if (payload.type === "media.changed") {
-          void queryClient.invalidateQueries({ queryKey: ["media", payload.agentId], exact: true });
+          void queryClient.invalidateQueries({
+            queryKey: ["media", payload.agentId],
+            exact: true,
+          });
           return;
         }
 
@@ -101,7 +110,10 @@ export function useSSE(
           return;
         }
 
-        if (payload.type === "feedback.created" || payload.type === "feedback.updated") {
+        if (
+          payload.type === "feedback.created" ||
+          payload.type === "feedback.updated"
+        ) {
           void queryClient.invalidateQueries({ queryKey: ["feedback"] });
           return;
         }
@@ -120,7 +132,9 @@ export function useSSE(
 
     const openSSE = () => {
       if (eventSourceRef.current) return;
-      const source = new EventSource("/api/v1/events", { withCredentials: true });
+      const source = new EventSource("/api/v1/events", {
+        withCredentials: true,
+      });
       eventSourceRef.current = source;
       source.onmessage = handleSSEMessage;
       source.onerror = () => {
@@ -153,5 +167,12 @@ export function useSSE(
       document.removeEventListener("visibilitychange", onVisChange);
       closeSSE();
     };
-  }, [authState, connectedAgentIdRef, markSeenInCache, queryClient, selectedAgentIdRef, setStreamingAgentIds]);
+  }, [
+    authState,
+    connectedAgentIdRef,
+    markSeenInCache,
+    queryClient,
+    selectedAgentIdRef,
+    setStreamingAgentIds,
+  ]);
 }

--- a/apps/web/src/hooks/use-temporary-state.ts
+++ b/apps/web/src/hooks/use-temporary-state.ts
@@ -1,6 +1,9 @@
 import React from "react";
 
-export function useTemporaryState<T>(initialValue: T, durationMs: number): readonly [T, (value: T) => void] {
+export function useTemporaryState<T>(
+  initialValue: T,
+  durationMs: number
+): readonly [T, (value: T) => void] {
   const [value, setValue] = React.useState(initialValue);
 
   React.useEffect(() => {

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -1,8 +1,20 @@
-import { type MutableRefObject, type RefCallback, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type MutableRefObject,
+  type RefCallback,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
-import { type Agent, type AuthState, type ConnState } from "@/components/app/types";
+import {
+  type Agent,
+  type AuthState,
+  type ConnState,
+} from "@/components/app/types";
 import { api } from "@/lib/api";
 import { recordWSReconnect } from "@/lib/energy-metrics";
 import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
@@ -10,7 +22,8 @@ import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
 const ACTIVE_SHELL_AGENT_KEY = "dispatch:activeShellAgentId";
 const TERMINAL_HEARTBEAT_INTERVAL_MS = 20_000;
 const TERMINAL_LIVENESS_GRACE_MS = 5_000;
-const TERMINAL_FRESHNESS_MS = TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
+const TERMINAL_FRESHNESS_MS =
+  TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
 const RESUME_RECONNECT_DEDUPE_MS = 150;
 const SOCKET_PROBE_TIMEOUT_MS = 1_500;
 
@@ -55,7 +68,10 @@ function persistActiveShellAgentId(agentId: string | null): void {
 /** Strip terminal line-wrap artifacts from copied text. */
 function cleanCopiedText(text: string): string {
   const joined = text.replace(/[ \t]*\r?\n[ \t]*/g, "");
-  if (/^https?:\/\//.test(joined) || (/\S/.test(joined) && !joined.includes(" "))) {
+  if (
+    /^https?:\/\//.test(joined) ||
+    (/\S/.test(joined) && !joined.includes(" "))
+  ) {
     return joined;
   }
   return text;
@@ -82,7 +98,11 @@ export function useTerminal(args: {
   terminalHostRef: RefCallback<HTMLDivElement>;
   ctrlPendingRef: MutableRefObject<boolean>;
   focusTerminal: () => void;
-  ensureTerminalConnected: (clearScreen?: boolean, userInitiated?: boolean, targetAgentId?: string) => Promise<void>;
+  ensureTerminalConnected: (
+    clearScreen?: boolean,
+    userInitiated?: boolean,
+    targetAgentId?: string
+  ) => Promise<void>;
   detachTerminal: () => void;
   sendTerminalInput: (data: string) => void;
 } {
@@ -102,16 +122,23 @@ export function useTerminal(args: {
 
   const [connState, setConnState] = useState<ConnState>("disconnected");
   const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
-  const [terminalMode, setTerminalMode] = useState<"tmux" | "inert" | null>(null);
-  const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<string | null>(null);
+  const [terminalMode, setTerminalMode] = useState<"tmux" | "inert" | null>(
+    null
+  );
+  const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<
+    string | null
+  >(null);
   const [statusMessage, setStatusMessage] = useState("Starting...");
-  const [restoreShellAgentId, setRestoreShellAgentId] = useState<string | null>(() => readActiveShellAgentId());
+  const [restoreShellAgentId, setRestoreShellAgentId] = useState<string | null>(
+    () => readActiveShellAgentId()
+  );
 
   const connectedAgentIdRef = useRef<string | null>(null);
   connectedAgentIdRef.current = connectedAgentId;
 
   const terminalHostRef = useRef<HTMLDivElement | null>(null);
-  const [terminalHostElement, setTerminalHostElement] = useState<HTMLDivElement | null>(null);
+  const [terminalHostElement, setTerminalHostElement] =
+    useState<HTMLDivElement | null>(null);
   const setTerminalHostRef = useCallback((node: HTMLDivElement | null) => {
     terminalHostRef.current = node;
     setTerminalHostElement(node);
@@ -149,7 +176,9 @@ export function useTerminal(args: {
     const ws = wsRef.current;
     const term = terminalRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN || !term) return;
-    ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+    ws.send(
+      JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows })
+    );
   }, []);
 
   const clearSocketHealth = useCallback(() => {
@@ -163,19 +192,22 @@ export function useTerminal(args: {
     };
   }, []);
 
-  const markSocketHealthy = useCallback((source: "open" | "heartbeat" | "output") => {
-    const now = Date.now();
-    if (source === "open") {
-      socketHealthRef.current.lastOpenAt = now;
-    } else if (source === "heartbeat") {
-      socketHealthRef.current.lastHeartbeatAt = now;
-    } else {
-      socketHealthRef.current.lastOutputAt = now;
-    }
-    socketHealthRef.current.lastHealthyAt = now;
-    socketHealthRef.current.lastErrorMessage = null;
-    socketHealthRef.current.sessionGone = false;
-  }, []);
+  const markSocketHealthy = useCallback(
+    (source: "open" | "heartbeat" | "output") => {
+      const now = Date.now();
+      if (source === "open") {
+        socketHealthRef.current.lastOpenAt = now;
+      } else if (source === "heartbeat") {
+        socketHealthRef.current.lastHeartbeatAt = now;
+      } else {
+        socketHealthRef.current.lastOutputAt = now;
+      }
+      socketHealthRef.current.lastHealthyAt = now;
+      socketHealthRef.current.lastErrorMessage = null;
+      socketHealthRef.current.sessionGone = false;
+    },
+    []
+  );
 
   const noteTerminalError = useCallback((message: string) => {
     socketHealthRef.current.lastErrorMessage = message;
@@ -186,43 +218,53 @@ export function useTerminal(args: {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return false;
     if (connectedAgentIdRef.current !== agentId) return false;
-    return Date.now() - socketHealthRef.current.lastHealthyAt <= TERMINAL_FRESHNESS_MS;
+    return (
+      Date.now() - socketHealthRef.current.lastHealthyAt <=
+      TERMINAL_FRESHNESS_MS
+    );
   }, []);
 
   /** Probe an open-but-stale socket: send a resize and wait for any server message. */
-  const probeSocket = useCallback((agentId: string): Promise<boolean> => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return Promise.resolve(false);
-    if (connectedAgentIdRef.current !== agentId) return Promise.resolve(false);
+  const probeSocket = useCallback(
+    (agentId: string): Promise<boolean> => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN)
+        return Promise.resolve(false);
+      if (connectedAgentIdRef.current !== agentId)
+        return Promise.resolve(false);
 
-    return new Promise((resolve) => {
-      let settled = false;
-      const settle = (alive: boolean) => {
-        if (settled) return;
-        settled = true;
-        ws.removeEventListener("message", onMsg);
-        ws.removeEventListener("close", onClose);
-        clearTimeout(timer);
-        resolve(alive);
-      };
+      return new Promise((resolve) => {
+        let settled = false;
+        const settle = (alive: boolean) => {
+          if (settled) return;
+          settled = true;
+          ws.removeEventListener("message", onMsg);
+          ws.removeEventListener("close", onClose);
+          clearTimeout(timer);
+          resolve(alive);
+        };
 
-      const onMsg = () => {
-        markSocketHealthy("heartbeat");
-        settle(true);
-      };
-      const onClose = () => settle(false);
-      const timer = setTimeout(() => settle(false), SOCKET_PROBE_TIMEOUT_MS);
+        const onMsg = () => {
+          markSocketHealthy("heartbeat");
+          settle(true);
+        };
+        const onClose = () => settle(false);
+        const timer = setTimeout(() => settle(false), SOCKET_PROBE_TIMEOUT_MS);
 
-      ws.addEventListener("message", onMsg);
-      ws.addEventListener("close", onClose);
+        ws.addEventListener("message", onMsg);
+        ws.addEventListener("close", onClose);
 
-      // Trigger server activity by sending a resize.
-      const term = terminalRef.current;
-      if (term) {
-        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
-      }
-    });
-  }, [markSocketHealthy]);
+        // Trigger server activity by sending a resize.
+        const term = terminalRef.current;
+        if (term) {
+          ws.send(
+            JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows })
+          );
+        }
+      });
+    },
+    [markSocketHealthy]
+  );
 
   const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current) {
@@ -244,36 +286,48 @@ export function useTerminal(args: {
 
   const closeSocketTransport = useCallback(() => {
     if (wsRef.current) {
-      try { wsRef.current.close(); } catch {}
+      try {
+        wsRef.current.close();
+      } catch {}
       wsRef.current = null;
     }
     clearSocketHealth();
   }, [clearSocketHealth]);
 
-  const restoreConnectedState = useCallback((agent: Agent, mode: "tmux" | "inert", message?: string) => {
-    clearReconnectTimer();
-    reconnectAttemptsRef.current = 0;
-    setConnState("connected");
-    setConnectedAgentId(agent.id);
-    setTerminalMode(mode);
-    setTerminalPlaceholderMessage(mode === "tmux" ? null : message ?? null);
-    setStatusMessage(message ?? `Connected to session ${agent.name}`);
-  }, [clearReconnectTimer]);
+  const restoreConnectedState = useCallback(
+    (agent: Agent, mode: "tmux" | "inert", message?: string) => {
+      clearReconnectTimer();
+      reconnectAttemptsRef.current = 0;
+      setConnState("connected");
+      setConnectedAgentId(agent.id);
+      setTerminalMode(mode);
+      setTerminalPlaceholderMessage(mode === "tmux" ? null : (message ?? null));
+      setStatusMessage(message ?? `Connected to session ${agent.name}`);
+    },
+    [clearReconnectTimer]
+  );
 
-  const closeSocket = useCallback((announce = true) => {
-    closeSocketTransport();
-    setConnectedAgentId(null);
-    setTerminalMode(null);
-    setTerminalPlaceholderMessage(null);
+  const closeSocket = useCallback(
+    (announce = true) => {
+      closeSocketTransport();
+      setConnectedAgentId(null);
+      setTerminalMode(null);
+      setTerminalPlaceholderMessage(null);
 
-    if (announce) {
-      setStatusMessage("Session disconnected.");
-      setConnState("disconnected");
-    }
-  }, [closeSocketTransport]);
+      if (announce) {
+        setStatusMessage("Session disconnected.");
+        setConnState("disconnected");
+      }
+    },
+    [closeSocketTransport]
+  );
 
   const ensureTerminalConnected = useCallback(
-    async (clearScreen = false, userInitiated = false, targetAgentId?: string) => {
+    async (
+      clearScreen = false,
+      userInitiated = false,
+      targetAgentId?: string
+    ) => {
       if (userInitiated) {
         shouldKeepAttachedRef.current = true;
       }
@@ -281,7 +335,10 @@ export function useTerminal(args: {
       const resolvedAgentId = targetAgentId ?? selectedAgentId;
       if (!shouldKeepAttachedRef.current || !resolvedAgentId) return;
 
-       if (!userInitiated && reconnectInFlightRef.current?.agentId === resolvedAgentId) {
+      if (
+        !userInitiated &&
+        reconnectInFlightRef.current?.agentId === resolvedAgentId
+      ) {
         await reconnectInFlightRef.current.promise;
         return;
       }
@@ -291,7 +348,8 @@ export function useTerminal(args: {
       // handler.  Read the current value here for the in-flight guard only.
       let attemptNonce = attachNonceRef.current;
       const isCurrentAttempt = () =>
-        shouldKeepAttachedRef.current && attemptNonce === attachNonceRef.current;
+        shouldKeepAttachedRef.current &&
+        attemptNonce === attachNonceRef.current;
 
       const scheduleReconnect = (message: string) => {
         if (!isCurrentAttempt() || !shouldKeepAttachedRef.current) {
@@ -313,12 +371,15 @@ export function useTerminal(args: {
 
       const connectPromise = (async () => {
         let agent: Agent | null = userInitiated
-          ? (agentsRef.current.find((item) => item.id === resolvedAgentId) ?? null)
+          ? (agentsRef.current.find((item) => item.id === resolvedAgentId) ??
+            null)
           : null;
 
         if (!agent || agent.status !== "running") {
           try {
-            const payload = await api<{ agent: Agent }>(`/api/v1/agents/${resolvedAgentId}?includeGitContext=false`);
+            const payload = await api<{ agent: Agent }>(
+              `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
+            );
             agent = payload.agent;
           } catch {
             if (!isCurrentAttempt()) return;
@@ -347,7 +408,10 @@ export function useTerminal(args: {
 
         // Socket is open but stale (no heartbeat during background throttle).
         // Probe it before tearing down — avoids a full reconnect cycle.
-        if (wsRef.current?.readyState === WebSocket.OPEN && connectedAgentIdRef.current === agent.id) {
+        if (
+          wsRef.current?.readyState === WebSocket.OPEN &&
+          connectedAgentIdRef.current === agent.id
+        ) {
           const alive = await probeSocket(agent.id);
           if (!isCurrentAttempt()) return;
           if (alive) {
@@ -361,7 +425,11 @@ export function useTerminal(args: {
         // invalidate any previous handler that is still attached.
         attemptNonce = ++attachNonceRef.current;
 
-        if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && connectedAgentIdRef.current === agent.id) {
+        if (
+          wsRef.current &&
+          wsRef.current.readyState === WebSocket.OPEN &&
+          connectedAgentIdRef.current === agent.id
+        ) {
           closeSocketTransport();
         }
 
@@ -380,10 +448,10 @@ export function useTerminal(args: {
           const terminalSession = await api<
             | { mode: "tmux"; token: string; wsUrl: string }
             | { mode: "inert"; message: string }
-          >(
-            `/api/v1/agents/${agent.id}/terminal/token`,
-            { method: "POST", body: JSON.stringify({}) }
-          );
+          >(`/api/v1/agents/${agent.id}/terminal/token`, {
+            method: "POST",
+            body: JSON.stringify({}),
+          });
 
           if (!isCurrentAttempt()) {
             return;
@@ -394,7 +462,8 @@ export function useTerminal(args: {
             return;
           }
 
-          const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+          const protocol =
+            window.location.protocol === "https:" ? "wss:" : "ws:";
           const term = terminalRef.current;
           const cols = term?.cols ?? 140;
           const rows = term?.rows ?? 42;
@@ -407,7 +476,9 @@ export function useTerminal(args: {
 
           ws.addEventListener("open", () => {
             if (wsRef.current !== ws || !isCurrentAttempt()) {
-              try { ws.close(); } catch {}
+              try {
+                ws.close();
+              } catch {}
               return;
             }
             markSocketHealthy("open");
@@ -419,7 +490,9 @@ export function useTerminal(args: {
             if (wsRef.current !== ws || !isCurrentAttempt()) {
               return;
             }
-            const payload = JSON.parse(String(event.data)) as TerminalSocketMessage;
+            const payload = JSON.parse(
+              String(event.data)
+            ) as TerminalSocketMessage;
 
             if (payload.type === "heartbeat") {
               markSocketHealthy("heartbeat");
@@ -463,7 +536,11 @@ export function useTerminal(args: {
               return;
             }
 
-            if (event.code === 1008 && lastErrorMessage && isRetriableTerminalFailure(lastErrorMessage)) {
+            if (
+              event.code === 1008 &&
+              lastErrorMessage &&
+              isRetriableTerminalFailure(lastErrorMessage)
+            ) {
               scheduleReconnect("Session token expired, retrying...");
               return;
             }
@@ -475,7 +552,10 @@ export function useTerminal(args: {
             return;
           }
 
-          const message = error instanceof Error ? error.message : "Session connection failed.";
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Session connection failed.";
           if (isTerminalSessionGone(message)) {
             shouldKeepAttachedRef.current = false;
             clearReconnectTimer();
@@ -494,7 +574,10 @@ export function useTerminal(args: {
         }
       })();
 
-      reconnectInFlightRef.current = { agentId: resolvedAgentId, promise: connectPromise };
+      reconnectInFlightRef.current = {
+        agentId: resolvedAgentId,
+        promise: connectPromise,
+      };
       try {
         await connectPromise;
       } finally {
@@ -529,7 +612,12 @@ export function useTerminal(args: {
     resetTerminalSurface();
     setConnState("disconnected");
     setStatusMessage("Detached from session.");
-  }, [clearReconnectTimer, closeSocket, invalidateAttachAttempt, resetTerminalSurface]);
+  }, [
+    clearReconnectTimer,
+    closeSocket,
+    invalidateAttachAttempt,
+    resetTerminalSurface,
+  ]);
 
   const sendTerminalInput = useCallback((data: string) => {
     const ws = wsRef.current;
@@ -568,7 +656,11 @@ export function useTerminal(args: {
     terminalRef.current = term;
     fitAddonRef.current = fit;
     term.loadAddon(fit);
-    try { term.loadAddon(new ClipboardAddon()); } catch (e) { console.warn("ClipboardAddon failed:", e); }
+    try {
+      term.loadAddon(new ClipboardAddon());
+    } catch (e) {
+      console.warn("ClipboardAddon failed:", e);
+    }
     term.open(host);
     fit.fit();
 
@@ -576,7 +668,10 @@ export function useTerminal(args: {
       if (term.hasSelection()) {
         e.preventDefault();
         e.stopPropagation();
-        e.clipboardData?.setData("text/plain", cleanCopiedText(term.getSelection()));
+        e.clipboardData?.setData(
+          "text/plain",
+          cleanCopiedText(term.getSelection())
+        );
       }
     };
     host.addEventListener("copy", handleCopy, true);
@@ -585,8 +680,16 @@ export function useTerminal(args: {
     // tools read it natively. This bridges the browser clipboard to the server.
     const syncClipboardImage = (blob: File): void => {
       const form = new FormData();
-      form.append("file", blob, `clipboard.${blob.type === "image/png" ? "png" : "jpg"}`);
-      fetch("/api/v1/clipboard/image", { method: "POST", body: form, credentials: "include" })
+      form.append(
+        "file",
+        blob,
+        `clipboard.${blob.type === "image/png" ? "png" : "jpg"}`
+      );
+      fetch("/api/v1/clipboard/image", {
+        method: "POST",
+        body: form,
+        credentials: "include",
+      })
         .then((res) => {
           if (!res.ok) throw new Error(`clipboard upload: ${res.status}`);
           const ws = wsRef.current;
@@ -599,8 +702,8 @@ export function useTerminal(args: {
 
     // Intercept paste events (Cmd+V) — clipboard data is available directly.
     const handlePaste = (e: ClipboardEvent) => {
-      const imageItem = Array.from(e.clipboardData?.items ?? []).find(
-        (item) => item.type.startsWith("image/"),
+      const imageItem = Array.from(e.clipboardData?.items ?? []).find((item) =>
+        item.type.startsWith("image/")
       );
       if (!imageItem) return; // no image — let xterm handle text paste normally
       const blob = imageItem.getAsFile();
@@ -630,12 +733,14 @@ export function useTerminal(args: {
       while (Math.abs(touchAccum) >= SCROLL_SENSITIVITY) {
         const direction = touchAccum > 0 ? 1 : -1;
         touchAccum -= direction * SCROLL_SENSITIVITY;
-        screenEl.dispatchEvent(new WheelEvent("wheel", {
-          deltaY: direction * 100,
-          deltaMode: 0,
-          bubbles: true,
-          cancelable: true,
-        }));
+        screenEl.dispatchEvent(
+          new WheelEvent("wheel", {
+            deltaY: direction * 100,
+            deltaMode: 0,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
       }
     };
     host.addEventListener("touchstart", onTouchStart, { passive: true });
@@ -644,25 +749,28 @@ export function useTerminal(args: {
     let dispatchingMouseDown = false;
     const onMouseDown = (e: MouseEvent) => {
       if (dispatchingMouseDown) return;
-      if (e.button !== 0 || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.button !== 0 || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey)
+        return;
       e.stopPropagation();
       e.preventDefault();
       dispatchingMouseDown = true;
-      (e.target as HTMLElement).dispatchEvent(new MouseEvent("mousedown", {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        detail: e.detail,
-        screenX: e.screenX,
-        screenY: e.screenY,
-        clientX: e.clientX,
-        clientY: e.clientY,
-        button: e.button,
-        buttons: e.buttons,
-        relatedTarget: e.relatedTarget,
-        shiftKey: true,
-        altKey: true,
-      }));
+      (e.target as HTMLElement).dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          detail: e.detail,
+          screenX: e.screenX,
+          screenY: e.screenY,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          button: e.button,
+          buttons: e.buttons,
+          relatedTarget: e.relatedTarget,
+          shiftKey: true,
+          altKey: true,
+        })
+      );
       dispatchingMouseDown = false;
     };
     if (screenEl) {
@@ -677,7 +785,12 @@ export function useTerminal(args: {
         if (code >= 65 && code <= 90) {
           ctrlPendingRef.current = false;
           window.dispatchEvent(new Event("ctrl-consumed"));
-          ws.send(JSON.stringify({ type: "input", data: String.fromCharCode(code - 64) }));
+          ws.send(
+            JSON.stringify({
+              type: "input",
+              data: String.fromCharCode(code - 64),
+            })
+          );
           return;
         }
       }
@@ -704,9 +817,12 @@ export function useTerminal(args: {
       host.removeEventListener("paste", handlePaste, true);
       host.removeEventListener("touchstart", onTouchStart);
       host.removeEventListener("touchmove", onTouchMove);
-      if (screenEl) screenEl.removeEventListener("mousedown", onMouseDown, true);
+      if (screenEl)
+        screenEl.removeEventListener("mousedown", onMouseDown, true);
       window.removeEventListener("resize", onResize);
-      try { wsRef.current?.close(); } catch {}
+      try {
+        wsRef.current?.close();
+      } catch {}
       wsRef.current = null;
       term.dispose();
       terminalRef.current = null;
@@ -717,7 +833,8 @@ export function useTerminal(args: {
   // Reconnect on visibility/focus.
   useEffect(() => {
     const requestForegroundReconnect = () => {
-      const targetAgentId = connectedAgentIdRef.current ?? selectedAgentId ?? undefined;
+      const targetAgentId =
+        connectedAgentIdRef.current ?? selectedAgentId ?? undefined;
       if (!targetAgentId) return;
       const now = Date.now();
       if (now - lastResumeTriggerAtRef.current < RESUME_RECONNECT_DEDUPE_MS) {
@@ -739,7 +856,11 @@ export function useTerminal(args: {
 
     const onOnline = () => {
       clearReconnectTimer();
-      void ensureTerminalConnected(false, false, connectedAgentIdRef.current ?? selectedAgentId ?? undefined);
+      void ensureTerminalConnected(
+        false,
+        false,
+        connectedAgentIdRef.current ?? selectedAgentId ?? undefined
+      );
     };
 
     document.addEventListener("visibilitychange", onVisible);
@@ -782,7 +903,9 @@ export function useTerminal(args: {
   useEffect(() => {
     if (!agentsLoaded || !restoreShellAgentId) return;
 
-    const restoreTarget = agents.find((agent) => agent.id === restoreShellAgentId);
+    const restoreTarget = agents.find(
+      (agent) => agent.id === restoreShellAgentId
+    );
     if (!restoreTarget || restoreTarget.status !== "running") {
       persistActiveShellAgentId(null);
       setRestoreShellAgentId(null);
@@ -794,8 +917,14 @@ export function useTerminal(args: {
     void ensureTerminalConnected(true, true, restoreTarget.id);
     setStatusMessage(`Restored session for ${restoreTarget.name}.`);
     setRestoreShellAgentId(null);
-  }, [agents, agentsLoaded, ensureTerminalConnected, setSelectedAgentId, refreshMedia, restoreShellAgentId]);
-
+  }, [
+    agents,
+    agentsLoaded,
+    ensureTerminalConnected,
+    setSelectedAgentId,
+    refreshMedia,
+    restoreShellAgentId,
+  ]);
 
   // Update terminal palette and reconnect when theme changes.
   const prevThemeRef = useRef(theme);
@@ -819,35 +948,44 @@ export function useTerminal(args: {
       void ensureTerminalConnected(true, true, agentId);
     }, 150);
     return () => window.clearTimeout(timer);
-  }, [theme, connState, connectedAgentId, detachTerminal, ensureTerminalConnected]);
+  }, [
+    theme,
+    connState,
+    connectedAgentId,
+    detachTerminal,
+    ensureTerminalConnected,
+  ]);
 
   const focusTerminal = useCallback(() => {
     terminalRef.current?.focus();
   }, []);
 
-  return useMemo(() => ({
-    connState,
-    connectedAgentId,
-    terminalMode,
-    terminalPlaceholderMessage,
-    statusMessage,
-    terminalHostRef: setTerminalHostRef,
-    ctrlPendingRef,
-    focusTerminal,
-    ensureTerminalConnected,
-    detachTerminal,
-    sendTerminalInput,
-    setTerminalHostRef,
-  }), [
-    connState,
-    connectedAgentId,
-    terminalMode,
-    terminalPlaceholderMessage,
-    statusMessage,
-    focusTerminal,
-    ensureTerminalConnected,
-    detachTerminal,
-    sendTerminalInput,
-    setTerminalHostRef,
-  ]);
+  return useMemo(
+    () => ({
+      connState,
+      connectedAgentId,
+      terminalMode,
+      terminalPlaceholderMessage,
+      statusMessage,
+      terminalHostRef: setTerminalHostRef,
+      ctrlPendingRef,
+      focusTerminal,
+      ensureTerminalConnected,
+      detachTerminal,
+      sendTerminalInput,
+      setTerminalHostRef,
+    }),
+    [
+      connState,
+      connectedAgentId,
+      terminalMode,
+      terminalPlaceholderMessage,
+      statusMessage,
+      focusTerminal,
+      ensureTerminalConnected,
+      detachTerminal,
+      sendTerminalInput,
+      setTerminalHostRef,
+    ]
+  );
 }

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type ThemeId = "default" | "cool-navy" | "oled-black" | "solarized-dark" | "light" | "vaporwave" | "matrix" | "midnight" | "mytra";
+export type ThemeId =
+  | "default"
+  | "cool-navy"
+  | "oled-black"
+  | "solarized-dark"
+  | "light"
+  | "vaporwave"
+  | "matrix"
+  | "midnight"
+  | "mytra";
 
 export type TerminalPalette = {
   minimumContrastRatio?: number;
@@ -199,7 +208,12 @@ export const THEMES: ThemeDefinition[] = [
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
-    terminal: { ...MONOKAI, background: "#0e1014", cursorAccent: "#0e1014", black: "#0e1014" },
+    terminal: {
+      ...MONOKAI,
+      background: "#0e1014",
+      cursorAccent: "#0e1014",
+      black: "#0e1014",
+    },
   },
   {
     id: "light",
@@ -227,14 +241,24 @@ export const THEMES: ThemeDefinition[] = [
     label: "Midnight",
     description: "OLED black with vibrant cyan & pink",
     swatches: ["#000000", "#58b8ff", "#ff5db1", "#f1e84f"],
-    terminal: { ...MONOKAI, background: "#000000", cursorAccent: "#000000", black: "#000000" },
+    terminal: {
+      ...MONOKAI,
+      background: "#000000",
+      cursorAccent: "#000000",
+      black: "#000000",
+    },
   },
   {
     id: "oled-black",
     label: "OLED Black",
     description: "True black for OLED screens",
     swatches: ["#000000", "#34d399", "#f0f0f0", "#222222"],
-    terminal: { ...MONOKAI, background: "#000000", cursorAccent: "#000000", black: "#000000" },
+    terminal: {
+      ...MONOKAI,
+      background: "#000000",
+      cursorAccent: "#000000",
+      black: "#000000",
+    },
   },
   {
     id: "solarized-dark",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -29,12 +29,12 @@
   --status-idle: 240 4% 46%;
 
   /* Chart colors */
-  --chart-1: 158 64% 52%;   /* teal — input tokens */
-  --chart-2: 45 96% 64%;    /* amber — output tokens */
-  --chart-3: 200 80% 55%;   /* sky — cache read */
-  --chart-4: 280 60% 60%;   /* purple — cache write */
-  --chart-5: 158 64% 42%;   /* deep teal — model bars */
-  --chart-6: 45 96% 54%;    /* deep amber — project bars */
+  --chart-1: 158 64% 52%; /* teal — input tokens */
+  --chart-2: 45 96% 64%; /* amber — output tokens */
+  --chart-3: 200 80% 55%; /* sky — cache read */
+  --chart-4: 280 60% 60%; /* purple — cache write */
+  --chart-5: 158 64% 42%; /* deep teal — model bars */
+  --chart-6: 45 96% 54%; /* deep amber — project bars */
 
   /* Surface & terminal */
   --surface: 50 15% 5%;
@@ -383,8 +383,16 @@ body {
 
 html[data-theme="mytra"] body {
   background-image:
-    radial-gradient(circle at top center, hsl(var(--primary) / 0.18), transparent 22%),
-    radial-gradient(circle at 50% 18%, hsl(var(--status-done) / 0.08), transparent 28%),
+    radial-gradient(
+      circle at top center,
+      hsl(var(--primary) / 0.18),
+      transparent 22%
+    ),
+    radial-gradient(
+      circle at 50% 18%,
+      hsl(var(--status-done) / 0.08),
+      transparent 28%
+    ),
     linear-gradient(180deg, hsl(var(--background)), hsl(var(--surface)));
 }
 
@@ -395,10 +403,29 @@ html[data-theme="mytra"] body::before {
   pointer-events: none;
   z-index: 0;
   background:
-    linear-gradient(180deg, hsl(var(--foreground) / 0.018), transparent 18%, transparent 84%, hsl(var(--foreground) / 0.02)),
-    radial-gradient(circle at 22% 24%, hsl(var(--primary) / 0.055), transparent 20%),
-    radial-gradient(circle at 78% 72%, hsl(var(--status-done) / 0.045), transparent 24%),
-    linear-gradient(118deg, transparent 0 64%, hsl(var(--primary) / 0.03) 72%, transparent 78%);
+    linear-gradient(
+      180deg,
+      hsl(var(--foreground) / 0.018),
+      transparent 18%,
+      transparent 84%,
+      hsl(var(--foreground) / 0.02)
+    ),
+    radial-gradient(
+      circle at 22% 24%,
+      hsl(var(--primary) / 0.055),
+      transparent 20%
+    ),
+    radial-gradient(
+      circle at 78% 72%,
+      hsl(var(--status-done) / 0.045),
+      transparent 24%
+    ),
+    linear-gradient(
+      118deg,
+      transparent 0 64%,
+      hsl(var(--primary) / 0.03) 72%,
+      transparent 78%
+    );
   opacity: 0.32;
 }
 
@@ -409,8 +436,16 @@ html[data-theme="mytra"] body::after {
   pointer-events: none;
   z-index: 0;
   background:
-    radial-gradient(circle at 50% -8%, hsl(var(--primary) / 0.22), transparent 24%),
-    radial-gradient(circle at 50% 108%, hsl(var(--status-done) / 0.12), transparent 30%);
+    radial-gradient(
+      circle at 50% -8%,
+      hsl(var(--primary) / 0.22),
+      transparent 24%
+    ),
+    radial-gradient(
+      circle at 50% 108%,
+      hsl(var(--status-done) / 0.12),
+      transparent 30%
+    );
   opacity: 0.9;
 }
 
@@ -427,7 +462,13 @@ html[data-theme="matrix"] body::before {
   pointer-events: none;
   z-index: 0;
   background-image:
-    linear-gradient(to bottom, hsl(var(--primary) / 0.045), transparent 22%, transparent 78%, hsl(var(--primary) / 0.03)),
+    linear-gradient(
+      to bottom,
+      hsl(var(--primary) / 0.045),
+      transparent 22%,
+      transparent 78%,
+      hsl(var(--primary) / 0.03)
+    ),
     linear-gradient(to right, hsl(var(--primary) / 0.05) 1px, transparent 1px),
     linear-gradient(to bottom, hsl(var(--primary) / 0.035) 1px, transparent 1px);
   background-size:
@@ -444,8 +485,16 @@ html[data-theme="matrix"] body::after {
   pointer-events: none;
   z-index: 0;
   background:
-    radial-gradient(circle at 50% -10%, hsl(var(--status-working) / 0.08), transparent 40%),
-    radial-gradient(circle at 50% 120%, hsl(var(--status-working) / 0.06), transparent 34%);
+    radial-gradient(
+      circle at 50% -10%,
+      hsl(var(--status-working) / 0.08),
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 50% 120%,
+      hsl(var(--status-working) / 0.06),
+      transparent 34%
+    );
 }
 
 #root {
@@ -654,18 +703,18 @@ html[data-theme="matrix"] [role="button"] {
 [data-theme="midnight"] .hljs-keyword,
 [data-theme="midnight"] .hljs-selector-tag,
 [data-theme="midnight"] .hljs-deletion {
-  color: hsl(var(--primary));             /* blue */
+  color: hsl(var(--primary)); /* blue */
 }
 [data-theme="midnight"] .hljs-string,
 [data-theme="midnight"] .hljs-doctag,
 [data-theme="midnight"] .hljs-regexp,
 [data-theme="midnight"] .hljs-addition {
-  color: hsl(var(--destructive));         /* pink */
+  color: hsl(var(--destructive)); /* pink */
 }
 [data-theme="midnight"] .hljs-title,
 [data-theme="midnight"] .hljs-title\.class_,
 [data-theme="midnight"] .hljs-title\.function_ {
-  color: hsl(var(--status-waiting));      /* yellow */
+  color: hsl(var(--status-waiting)); /* yellow */
 }
 [data-theme="midnight"] .hljs-attr,
 [data-theme="midnight"] .hljs-attribute {
@@ -674,52 +723,57 @@ html[data-theme="matrix"] [role="button"] {
 }
 [data-theme="midnight"] .hljs-name,
 [data-theme="midnight"] .hljs-tag {
-  color: hsl(var(--destructive));         /* pink for tags */
+  color: hsl(var(--destructive)); /* pink for tags */
 }
 [data-theme="midnight"] .hljs-meta,
 [data-theme="midnight"] .hljs-meta .hljs-keyword {
-  color: hsl(var(--status-working));      /* green for meta only */
+  color: hsl(var(--status-working)); /* green for meta only */
 }
 
 /* OLED Black: green primary is too monochrome — use blue/yellow/red accents */
 [data-theme="oled-black"] .hljs-keyword,
 [data-theme="oled-black"] .hljs-selector-tag,
 [data-theme="oled-black"] .hljs-deletion {
-  color: hsl(var(--status-done));         /* blue */
+  color: hsl(var(--status-done)); /* blue */
 }
 [data-theme="oled-black"] .hljs-string,
 [data-theme="oled-black"] .hljs-doctag,
 [data-theme="oled-black"] .hljs-regexp,
 [data-theme="oled-black"] .hljs-addition {
-  color: hsl(var(--destructive));         /* red */
+  color: hsl(var(--destructive)); /* red */
 }
 [data-theme="oled-black"] .hljs-title,
 [data-theme="oled-black"] .hljs-title\.class_,
 [data-theme="oled-black"] .hljs-title\.function_ {
-  color: hsl(var(--status-waiting));      /* yellow */
+  color: hsl(var(--status-waiting)); /* yellow */
 }
 [data-theme="oled-black"] .hljs-type,
 [data-theme="oled-black"] .hljs-built_in {
-  color: hsl(var(--primary));             /* green — just for types */
+  color: hsl(var(--primary)); /* green — just for types */
 }
 [data-theme="oled-black"] .hljs-attr,
 [data-theme="oled-black"] .hljs-attribute {
-  color: hsl(var(--status-done));         /* blue */
+  color: hsl(var(--status-done)); /* blue */
   opacity: 0.8;
 }
 [data-theme="oled-black"] .hljs-name,
 [data-theme="oled-black"] .hljs-tag {
-  color: hsl(var(--status-done));         /* blue */
+  color: hsl(var(--status-done)); /* blue */
 }
 [data-theme="oled-black"] .hljs-meta,
 [data-theme="oled-black"] .hljs-meta .hljs-keyword {
-  color: hsl(var(--status-waiting));      /* yellow for meta */
+  color: hsl(var(--status-waiting)); /* yellow for meta */
 }
 
 /* Persona reviewing animation — subtle pulse on the status icon */
 @keyframes persona-reviewing-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 .animate-persona-reviewing {
   animation: persona-reviewing-pulse 2s ease-in-out infinite;
@@ -760,8 +814,12 @@ html[data-theme="matrix"] [role="button"] {
 
 /* Persona reviewing row — subtle left-border shimmer */
 @keyframes persona-reviewing-shimmer {
-  0% { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 .persona-reviewing-row {

--- a/apps/web/src/lib/active-hours.ts
+++ b/apps/web/src/lib/active-hours.ts
@@ -29,9 +29,16 @@ export function buildActiveHours(
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
 
-  const effectiveStartMs = Number.isFinite(firstTimestamp) ? firstTimestamp : now.getTime();
-  const effectiveEndMs = Number.isFinite(lastTimestamp) ? Math.max(lastTimestamp, now.getTime()) : now.getTime();
-  const spanWeeks = Math.max(1, (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000));
+  const effectiveStartMs = Number.isFinite(firstTimestamp)
+    ? firstTimestamp
+    : now.getTime();
+  const effectiveEndMs = Number.isFinite(lastTimestamp)
+    ? Math.max(lastTimestamp, now.getTime())
+    : now.getTime();
+  const spanWeeks = Math.max(
+    1,
+    (effectiveEndMs - effectiveStartMs) / (7 * 24 * 60 * 60 * 1000)
+  );
 
   const cells: ActiveHoursCell[] = [];
   for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {

--- a/apps/web/src/lib/agent-types.ts
+++ b/apps/web/src/lib/agent-types.ts
@@ -5,7 +5,7 @@ export type AgentType = (typeof AGENT_TYPES)[number];
 export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   codex: "Codex",
   claude: "Claude",
-  opencode: "OpenCode"
+  opencode: "OpenCode",
 };
 
 export function isAgentType(value: string): value is AgentType {
@@ -18,7 +18,9 @@ export function sanitizeEnabledAgentTypes(value: unknown): AgentType[] {
   }
 
   const unique = value
-    .filter((item): item is AgentType => typeof item === "string" && isAgentType(item))
+    .filter(
+      (item): item is AgentType => typeof item === "string" && isAgentType(item)
+    )
     .filter((item, index, items) => items.indexOf(item) === index);
 
   return unique.length > 0 ? unique : [...AGENT_TYPES];

--- a/apps/web/src/lib/external-links.ts
+++ b/apps/web/src/lib/external-links.ts
@@ -3,12 +3,17 @@ const IOS_DEVICE_RE = /iPad|iPhone|iPod/i;
 type StandaloneNavigator = Navigator & { standalone?: boolean };
 
 function isIOSDevice(): boolean {
-  return IOS_DEVICE_RE.test(navigator.userAgent) || (navigator.maxTouchPoints > 1 && /Macintosh/.test(navigator.userAgent));
+  return (
+    IOS_DEVICE_RE.test(navigator.userAgent) ||
+    (navigator.maxTouchPoints > 1 && /Macintosh/.test(navigator.userAgent))
+  );
 }
 
 export function isStandaloneApp(): boolean {
-  return window.matchMedia("(display-mode: standalone)").matches ||
-    (navigator as StandaloneNavigator).standalone === true;
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as StandaloneNavigator).standalone === true
+  );
 }
 
 export function isStandaloneIOSApp(): boolean {

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -34,5 +34,8 @@ export function formatRelativeTime(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/apps/web/src/lib/pins.ts
+++ b/apps/web/src/lib/pins.ts
@@ -1,13 +1,22 @@
 import type { AgentPin } from "../components/app/types";
 
-export function splitPinValues(type: AgentPin["type"], value: string): string[] {
+export function splitPinValues(
+  type: AgentPin["type"],
+  value: string
+): string[] {
   if (type === "filename") {
-    const parts = value.split(/[,\n]+/).map((s) => s.trim()).filter(Boolean);
+    const parts = value
+      .split(/[,\n]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
     return parts.length > 0 ? parts : [value];
   }
 
   if (type === "port") {
-    const parts = value.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+    const parts = value
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
     return parts.length > 0 ? parts : [value];
   }
 

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -3,21 +3,26 @@ import { atomFamily } from "jotai/utils";
 import type { FeedbackDetailState } from "@/components/app/feedback-panel";
 
 function atomWithLocalStorage<T>(key: string, initialValue: T) {
-  const baseAtom = atom<T>((() => {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored === null) return initialValue;
-      return JSON.parse(stored) as T;
-    } catch {
-      return initialValue;
-    }
-  })());
+  const baseAtom = atom<T>(
+    (() => {
+      if (typeof window === "undefined") return initialValue;
+      try {
+        const stored = window.localStorage.getItem(key);
+        if (stored === null) return initialValue;
+        return JSON.parse(stored) as T;
+      } catch {
+        return initialValue;
+      }
+    })()
+  );
 
   const derivedAtom = atom(
     (get) => get(baseAtom),
     (_get, set, update: T | ((prev: T) => T)) => {
-      const nextValue = typeof update === "function" ? (update as (prev: T) => T)(_get(baseAtom)) : update;
+      const nextValue =
+        typeof update === "function"
+          ? (update as (prev: T) => T)(_get(baseAtom))
+          : update;
       set(baseAtom, nextValue);
       window.localStorage.setItem(key, JSON.stringify(nextValue));
     }
@@ -26,23 +31,38 @@ function atomWithLocalStorage<T>(key: string, initialValue: T) {
   return derivedAtom;
 }
 
-export const leftSidebarOpenAtom = atomWithLocalStorage("dispatch:leftSidebarOpen", true);
-export const mediaSidebarOpenAtom = atomWithLocalStorage("dispatch:mediaSidebarOpen", false);
-export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">("dispatch:mediaSidebarTab", "pins");
-export const feedbackDetailAtom = atomWithLocalStorage<FeedbackDetailState>("dispatch:feedbackDetail", null);
-export const expandedAgentIdAtom = atomWithLocalStorage<string | null>("dispatch:expandedAgentId", null);
+export const leftSidebarOpenAtom = atomWithLocalStorage(
+  "dispatch:leftSidebarOpen",
+  true
+);
+export const mediaSidebarOpenAtom = atomWithLocalStorage(
+  "dispatch:mediaSidebarOpen",
+  false
+);
+export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">(
+  "dispatch:mediaSidebarTab",
+  "pins"
+);
+export const feedbackDetailAtom = atomWithLocalStorage<FeedbackDetailState>(
+  "dispatch:feedbackDetail",
+  null
+);
+export const expandedAgentIdAtom = atomWithLocalStorage<string | null>(
+  "dispatch:expandedAgentId",
+  null
+);
 
 /** Per-directory full-access mode preference, backed by localStorage (sync read). */
 export const fullAccessByCwdAtom = atomFamily((cwd: string) =>
-  atomWithLocalStorage(`dispatch:fullAccess:${cwd}`, false),
+  atomWithLocalStorage(`dispatch:fullAccess:${cwd}`, false)
 );
 
 /** Per-directory last-used base branch, backed by localStorage (sync read). */
 export const baseBranchByCwdAtom = atomFamily((cwd: string) =>
-  atomWithLocalStorage(`dispatch:baseBranch:${cwd}`, "main"),
+  atomWithLocalStorage(`dispatch:baseBranch:${cwd}`, "main")
 );
 
 /** Per-directory autonomous review preference, backed by localStorage (sync read). */
 export const autoReviewByCwdAtom = atomFamily((cwd: string) =>
-  atomWithLocalStorage(`dispatch:autoReview:${cwd}`, false),
+  atomWithLocalStorage(`dispatch:autoReview:${cwd}`, false)
 );

--- a/apps/web/src/lib/web-notifications.ts
+++ b/apps/web/src/lib/web-notifications.ts
@@ -28,7 +28,9 @@ export function showWebNotification(payload: {
 
 /** Derive the app icon URL from the current page's apple-touch-icon link. */
 function getAppIconUrl(): string {
-  const link = document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]');
+  const link = document.querySelector<HTMLLinkElement>(
+    'link[rel="apple-touch-icon"]'
+  );
   if (link?.href) return link.href;
   return "/icons/teal/brand-icon-192.png";
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,7 +14,8 @@ import "./index.css";
 const isIPad =
   navigator.maxTouchPoints > 1 && /Macintosh/.test(navigator.userAgent);
 const isStandalone =
-  "standalone" in navigator && (navigator as Record<string, unknown>).standalone === true;
+  "standalone" in navigator &&
+  (navigator as Record<string, unknown>).standalone === true;
 if (isIPad && isStandalone) {
   document.documentElement.classList.add("ipad-pwa");
 }
@@ -37,9 +38,11 @@ if (import.meta.env.PROD) {
     immediate: true,
     onRegisteredSW(_swUrl, registration) {
       if (registration) {
-        setInterval(() => { void registration.update(); }, intervalMS);
+        setInterval(() => {
+          void registration.update();
+        }, intervalMS);
       }
-    }
+    },
   });
 } else if ("serviceWorker" in navigator) {
   void navigator.serviceWorker.getRegistrations().then((registrations) => {

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -16,26 +16,26 @@ export default {
         "terminal-bg": "hsl(var(--terminal-bg))",
         card: {
           DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))"
+          foreground: "hsl(var(--card-foreground))",
         },
         primary: {
           DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))"
+          foreground: "hsl(var(--primary-foreground))",
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))"
+          foreground: "hsl(var(--muted-foreground))",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))"
+          foreground: "hsl(var(--destructive-foreground))",
         },
         status: {
           working: "hsl(var(--status-working) / <alpha-value>)",
           blocked: "hsl(var(--status-blocked) / <alpha-value>)",
           waiting: "hsl(var(--status-waiting) / <alpha-value>)",
           done: "hsl(var(--status-done) / <alpha-value>)",
-          idle: "hsl(var(--status-idle) / <alpha-value>)"
+          idle: "hsl(var(--status-idle) / <alpha-value>)",
         },
         chart: {
           1: "hsl(var(--chart-1) / <alpha-value>)",
@@ -43,15 +43,15 @@ export default {
           3: "hsl(var(--chart-3) / <alpha-value>)",
           4: "hsl(var(--chart-4) / <alpha-value>)",
           5: "hsl(var(--chart-5) / <alpha-value>)",
-          6: "hsl(var(--chart-6) / <alpha-value>)"
-        }
+          6: "hsl(var(--chart-6) / <alpha-value>)",
+        },
       },
       borderRadius: {
         lg: "0.75rem",
         md: "0.6rem",
-        sm: "0.45rem"
-      }
-    }
+        sm: "0.45rem",
+      },
+    },
   },
-  plugins: [typography]
+  plugins: [typography],
 } satisfies Config;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: "autoUpdate",
-      includeAssets: ["icons/teal/apple-touch-icon.png", "icons/teal/favicon.png"],
+      includeAssets: [
+        "icons/teal/apple-touch-icon.png",
+        "icons/teal/favicon.png",
+      ],
       manifest: {
         id: "/",
         name: "Dispatch",
@@ -24,46 +27,48 @@ export default defineConfig({
             src: "/icons/teal/pwa-192.png",
             sizes: "192x192",
             type: "image/png",
-            purpose: "any"
+            purpose: "any",
           },
           {
             src: "/icons/teal/pwa-512.png",
             sizes: "512x512",
             type: "image/png",
-            purpose: "any"
+            purpose: "any",
           },
           {
             src: "/icons/teal/pwa-512.png",
             sizes: "512x512",
             type: "image/png",
-            purpose: "maskable"
-          }
-        ]
+            purpose: "maskable",
+          },
+        ],
       },
       workbox: {
         // Do not cache API traffic by default; this app is realtime-oriented.
-        navigateFallbackDenylist: [/^\/api\//]
-      }
-    })
+        navigateFallbackDenylist: [/^\/api\//],
+      },
+    }),
   ],
   server: {
     host: "0.0.0.0",
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_TARGET ?? `http://127.0.0.1:${process.env.DISPATCH_PORT}`,
+        target:
+          process.env.VITE_API_TARGET ??
+          `http://127.0.0.1:${process.env.DISPATCH_PORT}`,
         changeOrigin: true,
-        ws: true
-      }
-    }
+        ws: true,
+      },
+    },
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src")
-    }
+      "@": path.resolve(__dirname, "./src"),
+    },
   },
   build: {
     outDir: "dist",
-    emptyOutDir: true
-  }
+    emptyOutDir: true,
+  },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     ports:
       - "${DISPATCH_DB_PORT:-5433}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dispatch -d dispatch_${DISPATCH_DB_NAME:-dev}"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U dispatch -d dispatch_${DISPATCH_DB_NAME:-dev}",
+        ]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -32,25 +32,25 @@
 
 ## Authentication
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/auth/status` | Check auth state and whether password is configured |
-| POST | `/auth/setup` | Set initial password (first-run only) |
-| POST | `/auth/login` | Authenticate and create session cookie |
-| POST | `/auth/logout` | Invalidate session |
-| POST | `/auth/change-password` | Change password (requires valid session) |
+| Method | Path                    | Description                                         |
+| ------ | ----------------------- | --------------------------------------------------- |
+| GET    | `/auth/status`          | Check auth state and whether password is configured |
+| POST   | `/auth/setup`           | Set initial password (first-run only)               |
+| POST   | `/auth/login`           | Authenticate and create session cookie              |
+| POST   | `/auth/logout`          | Invalidate session                                  |
+| POST   | `/auth/change-password` | Change password (requires valid session)            |
 
 ## Agent Lifecycle
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/agents` | List all active agents |
-| GET | `/agents/:id` | Get agent details |
-| POST | `/agents` | Create new agent |
-| POST | `/agents/:id/start` | Start a stopped agent |
-| POST | `/agents/:id/stop` | Stop a running agent |
-| PATCH | `/agents/:id/review-agent-type` | Set preferred agent type for persona reviews |
-| DELETE | `/agents/:id` | Delete agent (soft delete) |
+| Method | Path                            | Description                                  |
+| ------ | ------------------------------- | -------------------------------------------- |
+| GET    | `/agents`                       | List all active agents                       |
+| GET    | `/agents/:id`                   | Get agent details                            |
+| POST   | `/agents`                       | Create new agent                             |
+| POST   | `/agents/:id/start`             | Start a stopped agent                        |
+| POST   | `/agents/:id/stop`              | Stop a running agent                         |
+| PATCH  | `/agents/:id/review-agent-type` | Set preferred agent type for persona reviews |
+| DELETE | `/agents/:id`                   | Delete agent (soft delete)                   |
 
 ### `POST /agents` — Create Agent
 
@@ -93,10 +93,10 @@ Query params: `cleanupWorktree=auto|keep|force` (default: `auto` — cleans up w
 
 Used during agent initialization to track setup progress.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/agents/:id/setup/phase` | Report setup phase (`worktree` → `env` → `deps` → `session`) |
-| POST | `/agents/:id/setup/complete` | Mark setup complete with resolved paths |
+| Method | Path                         | Description                                                  |
+| ------ | ---------------------------- | ------------------------------------------------------------ |
+| POST   | `/agents/:id/setup/phase`    | Report setup phase (`worktree` → `env` → `deps` → `session`) |
+| POST   | `/agents/:id/setup/complete` | Mark setup complete with resolved paths                      |
 
 ### `POST /agents/:id/setup/complete`
 
@@ -110,13 +110,13 @@ Used during agent initialization to track setup progress.
 
 ## Agent Events & State
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/agents/:id/latest-event` | Update agent's latest status event |
-| POST | `/focus` | Track which agent the user is viewing |
-| GET | `/events` | SSE stream of real-time UI events |
-| GET | `/agents/git-context` | Get git context for agents (filtered by `ids` query param) |
-| GET | `/agents/:id/worktree-status` | Check worktree for unmerged commits and uncommitted changes |
+| Method | Path                          | Description                                                 |
+| ------ | ----------------------------- | ----------------------------------------------------------- |
+| POST   | `/agents/:id/latest-event`    | Update agent's latest status event                          |
+| POST   | `/focus`                      | Track which agent the user is viewing                       |
+| GET    | `/events`                     | SSE stream of real-time UI events                           |
+| GET    | `/agents/git-context`         | Get git context for agents (filtered by `ids` query param)  |
+| GET    | `/agents/:id/worktree-status` | Check worktree for unmerged commits and uncommitted changes |
 
 ### `POST /agents/:id/latest-event`
 
@@ -136,46 +136,46 @@ Server-Sent Events stream. Events include agent state changes, media uploads, an
 
 ## Terminal
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/agents/:id/terminal/token` | Issue short-lived terminal access token |
-| WS | `/agents/:id/terminal/ws?token=...` | WebSocket for interactive terminal I/O |
+| Method | Path                                | Description                             |
+| ------ | ----------------------------------- | --------------------------------------- |
+| POST   | `/agents/:id/terminal/token`        | Issue short-lived terminal access token |
+| WS     | `/agents/:id/terminal/ws?token=...` | WebSocket for interactive terminal I/O  |
 
 The WebSocket provides bidirectional terminal I/O with resize support, bridging to the agent's tmux session.
 
 ## Media
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/agents/:id/media` | List media files with seen/unseen status |
-| GET | `/agents/:id/media/:file` | Download a media file |
-| POST | `/agents/:id/media` | Upload media (multipart form: file + description) |
-| POST | `/agents/:id/media/seen` | Mark media files as seen |
+| Method | Path                      | Description                                       |
+| ------ | ------------------------- | ------------------------------------------------- |
+| GET    | `/agents/:id/media`       | List media files with seen/unseen status          |
+| GET    | `/agents/:id/media/:file` | Download a media file                             |
+| POST   | `/agents/:id/media`       | Upload media (multipart form: file + description) |
+| POST   | `/agents/:id/media/seen`  | Mark media files as seen                          |
 
 ## Streaming
 
 Live Playwright browser streaming via Chrome DevTools Protocol.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/agents/:id/stream` | Start or stop a screen stream |
-| GET | `/agents/:id/stream` | MJPEG stream (`multipart/x-mixed-replace`) |
-| GET | `/agents/:id/stream/viewer` | HTML viewer page for the live stream |
+| Method | Path                        | Description                                |
+| ------ | --------------------------- | ------------------------------------------ |
+| POST   | `/agents/:id/stream`        | Start or stop a screen stream              |
+| GET    | `/agents/:id/stream`        | MJPEG stream (`multipart/x-mixed-replace`) |
+| GET    | `/agents/:id/stream/viewer` | HTML viewer page for the live stream       |
 
 ## Personas
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/personas` | List available personas (reads from `.dispatch/personas/` in the repo at `cwd`) |
+| Method | Path        | Description                                                                     |
+| ------ | ----------- | ------------------------------------------------------------------------------- |
+| GET    | `/personas` | List available personas (reads from `.dispatch/personas/` in the repo at `cwd`) |
 
 Query params: `cwd=/path/to/repo`
 
 ## Feedback
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/agents/:id/feedback` | Get feedback findings for an agent |
-| PATCH | `/agents/:id/feedback/:feedbackId` | Update feedback status |
+| Method | Path                               | Description                        |
+| ------ | ---------------------------------- | ---------------------------------- |
+| GET    | `/agents/:id/feedback`             | Get feedback findings for an agent |
+| PATCH  | `/agents/:id/feedback/:feedbackId` | Update feedback status             |
 
 ### `GET /agents/:id/feedback`
 
@@ -191,34 +191,34 @@ Status values: `open`, `dismissed`, `forwarded`, `fixed`, `ignored`
 
 ## Activity & Analytics
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/activity/heatmap` | Activity heatmap data (configurable `days`, `timezone`) |
-| GET | `/activity/stats` | Aggregate stats (working/blocked/waiting time, busiest day) |
-| GET | `/activity/daily-status` | Daily status breakdown |
-| GET | `/activity/active-hours` | Events marked as working/blocked/waiting_user |
-| GET | `/activity/agents-created` | Agent creation counts over time |
-| GET | `/activity/working-time-by-project` | Working time by project directory |
+| Method | Path                                | Description                                                 |
+| ------ | ----------------------------------- | ----------------------------------------------------------- |
+| GET    | `/activity/heatmap`                 | Activity heatmap data (configurable `days`, `timezone`)     |
+| GET    | `/activity/stats`                   | Aggregate stats (working/blocked/waiting time, busiest day) |
+| GET    | `/activity/daily-status`            | Daily status breakdown                                      |
+| GET    | `/activity/active-hours`            | Events marked as working/blocked/waiting_user               |
+| GET    | `/activity/agents-created`          | Agent creation counts over time                             |
+| GET    | `/activity/working-time-by-project` | Working time by project directory                           |
 
 ## Token Usage
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/activity/token-stats` | Total token usage (input, output, cache creation, cache reads) |
-| GET | `/activity/token-daily` | Daily token usage breakdown |
-| GET | `/activity/token-by-project` | Token usage by project (top 20) |
-| GET | `/activity/token-by-model` | Token usage by model |
-| POST | `/agents/:id/harvest-tokens` | Harvest token usage from an agent's session |
+| Method | Path                         | Description                                                    |
+| ------ | ---------------------------- | -------------------------------------------------------------- |
+| GET    | `/activity/token-stats`      | Total token usage (input, output, cache creation, cache reads) |
+| GET    | `/activity/token-daily`      | Daily token usage breakdown                                    |
+| GET    | `/activity/token-by-project` | Token usage by project (top 20)                                |
+| GET    | `/activity/token-by-model`   | Token usage by model                                           |
+| POST   | `/agents/:id/harvest-tokens` | Harvest token usage from an agent's session                    |
 
 All token endpoints accept `days` and `timezone` query params.
 
 ## History
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/history/projects` | List all projects where agents have worked |
-| GET | `/history/agents` | Paginated agent history with filtering and sorting |
-| GET | `/history/agents/:id` | Detailed agent history including events, tokens, and media |
+| Method | Path                  | Description                                                |
+| ------ | --------------------- | ---------------------------------------------------------- |
+| GET    | `/history/projects`   | List all projects where agents have worked                 |
+| GET    | `/history/agents`     | Paginated agent history with filtering and sorting         |
+| GET    | `/history/agents/:id` | Detailed agent history including events, tokens, and media |
 
 ### `GET /history/agents`
 
@@ -226,11 +226,11 @@ Query params: `project`, `type`, `sort` (`recent` | `oldest`), `limit`, `offset`
 
 ## Notifications
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/notifications/settings` | Get Slack webhook URL and enabled event types |
-| POST | `/notifications/settings` | Update webhook URL and event configuration |
-| POST | `/notifications/test` | Send a test message to the configured webhook |
+| Method | Path                      | Description                                   |
+| ------ | ------------------------- | --------------------------------------------- |
+| GET    | `/notifications/settings` | Get Slack webhook URL and enabled event types |
+| POST   | `/notifications/settings` | Update webhook URL and event configuration    |
+| POST   | `/notifications/test`     | Send a test message to the configured webhook |
 
 ### `POST /notifications/settings`
 
@@ -247,76 +247,76 @@ Query params: `project`, `type`, `sort` (`recent` | `oldest`), `limit`, `offset`
 
 ## Settings
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/agents/settings` | Get agent settings (worktree location) |
-| POST | `/agents/settings` | Update agent settings |
-| GET | `/app/settings/agent-types` | Get enabled agent types |
-| POST | `/app/settings/agent-types` | Set enabled agent types (`claude`, `codex`, `opencode`) |
+| Method | Path                        | Description                                             |
+| ------ | --------------------------- | ------------------------------------------------------- |
+| GET    | `/agents/settings`          | Get agent settings (worktree location)                  |
+| POST   | `/agents/settings`          | Update agent settings                                   |
+| GET    | `/app/settings/agent-types` | Get enabled agent types                                 |
+| POST   | `/app/settings/agent-types` | Set enabled agent types (`claude`, `codex`, `opencode`) |
 
 ## System
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/health` | Database connectivity check |
-| GET | `/app/version` | Current app version |
-| GET | `/app/branding` | App branding info (icon color) |
-| GET | `/system/defaults` | System defaults (home directory) |
-| GET | `/system/path-info` | Path validation (exists, isDirectory, isGitRepo) |
-| GET | `/system/path-completions` | Directory path autocomplete |
-| GET | `/git/branches` | List remote branches for a repo |
-| POST | `/clipboard/image` | Write browser clipboard image to macOS pasteboard |
-| POST | `/energy-report` | Report PWA energy metrics |
-| GET | `/diagnostics/git-context` | Git context refresh diagnostics |
+| Method | Path                       | Description                                       |
+| ------ | -------------------------- | ------------------------------------------------- |
+| GET    | `/health`                  | Database connectivity check                       |
+| GET    | `/app/version`             | Current app version                               |
+| GET    | `/app/branding`            | App branding info (icon color)                    |
+| GET    | `/system/defaults`         | System defaults (home directory)                  |
+| GET    | `/system/path-info`        | Path validation (exists, isDirectory, isGitRepo)  |
+| GET    | `/system/path-completions` | Directory path autocomplete                       |
+| GET    | `/git/branches`            | List remote branches for a repo                   |
+| POST   | `/clipboard/image`         | Write browser clipboard image to macOS pasteboard |
+| POST   | `/energy-report`           | Report PWA energy metrics                         |
+| GET    | `/diagnostics/git-context` | Git context refresh diagnostics                   |
 
 ## Release Management
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/release/status` | Current deployed release tag and timestamp |
-| GET | `/release/info` | Latest available version and unreleased commits |
-| GET | `/release/channel` | Get current release channel (stable or latest) |
-| POST | `/release/channel` | Set release channel |
-| GET | `/release/admin-check` | Check if current instance is a release admin |
-| POST | `/release/promote` | Promote a pre-release to stable (admin only) |
-| GET | `/releases` | List recent GitHub releases |
-| POST | `/release` | Trigger new release (`versionType`: major/minor/patch) |
-| POST | `/release/update` | Update to a specific release tag |
-| GET | `/release/stream` | SSE stream for release operation progress |
+| Method | Path                   | Description                                            |
+| ------ | ---------------------- | ------------------------------------------------------ |
+| GET    | `/release/status`      | Current deployed release tag and timestamp             |
+| GET    | `/release/info`        | Latest available version and unreleased commits        |
+| GET    | `/release/channel`     | Get current release channel (stable or latest)         |
+| POST   | `/release/channel`     | Set release channel                                    |
+| GET    | `/release/admin-check` | Check if current instance is a release admin           |
+| POST   | `/release/promote`     | Promote a pre-release to stable (admin only)           |
+| GET    | `/releases`            | List recent GitHub releases                            |
+| POST   | `/release`             | Trigger new release (`versionType`: major/minor/patch) |
+| POST   | `/release/update`      | Update to a specific release tag                       |
+| GET    | `/release/stream`      | SSE stream for release operation progress              |
 
 ## Jobs
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/jobs` | List all configured jobs |
-| POST | `/jobs` | Create a job |
-| PATCH | `/jobs` | Update a job configuration |
-| DELETE | `/jobs` | Delete a job configuration |
-| POST | `/jobs/enable` | Enable a job (registers cron schedule) |
-| POST | `/jobs/disable` | Disable a job (removes cron schedule) |
-| POST | `/jobs/run` | Manually trigger a job run |
-| GET | `/jobs/stats` | Get job run statistics |
-| GET | `/jobs/history` | Get job run history (filterable by `jobId`, `status`, `limit`, `offset`) |
+| Method | Path            | Description                                                              |
+| ------ | --------------- | ------------------------------------------------------------------------ |
+| GET    | `/jobs`         | List all configured jobs                                                 |
+| POST   | `/jobs`         | Create a job                                                             |
+| PATCH  | `/jobs`         | Update a job configuration                                               |
+| DELETE | `/jobs`         | Delete a job configuration                                               |
+| POST   | `/jobs/enable`  | Enable a job (registers cron schedule)                                   |
+| POST   | `/jobs/disable` | Disable a job (removes cron schedule)                                    |
+| POST   | `/jobs/run`     | Manually trigger a job run                                               |
+| GET    | `/jobs/stats`   | Get job run statistics                                                   |
+| GET    | `/jobs/history` | Get job run history (filterable by `jobId`, `status`, `limit`, `offset`) |
 
 ## MCP (Model Context Protocol)
 
 These endpoints use the `/api/mcp` base path (not `/api/v1`).
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/mcp` | Handle global MCP requests |
-| POST | `/api/mcp/:agentId` | Handle agent-scoped MCP requests with repo context |
-| POST | `/api/mcp/jobs/:runId/:agentId` | Handle job-scoped MCP requests (adds job lifecycle tools) |
+| Method | Path                            | Description                                               |
+| ------ | ------------------------------- | --------------------------------------------------------- |
+| POST   | `/api/mcp`                      | Handle global MCP requests                                |
+| POST   | `/api/mcp/:agentId`             | Handle agent-scoped MCP requests with repo context        |
+| POST   | `/api/mcp/jobs/:runId/:agentId` | Handle job-scoped MCP requests (adds job lifecycle tools) |
 
 Agent-scoped MCP loads repo tools from `.dispatch/tools.json` in the agent's working directory.
 
 ## Error Codes
 
-| Code | Meaning |
-|------|---------|
-| 400 | Invalid request body or parameters |
-| 401 | Not authenticated |
-| 403 | Unauthorized |
-| 404 | Agent or resource not found |
-| 409 | Lifecycle conflict (e.g., starting an already-running agent) |
-| 500 | Internal server error |
+| Code | Meaning                                                      |
+| ---- | ------------------------------------------------------------ |
+| 400  | Invalid request body or parameters                           |
+| 401  | Not authenticated                                            |
+| 403  | Unauthorized                                                 |
+| 404  | Agent or resource not found                                  |
+| 409  | Lifecycle conflict (e.g., starting an already-running agent) |
+| 500  | Internal server error                                        |

--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -13,18 +13,22 @@
 ## State Transitions
 
 1. Create
+
 - `creating -> running`
 - `creating -> error` on launch failure
 
 2. Stop
+
 - `running -> stopping -> stopped`
 - `running -> error` if stop command fails and process remains inconsistent
 
 3. Delete
+
 - `running|stopped -> archiving -> (soft deleted)` via archive phases: `stopping` → `worktree-check` → `worktree-cleanup` → `finalizing`
 - Returns HTTP 202 immediately; cleanup runs in the background
 
 4. Restart backend reconciliation
+
 - `unknown -> running` if tmux session exists
 - `unknown -> stopped` if session absent
 
@@ -81,8 +85,10 @@ tmux kill-session -t <sessionName>
 1. Load agents from DB where status in (`running`, `creating`, `unknown`).
 2. Query tmux sessions.
 3. For each agent:
+
 - session exists -> set `running`
 - session missing -> set `stopped` and clear transient pid/runtime fields
+
 4. Validate simulator reservation consistency.
 
 ## Idempotency Rules

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -67,6 +67,7 @@ curl -X POST http://127.0.0.1:6767/api/v1/release \
 ```
 
 The **release workflow** (GitHub Actions):
+
 - Runs type-check, lint, and build
 - Bumps version in `package.json` and `web/package.json`
 - Commits, creates a git tag, pushes, and publishes a GitHub Release
@@ -82,6 +83,7 @@ curl -X POST http://127.0.0.1:6767/api/v1/release/update \
 ```
 
 The server update flow operates on `~/.dispatch/server/` and:
+
 1. Records the current tag for rollback
 2. Fetches and checks out the target tag
 3. Installs deps, builds, restarts the managed service
@@ -108,6 +110,7 @@ The failure log includes: timestamp, failed step, rollback status, last 50 lines
 ## CI Pipeline
 
 Every PR to `main` triggers `.github/workflows/ci.yml`:
+
 - Type-check (`pnpm run check`)
 - Lint (`pnpm run lint:web`)
 - Build (`pnpm run build`)
@@ -127,6 +130,7 @@ bin/install-launchd --port 6767
 ```
 
 This script:
+
 1. Clones the repo to `~/.dispatch/server/`
 2. Copies `.env` (or `.env.example`) as `~/.dispatch/server/.env`
 3. Sets `DISPATCH_PORT` in the server `.env` if `--port` was specified
@@ -147,16 +151,16 @@ Unloads and removes the plist. Does not remove `~/.dispatch/server/`, the Homebr
 
 Server configuration lives in `~/.dispatch/server/.env`. Key variables:
 
-| Variable | Default | Description |
-|---|---|---|
-| `DISPATCH_HOST` | `127.0.0.1` | Interface to bind the API server to. Set `0.0.0.0` only when the machine must accept remote connections. |
-| `DISPATCH_PORT` | `6767` | HTTP port the server listens on |
-| `DATABASE_URL` | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string |
-| `MEDIA_ROOT` | `~/.dispatch/media` | File upload storage path |
-| `DISPATCH_AGENT_RUNTIME` | `tmux` | Agent runtime mode (`tmux` or `inert` for dev/test) |
-| `DISPATCH_COPY_DISPLAY` | — | Virtual X display for clipboard image paste on Linux (e.g. `:99`) |
-| `TLS_CERT` | — | Path to TLS certificate file (enables HTTPS when both cert and key are set) |
-| `TLS_KEY` | — | Path to TLS private key file |
+| Variable                 | Default                                                | Description                                                                                              |
+| ------------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `DISPATCH_HOST`          | `127.0.0.1`                                            | Interface to bind the API server to. Set `0.0.0.0` only when the machine must accept remote connections. |
+| `DISPATCH_PORT`          | `6767`                                                 | HTTP port the server listens on                                                                          |
+| `DATABASE_URL`           | `postgres://dispatch:dispatch@127.0.0.1:5432/dispatch` | Postgres connection string                                                                               |
+| `MEDIA_ROOT`             | `~/.dispatch/media`                                    | File upload storage path                                                                                 |
+| `DISPATCH_AGENT_RUNTIME` | `tmux`                                                 | Agent runtime mode (`tmux` or `inert` for dev/test)                                                      |
+| `DISPATCH_COPY_DISPLAY`  | —                                                      | Virtual X display for clipboard image paste on Linux (e.g. `:99`)                                        |
+| `TLS_CERT`               | —                                                      | Path to TLS certificate file (enables HTTPS when both cert and key are set)                              |
+| `TLS_KEY`                | —                                                      | Path to TLS private key file                                                                             |
 
 Changes to `.env` require a service restart to take effect.
 
@@ -288,12 +292,12 @@ Known limits:
 
 ## File Locations
 
-| Path | Description |
-|---|---|
-| `~/.dispatch/server/` | Server checkout (deploy target) |
-| `~/.dispatch/server/.env` | Server environment config |
-| `~/.dispatch/logs/dispatch.log` | Live server log |
-| `~/.dispatch/logs/last-release-failure.log` | Last deploy failure details |
-| `~/.dispatch/diagnostics/tmux-inventory.jsonl` | Periodic tmux inventory snapshots from reconcile |
-| `~/.dispatch/diagnostics/*-missing-session-<agentId>.json` | Incident bundle for missing tmux sessions |
-| `~/Library/LaunchAgents/com.dispatch.server.plist` | launchd service definition |
+| Path                                                       | Description                                      |
+| ---------------------------------------------------------- | ------------------------------------------------ |
+| `~/.dispatch/server/`                                      | Server checkout (deploy target)                  |
+| `~/.dispatch/server/.env`                                  | Server environment config                        |
+| `~/.dispatch/logs/dispatch.log`                            | Live server log                                  |
+| `~/.dispatch/logs/last-release-failure.log`                | Last deploy failure details                      |
+| `~/.dispatch/diagnostics/tmux-inventory.jsonl`             | Periodic tmux inventory snapshots from reconcile |
+| `~/.dispatch/diagnostics/*-missing-session-<agentId>.json` | Incident bundle for missing tmux sessions        |
+| `~/Library/LaunchAgents/com.dispatch.server.plist`         | launchd service definition                       |

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -6,24 +6,24 @@ Instructions for setting up Dispatch on a fresh Mac (e.g. Mac Studio, Mac mini) 
 
 The new machine needs:
 
-| Dependency | Purpose | Install |
-|---|---|---|
-| **Xcode CLI Tools** | Build tools for native npm modules (node-pty) | `xcode-select --install` |
-| **Homebrew** | Package manager | https://brew.sh |
-| **NVM** | Node version manager (Dispatch requires Node 22 LTS+) | `brew install nvm` or https://github.com/nvm-sh/nvm |
-| **PostgreSQL 17** | Database (via Homebrew, native — no Docker needed) | `brew install postgresql@17` |
-| **tmux** | Agent session management | `brew install tmux` |
-| **Git** | Source control | Included with Xcode CLI Tools |
-| **GitHub CLI** | Release automation | `brew install gh` |
-| **At least one agent CLI** | Agent runtime — install any you plan to use | See [Agent CLIs](#8-agent-clis) |
-| **Playwright browsers** | Headless Chrome for agent UI validation | `npx playwright install chromium` |
+| Dependency                 | Purpose                                               | Install                                             |
+| -------------------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| **Xcode CLI Tools**        | Build tools for native npm modules (node-pty)         | `xcode-select --install`                            |
+| **Homebrew**               | Package manager                                       | https://brew.sh                                     |
+| **NVM**                    | Node version manager (Dispatch requires Node 22 LTS+) | `brew install nvm` or https://github.com/nvm-sh/nvm |
+| **PostgreSQL 17**          | Database (via Homebrew, native — no Docker needed)    | `brew install postgresql@17`                        |
+| **tmux**                   | Agent session management                              | `brew install tmux`                                 |
+| **Git**                    | Source control                                        | Included with Xcode CLI Tools                       |
+| **GitHub CLI**             | Release automation                                    | `brew install gh`                                   |
+| **At least one agent CLI** | Agent runtime — install any you plan to use           | See [Agent CLIs](#8-agent-clis)                     |
+| **Playwright browsers**    | Headless Chrome for agent UI validation               | `npx playwright install chromium`                   |
 
 ### Optional
 
-| Dependency | Purpose | Install |
-|---|---|---|
+| Dependency         | Purpose                                   | Install                      |
+| ------------------ | ----------------------------------------- | ---------------------------- |
 | **Docker Desktop** | Isolated dev databases via docker-compose | `brew install --cask docker` |
-| **Xcode** (full) | iOS Simulator, `xcrun simctl` | App Store |
+| **Xcode** (full)   | iOS Simulator, `xcrun simctl`             | App Store                    |
 
 ## Agent Setup Prompt
 
@@ -141,6 +141,7 @@ bin/install-launchd --port 6767
 ```
 
 This:
+
 - Clones the repo to `~/.dispatch/server/` (separate checkout for production)
 - Copies your `.env` to `~/.dispatch/server/.env`
 - Builds the project
@@ -249,17 +250,17 @@ Updates include automatic rollback on health check failure.
 
 ## Key Paths Reference
 
-| Path | Purpose |
-|---|---|
-| `~/dev/apps/dispatch/` | Development checkout |
-| `~/.dispatch/server/` | Production checkout (managed by deploy scripts) |
-| `~/.dispatch/server/.env` | Production environment config |
-| `~/.dispatch/logs/dispatch.log` | Server stdout/stderr |
-| `~/.dispatch/logs/last-release-failure.log` | Deploy failure details |
-| `~/.dispatch/release.json` | Current release metadata |
-| `~/Library/LaunchAgents/com.dispatch.server.plist` | launchd service definition |
-| `~/.dispatch/media/` | Agent media storage (default) |
-| `~/.dispatch/env` | Agent session environment (sourced on every agent launch) |
+| Path                                               | Purpose                                                   |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| `~/dev/apps/dispatch/`                             | Development checkout                                      |
+| `~/.dispatch/server/`                              | Production checkout (managed by deploy scripts)           |
+| `~/.dispatch/server/.env`                          | Production environment config                             |
+| `~/.dispatch/logs/dispatch.log`                    | Server stdout/stderr                                      |
+| `~/.dispatch/logs/last-release-failure.log`        | Deploy failure details                                    |
+| `~/.dispatch/release.json`                         | Current release metadata                                  |
+| `~/Library/LaunchAgents/com.dispatch.server.plist` | launchd service definition                                |
+| `~/.dispatch/media/`                               | Agent media storage (default)                             |
+| `~/.dispatch/env`                                  | Agent session environment (sourced on every agent launch) |
 
 ### Agent environment (`~/.dispatch/env`)
 
@@ -277,12 +278,14 @@ export GH_TOKEN="ghp_..."
 ## Troubleshooting
 
 ### Server won't start
+
 ```bash
 tail -50 ~/.dispatch/logs/dispatch.log
 launchctl list com.dispatch.server   # Check exit code
 ```
 
 ### Database connection errors
+
 ```bash
 pg_isready                           # Is postgres running?
 brew services start postgresql@17    # Start it
@@ -290,12 +293,14 @@ tail -20 /opt/homebrew/var/log/postgresql@17.log  # Check logs
 ```
 
 ### node-pty build failures
+
 ```bash
 xcode-select --install               # Ensure CLI tools
 npm rebuild node-pty                  # Rebuild native module
 ```
 
 ### Agent can't use dispatch_event/dispatch_share MCP tools
+
 These tools are served via the Dispatch MCP server at `/api/mcp/:agentId`. They are available automatically to agents launched by Dispatch — no PATH or bin directory needed. If the tools are missing, verify that the Dispatch server is running and the agent's MCP config points to the correct URL.
 
 ---

--- a/docs/14-theming.md
+++ b/docs/14-theming.md
@@ -20,46 +20,46 @@ All theme colors live in `apps/web/src/index.css`. The default theme is defined 
 
 These are the standard shadcn tokens. Every theme must define all of them:
 
-| Variable | Purpose |
-|---|---|
-| `--background` | Page background |
-| `--foreground` | Default text color |
-| `--card` / `--card-foreground` | Card surfaces |
-| `--popover` / `--popover-foreground` | Popover/dropdown surfaces |
-| `--primary` / `--primary-foreground` | Primary action color (buttons, links) |
-| `--muted` / `--muted-foreground` | Muted/secondary surfaces and text |
-| `--accent` / `--accent-foreground` | Accent highlight |
-| `--destructive` / `--destructive-foreground` | Destructive/error actions |
-| `--border` | Border color |
-| `--input` | Input field border |
-| `--ring` | Focus ring color |
+| Variable                                     | Purpose                               |
+| -------------------------------------------- | ------------------------------------- |
+| `--background`                               | Page background                       |
+| `--foreground`                               | Default text color                    |
+| `--card` / `--card-foreground`               | Card surfaces                         |
+| `--popover` / `--popover-foreground`         | Popover/dropdown surfaces             |
+| `--primary` / `--primary-foreground`         | Primary action color (buttons, links) |
+| `--muted` / `--muted-foreground`             | Muted/secondary surfaces and text     |
+| `--accent` / `--accent-foreground`           | Accent highlight                      |
+| `--destructive` / `--destructive-foreground` | Destructive/error actions             |
+| `--border`                                   | Border color                          |
+| `--input`                                    | Input field border                    |
+| `--ring`                                     | Focus ring color                      |
 
 ### Status tokens
 
 These control agent state indicators, badges, buttons, and status dots throughout the UI:
 
-| Variable | Purpose | Default theme | Example usage |
-|---|---|---|---|
-| `--status-working` | Active/success state | Emerald | Agent working indicator, "running" badge, service OK dot |
-| `--status-blocked` | Error/blocked state | Red | Agent blocked, error badge, live stream indicator |
-| `--status-waiting` | Warning/pending state | Amber | Waiting for user, reconnect indicator, full-access warning |
-| `--status-done` | Info/complete state | Sky blue | Agent done, transitional badge, info buttons |
-| `--status-idle` | Neutral/idle state | Zinc gray | Idle agent border |
+| Variable           | Purpose               | Default theme | Example usage                                              |
+| ------------------ | --------------------- | ------------- | ---------------------------------------------------------- |
+| `--status-working` | Active/success state  | Emerald       | Agent working indicator, "running" badge, service OK dot   |
+| `--status-blocked` | Error/blocked state   | Red           | Agent blocked, error badge, live stream indicator          |
+| `--status-waiting` | Warning/pending state | Amber         | Waiting for user, reconnect indicator, full-access warning |
+| `--status-done`    | Info/complete state   | Sky blue      | Agent done, transitional badge, info buttons               |
+| `--status-idle`    | Neutral/idle state    | Zinc gray     | Idle agent border                                          |
 
 ### Surface tokens
 
-| Variable | Purpose |
-|---|---|
-| `--surface` | Header, footer, and toolbar background (slightly darker than `--background`) |
-| `--terminal-bg` | Terminal pane and xterm background |
+| Variable        | Purpose                                                                      |
+| --------------- | ---------------------------------------------------------------------------- |
+| `--surface`     | Header, footer, and toolbar background (slightly darker than `--background`) |
+| `--terminal-bg` | Terminal pane and xterm background                                           |
 
 ### Value format
 
 All values use **bare HSL components** without the `hsl()` wrapper — this allows Tailwind's opacity modifier syntax to work:
 
 ```css
---status-working: 158 64% 52%;   /* ✓ correct */
---status-working: hsl(158, 64%, 52%);  /* ✗ wrong — breaks Tailwind opacity */
+--status-working: 158 64% 52%; /* ✓ correct */
+--status-working: hsl(158, 64%, 52%); /* ✗ wrong — breaks Tailwind opacity */
 ```
 
 ## Tailwind integration
@@ -176,10 +176,10 @@ That's it — the theme picker, localStorage persistence, flash-free loading, an
 
 ## File reference
 
-| File | What to edit |
-|---|---|
-| `apps/web/src/index.css` | Add `[data-theme="..."]` CSS variable block |
-| `apps/web/src/hooks/use-theme.ts` | Add to `ThemeId` type and `THEMES` array |
-| `apps/web/tailwind.config.ts` | Only if adding new semantic color tokens (rarely needed) |
-| `apps/web/src/components/app/settings-pane.tsx` | Only if changing the picker UI itself |
-| `apps/web/index.html` | Only if changing the flash-prevention script |
+| File                                            | What to edit                                             |
+| ----------------------------------------------- | -------------------------------------------------------- |
+| `apps/web/src/index.css`                        | Add `[data-theme="..."]` CSS variable block              |
+| `apps/web/src/hooks/use-theme.ts`               | Add to `ThemeId` type and `THEMES` array                 |
+| `apps/web/tailwind.config.ts`                   | Only if adding new semantic color tokens (rarely needed) |
+| `apps/web/src/components/app/settings-pane.tsx` | Only if changing the picker UI itself                    |
+| `apps/web/index.html`                           | Only if changing the flash-prevention script             |

--- a/docs/15-personas-and-feedback.md
+++ b/docs/15-personas-and-feedback.md
@@ -44,18 +44,18 @@ a finding with appropriate severity, file path, and suggestion.
 
 ### Frontmatter Fields
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Display name shown in the UI |
-| `description` | Yes | Short description of the persona's purpose |
-| `feedbackFormat` | No | Hint for feedback structure (default: `findings`) |
+| Field            | Required | Description                                       |
+| ---------------- | -------- | ------------------------------------------------- |
+| `name`           | Yes      | Display name shown in the UI                      |
+| `description`    | Yes      | Short description of the persona's purpose        |
+| `feedbackFormat` | No       | Hint for feedback structure (default: `findings`) |
 
 ### Template Placeholders
 
-| Placeholder | Replaced With |
-|-------------|---------------|
-| `{{context}}` | The context briefing provided by the caller |
-| `{{diff}}` | Git diff of the current branch vs the base branch |
+| Placeholder   | Replaced With                                     |
+| ------------- | ------------------------------------------------- |
+| `{{context}}` | The context briefing provided by the caller       |
+| `{{diff}}`    | Git diff of the current branch vs the base branch |
 
 ## Feedback System
 
@@ -76,26 +76,26 @@ Agents submit findings via the `dispatch_feedback` MCP tool:
 
 ### Feedback Fields
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `severity` | No | `critical`, `high`, `medium`, `low`, or `info` (default: `info`) |
-| `filePath` | No | File path relative to repo root |
-| `lineNumber` | No | Line number in the file |
-| `description` | Yes | What was found — the issue or observation |
-| `suggestion` | No | Suggested fix or action |
-| `mediaRef` | No | Filename of previously shared media to attach |
+| Field         | Required | Description                                                      |
+| ------------- | -------- | ---------------------------------------------------------------- |
+| `severity`    | No       | `critical`, `high`, `medium`, `low`, or `info` (default: `info`) |
+| `filePath`    | No       | File path relative to repo root                                  |
+| `lineNumber`  | No       | Line number in the file                                          |
+| `description` | Yes      | What was found — the issue or observation                        |
+| `suggestion`  | No       | Suggested fix or action                                          |
+| `mediaRef`    | No       | Filename of previously shared media to attach                    |
 
 ### Feedback Status
 
 Each finding has a status that can be updated from the UI:
 
-| Status | Meaning |
-|--------|---------|
-| `open` | New finding, not yet reviewed |
-| `fixed` | Issue has been addressed |
+| Status      | Meaning                            |
+| ----------- | ---------------------------------- |
+| `open`      | New finding, not yet reviewed      |
+| `fixed`     | Issue has been addressed           |
 | `dismissed` | Finding was reviewed and dismissed |
-| `forwarded` | Sent to another agent or process |
-| `ignored` | Intentionally not addressing |
+| `forwarded` | Sent to another agent or process   |
+| `ignored`   | Intentionally not addressing       |
 
 ### Viewing Feedback
 
@@ -105,8 +105,8 @@ Each finding has a status that can be updated from the UI:
 
 ## API Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/v1/personas` | List available personas (requires `cwd` query param) |
-| GET | `/api/v1/agents/:id/feedback` | Get feedback for an agent (`scope=children` for child feedback) |
-| PATCH | `/api/v1/agents/:id/feedback/:feedbackId` | Update feedback status |
+| Method | Path                                      | Description                                                     |
+| ------ | ----------------------------------------- | --------------------------------------------------------------- |
+| GET    | `/api/v1/personas`                        | List available personas (requires `cwd` query param)            |
+| GET    | `/api/v1/agents/:id/feedback`             | Get feedback for an agent (`scope=children` for child feedback) |
+| PATCH  | `/api/v1/agents/:id/feedback/:feedbackId` | Update feedback status                                          |

--- a/docs/16-notifications.md
+++ b/docs/16-notifications.md
@@ -15,11 +15,11 @@ Dispatch sends Slack notifications when agents need attention, so you don't have
 
 You can enable or disable notifications for each event type:
 
-| Event | Default | Description |
-|-------|---------|-------------|
-| `done` | Enabled | Agent finished its task |
-| `waiting_user` | Enabled | Agent needs your input or a decision |
-| `blocked` | Disabled | Agent hit an error it can't resolve |
+| Event          | Default  | Description                          |
+| -------------- | -------- | ------------------------------------ |
+| `done`         | Enabled  | Agent finished its task              |
+| `waiting_user` | Enabled  | Agent needs your input or a decision |
+| `blocked`      | Disabled | Agent hit an error it can't resolve  |
 
 ## Focus-Aware Suppression
 
@@ -30,17 +30,18 @@ Focus tracking uses a 30-second TTL. If you switch away from an agent for more t
 ## Message Format
 
 Slack messages include:
+
 - Agent name and status emoji (green for done, yellow for waiting, red for blocked)
 - The event message from the agent
 - Color-coded attachment matching the event type
 
 ## API Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/v1/notifications/settings` | Get webhook URL and enabled events |
-| POST | `/api/v1/notifications/settings` | Update webhook URL and event config |
-| POST | `/api/v1/notifications/test` | Send test message to configured webhook |
+| Method | Path                             | Description                             |
+| ------ | -------------------------------- | --------------------------------------- |
+| GET    | `/api/v1/notifications/settings` | Get webhook URL and enabled events      |
+| POST   | `/api/v1/notifications/settings` | Update webhook URL and event config     |
+| POST   | `/api/v1/notifications/test`     | Send test message to configured webhook |
 
 ### `POST /api/v1/notifications/settings`
 

--- a/e2e/activity-range.spec.ts
+++ b/e2e/activity-range.spec.ts
@@ -1,14 +1,24 @@
 import { test, expect } from "@playwright/test";
 import { loadApp, seedActivityDemoViaDB } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
-function activityParams(opts: { daysBack?: number; granularity?: string } = {}): string {
+function activityParams(
+  opts: { daysBack?: number; granularity?: string } = {}
+): string {
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const now = new Date();
-  const params = new URLSearchParams({ tz, granularity: opts.granularity ?? "day" });
+  const params = new URLSearchParams({
+    tz,
+    granularity: opts.granularity ?? "day",
+  });
   if (opts.daysBack !== undefined) {
-    params.set("start", new Date(now.getTime() - opts.daysBack * 86400000).toISOString());
+    params.set(
+      "start",
+      new Date(now.getTime() - opts.daysBack * 86400000).toISOString()
+    );
     params.set("end", now.toISOString());
   }
   return params.toString();
@@ -22,9 +32,12 @@ test.describe("Activity range API", () => {
       { granularity: "month" }, // no start = all time
     ];
     for (const tc of testCases) {
-      const res = await request.get(`/api/v1/activity/stats?${activityParams(tc)}`, {
-        headers: authHeader,
-      });
+      const res = await request.get(
+        `/api/v1/activity/stats?${activityParams(tc)}`,
+        {
+          headers: authHeader,
+        }
+      );
       expect(res.ok()).toBeTruthy();
 
       const body = (await res.json()) as {
@@ -36,11 +49,15 @@ test.describe("Activity range API", () => {
       expect(typeof body.totalWorkingMs).toBe("number");
       expect(typeof body.avgBlockedMs).toBe("number");
       expect(typeof body.avgWaitingMs).toBe("number");
-      expect(body.busiestDay === null || typeof body.busiestDay === "string").toBe(true);
+      expect(
+        body.busiestDay === null || typeof body.busiestDay === "string"
+      ).toBe(true);
     }
   });
 
-  test("daily-status endpoint returns matching granularity", async ({ request }) => {
+  test("daily-status endpoint returns matching granularity", async ({
+    request,
+  }) => {
     const testCases = [
       { daysBack: 7, granularity: "day" },
       { daysBack: 30, granularity: "day" },
@@ -54,7 +71,10 @@ test.describe("Activity range API", () => {
       );
       expect(res.ok()).toBeTruthy();
 
-      const body = (await res.json()) as { days: unknown[]; granularity: string };
+      const body = (await res.json()) as {
+        days: unknown[];
+        granularity: string;
+      };
       expect(Array.isArray(body.days)).toBe(true);
       expect(body.granularity).toBe(tc.granularity);
     }
@@ -69,14 +89,20 @@ test.describe("Activity range API", () => {
     );
     expect(res.ok()).toBeTruthy();
 
-    const body = (await res.json()) as { events: Array<{ created_at: string }> };
+    const body = (await res.json()) as {
+      events: Array<{ created_at: string }>;
+    };
     expect(body.events.length).toBeGreaterThan(0);
-    expect(body.events.every((event) => typeof event.created_at === "string")).toBe(true);
+    expect(
+      body.events.every((event) => typeof event.created_at === "string")
+    ).toBe(true);
   });
 });
 
 test.describe("Active hours UI", () => {
-  test("activity pane renders the active-hours heatmap with seeded data", async ({ page }) => {
+  test("activity pane renders the active-hours heatmap with seeded data", async ({
+    page,
+  }) => {
     await seedActivityDemoViaDB();
     await loadApp(page);
 
@@ -86,6 +112,10 @@ test.describe("Active hours UI", () => {
 
     await page.getByTestId("activity-range-select").click();
     await page.getByRole("option", { name: "Last 30 days" }).click();
-    await expect(page.getByText("Average active-state events per week by weekday and hour for last 30 days.")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Average active-state events per week by weekday and hour for last 30 days."
+      )
+    ).toBeVisible();
   });
 });

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -1,25 +1,38 @@
 import { test, expect } from "@playwright/test";
 import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
 
-const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 test.describe("Agent CRUD", () => {
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);
   });
 
-  test("displays 'No agents yet' when the list is empty", async ({ page, request }) => {
+  test("displays 'No agents yet' when the list is empty", async ({
+    page,
+    request,
+  }) => {
     // Stop and delete only e2e-prefixed agents (never touch real agents)
-    const listRes = await request.get("/api/v1/agents", { headers: AUTH_HEADER });
-    const { agents } = (await listRes.json()) as { agents: Array<{ id: string; name: string; status: string }> };
+    const listRes = await request.get("/api/v1/agents", {
+      headers: AUTH_HEADER,
+    });
+    const { agents } = (await listRes.json()) as {
+      agents: Array<{ id: string; name: string; status: string }>;
+    };
     const e2eAgents = agents.filter((a) => a.name.startsWith("e2e-agent-"));
     for (const agent of e2eAgents) {
       if (agent.status !== "stopped") {
-        await request.post(`/api/v1/agents/${agent.id}/stop`, { headers: AUTH_HEADER });
+        await request.post(`/api/v1/agents/${agent.id}/stop`, {
+          headers: AUTH_HEADER,
+        });
       }
     }
     for (const agent of e2eAgents) {
-      await request.delete(`/api/v1/agents/${agent.id}`, { headers: AUTH_HEADER });
+      await request.delete(`/api/v1/agents/${agent.id}`, {
+        headers: AUTH_HEADER,
+      });
     }
 
     // Skip empty-state assertion if non-e2e agents remain
@@ -31,8 +44,12 @@ test.describe("Agent CRUD", () => {
     // Load page fresh — SSE snapshot should now be empty
     await loadApp(page);
 
-    await expect(page.getByTestId("no-agents-message")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("no-agents-message")).toHaveText("No agents yet.");
+    await expect(page.getByTestId("no-agents-message")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("no-agents-message")).toHaveText(
+      "No agents yet."
+    );
   });
 
   test("create agent via UI — dialog opens, submits, and agent appears in sidebar", async ({
@@ -61,8 +78,12 @@ test.describe("Agent CRUD", () => {
     // Agent should appear in the sidebar
     const sidebar = page.getByTestId("agent-sidebar");
     await expect(sidebar.getByText(agentName)).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("terminal-inert-state")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("terminal-inert-state")).toContainText("Agent running in inert mode");
+    await expect(page.getByTestId("terminal-inert-state")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("terminal-inert-state")).toContainText(
+      "Agent running in inert mode"
+    );
   });
 
   test("create dialog shows autonomous review checkbox that can be toggled", async ({
@@ -90,7 +111,9 @@ test.describe("Agent CRUD", () => {
   });
 
   test("POST /api/v1/agents accepts autoReview flag", async ({ request }) => {
-    const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+    const AUTH_HEADER = {
+      Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+    };
     const agentName = `e2e-agent-${Date.now()}`;
 
     const res = await request.post("/api/v1/agents", {
@@ -103,12 +126,18 @@ test.describe("Agent CRUD", () => {
       },
     });
     expect(res.status()).toBe(201);
-    const { agent } = (await res.json()) as { agent: { id: string; autoReview: boolean } };
+    const { agent } = (await res.json()) as {
+      agent: { id: string; autoReview: boolean };
+    };
     expect(agent.autoReview).toBe(true);
   });
 
-  test("POST /api/v1/agents defaults autoReview to false when omitted", async ({ request }) => {
-    const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+  test("POST /api/v1/agents defaults autoReview to false when omitted", async ({
+    request,
+  }) => {
+    const AUTH_HEADER = {
+      Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+    };
 
     const res = await request.post("/api/v1/agents", {
       headers: AUTH_HEADER,
@@ -119,11 +148,15 @@ test.describe("Agent CRUD", () => {
       },
     });
     expect(res.status()).toBe(201);
-    const { agent } = (await res.json()) as { agent: { id: string; autoReview: boolean } };
+    const { agent } = (await res.json()) as {
+      agent: { id: string; autoReview: boolean };
+    };
     expect(agent.autoReview).toBe(false);
   });
 
-  test("POST /api/v1/agents rejects non-boolean autoReview", async ({ request }) => {
+  test("POST /api/v1/agents rejects non-boolean autoReview", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents", {
       headers: AUTH_HEADER,
       data: {
@@ -139,7 +172,9 @@ test.describe("Agent CRUD", () => {
     });
   });
 
-  test("POST /api/v1/agents rejects oversized initialPrompt", async ({ request }) => {
+  test("POST /api/v1/agents rejects oversized initialPrompt", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents", {
       headers: AUTH_HEADER,
       data: {
@@ -172,7 +207,9 @@ test.describe("Agent CRUD", () => {
   }) => {
     await loadApp(page);
 
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+    });
 
     // SSE should push the new agent to the UI
     const sidebar = page.getByTestId("agent-sidebar");
@@ -183,13 +220,17 @@ test.describe("Agent CRUD", () => {
     page,
     request,
   }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+    });
     await loadApp(page);
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await page.getByTestId(`agent-expand-toggle-${agent.id}`).click();
 
-    await expect(agentCard.getByText("Working dir")).toBeVisible({ timeout: 3_000 });
+    await expect(agentCard.getByText("Working dir")).toBeVisible({
+      timeout: 3_000,
+    });
     await expect(agentCard.getByText("/tmp")).toBeVisible();
     await expect(page.getByTestId("terminal-empty-state")).toBeVisible();
   });
@@ -198,11 +239,19 @@ test.describe("Agent CRUD", () => {
     page,
     request,
   }) => {
-    const attachedAgent = await createAgentViaAPI(request, { name: `e2e-agent-attached-${Date.now()}` });
-    const peekAgent = await createAgentViaAPI(request, { name: `e2e-agent-peek-${Date.now()}` });
+    const attachedAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-attached-${Date.now()}`,
+    });
+    const peekAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-peek-${Date.now()}`,
+    });
 
-    await request.post(`/api/v1/agents/${attachedAgent.id}/start`, { headers: AUTH_HEADER });
-    await request.post(`/api/v1/agents/${peekAgent.id}/start`, { headers: AUTH_HEADER });
+    await request.post(`/api/v1/agents/${attachedAgent.id}/start`, {
+      headers: AUTH_HEADER,
+    });
+    await request.post(`/api/v1/agents/${peekAgent.id}/start`, {
+      headers: AUTH_HEADER,
+    });
 
     await loadApp(page);
 
@@ -210,7 +259,9 @@ test.describe("Agent CRUD", () => {
     const peekCard = page.getByTestId(`agent-card-${peekAgent.id}`);
 
     await page.getByTestId(`agent-row-${attachedAgent.id}`).click();
-    await expect(attachedCard.getByText("Working dir")).toBeVisible({ timeout: 5_000 });
+    await expect(attachedCard.getByText("Working dir")).toBeVisible({
+      timeout: 5_000,
+    });
 
     await page.getByTestId(`agent-expand-toggle-${peekAgent.id}`).click();
 
@@ -222,7 +273,9 @@ test.describe("Agent CRUD", () => {
     page,
     request,
   }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+    });
     await loadApp(page);
 
     const sidebar = page.getByTestId("agent-sidebar");
@@ -236,28 +289,38 @@ test.describe("Agent CRUD", () => {
     await page.getByTestId("delete-agent-confirm").click();
 
     // Agent should disappear from sidebar
-    await expect(sidebar.getByText(agent.name)).not.toBeVisible({ timeout: 5_000 });
+    await expect(sidebar.getByText(agent.name)).not.toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("archiving the selected attached agent resets the terminal to empty state", async ({
     page,
     request,
   }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+    });
     await loadApp(page);
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
     await expect(agentCard).toBeVisible({ timeout: 5_000 });
 
     await page.getByTestId(`agent-row-${agent.id}`).click();
-    await expect(agentCard.getByText("Working dir")).toBeVisible({ timeout: 5_000 });
+    await expect(agentCard.getByText("Working dir")).toBeVisible({
+      timeout: 5_000,
+    });
 
     await page.getByTestId(`agent-archive-${agent.id}`).click();
     await page.getByTestId("delete-agent-confirm").click();
 
     await expect(agentCard).not.toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("terminal-empty-state")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("terminal-empty-state")).toContainText("Tap an agent row to focus it.");
+    await expect(page.getByTestId("terminal-empty-state")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("terminal-empty-state")).toContainText(
+      "Tap an agent row to focus it."
+    );
     await expect(page.getByTestId("terminal-inert-state")).not.toBeVisible();
   });
 });

--- a/e2e/api-health.spec.ts
+++ b/e2e/api-health.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 test.describe("API health", () => {
   test("GET /api/v1/health returns ok", async ({ request }) => {

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -6,7 +6,9 @@ test.describe("App shell", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("renders the main layout without dedicated header or footer chrome", async ({ page }) => {
+  test("renders the main layout without dedicated header or footer chrome", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await expect(page.getByTestId("agent-sidebar")).toBeVisible();
@@ -15,7 +17,9 @@ test.describe("App shell", () => {
     await expect(page.getByTestId("app-header")).toHaveCount(0);
   });
 
-  test("shows the empty-state prompt when no agent is selected", async ({ page }) => {
+  test("shows the empty-state prompt when no agent is selected", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await expect(page.getByTestId("terminal-empty-state")).toBeVisible();
@@ -45,7 +49,9 @@ test.describe("App shell", () => {
   test("sidebar shows the Dispatch logo", async ({ page }) => {
     await loadApp(page);
 
-    const title = page.getByTestId("sidebar-shell").getByText("Dispatch", { exact: true });
+    const title = page
+      .getByTestId("sidebar-shell")
+      .getByText("Dispatch", { exact: true });
     await expect(title).toBeVisible();
   });
 });

--- a/e2e/base-branch.spec.ts
+++ b/e2e/base-branch.spec.ts
@@ -3,7 +3,9 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 /**
  * Helper to call the MCP tools/list endpoint for an agent and extract
@@ -30,7 +32,9 @@ async function getCreatePrBaseBranchDefault(
   const dataLine = text.split("\n").find((l) => l.startsWith("data: "));
   if (!dataLine) return undefined;
   const json = JSON.parse(dataLine.slice("data: ".length));
-  const createPr = json.result?.tools?.find((t: { name: string }) => t.name === "create_pr");
+  const createPr = json.result?.tools?.find(
+    (t: { name: string }) => t.name === "create_pr"
+  );
   return createPr?.inputSchema?.properties?.baseBranch?.default;
 }
 
@@ -43,10 +47,13 @@ function createTestRepo(suffix: string): string {
   mkdirSync(barePath, { recursive: true });
   execSync("git init --bare", { cwd: barePath, stdio: "ignore" });
   execSync(`git clone "${barePath}" "${repoPath}"`, { stdio: "ignore" });
-  execSync('git config user.email "test@test.com" && git config user.name "Test"', {
-    cwd: repoPath,
-    stdio: "ignore",
-  });
+  execSync(
+    'git config user.email "test@test.com" && git config user.name "Test"',
+    {
+      cwd: repoPath,
+      stdio: "ignore",
+    }
+  );
   writeFileSync(`${repoPath}/README.md`, "# test\n");
   execSync("git add -A && git commit -m 'initial' && git push origin main", {
     cwd: repoPath,
@@ -59,12 +66,18 @@ function createTestRepo(suffix: string): string {
 function cleanupTestRepo(repoPath: string): void {
   const barePath = repoPath.replace("-repo-", "-bare-");
   try {
-    const output = execSync("git worktree list --porcelain", { cwd: repoPath, encoding: "utf-8" });
+    const output = execSync("git worktree list --porcelain", {
+      cwd: repoPath,
+      encoding: "utf-8",
+    });
     for (const line of output.split("\n")) {
       if (line.startsWith("worktree ") && !line.includes(repoPath)) {
         const wtPath = line.replace("worktree ", "").trim();
         try {
-          execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoPath, stdio: "ignore" });
+          execSync(`git worktree remove --force "${wtPath}"`, {
+            cwd: repoPath,
+            stdio: "ignore",
+          });
         } catch {
           rmSync(wtPath, { recursive: true, force: true });
         }
@@ -103,7 +116,9 @@ test.describe("Agent base branch", () => {
     expect(body.agent.baseBranch).toBe("feature/foo");
   });
 
-  test("POST /api/v1/agents defaults baseBranch to null", async ({ request }) => {
+  test("POST /api/v1/agents defaults baseBranch to null", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents", {
       headers: authHeader,
       data: { cwd: "/tmp", useWorktree: false },
@@ -122,26 +137,48 @@ test.describe("Agent base branch", () => {
     expect(body.error).toContain("baseBranch");
   });
 
-  test("create_pr MCP tool defaults baseBranch from agent metadata", async ({ request }) => {
+  test("create_pr MCP tool defaults baseBranch from agent metadata", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents", {
       headers: authHeader,
-      data: { cwd: "/tmp", baseBranch: "develop", useWorktree: false, name: `e2e-agent-${Date.now()}` },
+      data: {
+        cwd: "/tmp",
+        baseBranch: "develop",
+        useWorktree: false,
+        name: `e2e-agent-${Date.now()}`,
+      },
     });
-    const body = (await res.json()) as { agent: { id: string; baseBranch: string | null } };
+    const body = (await res.json()) as {
+      agent: { id: string; baseBranch: string | null };
+    };
     expect(body.agent.baseBranch).toBe("develop");
 
-    const baseBranchDefault = await getCreatePrBaseBranchDefault(request, body.agent.id);
+    const baseBranchDefault = await getCreatePrBaseBranchDefault(
+      request,
+      body.agent.id
+    );
     expect(baseBranchDefault).toBe("develop");
   });
 
-  test("create_pr MCP tool defaults to main when agent has no baseBranch", async ({ request }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-${Date.now()}` });
+  test("create_pr MCP tool defaults to main when agent has no baseBranch", async ({
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+    });
 
-    const baseBranchDefault = await getCreatePrBaseBranchDefault(request, agent.id);
+    const baseBranchDefault = await getCreatePrBaseBranchDefault(
+      request,
+      agent.id
+    );
     expect(baseBranchDefault).toBe("main");
   });
 
-  test("sidebar details show main when a worktree agent has no baseBranch", async ({ page, request }) => {
+  test("sidebar details show main when a worktree agent has no baseBranch", async ({
+    page,
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
       cwd: repoPath,
@@ -157,6 +194,8 @@ test.describe("Agent base branch", () => {
 
     await expect(agentCard.getByText("Branch")).toBeVisible({ timeout: 5_000 });
     await expect(agentCard.getByText("main", { exact: true })).toBeVisible();
-    await expect(agentCard.getByText(agent.worktreeBranch!, { exact: true })).toBeVisible();
+    await expect(
+      agentCard.getByText(agent.worktreeBranch!, { exact: true })
+    ).toBeVisible();
   });
 });

--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from "@playwright/test";
 import { loadApp } from "./helpers";
 
 test.describe("Create agent dialog", () => {
-  test("defaults the working directory to a non-empty value", async ({ page }) => {
+  test("defaults the working directory to a non-empty value", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await page.getByTestId("create-agent-button").click();
@@ -31,7 +33,9 @@ test.describe("Create agent dialog", () => {
     // The dropdown options should be visible
     const claudeOption = page.getByRole("option", { name: "Claude" });
     await expect(claudeOption).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByRole("option", { name: "OpenCode" })).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByRole("option", { name: "OpenCode" })).toBeVisible({
+      timeout: 3_000,
+    });
 
     // Select "Claude"
     await claudeOption.click();
@@ -44,7 +48,9 @@ test.describe("Create agent dialog", () => {
     await expect(form).not.toBeVisible({ timeout: 3_000 });
   });
 
-  test("recent directories remain visible while typing a new path", async ({ page }) => {
+  test("recent directories remain visible while typing a new path", async ({
+    page,
+  }) => {
     await page.addInitScript(() => {
       window.localStorage.setItem(
         "dispatch:cwdHistory",
@@ -62,8 +68,12 @@ test.describe("Create agent dialog", () => {
     await cwdInput.fill("/brand/new/path");
     const recentOptions = form.getByTestId("create-agent-cwd-history-option");
 
-    await expect(page.getByRole("option", { name: "/home/user/projects/myapp" })).toBeVisible();
-    await expect(page.getByRole("option", { name: "/tmp/existing-project" })).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "/home/user/projects/myapp" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "/tmp/existing-project" })
+    ).toBeVisible();
     await expect(recentOptions).toHaveCount(2);
     await expect(cwdInput).toHaveValue("/brand/new/path");
   });

--- a/e2e/docs.spec.ts
+++ b/e2e/docs.spec.ts
@@ -8,20 +8,30 @@ test.describe("Docs pane", () => {
     await page.getByTestId("settings-button").click();
     await page.getByRole("button", { name: "Help" }).click();
 
-    await expect(page.getByRole("heading", { level: 2, name: "Agents" })).toBeVisible({ timeout: 3_000 });
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Agents" })
+    ).toBeVisible({ timeout: 3_000 });
 
     await page.getByRole("button", { name: "Repo Tools" }).click();
-    await expect(page.getByRole("heading", { level: 2, name: "Repo Tools" })).toBeVisible();
-    await expect(page.getByRole("heading", { level: 3, name: "Defining tools" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Repo Tools" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 3, name: "Defining tools" })
+    ).toBeVisible();
   });
 
-  test("redirects legacy docs URLs into settings help deep links", async ({ page }) => {
+  test("redirects legacy docs URLs into settings help deep links", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await page.goto("/docs/tools", { waitUntil: "domcontentloaded" });
 
     await expect(page).toHaveURL(/\/settings\/help\/tools$/);
     await expect(page.getByRole("button", { name: "Help" })).toBeVisible();
-    await expect(page.getByRole("heading", { level: 2, name: "Repo Tools" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Repo Tools" })
+    ).toBeVisible();
   });
 });

--- a/e2e/energy-visibility.spec.ts
+++ b/e2e/energy-visibility.spec.ts
@@ -41,7 +41,9 @@ async function simulateVisible(page: Page): Promise<void> {
  * Read energy metrics from localStorage. Going hidden triggers a save,
  * so call simulateHidden first if you need fresh data.
  */
-async function readMetrics(page: Page): Promise<Record<string, unknown> | null> {
+async function readMetrics(
+  page: Page
+): Promise<Record<string, unknown> | null> {
   return page.evaluate(() => {
     const raw = localStorage.getItem("dispatch:energyMetrics");
     return raw ? JSON.parse(raw) : null;
@@ -71,7 +73,9 @@ test.describe("Energy / visibility-aware pausing", () => {
 
     // Health poll should resume — check API status in Settings still shows ok
     await page.getByTestId("settings-button").click();
-    const apiStatus = page.getByTestId("sidebar-shell").getByTestId("service-status-api");
+    const apiStatus = page
+      .getByTestId("sidebar-shell")
+      .getByTestId("service-status-api");
     await expect(apiStatus).toContainText("ok", { timeout: 15_000 });
   });
 
@@ -125,7 +129,9 @@ test.describe("Energy / visibility-aware pausing", () => {
     const metrics = await readMetrics(page);
     expect(metrics).not.toBeNull();
     // At least 2 transitions recorded (hidden→visible cycle)
-    expect((metrics!.visibilityChanges as unknown[]).length).toBeGreaterThanOrEqual(2);
+    expect(
+      (metrics!.visibilityChanges as unknown[]).length
+    ).toBeGreaterThanOrEqual(2);
     expect(metrics!.totalHiddenMs).toBeGreaterThan(0);
   });
 

--- a/e2e/focus-tracking.spec.ts
+++ b/e2e/focus-tracking.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect, type Page } from "@playwright/test";
 import { createAgentViaAPI, loadApp } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 test.describe("Focus tracking API", () => {
   test("POST /api/v1/focus accepts a valid agentId", async ({ request }) => {
@@ -21,7 +23,9 @@ test.describe("Focus tracking API", () => {
     expect(res.status()).toBe(204);
   });
 
-  test("POST /api/v1/focus rejects empty string agentId", async ({ request }) => {
+  test("POST /api/v1/focus rejects empty string agentId", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/focus", {
       headers: authHeader,
       data: { agentId: "" },
@@ -29,7 +33,9 @@ test.describe("Focus tracking API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/focus accepts missing agentId (treated as null)", async ({ request }) => {
+  test("POST /api/v1/focus accepts missing agentId (treated as null)", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/focus", {
       headers: authHeader,
       data: {},
@@ -84,7 +90,9 @@ test.describe("Focus tracking frontend", () => {
     // Set up route intercept BEFORE loading the app
     const focusRequests: Array<{ agentId: string | null }> = [];
     await page.route("**/api/v1/focus", async (route) => {
-      const postData = route.request().postDataJSON() as { agentId: string | null };
+      const postData = route.request().postDataJSON() as {
+        agentId: string | null;
+      };
       focusRequests.push(postData);
       await route.fulfill({ status: 204 });
     });
@@ -107,18 +115,25 @@ test.describe("Focus tracking frontend", () => {
     expect(focusRequest).toBeDefined();
   });
 
-  test("sends null focus when page becomes hidden", async ({ page, request }) => {
+  test("sends null focus when page becomes hidden", async ({
+    page,
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request);
 
     const focusRequests: Array<{ agentId: string | null }> = [];
     await page.route("**/api/v1/focus", async (route) => {
-      const postData = route.request().postDataJSON() as { agentId: string | null };
+      const postData = route.request().postDataJSON() as {
+        agentId: string | null;
+      };
       focusRequests.push(postData);
       await route.fulfill({ status: 204 });
     });
 
     await loadApp(page);
-    await page.evaluate(() => { document.hasFocus = () => true; });
+    await page.evaluate(() => {
+      document.hasFocus = () => true;
+    });
 
     // Select the agent to start focus tracking
     await page.getByText(agent.name).click();
@@ -146,13 +161,17 @@ test.describe("Focus tracking frontend", () => {
 
     const focusRequests: Array<{ agentId: string | null }> = [];
     await page.route("**/api/v1/focus", async (route) => {
-      const postData = route.request().postDataJSON() as { agentId: string | null };
+      const postData = route.request().postDataJSON() as {
+        agentId: string | null;
+      };
       focusRequests.push(postData);
       await route.fulfill({ status: 204 });
     });
 
     await loadApp(page);
-    await page.evaluate(() => { document.hasFocus = () => true; });
+    await page.evaluate(() => {
+      document.hasFocus = () => true;
+    });
     await page.getByText(agent.name).click();
     await page.waitForTimeout(1000);
 

--- a/e2e/header-overflow.spec.ts
+++ b/e2e/header-overflow.spec.ts
@@ -1,20 +1,31 @@
 import { test, expect } from "@playwright/test";
 
-import { cleanupE2EAgents, createAgentViaAPI, loadApp, setAgentLatestEventViaAPI } from "./helpers";
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  loadApp,
+  setAgentLatestEventViaAPI,
+} from "./helpers";
 
 test.describe("Chrome overflow", () => {
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);
   });
 
-  test("long agent status messages do not recreate a dedicated header row", async ({ page, request }) => {
+  test("long agent status messages do not recreate a dedicated header row", async ({
+    page,
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
     });
     const longMessage =
       "This is a deliberately long agent description used to verify that status text no longer reserves a dedicated header row or pushes the terminal layout beyond the viewport width while a session is attached and actively reporting status updates.";
 
-    await setAgentLatestEventViaAPI(request, agent.id, { type: "working", message: longMessage });
+    await setAgentLatestEventViaAPI(request, agent.id, {
+      type: "working",
+      message: longMessage,
+    });
     await loadApp(page);
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
@@ -27,14 +38,19 @@ test.describe("Chrome overflow", () => {
         viewportWidth: window.innerWidth,
         documentScrollWidth: document.documentElement.scrollWidth,
         mainWidth: main?.getBoundingClientRect().width ?? 0,
-        topPadding: Number.parseFloat(window.getComputedStyle(main ?? document.body).paddingTop || "0"),
-        headerNodeCount: document.querySelectorAll("[data-testid='app-header']").length,
+        topPadding: Number.parseFloat(
+          window.getComputedStyle(main ?? document.body).paddingTop || "0"
+        ),
+        headerNodeCount: document.querySelectorAll("[data-testid='app-header']")
+          .length,
       };
     });
 
     await expect(page.getByTestId("app-header")).toHaveCount(0);
 
-    expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+    expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(
+      dimensions.viewportWidth
+    );
     expect(dimensions.mainWidth).toBeGreaterThan(0);
     expect(dimensions.topPadding).toBe(0);
     expect(dimensions.headerNodeCount).toBe(0);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -31,7 +31,13 @@ type AgentPinRecord = {
  */
 export async function createAgentViaAPI(
   request: APIRequestContext,
-  overrides: { name?: string; type?: string; cwd?: string; useWorktree?: boolean; worktreeBranch?: string } = {}
+  overrides: {
+    name?: string;
+    type?: string;
+    cwd?: string;
+    useWorktree?: boolean;
+    worktreeBranch?: string;
+  } = {}
 ): Promise<AgentResult> {
   const res = await request.post(`${API}/agents`, {
     headers: authHeaders(),
@@ -69,21 +75,36 @@ export async function createAgentViaAPI(
 export async function getWorktreeStatusViaAPI(
   request: APIRequestContext,
   agentId: string
-): Promise<{ hasWorktree: boolean; hasUnmergedCommits: boolean; worktreePath: string | null; branchName: string | null; changedFiles: string[] }> {
+): Promise<{
+  hasWorktree: boolean;
+  hasUnmergedCommits: boolean;
+  worktreePath: string | null;
+  branchName: string | null;
+  changedFiles: string[];
+}> {
   const res = await request.get(`${API}/agents/${agentId}/worktree-status`, {
     headers: authHeaders(),
   });
-  return (await res.json()) as { hasWorktree: boolean; hasUnmergedCommits: boolean; worktreePath: string | null; branchName: string | null; changedFiles: string[] };
+  return (await res.json()) as {
+    hasWorktree: boolean;
+    hasUnmergedCommits: boolean;
+    worktreePath: string | null;
+    branchName: string | null;
+    changedFiles: string[];
+  };
 }
 
 export async function setAgentLatestEventViaAPI(
   request: APIRequestContext,
   agentId: string,
-  event: { type: "working" | "blocked" | "waiting_user" | "done" | "idle"; message: string }
+  event: {
+    type: "working" | "blocked" | "waiting_user" | "done" | "idle";
+    message: string;
+  }
 ): Promise<void> {
   await request.post(`${API}/agents/${agentId}/latest-event`, {
     headers: authHeaders(),
-    data: event
+    data: event,
   });
 }
 
@@ -130,7 +151,10 @@ export async function uploadMediaViaAPI(
   }
 }
 
-export async function setAgentPinsViaDB(agentId: string, pins: AgentPinRecord[]): Promise<void> {
+export async function setAgentPinsViaDB(
+  agentId: string,
+  pins: AgentPinRecord[]
+): Promise<void> {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
     throw new Error("DATABASE_URL is required to seed agent pins.");
@@ -155,16 +179,23 @@ export async function deleteAgentViaAPI(
   agentId: string,
   cleanupWorktree: "auto" | "keep" | "force" = "force"
 ): Promise<void> {
-  await request.post(`${API}/agents/${agentId}/stop`, {
-    headers: authHeaders(),
-    data: { force: true },
-  }).catch(() => {});
-  await request.delete(`${API}/agents/${agentId}?force=true&cleanupWorktree=${cleanupWorktree}`, {
-    headers: authHeaders(),
-  });
+  await request
+    .post(`${API}/agents/${agentId}/stop`, {
+      headers: authHeaders(),
+      data: { force: true },
+    })
+    .catch(() => {});
+  await request.delete(
+    `${API}/agents/${agentId}?force=true&cleanupWorktree=${cleanupWorktree}`,
+    {
+      headers: authHeaders(),
+    }
+  );
   // Archive is async — poll until the agent is actually gone
   for (let i = 0; i < 50; i++) {
-    const res = await request.get(`${API}/agents/${agentId}`, { headers: authHeaders() });
+    const res = await request.get(`${API}/agents/${agentId}`, {
+      headers: authHeaders(),
+    });
     if (res.status() === 404) return;
     await new Promise((r) => setTimeout(r, 100));
   }
@@ -173,9 +204,13 @@ export async function deleteAgentViaAPI(
 /**
  * Delete all agents whose name starts with `e2e-agent-` to keep the dev DB clean.
  */
-export async function cleanupE2EAgents(request: APIRequestContext): Promise<void> {
+export async function cleanupE2EAgents(
+  request: APIRequestContext
+): Promise<void> {
   const res = await request.get(`${API}/agents`, { headers: authHeaders() });
-  const body = (await res.json()) as { agents?: Array<{ id: string; name: string }> };
+  const body = (await res.json()) as {
+    agents?: Array<{ id: string; name: string }>;
+  };
   if (!body.agents) return;
   for (const agent of body.agents) {
     if (agent.name.startsWith("e2e-agent-")) {
@@ -222,29 +257,42 @@ function buildDemoActivitySeed(now = new Date()): DemoSeedRow[] {
     const project = projects[projectIndex];
     const random = mulberry32(dayOffset * 97 + projectIndex * 131 + 17);
 
-    const activeAgents = weekend ? (random() > 0.58 ? 1 : 0) : (random() > 0.82 ? 3 : 2);
+    const activeAgents = weekend
+      ? random() > 0.58
+        ? 1
+        : 0
+      : random() > 0.82
+        ? 3
+        : 2;
     for (let agentIndex = 0; agentIndex < activeAgents; agentIndex += 1) {
-      const startHour =
-        weekend
-          ? 9 + Math.floor(random() * 6)
-          : 8 + Math.floor(random() * 3) + (agentIndex === 2 ? 1 : 0);
+      const startHour = weekend
+        ? 9 + Math.floor(random() * 6)
+        : 8 + Math.floor(random() * 3) + (agentIndex === 2 ? 1 : 0);
       const startMinute = Math.floor(random() * 40);
       const workingBlockMinutes = weekend
         ? 70 + Math.floor(random() * 80)
         : 105 + Math.floor(random() * 85);
-      const blockedMinutes = random() > (weekend ? 0.78 : 0.55) ? 0 : 10 + Math.floor(random() * 35);
-      const waitingMinutes = random() > (weekend ? 0.88 : 0.68) ? 0 : 8 + Math.floor(random() * 28);
-      const reviewBlockMinutes = weekend ? 20 + Math.floor(random() * 40) : 45 + Math.floor(random() * 55);
+      const blockedMinutes =
+        random() > (weekend ? 0.78 : 0.55) ? 0 : 10 + Math.floor(random() * 35);
+      const waitingMinutes =
+        random() > (weekend ? 0.88 : 0.68) ? 0 : 8 + Math.floor(random() * 28);
+      const reviewBlockMinutes = weekend
+        ? 20 + Math.floor(random() * 40)
+        : 45 + Math.floor(random() * 55);
       const agentId = `seed-active-hours-${projectIndex}-${agentIndex}`;
-      const agentName = weekend ? `Weekend ${agentIndex + 1}` : `Builder ${projectIndex + 1}-${agentIndex + 1}`;
+      const agentName = weekend
+        ? `Weekend ${agentIndex + 1}`
+        : `Builder ${projectIndex + 1}-${agentIndex + 1}`;
 
-      const workingAt = new Date(Date.UTC(
-        day.getUTCFullYear(),
-        day.getUTCMonth(),
-        day.getUTCDate(),
-        startHour,
-        startMinute,
-      ));
+      const workingAt = new Date(
+        Date.UTC(
+          day.getUTCFullYear(),
+          day.getUTCMonth(),
+          day.getUTCDate(),
+          startHour,
+          startMinute
+        )
+      );
       rows.push({
         agent_id: agentId,
         event_type: "working",
@@ -256,7 +304,9 @@ function buildDemoActivitySeed(now = new Date()): DemoSeedRow[] {
         project_dir: project.dir,
       });
 
-      let cursor = new Date(workingAt.getTime() + workingBlockMinutes * 60 * 1000);
+      let cursor = new Date(
+        workingAt.getTime() + workingBlockMinutes * 60 * 1000
+      );
       if (blockedMinutes > 0) {
         rows.push({
           agent_id: agentId,
@@ -369,15 +419,19 @@ export async function loadApp(page: Page): Promise<void> {
 
   await Promise.race([
     loginInput.waitFor({ state: "visible", timeout: 15_000 }).catch(() => null),
-    sidebar.waitFor({ state: "visible", timeout: 15_000 }).catch(() => null)
+    sidebar.waitFor({ state: "visible", timeout: 15_000 }).catch(() => null),
   ]);
 
   // If login page is showing, that's unexpected in e2e (fresh DB = no password).
   // But handle it gracefully just in case.
   if (await loginInput.isVisible().catch(() => false)) {
-    throw new Error("Unexpected login page in e2e test — DB should have no password set.");
+    throw new Error(
+      "Unexpected login page in e2e test — DB should have no password set."
+    );
   }
 
   await sidebar.waitFor({ state: "visible", timeout: 15_000 });
-  await page.getByTestId("terminal-pane").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .getByTestId("terminal-pane")
+    .waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/e2e/jobs-api.spec.ts
+++ b/e2e/jobs-api.spec.ts
@@ -3,7 +3,9 @@ import { mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-const AUTH_HEADER = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 const HEADERS = { ...AUTH_HEADER, "Content-Type": "application/json" };
 
 // Use a unique directory per test run to avoid collisions
@@ -11,14 +13,17 @@ const jobDir = join(tmpdir(), `dispatch-e2e-jobs-${Date.now()}`);
 mkdirSync(jobDir, { recursive: true });
 
 // Helper to create the shared test job used by several tests
-async function ensureTestJob(request: import("@playwright/test").APIRequestContext) {
+async function ensureTestJob(
+  request: import("@playwright/test").APIRequestContext
+) {
   // Try to create — ignore if already exists
   const res = await request.post("/api/v1/jobs", {
     headers: HEADERS,
     data: {
       name: "E2E Test Job",
       directory: jobDir,
-      prompt: 'This is an E2E test job. Call job_complete immediately with status "completed", summary "E2E passed", and one task "check" with status "success" and summary "ok".',
+      prompt:
+        'This is an E2E test job. Call job_complete immediately with status "completed", summary "E2E passed", and one task "check" with status "success" and summary "ok".',
       schedule: "0 * * * *",
       timeoutMs: 120000,
       needsInputTimeoutMs: 86400000,
@@ -64,11 +69,18 @@ test.describe("Jobs API", () => {
     expect(body.agentId).toBeTruthy();
     expect(body.status).toBe("running");
 
-    const params = new URLSearchParams({ name: "E2E Test Job", directory: jobDir });
-    const historyRes = await request.get(`/api/v1/jobs/history?${params}`, { headers: AUTH_HEADER });
+    const params = new URLSearchParams({
+      name: "E2E Test Job",
+      directory: jobDir,
+    });
+    const historyRes = await request.get(`/api/v1/jobs/history?${params}`, {
+      headers: AUTH_HEADER,
+    });
     expect(historyRes.ok()).toBeTruthy();
     const history = await historyRes.json();
-    const run = history.runs.find((entry: { id: string }) => entry.id === body.runId);
+    const run = history.runs.find(
+      (entry: { id: string }) => entry.id === body.runId
+    );
     expect(run.config.triggerSource).toBe("manual");
   });
 
@@ -79,13 +91,19 @@ test.describe("Jobs API", () => {
     expect(res.ok()).toBeTruthy();
 
     const body = await res.json();
-    const job = body.find((j: { name: string; directory: string }) => j.name === "E2E Test Job" && j.directory === jobDir);
+    const job = body.find(
+      (j: { name: string; directory: string }) =>
+        j.name === "E2E Test Job" && j.directory === jobDir
+    );
     expect(job).toBeTruthy();
     expect(job.schedule).toBe("0 * * * *");
   });
 
   test("POST /api/v1/jobs accepts full config", async ({ request }) => {
-    const configDir = join(tmpdir(), `dispatch-e2e-add-job-config-${Date.now()}`);
+    const configDir = join(
+      tmpdir(),
+      `dispatch-e2e-add-job-config-${Date.now()}`
+    );
     const res = await request.post("/api/v1/jobs", {
       headers: HEADERS,
       data: {
@@ -157,7 +175,9 @@ test.describe("Jobs API", () => {
     expect(body.enabled).toBe(true);
   });
 
-  test("POST /api/v1/jobs/enable validates schedule exists", async ({ request }) => {
+  test("POST /api/v1/jobs/enable validates schedule exists", async ({
+    request,
+  }) => {
     const noScheduleDir = join(tmpdir(), `dispatch-e2e-nosched-${Date.now()}`);
     // Create a job without a schedule
     const createRes = await request.post("/api/v1/jobs", {
@@ -181,7 +201,9 @@ test.describe("Jobs API", () => {
     expect(body.error).toContain("no schedule");
   });
 
-  test("POST /api/v1/jobs/enable + disable toggles enabled", async ({ request }) => {
+  test("POST /api/v1/jobs/enable + disable toggles enabled", async ({
+    request,
+  }) => {
     await ensureTestJob(request);
 
     // Enable
@@ -190,7 +212,10 @@ test.describe("Jobs API", () => {
       data: { name: "E2E Test Job", directory: jobDir },
     });
     const enableBody = await enableRes.json();
-    expect(enableRes.ok(), `Enable failed: ${JSON.stringify(enableBody)}`).toBeTruthy();
+    expect(
+      enableRes.ok(),
+      `Enable failed: ${JSON.stringify(enableBody)}`
+    ).toBeTruthy();
     expect(enableBody.enabled).toBe(true);
 
     // Verify in list
@@ -210,14 +235,18 @@ test.describe("Jobs API", () => {
     expect(disabled.enabled).toBe(false);
 
     // Verify in list
-    const listRes2 = await request.get("/api/v1/jobs", { headers: AUTH_HEADER });
+    const listRes2 = await request.get("/api/v1/jobs", {
+      headers: AUTH_HEADER,
+    });
     const jobs2 = await listRes2.json();
     const job2 = jobs2.find((j: { id: string }) => j.id === enableBody.id);
     expect(job2.enabled).toBe(false);
     expect(job2.nextRun).toBeNull();
   });
 
-  test("GET /api/v1/jobs/history returns runs for a job", async ({ request }) => {
+  test("GET /api/v1/jobs/history returns runs for a job", async ({
+    request,
+  }) => {
     await ensureTestJob(request);
 
     // Ensure job has at least one run
@@ -226,8 +255,13 @@ test.describe("Jobs API", () => {
       data: { name: "E2E Test Job", directory: jobDir, wait: false },
     });
 
-    const params = new URLSearchParams({ name: "E2E Test Job", directory: jobDir });
-    const res = await request.get(`/api/v1/jobs/history?${params}`, { headers: AUTH_HEADER });
+    const params = new URLSearchParams({
+      name: "E2E Test Job",
+      directory: jobDir,
+    });
+    const res = await request.get(`/api/v1/jobs/history?${params}`, {
+      headers: AUTH_HEADER,
+    });
     const body = await res.json();
     expect(res.ok(), `History failed: ${JSON.stringify(body)}`).toBeTruthy();
 
@@ -237,7 +271,9 @@ test.describe("Jobs API", () => {
     expect(body.runs.length).toBeGreaterThan(0);
   });
 
-  test("POST /api/v1/jobs/run validates required fields", async ({ request }) => {
+  test("POST /api/v1/jobs/run validates required fields", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/jobs/run", {
       headers: HEADERS,
       data: {},
@@ -245,7 +281,9 @@ test.describe("Jobs API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/jobs/enable validates required fields", async ({ request }) => {
+  test("POST /api/v1/jobs/enable validates required fields", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/jobs/enable", {
       headers: HEADERS,
       data: {},
@@ -253,7 +291,9 @@ test.describe("Jobs API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/jobs/disable validates required fields", async ({ request }) => {
+  test("POST /api/v1/jobs/disable validates required fields", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/jobs/disable", {
       headers: HEADERS,
       data: {},
@@ -261,13 +301,22 @@ test.describe("Jobs API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("GET /api/v1/jobs/history returns 404 for unknown job", async ({ request }) => {
-    const params = new URLSearchParams({ name: "nonexistent", directory: "/tmp/nope" });
-    const res = await request.get(`/api/v1/jobs/history?${params}`, { headers: AUTH_HEADER });
+  test("GET /api/v1/jobs/history returns 404 for unknown job", async ({
+    request,
+  }) => {
+    const params = new URLSearchParams({
+      name: "nonexistent",
+      directory: "/tmp/nope",
+    });
+    const res = await request.get(`/api/v1/jobs/history?${params}`, {
+      headers: AUTH_HEADER,
+    });
     expect(res.status()).toBe(404);
   });
 
-  test("POST /api/v1/jobs/run with nonexistent job returns error", async ({ request }) => {
+  test("POST /api/v1/jobs/run with nonexistent job returns error", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/jobs/run", {
       headers: HEADERS,
       data: { name: "does-not-exist", directory: "/tmp/no-such-dir" },

--- a/e2e/jobs-sse.spec.ts
+++ b/e2e/jobs-sse.spec.ts
@@ -55,7 +55,7 @@ function openSSEStream(baseURL: string): {
           }
         });
         res.on("error", reject);
-      },
+      }
     );
     req.on("error", reject);
   });
@@ -72,7 +72,7 @@ async function waitForEvents(
   events: Array<{ type: string }>,
   predicate: (e: { type: string }) => boolean,
   count: number,
-  timeoutMs = 5000,
+  timeoutMs = 5000
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -81,7 +81,7 @@ async function waitForEvents(
   }
   const matched = events.filter(predicate).length;
   throw new Error(
-    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms). All events: ${JSON.stringify(events.map((e) => e.type))}`,
+    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms). All events: ${JSON.stringify(events.map((e) => e.type))}`
   );
 }
 
@@ -97,7 +97,7 @@ test.describe("Jobs SSE events", () => {
       await sse.ready;
       // Clear snapshot from events count
       const baselineCount = sse.events.filter(
-        (e) => e.type === "job.changed",
+        (e) => e.type === "job.changed"
       ).length;
 
       // 1. Create a job → expect job.changed
@@ -116,7 +116,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 1,
+        baselineCount + 1
       );
 
       // 2. Update the job → expect another job.changed
@@ -133,7 +133,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 2,
+        baselineCount + 2
       );
 
       // 3. Enable the job → expect another job.changed
@@ -145,7 +145,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 3,
+        baselineCount + 3
       );
 
       // 4. Disable the job → expect another job.changed
@@ -157,7 +157,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 4,
+        baselineCount + 4
       );
 
       // 5. Delete the job → expect another job.changed
@@ -169,7 +169,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 5,
+        baselineCount + 5
       );
     } finally {
       sse.close();
@@ -201,7 +201,7 @@ test.describe("Jobs SSE events", () => {
     try {
       await sse.ready;
       const baselineCount = sse.events.filter(
-        (e) => e.type === "job.changed",
+        (e) => e.type === "job.changed"
       ).length;
 
       // Run the job (non-blocking)
@@ -215,7 +215,7 @@ test.describe("Jobs SSE events", () => {
       await waitForEvents(
         sse.events,
         (e) => e.type === "job.changed",
-        baselineCount + 2,
+        baselineCount + 2
       );
     } finally {
       sse.close();

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -1,10 +1,21 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { cleanupE2EAgents, createAgentViaAPI, loadApp, setAgentPinsViaDB, uploadMediaViaAPI } from "./helpers";
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  loadApp,
+  setAgentPinsViaDB,
+  uploadMediaViaAPI,
+} from "./helpers";
 
-async function openMediaSidebarForAgent(page: Page, agent: { id: string; name: string }) {
+async function openMediaSidebarForAgent(
+  page: Page,
+  agent: { id: string; name: string }
+) {
   await page.getByText(agent.name, { exact: true }).click();
-  await expect(page.getByTestId(`agent-card-${agent.id}`)).toHaveClass(/bg-muted\/60/);
+  await expect(page.getByTestId(`agent-card-${agent.id}`)).toHaveClass(
+    /bg-muted\/60/
+  );
   const toggle = page.getByTestId("toggle-media-sidebar");
   await expect(toggle).toBeVisible();
   await toggle.evaluate((el) => (el as HTMLButtonElement).click());
@@ -15,11 +26,23 @@ test.describe("Media sidebar", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("refreshes cached media when switching back to an agent", async ({ page, request }) => {
-    const firstAgent = await createAgentViaAPI(request, { name: `e2e-agent-media-a-${Date.now()}` });
-    const secondAgent = await createAgentViaAPI(request, { name: `e2e-agent-media-b-${Date.now()}` });
+  test("refreshes cached media when switching back to an agent", async ({
+    page,
+    request,
+  }) => {
+    const firstAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-media-a-${Date.now()}`,
+    });
+    const secondAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-media-b-${Date.now()}`,
+    });
 
-    await uploadMediaViaAPI(request, firstAgent.id, "First image", "first-image.png");
+    await uploadMediaViaAPI(
+      request,
+      firstAgent.id,
+      "First image",
+      "first-image.png"
+    );
 
     await loadApp(page);
 
@@ -35,19 +58,41 @@ test.describe("Media sidebar", () => {
     await page.getByText(secondAgent.name, { exact: true }).click();
     // Agent switch resets to Pins tab — switch back to Media
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
-    await uploadMediaViaAPI(request, firstAgent.id, "Second image", "second-image.png");
+    await uploadMediaViaAPI(
+      request,
+      firstAgent.id,
+      "Second image",
+      "second-image.png"
+    );
     await page.getByText(firstAgent.name, { exact: true }).click();
     // Agent switch resets to Pins tab again
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
 
-    await expect(mediaSidebar.getByText("Second image")).toBeVisible({ timeout: 10_000 });
+    await expect(mediaSidebar.getByText("Second image")).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
-  test("navigates between fullscreen media items", async ({ page, request }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-lightbox-${Date.now()}` });
+  test("navigates between fullscreen media items", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-lightbox-${Date.now()}`,
+    });
 
-    await uploadMediaViaAPI(request, agent.id, "First image", "first-image.png");
-    await uploadMediaViaAPI(request, agent.id, "Second image", "second-image.png");
+    await uploadMediaViaAPI(
+      request,
+      agent.id,
+      "First image",
+      "first-image.png"
+    );
+    await uploadMediaViaAPI(
+      request,
+      agent.id,
+      "Second image",
+      "second-image.png"
+    );
 
     await loadApp(page);
 
@@ -78,10 +123,20 @@ test.describe("Media sidebar", () => {
     await expect(lightbox).toBeHidden();
   });
 
-  test("marks visible media as seen and persists to server", async ({ page, request }) => {
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-seen-${Date.now()}` });
+  test("marks visible media as seen and persists to server", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-seen-${Date.now()}`,
+    });
 
-    await uploadMediaViaAPI(request, agent.id, "Seen test image", "seen-test.png");
+    await uploadMediaViaAPI(
+      request,
+      agent.id,
+      "Seen test image",
+      "seen-test.png"
+    );
 
     await loadApp(page);
     await openMediaSidebarForAgent(page, agent);
@@ -95,30 +150,55 @@ test.describe("Media sidebar", () => {
 
     // Verify it persisted to the server.
     const res = await request.get(`/api/v1/agents/${agent.id}/media`, {
-      headers: { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` },
+      headers: {
+        Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+      },
     });
     const body = (await res.json()) as { files: Array<{ seen?: boolean }> };
     expect(body.files[0].seen).toBe(true);
   });
 
-  test("preserves string pin whitespace and splits filename pins", async ({ page, request }) => {
+  test("preserves string pin whitespace and splits filename pins", async ({
+    page,
+    request,
+  }) => {
     const workspaceRoot = process.cwd();
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-pins-${Date.now()}`, cwd: workspaceRoot });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-pins-${Date.now()}`,
+      cwd: workspaceRoot,
+    });
     await setAgentPinsViaDB(agent.id, [
       { label: "Notes", type: "string", value: "line 1\n\n  line 2" },
       {
         label: "Summary",
         type: "markdown",
-        value: "**Status**\n- Ready for review\n- URL: https://example.com/visible\n- Branch: `feat/log-rotation`\n- Owner: **Dispatch**\n- Marker: 🚀\n- Step: validate in sidebar\n- Step: keep lines wrapped\n\n```sh\npnpm run check\npnpm run test\npnpm run finalize:web\npnpm run test:e2e\nnpm run lint || true\n```",
+        value:
+          "**Status**\n- Ready for review\n- URL: https://example.com/visible\n- Branch: `feat/log-rotation`\n- Owner: **Dispatch**\n- Marker: 🚀\n- Step: validate in sidebar\n- Step: keep lines wrapped\n\n```sh\npnpm run check\npnpm run test\npnpm run finalize:web\npnpm run test:e2e\nnpm run lint || true\n```",
       },
       { label: "Files", type: "filename", value: "one.ts,\ntwo.ts\nthree.ts" },
       { label: "Workspace root", type: "filename", value: workspaceRoot },
-      { label: "Long file", type: "filename", value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx` },
+      {
+        label: "Long file",
+        type: "filename",
+        value: `${workspaceRoot}/apps/web/src/components/app/pins-panel.tsx`,
+      },
       { label: "Ports", type: "port", value: "3000 4000,\n5000" },
-      { label: "API", type: "url", value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" },
-      { label: "Local URL", type: "url", value: "127.0.0.1:8788/api/v1/health" },
+      {
+        label: "API",
+        type: "url",
+        value: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins",
+      },
+      {
+        label: "Local URL",
+        type: "url",
+        value: "127.0.0.1:8788/api/v1/health",
+      },
       { label: "Dev Web", type: "url", value: "  http://127.0.0.1:52804 \n" },
-      { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
+      {
+        label: "PR",
+        type: "pr",
+        value: "https://github.com/selfcontained/dispatch/pull/123",
+      },
       { label: "Review", type: "pr", value: "Review queue" },
       { label: "Agent ID", type: "code", value: "DISPATCH_AGENT_ID=agt_123" },
     ]);
@@ -129,53 +209,99 @@ test.describe("Media sidebar", () => {
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
-    await mediaSidebar.getByRole("button", { name: "Pins" }).evaluate((el) => (el as HTMLButtonElement).click());
+    await mediaSidebar
+      .getByRole("button", { name: "Pins" })
+      .evaluate((el) => (el as HTMLButtonElement).click());
 
     const notesPre = mediaSidebar.locator("[data-pin-label='Notes'] pre");
     await expect(notesPre).toHaveText("line 1\n\n  line 2");
 
-    const markdownPin = mediaSidebar.locator("[data-pin-label='Summary'] [data-testid='markdown-pin-body']");
-    await expect(markdownPin.getByText("Status", { exact: true })).toBeVisible();
+    const markdownPin = mediaSidebar.locator(
+      "[data-pin-label='Summary'] [data-testid='markdown-pin-body']"
+    );
+    await expect(
+      markdownPin.getByText("Status", { exact: true })
+    ).toBeVisible();
     await expect(markdownPin.locator("strong").first()).toHaveText("Status");
-    await expect(markdownPin.getByText("Ready for review", { exact: true })).toBeVisible();
+    await expect(
+      markdownPin.getByText("Ready for review", { exact: true })
+    ).toBeVisible();
     await expect(markdownPin).toContainText("https://example.com/visible");
-    await expect(markdownPin.getByText("feat/log-rotation", { exact: true })).toBeVisible();
+    await expect(
+      markdownPin.getByText("feat/log-rotation", { exact: true })
+    ).toBeVisible();
     await expect(markdownPin).toContainText("pnpm run check");
     await expect(markdownPin).toContainText("pnpm run test");
     await expect(markdownPin.getByRole("link")).toHaveCount(0);
 
-    const scrollMetrics = await mediaSidebar.locator("[data-pin-label='Summary'] [data-testid='markdown-pin-scroll']").evaluate((el) => {
-      const container = el as HTMLElement;
-      return { clientHeight: container.clientHeight, scrollHeight: container.scrollHeight };
-    });
+    const scrollMetrics = await mediaSidebar
+      .locator("[data-pin-label='Summary'] [data-testid='markdown-pin-scroll']")
+      .evaluate((el) => {
+        const container = el as HTMLElement;
+        return {
+          clientHeight: container.clientHeight,
+          scrollHeight: container.scrollHeight,
+        };
+      });
     expect(scrollMetrics).not.toBeNull();
-    expect(scrollMetrics!.scrollHeight).toBeGreaterThan(scrollMetrics!.clientHeight);
+    expect(scrollMetrics!.scrollHeight).toBeGreaterThan(
+      scrollMetrics!.clientHeight
+    );
 
-    await expect(mediaSidebar.getByText("one.ts", { exact: true })).toBeVisible();
-    await expect(mediaSidebar.getByText("two.ts", { exact: true })).toBeVisible();
-    await expect(mediaSidebar.getByText("three.ts", { exact: true })).toBeVisible();
-    const workspaceRootPin = mediaSidebar.locator("[data-pin-label='Workspace root']");
+    await expect(
+      mediaSidebar.getByText("one.ts", { exact: true })
+    ).toBeVisible();
+    await expect(
+      mediaSidebar.getByText("two.ts", { exact: true })
+    ).toBeVisible();
+    await expect(
+      mediaSidebar.getByText("three.ts", { exact: true })
+    ).toBeVisible();
+    const workspaceRootPin = mediaSidebar.locator(
+      "[data-pin-label='Workspace root']"
+    );
     await expect(workspaceRootPin).toContainText("./");
-    await expect(workspaceRootPin.locator(`[title="${workspaceRoot}"]`)).toHaveText("./");
+    await expect(
+      workspaceRootPin.locator(`[title="${workspaceRoot}"]`)
+    ).toHaveText("./");
     const longFilePin = mediaSidebar.locator("[data-pin-label='Long file']");
     await expect(longFilePin).toContainText("pins-panel.tsx");
-    await expect(longFilePin).toContainText("apps/web/src/components/app/pins-panel.tsx");
+    await expect(longFilePin).toContainText(
+      "apps/web/src/components/app/pins-panel.tsx"
+    );
     await expect(longFilePin).not.toContainText(workspaceRoot);
     await expect(longFilePin).not.toContainText("pins-panel.tsx/");
     await expect(mediaSidebar.getByText("3000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("4000", { exact: true })).toBeVisible();
     await expect(mediaSidebar.getByText("5000", { exact: true })).toBeVisible();
-    await expect(mediaSidebar.getByRole("link", { name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins" })).toBeVisible();
+    await expect(
+      mediaSidebar.getByRole("link", {
+        name: "http://127.0.0.1:8788/api/v1/agents?view=full&tab=pins",
+      })
+    ).toBeVisible();
     const localUrlPin = mediaSidebar.locator("[data-pin-label='Local URL']");
-    await expect(localUrlPin.getByRole("link", { name: "127.0.0.1:8788/api/v1/health" })).toHaveAttribute("href", "http://127.0.0.1:8788/api/v1/health");
+    await expect(
+      localUrlPin.getByRole("link", { name: "127.0.0.1:8788/api/v1/health" })
+    ).toHaveAttribute("href", "http://127.0.0.1:8788/api/v1/health");
     const devWebPin = mediaSidebar.locator("[data-pin-label='Dev Web']");
-    await expect(devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })).toBeVisible();
-    await expect(mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })).toBeVisible();
-    await expect(mediaSidebar.getByText("Review queue", { exact: true })).toBeVisible();
-    await expect(mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })).toBeVisible();
+    await expect(
+      devWebPin.getByRole("link", { name: "http://127.0.0.1:52804" })
+    ).toBeVisible();
+    await expect(
+      mediaSidebar.getByRole("link", { name: "selfcontained/dispatch#123" })
+    ).toBeVisible();
+    await expect(
+      mediaSidebar.getByText("Review queue", { exact: true })
+    ).toBeVisible();
+    await expect(
+      mediaSidebar.getByText("DISPATCH_AGENT_ID=agt_123", { exact: true })
+    ).toBeVisible();
   });
 
-  test("shows a separate Safari handoff button for pins in standalone iOS mode", async ({ page, request }) => {
+  test("shows a separate Safari handoff button for pins in standalone iOS mode", async ({
+    page,
+    request,
+  }) => {
     await page.addInitScript(() => {
       Object.defineProperty(window.navigator, "standalone", {
         configurable: true,
@@ -183,7 +309,8 @@ test.describe("Media sidebar", () => {
       });
       Object.defineProperty(window.navigator, "userAgent", {
         configurable: true,
-        get: () => "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        get: () =>
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
       });
       const originalMatchMedia = window.matchMedia.bind(window);
       window.matchMedia = ((query: string) => {
@@ -203,25 +330,51 @@ test.describe("Media sidebar", () => {
       }) as typeof window.matchMedia;
     });
 
-    const agent = await createAgentViaAPI(request, { name: `e2e-agent-pwa-pins-${Date.now()}` });
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-pwa-pins-${Date.now()}`,
+    });
     await setAgentPinsViaDB(agent.id, [
       { label: "API", type: "url", value: "https://example.com/docs" },
-      { label: "PR", type: "pr", value: "https://github.com/selfcontained/dispatch/pull/123" },
+      {
+        label: "PR",
+        type: "pr",
+        value: "https://github.com/selfcontained/dispatch/pull/123",
+      },
     ]);
 
     await loadApp(page);
     await openMediaSidebarForAgent(page, agent);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
-    await mediaSidebar.getByRole("button", { name: "Pins" }).evaluate((el) => (el as HTMLButtonElement).click());
+    await mediaSidebar
+      .getByRole("button", { name: "Pins" })
+      .evaluate((el) => (el as HTMLButtonElement).click());
 
-    await expect(mediaSidebar.locator("[data-pin-label='API']").getByRole("link", { name: "https://example.com/docs" }))
-      .toHaveAttribute("href", "https://example.com/docs");
-    await expect(mediaSidebar.locator("[data-pin-label='PR']").getByRole("link", { name: "selfcontained/dispatch#123" }))
-      .toHaveAttribute("href", "https://github.com/selfcontained/dispatch/pull/123");
-    await expect(mediaSidebar.locator("[data-pin-label='API']").getByRole("link", { name: "Open in Safari" }))
-      .toHaveAttribute("href", "x-safari-https://example.com/docs");
-    await expect(mediaSidebar.locator("[data-pin-label='PR']").getByRole("link", { name: "Open in Safari" }))
-      .toHaveAttribute("href", "x-safari-https://github.com/selfcontained/dispatch/pull/123");
+    await expect(
+      mediaSidebar
+        .locator("[data-pin-label='API']")
+        .getByRole("link", { name: "https://example.com/docs" })
+    ).toHaveAttribute("href", "https://example.com/docs");
+    await expect(
+      mediaSidebar
+        .locator("[data-pin-label='PR']")
+        .getByRole("link", { name: "selfcontained/dispatch#123" })
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/selfcontained/dispatch/pull/123"
+    );
+    await expect(
+      mediaSidebar
+        .locator("[data-pin-label='API']")
+        .getByRole("link", { name: "Open in Safari" })
+    ).toHaveAttribute("href", "x-safari-https://example.com/docs");
+    await expect(
+      mediaSidebar
+        .locator("[data-pin-label='PR']")
+        .getByRole("link", { name: "Open in Safari" })
+    ).toHaveAttribute(
+      "href",
+      "x-safari-https://github.com/selfcontained/dispatch/pull/123"
+    );
   });
 });

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 
 import {
   cleanupE2EAgents,
@@ -38,7 +44,10 @@ async function createJobViaAPI(
     },
   });
 
-  expect(res.ok(), `Failed to create job ${name}: ${await res.text()}`).toBeTruthy();
+  expect(
+    res.ok(),
+    `Failed to create job ${name}: ${await res.text()}`
+  ).toBeTruthy();
 }
 
 async function getScrollMetrics(locator: Locator): Promise<ScrollMetrics> {
@@ -53,10 +62,12 @@ async function getScrollMetrics(locator: Locator): Promise<ScrollMetrics> {
 }
 
 async function expectOverflow(locator: Locator): Promise<void> {
-  await expect.poll(async () => {
-    const { clientHeight, scrollHeight } = await getScrollMetrics(locator);
-    return scrollHeight - clientHeight;
-  }).toBeGreaterThan(40);
+  await expect
+    .poll(async () => {
+      const { clientHeight, scrollHeight } = await getScrollMetrics(locator);
+      return scrollHeight - clientHeight;
+    })
+    .toBeGreaterThan(40);
 }
 
 async function scrollToBottom(locator: Locator): Promise<void> {
@@ -70,7 +81,10 @@ async function getWindowScrollY(page: Page): Promise<number> {
   return page.evaluate(() => window.scrollY);
 }
 
-async function seedOverflowAgents(request: APIRequestContext, count: number): Promise<Array<{ id: string; name: string }>> {
+async function seedOverflowAgents(
+  request: APIRequestContext,
+  count: number
+): Promise<Array<{ id: string; name: string }>> {
   const created = await Promise.all(
     Array.from({ length: count }, async (_, index) => {
       const agent = await createAgentViaAPI(request, {
@@ -93,7 +107,10 @@ test.describe("Overflow layout", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("agents workspace keeps sidebar, media, and terminal overflow isolated", async ({ page, request }) => {
+  test("agents workspace keeps sidebar, media, and terminal overflow isolated", async ({
+    page,
+    request,
+  }) => {
     const agents = await seedOverflowAgents(request, 24);
     const focusAgent = agents[0]!;
 
@@ -108,7 +125,12 @@ test.describe("Overflow layout", () => {
 
     await Promise.all(
       Array.from({ length: 14 }, (_, index) =>
-        uploadMediaViaAPI(request, focusAgent.id, `Overflow media item ${index + 1}`, `overflow-media-${index + 1}.png`)
+        uploadMediaViaAPI(
+          request,
+          focusAgent.id,
+          `Overflow media item ${index + 1}`,
+          `overflow-media-${index + 1}.png`
+        )
       )
     );
 
@@ -145,7 +167,11 @@ test.describe("Overflow layout", () => {
 
     const terminalBoxAfterSidebarScroll = await terminalPane.boundingBox();
     expect(terminalBoxAfterSidebarScroll).not.toBeNull();
-    expect(Math.abs(terminalBoxAfterSidebarScroll!.height - terminalBoxBefore!.height)).toBeLessThan(2);
+    expect(
+      Math.abs(
+        terminalBoxAfterSidebarScroll!.height - terminalBoxBefore!.height
+      )
+    ).toBeLessThan(2);
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
@@ -163,10 +189,15 @@ test.describe("Overflow layout", () => {
 
     const terminalBoxAfterMediaScroll = await terminalPane.boundingBox();
     expect(terminalBoxAfterMediaScroll).not.toBeNull();
-    expect(Math.abs(terminalBoxAfterMediaScroll!.height - terminalBoxBefore!.height)).toBeLessThan(2);
+    expect(
+      Math.abs(terminalBoxAfterMediaScroll!.height - terminalBoxBefore!.height)
+    ).toBeLessThan(2);
   });
 
-  test("jobs page keeps sidebar overflow isolated from the shell", async ({ page, request }) => {
+  test("jobs page keeps sidebar overflow isolated from the shell", async ({
+    page,
+    request,
+  }) => {
     const stamp = Date.now();
 
     await Promise.all(

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -5,8 +5,13 @@ test.describe("Settings pane", () => {
   test.afterEach(async ({ request }) => {
     await setEnabledAgentTypesViaAPI(request, ["codex", "claude", "opencode"]);
     await request.post("/api/v1/notifications/settings", {
-      headers: { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` },
-      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      headers: {
+        Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+      },
+      data: {
+        webNotifyEnabled: false,
+        webNotifyEvents: ["done", "waiting_user", "blocked"],
+      },
     });
   });
 
@@ -18,7 +23,9 @@ test.describe("Settings pane", () => {
 
     // Settings nav should appear in the sidebar with "General" nav item
     const sidebar = page.getByTestId("sidebar-shell");
-    await expect(sidebar.getByText("Settings").first()).toBeVisible({ timeout: 3_000 });
+    await expect(sidebar.getByText("Settings").first()).toBeVisible({
+      timeout: 3_000,
+    });
     const generalNav = sidebar.getByText("General");
     await expect(generalNav).toBeVisible();
 
@@ -33,7 +40,10 @@ test.describe("Settings pane", () => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByTestId("sidebar-shell").getByText("Updates", { exact: true }).click();
+    await page
+      .getByTestId("sidebar-shell")
+      .getByText("Updates", { exact: true })
+      .click();
 
     // Version info is displayed in the Updates section
     await expect(page.getByText("Current version")).toBeVisible();
@@ -41,11 +51,16 @@ test.describe("Settings pane", () => {
     await expect(page.getByText("Release channel")).toBeVisible();
   });
 
-  test("agent type settings filter the create-agent dialog", async ({ page }) => {
+  test("agent type settings filter the create-agent dialog", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByTestId("sidebar-shell").getByText("Agents", { exact: true }).click();
+    await page
+      .getByTestId("sidebar-shell")
+      .getByText("Agents", { exact: true })
+      .click();
 
     const claudeToggle = page.getByTestId("agent-type-toggle-claude");
     await expect(claudeToggle).toBeChecked();
@@ -65,6 +80,8 @@ test.describe("Settings pane", () => {
 
     await expect(page.getByRole("option", { name: "Codex" })).toBeVisible();
     await expect(page.getByRole("option", { name: "OpenCode" })).toBeVisible();
-    await expect(page.getByRole("option", { name: "Claude" })).not.toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Claude" })
+    ).not.toBeVisible();
   });
 });

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from "@playwright/test";
 import { loadApp } from "./helpers";
 
-async function expectMobileSidebarOpen(page: import("@playwright/test").Page): Promise<void> {
+async function expectMobileSidebarOpen(
+  page: import("@playwright/test").Page
+): Promise<void> {
   const dialog = page.getByRole("dialog", { name: "Navigation sidebar" });
   await expect(dialog.getByTitle("Close sidebar")).toBeVisible();
   await expect
-    .poll(async () => dialog.evaluate((el) => Math.round(el.getBoundingClientRect().left)))
+    .poll(async () =>
+      dialog.evaluate((el) => Math.round(el.getBoundingClientRect().left))
+    )
     .toBe(0);
 }
 
@@ -25,17 +29,23 @@ test.describe("Sidebar interactions", () => {
 
     // The outermost wrapper of the GlassSidebar has the width transition
     // Structure: outer div (transition) > inner div (fixed width) > aside[sidebar-shell]
-    await expect.poll(async () => {
-      const shell = page.getByTestId("sidebar-shell");
-      const outerWrapper = shell.locator("..").locator("..");
-      return outerWrapper.evaluate((el) => Math.round(el.getBoundingClientRect().width));
-    }).toBeLessThan(4);
+    await expect
+      .poll(async () => {
+        const shell = page.getByTestId("sidebar-shell");
+        const outerWrapper = shell.locator("..").locator("..");
+        return outerWrapper.evaluate((el) =>
+          Math.round(el.getBoundingClientRect().width)
+        );
+      })
+      .toBeLessThan(4);
 
     // Reopen using the header button
     await page.getByTitle("Open sidebar").click();
 
     // Create button should be visible again after the sidebar expands
-    await expect(page.getByTestId("create-agent-button")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("create-agent-button")).toBeVisible({
+      timeout: 3_000,
+    });
   });
 
   test("Create button opens the create agent dialog", async ({ page }) => {
@@ -43,11 +53,15 @@ test.describe("Sidebar interactions", () => {
 
     await page.getByTestId("create-agent-button").click();
 
-    await expect(page.getByTestId("create-agent-form")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("create-agent-form")).toBeVisible({
+      timeout: 3_000,
+    });
     await expect(page.getByText("Create Agent")).toBeVisible();
   });
 
-  test("mobile navigation back to agents opens the sidebar", async ({ page }) => {
+  test("mobile navigation back to agents opens the sidebar", async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await loadApp(page);
 
@@ -57,7 +71,9 @@ test.describe("Sidebar interactions", () => {
     await expect(page).toHaveURL(/\/jobs$/);
 
     // Sidebar auto-opens on mobile when switching sections — wait for it
-    await expect(page.getByTestId("agents-button")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("agents-button")).toBeVisible({
+      timeout: 3_000,
+    });
     await page.getByTestId("agents-button").click();
     await expect(page).toHaveURL(/\/$/);
     await expectMobileSidebarOpen(page);

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
+import {
+  test,
+  expect,
+  type Page,
+  type APIRequestContext,
+} from "@playwright/test";
 import { execSync } from "child_process";
 import { cleanupE2EAgents, loadApp } from "./helpers";
 
@@ -17,7 +22,9 @@ async function createAndStartAgent(
     headers: authHeaders(),
     data: { name, type: "codex", cwd: "/tmp" },
   });
-  const { agent } = (await createRes.json()) as { agent: { id: string; name: string } };
+  const { agent } = (await createRes.json()) as {
+    agent: { id: string; name: string };
+  };
 
   await request.post(`/api/v1/agents/${agent.id}/start`, {
     headers: authHeaders(),
@@ -26,11 +33,14 @@ async function createAndStartAgent(
   return agent;
 }
 
-async function waitForTerminalConnected(page: Page, timeoutMs = 10_000): Promise<void> {
+async function waitForTerminalConnected(
+  page: Page,
+  timeoutMs = 10_000
+): Promise<void> {
   // The detach button in the header is visible when the terminal WebSocket is connected
-  await expect(
-    page.getByTestId("detach-button")
-  ).toBeVisible({ timeout: timeoutMs });
+  await expect(page.getByTestId("detach-button")).toBeVisible({
+    timeout: timeoutMs,
+  });
 }
 
 async function simulateHidden(page: Page): Promise<void> {
@@ -87,7 +97,10 @@ test.describe("Terminal live connection", () => {
     await waitForTerminalConnected(page, 3_000);
   });
 
-  test("terminal stays connected during SSE agent events", async ({ page, request }) => {
+  test("terminal stays connected during SSE agent events", async ({
+    page,
+    request,
+  }) => {
     test.skip(!IS_LIVE, "Requires --live agent runtime");
 
     const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
@@ -103,7 +116,11 @@ test.describe("Terminal live connection", () => {
     for (let i = 0; i < 3; i++) {
       await request.post("/api/v1/agents", {
         headers: authHeaders(),
-        data: { name: `e2e-agent-noise-${Date.now()}-${i}`, type: "shell", cwd: "/tmp" },
+        data: {
+          name: `e2e-agent-noise-${Date.now()}-${i}`,
+          type: "shell",
+          cwd: "/tmp",
+        },
       });
       // Small delay so events fire individually
       await page.waitForTimeout(200);
@@ -148,8 +165,14 @@ test.describe("Terminal live connection", () => {
   test("rapid agent switching stays stable", async ({ page, request }) => {
     test.skip(!IS_LIVE, "Requires --live agent runtime");
 
-    const agentA = await createAndStartAgent(request, `e2e-agent-A-${Date.now()}`);
-    const agentB = await createAndStartAgent(request, `e2e-agent-B-${Date.now()}`);
+    const agentA = await createAndStartAgent(
+      request,
+      `e2e-agent-A-${Date.now()}`
+    );
+    const agentB = await createAndStartAgent(
+      request,
+      `e2e-agent-B-${Date.now()}`
+    );
     await loadApp(page);
 
     const cardA = page.getByTestId(`agent-card-${agentA.id}`);
@@ -168,13 +191,19 @@ test.describe("Terminal live connection", () => {
     await waitForTerminalConnected(page, 5_000);
   });
 
-  test("healthy resume does not fetch a duplicate terminal token", async ({ page, request }) => {
+  test("healthy resume does not fetch a duplicate terminal token", async ({
+    page,
+    request,
+  }) => {
     test.skip(!IS_LIVE, "Requires --live agent runtime");
 
     const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
     let tokenRequests = 0;
     page.on("request", (req) => {
-      if (req.method() === "POST" && req.url().includes(`/api/v1/agents/${agent.id}/terminal/token`)) {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/terminal/token`)
+      ) {
         tokenRequests += 1;
       }
     });
@@ -196,7 +225,9 @@ test.describe("Terminal live connection", () => {
     await expect.poll(() => tokenRequests).toBe(1);
   });
 
-  test("terminal-features not duplicated across attaches", async ({ request }) => {
+  test("terminal-features not duplicated across attaches", async ({
+    request,
+  }) => {
     test.skip(!IS_LIVE, "Requires --live agent runtime");
 
     const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);

--- a/e2e/token-usage.spec.ts
+++ b/e2e/token-usage.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from "@playwright/test";
 import { Pool } from "pg";
 import { loadApp } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 async function seedTokenUsage(
   rows: Array<{
@@ -36,9 +38,13 @@ async function seedTokenUsage(
           output_tokens = EXCLUDED.output_tokens,
           message_count = EXCLUDED.message_count`,
         [
-          row.agent_id, row.session_id, row.model,
-          row.input_tokens, row.cache_creation_tokens ?? 0,
-          row.cache_read_tokens ?? 0, row.output_tokens,
+          row.agent_id,
+          row.session_id,
+          row.model,
+          row.input_tokens,
+          row.cache_creation_tokens ?? 0,
+          row.cache_read_tokens ?? 0,
+          row.output_tokens,
           row.message_count ?? 1,
         ]
       );
@@ -52,27 +58,43 @@ async function seedTokenUsage(
 async function cleanupTokenUsage(agentIdPrefix: string): Promise<void> {
   const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 1 });
   try {
-    await pool.query(`DELETE FROM agent_token_usage WHERE agent_id LIKE $1`, [`${agentIdPrefix}%`]);
-    await pool.query(`DELETE FROM agents WHERE id LIKE $1`, [`${agentIdPrefix}%`]);
+    await pool.query(`DELETE FROM agent_token_usage WHERE agent_id LIKE $1`, [
+      `${agentIdPrefix}%`,
+    ]);
+    await pool.query(`DELETE FROM agents WHERE id LIKE $1`, [
+      `${agentIdPrefix}%`,
+    ]);
   } finally {
     await pool.end();
   }
 }
 
-function activityParams(opts: { daysBack?: number; granularity?: string } = {}): string {
+function activityParams(
+  opts: { daysBack?: number; granularity?: string } = {}
+): string {
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const now = new Date();
-  const params = new URLSearchParams({ tz, granularity: opts.granularity ?? "day" });
+  const params = new URLSearchParams({
+    tz,
+    granularity: opts.granularity ?? "day",
+  });
   if (opts.daysBack !== undefined) {
-    params.set("start", new Date(now.getTime() - opts.daysBack * 86400000).toISOString());
+    params.set(
+      "start",
+      new Date(now.getTime() - opts.daysBack * 86400000).toISOString()
+    );
     params.set("end", now.toISOString());
   }
   return params.toString();
 }
 
 test.describe("Token usage API", () => {
-  test("GET /api/v1/activity/token-stats returns zeroes when empty", async ({ request }) => {
-    const res = await request.get("/api/v1/activity/token-stats", { headers: authHeader });
+  test("GET /api/v1/activity/token-stats returns zeroes when empty", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/v1/activity/token-stats", {
+      headers: authHeader,
+    });
     expect(res.ok()).toBeTruthy();
 
     const body = (await res.json()) as {
@@ -88,7 +110,9 @@ test.describe("Token usage API", () => {
     expect(body.total_sessions).toBe(0);
   });
 
-  test("GET /api/v1/activity/token-daily returns empty days array when no data", async ({ request }) => {
+  test("GET /api/v1/activity/token-daily returns empty days array when no data", async ({
+    request,
+  }) => {
     const res = await request.get(
       `/api/v1/activity/token-daily?${activityParams({ daysBack: 30, granularity: "day" })}`,
       { headers: authHeader }
@@ -101,8 +125,12 @@ test.describe("Token usage API", () => {
     expect(body.granularity).toBe("day");
   });
 
-  test("GET /api/v1/activity/token-by-project returns empty projects array when no data", async ({ request }) => {
-    const res = await request.get("/api/v1/activity/token-by-project", { headers: authHeader });
+  test("GET /api/v1/activity/token-by-project returns empty projects array when no data", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/v1/activity/token-by-project", {
+      headers: authHeader,
+    });
     expect(res.ok()).toBeTruthy();
 
     const body = (await res.json()) as { projects: unknown[] };
@@ -110,10 +138,15 @@ test.describe("Token usage API", () => {
     expect(body.projects.length).toBe(0);
   });
 
-  test("POST /api/v1/agents/:id/harvest-tokens returns 404 for unknown agent", async ({ request }) => {
-    const res = await request.post("/api/v1/agents/nonexistent-agent/harvest-tokens", {
-      headers: authHeader,
-    });
+  test("POST /api/v1/agents/:id/harvest-tokens returns 404 for unknown agent", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      "/api/v1/agents/nonexistent-agent/harvest-tokens",
+      {
+        headers: authHeader,
+      }
+    );
     expect(res.status()).toBe(404);
   });
 
@@ -123,21 +156,27 @@ test.describe("Token usage API", () => {
       { headers: authHeader }
     );
     expect(daily7.ok()).toBeTruthy();
-    expect(((await daily7.json()) as { granularity: string }).granularity).toBe("day");
+    expect(((await daily7.json()) as { granularity: string }).granularity).toBe(
+      "day"
+    );
 
     const daily30 = await request.get(
       `/api/v1/activity/token-daily?${activityParams({ daysBack: 30, granularity: "day" })}`,
       { headers: authHeader }
     );
     expect(daily30.ok()).toBeTruthy();
-    expect(((await daily30.json()) as { granularity: string }).granularity).toBe("day");
+    expect(
+      ((await daily30.json()) as { granularity: string }).granularity
+    ).toBe("day");
 
     const dailyMonth = await request.get(
       `/api/v1/activity/token-daily?${activityParams({ granularity: "month" })}`,
       { headers: authHeader }
     );
     expect(dailyMonth.ok()).toBeTruthy();
-    expect(((await dailyMonth.json()) as { granularity: string }).granularity).toBe("month");
+    expect(
+      ((await dailyMonth.json()) as { granularity: string }).granularity
+    ).toBe("month");
 
     const totals = await request.get(
       `/api/v1/activity/token-stats?${activityParams({ granularity: "month" })}`,
@@ -160,7 +199,9 @@ test.describe("Token usage API", () => {
 });
 
 test.describe("Token usage UI", () => {
-  test("Activity pane scopes requests when time range changes", async ({ page }) => {
+  test("Activity pane scopes requests when time range changes", async ({
+    page,
+  }) => {
     const requests: string[] = [];
     await page.route("**/api/v1/activity/**", async (route) => {
       requests.push(route.request().url());
@@ -178,12 +219,19 @@ test.describe("Token usage UI", () => {
     await page.getByTestId("activity-range-select").click();
     await page.getByRole("option", { name: "This year" }).click();
 
-    await expect(page.getByTestId("activity-range-select")).toContainText("This year");
+    await expect(page.getByTestId("activity-range-select")).toContainText(
+      "This year"
+    );
 
     // After switching to "This year", requests should include tz and granularity params
-    await expect.poll(
-      () => requests.filter((url) => url.includes("tz=") && url.includes("granularity=")).length
-    ).toBeGreaterThanOrEqual(6);
+    await expect
+      .poll(
+        () =>
+          requests.filter(
+            (url) => url.includes("tz=") && url.includes("granularity=")
+          ).length
+      )
+      .toBeGreaterThanOrEqual(6);
 
     // Navigate back to agents to close activity
     await page.getByTestId("agents-button").click();
@@ -198,7 +246,9 @@ test.describe("Token stats with seeded data", () => {
     await cleanupTokenUsage(AGENT_PREFIX);
   });
 
-  test("token-stats returns correct totals for seeded data", async ({ request }) => {
+  test("token-stats returns correct totals for seeded data", async ({
+    request,
+  }) => {
     await seedTokenUsage([
       {
         agent_id: `${AGENT_PREFIX}a1`,
@@ -220,7 +270,9 @@ test.describe("Token stats with seeded data", () => {
       },
     ]);
 
-    const res = await request.get("/api/v1/activity/token-stats", { headers: authHeader });
+    const res = await request.get("/api/v1/activity/token-stats", {
+      headers: authHeader,
+    });
     expect(res.ok()).toBeTruthy();
 
     const body = await res.json();
@@ -232,14 +284,23 @@ test.describe("Token stats with seeded data", () => {
     expect(body.total_sessions).toBeGreaterThanOrEqual(2);
 
     // All values must be numbers, not strings (bigint parser check)
-    for (const key of ["total_input", "total_cache_creation", "total_cache_read", "total_output", "total_messages", "total_sessions"]) {
+    for (const key of [
+      "total_input",
+      "total_cache_creation",
+      "total_cache_read",
+      "total_output",
+      "total_messages",
+      "total_sessions",
+    ]) {
       expect(typeof body[key]).toBe("number");
     }
 
     await cleanupTokenUsage(AGENT_PREFIX);
   });
 
-  test("token-stats handles values exceeding int32 max without error", async ({ request }) => {
+  test("token-stats handles values exceeding int32 max without error", async ({
+    request,
+  }) => {
     // Insert rows that would overflow a 32-bit int when summed (~2.15B each)
     await seedTokenUsage([
       {
@@ -258,7 +319,9 @@ test.describe("Token stats with seeded data", () => {
       },
     ]);
 
-    const res = await request.get("/api/v1/activity/token-stats", { headers: authHeader });
+    const res = await request.get("/api/v1/activity/token-stats", {
+      headers: authHeader,
+    });
     expect(res.ok()).toBeTruthy();
 
     const body = await res.json();

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -1,10 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { createAgentViaAPI, setAgentLatestEventViaAPI } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 test.describe("Web notification settings API", () => {
-  test("GET /api/v1/notifications/settings returns web notification fields", async ({ request }) => {
+  test("GET /api/v1/notifications/settings returns web notification fields", async ({
+    request,
+  }) => {
     const res = await request.get("/api/v1/notifications/settings", {
       headers: authHeader,
     });
@@ -15,7 +19,9 @@ test.describe("Web notification settings API", () => {
     expect(Array.isArray(data.webNotifyEvents)).toBe(true);
   });
 
-  test("POST /api/v1/notifications/settings saves web notification settings", async ({ request }) => {
+  test("POST /api/v1/notifications/settings saves web notification settings", async ({
+    request,
+  }) => {
     // Enable web notifications with only "done" events
     const res = await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -40,11 +46,16 @@ test.describe("Web notification settings API", () => {
     // Reset
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
-      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      data: {
+        webNotifyEnabled: false,
+        webNotifyEvents: ["done", "waiting_user", "blocked"],
+      },
     });
   });
 
-  test("POST /api/v1/notifications/settings validates webNotifyEnabled type", async ({ request }) => {
+  test("POST /api/v1/notifications/settings validates webNotifyEnabled type", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
       data: { webNotifyEnabled: "yes" },
@@ -52,7 +63,9 @@ test.describe("Web notification settings API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/notifications/settings validates webNotifyEvents type", async ({ request }) => {
+  test("POST /api/v1/notifications/settings validates webNotifyEvents type", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
       data: { webNotifyEvents: "done" },
@@ -60,7 +73,9 @@ test.describe("Web notification settings API", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/notifications/settings filters invalid event types", async ({ request }) => {
+  test("POST /api/v1/notifications/settings filters invalid event types", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
       data: { webNotifyEvents: ["done", "invalid_event", "blocked"] },
@@ -78,11 +93,16 @@ test.describe("Web notification settings API", () => {
 });
 
 test.describe("Web notification SSE events", () => {
-  test("web notification settings integrate with event pipeline", async ({ request }) => {
+  test("web notification settings integrate with event pipeline", async ({
+    request,
+  }) => {
     // Enable web notifications
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
-      data: { webNotifyEnabled: true, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      data: {
+        webNotifyEnabled: true,
+        webNotifyEvents: ["done", "waiting_user", "blocked"],
+      },
     });
 
     // Report browser permission as granted via focus heartbeat
@@ -113,7 +133,9 @@ test.describe("Web notification SSE events", () => {
     });
   });
 
-  test("web notification respects event type filtering", async ({ request }) => {
+  test("web notification respects event type filtering", async ({
+    request,
+  }) => {
     // Enable web notifications for "done" only
     const res = await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -130,13 +152,18 @@ test.describe("Web notification SSE events", () => {
     // Clean up
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
-      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      data: {
+        webNotifyEnabled: false,
+        webNotifyEvents: ["done", "waiting_user", "blocked"],
+      },
     });
   });
 });
 
 test.describe("Focus heartbeat includes notification permission", () => {
-  test("POST /api/v1/focus accepts webNotifyPermission field", async ({ request }) => {
+  test("POST /api/v1/focus accepts webNotifyPermission field", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/focus", {
       headers: authHeader,
       data: { agentId: null, webNotifyPermission: "granted" },
@@ -144,7 +171,9 @@ test.describe("Focus heartbeat includes notification permission", () => {
     expect(res.status()).toBe(204);
   });
 
-  test("POST /api/v1/focus accepts all valid permission values", async ({ request }) => {
+  test("POST /api/v1/focus accepts all valid permission values", async ({
+    request,
+  }) => {
     for (const perm of ["granted", "denied", "default"]) {
       const res = await request.post("/api/v1/focus", {
         headers: authHeader,
@@ -154,7 +183,9 @@ test.describe("Focus heartbeat includes notification permission", () => {
     }
   });
 
-  test("POST /api/v1/focus ignores invalid permission values", async ({ request }) => {
+  test("POST /api/v1/focus ignores invalid permission values", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/focus", {
       headers: authHeader,
       data: { agentId: null, webNotifyPermission: "invalid" },

--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -1,9 +1,23 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { test, expect } from "@playwright/test";
-import { cleanupE2EAgents, createAgentViaAPI, deleteAgentViaAPI, getWorktreeStatusViaAPI, loadApp } from "./helpers";
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  deleteAgentViaAPI,
+  getWorktreeStatusViaAPI,
+  loadApp,
+} from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
 
 /** Create a minimal git repo in /tmp with one commit and a local origin, returning the repo path. */
 function createTestRepo(suffix: string): string {
@@ -18,10 +32,13 @@ function createTestRepo(suffix: string): string {
 
   // Clone it as the working repo
   execSync(`git clone "${barePath}" "${repoPath}"`, { stdio: "ignore" });
-  execSync('git config user.email "test@test.com" && git config user.name "Test"', {
-    cwd: repoPath,
-    stdio: "ignore",
-  });
+  execSync(
+    'git config user.email "test@test.com" && git config user.name "Test"',
+    {
+      cwd: repoPath,
+      stdio: "ignore",
+    }
+  );
   writeFileSync(`${repoPath}/README.md`, "# test\n");
   writeFileSync(`${repoPath}/.gitignore`, ".env\n");
   execSync("git add -A && git commit -m 'initial' && git push origin main", {
@@ -36,12 +53,18 @@ function cleanupTestRepo(repoPath: string): void {
   const barePath = repoPath.replace("-repo-", "-bare-");
   // Remove any worktrees git knows about (they'll be siblings)
   try {
-    const output = execSync("git worktree list --porcelain", { cwd: repoPath, encoding: "utf-8" });
+    const output = execSync("git worktree list --porcelain", {
+      cwd: repoPath,
+      encoding: "utf-8",
+    });
     for (const line of output.split("\n")) {
       if (line.startsWith("worktree ") && !line.includes(repoPath)) {
         const wtPath = line.replace("worktree ", "").trim();
         try {
-          execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoPath, stdio: "ignore" });
+          execSync(`git worktree remove --force "${wtPath}"`, {
+            cwd: repoPath,
+            stdio: "ignore",
+          });
         } catch {
           rmSync(wtPath, { recursive: true, force: true });
         }
@@ -59,7 +82,9 @@ test.describe("Worktree", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("create dialog shows worktree checkbox defaulting to checked", async ({ page }) => {
+  test("create dialog shows worktree checkbox defaulting to checked", async ({
+    page,
+  }) => {
     await loadApp(page);
 
     await page.getByTestId("create-agent-button").click();
@@ -102,7 +127,9 @@ test.describe("Worktree", () => {
     expect(agent.worktreePath).toBeNull();
   });
 
-  test("POST /api/v1/agents validates useWorktree type", async ({ request }) => {
+  test("POST /api/v1/agents validates useWorktree type", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents", {
       headers: authHeader,
       data: { cwd: "/tmp", useWorktree: "not-a-boolean" },
@@ -113,7 +140,9 @@ test.describe("Worktree", () => {
     expect(body.error).toContain("useWorktree");
   });
 
-  test("GET /api/v1/agents/:id/worktree-status returns status for agent without worktree", async ({ request }) => {
+  test("GET /api/v1/agents/:id/worktree-status returns status for agent without worktree", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
       useWorktree: false,
@@ -127,7 +156,9 @@ test.describe("Worktree", () => {
     expect(status.branchName).toBeNull();
   });
 
-  test("DELETE /api/v1/agents/:id accepts cleanupWorktree param", async ({ request }) => {
+  test("DELETE /api/v1/agents/:id accepts cleanupWorktree param", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-${Date.now()}`,
       useWorktree: false,
@@ -140,9 +171,12 @@ test.describe("Worktree", () => {
     });
 
     // Delete with cleanupWorktree=keep should succeed
-    const res = await request.delete(`/api/v1/agents/${agent.id}?cleanupWorktree=keep`, {
-      headers: authHeader,
-    });
+    const res = await request.delete(
+      `/api/v1/agents/${agent.id}?cleanupWorktree=keep`,
+      {
+        headers: authHeader,
+      }
+    );
     expect(res.status()).toBe(202);
   });
 
@@ -164,12 +198,16 @@ test.describe("Worktree", () => {
     await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // Should show standard archive confirmation (not worktree choice)
-    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({
+      timeout: 3_000,
+    });
     await expect(page.getByText("removes the agent record")).toBeVisible();
 
     // Confirm deletion
     await page.getByTestId("delete-agent-confirm").click();
-    await expect(sidebar.getByText(agent.name)).not.toBeVisible({ timeout: 5_000 });
+    await expect(sidebar.getByText(agent.name)).not.toBeVisible({
+      timeout: 5_000,
+    });
   });
 });
 
@@ -212,13 +250,19 @@ test.describe("Worktree filesystem", () => {
 
     // The agent's cwd should be the worktree, not the original repo
     const agentRes = await request.get(`/api/v1/agents/${agent.id}`, {
-      headers: { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` },
+      headers: {
+        Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+      },
     });
-    const { agent: fullAgent } = (await agentRes.json()) as { agent: { cwd: string } };
+    const { agent: fullAgent } = (await agentRes.json()) as {
+      agent: { cwd: string };
+    };
     expect(fullAgent.cwd).toBe(agent.worktreePath);
   });
 
-  test("auto-generates branch name from agent id and name", async ({ request }) => {
+  test("auto-generates branch name from agent id and name", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-autobranch-${Date.now()}`,
       cwd: repoPath,
@@ -278,7 +322,9 @@ test.describe("Worktree filesystem", () => {
     expect(content).toContain("DB_URL=localhost");
   });
 
-  test("worktree-status reports no unmerged commits for clean worktree", async ({ request }) => {
+  test("worktree-status reports no unmerged commits for clean worktree", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-clean-${Date.now()}`,
       cwd: repoPath,
@@ -293,7 +339,9 @@ test.describe("Worktree filesystem", () => {
     expect(status.worktreePath).toBe(agent.worktreePath);
   });
 
-  test("deleting agent with clean worktree removes it from disk", async ({ request }) => {
+  test("deleting agent with clean worktree removes it from disk", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-delclean-${Date.now()}`,
       cwd: repoPath,
@@ -309,7 +357,9 @@ test.describe("Worktree filesystem", () => {
     expect(existsSync(wtPath)).toBe(false);
   });
 
-  test("worktree-status reports unmerged commits after local commit", async ({ request }) => {
+  test("worktree-status reports unmerged commits after local commit", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-dirty-${Date.now()}`,
       cwd: repoPath,
@@ -329,7 +379,9 @@ test.describe("Worktree filesystem", () => {
     expect(status.changedFiles).toContain("new-file.txt");
   });
 
-  test("worktree-status reports uncommitted changes for modified files", async ({ request }) => {
+  test("worktree-status reports uncommitted changes for modified files", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-uncommitted-${Date.now()}`,
       cwd: repoPath,
@@ -337,7 +389,10 @@ test.describe("Worktree filesystem", () => {
     });
 
     // Create an unstaged file in the worktree (no commit)
-    writeFileSync(`${agent.worktreePath}/uncommitted-file.txt`, "uncommitted work\n");
+    writeFileSync(
+      `${agent.worktreePath}/uncommitted-file.txt`,
+      "uncommitted work\n"
+    );
 
     const status = await getWorktreeStatusViaAPI(request, agent.id);
     expect(status.hasWorktree).toBe(true);
@@ -346,7 +401,9 @@ test.describe("Worktree filesystem", () => {
     expect(status.uncommittedFiles).toContain("?? uncommitted-file.txt");
   });
 
-  test("deleting agent with uncommitted changes and cleanupWorktree=auto preserves worktree", async ({ request }) => {
+  test("deleting agent with uncommitted changes and cleanupWorktree=auto preserves worktree", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-keepuncommitted-${Date.now()}`,
       cwd: repoPath,
@@ -362,10 +419,14 @@ test.describe("Worktree filesystem", () => {
     expect(existsSync(wtPath)).toBe(true);
 
     // Clean up manually
-    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, { stdio: "ignore" });
+    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, {
+      stdio: "ignore",
+    });
   });
 
-  test("deleting agent with unmerged commits and cleanupWorktree=auto preserves worktree", async ({ request }) => {
+  test("deleting agent with unmerged commits and cleanupWorktree=auto preserves worktree", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-keepwt-${Date.now()}`,
       cwd: repoPath,
@@ -386,10 +447,14 @@ test.describe("Worktree filesystem", () => {
     expect(existsSync(wtPath)).toBe(true);
 
     // Clean up manually
-    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, { stdio: "ignore" });
+    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, {
+      stdio: "ignore",
+    });
   });
 
-  test("deleting agent with unmerged commits and cleanupWorktree=force removes worktree", async ({ request }) => {
+  test("deleting agent with unmerged commits and cleanupWorktree=force removes worktree", async ({
+    request,
+  }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-agent-forcewt-${Date.now()}`,
       cwd: repoPath,
@@ -437,11 +502,15 @@ test.describe("Worktree filesystem", () => {
     await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // First step: standard archive confirmation
-    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({
+      timeout: 3_000,
+    });
     await page.getByTestId("delete-agent-confirm").click();
 
     // Second step: worktree choice dialog should appear
-    await expect(page.getByText("Worktree Has Outstanding Changes")).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByText("Worktree Has Outstanding Changes")
+    ).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("delete-agent-keep-worktree")).toBeVisible();
     await expect(page.getByTestId("delete-agent-force-worktree")).toBeVisible();
 
@@ -456,7 +525,9 @@ test.describe("Worktree filesystem", () => {
     expect(existsSync(wtPath)).toBe(true);
 
     // Clean up manually
-    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, { stdio: "ignore" });
+    execSync(`git -C "${repoPath}" worktree remove --force "${wtPath}"`, {
+      stdio: "ignore",
+    });
   });
 
   test("delete dialog force-delete worktree option removes it", async ({
@@ -485,11 +556,15 @@ test.describe("Worktree filesystem", () => {
     await page.getByTestId(`agent-archive-${agent.id}`).click();
 
     // First step: standard archive confirmation
-    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("delete-agent-confirm")).toBeVisible({
+      timeout: 3_000,
+    });
     await page.getByTestId("delete-agent-confirm").click();
 
     // Second step: worktree choice dialog
-    await expect(page.getByText("Worktree Has Outstanding Changes")).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByText("Worktree Has Outstanding Changes")
+    ).toBeVisible({ timeout: 5_000 });
 
     // Choose "Archive and remove worktree"
     const wtPath = agent.worktreePath!;
@@ -524,14 +599,20 @@ test.describe("Worktree location setting", () => {
     await cleanupE2EAgents(request);
   });
 
-  test("GET /api/v1/agents/settings returns default worktree location", async ({ request }) => {
-    const res = await request.get("/api/v1/agents/settings", { headers: authHeader });
+  test("GET /api/v1/agents/settings returns default worktree location", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/v1/agents/settings", {
+      headers: authHeader,
+    });
     expect(res.ok()).toBeTruthy();
     const body = (await res.json()) as { worktreeLocation: string };
     expect(body.worktreeLocation).toBe("sibling");
   });
 
-  test("POST /api/v1/agents/settings persists worktree location", async ({ request }) => {
+  test("POST /api/v1/agents/settings persists worktree location", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents/settings", {
       headers: authHeader,
       data: { worktreeLocation: "nested" },
@@ -541,12 +622,16 @@ test.describe("Worktree location setting", () => {
     expect(body.worktreeLocation).toBe("nested");
 
     // Verify it persisted
-    const getRes = await request.get("/api/v1/agents/settings", { headers: authHeader });
+    const getRes = await request.get("/api/v1/agents/settings", {
+      headers: authHeader,
+    });
     const getBody = (await getRes.json()) as { worktreeLocation: string };
     expect(getBody.worktreeLocation).toBe("nested");
   });
 
-  test("POST /api/v1/agents/settings validates worktree location", async ({ request }) => {
+  test("POST /api/v1/agents/settings validates worktree location", async ({
+    request,
+  }) => {
     const res = await request.post("/api/v1/agents/settings", {
       headers: authHeader,
       data: { worktreeLocation: "invalid" },
@@ -554,7 +639,9 @@ test.describe("Worktree location setting", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("sibling location creates worktree next to the repo", async ({ request }) => {
+  test("sibling location creates worktree next to the repo", async ({
+    request,
+  }) => {
     await request.post("/api/v1/agents/settings", {
       headers: authHeader,
       data: { worktreeLocation: "sibling" },
@@ -572,7 +659,9 @@ test.describe("Worktree location setting", () => {
     expect(existsSync(agent.worktreePath!)).toBe(true);
   });
 
-  test("nested location creates worktree inside .dispatch/worktrees", async ({ request }) => {
+  test("nested location creates worktree inside .dispatch/worktrees", async ({
+    request,
+  }) => {
     await request.post("/api/v1/agents/settings", {
       headers: authHeader,
       data: { worktreeLocation: "nested" },
@@ -586,7 +675,9 @@ test.describe("Worktree location setting", () => {
 
     expect(agent.worktreePath).toBeTruthy();
     // Nested: worktree is inside <repoPath>/.dispatch/worktrees/
-    expect(agent.worktreePath!.startsWith(`${repoPath}/.dispatch/worktrees/`)).toBe(true);
+    expect(
+      agent.worktreePath!.startsWith(`${repoPath}/.dispatch/worktrees/`)
+    ).toBe(true);
     expect(existsSync(agent.worktreePath!)).toBe(true);
   });
 
@@ -594,9 +685,14 @@ test.describe("Worktree location setting", () => {
     await loadApp(page);
 
     await page.getByTestId("settings-button").click();
-    await page.getByRole("navigation").getByText("Agents", { exact: true }).click();
+    await page
+      .getByRole("navigation")
+      .getByText("Agents", { exact: true })
+      .click();
 
-    await expect(page.getByText("Worktree location")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("Worktree location")).toBeVisible({
+      timeout: 3_000,
+    });
     await expect(page.getByText("Sibling directories")).toBeVisible();
     await expect(page.getByText("Inside .dispatch/worktrees")).toBeVisible();
   });

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "check:web": "pnpm --filter @dispatch/web check",
     "lint:web": "pnpm --filter @dispatch/web lint",
     "finalize:web": "pnpm run check:web && pnpm run build:web",
+    "format": "prettier --check .",
+    "format:write": "prettier --write .",
     "start": "pnpm --filter @dispatch/server start",
     "release": "bin/dispatch-server update",
     "db:migrate": "pnpm --filter @dispatch/server db:migrate",
     "check": "pnpm --filter @dispatch/server check && pnpm run check:web",
+    "ci": "pnpm run format && pnpm run check && pnpm run lint:web && pnpm run build && pnpm run test && pnpm run test:e2e",
     "test": "pnpm --filter @dispatch/server test",
     "test:watch": "pnpm --filter @dispatch/server test:watch",
     "test:e2e": "bash scripts/e2e-isolated.sh",
@@ -43,6 +46,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "playwright": "^1.54.2",
+    "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "typescript": "^5.9.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,14 +1,13 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
-      '@playwright/test':
+      "@playwright/test":
         specifier: ^1.58.2
         version: 1.58.2
       husky:
@@ -20,6 +19,9 @@ importers:
       playwright:
         specifier: ^1.54.2
         version: 1.58.2
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -29,22 +31,22 @@ importers:
 
   apps/server:
     dependencies:
-      '@fastify/cookie':
+      "@fastify/cookie":
         specifier: ^9.4.0
         version: 9.4.0
-      '@fastify/multipart':
+      "@fastify/multipart":
         specifier: ^8.3.1
         version: 8.3.1
-      '@fastify/rate-limit':
-        specifier: '9'
+      "@fastify/rate-limit":
+        specifier: "9"
         version: 9.1.0
-      '@fastify/static':
+      "@fastify/static":
         specifier: ^6.12.0
         version: 6.12.0
-      '@fastify/websocket':
+      "@fastify/websocket":
         specifier: ^8.3.1
         version: 8.3.1
-      '@modelcontextprotocol/sdk':
+      "@modelcontextprotocol/sdk":
         specifier: ^1.27.1
         version: 1.28.0(zod@4.3.6)
       bcryptjs:
@@ -72,16 +74,16 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@types/bcryptjs':
+      "@types/bcryptjs":
         specifier: ^2.4.6
         version: 2.4.6
-      '@types/node':
+      "@types/node":
         specifier: ^24.10.0
         version: 24.12.0
-      '@types/pg':
+      "@types/pg":
         specifier: ^8.18.0
         version: 8.20.0
-      '@types/ws':
+      "@types/ws":
         specifier: ^8.18.1
         version: 8.18.1
       tsx:
@@ -96,43 +98,43 @@ importers:
 
   apps/web:
     dependencies:
-      '@formkit/auto-animate':
+      "@formkit/auto-animate":
         specifier: ^0.9.0
         version: 0.9.0
-      '@radix-ui/react-checkbox':
+      "@radix-ui/react-checkbox":
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dialog':
+      "@radix-ui/react-dialog":
         specifier: ^1.1.2
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dropdown-menu':
+      "@radix-ui/react-dropdown-menu":
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popover':
+      "@radix-ui/react-popover":
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-scroll-area':
+      "@radix-ui/react-scroll-area":
         specifier: ^1.2.0
         version: 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-select':
+      "@radix-ui/react-select":
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot':
+      "@radix-ui/react-slot":
         specifier: ^1.1.0
         version: 1.2.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-tooltip':
+      "@radix-ui/react-tooltip":
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/react-query':
+      "@tanstack/react-query":
         specifier: ^5.91.2
         version: 5.95.2(react@18.3.1)
-      '@xterm/addon-clipboard':
+      "@xterm/addon-clipboard":
         specifier: ^0.2.0
         version: 0.2.0
-      '@xterm/addon-fit':
+      "@xterm/addon-fit":
         specifier: ^0.11.0
         version: 0.11.0
-      '@xterm/xterm':
+      "@xterm/xterm":
         specifier: ^6.0.0
         version: 6.0.0
       class-variance-authority:
@@ -190,19 +192,19 @@ importers:
         specifier: ^2.5.4
         version: 2.6.1
     devDependencies:
-      '@eslint/js':
+      "@eslint/js":
         specifier: ^9.39.4
         version: 9.39.4
-      '@tailwindcss/typography':
+      "@tailwindcss/typography":
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
-      '@types/react':
+      "@types/react":
         specifier: ^18.3.12
         version: 18.3.28
-      '@types/react-dom':
+      "@types/react-dom":
         specifier: ^18.3.1
         version: 18.3.7(@types/react@18.3.28)
-      '@vitejs/plugin-react':
+      "@vitejs/plugin-react":
         specifier: ^4.3.3
         version: 4.7.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))
       autoprefixer:
@@ -240,1688 +242,2530 @@ importers:
         version: 1.2.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
 
 packages:
+  "@alloc/quick-lru@5.2.0":
+    resolution:
+      {
+        integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
+      }
+    engines: { node: ">=10" }
 
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
-
-  '@apideck/better-ajv-errors@0.3.7':
-    resolution: {integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==}
-    engines: {node: '>=10'}
+  "@apideck/better-ajv-errors@0.3.7":
+    resolution:
+      {
+        integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      ajv: '>=8'
+      ajv: ">=8"
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/code-frame@7.29.0":
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/compat-data@7.29.0":
+    resolution:
+      {
+        integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/core@7.29.0":
+    resolution:
+      {
+        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/generator@7.29.1":
+    resolution:
+      {
+        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-annotate-as-pure@7.27.3":
+    resolution:
+      {
+        integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-compilation-targets@7.28.6":
+    resolution:
+      {
+        integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-create-class-features-plugin@7.28.6':
-    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-create-class-features-plugin@7.28.6":
+    resolution:
+      {
+        integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5':
-    resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-create-regexp-features-plugin@7.28.5":
+    resolution:
+      {
+        integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-define-polyfill-provider@0.6.8':
-    resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
+  "@babel/helper-define-polyfill-provider@0.6.8":
+    resolution:
+      {
+        integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==,
+      }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-globals@7.28.0":
+    resolution:
+      {
+        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
-    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-member-expression-to-functions@7.28.5":
+    resolution:
+      {
+        integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-imports@7.28.6":
+    resolution:
+      {
+        integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-transforms@7.28.6":
+    resolution:
+      {
+        integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.27.1':
-    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-optimise-call-expression@7.27.1":
+    resolution:
+      {
+        integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-plugin-utils@7.28.6":
+    resolution:
+      {
+        integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-remap-async-to-generator@7.27.1':
-    resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-remap-async-to-generator@7.27.1":
+    resolution:
+      {
+        integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-replace-supers@7.28.6':
-    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-replace-supers@7.28.6":
+    resolution:
+      {
+        integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-skip-transparent-expression-wrappers@7.27.1":
+    resolution:
+      {
+        integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-string-parser@7.27.1":
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.28.5":
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-option@7.27.1":
+    resolution:
+      {
+        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-wrap-function@7.28.6':
-    resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-wrap-function@7.28.6":
+    resolution:
+      {
+        integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helpers@7.29.2":
+    resolution:
+      {
+        integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
+  "@babel/parser@7.29.2":
+    resolution:
+      {
+        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
-    resolution: {integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1':
-    resolution: {integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
-    resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1':
-    resolution: {integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.13.0
-
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
-    resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
-    resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-assertions@7.28.6':
-    resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.28.6':
-    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
-    resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-transform-arrow-functions@7.27.1':
-    resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-async-generator-functions@7.29.0':
-    resolution: {integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-async-to-generator@7.28.6':
-    resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-block-scoped-functions@7.27.1':
-    resolution: {integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-block-scoping@7.28.6':
-    resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-class-properties@7.28.6':
-    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-class-static-block@7.28.6':
-    resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-
-  '@babel/plugin-transform-classes@7.28.6':
-    resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-computed-properties@7.28.6':
-    resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-destructuring@7.28.5':
-    resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-dotall-regex@7.28.6':
-    resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-duplicate-keys@7.27.1':
-    resolution: {integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0':
-    resolution: {integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-transform-dynamic-import@7.27.1':
-    resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-explicit-resource-management@7.28.6':
-    resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-exponentiation-operator@7.28.6':
-    resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-export-namespace-from@7.27.1':
-    resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-for-of@7.27.1':
-    resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-function-name@7.27.1':
-    resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-json-strings@7.28.6':
-    resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-literals@7.27.1':
-    resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6':
-    resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-member-expression-literals@7.27.1':
-    resolution: {integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-amd@7.27.1':
-    resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-umd@7.27.1':
-    resolution: {integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
-    resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-transform-new-target@7.27.1':
-    resolution: {integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
-    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-numeric-separator@7.28.6':
-    resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-object-rest-spread@7.28.6':
-    resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-object-super@7.27.1':
-    resolution: {integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-optional-catch-binding@7.28.6':
-    resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-optional-chaining@7.28.6':
-    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-parameters@7.27.7':
-    resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-private-methods@7.28.6':
-    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-private-property-in-object@7.28.6':
-    resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-property-literals@7.27.1':
-    resolution: {integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-regenerator@7.29.0':
-    resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-regexp-modifiers@7.28.6':
-    resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-transform-reserved-words@7.27.1':
-    resolution: {integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-shorthand-properties@7.27.1':
-    resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-spread@7.28.6':
-    resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-sticky-regex@7.27.1':
-    resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-template-literals@7.27.1':
-    resolution: {integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-typeof-symbol@7.27.1':
-    resolution: {integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-unicode-escapes@7.27.1':
-    resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-unicode-property-regex@7.28.6':
-    resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-unicode-regex@7.27.1':
-    resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6':
-    resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-modules@0.1.6-no-external-plugins':
-    resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
-
-  '@date-fns/tz@1.4.1':
-    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
-
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5":
+    resolution:
+      {
+        integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1":
+    resolution:
+      {
+        integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1":
+    resolution:
+      {
+        integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1":
+    resolution:
+      {
+        integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.13.0
+
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6":
+    resolution:
+      {
+        integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+    resolution:
+      {
+        integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-assertions@7.28.6":
+    resolution:
+      {
+        integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-attributes@7.28.6":
+    resolution:
+      {
+        integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6":
+    resolution:
+      {
+        integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-arrow-functions@7.27.1":
+    resolution:
+      {
+        integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-generator-functions@7.29.0":
+    resolution:
+      {
+        integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-to-generator@7.28.6":
+    resolution:
+      {
+        integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoped-functions@7.27.1":
+    resolution:
+      {
+        integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoping@7.28.6":
+    resolution:
+      {
+        integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-properties@7.28.6":
+    resolution:
+      {
+        integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-static-block@7.28.6":
+    resolution:
+      {
+        integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.12.0
+
+  "@babel/plugin-transform-classes@7.28.6":
+    resolution:
+      {
+        integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-computed-properties@7.28.6":
+    resolution:
+      {
+        integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-destructuring@7.28.5":
+    resolution:
+      {
+        integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-dotall-regex@7.28.6":
+    resolution:
+      {
+        integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-keys@7.27.1":
+    resolution:
+      {
+        integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0":
+    resolution:
+      {
+        integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-dynamic-import@7.27.1":
+    resolution:
+      {
+        integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-explicit-resource-management@7.28.6":
+    resolution:
+      {
+        integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-exponentiation-operator@7.28.6":
+    resolution:
+      {
+        integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-export-namespace-from@7.27.1":
+    resolution:
+      {
+        integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-for-of@7.27.1":
+    resolution:
+      {
+        integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-function-name@7.27.1":
+    resolution:
+      {
+        integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-json-strings@7.28.6":
+    resolution:
+      {
+        integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-literals@7.27.1":
+    resolution:
+      {
+        integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-logical-assignment-operators@7.28.6":
+    resolution:
+      {
+        integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-member-expression-literals@7.27.1":
+    resolution:
+      {
+        integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-amd@7.27.1":
+    resolution:
+      {
+        integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-commonjs@7.28.6":
+    resolution:
+      {
+        integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-systemjs@7.29.0":
+    resolution:
+      {
+        integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-umd@7.27.1":
+    resolution:
+      {
+        integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.0":
+    resolution:
+      {
+        integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-new-target@7.27.1":
+    resolution:
+      {
+        integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-nullish-coalescing-operator@7.28.6":
+    resolution:
+      {
+        integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-numeric-separator@7.28.6":
+    resolution:
+      {
+        integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-rest-spread@7.28.6":
+    resolution:
+      {
+        integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-super@7.27.1":
+    resolution:
+      {
+        integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-catch-binding@7.28.6":
+    resolution:
+      {
+        integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-chaining@7.28.6":
+    resolution:
+      {
+        integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-parameters@7.27.7":
+    resolution:
+      {
+        integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-methods@7.28.6":
+    resolution:
+      {
+        integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-property-in-object@7.28.6":
+    resolution:
+      {
+        integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-property-literals@7.27.1":
+    resolution:
+      {
+        integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-jsx-self@7.27.1":
+    resolution:
+      {
+        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-jsx-source@7.27.1":
+    resolution:
+      {
+        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-regenerator@7.29.0":
+    resolution:
+      {
+        integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-regexp-modifiers@7.28.6":
+    resolution:
+      {
+        integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-reserved-words@7.27.1":
+    resolution:
+      {
+        integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-shorthand-properties@7.27.1":
+    resolution:
+      {
+        integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-spread@7.28.6":
+    resolution:
+      {
+        integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-sticky-regex@7.27.1":
+    resolution:
+      {
+        integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-template-literals@7.27.1":
+    resolution:
+      {
+        integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-typeof-symbol@7.27.1":
+    resolution:
+      {
+        integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-escapes@7.27.1":
+    resolution:
+      {
+        integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-property-regex@7.28.6":
+    resolution:
+      {
+        integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-regex@7.27.1":
+    resolution:
+      {
+        integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-sets-regex@7.28.6":
+    resolution:
+      {
+        integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/preset-env@7.29.2":
+    resolution:
+      {
+        integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/preset-modules@0.1.6-no-external-plugins":
+    resolution:
+      {
+        integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0 || ^8.0.0-0 <8.0.0
+
+  "@babel/runtime@7.29.2":
+    resolution:
+      {
+        integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/template@7.28.6":
+    resolution:
+      {
+        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/traverse@7.29.0":
+    resolution:
+      {
+        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/types@7.29.0":
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@date-fns/tz@1.4.1":
+    resolution:
+      {
+        integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==,
+      }
+
+  "@emnapi/runtime@1.9.2":
+    resolution:
+      {
+        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
+      }
+
+  "@esbuild/aix-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  "@esbuild/android-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-loong64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
+      }
+    engines: { node: ">=12" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-mips64el@0.21.5":
+    resolution:
+      {
+        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
+      }
+    engines: { node: ">=12" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.25.12":
+    resolution:
+      {
+        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.27.4":
+    resolution:
+      {
+        integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-riscv64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
+      }
+    engines: { node: ">=12" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-s390x@0.21.5":
+    resolution:
+      {
+        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
+      }
+    engines: { node: ">=12" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  "@esbuild/netbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  "@esbuild/openbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  "@esbuild/sunos-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  "@eslint-community/eslint-utils@4.9.1":
+    resolution:
+      {
+        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+  "@eslint-community/regexpp@4.12.2":
+    resolution:
+      {
+        integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  '@eslint/config-array@0.21.2':
-    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-array@0.21.2":
+    resolution:
+      {
+        integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-helpers@0.4.2":
+    resolution:
+      {
+        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/core@0.17.0":
+    resolution:
+      {
+        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/eslintrc@3.3.5':
-    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/eslintrc@3.3.5":
+    resolution:
+      {
+        integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/js@9.39.4':
-    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/js@9.39.4":
+    resolution:
+      {
+        integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/object-schema@2.1.7":
+    resolution:
+      {
+        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/plugin-kit@0.4.1":
+    resolution:
+      {
+        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@fastify/accept-negotiator@1.1.0':
-    resolution: {integrity: sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==}
-    engines: {node: '>=14'}
+  "@fastify/accept-negotiator@1.1.0":
+    resolution:
+      {
+        integrity: sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==,
+      }
+    engines: { node: ">=14" }
 
-  '@fastify/ajv-compiler@3.6.0':
-    resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
+  "@fastify/ajv-compiler@3.6.0":
+    resolution:
+      {
+        integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==,
+      }
 
-  '@fastify/busboy@3.2.0':
-    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+  "@fastify/busboy@3.2.0":
+    resolution:
+      {
+        integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==,
+      }
 
-  '@fastify/cookie@9.4.0':
-    resolution: {integrity: sha512-Th+pt3kEkh4MQD/Q2q1bMuJIB5NX/D5SwSpOKu3G/tjoGbwfpurIMJsWSPS0SJJ4eyjtmQ8OipDQspf8RbUOlg==}
+  "@fastify/cookie@9.4.0":
+    resolution:
+      {
+        integrity: sha512-Th+pt3kEkh4MQD/Q2q1bMuJIB5NX/D5SwSpOKu3G/tjoGbwfpurIMJsWSPS0SJJ4eyjtmQ8OipDQspf8RbUOlg==,
+      }
 
-  '@fastify/deepmerge@2.0.2':
-    resolution: {integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==}
+  "@fastify/deepmerge@2.0.2":
+    resolution:
+      {
+        integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==,
+      }
 
-  '@fastify/error@3.4.1':
-    resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
+  "@fastify/error@3.4.1":
+    resolution:
+      {
+        integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==,
+      }
 
-  '@fastify/error@4.2.0':
-    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+  "@fastify/error@4.2.0":
+    resolution:
+      {
+        integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==,
+      }
 
-  '@fastify/fast-json-stringify-compiler@4.3.0':
-    resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
+  "@fastify/fast-json-stringify-compiler@4.3.0":
+    resolution:
+      {
+        integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==,
+      }
 
-  '@fastify/merge-json-schemas@0.1.1':
-    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+  "@fastify/merge-json-schemas@0.1.1":
+    resolution:
+      {
+        integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==,
+      }
 
-  '@fastify/multipart@8.3.1':
-    resolution: {integrity: sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==}
+  "@fastify/multipart@8.3.1":
+    resolution:
+      {
+        integrity: sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==,
+      }
 
-  '@fastify/rate-limit@9.1.0':
-    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
+  "@fastify/rate-limit@9.1.0":
+    resolution:
+      {
+        integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==,
+      }
 
-  '@fastify/send@2.1.0':
-    resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
+  "@fastify/send@2.1.0":
+    resolution:
+      {
+        integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==,
+      }
 
-  '@fastify/static@6.12.0':
-    resolution: {integrity: sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==}
+  "@fastify/static@6.12.0":
+    resolution:
+      {
+        integrity: sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==,
+      }
 
-  '@fastify/websocket@8.3.1':
-    resolution: {integrity: sha512-hsQYHHJme/kvP3ZS4v/WMUznPBVeeQHHwAoMy1LiN6m/HuPfbdXq1MBJ4Nt8qX1YI+eVbog4MnOsU7MTozkwYA==}
+  "@fastify/websocket@8.3.1":
+    resolution:
+      {
+        integrity: sha512-hsQYHHJme/kvP3ZS4v/WMUznPBVeeQHHwAoMy1LiN6m/HuPfbdXq1MBJ4Nt8qX1YI+eVbog4MnOsU7MTozkwYA==,
+      }
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+  "@floating-ui/core@1.7.5":
+    resolution:
+      {
+        integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==,
+      }
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+  "@floating-ui/dom@1.7.6":
+    resolution:
+      {
+        integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==,
+      }
 
-  '@floating-ui/react-dom@2.1.8':
-    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+  "@floating-ui/react-dom@2.1.8":
+    resolution:
+      {
+        integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==,
+      }
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
 
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+  "@floating-ui/utils@0.2.11":
+    resolution:
+      {
+        integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
+      }
 
-  '@formkit/auto-animate@0.9.0':
-    resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
+  "@formkit/auto-animate@0.9.0":
+    resolution:
+      {
+        integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==,
+      }
 
-  '@hono/node-server@1.19.12':
-    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
-    engines: {node: '>=18.14.1'}
+  "@hono/node-server@1.19.12":
+    resolution:
+      {
+        integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==,
+      }
+    engines: { node: ">=18.14.1" }
     peerDependencies:
       hono: ^4
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/core@0.19.1":
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/node@0.16.7":
+    resolution:
+      {
+        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
+  "@humanwhocodes/module-importer@1.0.1":
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: ">=12.22" }
 
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
+  "@humanwhocodes/retry@0.4.3":
+    resolution:
+      {
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+      }
+    engines: { node: ">=18.18" }
 
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
+  "@img/colour@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
+      }
+    engines: { node: ">=18" }
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-darwin-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-darwin-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  "@img/sharp-libvips-darwin-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
+      }
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  "@img/sharp-libvips-darwin-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
+      }
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  "@img/sharp-libvips-linux-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  "@img/sharp-libvips-linux-arm@1.2.4":
+    resolution:
+      {
+        integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  "@img/sharp-libvips-linux-ppc64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  "@img/sharp-libvips-linux-riscv64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  "@img/sharp-libvips-linux-s390x@1.2.4":
+    resolution:
+      {
+        integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
+      }
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  "@img/sharp-libvips-linux-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  "@img/sharp-libvips-linuxmusl-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-arm@0.34.5":
+    resolution:
+      {
+        integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-ppc64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-riscv64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-s390x@0.34.5":
+    resolution:
+      {
+        integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linux-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linuxmusl-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-linuxmusl-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-wasm32@0.34.5":
+    resolution:
+      {
+        integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-win32-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-win32-ia32@0.34.5":
+    resolution:
+      {
+        integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  "@img/sharp-win32-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
+  "@isaacs/cliui@9.0.0":
+    resolution:
+      {
+        integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==,
+      }
+    engines: { node: ">=18" }
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+  "@jridgewell/gen-mapping@0.3.13":
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+  "@jridgewell/remapping@2.3.5":
+    resolution:
+      {
+        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+      }
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+  "@jridgewell/resolve-uri@3.1.2":
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: ">=6.0.0" }
 
-  '@jridgewell/source-map@0.3.11':
-    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+  "@jridgewell/source-map@0.3.11":
+    resolution:
+      {
+        integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==,
+      }
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+  "@jridgewell/trace-mapping@0.3.31":
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
 
-  '@lukeed/ms@2.0.2':
-    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
-    engines: {node: '>=8'}
+  "@lukeed/ms@2.0.2":
+    resolution:
+      {
+        integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==,
+      }
+    engines: { node: ">=8" }
 
-  '@modelcontextprotocol/sdk@1.28.0':
-    resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
-    engines: {node: '>=18'}
+  "@modelcontextprotocol/sdk@1.28.0":
+    resolution:
+      {
+        integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
+      "@cfworker/json-schema": ^4.1.1
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
-      '@cfworker/json-schema':
+      "@cfworker/json-schema":
         optional: true
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.scandir@2.1.5":
+    resolution:
+      {
+        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.stat@2.0.5":
+    resolution:
+      {
+        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.walk@1.2.8":
+    resolution:
+      {
+        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+      }
+    engines: { node: ">= 8" }
 
-  '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+  "@pinojs/redact@0.4.0":
+    resolution:
+      {
+        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+      }
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
-    engines: {node: '>=18'}
+  "@playwright/test@1.58.2":
+    resolution:
+      {
+        integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
-  '@radix-ui/number@1.1.1':
-    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+  "@radix-ui/number@1.1.1":
+    resolution:
+      {
+        integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==,
+      }
 
-  '@radix-ui/primitive@1.1.3':
-    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+  "@radix-ui/primitive@1.1.3":
+    resolution:
+      {
+        integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==,
+      }
 
-  '@radix-ui/react-arrow@1.1.7':
-    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+  "@radix-ui/react-arrow@1.1.7":
+    resolution:
+      {
+        integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-checkbox@1.3.3':
-    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+  "@radix-ui/react-checkbox@1.3.3":
+    resolution:
+      {
+        integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-collection@1.1.7':
-    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+  "@radix-ui/react-collection@1.1.7":
+    resolution:
+      {
+        integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-compose-refs@1.1.2':
-    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+  "@radix-ui/react-compose-refs@1.1.2":
+    resolution:
+      {
+        integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==,
+      }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
-  '@radix-ui/react-context@1.1.2':
-    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+  "@radix-ui/react-context@1.1.2":
+    resolution:
+      {
+        integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==,
+      }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
-  '@radix-ui/react-dialog@1.1.15':
-    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+  "@radix-ui/react-dialog@1.1.15":
+    resolution:
+      {
+        integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-direction@1.1.1':
-    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.11':
-    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+  "@radix-ui/react-direction@1.1.1":
+    resolution:
+      {
+        integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-dismissable-layer@1.1.11":
+    resolution:
+      {
+        integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.3':
-    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.7':
-    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+  "@radix-ui/react-dropdown-menu@2.1.16":
+    resolution:
+      {
+        integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-id@1.1.1':
-    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+  "@radix-ui/react-focus-guards@1.1.3":
+    resolution:
+      {
+        integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==,
+      }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+  "@radix-ui/react-focus-scope@1.1.7":
+    resolution:
+      {
+        integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popover@1.1.15':
-    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-popper@1.2.8':
-    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+  "@radix-ui/react-id@1.1.1":
+    resolution:
+      {
+        integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-menu@2.1.16":
+    resolution:
+      {
+        integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-portal@1.1.9':
-    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+  "@radix-ui/react-popover@1.1.15":
+    resolution:
+      {
+        integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-presence@1.1.5':
-    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+  "@radix-ui/react-popper@1.2.8":
+    resolution:
+      {
+        integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-primitive@2.1.3':
-    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+  "@radix-ui/react-portal@1.1.9":
+    resolution:
+      {
+        integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-primitive@2.1.4':
-    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+  "@radix-ui/react-presence@1.1.5":
+    resolution:
+      {
+        integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-roving-focus@1.1.11':
-    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+  "@radix-ui/react-primitive@2.1.3":
+    resolution:
+      {
+        integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-scroll-area@1.2.10':
-    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+  "@radix-ui/react-primitive@2.1.4":
+    resolution:
+      {
+        integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-select@2.2.6':
-    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+  "@radix-ui/react-roving-focus@1.1.11":
+    resolution:
+      {
+        integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.3':
-    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-slot@1.2.4':
-    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+  "@radix-ui/react-scroll-area@1.2.10":
+    resolution:
+      {
+        integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-use-callback-ref@1.1.1':
-    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/react-use-controllable-state@1.2.2':
-    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+  "@radix-ui/react-select@2.2.6":
+    resolution:
+      {
+        integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==,
+      }
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-effect-event@0.0.2':
-    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.1':
-    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.1':
-    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-previous@1.1.1':
-    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-rect@1.1.1':
-    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-size@1.1.1':
-    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.3':
-    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      "@types/react": "*"
+      "@types/react-dom": "*"
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
-      '@types/react-dom':
+      "@types/react-dom":
         optional: true
 
-  '@radix-ui/rect@1.1.1':
-    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+  "@radix-ui/react-slot@1.2.3":
+    resolution:
+      {
+        integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
 
-  '@reduxjs/toolkit@2.11.2':
-    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+  "@radix-ui/react-slot@1.2.4":
+    resolution:
+      {
+        integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-tooltip@1.2.8":
+    resolution:
+      {
+        integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-use-callback-ref@1.1.1":
+    resolution:
+      {
+        integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-controllable-state@1.2.2":
+    resolution:
+      {
+        integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-effect-event@0.0.2":
+    resolution:
+      {
+        integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-escape-keydown@1.1.1":
+    resolution:
+      {
+        integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-layout-effect@1.1.1":
+    resolution:
+      {
+        integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-previous@1.1.1":
+    resolution:
+      {
+        integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-rect@1.1.1":
+    resolution:
+      {
+        integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-size@1.1.1":
+    resolution:
+      {
+        integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-visually-hidden@1.2.3":
+    resolution:
+      {
+        integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/rect@1.1.1":
+    resolution:
+      {
+        integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
+      }
+
+  "@reduxjs/toolkit@2.11.2":
+    resolution:
+      {
+        integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==,
+      }
     peerDependencies:
       react: ^16.9.0 || ^17.0.0 || ^18 || ^19
       react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
@@ -1931,395 +2775,665 @@ packages:
       react-redux:
         optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  "@rolldown/pluginutils@1.0.0-beta.27":
+    resolution:
+      {
+        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
+      }
 
-  '@rollup/plugin-babel@5.3.1':
-    resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
-    engines: {node: '>= 10.0.0'}
+  "@rollup/plugin-babel@5.3.1":
+    resolution:
+      {
+        integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==,
+      }
+    engines: { node: ">= 10.0.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/babel__core': ^7.1.9
+      "@babel/core": ^7.0.0
+      "@types/babel__core": ^7.1.9
       rollup: ^1.20.0||^2.0.0
     peerDependenciesMeta:
-      '@types/babel__core':
+      "@types/babel__core":
         optional: true
 
-  '@rollup/plugin-node-resolve@15.3.1':
-    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
-    engines: {node: '>=14.0.0'}
+  "@rollup/plugin-node-resolve@15.3.1":
+    resolution:
+      {
+        integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/plugin-replace@2.4.2':
-    resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
+  "@rollup/plugin-replace@2.4.2":
+    resolution:
+      {
+        integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==,
+      }
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
 
-  '@rollup/plugin-terser@0.4.4':
-    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
-    engines: {node: '>=14.0.0'}
+  "@rollup/plugin-terser@0.4.4":
+    resolution:
+      {
+        integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       rollup: ^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/pluginutils@3.1.0':
-    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
-    engines: {node: '>= 8.0.0'}
+  "@rollup/pluginutils@3.1.0":
+    resolution:
+      {
+        integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==,
+      }
+    engines: { node: ">= 8.0.0" }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
 
-  '@rollup/pluginutils@5.3.0':
-    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
-    engines: {node: '>=14.0.0'}
+  "@rollup/pluginutils@5.3.0":
+    resolution:
+      {
+        integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+  "@rollup/rollup-android-arm-eabi@4.60.1":
+    resolution:
+      {
+        integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==,
+      }
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  "@rollup/rollup-android-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==,
+      }
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  "@rollup/rollup-darwin-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==,
+      }
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  "@rollup/rollup-darwin-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==,
+      }
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+  "@rollup/rollup-freebsd-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  "@rollup/rollup-freebsd-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==,
+      }
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
+    resolution:
+      {
+        integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
+    resolution:
+      {
+        integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  "@rollup/rollup-linux-arm64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  "@rollup/rollup-linux-arm64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+  "@rollup/rollup-linux-loong64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==,
+      }
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+  "@rollup/rollup-linux-loong64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==,
+      }
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+  "@rollup/rollup-linux-ppc64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+  "@rollup/rollup-linux-riscv64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  "@rollup/rollup-linux-s390x-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==,
+      }
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  "@rollup/rollup-linux-x64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  "@rollup/rollup-linux-x64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+  "@rollup/rollup-openbsd-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==,
+      }
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  "@rollup/rollup-openharmony-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  "@rollup/rollup-win32-arm64-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==,
+      }
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+  "@rollup/rollup-win32-ia32-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==,
+      }
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  "@rollup/rollup-win32-x64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+  "@rollup/rollup-win32-x64-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+  "@standard-schema/utils@0.3.0":
+    resolution:
+      {
+        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
+      }
 
-  '@surma/rollup-plugin-off-main-thread@2.2.3':
-    resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
+  "@surma/rollup-plugin-off-main-thread@2.2.3":
+    resolution:
+      {
+        integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==,
+      }
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
+  "@tabby_ai/hijri-converter@1.0.5":
+    resolution:
+      {
+        integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==,
+      }
+    engines: { node: ">=16.0.0" }
 
-  '@tailwindcss/typography@0.5.19':
-    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+  "@tailwindcss/typography@0.5.19":
+    resolution:
+      {
+        integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==,
+      }
     peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+      tailwindcss: ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
 
-  '@tanstack/query-core@5.95.2':
-    resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
+  "@tanstack/query-core@5.95.2":
+    resolution:
+      {
+        integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==,
+      }
 
-  '@tanstack/react-query@5.95.2':
-    resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
+  "@tanstack/react-query@5.95.2":
+    resolution:
+      {
+        integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==,
+      }
     peerDependencies:
       react: ^18 || ^19
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+  "@types/babel__core@7.20.5":
+    resolution:
+      {
+        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
+      }
 
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+  "@types/babel__generator@7.27.0":
+    resolution:
+      {
+        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
+      }
 
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+  "@types/babel__template@7.4.4":
+    resolution:
+      {
+        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
+      }
 
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+  "@types/babel__traverse@7.28.0":
+    resolution:
+      {
+        integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
+      }
 
-  '@types/bcryptjs@2.4.6':
-    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+  "@types/bcryptjs@2.4.6":
+    resolution:
+      {
+        integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==,
+      }
 
-  '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+  "@types/d3-array@3.2.2":
+    resolution:
+      {
+        integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==,
+      }
 
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+  "@types/d3-color@3.1.3":
+    resolution:
+      {
+        integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==,
+      }
 
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+  "@types/d3-ease@3.0.2":
+    resolution:
+      {
+        integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==,
+      }
 
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+  "@types/d3-interpolate@3.0.4":
+    resolution:
+      {
+        integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==,
+      }
 
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+  "@types/d3-path@3.1.1":
+    resolution:
+      {
+        integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==,
+      }
 
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+  "@types/d3-scale@4.0.9":
+    resolution:
+      {
+        integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==,
+      }
 
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+  "@types/d3-shape@3.1.8":
+    resolution:
+      {
+        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==,
+      }
 
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+  "@types/d3-time@3.0.4":
+    resolution:
+      {
+        integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==,
+      }
 
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+  "@types/d3-timer@3.0.2":
+    resolution:
+      {
+        integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==,
+      }
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+  "@types/debug@4.1.13":
+    resolution:
+      {
+        integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
+      }
 
-  '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
 
-  '@types/estree-jsx@1.0.5':
-    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+  "@types/estree-jsx@1.0.5":
+    resolution:
+      {
+        integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
+      }
 
-  '@types/estree@0.0.39':
-    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+  "@types/estree@0.0.39":
+    resolution:
+      {
+        integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==,
+      }
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+  "@types/hast@3.0.4":
+    resolution:
+      {
+        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+      }
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+  "@types/json-schema@7.0.15":
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
 
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+  "@types/mdast@4.0.4":
+    resolution:
+      {
+        integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+      }
 
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+  "@types/ms@2.1.0":
+    resolution:
+      {
+        integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
+      }
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+  "@types/node@20.19.39":
+    resolution:
+      {
+        integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==,
+      }
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+  "@types/node@24.12.0":
+    resolution:
+      {
+        integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
+      }
 
-  '@types/pg@8.20.0':
-    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+  "@types/pg@8.20.0":
+    resolution:
+      {
+        integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==,
+      }
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+  "@types/prop-types@15.7.15":
+    resolution:
+      {
+        integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==,
+      }
 
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  "@types/react-dom@18.3.7":
+    resolution:
+      {
+        integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==,
+      }
     peerDependencies:
-      '@types/react': ^18.0.0
+      "@types/react": ^18.0.0
 
-  '@types/react@18.3.28':
-    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+  "@types/react@18.3.28":
+    resolution:
+      {
+        integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==,
+      }
 
-  '@types/resolve@1.20.2':
-    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+  "@types/resolve@1.20.2":
+    resolution:
+      {
+        integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==,
+      }
 
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
+      }
 
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+  "@types/unist@2.0.11":
+    resolution:
+      {
+        integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
+      }
 
-  '@types/unist@3.0.3':
-    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+  "@types/unist@3.0.3":
+    resolution:
+      {
+        integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
+      }
 
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+  "@types/use-sync-external-store@0.0.6":
+    resolution:
+      {
+        integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==,
+      }
 
-  '@types/whatwg-mimetype@3.0.2':
-    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+  "@types/whatwg-mimetype@3.0.2":
+    resolution:
+      {
+        integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==,
+      }
 
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+  "@types/ws@8.18.1":
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+      }
 
-  '@typescript-eslint/eslint-plugin@8.57.2':
-    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/eslint-plugin@8.57.2":
+    resolution:
+      {
+        integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@typescript-eslint/parser': ^8.57.2
+      "@typescript-eslint/parser": ^8.57.2
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@typescript-eslint/parser@8.57.2':
-    resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/parser@8.57.2":
+    resolution:
+      {
+        integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@typescript-eslint/project-service@8.57.2':
-    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/project-service@8.57.2":
+    resolution:
+      {
+        integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@typescript-eslint/scope-manager@8.57.2':
-    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/scope-manager@8.57.2":
+    resolution:
+      {
+        integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@typescript-eslint/tsconfig-utils@8.57.2':
-    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/tsconfig-utils@8.57.2":
+    resolution:
+      {
+        integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@typescript-eslint/type-utils@8.57.2':
-    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/types@8.57.2':
-    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.57.2':
-    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/utils@8.57.2':
-    resolution: {integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/type-utils@8.57.2":
+    resolution:
+      {
+        integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@typescript-eslint/visitor-keys@8.57.2':
-    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/types@8.57.2":
+    resolution:
+      {
+        integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+  "@typescript-eslint/typescript-estree@8.57.2":
+    resolution:
+      {
+        integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.0.0"
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  "@typescript-eslint/utils@8.57.2":
+    resolution:
+      {
+        integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.0.0"
+
+  "@typescript-eslint/visitor-keys@8.57.2":
+    resolution:
+      {
+        integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@ungap/structured-clone@1.3.0":
+    resolution:
+      {
+        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+      }
+
+  "@vitejs/plugin-react@4.7.0":
+    resolution:
+      {
+        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  "@vitest/expect@4.1.2":
+    resolution:
+      {
+        integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==,
+      }
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  "@vitest/mocker@4.1.2":
+    resolution:
+      {
+        integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==,
+      }
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2329,49 +3443,88 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  "@vitest/pretty-format@4.1.2":
+    resolution:
+      {
+        integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==,
+      }
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  "@vitest/runner@4.1.2":
+    resolution:
+      {
+        integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==,
+      }
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  "@vitest/snapshot@4.1.2":
+    resolution:
+      {
+        integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==,
+      }
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  "@vitest/spy@4.1.2":
+    resolution:
+      {
+        integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==,
+      }
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  "@vitest/utils@4.1.2":
+    resolution:
+      {
+        integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==,
+      }
 
-  '@xterm/addon-clipboard@0.2.0':
-    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
+  "@xterm/addon-clipboard@0.2.0":
+    resolution:
+      {
+        integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==,
+      }
 
-  '@xterm/addon-fit@0.11.0':
-    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+  "@xterm/addon-fit@0.11.0":
+    resolution:
+      {
+        integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==,
+      }
 
-  '@xterm/xterm@6.0.0':
-    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+  "@xterm/xterm@6.0.0":
+    resolution:
+      {
+        integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==,
+      }
 
   abstract-logging@2.0.1:
-    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+    resolution:
+      {
+        integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==,
+      }
 
   accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
+      }
+    engines: { node: ">= 0.6" }
 
   acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
 
   ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    resolution:
+      {
+        integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==,
+      }
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -2379,7 +3532,10 @@ packages:
         optional: true
 
   ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    resolution:
+      {
+        integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==,
+      }
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -2387,712 +3543,1264 @@ packages:
         optional: true
 
   ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+    resolution:
+      {
+        integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
+      }
 
   ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+    resolution:
+      {
+        integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
+      }
 
   ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
+      }
+    engines: { node: ">=18" }
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+      }
+    engines: { node: ">=8" }
 
   ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+      }
+    engines: { node: ">=12" }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
 
   ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
+      }
+    engines: { node: ">=12" }
 
   any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+    resolution:
+      {
+        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
+      }
 
   anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
+      }
+    engines: { node: ">= 8" }
 
   arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    resolution:
+      {
+        integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==,
+      }
+    engines: { node: ">=10" }
 
   array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==,
+      }
+    engines: { node: ">= 0.4" }
 
   array-includes@3.1.9:
-    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.flat@1.3.3:
-    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.flatmap@1.3.3:
-    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==,
+      }
+    engines: { node: ">= 0.4" }
 
   arraybuffer.prototype.slice@1.0.4:
-    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
 
   async-function@1.0.0:
-    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==,
+      }
+    engines: { node: ">= 0.4" }
 
   async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+    resolution:
+      {
+        integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==,
+      }
 
   at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
+      }
+    engines: { node: ">= 4.0.0" }
 
   atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: ">=8.0.0" }
 
   autoprefixer@10.4.27:
-    resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
 
   available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   avvio@8.4.0:
-    resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
+    resolution:
+      {
+        integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==,
+      }
 
   babel-plugin-polyfill-corejs2@0.4.17:
-    resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
+    resolution:
+      {
+        integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==,
+      }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
   babel-plugin-polyfill-corejs3@0.14.2:
-    resolution: {integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==}
+    resolution:
+      {
+        integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==,
+      }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
   babel-plugin-polyfill-regenerator@0.6.8:
-    resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
+    resolution:
+      {
+        integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==,
+      }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
   bail@2.0.2:
-    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+    resolution:
+      {
+        integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
+      }
 
   balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
 
   balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   baseline-browser-mapping@2.10.12:
-    resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
   bcryptjs@3.0.3:
-    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    resolution:
+      {
+        integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==,
+      }
     hasBin: true
 
   binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
+      }
+    engines: { node: ">=8" }
 
   body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==,
+      }
+    engines: { node: ">=18" }
 
   brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+    resolution:
+      {
+        integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==,
+      }
 
   brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+    resolution:
+      {
+        integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==,
+      }
 
   brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: ">=8" }
 
   browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    resolution:
+      {
+        integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
   buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    resolution:
+      {
+        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+      }
 
   bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: ">= 0.8" }
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==,
+      }
+    engines: { node: ">= 0.4" }
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+      }
+    engines: { node: ">= 0.4" }
 
   callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: ">=6" }
 
   camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==,
+      }
+    engines: { node: ">= 6" }
 
   caniuse-lite@1.0.30001782:
-    resolution: {integrity: sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==}
+    resolution:
+      {
+        integrity: sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==,
+      }
 
   ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    resolution:
+      {
+        integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
+      }
 
   chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: ">=10" }
 
   character-entities-html4@2.1.0:
-    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+    resolution:
+      {
+        integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
+      }
 
   character-entities-legacy@3.0.0:
-    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+    resolution:
+      {
+        integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
+      }
 
   character-entities@2.0.2:
-    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    resolution:
+      {
+        integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
+      }
 
   character-reference-invalid@2.0.1:
-    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    resolution:
+      {
+        integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
+      }
 
   chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+    resolution:
+      {
+        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
+      }
+    engines: { node: ">= 8.10.0" }
 
   class-variance-authority@0.7.1:
-    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+    resolution:
+      {
+        integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==,
+      }
 
   cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
+      }
+    engines: { node: ">=18" }
 
   cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
+      }
+    engines: { node: ">=20" }
 
   cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+      }
+    engines: { node: ">=12" }
 
   clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
+      }
+    engines: { node: ">=6" }
 
   cmdk@1.1.1:
-    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    resolution:
+      {
+        integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==,
+      }
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
 
   comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+    resolution:
+      {
+        integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
+      }
 
   commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+      }
+    engines: { node: ">=20" }
 
   commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    resolution:
+      {
+        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+      }
 
   commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: ">= 6" }
 
   common-tags@1.8.2:
-    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==,
+      }
+    engines: { node: ">=4.0.0" }
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==,
+      }
+    engines: { node: ">= 0.6" }
 
   content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==,
+      }
+    engines: { node: ">=18" }
 
   content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+      }
+    engines: { node: ">= 0.6" }
 
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
 
   cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
+    resolution:
+      {
+        integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==,
+      }
+    engines: { node: ">=6.6.0" }
 
   cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
+      }
+    engines: { node: ">= 0.6" }
 
   cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
+      }
+    engines: { node: ">=18" }
 
   core-js-compat@3.49.0:
-    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+    resolution:
+      {
+        integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==,
+      }
 
   cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==,
+      }
+    engines: { node: ">= 0.10" }
 
   croner@10.0.1:
-    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
-    engines: {node: '>=18.0'}
+    resolution:
+      {
+        integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==,
+      }
+    engines: { node: ">=18.0" }
 
   cronstrue@3.14.0:
-    resolution: {integrity: sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA==}
+    resolution:
+      {
+        integrity: sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA==,
+      }
     hasBin: true
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
 
   crypto-random-string@2.0.0:
-    resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==,
+      }
+    engines: { node: ">=8" }
 
   cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
 
   csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
 
   d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==,
+      }
+    engines: { node: ">=12" }
 
   d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==,
+      }
+    engines: { node: ">=12" }
 
   d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==,
+      }
+    engines: { node: ">=12" }
 
   d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==,
+      }
+    engines: { node: ">=12" }
 
   d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==,
+      }
+    engines: { node: ">=12" }
 
   d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==,
+      }
+    engines: { node: ">=12" }
 
   d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==,
+      }
+    engines: { node: ">=12" }
 
   d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==,
+      }
+    engines: { node: ">=12" }
 
   d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==,
+      }
+    engines: { node: ">=12" }
 
   data-view-buffer@1.0.2:
-    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   data-view-byte-length@1.0.2:
-    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   data-view-byte-offset@1.0.1:
-    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+    resolution:
+      {
+        integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==,
+      }
 
   date-fns@4.1.0:
-    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+    resolution:
+      {
+        integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==,
+      }
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   decimal.js-light@2.5.1:
-    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+    resolution:
+      {
+        integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==,
+      }
 
   decode-named-character-reference@1.3.0:
-    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+    resolution:
+      {
+        integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
+      }
 
   deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
 
   deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
+      }
+    engines: { node: ">=0.10.0" }
 
   define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+      }
+    engines: { node: ">= 0.4" }
 
   depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: ">= 0.8" }
 
   dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+      }
+    engines: { node: ">=6" }
 
   detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: ">=8" }
 
   detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+    resolution:
+      {
+        integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==,
+      }
 
   devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+    resolution:
+      {
+        integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
+      }
 
   didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    resolution:
+      {
+        integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
+      }
 
   dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    resolution:
+      {
+        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
+      }
 
   doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==,
+      }
+    engines: { node: ">=12" }
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution:
+      {
+        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
 
   ejs@3.1.10:
-    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==,
+      }
+    engines: { node: ">=0.10.0" }
     hasBin: true
 
   electron-to-chromium@1.5.328:
-    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+    resolution:
+      {
+        integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==,
+      }
 
   emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+    resolution:
+      {
+        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
+      }
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
 
   encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
+      }
+    engines: { node: ">= 0.8" }
 
   environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
+      }
+    engines: { node: ">=18" }
 
   es-abstract@1.24.1:
-    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-iterator-helpers@1.3.1:
-    resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+    resolution:
+      {
+        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
+      }
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-shim-unscopables@1.1.0:
-    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-to-primitive@1.3.0:
-    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-toolkit@1.45.1:
-    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+    resolution:
+      {
+        integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==,
+      }
 
   esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
+      }
+    engines: { node: ">=12" }
     hasBin: true
 
   esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: ">=6" }
 
   escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
 
   escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: ">=10" }
 
   escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
+      }
+    engines: { node: ">=12" }
 
   eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react-refresh@0.4.26:
-    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
+    resolution:
+      {
+        integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==,
+      }
     peerDependencies:
-      eslint: '>=8.40'
+      eslint: ">=8.40"
 
   eslint-plugin-react@7.37.5:
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==,
+      }
+    engines: { node: ">=4" }
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   eslint@9.39.4:
-    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
     peerDependencies:
-      jiti: '*'
+      jiti: "*"
     peerDependenciesMeta:
       jiti:
         optional: true
 
   espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
+      }
+    engines: { node: ">=0.10" }
 
   esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: ">=4.0" }
 
   estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: ">=4.0" }
 
   estree-util-is-identifier-name@3.0.0:
-    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+    resolution:
+      {
+        integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
+      }
 
   estree-walker@1.0.1:
-    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    resolution:
+      {
+        integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==,
+      }
 
   estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
 
   estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
 
   esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+      }
+    engines: { node: ">= 0.6" }
 
   eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+    resolution:
+      {
+        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
 
   eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==,
+      }
+    engines: { node: ">=18.0.0" }
 
   eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==,
+      }
+    engines: { node: ">=18.0.0" }
 
   expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
 
   express-rate-limit@8.3.1:
-    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
-    engines: {node: '>= 16'}
+    resolution:
+      {
+        integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==,
+      }
+    engines: { node: ">= 16" }
     peerDependencies:
-      express: '>= 4.11'
+      express: ">= 4.11"
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==,
+      }
+    engines: { node: ">= 18" }
 
   extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
 
   fast-content-type-parse@1.1.0:
-    resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
+    resolution:
+      {
+        integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==,
+      }
 
   fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+    resolution:
+      {
+        integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==,
+      }
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
 
   fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
+    resolution:
+      {
+        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+      }
+    engines: { node: ">=8.6.0" }
 
   fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
 
   fast-json-stringify@5.16.1:
-    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+    resolution:
+      {
+        integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==,
+      }
 
   fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
 
   fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+    resolution:
+      {
+        integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==,
+      }
 
   fast-uri@2.4.0:
-    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+    resolution:
+      {
+        integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==,
+      }
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    resolution:
+      {
+        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+      }
 
   fastify-plugin@4.5.1:
-    resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
+    resolution:
+      {
+        integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==,
+      }
 
   fastify@4.29.1:
-    resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
+    resolution:
+      {
+        integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==,
+      }
 
   fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+    resolution:
+      {
+        integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
+      }
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3100,58 +4808,97 @@ packages:
         optional: true
 
   file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: ">=16.0.0" }
 
   filelist@1.0.6:
-    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+    resolution:
+      {
+        integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==,
+      }
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: ">=8" }
 
   finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
+    resolution:
+      {
+        integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==,
+      }
+    engines: { node: ">= 18.0.0" }
 
   find-my-way@8.2.2:
-    resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==,
+      }
+    engines: { node: ">=14" }
 
   find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: ">=10" }
 
   flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: ">=16" }
 
   flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+    resolution:
+      {
+        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+      }
 
   for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
+      }
+    engines: { node: ">= 0.4" }
 
   foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+      }
+    engines: { node: ">=14" }
 
   forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
+      }
+    engines: { node: ">= 0.6" }
 
   fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+    resolution:
+      {
+        integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
+      }
 
   framer-motion@12.38.0:
-    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    resolution:
+      {
+        integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==,
+      }
     peerDependencies:
-      '@emotion/is-prop-valid': '*'
+      "@emotion/is-prop-valid": "*"
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      '@emotion/is-prop-valid':
+      "@emotion/is-prop-valid":
         optional: true
       react:
         optional: true
@@ -3159,978 +4906,1755 @@ packages:
         optional: true
 
   fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
+      }
+    engines: { node: ">= 0.8" }
 
   fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==,
+      }
+    engines: { node: ">=10" }
 
   fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    resolution:
+      {
+        integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
+      }
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
 
   function.prototype.name@1.1.8:
-    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==,
+      }
+    engines: { node: ">= 0.4" }
 
   functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    resolution:
+      {
+        integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
+      }
 
   generator-function@2.0.1:
-    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==,
+      }
+    engines: { node: ">= 0.4" }
 
   gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: ">=6.9.0" }
 
   get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
 
   get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
+      }
+    engines: { node: ">=18" }
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==,
+      }
+    engines: { node: ">=6" }
 
   get-own-enumerable-property-symbols@3.0.2:
-    resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
+    resolution:
+      {
+        integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==,
+      }
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-symbol-description@1.1.0:
-    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+    resolution:
+      {
+        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
+      }
 
   glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+      }
+    engines: { node: ">= 6" }
 
   glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: ">=10.13.0" }
 
   glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==,
+      }
+    engines: { node: 20 || >=22 }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==,
+      }
+    engines: { node: ">=12" }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: ">=18" }
 
   globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==,
+      }
+    engines: { node: ">=18" }
 
   globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: ">= 0.4" }
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
 
   happy-dom@18.0.1:
-    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==,
+      }
+    engines: { node: ">=20.0.0" }
 
   has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
 
   has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    resolution:
+      {
+        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+      }
 
   has-proto@1.2.0:
-    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   hast-util-to-jsx-runtime@2.3.6:
-    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+    resolution:
+      {
+        integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
+      }
 
   hast-util-whitespace@3.0.0:
-    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+    resolution:
+      {
+        integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
+      }
 
   highlight.js@11.11.1:
-    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==,
+      }
+    engines: { node: ">=12.0.0" }
 
   hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
-    engines: {node: '>=16.9.0'}
+    resolution:
+      {
+        integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==,
+      }
+    engines: { node: ">=16.9.0" }
 
   html-url-attributes@3.0.1:
-    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+    resolution:
+      {
+        integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==,
+      }
 
   http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   idb@7.1.1:
-    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+    resolution:
+      {
+        integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==,
+      }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: ">= 4" }
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+      }
+    engines: { node: ">= 4" }
 
   immer@10.2.0:
-    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+    resolution:
+      {
+        integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==,
+      }
 
   immer@11.1.4:
-    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+    resolution:
+      {
+        integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==,
+      }
 
   import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: ">=6" }
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: ">=0.8.19" }
 
   inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    resolution:
+      {
+        integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
+      }
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   inline-style-parser@0.2.7:
-    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+    resolution:
+      {
+        integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
+      }
 
   internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
+      }
+    engines: { node: ">= 0.4" }
 
   internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==,
+      }
+    engines: { node: ">=12" }
 
   ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==,
+      }
+    engines: { node: ">= 12" }
 
   ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
+      }
+    engines: { node: ">= 0.10" }
 
   is-alphabetical@2.0.1:
-    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+    resolution:
+      {
+        integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
+      }
 
   is-alphanumerical@2.0.1:
-    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+    resolution:
+      {
+        integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
+      }
 
   is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-async-function@2.1.1:
-    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
+      }
+    engines: { node: ">=8" }
 
   is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-data-view@1.0.2:
-    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-decimal@2.0.1:
-    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+    resolution:
+      {
+        integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
+      }
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-finalizationregistry@1.1.1:
-    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: ">=8" }
 
   is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
+      }
+    engines: { node: ">=18" }
 
   is-generator-function@1.1.2:
-    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-hexadecimal@2.0.1:
-    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+    resolution:
+      {
+        integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
+      }
 
   is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    resolution:
+      {
+        integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==,
+      }
 
   is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: ">=0.12.0" }
 
   is-obj@1.0.1:
-    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+      }
+    engines: { node: ">=12" }
 
   is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    resolution:
+      {
+        integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
+      }
 
   is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-regexp@1.0.0:
-    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: ">=8" }
 
   is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-weakref@1.1.1:
-    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    resolution:
+      {
+        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+      }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   iterator.prototype@1.1.5:
-    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==,
+      }
+    engines: { node: ">= 0.4" }
 
   jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==,
+      }
+    engines: { node: 20 || >=22 }
 
   jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    resolution:
+      {
+        integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==,
+      }
     hasBin: true
 
   jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+    resolution:
+      {
+        integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==,
+      }
 
   jotai@2.19.0:
-    resolution: {integrity: sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ==}
-    engines: {node: '>=12.20.0'}
+    resolution:
+      {
+        integrity: sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ==,
+      }
+    engines: { node: ">=12.20.0" }
     peerDependencies:
-      '@babel/core': '>=7.0.0'
-      '@babel/template': '>=7.0.0'
-      '@types/react': '>=17.0.0'
-      react: '>=17.0.0'
+      "@babel/core": ">=7.0.0"
+      "@babel/template": ">=7.0.0"
+      "@types/react": ">=17.0.0"
+      react: ">=17.0.0"
     peerDependenciesMeta:
-      '@babel/core':
+      "@babel/core":
         optional: true
-      '@babel/template':
+      "@babel/template":
         optional: true
-      '@types/react':
+      "@types/react":
         optional: true
       react:
         optional: true
 
   js-base64@3.7.8:
-    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+    resolution:
+      {
+        integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==,
+      }
 
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
 
   json-schema-ref-resolver@1.0.1:
-    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+    resolution:
+      {
+        integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==,
+      }
 
   json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
 
   json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    resolution:
+      {
+        integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==,
+      }
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+    resolution:
+      {
+        integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==,
+      }
 
   jsonpointer@5.0.1:
-    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==,
+      }
+    engines: { node: ">=4.0" }
 
   keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
 
   leven@3.1.0:
-    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
+      }
+    engines: { node: ">=6" }
 
   levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   light-my-request@5.14.0:
-    resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
+    resolution:
+      {
+        integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==,
+      }
 
   lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
+      }
+    engines: { node: ">=14" }
 
   lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+      }
 
   lint-staged@16.4.0:
-    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
-    engines: {node: '>=20.17'}
+    resolution:
+      {
+        integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==,
+      }
+    engines: { node: ">=20.17" }
     hasBin: true
 
   listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+      }
+    engines: { node: ">=20.0.0" }
 
   locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: ">=10" }
 
   lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    resolution:
+      {
+        integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
+      }
 
   lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
 
   lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+    resolution:
+      {
+        integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==,
+      }
 
   lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+    resolution:
+      {
+        integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
+      }
 
   log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
+      }
+    engines: { node: ">=18" }
 
   longest-streak@3.1.0:
-    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    resolution:
+      {
+        integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
+      }
 
   loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    resolution:
+      {
+        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
+      }
     hasBin: true
 
   lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==,
+      }
+    engines: { node: 20 || >=22 }
 
   lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+      }
 
   lucide-react@0.468.0:
-    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
+    resolution:
+      {
+        integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==,
+      }
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    resolution:
+      {
+        integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==,
+      }
 
   magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   markdown-table@3.0.4:
-    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+    resolution:
+      {
+        integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
+      }
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: ">= 0.4" }
 
   mdast-util-find-and-replace@3.0.2:
-    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+    resolution:
+      {
+        integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
+      }
 
   mdast-util-from-markdown@2.0.3:
-    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+    resolution:
+      {
+        integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
+      }
 
   mdast-util-gfm-autolink-literal@2.0.1:
-    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+    resolution:
+      {
+        integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==,
+      }
 
   mdast-util-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+    resolution:
+      {
+        integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==,
+      }
 
   mdast-util-gfm-strikethrough@2.0.0:
-    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+    resolution:
+      {
+        integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==,
+      }
 
   mdast-util-gfm-table@2.0.0:
-    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+    resolution:
+      {
+        integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
+      }
 
   mdast-util-gfm-task-list-item@2.0.0:
-    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+    resolution:
+      {
+        integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==,
+      }
 
   mdast-util-gfm@3.1.0:
-    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+    resolution:
+      {
+        integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==,
+      }
 
   mdast-util-mdx-expression@2.0.1:
-    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+    resolution:
+      {
+        integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
+      }
 
   mdast-util-mdx-jsx@3.2.0:
-    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+    resolution:
+      {
+        integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
+      }
 
   mdast-util-mdxjs-esm@2.0.1:
-    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+    resolution:
+      {
+        integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
+      }
 
   mdast-util-phrasing@4.1.0:
-    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+    resolution:
+      {
+        integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
+      }
 
   mdast-util-to-hast@13.2.1:
-    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+    resolution:
+      {
+        integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
+      }
 
   mdast-util-to-markdown@2.1.2:
-    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+    resolution:
+      {
+        integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
+      }
 
   mdast-util-to-string@4.0.0:
-    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+    resolution:
+      {
+        integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
+      }
 
   media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==,
+      }
+    engines: { node: ">= 0.8" }
 
   merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==,
+      }
+    engines: { node: ">=18" }
 
   merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+      }
+    engines: { node: ">= 8" }
 
   micromark-core-commonmark@2.0.3:
-    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+    resolution:
+      {
+        integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
+      }
 
   micromark-extension-gfm-autolink-literal@2.1.0:
-    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+    resolution:
+      {
+        integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==,
+      }
 
   micromark-extension-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+    resolution:
+      {
+        integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==,
+      }
 
   micromark-extension-gfm-strikethrough@2.1.0:
-    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+    resolution:
+      {
+        integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==,
+      }
 
   micromark-extension-gfm-table@2.1.1:
-    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+    resolution:
+      {
+        integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
+      }
 
   micromark-extension-gfm-tagfilter@2.0.0:
-    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+    resolution:
+      {
+        integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==,
+      }
 
   micromark-extension-gfm-task-list-item@2.1.0:
-    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+    resolution:
+      {
+        integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==,
+      }
 
   micromark-extension-gfm@3.0.0:
-    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+    resolution:
+      {
+        integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==,
+      }
 
   micromark-factory-destination@2.0.1:
-    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+    resolution:
+      {
+        integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
+      }
 
   micromark-factory-label@2.0.1:
-    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+    resolution:
+      {
+        integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
+      }
 
   micromark-factory-space@2.0.1:
-    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+    resolution:
+      {
+        integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
+      }
 
   micromark-factory-title@2.0.1:
-    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+    resolution:
+      {
+        integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
+      }
 
   micromark-factory-whitespace@2.0.1:
-    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+    resolution:
+      {
+        integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
+      }
 
   micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+    resolution:
+      {
+        integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
+      }
 
   micromark-util-chunked@2.0.1:
-    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+    resolution:
+      {
+        integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
+      }
 
   micromark-util-classify-character@2.0.1:
-    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+    resolution:
+      {
+        integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
+      }
 
   micromark-util-combine-extensions@2.0.1:
-    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+    resolution:
+      {
+        integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
+      }
 
   micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+    resolution:
+      {
+        integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
+      }
 
   micromark-util-decode-string@2.0.1:
-    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+    resolution:
+      {
+        integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
+      }
 
   micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+    resolution:
+      {
+        integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
+      }
 
   micromark-util-html-tag-name@2.0.1:
-    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+    resolution:
+      {
+        integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
+      }
 
   micromark-util-normalize-identifier@2.0.1:
-    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+    resolution:
+      {
+        integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
+      }
 
   micromark-util-resolve-all@2.0.1:
-    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+    resolution:
+      {
+        integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
+      }
 
   micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+    resolution:
+      {
+        integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
+      }
 
   micromark-util-subtokenize@2.1.0:
-    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+    resolution:
+      {
+        integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
+      }
 
   micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+    resolution:
+      {
+        integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
+      }
 
   micromark-util-types@2.0.2:
-    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+    resolution:
+      {
+        integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
+      }
 
   micromark@4.0.2:
-    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+    resolution:
+      {
+        integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
+      }
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: ">=8.6" }
 
   mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==,
+      }
+    engines: { node: ">= 0.6" }
 
   mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
+      }
+    engines: { node: ">=18" }
 
   mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==,
+      }
+    engines: { node: ">=10.0.0" }
     hasBin: true
 
   mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+      }
+    engines: { node: ">=18" }
 
   minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+    resolution:
+      {
+        integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
+      }
 
   minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==,
+      }
+    engines: { node: ">=10" }
 
   minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   motion-dom@12.38.0:
-    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+    resolution:
+      {
+        integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==,
+      }
 
   motion-utils@12.36.0:
-    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+    resolution:
+      {
+        integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==,
+      }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    resolution:
+      {
+        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
+      }
 
   nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+    resolution:
+      {
+        integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==,
+      }
 
   nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
 
   negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
+      }
+    engines: { node: ">= 0.6" }
 
   node-exports-info@1.6.0:
-    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==,
+      }
+    engines: { node: ">= 0.4" }
 
   node-pg-migrate@8.0.4:
-    resolution: {integrity: sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==}
-    engines: {node: '>=20.11.0'}
+    resolution:
+      {
+        integrity: sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==,
+      }
+    engines: { node: ">=20.11.0" }
     hasBin: true
     peerDependencies:
-      '@types/pg': '>=6.0.0 <9.0.0'
-      pg: '>=4.3.0 <9.0.0'
+      "@types/pg": ">=6.0.0 <9.0.0"
+      pg: ">=4.3.0 <9.0.0"
     peerDependenciesMeta:
-      '@types/pg':
+      "@types/pg":
         optional: true
 
   node-pty@1.0.0:
-    resolution: {integrity: sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==}
+    resolution:
+      {
+        integrity: sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==,
+      }
 
   node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+    resolution:
+      {
+        integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==,
+      }
 
   normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==,
+      }
+    engines: { node: ">= 6" }
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
 
   object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.entries@1.1.9:
-    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.values@1.2.1:
-    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
+      }
+    engines: { node: ">= 0.4" }
 
   obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+      }
+    engines: { node: ">=14.0.0" }
 
   on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+      }
+    engines: { node: ">= 0.8" }
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
 
   onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
+      }
+    engines: { node: ">=18" }
 
   optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   own-keys@1.0.1:
-    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: ">=10" }
 
   p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: ">=10" }
 
   package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    resolution:
+      {
+        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
+      }
 
   parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: ">=6" }
 
   parse-entities@4.0.2:
-    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+    resolution:
+      {
+        integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
+      }
 
   parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
 
   path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
 
   path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   path-to-regexp@8.4.0:
-    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
+    resolution:
+      {
+        integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==,
+      }
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
 
   pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+    resolution:
+      {
+        integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==,
+      }
 
   pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+    resolution:
+      {
+        integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==,
+      }
 
   pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+      }
+    engines: { node: ">=4.0.0" }
 
   pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    resolution:
+      {
+        integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==,
+      }
     peerDependencies:
-      pg: '>=8.0'
+      pg: ">=8.0"
 
   pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+    resolution:
+      {
+        integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==,
+      }
 
   pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+      }
+    engines: { node: ">=4" }
 
   pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
-    engines: {node: '>= 16.0.0'}
+    resolution:
+      {
+        integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==,
+      }
+    engines: { node: ">= 16.0.0" }
     peerDependencies:
-      pg-native: '>=3.0.1'
+      pg-native: ">=3.0.1"
     peerDependenciesMeta:
       pg-native:
         optional: true
 
   pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+      }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
+      }
+    engines: { node: ">=8.6" }
 
   picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
 
   pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
+      }
+    engines: { node: ">=0.10.0" }
 
   pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+    resolution:
+      {
+        integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==,
+      }
 
   pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+    resolution:
+      {
+        integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
+      }
 
   pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    resolution:
+      {
+        integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==,
+      }
     hasBin: true
 
   pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: ">= 6" }
 
   pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
+    resolution:
+      {
+        integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==,
+      }
+    engines: { node: ">=16.20.0" }
 
   playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
+      }
+    engines: { node: ">= 0.4" }
 
   postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       postcss: ^8.0.0
 
   postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
+    resolution:
+      {
+        integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==,
+      }
+    engines: { node: ^12 || ^14 || >= 16 }
     peerDependencies:
       postcss: ^8.4.21
 
   postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
+      }
+    engines: { node: ">= 18" }
     peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      jiti: ">=1.21.0"
+      postcss: ">=8.0.9"
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -4144,820 +6668,1413 @@ packages:
         optional: true
 
   postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
+    resolution:
+      {
+        integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==,
+      }
+    engines: { node: ">=12.0" }
     peerDependencies:
       postcss: ^8.2.14
 
   postcss-selector-parser@6.0.10:
-    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==,
+      }
+    engines: { node: ">=4" }
 
   postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
+      }
+    engines: { node: ">=4" }
 
   postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    resolution:
+      {
+        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
+      }
 
   postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+      }
+    engines: { node: ">=4" }
 
   postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+      }
+    engines: { node: ">=0.10.0" }
 
   postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: ">= 0.8.0" }
+
+  prettier@3.8.3:
+    resolution:
+      {
+        integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
 
   pretty-bytes@5.6.0:
-    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==,
+      }
+    engines: { node: ">=6" }
 
   pretty-bytes@6.1.1:
-    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==,
+      }
+    engines: { node: ^14.13.1 || >=16.0.0 }
 
   process-warning@3.0.0:
-    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+    resolution:
+      {
+        integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==,
+      }
 
   process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+    resolution:
+      {
+        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+      }
 
   prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+    resolution:
+      {
+        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+      }
 
   property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+    resolution:
+      {
+        integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
+      }
 
   proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
+      }
+    engines: { node: ">= 0.10" }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: ">=6" }
 
   qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==,
+      }
+    engines: { node: ">=0.6" }
 
   queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution:
+      {
+        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
 
   quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
 
   randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    resolution:
+      {
+        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
+      }
 
   range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+      }
+    engines: { node: ">= 0.6" }
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==,
+      }
+    engines: { node: ">= 0.10" }
 
   react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      react: '>=16.8.0'
+      react: ">=16.8.0"
 
   react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    resolution:
+      {
+        integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
+      }
     peerDependencies:
       react: ^18.3.1
 
   react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    resolution:
+      {
+        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+      }
 
   react-markdown@10.1.0:
-    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    resolution:
+      {
+        integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==,
+      }
     peerDependencies:
-      '@types/react': '>=18'
-      react: '>=18'
+      "@types/react": ">=18"
+      react: ">=18"
 
   react-redux@9.2.0:
-    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    resolution:
+      {
+        integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==,
+      }
     peerDependencies:
-      '@types/react': ^18.2.25 || ^19
+      "@types/react": ^18.2.25 || ^19
       react: ^18.0 || ^19
       redux: ^5.0.0
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
       redux:
         optional: true
 
   react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
   react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
   react-router-dom@7.14.0:
-    resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==,
+      }
+    engines: { node: ">=20.0.0" }
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: ">=18"
+      react-dom: ">=18"
 
   react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==,
+      }
+    engines: { node: ">=20.0.0" }
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: ">=18"
+      react-dom: ">=18"
     peerDependenciesMeta:
       react-dom:
         optional: true
 
   react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
   react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    resolution:
+      {
+        integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==,
+      }
 
   readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+    resolution:
+      {
+        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
+      }
+    engines: { node: ">=8.10.0" }
 
   real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
+    resolution:
+      {
+        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+      }
+    engines: { node: ">= 12.13.0" }
 
   recharts@3.8.1:
-    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redux-thunk@3.1.0:
-    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    resolution:
+      {
+        integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==,
+      }
     peerDependencies:
       redux: ^5.0.0
 
   redux@5.0.1:
-    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+    resolution:
+      {
+        integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==,
+      }
 
   reflect.getprototypeof@1.0.10:
-    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
+      }
+    engines: { node: ">= 0.4" }
 
   regenerate-unicode-properties@10.2.2:
-    resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==,
+      }
+    engines: { node: ">=4" }
 
   regenerate@1.4.2:
-    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+    resolution:
+      {
+        integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==,
+      }
 
   regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
+      }
+    engines: { node: ">= 0.4" }
 
   regexpu-core@6.4.0:
-    resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==,
+      }
+    engines: { node: ">=4" }
 
   regjsgen@0.8.0:
-    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+    resolution:
+      {
+        integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==,
+      }
 
   regjsparser@0.13.0:
-    resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
+    resolution:
+      {
+        integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==,
+      }
     hasBin: true
 
   remark-gfm@4.0.1:
-    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+    resolution:
+      {
+        integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==,
+      }
 
   remark-parse@11.0.0:
-    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+    resolution:
+      {
+        integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
+      }
 
   remark-rehype@11.1.2:
-    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+    resolution:
+      {
+        integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
+      }
 
   remark-stringify@11.0.0:
-    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+    resolution:
+      {
+        integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
+      }
 
   require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: ">=0.10.0" }
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+    resolution:
+      {
+        integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==,
+      }
 
   resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: ">=4" }
 
   resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
+      }
+    engines: { node: ">= 0.4" }
     hasBin: true
 
   resolve@2.0.0-next.6:
-    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==,
+      }
+    engines: { node: ">= 0.4" }
     hasBin: true
 
   restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
+      }
+    engines: { node: ">=18" }
 
   ret@0.4.3:
-    resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==,
+      }
+    engines: { node: ">=10" }
 
   reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+      }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
   rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+    resolution:
+      {
+        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
 
   rollup@2.80.0:
-    resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==,
+      }
+    engines: { node: ">=10.0.0" }
     hasBin: true
 
   rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
   router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==,
+      }
+    engines: { node: ">= 18" }
 
   run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution:
+      {
+        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+      }
 
   safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
-    engines: {node: '>=0.4'}
+    resolution:
+      {
+        integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==,
+      }
+    engines: { node: ">=0.4" }
 
   safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
 
   safe-push-apply@1.0.0:
-    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==,
+      }
+    engines: { node: ">= 0.4" }
 
   safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
+      }
+    engines: { node: ">= 0.4" }
 
   safe-regex2@3.1.0:
-    resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
+    resolution:
+      {
+        integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==,
+      }
 
   safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+      }
+    engines: { node: ">=10" }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+    resolution:
+      {
+        integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
+      }
 
   secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+    resolution:
+      {
+        integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==,
+      }
 
   semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    resolution:
+      {
+        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+      }
     hasBin: true
 
   semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
+      }
+    engines: { node: ">= 18" }
 
   serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+    resolution:
+      {
+        integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
+      }
 
   serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==,
+      }
+    engines: { node: ">= 18" }
 
   set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+    resolution:
+      {
+        integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==,
+      }
 
   set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   set-proto@1.0.0:
-    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==,
+      }
+    engines: { node: ">= 0.4" }
 
   setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
 
   sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+      }
+    engines: { node: ">= 0.4" }
 
   siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: ">=14" }
 
   simple-icons@16.14.0:
-    resolution: {integrity: sha512-2Nvs3jJpCfMWQerD4zdv91g/MpnWn81a7uhyAC0reuhrjmS2MtSmwIKwewOJR6Xe97ZmfltDntCDqKJIBawQOw==}
-    engines: {node: '>=0.12.18'}
+    resolution:
+      {
+        integrity: sha512-2Nvs3jJpCfMWQerD4zdv91g/MpnWn81a7uhyAC0reuhrjmS2MtSmwIKwewOJR6Xe97ZmfltDntCDqKJIBawQOw==,
+      }
+    engines: { node: ">=0.12.18" }
 
   slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
+      }
+    engines: { node: ">=18" }
 
   slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+      }
+    engines: { node: ">=20" }
 
   smob@1.6.1:
-    resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==,
+      }
+    engines: { node: ">=20.0.0" }
 
   sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+    resolution:
+      {
+        integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==,
+      }
 
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    resolution:
+      {
+        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+      }
 
   source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==,
+      }
+    engines: { node: ">= 8" }
     deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    resolution:
+      {
+        integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==,
+      }
     deprecated: Please use @jridgewell/sourcemap-codec instead
 
   space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+    resolution:
+      {
+        integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
+      }
 
   split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: ">= 10.x" }
 
   stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
 
   statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
+      }
+    engines: { node: ">= 0.8" }
 
   std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+    resolution:
+      {
+        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
+      }
 
   stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   stream-wormhole@1.1.0:
-    resolution: {integrity: sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==,
+      }
+    engines: { node: ">=4.0.0" }
 
   string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
+    resolution:
+      {
+        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
+      }
+    engines: { node: ">=0.6.19" }
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+      }
+    engines: { node: ">=8" }
 
   string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
+      }
+    engines: { node: ">=18" }
 
   string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==,
+      }
+    engines: { node: ">=20" }
 
   string.prototype.matchall@4.0.12:
-    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.repeat@1.0.0:
-    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+    resolution:
+      {
+        integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==,
+      }
 
   string.prototype.trim@1.2.10:
-    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   stringify-entities@4.0.4:
-    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+    resolution:
+      {
+        integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
+      }
 
   stringify-object@3.3.0:
-    resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==,
+      }
+    engines: { node: ">=4" }
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+      }
+    engines: { node: ">=8" }
 
   strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
+      }
+    engines: { node: ">=12" }
 
   strip-comments@2.0.1:
-    resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==,
+      }
+    engines: { node: ">=10" }
 
   strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: ">=8" }
 
   style-to-js@1.1.21:
-    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+    resolution:
+      {
+        integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
+      }
 
   style-to-object@1.0.14:
-    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+    resolution:
+      {
+        integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
+      }
 
   sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
     hasBin: true
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
 
   supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: ">= 0.4" }
 
   tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+    resolution:
+      {
+        integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==,
+      }
 
   tailwindcss@3.4.19:
-    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==,
+      }
+    engines: { node: ">=14.0.0" }
     hasBin: true
 
   temp-dir@2.0.0:
-    resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==,
+      }
+    engines: { node: ">=8" }
 
   tempy@0.6.0:
-    resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==,
+      }
+    engines: { node: ">=10" }
 
   terser@5.46.1:
-    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
+      }
+    engines: { node: ">=0.8" }
 
   thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    resolution:
+      {
+        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
 
   thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+    resolution:
+      {
+        integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==,
+      }
 
   tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+    resolution:
+      {
+        integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
+      }
 
   tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
 
   tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
+      }
+    engines: { node: ">=18" }
 
   tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: ">=12.0.0" }
 
   tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: ">=8.0" }
 
   toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==,
+      }
+    engines: { node: ">=12" }
 
   toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: ">=0.6" }
 
   tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+    resolution:
+      {
+        integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==,
+      }
 
   trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    resolution:
+      {
+        integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
+      }
 
   trough@2.2.0:
-    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+    resolution:
+      {
+        integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
+      }
 
   ts-api-utils@2.5.0:
-    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
-    engines: {node: '>=18.12'}
+    resolution:
+      {
+        integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
+      }
+    engines: { node: ">=18.12" }
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: ">=4.8.4"
 
   ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    resolution:
+      {
+        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
+      }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: ">=18.0.0" }
     hasBin: true
 
   type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   type-fest@0.16.0:
-    resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==,
+      }
+    engines: { node: ">=10" }
 
   type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==,
+      }
+    engines: { node: ">= 0.6" }
 
   typed-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-byte-length@1.0.3:
-    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-byte-offset@1.0.4:
-    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-length@1.0.7:
-    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==,
+      }
+    engines: { node: ">= 0.4" }
 
   typescript-eslint@8.57.2:
-    resolution: {integrity: sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ">=4.8.4 <6.0.0"
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   unbox-primitive@1.1.0:
-    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==,
+      }
+    engines: { node: ">= 0.4" }
 
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
 
   undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+    resolution:
+      {
+        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
+      }
 
   unicode-canonical-property-names-ecmascript@2.0.1:
-    resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==,
+      }
+    engines: { node: ">=4" }
 
   unicode-match-property-ecmascript@2.0.0:
-    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==,
+      }
+    engines: { node: ">=4" }
 
   unicode-match-property-value-ecmascript@2.2.1:
-    resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==,
+      }
+    engines: { node: ">=4" }
 
   unicode-property-aliases-ecmascript@2.2.0:
-    resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==,
+      }
+    engines: { node: ">=4" }
 
   unified@11.0.5:
-    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+    resolution:
+      {
+        integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
+      }
 
   unique-string@2.0.0:
-    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==,
+      }
+    engines: { node: ">=8" }
 
   unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+    resolution:
+      {
+        integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
+      }
 
   unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+    resolution:
+      {
+        integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
+      }
 
   unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+    resolution:
+      {
+        integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
+      }
 
   unist-util-visit-parents@6.0.2:
-    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+    resolution:
+      {
+        integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
+      }
 
   unist-util-visit@5.1.0:
-    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+    resolution:
+      {
+        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
+      }
 
   universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
+      }
+    engines: { node: ">= 10.0.0" }
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   upath@1.2.0:
-    resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==,
+      }
+    engines: { node: ">=4" }
 
   update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+      }
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ">= 4.21.0"
 
   uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
 
   use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
   use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==,
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      '@types/react': '*'
+      "@types/react": "*"
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
-      '@types/react':
+      "@types/react":
         optional: true
 
   use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: ">= 0.8" }
 
   vfile-message@4.0.3:
-    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+    resolution:
+      {
+        integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
+      }
 
   vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+    resolution:
+      {
+        integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
+      }
 
   victory-vendor@37.3.6:
-    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+    resolution:
+      {
+        integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==,
+      }
 
   vite-plugin-pwa@1.2.0:
-    resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==,
+      }
+    engines: { node: ">=16.0.0" }
     peerDependencies:
-      '@vite-pwa/assets-generator': ^1.0.0
+      "@vite-pwa/assets-generator": ^1.0.0
       vite: ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       workbox-build: ^7.4.0
       workbox-window: ^7.4.0
     peerDependenciesMeta:
-      '@vite-pwa/assets-generator':
+      "@vite-pwa/assets-generator":
         optional: true
 
   vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+    resolution:
+      {
+        integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
+      "@types/node": ^18.0.0 || >=20.0.0
+      less: "*"
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.4.0
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       less:
         optional: true
@@ -4975,23 +8092,26 @@ packages:
         optional: true
 
   vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    resolution:
+      {
+        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: ">=1.21.0"
+      less: "*"
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       jiti:
         optional: true
@@ -5015,34 +8135,37 @@ packages:
         optional: true
 
   vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    resolution:
+      {
+        integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
     peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
-      happy-dom: '*'
-      jsdom: '*'
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.2
+      "@vitest/browser-preview": 4.1.2
+      "@vitest/browser-webdriverio": 4.1.2
+      "@vitest/ui": 4.1.2
+      happy-dom: "*"
+      jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
-      '@edge-runtime/vm':
+      "@edge-runtime/vm":
         optional: true
-      '@opentelemetry/api':
+      "@opentelemetry/api":
         optional: true
-      '@types/node':
+      "@types/node":
         optional: true
-      '@vitest/browser-playwright':
+      "@vitest/browser-playwright":
         optional: true
-      '@vitest/browser-preview':
+      "@vitest/browser-preview":
         optional: true
-      '@vitest/browser-webdriverio':
+      "@vitest/browser-webdriverio":
         optional: true
-      '@vitest/ui':
+      "@vitest/ui":
         optional: true
       happy-dom:
         optional: true
@@ -5050,111 +8173,201 @@ packages:
         optional: true
 
   webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    resolution:
+      {
+        integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==,
+      }
 
   whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==,
+      }
+    engines: { node: ">=12" }
 
   whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+    resolution:
+      {
+        integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==,
+      }
 
   which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-builtin-type@1.2.1:
-    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==,
+      }
+    engines: { node: ">= 0.4" }
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
 
   word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   workbox-background-sync@7.4.0:
-    resolution: {integrity: sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==}
+    resolution:
+      {
+        integrity: sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==,
+      }
 
   workbox-broadcast-update@7.4.0:
-    resolution: {integrity: sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==}
+    resolution:
+      {
+        integrity: sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==,
+      }
 
   workbox-build@7.4.0:
-    resolution: {integrity: sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==,
+      }
+    engines: { node: ">=20.0.0" }
 
   workbox-cacheable-response@7.4.0:
-    resolution: {integrity: sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==}
+    resolution:
+      {
+        integrity: sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==,
+      }
 
   workbox-core@7.4.0:
-    resolution: {integrity: sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==}
+    resolution:
+      {
+        integrity: sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==,
+      }
 
   workbox-expiration@7.4.0:
-    resolution: {integrity: sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==}
+    resolution:
+      {
+        integrity: sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==,
+      }
 
   workbox-google-analytics@7.4.0:
-    resolution: {integrity: sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==}
+    resolution:
+      {
+        integrity: sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==,
+      }
 
   workbox-navigation-preload@7.4.0:
-    resolution: {integrity: sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==}
+    resolution:
+      {
+        integrity: sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==,
+      }
 
   workbox-precaching@7.4.0:
-    resolution: {integrity: sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==}
+    resolution:
+      {
+        integrity: sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==,
+      }
 
   workbox-range-requests@7.4.0:
-    resolution: {integrity: sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==}
+    resolution:
+      {
+        integrity: sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==,
+      }
 
   workbox-recipes@7.4.0:
-    resolution: {integrity: sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==}
+    resolution:
+      {
+        integrity: sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==,
+      }
 
   workbox-routing@7.4.0:
-    resolution: {integrity: sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==}
+    resolution:
+      {
+        integrity: sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==,
+      }
 
   workbox-strategies@7.4.0:
-    resolution: {integrity: sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==}
+    resolution:
+      {
+        integrity: sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==,
+      }
 
   workbox-streams@7.4.0:
-    resolution: {integrity: sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==}
+    resolution:
+      {
+        integrity: sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==,
+      }
 
   workbox-sw@7.4.0:
-    resolution: {integrity: sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==}
+    resolution:
+      {
+        integrity: sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==,
+      }
 
   workbox-window@7.4.0:
-    resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
+    resolution:
+      {
+        integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==,
+      }
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: ">=10" }
 
   wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
+      }
+    engines: { node: ">=18" }
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+      }
+    engines: { node: ">=10.0.0" }
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
+      utf-8-validate: ">=5.0.2"
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5162,74 +8375,103 @@ packages:
         optional: true
 
   xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: ">=0.4" }
 
   y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+      }
+    engines: { node: ">=10" }
 
   yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
 
   yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
+    resolution:
+      {
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
+      }
+    engines: { node: ">= 14.6" }
     hasBin: true
 
   yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+      }
+    engines: { node: ">=12" }
 
   yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+      }
+    engines: { node: ">=12" }
 
   yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: ">=10" }
 
   zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    resolution:
+      {
+        integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==,
+      }
     peerDependencies:
       zod: ^3.25.28 || ^4
 
   zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+    resolution:
+      {
+        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+      }
 
   zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+    resolution:
+      {
+        integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
+      }
 
 snapshots:
+  "@alloc/quick-lru@5.2.0": {}
 
-  '@alloc/quick-lru@5.2.0': {}
-
-  '@apideck/better-ajv-errors@0.3.7(ajv@8.18.0)':
+  "@apideck/better-ajv-errors@0.3.7(ajv@8.18.0)":
     dependencies:
       ajv: 8.18.0
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@babel/code-frame@7.29.0':
+  "@babel/code-frame@7.29.0":
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-validator-identifier": 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  "@babel/compat-data@7.29.0": {}
 
-  '@babel/core@7.29.0':
+  "@babel/core@7.29.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helpers": 7.29.2
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
+      "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -5238,602 +8480,602 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  "@babel/generator@7.29.1":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.27.3':
+  "@babel/helper-annotate-as-pure@7.27.3":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  "@babel/helper-compilation-targets@7.28.6":
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
+      "@babel/compat-data": 7.29.0
+      "@babel/helper-validator-option": 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  "@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-annotate-as-pure": 7.27.3
+      "@babel/helper-member-expression-to-functions": 7.28.5
+      "@babel/helper-optimise-call-expression": 7.27.1
+      "@babel/helper-replace-supers": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
+      "@babel/traverse": 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  "@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
+      "@babel/core": 7.29.0
+      "@babel/helper-annotate-as-pure": 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  "@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-plugin-utils": 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
+  "@babel/helper-globals@7.28.0": {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
+  "@babel/helper-member-expression-to-functions@7.28.5":
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6':
+  "@babel/helper-module-imports@7.28.6":
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-module-imports": 7.28.6
+      "@babel/helper-validator-identifier": 7.28.5
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@7.27.1':
+  "@babel/helper-optimise-call-expression@7.27.1":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/helper-plugin-utils@7.28.6': {}
+  "@babel/helper-plugin-utils@7.28.6": {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  "@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-annotate-as-pure": 7.27.3
+      "@babel/helper-wrap-function": 7.28.6
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  "@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-member-expression-to-functions": 7.28.5
+      "@babel/helper-optimise-call-expression": 7.27.1
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+  "@babel/helper-skip-transparent-expression-wrappers@7.27.1":
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
+  "@babel/helper-string-parser@7.27.1": {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  "@babel/helper-validator-identifier@7.28.5": {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  "@babel/helper-validator-option@7.27.1": {}
 
-  '@babel/helper-wrap-function@7.28.6':
+  "@babel/helper-wrap-function@7.28.6":
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      "@babel/template": 7.28.6
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.29.2':
+  "@babel/helpers@7.29.2":
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
 
-  '@babel/parser@7.29.2':
+  "@babel/parser@7.29.2":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
+      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
+      "@babel/core": 7.29.0
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
+  "@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-remap-async-to-generator": 7.27.1(@babel/core@7.29.0)
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-module-imports": 7.28.6
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-remap-async-to-generator": 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-class-features-plugin": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-class-features-plugin": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-annotate-as-pure": 7.27.3
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-globals": 7.28.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-replace-supers": 7.28.6(@babel/core@7.29.0)
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/template': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/template": 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  "@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/plugin-transform-destructuring": 7.28.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  "@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-validator-identifier": 7.28.5
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/plugin-transform-destructuring": 7.28.5(@babel/core@7.29.0)
+      "@babel/plugin-transform-parameters": 7.27.7(@babel/core@7.29.0)
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-replace-supers": 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  "@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-class-features-plugin": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-annotate-as-pure": 7.27.3
+      "@babel/helper-create-class-features-plugin": 7.28.6(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  "@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  "@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-create-regexp-features-plugin": 7.28.5(@babel/core@7.29.0)
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  "@babel/preset-env@7.29.2(@babel/core@7.29.0)":
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
+      "@babel/compat-data": 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/helper-validator-option": 7.27.1
+      "@babel/plugin-bugfix-firefox-class-in-computed-class-key": 7.28.5(@babel/core@7.29.0)
+      "@babel/plugin-bugfix-safari-class-field-initializer-scope": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
+      "@babel/plugin-syntax-import-assertions": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-syntax-import-attributes": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-syntax-unicode-sets-regex": 7.18.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-arrow-functions": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-async-generator-functions": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-async-to-generator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-block-scoped-functions": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-block-scoping": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-class-properties": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-class-static-block": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-classes": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-computed-properties": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-destructuring": 7.28.5(@babel/core@7.29.0)
+      "@babel/plugin-transform-dotall-regex": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-duplicate-keys": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-duplicate-named-capturing-groups-regex": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-dynamic-import": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-explicit-resource-management": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-exponentiation-operator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-export-namespace-from": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-for-of": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-function-name": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-json-strings": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-literals": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-logical-assignment-operators": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-member-expression-literals": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-modules-amd": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-modules-commonjs": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-modules-systemjs": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-modules-umd": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-new-target": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-numeric-separator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-object-rest-spread": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-object-super": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-optional-catch-binding": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-parameters": 7.27.7(@babel/core@7.29.0)
+      "@babel/plugin-transform-private-methods": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-private-property-in-object": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-property-literals": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-regenerator": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-regexp-modifiers": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-reserved-words": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-shorthand-properties": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-spread": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-sticky-regex": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-template-literals": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-typeof-symbol": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-escapes": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-property-regex": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-regex": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-sets-regex": 7.28.6(@babel/core@7.29.0)
+      "@babel/preset-modules": 0.1.6-no-external-plugins(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
@@ -5842,294 +9084,294 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  "@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
+      "@babel/types": 7.29.0
       esutils: 2.0.3
 
-  '@babel/runtime@7.29.2': {}
+  "@babel/runtime@7.29.2": {}
 
-  '@babel/template@7.28.6':
+  "@babel/template@7.28.6":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
 
-  '@babel/traverse@7.29.0':
+  "@babel/traverse@7.29.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/helper-globals": 7.28.0
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
+  "@babel/types@7.29.0":
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-string-parser": 7.27.1
+      "@babel/helper-validator-identifier": 7.28.5
 
-  '@date-fns/tz@1.4.1': {}
+  "@date-fns/tz@1.4.1": {}
 
-  '@emnapi/runtime@1.9.2':
+  "@emnapi/runtime@1.9.2":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
+  "@esbuild/aix-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.12':
+  "@esbuild/aix-ppc64@0.25.12":
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.4':
+  "@esbuild/aix-ppc64@0.27.4":
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  "@esbuild/android-arm64@0.21.5":
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
+  "@esbuild/android-arm64@0.25.12":
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  "@esbuild/android-arm64@0.27.4":
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  "@esbuild/android-arm@0.21.5":
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
+  "@esbuild/android-arm@0.25.12":
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  "@esbuild/android-arm@0.27.4":
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  "@esbuild/android-x64@0.21.5":
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
+  "@esbuild/android-x64@0.25.12":
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  "@esbuild/android-x64@0.27.4":
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  "@esbuild/darwin-arm64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
+  "@esbuild/darwin-arm64@0.25.12":
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  "@esbuild/darwin-arm64@0.27.4":
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  "@esbuild/darwin-x64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
+  "@esbuild/darwin-x64@0.25.12":
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  "@esbuild/darwin-x64@0.27.4":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  "@esbuild/freebsd-arm64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
+  "@esbuild/freebsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  "@esbuild/freebsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  "@esbuild/freebsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
+  "@esbuild/freebsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  "@esbuild/freebsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  "@esbuild/linux-arm64@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
+  "@esbuild/linux-arm64@0.25.12":
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  "@esbuild/linux-arm64@0.27.4":
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  "@esbuild/linux-arm@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
+  "@esbuild/linux-arm@0.25.12":
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  "@esbuild/linux-arm@0.27.4":
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  "@esbuild/linux-ia32@0.21.5":
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
+  "@esbuild/linux-ia32@0.25.12":
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  "@esbuild/linux-ia32@0.27.4":
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  "@esbuild/linux-loong64@0.21.5":
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
+  "@esbuild/linux-loong64@0.25.12":
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  "@esbuild/linux-loong64@0.27.4":
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  "@esbuild/linux-mips64el@0.21.5":
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
+  "@esbuild/linux-mips64el@0.25.12":
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  "@esbuild/linux-mips64el@0.27.4":
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  "@esbuild/linux-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.12':
+  "@esbuild/linux-ppc64@0.25.12":
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  "@esbuild/linux-ppc64@0.27.4":
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  "@esbuild/linux-riscv64@0.21.5":
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
+  "@esbuild/linux-riscv64@0.25.12":
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  "@esbuild/linux-riscv64@0.27.4":
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  "@esbuild/linux-s390x@0.21.5":
     optional: true
 
-  '@esbuild/linux-s390x@0.25.12':
+  "@esbuild/linux-s390x@0.25.12":
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  "@esbuild/linux-s390x@0.27.4":
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  "@esbuild/linux-x64@0.21.5":
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
+  "@esbuild/linux-x64@0.25.12":
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  "@esbuild/linux-x64@0.27.4":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.12':
+  "@esbuild/netbsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  "@esbuild/netbsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  "@esbuild/netbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
+  "@esbuild/netbsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  "@esbuild/netbsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.12':
+  "@esbuild/openbsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  "@esbuild/openbsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  "@esbuild/openbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
+  "@esbuild/openbsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  "@esbuild/openbsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.12':
+  "@esbuild/openharmony-arm64@0.25.12":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  "@esbuild/openharmony-arm64@0.27.4":
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  "@esbuild/sunos-x64@0.21.5":
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
+  "@esbuild/sunos-x64@0.25.12":
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  "@esbuild/sunos-x64@0.27.4":
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  "@esbuild/win32-arm64@0.21.5":
     optional: true
 
-  '@esbuild/win32-arm64@0.25.12':
+  "@esbuild/win32-arm64@0.25.12":
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  "@esbuild/win32-arm64@0.27.4":
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  "@esbuild/win32-ia32@0.21.5":
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
+  "@esbuild/win32-ia32@0.25.12":
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  "@esbuild/win32-ia32@0.27.4":
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  "@esbuild/win32-x64@0.21.5":
     optional: true
 
-  '@esbuild/win32-x64@0.25.12':
+  "@esbuild/win32-x64@0.25.12":
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  "@esbuild/win32-x64@0.27.4":
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
+  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))":
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.2': {}
+  "@eslint-community/regexpp@4.12.2": {}
 
-  '@eslint/config-array@0.21.2':
+  "@eslint/config-array@0.21.2":
     dependencies:
-      '@eslint/object-schema': 2.1.7
+      "@eslint/object-schema": 2.1.7
       debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.2':
+  "@eslint/config-helpers@0.4.2":
     dependencies:
-      '@eslint/core': 0.17.0
+      "@eslint/core": 0.17.0
 
-  '@eslint/core@0.17.0':
+  "@eslint/core@0.17.0":
     dependencies:
-      '@types/json-schema': 7.0.15
+      "@types/json-schema": 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  "@eslint/eslintrc@3.3.5":
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3
@@ -6143,77 +9385,77 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.39.4': {}
+  "@eslint/js@9.39.4": {}
 
-  '@eslint/object-schema@2.1.7': {}
+  "@eslint/object-schema@2.1.7": {}
 
-  '@eslint/plugin-kit@0.4.1':
+  "@eslint/plugin-kit@0.4.1":
     dependencies:
-      '@eslint/core': 0.17.0
+      "@eslint/core": 0.17.0
       levn: 0.4.1
 
-  '@fastify/accept-negotiator@1.1.0': {}
+  "@fastify/accept-negotiator@1.1.0": {}
 
-  '@fastify/ajv-compiler@3.6.0':
+  "@fastify/ajv-compiler@3.6.0":
     dependencies:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       fast-uri: 2.4.0
 
-  '@fastify/busboy@3.2.0': {}
+  "@fastify/busboy@3.2.0": {}
 
-  '@fastify/cookie@9.4.0':
+  "@fastify/cookie@9.4.0":
     dependencies:
       cookie-signature: 1.2.2
       fastify-plugin: 4.5.1
 
-  '@fastify/deepmerge@2.0.2': {}
+  "@fastify/deepmerge@2.0.2": {}
 
-  '@fastify/error@3.4.1': {}
+  "@fastify/error@3.4.1": {}
 
-  '@fastify/error@4.2.0': {}
+  "@fastify/error@4.2.0": {}
 
-  '@fastify/fast-json-stringify-compiler@4.3.0':
+  "@fastify/fast-json-stringify-compiler@4.3.0":
     dependencies:
       fast-json-stringify: 5.16.1
 
-  '@fastify/merge-json-schemas@0.1.1':
+  "@fastify/merge-json-schemas@0.1.1":
     dependencies:
       fast-deep-equal: 3.1.3
 
-  '@fastify/multipart@8.3.1':
+  "@fastify/multipart@8.3.1":
     dependencies:
-      '@fastify/busboy': 3.2.0
-      '@fastify/deepmerge': 2.0.2
-      '@fastify/error': 4.2.0
+      "@fastify/busboy": 3.2.0
+      "@fastify/deepmerge": 2.0.2
+      "@fastify/error": 4.2.0
       fastify-plugin: 4.5.1
       secure-json-parse: 2.7.0
       stream-wormhole: 1.1.0
 
-  '@fastify/rate-limit@9.1.0':
+  "@fastify/rate-limit@9.1.0":
     dependencies:
-      '@lukeed/ms': 2.0.2
+      "@lukeed/ms": 2.0.2
       fastify-plugin: 4.5.1
       toad-cache: 3.7.0
 
-  '@fastify/send@2.1.0':
+  "@fastify/send@2.1.0":
     dependencies:
-      '@lukeed/ms': 2.0.2
+      "@lukeed/ms": 2.0.2
       escape-html: 1.0.3
       fast-decode-uri-component: 1.0.1
       http-errors: 2.0.0
       mime: 3.0.0
 
-  '@fastify/static@6.12.0':
+  "@fastify/static@6.12.0":
     dependencies:
-      '@fastify/accept-negotiator': 1.1.0
-      '@fastify/send': 2.1.0
+      "@fastify/accept-negotiator": 1.1.0
+      "@fastify/send": 2.1.0
       content-disposition: 0.5.4
       fastify-plugin: 4.5.1
       glob: 8.1.0
       p-limit: 3.1.0
 
-  '@fastify/websocket@8.3.1':
+  "@fastify/websocket@8.3.1":
     dependencies:
       fastify-plugin: 4.5.1
       ws: 8.20.0
@@ -6221,167 +9463,167 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@floating-ui/core@1.7.5':
+  "@floating-ui/core@1.7.5":
     dependencies:
-      '@floating-ui/utils': 0.2.11
+      "@floating-ui/utils": 0.2.11
 
-  '@floating-ui/dom@1.7.6':
+  "@floating-ui/dom@1.7.6":
     dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
+      "@floating-ui/core": 1.7.5
+      "@floating-ui/utils": 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      "@floating-ui/dom": 1.7.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/utils@0.2.11': {}
+  "@floating-ui/utils@0.2.11": {}
 
-  '@formkit/auto-animate@0.9.0': {}
+  "@formkit/auto-animate@0.9.0": {}
 
-  '@hono/node-server@1.19.12(hono@4.12.9)':
+  "@hono/node-server@1.19.12(hono@4.12.9)":
     dependencies:
       hono: 4.12.9
 
-  '@humanfs/core@0.19.1': {}
+  "@humanfs/core@0.19.1": {}
 
-  '@humanfs/node@0.16.7':
+  "@humanfs/node@0.16.7":
     dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.4.3
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.4.3
 
-  '@humanwhocodes/module-importer@1.0.1': {}
+  "@humanwhocodes/module-importer@1.0.1": {}
 
-  '@humanwhocodes/retry@0.4.3': {}
+  "@humanwhocodes/retry@0.4.3": {}
 
-  '@img/colour@1.1.0': {}
+  "@img/colour@1.1.0": {}
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  "@img/sharp-darwin-arm64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      "@img/sharp-libvips-darwin-arm64": 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  "@img/sharp-darwin-x64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      "@img/sharp-libvips-darwin-x64": 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  "@img/sharp-libvips-darwin-arm64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  "@img/sharp-libvips-darwin-x64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  "@img/sharp-libvips-linux-arm64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  "@img/sharp-libvips-linux-arm@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  "@img/sharp-libvips-linux-ppc64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  "@img/sharp-libvips-linux-riscv64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  "@img/sharp-libvips-linux-s390x@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  "@img/sharp-libvips-linux-x64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  "@img/sharp-libvips-linuxmusl-x64@1.2.4":
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  "@img/sharp-linux-arm64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      "@img/sharp-libvips-linux-arm64": 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  "@img/sharp-linux-arm@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      "@img/sharp-libvips-linux-arm": 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  "@img/sharp-linux-ppc64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      "@img/sharp-libvips-linux-ppc64": 1.2.4
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  "@img/sharp-linux-riscv64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      "@img/sharp-libvips-linux-riscv64": 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  "@img/sharp-linux-s390x@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      "@img/sharp-libvips-linux-s390x": 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  "@img/sharp-linux-x64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      "@img/sharp-libvips-linux-x64": 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  "@img/sharp-linuxmusl-arm64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  "@img/sharp-linuxmusl-x64@0.34.5":
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  "@img/sharp-wasm32@0.34.5":
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      "@emnapi/runtime": 1.9.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  "@img/sharp-win32-arm64@0.34.5":
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  "@img/sharp-win32-ia32@0.34.5":
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  "@img/sharp-win32-x64@0.34.5":
     optional: true
 
-  '@isaacs/cliui@9.0.0': {}
+  "@isaacs/cliui@9.0.0": {}
 
-  '@jridgewell/gen-mapping@0.3.13':
+  "@jridgewell/gen-mapping@0.3.13":
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/sourcemap-codec": 1.5.5
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
+  "@jridgewell/remapping@2.3.5":
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/resolve-uri@3.1.2': {}
+  "@jridgewell/resolve-uri@3.1.2": {}
 
-  '@jridgewell/source-map@0.3.11':
+  "@jridgewell/source-map@0.3.11":
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  "@jridgewell/sourcemap-codec@1.5.5": {}
 
-  '@jridgewell/trace-mapping@0.3.31':
+  "@jridgewell/trace-mapping@0.3.31":
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.5
 
-  '@lukeed/ms@2.0.2': {}
+  "@lukeed/ms@2.0.2": {}
 
-  '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
+  "@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)":
     dependencies:
-      '@hono/node-server': 1.19.12(hono@4.12.9)
+      "@hono/node-server": 1.19.12(hono@4.12.9)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6401,428 +9643,428 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nodelib/fs.scandir@2.1.5':
+  "@nodelib/fs.scandir@2.1.5":
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
+      "@nodelib/fs.stat": 2.0.5
       run-parallel: 1.2.0
 
-  '@nodelib/fs.stat@2.0.5': {}
+  "@nodelib/fs.stat@2.0.5": {}
 
-  '@nodelib/fs.walk@1.2.8':
+  "@nodelib/fs.walk@1.2.8":
     dependencies:
-      '@nodelib/fs.scandir': 2.1.5
+      "@nodelib/fs.scandir": 2.1.5
       fastq: 1.20.1
 
-  '@pinojs/redact@0.4.0': {}
+  "@pinojs/redact@0.4.0": {}
 
-  '@playwright/test@1.58.2':
+  "@playwright/test@1.58.2":
     dependencies:
       playwright: 1.58.2
 
-  '@radix-ui/number@1.1.1': {}
+  "@radix-ui/number@1.1.1": {}
 
-  '@radix-ui/primitive@1.1.3': {}
+  "@radix-ui/primitive@1.1.3": {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-previous": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-size": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-focus-guards": 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-focus-scope": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
-
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-escape-keydown": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-menu": 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-id@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
+
+  "@radix-ui/react-id@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-collection": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-direction": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-focus-guards": 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-focus-scope": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-popper": 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-roving-focus": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-focus-guards": 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-focus-scope": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-popper": 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/rect': 1.1.1
+      "@floating-ui/react-dom": 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-arrow": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-rect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-size": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/rect": 1.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-primitive@2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.4(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-collection": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-direction": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-scroll-area@1.2.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/number": 1.1.1
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-direction": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/number": 1.1.1
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-collection": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-direction": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-focus-guards": 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-focus-scope": 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-popper": 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-previous": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-visually-hidden": 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-slot@1.2.4(@types/react@18.3.28)(react@18.3.1)':
+  "@radix-ui/react-slot@1.2.4(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  "@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
-
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-popper": 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-visually-hidden": 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/rect@1.1.1': {}
-
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+  "@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)":
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@standard-schema/utils': 0.3.0
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-use-effect-event": 0.0.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-previous@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/rect": 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      "@types/react": 18.3.28
+
+  "@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      "@types/react": 18.3.28
+      "@types/react-dom": 18.3.7(@types/react@18.3.28)
+
+  "@radix-ui/rect@1.1.1": {}
+
+  "@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)":
+    dependencies:
+      "@standard-schema/spec": 1.1.0
+      "@standard-schema/utils": 0.3.0
       immer: 11.1.4
       redux: 5.0.1
       redux-thunk: 3.1.0(redux@5.0.1)
@@ -6831,36 +10073,36 @@ snapshots:
       react: 18.3.1
       react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  "@rolldown/pluginutils@1.0.0-beta.27": {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
+  "@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-module-imports": 7.28.6
+      "@rollup/pluginutils": 3.1.0(rollup@2.80.0)
       rollup: 2.80.0
     optionalDependencies:
-      '@types/babel__core': 7.20.5
+      "@types/babel__core": 7.20.5
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@2.80.0)':
+  "@rollup/plugin-node-resolve@15.3.1(rollup@2.80.0)":
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@2.80.0)
-      '@types/resolve': 1.20.2
+      "@rollup/pluginutils": 5.3.0(rollup@2.80.0)
+      "@types/resolve": 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
       rollup: 2.80.0
 
-  '@rollup/plugin-replace@2.4.2(rollup@2.80.0)':
+  "@rollup/plugin-replace@2.4.2(rollup@2.80.0)":
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      "@rollup/pluginutils": 3.1.0(rollup@2.80.0)
       magic-string: 0.25.9
       rollup: 2.80.0
 
-  '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
+  "@rollup/plugin-terser@0.4.4(rollup@2.80.0)":
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.6.1
@@ -6868,250 +10110,250 @@ snapshots:
     optionalDependencies:
       rollup: 2.80.0
 
-  '@rollup/pluginutils@3.1.0(rollup@2.80.0)':
+  "@rollup/pluginutils@3.1.0(rollup@2.80.0)":
     dependencies:
-      '@types/estree': 0.0.39
+      "@types/estree": 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.2
       rollup: 2.80.0
 
-  '@rollup/pluginutils@5.3.0(rollup@2.80.0)':
+  "@rollup/pluginutils@5.3.0(rollup@2.80.0)":
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
       rollup: 2.80.0
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  "@rollup/rollup-android-arm-eabi@4.60.1":
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  "@rollup/rollup-android-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  "@rollup/rollup-darwin-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  "@rollup/rollup-darwin-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  "@rollup/rollup-freebsd-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  "@rollup/rollup-freebsd-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  "@rollup/rollup-linux-arm64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  "@rollup/rollup-linux-arm64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  "@rollup/rollup-linux-loong64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  "@rollup/rollup-linux-loong64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  "@rollup/rollup-linux-ppc64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+  "@rollup/rollup-linux-riscv64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+  "@rollup/rollup-linux-s390x-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
+  "@rollup/rollup-linux-x64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
+  "@rollup/rollup-linux-x64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
+  "@rollup/rollup-openbsd-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
+  "@rollup/rollup-openharmony-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+  "@rollup/rollup-win32-arm64-msvc@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+  "@rollup/rollup-win32-ia32-msvc@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
+  "@rollup/rollup-win32-x64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
+  "@rollup/rollup-win32-x64-msvc@4.60.1":
     optional: true
 
-  '@standard-schema/spec@1.1.0': {}
+  "@standard-schema/spec@1.1.0": {}
 
-  '@standard-schema/utils@0.3.0': {}
+  "@standard-schema/utils@0.3.0": {}
 
-  '@surma/rollup-plugin-off-main-thread@2.2.3':
+  "@surma/rollup-plugin-off-main-thread@2.2.3":
     dependencies:
       ejs: 3.1.10
       json5: 2.2.3
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
+  "@tabby_ai/hijri-converter@1.0.5": {}
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
+  "@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
-  '@tanstack/query-core@5.95.2': {}
+  "@tanstack/query-core@5.95.2": {}
 
-  '@tanstack/react-query@5.95.2(react@18.3.1)':
+  "@tanstack/react-query@5.95.2(react@18.3.1)":
     dependencies:
-      '@tanstack/query-core': 5.95.2
+      "@tanstack/query-core": 5.95.2
       react: 18.3.1
 
-  '@types/babel__core@7.20.5':
+  "@types/babel__core@7.20.5":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      "@types/babel__generator": 7.27.0
+      "@types/babel__template": 7.4.4
+      "@types/babel__traverse": 7.28.0
 
-  '@types/babel__generator@7.27.0':
+  "@types/babel__generator@7.27.0":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@types/babel__template@7.4.4':
+  "@types/babel__template@7.4.4":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
 
-  '@types/babel__traverse@7.28.0':
+  "@types/babel__traverse@7.28.0":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@types/bcryptjs@2.4.6': {}
+  "@types/bcryptjs@2.4.6": {}
 
-  '@types/chai@5.2.3':
+  "@types/chai@5.2.3":
     dependencies:
-      '@types/deep-eql': 4.0.2
+      "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
 
-  '@types/d3-array@3.2.2': {}
+  "@types/d3-array@3.2.2": {}
 
-  '@types/d3-color@3.1.3': {}
+  "@types/d3-color@3.1.3": {}
 
-  '@types/d3-ease@3.0.2': {}
+  "@types/d3-ease@3.0.2": {}
 
-  '@types/d3-interpolate@3.0.4':
+  "@types/d3-interpolate@3.0.4":
     dependencies:
-      '@types/d3-color': 3.1.3
+      "@types/d3-color": 3.1.3
 
-  '@types/d3-path@3.1.1': {}
+  "@types/d3-path@3.1.1": {}
 
-  '@types/d3-scale@4.0.9':
+  "@types/d3-scale@4.0.9":
     dependencies:
-      '@types/d3-time': 3.0.4
+      "@types/d3-time": 3.0.4
 
-  '@types/d3-shape@3.1.8':
+  "@types/d3-shape@3.1.8":
     dependencies:
-      '@types/d3-path': 3.1.1
+      "@types/d3-path": 3.1.1
 
-  '@types/d3-time@3.0.4': {}
+  "@types/d3-time@3.0.4": {}
 
-  '@types/d3-timer@3.0.2': {}
+  "@types/d3-timer@3.0.2": {}
 
-  '@types/debug@4.1.13':
+  "@types/debug@4.1.13":
     dependencies:
-      '@types/ms': 2.1.0
+      "@types/ms": 2.1.0
 
-  '@types/deep-eql@4.0.2': {}
+  "@types/deep-eql@4.0.2": {}
 
-  '@types/estree-jsx@1.0.5':
+  "@types/estree-jsx@1.0.5":
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
-  '@types/estree@0.0.39': {}
+  "@types/estree@0.0.39": {}
 
-  '@types/estree@1.0.8': {}
+  "@types/estree@1.0.8": {}
 
-  '@types/hast@3.0.4':
+  "@types/hast@3.0.4":
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
-  '@types/json-schema@7.0.15': {}
+  "@types/json-schema@7.0.15": {}
 
-  '@types/mdast@4.0.4':
+  "@types/mdast@4.0.4":
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
-  '@types/ms@2.1.0': {}
+  "@types/ms@2.1.0": {}
 
-  '@types/node@20.19.39':
+  "@types/node@20.19.39":
     dependencies:
       undici-types: 6.21.0
     optional: true
 
-  '@types/node@24.12.0':
+  "@types/node@24.12.0":
     dependencies:
       undici-types: 7.16.0
 
-  '@types/pg@8.20.0':
+  "@types/pg@8.20.0":
     dependencies:
-      '@types/node': 24.12.0
+      "@types/node": 24.12.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
-  '@types/prop-types@15.7.15': {}
+  "@types/prop-types@15.7.15": {}
 
-  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+  "@types/react-dom@18.3.7(@types/react@18.3.28)":
     dependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
-  '@types/react@18.3.28':
+  "@types/react@18.3.28":
     dependencies:
-      '@types/prop-types': 15.7.15
+      "@types/prop-types": 15.7.15
       csstype: 3.2.3
 
-  '@types/resolve@1.20.2': {}
+  "@types/resolve@1.20.2": {}
 
-  '@types/trusted-types@2.0.7': {}
+  "@types/trusted-types@2.0.7": {}
 
-  '@types/unist@2.0.11': {}
+  "@types/unist@2.0.11": {}
 
-  '@types/unist@3.0.3': {}
+  "@types/unist@3.0.3": {}
 
-  '@types/use-sync-external-store@0.0.6': {}
+  "@types/use-sync-external-store@0.0.6": {}
 
-  '@types/whatwg-mimetype@3.0.2':
+  "@types/whatwg-mimetype@3.0.2":
     optional: true
 
-  '@types/ws@8.18.1':
+  "@types/ws@8.18.1":
     dependencies:
-      '@types/node': 24.12.0
+      "@types/node": 24.12.0
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  "@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/type-utils': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.2
+      "@eslint-community/regexpp": 4.12.2
+      "@typescript-eslint/parser": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.57.2
+      "@typescript-eslint/type-utils": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.57.2
       eslint: 9.39.4(jiti@1.21.7)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -7120,41 +10362,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  "@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.2
+      "@typescript-eslint/scope-manager": 8.57.2
+      "@typescript-eslint/types": 8.57.2
+      "@typescript-eslint/typescript-estree": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.57.2
       debug: 4.4.3
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
+  "@typescript-eslint/project-service@8.57.2(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
+      "@typescript-eslint/tsconfig-utils": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/types": 8.57.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.57.2':
+  "@typescript-eslint/scope-manager@8.57.2":
     dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/visitor-keys': 8.57.2
+      "@typescript-eslint/types": 8.57.2
+      "@typescript-eslint/visitor-keys": 8.57.2
 
-  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
+  "@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)":
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  "@typescript-eslint/type-utils@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/types": 8.57.2
+      "@typescript-eslint/typescript-estree": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@1.21.7)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -7162,14 +10404,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.57.2': {}
+  "@typescript-eslint/types@8.57.2": {}
 
-  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
+  "@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/visitor-keys': 8.57.2
+      "@typescript-eslint/project-service": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/types": 8.57.2
+      "@typescript-eslint/visitor-keys": 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
@@ -7179,84 +10421,84 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  "@typescript-eslint/utils@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      "@typescript-eslint/scope-manager": 8.57.2
+      "@typescript-eslint/types": 8.57.2
+      "@typescript-eslint/typescript-estree": 8.57.2(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.57.2':
+  "@typescript-eslint/visitor-keys@8.57.2":
     dependencies:
-      '@typescript-eslint/types': 8.57.2
+      "@typescript-eslint/types": 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@ungap/structured-clone@1.3.0': {}
+  "@ungap/structured-clone@1.3.0": {}
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))':
+  "@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
+      "@babel/core": 7.29.0
+      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
+      "@rolldown/pluginutils": 1.0.0-beta.27
+      "@types/babel__core": 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.21(@types/node@24.12.0)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.2':
+  "@vitest/expect@4.1.2":
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.2
+      "@vitest/utils": 4.1.2
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  "@vitest/mocker@4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
-      '@vitest/spy': 4.1.2
+      "@vitest/spy": 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.2':
+  "@vitest/pretty-format@4.1.2":
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  "@vitest/runner@4.1.2":
     dependencies:
-      '@vitest/utils': 4.1.2
+      "@vitest/utils": 4.1.2
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  "@vitest/snapshot@4.1.2":
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      "@vitest/pretty-format": 4.1.2
+      "@vitest/utils": 4.1.2
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  "@vitest/spy@4.1.2": {}
 
-  '@vitest/utils@4.1.2':
+  "@vitest/utils@4.1.2":
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      "@vitest/pretty-format": 4.1.2
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xterm/addon-clipboard@0.2.0':
+  "@xterm/addon-clipboard@0.2.0":
     dependencies:
       js-base64: 3.7.8
 
-  '@xterm/addon-fit@0.11.0': {}
+  "@xterm/addon-fit@0.11.0": {}
 
-  '@xterm/xterm@6.0.0': {}
+  "@xterm/xterm@6.0.0": {}
 
   abstract-logging@2.0.1: {}
 
@@ -7404,30 +10646,30 @@ snapshots:
 
   avvio@8.4.0:
     dependencies:
-      '@fastify/error': 3.4.1
+      "@fastify/error": 3.4.1
       fastq: 1.20.1
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      "@babel/compat-data": 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      "@babel/core": 7.29.0
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7561,15 +10803,15 @@ snapshots:
 
   cmdk@1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-dialog": 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      "@radix-ui/react-primitive": 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
+      - "@types/react"
+      - "@types/react-dom"
 
   color-convert@2.0.1:
     dependencies:
@@ -7870,87 +11112,87 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      "@esbuild/aix-ppc64": 0.21.5
+      "@esbuild/android-arm": 0.21.5
+      "@esbuild/android-arm64": 0.21.5
+      "@esbuild/android-x64": 0.21.5
+      "@esbuild/darwin-arm64": 0.21.5
+      "@esbuild/darwin-x64": 0.21.5
+      "@esbuild/freebsd-arm64": 0.21.5
+      "@esbuild/freebsd-x64": 0.21.5
+      "@esbuild/linux-arm": 0.21.5
+      "@esbuild/linux-arm64": 0.21.5
+      "@esbuild/linux-ia32": 0.21.5
+      "@esbuild/linux-loong64": 0.21.5
+      "@esbuild/linux-mips64el": 0.21.5
+      "@esbuild/linux-ppc64": 0.21.5
+      "@esbuild/linux-riscv64": 0.21.5
+      "@esbuild/linux-s390x": 0.21.5
+      "@esbuild/linux-x64": 0.21.5
+      "@esbuild/netbsd-x64": 0.21.5
+      "@esbuild/openbsd-x64": 0.21.5
+      "@esbuild/sunos-x64": 0.21.5
+      "@esbuild/win32-arm64": 0.21.5
+      "@esbuild/win32-ia32": 0.21.5
+      "@esbuild/win32-x64": 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
+      "@esbuild/aix-ppc64": 0.25.12
+      "@esbuild/android-arm": 0.25.12
+      "@esbuild/android-arm64": 0.25.12
+      "@esbuild/android-x64": 0.25.12
+      "@esbuild/darwin-arm64": 0.25.12
+      "@esbuild/darwin-x64": 0.25.12
+      "@esbuild/freebsd-arm64": 0.25.12
+      "@esbuild/freebsd-x64": 0.25.12
+      "@esbuild/linux-arm": 0.25.12
+      "@esbuild/linux-arm64": 0.25.12
+      "@esbuild/linux-ia32": 0.25.12
+      "@esbuild/linux-loong64": 0.25.12
+      "@esbuild/linux-mips64el": 0.25.12
+      "@esbuild/linux-ppc64": 0.25.12
+      "@esbuild/linux-riscv64": 0.25.12
+      "@esbuild/linux-s390x": 0.25.12
+      "@esbuild/linux-x64": 0.25.12
+      "@esbuild/netbsd-arm64": 0.25.12
+      "@esbuild/netbsd-x64": 0.25.12
+      "@esbuild/openbsd-arm64": 0.25.12
+      "@esbuild/openbsd-x64": 0.25.12
+      "@esbuild/openharmony-arm64": 0.25.12
+      "@esbuild/sunos-x64": 0.25.12
+      "@esbuild/win32-arm64": 0.25.12
+      "@esbuild/win32-ia32": 0.25.12
+      "@esbuild/win32-x64": 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      "@esbuild/aix-ppc64": 0.27.4
+      "@esbuild/android-arm": 0.27.4
+      "@esbuild/android-arm64": 0.27.4
+      "@esbuild/android-x64": 0.27.4
+      "@esbuild/darwin-arm64": 0.27.4
+      "@esbuild/darwin-x64": 0.27.4
+      "@esbuild/freebsd-arm64": 0.27.4
+      "@esbuild/freebsd-x64": 0.27.4
+      "@esbuild/linux-arm": 0.27.4
+      "@esbuild/linux-arm64": 0.27.4
+      "@esbuild/linux-ia32": 0.27.4
+      "@esbuild/linux-loong64": 0.27.4
+      "@esbuild/linux-mips64el": 0.27.4
+      "@esbuild/linux-ppc64": 0.27.4
+      "@esbuild/linux-riscv64": 0.27.4
+      "@esbuild/linux-s390x": 0.27.4
+      "@esbuild/linux-x64": 0.27.4
+      "@esbuild/netbsd-arm64": 0.27.4
+      "@esbuild/netbsd-x64": 0.27.4
+      "@esbuild/openbsd-arm64": 0.27.4
+      "@esbuild/openbsd-x64": 0.27.4
+      "@esbuild/openharmony-arm64": 0.27.4
+      "@esbuild/sunos-x64": 0.27.4
+      "@esbuild/win32-arm64": 0.27.4
+      "@esbuild/win32-ia32": 0.27.4
+      "@esbuild/win32-x64": 0.27.4
 
   escalade@3.2.0: {}
 
@@ -8003,18 +11245,18 @@ snapshots:
 
   eslint@9.39.4(jiti@1.21.7):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
-      '@eslint/js': 9.39.4
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      "@eslint-community/regexpp": 4.12.2
+      "@eslint/config-array": 0.21.2
+      "@eslint/config-helpers": 0.4.2
+      "@eslint/core": 0.17.0
+      "@eslint/eslintrc": 3.3.5
+      "@eslint/js": 9.39.4
+      "@eslint/plugin-kit": 0.4.1
+      "@humanfs/node": 0.16.7
+      "@humanwhocodes/module-importer": 1.0.1
+      "@humanwhocodes/retry": 0.4.3
+      "@types/estree": 1.0.8
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -8066,7 +11308,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
   esutils@2.0.3: {}
 
@@ -8130,8 +11372,8 @@ snapshots:
 
   fast-glob@3.3.3:
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
+      "@nodelib/fs.stat": 2.0.5
+      "@nodelib/fs.walk": 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
@@ -8140,7 +11382,7 @@ snapshots:
 
   fast-json-stringify@5.16.1:
     dependencies:
-      '@fastify/merge-json-schemas': 0.1.1
+      "@fastify/merge-json-schemas": 0.1.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-deep-equal: 3.1.3
@@ -8162,9 +11404,9 @@ snapshots:
 
   fastify@4.29.1:
     dependencies:
-      '@fastify/ajv-compiler': 3.6.0
-      '@fastify/error': 3.4.1
-      '@fastify/fast-json-stringify-compiler': 4.3.0
+      "@fastify/ajv-compiler": 3.6.0
+      "@fastify/error": 3.4.1
+      "@fastify/fast-json-stringify-compiler": 4.3.0
       abstract-logging: 2.0.1
       avvio: 8.4.0
       fast-content-type-parse: 1.1.0
@@ -8360,8 +11602,8 @@ snapshots:
 
   happy-dom@18.0.1:
     dependencies:
-      '@types/node': 20.19.39
-      '@types/whatwg-mimetype': 3.0.2
+      "@types/node": 20.19.39
+      "@types/whatwg-mimetype": 3.0.2
       whatwg-mimetype: 3.0.0
     optional: true
 
@@ -8389,9 +11631,9 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.8
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
+      "@types/estree": 1.0.8
+      "@types/hast": 3.0.4
+      "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -8409,7 +11651,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      "@types/hast": 3.0.4
 
   highlight.js@11.11.1: {}
 
@@ -8633,7 +11875,7 @@ snapshots:
 
   jackspeak@4.2.3:
     dependencies:
-      '@isaacs/cliui': 9.0.0
+      "@isaacs/cliui": 9.0.0
 
   jake@10.9.4:
     dependencies:
@@ -8647,9 +11889,9 @@ snapshots:
 
   jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:
-      '@babel/core': 7.29.0
-      '@babel/template': 7.28.6
-      '@types/react': 18.3.28
+      "@babel/core": 7.29.0
+      "@babel/template": 7.28.6
+      "@types/react": 18.3.28
       react: 18.3.1
 
   js-base64@3.7.8: {}
@@ -8774,7 +12016,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/sourcemap-codec": 1.5.5
 
   markdown-table@3.0.4: {}
 
@@ -8782,15 +12024,15 @@ snapshots:
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       escape-string-regexp: 5.0.0
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
@@ -8806,7 +12048,7 @@ snapshots:
 
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-find-and-replace: 3.0.2
@@ -8814,7 +12056,7 @@ snapshots:
 
   mdast-util-gfm-footnote@2.1.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8824,7 +12066,7 @@ snapshots:
 
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
@@ -8832,7 +12074,7 @@ snapshots:
 
   mdast-util-gfm-table@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
       mdast-util-from-markdown: 2.0.3
@@ -8842,7 +12084,7 @@ snapshots:
 
   mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8863,9 +12105,9 @@ snapshots:
 
   mdast-util-mdx-expression@2.0.1:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8874,10 +12116,10 @@ snapshots:
 
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -8891,9 +12133,9 @@ snapshots:
 
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8902,14 +12144,14 @@ snapshots:
 
   mdast-util-phrasing@4.1.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@ungap/structured-clone": 1.3.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -8919,8 +12161,8 @@ snapshots:
 
   mdast-util-to-markdown@2.1.2:
     dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
@@ -8931,7 +12173,7 @@ snapshots:
 
   mdast-util-to-string@4.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
 
   media-typer@1.1.0: {}
 
@@ -9110,7 +12352,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      '@types/debug': 4.1.13
+      "@types/debug": 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -9194,7 +12436,7 @@ snapshots:
       pg: 8.20.0
       yargs: 17.7.2
     optionalDependencies:
-      '@types/pg': 8.20.0
+      "@types/pg": 8.20.0
 
   node-pty@1.0.0:
     dependencies:
@@ -9289,7 +12531,7 @@ snapshots:
 
   parse-entities@4.0.2:
     dependencies:
-      '@types/unist': 2.0.11
+      "@types/unist": 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
       decode-named-character-reference: 1.3.0
@@ -9365,7 +12607,7 @@ snapshots:
 
   pino@9.14.0:
     dependencies:
-      '@pinojs/redact': 0.4.0
+      "@pinojs/redact": 0.4.0
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
@@ -9447,6 +12689,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@3.8.3: {}
+
   pretty-bytes@5.6.0: {}
 
   pretty-bytes@6.1.1: {}
@@ -9493,8 +12737,8 @@ snapshots:
 
   react-day-picker@9.14.0(react@18.3.1):
     dependencies:
-      '@date-fns/tz': 1.4.1
-      '@tabby_ai/hijri-converter': 1.0.5
+      "@date-fns/tz": 1.4.1
+      "@tabby_ai/hijri-converter": 1.0.5
       date-fns: 4.1.0
       date-fns-jalali: 4.1.0-0
       react: 18.3.1
@@ -9509,9 +12753,9 @@ snapshots:
 
   react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 18.3.28
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@types/react": 18.3.28
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -9527,11 +12771,11 @@ snapshots:
 
   react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1):
     dependencies:
-      '@types/use-sync-external-store': 0.0.6
+      "@types/use-sync-external-store": 0.0.6
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
       redux: 5.0.1
 
   react-refresh@0.17.0: {}
@@ -9542,7 +12786,7 @@ snapshots:
       react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
   react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -9553,7 +12797,7 @@ snapshots:
       use-callback-ref: 1.3.3(@types/react@18.3.28)(react@18.3.1)
       use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
   react-router-dom@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -9575,7 +12819,7 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
   react@18.3.1:
     dependencies:
@@ -9593,7 +12837,7 @@ snapshots:
 
   recharts@3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      "@reduxjs/toolkit": 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.45.1
@@ -9608,7 +12852,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
       victory-vendor: 37.3.6
     transitivePeerDependencies:
-      - '@types/react'
+      - "@types/react"
       - redux
 
   redux-thunk@3.1.0(redux@5.0.1):
@@ -9660,7 +12904,7 @@ snapshots:
 
   remark-gfm@4.0.1:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
@@ -9671,7 +12915,7 @@ snapshots:
 
   remark-parse@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
@@ -9680,15 +12924,15 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
   remark-stringify@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
@@ -9734,33 +12978,33 @@ snapshots:
 
   rollup@4.60.1:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      "@rollup/rollup-android-arm-eabi": 4.60.1
+      "@rollup/rollup-android-arm64": 4.60.1
+      "@rollup/rollup-darwin-arm64": 4.60.1
+      "@rollup/rollup-darwin-x64": 4.60.1
+      "@rollup/rollup-freebsd-arm64": 4.60.1
+      "@rollup/rollup-freebsd-x64": 4.60.1
+      "@rollup/rollup-linux-arm-gnueabihf": 4.60.1
+      "@rollup/rollup-linux-arm-musleabihf": 4.60.1
+      "@rollup/rollup-linux-arm64-gnu": 4.60.1
+      "@rollup/rollup-linux-arm64-musl": 4.60.1
+      "@rollup/rollup-linux-loong64-gnu": 4.60.1
+      "@rollup/rollup-linux-loong64-musl": 4.60.1
+      "@rollup/rollup-linux-ppc64-gnu": 4.60.1
+      "@rollup/rollup-linux-ppc64-musl": 4.60.1
+      "@rollup/rollup-linux-riscv64-gnu": 4.60.1
+      "@rollup/rollup-linux-riscv64-musl": 4.60.1
+      "@rollup/rollup-linux-s390x-gnu": 4.60.1
+      "@rollup/rollup-linux-x64-gnu": 4.60.1
+      "@rollup/rollup-linux-x64-musl": 4.60.1
+      "@rollup/rollup-openbsd-x64": 4.60.1
+      "@rollup/rollup-openharmony-arm64": 4.60.1
+      "@rollup/rollup-win32-arm64-msvc": 4.60.1
+      "@rollup/rollup-win32-ia32-msvc": 4.60.1
+      "@rollup/rollup-win32-x64-gnu": 4.60.1
+      "@rollup/rollup-win32-x64-msvc": 4.60.1
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -9873,34 +13117,34 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.1.0
+      "@img/colour": 1.1.0
       detect-libc: 2.1.2
       semver: 7.7.4
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      "@img/sharp-darwin-arm64": 0.34.5
+      "@img/sharp-darwin-x64": 0.34.5
+      "@img/sharp-libvips-darwin-arm64": 1.2.4
+      "@img/sharp-libvips-darwin-x64": 1.2.4
+      "@img/sharp-libvips-linux-arm": 1.2.4
+      "@img/sharp-libvips-linux-arm64": 1.2.4
+      "@img/sharp-libvips-linux-ppc64": 1.2.4
+      "@img/sharp-libvips-linux-riscv64": 1.2.4
+      "@img/sharp-libvips-linux-s390x": 1.2.4
+      "@img/sharp-libvips-linux-x64": 1.2.4
+      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
+      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
+      "@img/sharp-linux-arm": 0.34.5
+      "@img/sharp-linux-arm64": 0.34.5
+      "@img/sharp-linux-ppc64": 0.34.5
+      "@img/sharp-linux-riscv64": 0.34.5
+      "@img/sharp-linux-s390x": 0.34.5
+      "@img/sharp-linux-x64": 0.34.5
+      "@img/sharp-linuxmusl-arm64": 0.34.5
+      "@img/sharp-linuxmusl-x64": 0.34.5
+      "@img/sharp-wasm32": 0.34.5
+      "@img/sharp-win32-arm64": 0.34.5
+      "@img/sharp-win32-ia32": 0.34.5
+      "@img/sharp-win32-x64": 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -10088,7 +13332,7 @@ snapshots:
 
   sucrase@3.35.1:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
+      "@jridgewell/gen-mapping": 0.3.13
       commander: 4.1.1
       lines-and-columns: 1.2.4
       mz: 2.7.0
@@ -10106,7 +13350,7 @@ snapshots:
 
   tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      '@alloc/quick-lru': 5.2.0
+      "@alloc/quick-lru": 5.2.0
       arg: 5.0.2
       chokidar: 3.6.0
       didyoumean: 1.2.2
@@ -10143,7 +13387,7 @@ snapshots:
 
   terser@5.46.1:
     dependencies:
-      '@jridgewell/source-map': 0.3.11
+      "@jridgewell/source-map": 0.3.11
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -10251,10 +13495,10 @@ snapshots:
 
   typescript-eslint@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/eslint-plugin": 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.57.2(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10287,7 +13531,7 @@ snapshots:
 
   unified@11.0.5:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       bail: 2.0.2
       devlop: 1.1.0
       extend: 3.0.2
@@ -10301,24 +13545,24 @@ snapshots:
 
   unist-util-is@6.0.1:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-visit-parents@6.0.2:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-is: 6.0.1
 
   unist-util-visit@5.1.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
@@ -10343,7 +13587,7 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
   use-sidecar@1.1.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -10351,7 +13595,7 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.3.28
+      "@types/react": 18.3.28
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
@@ -10363,23 +13607,23 @@ snapshots:
 
   vfile-message@4.0.3:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile@6.0.3:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
   victory-vendor@37.3.6:
     dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-ease': 3.0.2
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-scale': 4.0.9
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-timer': 3.0.2
+      "@types/d3-array": 3.2.2
+      "@types/d3-ease": 3.0.2
+      "@types/d3-interpolate": 3.0.4
+      "@types/d3-scale": 4.0.9
+      "@types/d3-shape": 3.1.8
+      "@types/d3-time": 3.0.4
+      "@types/d3-timer": 3.0.2
       d3-array: 3.2.4
       d3-ease: 3.0.1
       d3-interpolate: 3.0.1
@@ -10405,7 +13649,7 @@ snapshots:
       postcss: 8.5.8
       rollup: 4.60.1
     optionalDependencies:
-      '@types/node': 24.12.0
+      "@types/node": 24.12.0
       fsevents: 2.3.3
       terser: 5.46.1
 
@@ -10418,7 +13662,7 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.12.0
+      "@types/node": 24.12.0
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.1
@@ -10427,13 +13671,13 @@ snapshots:
 
   vitest@4.1.2(@types/node@24.12.0)(happy-dom@18.0.1)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      "@vitest/expect": 4.1.2
+      "@vitest/mocker": 4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      "@vitest/pretty-format": 4.1.2
+      "@vitest/runner": 4.1.2
+      "@vitest/snapshot": 4.1.2
+      "@vitest/spy": 4.1.2
+      "@vitest/utils": 4.1.2
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10448,7 +13692,7 @@ snapshots:
       vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.0
+      "@types/node": 24.12.0
       happy-dom: 18.0.1
     transitivePeerDependencies:
       - msw
@@ -10527,15 +13771,15 @@ snapshots:
 
   workbox-build@7.4.0(@types/babel__core@7.20.5):
     dependencies:
-      '@apideck/better-ajv-errors': 0.3.7(ajv@8.18.0)
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@2.80.0)
-      '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)
-      '@rollup/plugin-terser': 0.4.4(rollup@2.80.0)
-      '@surma/rollup-plugin-off-main-thread': 2.2.3
+      "@apideck/better-ajv-errors": 0.3.7(ajv@8.18.0)
+      "@babel/core": 7.29.0
+      "@babel/preset-env": 7.29.2(@babel/core@7.29.0)
+      "@babel/runtime": 7.29.2
+      "@rollup/plugin-babel": 5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)
+      "@rollup/plugin-node-resolve": 15.3.1(rollup@2.80.0)
+      "@rollup/plugin-replace": 2.4.2(rollup@2.80.0)
+      "@rollup/plugin-terser": 0.4.4(rollup@2.80.0)
+      "@surma/rollup-plugin-off-main-thread": 2.2.3
       ajv: 8.18.0
       common-tags: 1.8.2
       fast-json-stable-stringify: 2.1.0
@@ -10565,7 +13809,7 @@ snapshots:
       workbox-sw: 7.4.0
       workbox-window: 7.4.0
     transitivePeerDependencies:
-      - '@types/babel__core'
+      - "@types/babel__core"
       - supports-color
 
   workbox-cacheable-response@7.4.0:
@@ -10626,7 +13870,7 @@ snapshots:
 
   workbox-window@7.4.0:
     dependencies:
-      '@types/trusted-types': 2.0.7
+      "@types/trusted-types": 2.0.7
       workbox-core: 7.4.0
 
   wrap-ansi@7.0.0:

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import("prettier").Config} */
+export default {
+  semi: true,
+  singleQuote: false,
+  trailingComma: "es5",
+};

--- a/public/app.css
+++ b/public/app.css
@@ -28,8 +28,16 @@ body {
   font-family: "Inter", "Segoe UI", sans-serif;
   color: var(--text);
   background:
-    radial-gradient(700px 420px at 20% -10%, rgb(59 130 246 / 8%), transparent 70%),
-    radial-gradient(620px 360px at 95% 105%, rgb(139 92 246 / 8%), transparent 70%),
+    radial-gradient(
+      700px 420px at 20% -10%,
+      rgb(59 130 246 / 8%),
+      transparent 70%
+    ),
+    radial-gradient(
+      620px 360px at 95% 105%,
+      rgb(139 92 246 / 8%),
+      transparent 70%
+    ),
     linear-gradient(180deg, #0a0c10 0%, var(--bg) 100%);
 }
 
@@ -111,7 +119,10 @@ button {
   color: var(--text);
   background: #161b25;
   cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 button:hover {
@@ -169,7 +180,11 @@ button:focus-visible {
 
 .agent--active {
   border-color: var(--accent-blue);
-  background: linear-gradient(90deg, rgb(59 130 246 / 12%) 0%, rgb(139 92 246 / 12%) 100%);
+  background: linear-gradient(
+    90deg,
+    rgb(59 130 246 / 12%) 0%,
+    rgb(139 92 246 / 12%) 100%
+  );
 }
 
 .agent-head {
@@ -268,7 +283,11 @@ button:focus-visible {
   align-items: center;
   padding: 0.75rem 0.9rem;
   border-bottom: 1px solid var(--border);
-  background: linear-gradient(90deg, rgb(139 92 246 / 8%) 0%, rgb(59 130 246 / 8%) 100%);
+  background: linear-gradient(
+    90deg,
+    rgb(139 92 246 / 8%) 0%,
+    rgb(59 130 246 / 8%) 100%
+  );
 }
 
 .conn-badge {
@@ -305,7 +324,11 @@ button:focus-visible {
   min-height: 0;
   overflow: hidden;
   background:
-    radial-gradient(1200px 300px at 50% 120%, rgb(34 197 94 / 6%), transparent 60%),
+    radial-gradient(
+      1200px 300px at 50% 120%,
+      rgb(34 197 94 / 6%),
+      transparent 60%
+    ),
     linear-gradient(180deg, #0a0f17 0%, #070b11 100%);
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -5,7 +5,7 @@ const state = {
   shouldKeepTerminalAttached: false,
   reconnectTimer: null,
   reconnectAttempts: 0,
-  activeAttachNonce: 0
+  activeAttachNonce: 0,
 };
 
 const el = {
@@ -28,7 +28,7 @@ const el = {
   lightbox: document.querySelector("[data-lightbox]"),
   lightboxImage: document.querySelector("[data-lightbox-image]"),
   lightboxCaption: document.querySelector("[data-lightbox-caption]"),
-  lightboxClose: document.querySelector("[data-lightbox-close]")
+  lightboxClose: document.querySelector("[data-lightbox-close]"),
 };
 
 const term = new window.Terminal({
@@ -38,8 +38,8 @@ const term = new window.Terminal({
   fontSize: 13,
   scrollback: 5000,
   theme: {
-    background: "#061714"
-  }
+    background: "#061714",
+  },
 });
 const fitAddon = new window.FitAddon.FitAddon();
 term.loadAddon(fitAddon);
@@ -51,9 +51,9 @@ async function api(path, options = {}) {
   const response = await fetch(path, {
     headers: {
       ...(hasBody ? { "content-type": "application/json" } : {}),
-      ...(options.headers ?? {})
+      ...(options.headers ?? {}),
     },
-    ...options
+    ...options,
   });
 
   if (!response.ok) {
@@ -84,7 +84,9 @@ function setConnectionBadge(kind) {
 }
 
 function selectedAgent() {
-  return state.agents.find((agent) => agent.id === state.selectedAgentId) ?? null;
+  return (
+    state.agents.find((agent) => agent.id === state.selectedAgentId) ?? null
+  );
 }
 
 function renderAgents() {
@@ -129,7 +131,7 @@ function renderAgents() {
       if (agent.status !== "running") {
         await api(`/api/v1/agents/${agent.id}/start`, {
           method: "POST",
-          body: JSON.stringify({})
+          body: JSON.stringify({}),
         });
         await refreshAgents();
       }
@@ -144,7 +146,7 @@ function renderAgents() {
     stop.addEventListener("click", async () => {
       await api(`/api/v1/agents/${agent.id}/stop`, {
         method: "POST",
-        body: JSON.stringify({ force: true })
+        body: JSON.stringify({ force: true }),
       });
       if (state.selectedAgentId === agent.id) {
         closeSocket(false);
@@ -166,7 +168,7 @@ function renderAgents() {
       if (agent.status === "running") {
         await api(`/api/v1/agents/${agent.id}/stop`, {
           method: "POST",
-          body: JSON.stringify({ force: true })
+          body: JSON.stringify({ force: true }),
         });
       }
 
@@ -238,7 +240,7 @@ function sendTerminalResize() {
     JSON.stringify({
       type: "resize",
       cols: term.cols,
-      rows: term.rows
+      rows: term.rows,
     })
   );
 }
@@ -268,7 +270,7 @@ async function attachTerminal(clearScreen = true) {
 
   const tokenPayload = await api(`/api/v1/agents/${agent.id}/terminal/token`, {
     method: "POST",
-    body: JSON.stringify({})
+    body: JSON.stringify({}),
   });
 
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -287,7 +289,10 @@ async function attachTerminal(clearScreen = true) {
     const payload = JSON.parse(event.data);
     if (payload.type === "output" && typeof payload.data === "string") {
       term.write(payload.data);
-    } else if (payload.type === "error" && typeof payload.message === "string") {
+    } else if (
+      payload.type === "error" &&
+      typeof payload.message === "string"
+    ) {
       setStatus(`Terminal error: ${payload.message}`);
     } else if (payload.type === "exit") {
       setStatus("Terminal session ended.");
@@ -339,7 +344,10 @@ function scheduleReconnect(statusMessage) {
   }, delayMs);
 }
 
-async function ensureTerminalConnected(clearScreen = false, userInitiated = false) {
+async function ensureTerminalConnected(
+  clearScreen = false,
+  userInitiated = false
+) {
   if (userInitiated) {
     state.shouldKeepTerminalAttached = true;
   }
@@ -365,8 +373,8 @@ async function ensureTerminalConnected(clearScreen = false, userInitiated = fals
       return;
     }
 
-      await attachTerminal(clearScreen);
-      state.reconnectAttempts = 0;
+    await attachTerminal(clearScreen);
+    state.reconnectAttempts = 0;
   } catch (error) {
     setStatus(`Reconnect failed: ${error.message}`);
     scheduleReconnect("Retrying terminal reconnect...");
@@ -382,7 +390,7 @@ async function stopSelectedAgent() {
 
   await api(`/api/v1/agents/${agent.id}/stop`, {
     method: "POST",
-    body: JSON.stringify({ force: true })
+    body: JSON.stringify({ force: true }),
   });
 
   detachTerminal();
@@ -408,12 +416,12 @@ async function deleteSelectedAgent() {
   if (agent.status === "running") {
     await api(`/api/v1/agents/${agent.id}/stop`, {
       method: "POST",
-      body: JSON.stringify({ force: true })
+      body: JSON.stringify({ force: true }),
     });
   }
 
   await api(`/api/v1/agents/${agent.id}`, {
-    method: "DELETE"
+    method: "DELETE",
   });
 
   if (state.selectedAgentId === agent.id) {
@@ -436,7 +444,7 @@ async function createAgent(event) {
 
   const payload = await api("/api/v1/agents", {
     method: "POST",
-    body: JSON.stringify({ name, cwd })
+    body: JSON.stringify({ name, cwd }),
   });
 
   closeCreateModal();

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,8 @@
             <button data-media-refresh-btn type="button">Refresh media</button>
           </div>
           <div class="media-hint">
-            Use the <code>dispatch_share</code> MCP tool to publish media. Files auto-render here.
+            Use the <code>dispatch_share</code> MCP tool to publish media. Files
+            auto-render here.
           </div>
           <div class="media-grid" data-media-grid></div>
         </section>
@@ -65,11 +66,20 @@
         <form class="stack" data-create-form>
           <label>
             Name
-            <input data-create-name type="text" placeholder="agent name (optional)" />
+            <input
+              data-create-name
+              type="text"
+              placeholder="agent name (optional)"
+            />
           </label>
           <label>
             Working directory
-            <input data-create-cwd type="text" placeholder="/absolute/path" required />
+            <input
+              data-create-cwd
+              type="text"
+              placeholder="/absolute/path"
+              required
+            />
           </label>
           <div class="row">
             <button type="submit">Create + open</button>
@@ -79,8 +89,14 @@
       </div>
     </div>
     <div class="lightbox" data-lightbox hidden>
-      <button class="lightbox-close" data-lightbox-close type="button">Close</button>
-      <img class="lightbox-image" data-lightbox-image alt="Expanded media view" />
+      <button class="lightbox-close" data-lightbox-close type="button">
+        Close
+      </button>
+      <img
+        class="lightbox-image"
+        data-lightbox-image
+        alt="Expanded media view"
+      />
       <div class="lightbox-caption" data-lightbox-caption></div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>

--- a/scripts/generate-icon-colors.ts
+++ b/scripts/generate-icon-colors.ts
@@ -62,7 +62,10 @@ async function main() {
       .replaceAll(ORIGINAL_PRIMARY, color.primary)
       .replaceAll(ORIGINAL_DARK, color.dark);
 
-    fs.writeFileSync(path.join(colorDir, "brand-full-logo.svg"), recoloredFullLogo);
+    fs.writeFileSync(
+      path.join(colorDir, "brand-full-logo.svg"),
+      recoloredFullLogo
+    );
 
     // Create a composite SVG at 512x512 with dark background + centered icon
     // The brand icon viewBox is 299.347656 x 285.824219
@@ -93,7 +96,10 @@ function extractSvgContent(svg: string): string {
   // Remove XML declaration if present
   let s = svg.replace(/<\?xml[^?]*\?>/, "").trim();
   // Remove outer <svg ...> and </svg>
-  s = s.replace(/<svg[^>]*>/, "").replace(/<\/svg>/, "").trim();
+  s = s
+    .replace(/<svg[^>]*>/, "")
+    .replace(/<\/svg>/, "")
+    .trim();
   return s;
 }
 


### PR DESCRIPTION
## Summary
- add Prettier config, ignore rules, and root format scripts
- add Prettier to the root devDependencies and update the lockfile
- fold formatting into a new root `ci` script and have the GitHub CI workflow call it
- run a one-time repo-wide Prettier formatting sweep so the new check passes

## Validation
- `pnpm run format`
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test`
- `pnpm run test:e2e`
- `pnpm run ci`