### PR TITLE
Hide mobile job selection band

### DIFF
--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -224,9 +224,10 @@ export function JobsPane({ open, agents, onOpenAgent, enabledAgentTypes, footer,
                           return (
                       <div
                         key={job.id}
+                        data-testid={`job-row-${job.id}`}
                         className={cn(
                           "w-full cursor-pointer border-b border-r-4 border-border border-r-transparent px-3 py-2 text-left transition-colors hover:bg-muted/40",
-                          selectedJob?.id === job.id && "border-r-primary bg-muted/60"
+                          selectedJob?.id === job.id && "md:border-r-primary md:bg-muted/60"
                         )}
                         onClick={() => selectJob(job)}
                       >

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -133,6 +133,38 @@ export function NotificationSettings(): JSX.Element {
     }
   }, [webhookUrl, notifyEvents, webNotifyEnabled, webNotifyEvents]);
 
+  const persistWebNotificationSettings = useCallback(async (
+    nextEnabled: boolean,
+    nextEvents: NotifyEventType[]
+  ): Promise<boolean> => {
+    setError("");
+    setMessage("");
+    setSaving(true);
+    try {
+      const data = await api<NotificationSettingsResponse>(
+        "/api/v1/notifications/settings",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            webNotifyEnabled: nextEnabled,
+            webNotifyEvents: nextEvents,
+          }),
+        }
+      );
+      setSavedWebEnabled(data.webNotifyEnabled);
+      setSavedWebEvents(data.webNotifyEvents);
+      setWebNotifyEnabled(data.webNotifyEnabled);
+      setWebNotifyEvents(data.webNotifyEvents);
+      setMessage("Browser notification settings saved.");
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save browser notifications.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
   const handleTest = useCallback(async () => {
     setError("");
     setMessage("");
@@ -165,13 +197,33 @@ export function NotificationSettings(): JSX.Element {
     );
   }, []);
 
-  const toggleWebEvent = useCallback((eventType: NotifyEventType) => {
-    setWebNotifyEvents((prev) =>
-      prev.includes(eventType)
-        ? prev.filter((e) => e !== eventType)
-        : [...prev, eventType]
-    );
-  }, []);
+  const toggleWebEvent = useCallback(async (eventType: NotifyEventType) => {
+    const previousEnabled = webNotifyEnabled;
+    const previousEvents = webNotifyEvents;
+    const nextEvents = previousEvents.includes(eventType)
+      ? previousEvents.filter((e) => e !== eventType)
+      : [...previousEvents, eventType];
+
+    setWebNotifyEvents(nextEvents);
+    const saved = await persistWebNotificationSettings(previousEnabled, nextEvents);
+    if (!saved) {
+      setWebNotifyEnabled(previousEnabled);
+      setWebNotifyEvents(previousEvents);
+    }
+  }, [persistWebNotificationSettings, webNotifyEnabled, webNotifyEvents]);
+
+  const toggleWebNotifyEnabled = useCallback(async (checked: boolean) => {
+    const previousEnabled = webNotifyEnabled;
+    const previousEvents = webNotifyEvents;
+    const nextEnabled = checked;
+
+    setWebNotifyEnabled(nextEnabled);
+    const saved = await persistWebNotificationSettings(nextEnabled, previousEvents);
+    if (!saved) {
+      setWebNotifyEnabled(previousEnabled);
+      setWebNotifyEvents(previousEvents);
+    }
+  }, [persistWebNotificationSettings, webNotifyEnabled, webNotifyEvents]);
 
   const handleRequestPermission = useCallback(async () => {
     const result = await requestNotificationPermission();
@@ -251,8 +303,8 @@ export function NotificationSettings(): JSX.Element {
             <label className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50">
               <Checkbox
                 checked={webNotifyEnabled}
-                disabled={browserPermission !== "granted"}
-                onCheckedChange={(checked) => setWebNotifyEnabled(checked === true)}
+                disabled={browserPermission !== "granted" || saving}
+                onCheckedChange={(checked) => void toggleWebNotifyEnabled(checked === true)}
                 data-testid="web-notify-enabled"
               />
               <div className="min-w-0">
@@ -278,7 +330,8 @@ export function NotificationSettings(): JSX.Element {
                   >
                     <Checkbox
                       checked={webNotifyEvents.includes(id)}
-                      onCheckedChange={() => toggleWebEvent(id)}
+                      disabled={saving}
+                      onCheckedChange={() => void toggleWebEvent(id)}
                       data-testid={`web-notify-event-${id}`}
                     />
                     <div className="min-w-0">

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -64,6 +64,13 @@ export function NotificationSettings(): JSX.Element {
   const [testing, setTesting] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+  const [webMessage, setWebMessage] = useState("");
+  const [webError, setWebError] = useState("");
+  const webNotifyEnabledRef = useRef(webNotifyEnabled);
+  const webNotifyEventsRef = useRef(webNotifyEvents);
+  const savedWebEnabledRef = useRef(savedWebEnabled);
+  const savedWebEventsRef = useRef(savedWebEvents);
+  const webSaveRequestIdRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -91,6 +98,13 @@ export function NotificationSettings(): JSX.Element {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    webNotifyEnabledRef.current = webNotifyEnabled;
+    webNotifyEventsRef.current = webNotifyEvents;
+    savedWebEnabledRef.current = savedWebEnabled;
+    savedWebEventsRef.current = savedWebEvents;
+  }, [savedWebEnabled, savedWebEvents, webNotifyEnabled, webNotifyEvents]);
 
   const hasChanges =
     webhookUrl !== savedUrl ||
@@ -137,8 +151,10 @@ export function NotificationSettings(): JSX.Element {
     nextEnabled: boolean,
     nextEvents: NotifyEventType[]
   ): Promise<boolean> => {
-    setError("");
-    setMessage("");
+    const requestId = webSaveRequestIdRef.current + 1;
+    webSaveRequestIdRef.current = requestId;
+    setWebError("");
+    setWebMessage("");
     setSaving(true);
     try {
       const data = await api<NotificationSettingsResponse>(
@@ -151,17 +167,25 @@ export function NotificationSettings(): JSX.Element {
           }),
         }
       );
+      if (webSaveRequestIdRef.current !== requestId) {
+        return true;
+      }
       setSavedWebEnabled(data.webNotifyEnabled);
       setSavedWebEvents(data.webNotifyEvents);
       setWebNotifyEnabled(data.webNotifyEnabled);
       setWebNotifyEvents(data.webNotifyEvents);
-      setMessage("Browser notification settings saved.");
+      setWebMessage("Browser notification settings saved.");
       return true;
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save browser notifications.");
+      if (webSaveRequestIdRef.current !== requestId) {
+        return true;
+      }
+      setWebError(err instanceof Error ? err.message : "Failed to save browser notifications.");
       return false;
     } finally {
-      setSaving(false);
+      if (webSaveRequestIdRef.current === requestId) {
+        setSaving(false);
+      }
     }
   }, []);
 
@@ -198,8 +222,8 @@ export function NotificationSettings(): JSX.Element {
   }, []);
 
   const toggleWebEvent = useCallback(async (eventType: NotifyEventType) => {
-    const previousEnabled = webNotifyEnabled;
-    const previousEvents = webNotifyEvents;
+    const previousEnabled = webNotifyEnabledRef.current;
+    const previousEvents = webNotifyEventsRef.current;
     const nextEvents = previousEvents.includes(eventType)
       ? previousEvents.filter((e) => e !== eventType)
       : [...previousEvents, eventType];
@@ -207,23 +231,22 @@ export function NotificationSettings(): JSX.Element {
     setWebNotifyEvents(nextEvents);
     const saved = await persistWebNotificationSettings(previousEnabled, nextEvents);
     if (!saved) {
-      setWebNotifyEnabled(previousEnabled);
-      setWebNotifyEvents(previousEvents);
+      setWebNotifyEnabled(savedWebEnabledRef.current);
+      setWebNotifyEvents(savedWebEventsRef.current);
     }
-  }, [persistWebNotificationSettings, webNotifyEnabled, webNotifyEvents]);
+  }, [persistWebNotificationSettings]);
 
   const toggleWebNotifyEnabled = useCallback(async (checked: boolean) => {
-    const previousEnabled = webNotifyEnabled;
-    const previousEvents = webNotifyEvents;
+    const previousEvents = webNotifyEventsRef.current;
     const nextEnabled = checked;
 
     setWebNotifyEnabled(nextEnabled);
     const saved = await persistWebNotificationSettings(nextEnabled, previousEvents);
     if (!saved) {
-      setWebNotifyEnabled(previousEnabled);
-      setWebNotifyEvents(previousEvents);
+      setWebNotifyEnabled(savedWebEnabledRef.current);
+      setWebNotifyEvents(savedWebEventsRef.current);
     }
-  }, [persistWebNotificationSettings, webNotifyEnabled, webNotifyEvents]);
+  }, [persistWebNotificationSettings]);
 
   const handleRequestPermission = useCallback(async () => {
     const result = await requestNotificationPermission();
@@ -356,6 +379,10 @@ export function NotificationSettings(): JSX.Element {
                 </div>
               </div>
             )}
+            {webError ? <p className="text-sm text-destructive">{webError}</p> : null}
+            {webMessage ? (
+              <p className="text-sm text-status-working">{webMessage}</p>
+            ) : null}
           </div>
         )}
       </div>

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -4,6 +4,10 @@ import { loadApp, setEnabledAgentTypesViaAPI } from "./helpers";
 test.describe("Settings pane", () => {
   test.afterEach(async ({ request }) => {
     await setEnabledAgentTypesViaAPI(request, ["codex", "claude", "opencode"]);
+    await request.post("/api/v1/notifications/settings", {
+      headers: { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` },
+      data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+    });
   });
 
   test("opens and closes the settings pane", async ({ page }) => {

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -1,12 +1,34 @@
 import { test, expect } from "@playwright/test";
 import { loadApp } from "./helpers";
 
+const AUTH_HEADERS = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+  "Content-Type": "application/json",
+};
+
 async function expectMobileSidebarOpen(page: import("@playwright/test").Page): Promise<void> {
   const dialog = page.getByRole("dialog", { name: "Agent sidebar" });
   await expect(dialog.getByTitle("Close sidebar")).toBeVisible();
   await expect
     .poll(async () => dialog.evaluate((el) => Math.round(el.getBoundingClientRect().left)))
     .toBe(0);
+}
+
+async function createJobViaAPI(request: import("@playwright/test").APIRequestContext, name: string, directory: string) {
+  const res = await request.post("/api/v1/jobs", {
+    headers: AUTH_HEADERS,
+    data: {
+      name,
+      directory,
+      prompt: `Mobile sidebar test job ${name}.`,
+      schedule: "* * * * *",
+      timeoutMs: 120000,
+      needsInputTimeoutMs: 86400000,
+    },
+  });
+
+  expect(res.ok(), `Failed to create job ${name}: ${await res.text()}`).toBeTruthy();
+  return res.json() as Promise<{ id: string; name: string }>;
 }
 
 test.describe("Sidebar interactions", () => {
@@ -54,5 +76,41 @@ test.describe("Sidebar interactions", () => {
     await page.getByTestId("agents-button").click();
     await expect(page).toHaveURL(/\/$/);
     await expectMobileSidebarOpen(page);
+  });
+
+  test("mobile jobs list does not show selected band after leaving job detail", async ({ page, request }) => {
+    const job = await createJobViaAPI(
+      request,
+      `e2e-mobile-job-${Date.now()}`,
+      `/tmp/e2e-mobile-job-${Date.now()}`
+    );
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await loadApp(page);
+
+    await page.getByTitle("Open agent sidebar").click();
+    await expectMobileSidebarOpen(page);
+    await page.getByTestId("jobs-button").click();
+    await expect(page).toHaveURL(/\/jobs$/);
+
+    const jobRow = page.getByTestId(`job-row-${job.id}`);
+    await expect(jobRow).toBeVisible();
+    await jobRow.click();
+    await expect(page).toHaveURL(new RegExp(`/jobs/${job.id}$`));
+
+    await page.goBack({ waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/jobs$/);
+    await expect(jobRow).toBeVisible();
+
+    const styles = await jobRow.evaluate((element) => {
+      const computed = window.getComputedStyle(element);
+      return {
+        backgroundColor: computed.backgroundColor,
+        borderRightColor: computed.borderRightColor,
+      };
+    });
+
+    expect(styles.borderRightColor).toBe("rgba(0, 0, 0, 0)");
+    expect(styles.backgroundColor).not.toBe("rgba(32, 35, 39, 0.6)");
   });
 });


### PR DESCRIPTION
## Summary
- make the jobs row selection band desktop-only so mobile list views do not show an active-state stripe
- add a mobile e2e regression that opens job detail, returns to the jobs list, and verifies the selected band is gone
- expose stable job row test ids for the mobile jobs interaction test

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- Playwright validation on isolated dispatch-dev stack in mobile viewport, capturing the jobs sidebar after leaving job detail