### PR TITLE
feat: add browser notifications with web/Slack channel switching

### DIFF
--- a/apps/server/src/focus-tracker.ts
+++ b/apps/server/src/focus-tracker.ts
@@ -10,6 +10,15 @@ const FOCUS_TTL_MS = 30_000;
 export class FocusTracker {
   private focusedAgents = new Map<string, number>();
 
+  /**
+   * Browser notification permission reported by the client via focus heartbeat.
+   * Mirrors the browser's NotificationPermission: "default" | "granted" | "denied".
+   * Defaults to "default" (not granted) — safe default means Slack is not suppressed
+   * until the client explicitly reports "granted".
+   */
+  private webNotifyPermission: "default" | "granted" | "denied" = "default";
+  private webNotifyPermissionUpdatedAt = 0;
+
   /** Mark an agent as focused (user is actively viewing it). */
   setFocused(agentId: string): void {
     this.focusedAgents.set(agentId, Date.now());
@@ -33,6 +42,24 @@ export class FocusTracker {
       this.focusedAgents.delete(agentId);
       return false;
     }
+    return true;
+  }
+
+  /** Update the browser notification permission state reported by the client. */
+  setWebNotifyPermission(permission: "default" | "granted" | "denied"): void {
+    this.webNotifyPermission = permission;
+    this.webNotifyPermissionUpdatedAt = Date.now();
+  }
+
+  /**
+   * Returns true if the browser has notification permission granted
+   * and the permission was reported recently (within the focus TTL).
+   */
+  hasWebNotifyPermission(): boolean {
+    if (this.webNotifyPermission !== "granted") return false;
+    // Expire stale permission reports — if the client stopped sending
+    // heartbeats, assume permission is no longer available.
+    if (Date.now() - this.webNotifyPermissionUpdatedAt > FOCUS_TTL_MS) return false;
     return true;
   }
 }

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -102,24 +102,11 @@ export class SlackNotifier {
   }
 
   async getNotifyEvents(): Promise<NotifyEventType[]> {
-    const raw = await getSetting(this.pool, SETTING_NOTIFY_EVENTS);
-    if (!raw) return [...NOTIFY_EVENT_TYPES];
-    try {
-      const parsed = JSON.parse(raw) as string[];
-      return parsed.filter((e): e is NotifyEventType =>
-        NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
-      );
-    } catch {
-      return [...NOTIFY_EVENT_TYPES];
-    }
+    return this.getEventSetting(SETTING_NOTIFY_EVENTS);
   }
 
   async setNotifyEvents(events: string[]): Promise<void> {
-    const filtered = events.filter((e): e is NotifyEventType =>
-      NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
-    );
-    await setSetting(this.pool, SETTING_NOTIFY_EVENTS, JSON.stringify(filtered));
-    this.invalidateCache();
+    return this.setEventSetting(SETTING_NOTIFY_EVENTS, events);
   }
 
   async getSettings(): Promise<{
@@ -148,24 +135,11 @@ export class SlackNotifier {
   }
 
   async getWebNotifyEvents(): Promise<NotifyEventType[]> {
-    const raw = await getSetting(this.pool, SETTING_WEB_NOTIFY_EVENTS);
-    if (!raw) return [...NOTIFY_EVENT_TYPES];
-    try {
-      const parsed = JSON.parse(raw) as string[];
-      return parsed.filter((e): e is NotifyEventType =>
-        NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
-      );
-    } catch {
-      return [...NOTIFY_EVENT_TYPES];
-    }
+    return this.getEventSetting(SETTING_WEB_NOTIFY_EVENTS);
   }
 
   async setWebNotifyEvents(events: string[]): Promise<void> {
-    const filtered = events.filter((e): e is NotifyEventType =>
-      NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
-    );
-    await setSetting(this.pool, SETTING_WEB_NOTIFY_EVENTS, JSON.stringify(filtered));
-    this.invalidateCache();
+    return this.setEventSetting(SETTING_WEB_NOTIFY_EVENTS, events);
   }
 
   /**
@@ -201,13 +175,8 @@ export class SlackNotifier {
    * Called on every agent event upsert. Uses a short-lived cache to avoid
    * hitting the DB on the hot path (most events are "working"/"idle" and
    * are filtered out before the cache is even checked).
-   *
-   * When `skipSlack` is true, the Slack message is suppressed (e.g. because
-   * a web notification was sent instead).
    */
-  async onAgentEvent(agent: AgentRecord, skipSlack = false): Promise<void> {
-    if (skipSlack) return;
-
+  async onAgentEvent(agent: AgentRecord): Promise<void> {
     const event = agent.latestEvent;
     if (!event) return;
     if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return;
@@ -351,6 +320,27 @@ export class SlackNotifier {
     const timestamps = this.notifyTimestamps.get(agentId) ?? [];
     timestamps.push(Date.now());
     this.notifyTimestamps.set(agentId, timestamps);
+  }
+
+  private async getEventSetting(key: string): Promise<NotifyEventType[]> {
+    const raw = await getSetting(this.pool, key);
+    if (!raw) return [...NOTIFY_EVENT_TYPES];
+    try {
+      const parsed = JSON.parse(raw) as string[];
+      return parsed.filter((e): e is NotifyEventType =>
+        NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+      );
+    } catch {
+      return [...NOTIFY_EVENT_TYPES];
+    }
+  }
+
+  private async setEventSetting(key: string, events: string[]): Promise<void> {
+    const filtered = events.filter((e): e is NotifyEventType =>
+      NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+    );
+    await setSetting(this.pool, key, JSON.stringify(filtered));
+    this.invalidateCache();
   }
 
   private async getCachedSettings(): Promise<{

--- a/apps/server/src/notifications/slack.ts
+++ b/apps/server/src/notifications/slack.ts
@@ -30,6 +30,8 @@ export type { NotifyInput, NotifyResult };
 const SLACK_WEBHOOK_PREFIX = "https://hooks.slack.com/";
 const SETTING_WEBHOOK_URL = "slack_webhook_url";
 const SETTING_NOTIFY_EVENTS = "slack_notify_events";
+const SETTING_WEB_NOTIFY_ENABLED = "web_notify_enabled";
+const SETTING_WEB_NOTIFY_EVENTS = "web_notify_events";
 
 /** Short-lived cache to avoid DB reads on every agent event. */
 const CACHE_TTL_MS = 10_000;
@@ -41,6 +43,8 @@ const NOTIFY_RATE_WINDOW_MS = 60_000;
 type CachedSettings = {
   webhookUrl: string | null;
   notifyEvents: NotifyEventType[];
+  webNotifyEnabled: boolean;
+  webNotifyEvents: NotifyEventType[];
   expiresAt: number;
 };
 
@@ -121,20 +125,89 @@ export class SlackNotifier {
   async getSettings(): Promise<{
     webhookUrl: string;
     notifyEvents: NotifyEventType[];
+    webNotifyEnabled: boolean;
+    webNotifyEvents: NotifyEventType[];
   }> {
-    const [webhookUrl, notifyEvents] = await Promise.all([
+    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] = await Promise.all([
       this.getWebhookUrl(),
       this.getNotifyEvents(),
+      this.getWebNotifyEnabled(),
+      this.getWebNotifyEvents(),
     ]);
-    return { webhookUrl: webhookUrl ?? "", notifyEvents };
+    return { webhookUrl: webhookUrl ?? "", notifyEvents, webNotifyEnabled, webNotifyEvents };
+  }
+
+  async getWebNotifyEnabled(): Promise<boolean> {
+    const raw = await getSetting(this.pool, SETTING_WEB_NOTIFY_ENABLED);
+    return raw === "true";
+  }
+
+  async setWebNotifyEnabled(enabled: boolean): Promise<void> {
+    await setSetting(this.pool, SETTING_WEB_NOTIFY_ENABLED, String(enabled));
+    this.invalidateCache();
+  }
+
+  async getWebNotifyEvents(): Promise<NotifyEventType[]> {
+    const raw = await getSetting(this.pool, SETTING_WEB_NOTIFY_EVENTS);
+    if (!raw) return [...NOTIFY_EVENT_TYPES];
+    try {
+      const parsed = JSON.parse(raw) as string[];
+      return parsed.filter((e): e is NotifyEventType =>
+        NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+      );
+    } catch {
+      return [...NOTIFY_EVENT_TYPES];
+    }
+  }
+
+  async setWebNotifyEvents(events: string[]): Promise<void> {
+    const filtered = events.filter((e): e is NotifyEventType =>
+      NOTIFY_EVENT_TYPES.includes(e as NotifyEventType)
+    );
+    await setSetting(this.pool, SETTING_WEB_NOTIFY_EVENTS, JSON.stringify(filtered));
+    this.invalidateCache();
+  }
+
+  /**
+   * Check whether a web notification should be sent for this agent event.
+   * Returns the notification payload if web notifications are enabled and
+   * the event type is configured, or null if not applicable.
+   */
+  async shouldWebNotify(agent: AgentRecord): Promise<{
+    agentId: string;
+    agentName: string;
+    eventType: string;
+    message: string;
+  } | null> {
+    const event = agent.latestEvent;
+    if (!event) return null;
+    if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return null;
+
+    if (this.isFocused?.(agent.id)) return null;
+
+    const settings = await this.getCachedSettings();
+    if (!settings.webNotifyEnabled) return null;
+    if (!settings.webNotifyEvents.includes(event.type as NotifyEventType)) return null;
+
+    return {
+      agentId: agent.id,
+      agentName: agent.name || agent.id.slice(0, 8),
+      eventType: event.type,
+      message: event.message,
+    };
   }
 
   /**
    * Called on every agent event upsert. Uses a short-lived cache to avoid
    * hitting the DB on the hot path (most events are "working"/"idle" and
    * are filtered out before the cache is even checked).
+   *
+   * When `skipSlack` is true, the Slack message is suppressed (e.g. because
+   * a web notification was sent instead).
    */
-  async onAgentEvent(agent: AgentRecord): Promise<void> {
+  async onAgentEvent(agent: AgentRecord, skipSlack = false): Promise<void> {
+    if (skipSlack) return;
+
     const event = agent.latestEvent;
     if (!event) return;
     if (!NOTIFY_EVENT_TYPES.includes(event.type as NotifyEventType)) return;
@@ -280,15 +353,22 @@ export class SlackNotifier {
     this.notifyTimestamps.set(agentId, timestamps);
   }
 
-  private async getCachedSettings(): Promise<{ webhookUrl: string | null; notifyEvents: NotifyEventType[] }> {
+  private async getCachedSettings(): Promise<{
+    webhookUrl: string | null;
+    notifyEvents: NotifyEventType[];
+    webNotifyEnabled: boolean;
+    webNotifyEvents: NotifyEventType[];
+  }> {
     if (this.cachedSettings && Date.now() < this.cachedSettings.expiresAt) {
       return this.cachedSettings;
     }
-    const [webhookUrl, notifyEvents] = await Promise.all([
+    const [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents] = await Promise.all([
       this.getWebhookUrl(),
       this.getNotifyEvents(),
+      this.getWebNotifyEnabled(),
+      this.getWebNotifyEvents(),
     ]);
-    this.cachedSettings = { webhookUrl, notifyEvents, expiresAt: Date.now() + CACHE_TTL_MS };
+    this.cachedSettings = { webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents, expiresAt: Date.now() + CACHE_TTL_MS };
     return this.cachedSettings;
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -113,13 +113,13 @@ jobService.onRunStateChange((run) => {
 // When web notifications are enabled and an SSE client is connected, send a
 // notification event via SSE and skip Slack. Otherwise fall back to Slack.
 agentManager.onLatestEvent((agent) => {
-  const sendNotification = async (skipSlack: boolean) => {
+  const sendSlackNotification = async () => {
     if (!agent.name?.startsWith("job-")) {
-      await slackNotifier.onAgentEvent(agent, skipSlack);
+      await slackNotifier.onAgentEvent(agent);
       return;
     }
     const run = await jobService.getLatestRunForAgent(agent.id);
-    if (!run) await slackNotifier.onAgentEvent(agent, skipSlack);
+    if (!run) await slackNotifier.onAgentEvent(agent);
   };
 
   void (async () => {
@@ -132,9 +132,8 @@ agentManager.onLatestEvent((agent) => {
       const webPayload = await slackNotifier.shouldWebNotify(agent);
       if (webPayload && uiEventBroker.hasConnectedClient() && focusTracker.hasWebNotifyPermission()) {
         uiEventBroker.publish({ type: "notification", ...webPayload });
-        await sendNotification(/* skipSlack */ true);
       } else {
-        await sendNotification(/* skipSlack */ false);
+        await sendSlackNotification();
       }
     } catch (err) {
       app.log.warn({ err, agentId: agent.id }, "Agent notification failed");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -110,18 +110,32 @@ jobService.onRunStateChange((run) => {
 });
 // Suppress agent-level Slack notifications for job agents (job notifier handles those).
 // Job agents are named "job-*" — skip the DB lookup for regular agents.
+// When web notifications are enabled and an SSE client is connected, send a
+// notification event via SSE and skip Slack. Otherwise fall back to Slack.
 agentManager.onLatestEvent((agent) => {
-  if (!agent.name?.startsWith("job-")) {
-    void slackNotifier.onAgentEvent(agent).catch((err) => {
-      app.log.warn({ err, agentId: agent.id }, "Slack agent notification failed");
-    });
-    return;
-  }
-  void jobService.getLatestRunForAgent(agent.id).then((run) => {
-    if (!run) return slackNotifier.onAgentEvent(agent);
-  }).catch((err) => {
-    app.log.warn({ err, agentId: agent.id }, "Job agent notification lookup failed");
-  });
+  const sendNotification = async (skipSlack: boolean) => {
+    if (!agent.name?.startsWith("job-")) {
+      await slackNotifier.onAgentEvent(agent, skipSlack);
+      return;
+    }
+    const run = await jobService.getLatestRunForAgent(agent.id);
+    if (!run) await slackNotifier.onAgentEvent(agent, skipSlack);
+  };
+
+  void (async () => {
+    try {
+      // Check if we should send a web notification instead of Slack
+      const webPayload = await slackNotifier.shouldWebNotify(agent);
+      if (webPayload && uiEventBroker.hasConnectedClient()) {
+        uiEventBroker.publish({ type: "notification", ...webPayload });
+        await sendNotification(/* skipSlack */ true);
+      } else {
+        await sendNotification(/* skipSlack */ false);
+      }
+    } catch (err) {
+      app.log.warn({ err, agentId: agent.id }, "Agent notification failed");
+    }
+  })();
 });
 const activeArchives = new Set<Promise<void>>();
 const archivingAgentIds = new Set<string>();
@@ -169,7 +183,8 @@ type UiEvent =
   | { type: "stream.stopped"; agentId: string }
   | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
   | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
-  | { type: "job.changed" };
+  | { type: "job.changed" }
+  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -180,6 +195,11 @@ class UiEventBroker {
     return () => {
       this.clients.delete(stream);
     };
+  }
+
+  /** Returns true if at least one SSE client is currently connected. */
+  hasConnectedClient(): boolean {
+    return this.clients.size > 0;
   }
 
   publish(event: UiEvent): void {
@@ -1942,6 +1962,8 @@ async function registerRoutes() {
     const body = request.body as {
       webhookUrl?: unknown;
       notifyEvents?: unknown;
+      webNotifyEnabled?: unknown;
+      webNotifyEvents?: unknown;
     } | null;
 
     if (body?.webhookUrl !== undefined) {
@@ -1959,6 +1981,20 @@ async function registerRoutes() {
         return reply.code(400).send({ error: "notifyEvents must be an array." });
       }
       await slackNotifier.setNotifyEvents(body.notifyEvents as string[]);
+    }
+
+    if (body?.webNotifyEnabled !== undefined) {
+      if (typeof body.webNotifyEnabled !== "boolean") {
+        return reply.code(400).send({ error: "webNotifyEnabled must be a boolean." });
+      }
+      await slackNotifier.setWebNotifyEnabled(body.webNotifyEnabled);
+    }
+
+    if (body?.webNotifyEvents !== undefined) {
+      if (!Array.isArray(body.webNotifyEvents)) {
+        return reply.code(400).send({ error: "webNotifyEvents must be an array." });
+      }
+      await slackNotifier.setWebNotifyEvents(body.webNotifyEvents as string[]);
     }
 
     return slackNotifier.getSettings();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -124,9 +124,13 @@ agentManager.onLatestEvent((agent) => {
 
   void (async () => {
     try {
-      // Check if we should send a web notification instead of Slack
+      // Check if we should send a web notification instead of Slack.
+      // All three conditions must be met to skip Slack:
+      // 1. Web notifications are enabled and configured for this event type
+      // 2. An SSE client is connected (app is open)
+      // 3. The browser has notification permission granted (reported via focus heartbeat)
       const webPayload = await slackNotifier.shouldWebNotify(agent);
-      if (webPayload && uiEventBroker.hasConnectedClient()) {
+      if (webPayload && uiEventBroker.hasConnectedClient() && focusTracker.hasWebNotifyPermission()) {
         uiEventBroker.publish({ type: "notification", ...webPayload });
         await sendNotification(/* skipSlack */ true);
       } else {
@@ -2664,8 +2668,16 @@ async function registerRoutes() {
   });
 
   app.post("/api/v1/focus", async (request, reply) => {
-    const body = request.body as { agentId?: unknown };
+    const body = request.body as { agentId?: unknown; webNotifyPermission?: unknown };
     const agentId = body?.agentId;
+
+    // Track browser notification permission state from the client
+    if (typeof body?.webNotifyPermission === "string") {
+      const perm = body.webNotifyPermission;
+      if (perm === "granted" || perm === "denied" || perm === "default") {
+        focusTracker.setWebNotifyPermission(perm);
+      }
+    }
 
     if (agentId === null || agentId === undefined) {
       // User is no longer focused on any agent — clear all focus immediately

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -3,12 +3,18 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
+import {
+  getNotificationPermission,
+  requestNotificationPermission,
+} from "@/lib/web-notifications";
 
 type NotifyEventType = "done" | "waiting_user" | "blocked";
 
 type NotificationSettingsResponse = {
   webhookUrl: string;
   notifyEvents: NotifyEventType[];
+  webNotifyEnabled: boolean;
+  webNotifyEvents: NotifyEventType[];
 };
 
 const EVENT_OPTIONS: Array<{ id: NotifyEventType; label: string; description: string }> = [
@@ -18,6 +24,7 @@ const EVENT_OPTIONS: Array<{ id: NotifyEventType; label: string; description: st
 ];
 
 export function NotificationSettings(): JSX.Element {
+  // Slack settings
   const [webhookUrl, setWebhookUrl] = useState("");
   const [savedUrl, setSavedUrl] = useState("");
   const [notifyEvents, setNotifyEvents] = useState<NotifyEventType[]>([
@@ -26,6 +33,20 @@ export function NotificationSettings(): JSX.Element {
     "blocked",
   ]);
   const [savedEvents, setSavedEvents] = useState<NotifyEventType[]>([]);
+
+  // Web notification settings
+  const [webNotifyEnabled, setWebNotifyEnabled] = useState(false);
+  const [savedWebEnabled, setSavedWebEnabled] = useState(false);
+  const [webNotifyEvents, setWebNotifyEvents] = useState<NotifyEventType[]>([
+    "done",
+    "waiting_user",
+    "blocked",
+  ]);
+  const [savedWebEvents, setSavedWebEvents] = useState<NotifyEventType[]>([]);
+  const [browserPermission, setBrowserPermission] = useState<NotificationPermission>(
+    getNotificationPermission()
+  );
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -44,6 +65,10 @@ export function NotificationSettings(): JSX.Element {
         setSavedUrl(data.webhookUrl);
         setNotifyEvents(data.notifyEvents);
         setSavedEvents(data.notifyEvents);
+        setWebNotifyEnabled(data.webNotifyEnabled);
+        setSavedWebEnabled(data.webNotifyEnabled);
+        setWebNotifyEvents(data.webNotifyEvents);
+        setSavedWebEvents(data.webNotifyEvents);
       } catch {
         // ignore — first load may fail if server is starting
       } finally {
@@ -58,7 +83,10 @@ export function NotificationSettings(): JSX.Element {
   const hasChanges =
     webhookUrl !== savedUrl ||
     JSON.stringify([...notifyEvents].sort()) !==
-      JSON.stringify([...savedEvents].sort());
+      JSON.stringify([...savedEvents].sort()) ||
+    webNotifyEnabled !== savedWebEnabled ||
+    JSON.stringify([...webNotifyEvents].sort()) !==
+      JSON.stringify([...savedWebEvents].sort());
 
   const handleSave = useCallback(async () => {
     setError("");
@@ -69,20 +97,29 @@ export function NotificationSettings(): JSX.Element {
         "/api/v1/notifications/settings",
         {
           method: "POST",
-          body: JSON.stringify({ webhookUrl, notifyEvents }),
+          body: JSON.stringify({
+            webhookUrl,
+            notifyEvents,
+            webNotifyEnabled,
+            webNotifyEvents,
+          }),
         }
       );
       setSavedUrl(data.webhookUrl);
       setSavedEvents(data.notifyEvents);
       setWebhookUrl(data.webhookUrl);
       setNotifyEvents(data.notifyEvents);
+      setSavedWebEnabled(data.webNotifyEnabled);
+      setSavedWebEvents(data.webNotifyEvents);
+      setWebNotifyEnabled(data.webNotifyEnabled);
+      setWebNotifyEvents(data.webNotifyEvents);
       setMessage("Settings saved.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save.");
     } finally {
       setSaving(false);
     }
-  }, [webhookUrl, notifyEvents]);
+  }, [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents]);
 
   const handleTest = useCallback(async () => {
     setError("");
@@ -116,31 +153,163 @@ export function NotificationSettings(): JSX.Element {
     );
   }, []);
 
+  const toggleWebEvent = useCallback((eventType: NotifyEventType) => {
+    setWebNotifyEvents((prev) =>
+      prev.includes(eventType)
+        ? prev.filter((e) => e !== eventType)
+        : [...prev, eventType]
+    );
+  }, []);
+
+  const handleRequestPermission = useCallback(async () => {
+    const result = await requestNotificationPermission();
+    setBrowserPermission(result);
+  }, []);
+
+  const handleTestWebNotification = useCallback(() => {
+    if (Notification.permission !== "granted") return;
+    new Notification("Dispatch test notification", {
+      body: "Browser notifications are working!",
+      tag: "dispatch-test",
+    });
+    setMessage("Test notification sent — check your browser!");
+  }, []);
+
   if (loading) {
     return (
       <div className="p-6 text-sm text-muted-foreground">Loading...</div>
     );
   }
 
+  const notificationsSupported = typeof Notification !== "undefined";
+
   return (
     <div className="flex flex-col gap-8 overflow-y-auto p-6">
-      {/* Slack Webhook */}
+      {/* Browser Notifications */}
       <div>
+        <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Browser Notifications
+        </h3>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Get native desktop or mobile notifications when agents need attention.
+          When enabled and the app is open, browser notifications are used instead of Slack.
+        </p>
+
+        {!notificationsSupported ? (
+          <p className="text-sm text-muted-foreground/70">
+            Browser notifications are not supported in this browser.
+            On iOS/iPadOS, install Dispatch as a PWA (Add to Home Screen) to enable notifications.
+          </p>
+        ) : (
+          <div className="max-w-lg space-y-4">
+            {/* Permission status + grant button */}
+            {browserPermission === "denied" ? (
+              <div className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
+                Notifications are blocked by your browser. To enable them, update the
+                notification permission for this site in your browser settings.
+              </div>
+            ) : browserPermission === "default" ? (
+              <div className="flex items-center gap-3 rounded border border-border px-3 py-2.5">
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-foreground">
+                    Permission required
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    Your browser needs permission to show notifications
+                  </div>
+                </div>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => void handleRequestPermission()}
+                >
+                  Allow
+                </Button>
+              </div>
+            ) : null}
+
+            {/* Enable toggle */}
+            <label className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50">
+              <Checkbox
+                checked={webNotifyEnabled}
+                disabled={browserPermission !== "granted"}
+                onCheckedChange={(checked) => setWebNotifyEnabled(checked === true)}
+                data-testid="web-notify-enabled"
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">
+                  Enable browser notifications
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {browserPermission === "granted"
+                    ? "Show notifications when agents change status"
+                    : "Grant permission above to enable"}
+                </div>
+              </div>
+            </label>
+
+            {/* Web event toggles */}
+            {webNotifyEnabled && browserPermission === "granted" && (
+              <div className="space-y-2 pl-1">
+                <div className="text-xs text-muted-foreground">Notify on:</div>
+                {EVENT_OPTIONS.map(({ id, label, description }) => (
+                  <label
+                    key={id}
+                    className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={webNotifyEvents.includes(id)}
+                      onCheckedChange={() => toggleWebEvent(id)}
+                      data-testid={`web-notify-event-${id}`}
+                    />
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground">
+                        {label}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {description}
+                      </div>
+                    </div>
+                  </label>
+                ))}
+                <div className="pt-1">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={handleTestWebNotification}
+                    data-testid="test-web-notification"
+                  >
+                    Send test
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Slack Webhook */}
+      <div className="border-t border-border pt-8">
         <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
           Slack Webhook
         </h3>
         <p className="mb-3 text-sm text-muted-foreground">
           Receive notifications in Slack when agents finish, need input, or get blocked.
-          Create an{" "}
-          <a
-            href="https://api.slack.com/messaging/webhooks"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-400 hover:underline"
-          >
-            Incoming Webhook
-          </a>{" "}
-          in your Slack workspace and paste the URL below.
+          {webNotifyEnabled && (
+            <> When browser notifications are active, Slack is used as a fallback for when the app is closed.</>
+          )}
+          {!webNotifyEnabled && (
+            <>{" "}Create an{" "}
+              <a
+                href="https://api.slack.com/messaging/webhooks"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:underline"
+              >
+                Incoming Webhook
+              </a>{" "}
+              in your Slack workspace and paste the URL below.</>
+          )}
         </p>
         <div className="max-w-lg space-y-3">
           <Input
@@ -157,10 +326,10 @@ export function NotificationSettings(): JSX.Element {
         </div>
       </div>
 
-      {/* Event toggles */}
+      {/* Slack Event toggles */}
       <div>
         <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
-          Notify on
+          Slack notify on
         </h3>
         <p className="mb-3 text-sm text-muted-foreground">
           Choose which agent status changes trigger a Slack notification.
@@ -210,7 +379,7 @@ export function NotificationSettings(): JSX.Element {
             onClick={() => void handleTest()}
             data-testid="test-slack-webhook"
           >
-            {testing ? "Sending..." : "Send test"}
+            {testing ? "Sending..." : "Send Slack test"}
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -47,6 +47,18 @@ export function NotificationSettings(): JSX.Element {
     getNotificationPermission()
   );
 
+  // Re-check permission when the user returns to this page (e.g. after
+  // changing settings in iOS Settings or browser site settings).
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        setBrowserPermission(getNotificationPermission());
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -182,6 +194,10 @@ export function NotificationSettings(): JSX.Element {
   }
 
   const notificationsSupported = typeof Notification !== "undefined";
+  const isStandalone = window.matchMedia("(display-mode: standalone)").matches
+    || ("standalone" in navigator && (navigator as { standalone?: boolean }).standalone === true);
+  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+    || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 
   return (
     <div className="flex flex-col gap-8 overflow-y-auto p-6">
@@ -198,24 +214,27 @@ export function NotificationSettings(): JSX.Element {
         {!notificationsSupported ? (
           <p className="text-sm text-muted-foreground/70">
             Browser notifications are not supported in this browser.
-            On iOS/iPadOS, install Dispatch as a PWA (Add to Home Screen) to enable notifications.
+            {isIOS && !isStandalone
+              ? " On iOS/iPadOS, install Dispatch as a PWA (Add to Home Screen) to enable notifications."
+              : ""}
           </p>
         ) : (
           <div className="max-w-lg space-y-4">
             {/* Permission status + grant button */}
-            {browserPermission === "denied" ? (
-              <div className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
-                Notifications are blocked by your browser. To enable them, update the
-                notification permission for this site in your browser settings.
-              </div>
-            ) : browserPermission === "default" ? (
+            {browserPermission !== "granted" ? (
               <div className="flex items-center gap-3 rounded border border-border px-3 py-2.5">
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-foreground">
-                    Permission required
+                    {browserPermission === "denied" ? "Notifications blocked" : "Permission required"}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    Your browser needs permission to show notifications
+                    {browserPermission === "denied"
+                      ? isIOS
+                        ? "Open device Settings > Notifications > Dispatch to enable, or tap Allow to re-request"
+                        : "Update the notification permission in your browser settings, or tap Allow to re-request"
+                      : isIOS
+                        ? "Tap Allow, then confirm in the system prompt"
+                        : "Your browser needs permission to show notifications"}
                   </div>
                 </div>
                 <Button

--- a/apps/web/src/hooks/use-agent-focus.ts
+++ b/apps/web/src/hooks/use-agent-focus.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { AuthState } from "@/components/app/types";
+import { getNotificationPermission } from "@/lib/web-notifications";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 
@@ -7,6 +8,9 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
  * Sends periodic focus heartbeats to the server so it knows the user is
  * actively viewing a specific agent. The server uses this to suppress
  * redundant Slack notifications.
+ *
+ * Also reports the browser notification permission state so the server
+ * can decide whether to use web notifications or fall back to Slack.
  *
  * Heartbeats are only sent when:
  * - The user is authenticated
@@ -31,7 +35,10 @@ export function useAgentFocus(
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ agentId }),
+        body: JSON.stringify({
+          agentId,
+          webNotifyPermission: getNotificationPermission(),
+        }),
         keepalive: true,
       }).catch(() => {});
     };

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { type Agent, type AuthState } from "@/components/app/types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
+import { showWebNotification } from "@/lib/web-notifications";
 
 type UiEvent =
   | { type: "snapshot"; agents: Agent[] }
@@ -14,7 +15,8 @@ type UiEvent =
   | { type: "stream.stopped"; agentId: string }
   | { type: "feedback.created"; agentId: string }
   | { type: "feedback.updated"; agentId: string }
-  | { type: "job.changed" };
+  | { type: "job.changed" }
+  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
 
 export function useSSE(
   authState: AuthState,
@@ -106,6 +108,11 @@ export function useSSE(
 
         if (payload.type === "job.changed") {
           void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+          return;
+        }
+
+        if (payload.type === "notification") {
+          showWebNotification(payload);
           return;
         }
       } catch {}

--- a/apps/web/src/lib/web-notifications.ts
+++ b/apps/web/src/lib/web-notifications.ts
@@ -1,0 +1,38 @@
+const EVENT_LABELS: Record<string, string> = {
+  done: "finished",
+  waiting_user: "needs your input",
+  blocked: "is blocked",
+};
+
+/**
+ * Show a browser notification for an agent event.
+ * Only fires when the Notification API is available and permission is granted.
+ */
+export function showWebNotification(payload: {
+  agentName: string;
+  eventType: string;
+  message: string;
+}): void {
+  if (typeof Notification === "undefined") return;
+  if (Notification.permission !== "granted") return;
+
+  const verb = EVENT_LABELS[payload.eventType] ?? payload.eventType;
+  const title = `Agent "${payload.agentName}" ${verb}`;
+
+  new Notification(title, {
+    body: payload.message,
+    tag: `dispatch-${payload.agentName}-${payload.eventType}`,
+  });
+}
+
+/** Request notification permission from the browser. Returns the resulting permission state. */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (typeof Notification === "undefined") return "denied";
+  return Notification.requestPermission();
+}
+
+/** Get the current notification permission state without prompting. */
+export function getNotificationPermission(): NotificationPermission {
+  if (typeof Notification === "undefined") return "denied";
+  return Notification.permission;
+}

--- a/apps/web/src/lib/web-notifications.ts
+++ b/apps/web/src/lib/web-notifications.ts
@@ -17,12 +17,20 @@ export function showWebNotification(payload: {
   if (Notification.permission !== "granted") return;
 
   const verb = EVENT_LABELS[payload.eventType] ?? payload.eventType;
-  const title = `Agent "${payload.agentName}" ${verb}`;
+  const title = `${payload.agentName} ${verb}`;
 
   new Notification(title, {
     body: payload.message,
     tag: `dispatch-${payload.agentName}-${payload.eventType}`,
+    icon: getAppIconUrl(),
   });
+}
+
+/** Derive the app icon URL from the current page's apple-touch-icon link. */
+function getAppIconUrl(): string {
+  const link = document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]');
+  if (link?.href) return link.href;
+  return "/icons/teal/brand-icon-192.png";
 }
 
 /** Request notification permission from the browser. Returns the resulting permission state. */

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from "@playwright/test";
+import { createAgentViaAPI, setAgentLatestEventViaAPI } from "./helpers";
+
+const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+
+test.describe("Web notification settings API", () => {
+  test("GET /api/v1/notifications/settings returns web notification fields", async ({ request }) => {
+    const res = await request.get("/api/v1/notifications/settings", {
+      headers: authHeader,
+    });
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data).toHaveProperty("webNotifyEnabled");
+    expect(data).toHaveProperty("webNotifyEvents");
+    expect(Array.isArray(data.webNotifyEvents)).toBe(true);
+  });
+
+  test("POST /api/v1/notifications/settings saves web notification settings", async ({ request }) => {
+    // Enable web notifications with only "done" events
+    const res = await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: {
+        webNotifyEnabled: true,
+        webNotifyEvents: ["done"],
+      },
+    });
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data.webNotifyEnabled).toBe(true);
+    expect(data.webNotifyEvents).toEqual(["done"]);
+
+    // Verify it persists
+    const verify = await request.get("/api/v1/notifications/settings", {
+      headers: authHeader,
+    });
+    const verifyData = await verify.json();
+    expect(verifyData.webNotifyEnabled).toBe(true);
+    expect(verifyData.webNotifyEvents).toEqual(["done"]);
+
+    // Reset
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+    });
+  });
+
+  test("POST /api/v1/notifications/settings validates webNotifyEnabled type", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: "yes" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST /api/v1/notifications/settings validates webNotifyEvents type", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEvents: "done" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST /api/v1/notifications/settings filters invalid event types", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEvents: ["done", "invalid_event", "blocked"] },
+    });
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data.webNotifyEvents).toEqual(["done", "blocked"]);
+
+    // Reset
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEvents: ["done", "waiting_user", "blocked"] },
+    });
+  });
+});
+
+test.describe("Web notification SSE events", () => {
+  test("web notification settings integrate with event pipeline", async ({ request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+    });
+
+    // Report browser permission as granted via focus heartbeat
+    await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: null, webNotifyPermission: "granted" },
+    });
+
+    // Create an agent and set it to "done"
+    const agent = await createAgentViaAPI(request);
+    await setAgentLatestEventViaAPI(request, agent.id, {
+      type: "done",
+      message: "Task completed successfully",
+    });
+
+    // Verify the settings are still correct after event processing
+    const settings = await request.get("/api/v1/notifications/settings", {
+      headers: authHeader,
+    });
+    const data = await settings.json();
+    expect(data.webNotifyEnabled).toBe(true);
+    expect(data.webNotifyEvents).toEqual(["done", "waiting_user", "blocked"]);
+
+    // Clean up
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: false },
+    });
+  });
+
+  test("web notification respects event type filtering", async ({ request }) => {
+    // Enable web notifications for "done" only
+    const res = await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data.webNotifyEvents).toEqual(["done"]);
+
+    // "blocked" is not in the configured events — verify it's excluded
+    expect(data.webNotifyEvents).not.toContain("blocked");
+    expect(data.webNotifyEvents).not.toContain("waiting_user");
+
+    // Clean up
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+    });
+  });
+});
+
+test.describe("Focus heartbeat includes notification permission", () => {
+  test("POST /api/v1/focus accepts webNotifyPermission field", async ({ request }) => {
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: null, webNotifyPermission: "granted" },
+    });
+    expect(res.status()).toBe(204);
+  });
+
+  test("POST /api/v1/focus accepts all valid permission values", async ({ request }) => {
+    for (const perm of ["granted", "denied", "default"]) {
+      const res = await request.post("/api/v1/focus", {
+        headers: authHeader,
+        data: { agentId: null, webNotifyPermission: perm },
+      });
+      expect(res.status()).toBe(204);
+    }
+  });
+
+  test("POST /api/v1/focus ignores invalid permission values", async ({ request }) => {
+    const res = await request.post("/api/v1/focus", {
+      headers: authHeader,
+      data: { agentId: null, webNotifyPermission: "invalid" },
+    });
+    // Should still succeed — invalid values are silently ignored
+    expect(res.status()).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds native browser notifications as a notification channel alongside Slack
- When browser notifications are enabled and the app is open (SSE connected), agent status notifications (done, waiting_user, blocked) are delivered as native browser notifications instead of Slack
- When the app is closed/tab hidden, notifications automatically fall back to Slack
- New "Browser Notifications" section in Settings > Notifications with permission management, enable/disable toggle, and per-event-type configuration

## Changes
- **Server**: Added `web_notify_enabled` and `web_notify_events` settings, `shouldWebNotify()` method on SlackNotifier, `hasConnectedClient()` on UiEventBroker, new `notification` SSE event type, and channel-switching logic in the agent event listener
- **Client**: New `web-notifications.ts` utility for Notification API integration, SSE handler for `notification` events, updated settings UI with browser notification section including permission grant flow

## Test plan
- [x] `pnpm run check` passes (server + web type checking)
- [x] `pnpm run finalize:web` passes (production build)
- [x] `pnpm run test:e2e` — 112 passed, 6 skipped
- [x] `pnpm run test` — 319 passed, 11 skipped
- [x] UI validated via Playwright — notification settings page renders correctly with browser notification section

🤖 Generated with [Claude Code](https://claude.com/claude-code)