### PR TITLE
Ack-based web notification delivery with Slack fallback

### DIFF
--- a/apps/server/src/focus-tracker.ts
+++ b/apps/server/src/focus-tracker.ts
@@ -1,23 +1,14 @@
 /**
  * In-memory tracker for which agents the user is actively viewing in the UI.
- * Used to suppress redundant Slack notifications when the user is already
- * looking at the agent. State is ephemeral — server restart clears all focus,
- * which is the safe default (notifications resume).
+ * Used to suppress redundant notifications (both web and Slack) when the user
+ * is already looking at the agent. State is ephemeral — server restart clears
+ * all focus, which is the safe default (notifications resume).
  */
 
 const FOCUS_TTL_MS = 30_000;
 
 export class FocusTracker {
   private focusedAgents = new Map<string, number>();
-
-  /**
-   * Browser notification permission reported by the client via focus heartbeat.
-   * Mirrors the browser's NotificationPermission: "default" | "granted" | "denied".
-   * Defaults to "default" (not granted) — safe default means Slack is not suppressed
-   * until the client explicitly reports "granted".
-   */
-  private webNotifyPermission: "default" | "granted" | "denied" = "default";
-  private webNotifyPermissionUpdatedAt = 0;
 
   /** Mark an agent as focused (user is actively viewing it). */
   setFocused(agentId: string): void {
@@ -42,24 +33,6 @@ export class FocusTracker {
       this.focusedAgents.delete(agentId);
       return false;
     }
-    return true;
-  }
-
-  /** Update the browser notification permission state reported by the client. */
-  setWebNotifyPermission(permission: "default" | "granted" | "denied"): void {
-    this.webNotifyPermission = permission;
-    this.webNotifyPermissionUpdatedAt = Date.now();
-  }
-
-  /**
-   * Returns true if the browser has notification permission granted
-   * and the permission was reported recently (within the focus TTL).
-   */
-  hasWebNotifyPermission(): boolean {
-    if (this.webNotifyPermission !== "granted") return false;
-    // Expire stale permission reports — if the client stopped sending
-    // heartbeats, assume permission is no longer available.
-    if (Date.now() - this.webNotifyPermissionUpdatedAt > FOCUS_TTL_MS) return false;
     return true;
   }
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -189,7 +189,7 @@ agentManager.onLatestEvent((agent) => {
           pendingWebNotifications.delete(notificationId);
           app.log.debug(
             { notificationId, agentId: agent.id },
-            "Web notification not acked — falling back to Slack",
+            "Web notification not acked — falling back to Slack"
           );
           void sendSlackNotification();
         }, WEB_NOTIFY_ACK_TIMEOUT_MS);
@@ -3218,7 +3218,7 @@ async function registerRoutes() {
     const found = ackWebNotification(body.notificationId);
     app.log.debug(
       { notificationId: body.notificationId, found },
-      "Web notification ack received",
+      "Web notification ack received"
     );
     return reply.code(204).send();
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4223,6 +4223,13 @@ async function cleanupAppResources(): Promise<void> {
   stopAgentStatusReconcileLoop();
   stopSessionCleanupTimer();
 
+  // Cancel pending web notification fallback timers so they don't fire
+  // Slack notifications after the pool is closed.
+  for (const timer of pendingWebNotifications.values()) {
+    clearTimeout(timer);
+  }
+  pendingWebNotifications.clear();
+
   // Wait for in-flight archives to finish so clean shutdowns don't leave agents stuck in "archiving"
   if (activeArchives.size > 0) {
     app.log.info({ count: activeArchives.size }, "Waiting for in-flight archives to complete…");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -110,8 +110,21 @@ jobService.onRunStateChange((run) => {
 });
 // Suppress agent-level Slack notifications for job agents (job notifier handles those).
 // Job agents are named "job-*" — skip the DB lookup for regular agents.
-// When web notifications are enabled and an SSE client is connected, send a
-// notification event via SSE and skip Slack. Otherwise fall back to Slack.
+// When web notifications are enabled and an SSE client is connected, broadcast
+// a notification via SSE and wait for an ack from any client. If no ack arrives
+// within the timeout, fall back to Slack.
+const WEB_NOTIFY_ACK_TIMEOUT_MS = 3_000;
+const pendingWebNotifications = new Map<string, NodeJS.Timeout>();
+
+/** Called by the ack endpoint when a client confirms delivery. */
+function ackWebNotification(notificationId: string): boolean {
+  const timer = pendingWebNotifications.get(notificationId);
+  if (!timer) return false;
+  clearTimeout(timer);
+  pendingWebNotifications.delete(notificationId);
+  return true;
+}
+
 agentManager.onLatestEvent((agent) => {
   const sendSlackNotification = async () => {
     if (!agent.name?.startsWith("job-")) {
@@ -124,14 +137,23 @@ agentManager.onLatestEvent((agent) => {
 
   void (async () => {
     try {
-      // Check if we should send a web notification instead of Slack.
-      // All three conditions must be met to skip Slack:
-      // 1. Web notifications are enabled and configured for this event type
-      // 2. An SSE client is connected (app is open)
-      // 3. The browser has notification permission granted (reported via focus heartbeat)
+      // Check if we should attempt a web notification.
+      // Conditions: web notifications enabled, event type configured, agent not focused.
       const webPayload = await slackNotifier.shouldWebNotify(agent);
-      if (webPayload && uiEventBroker.hasConnectedClient() && focusTracker.hasWebNotifyPermission()) {
-        uiEventBroker.publish({ type: "notification", ...webPayload });
+      if (webPayload && uiEventBroker.hasConnectedClient()) {
+        // Broadcast notification via SSE with a unique ID.
+        // If any client acks within the timeout, Slack is suppressed.
+        // Otherwise fall back to Slack.
+        const notificationId = randomUUID();
+        uiEventBroker.publish({ type: "notification", notificationId, ...webPayload });
+
+        const fallbackTimer = setTimeout(() => {
+          pendingWebNotifications.delete(notificationId);
+          app.log.debug({ notificationId, agentId: agent.id }, "Web notification not acked — falling back to Slack");
+          void sendSlackNotification();
+        }, WEB_NOTIFY_ACK_TIMEOUT_MS);
+
+        pendingWebNotifications.set(notificationId, fallbackTimer);
       } else {
         await sendSlackNotification();
       }
@@ -187,7 +209,7 @@ type UiEvent =
   | { type: "feedback.created"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
   | { type: "feedback.updated"; agentId: string; feedback: import("./agents/manager.js").FeedbackRecord }
   | { type: "job.changed" }
-  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
+  | { type: "notification"; notificationId: string; agentId: string; agentName: string; eventType: string; message: string };
 
 class UiEventBroker {
   private clients = new Set<NodeJS.WritableStream>();
@@ -2666,17 +2688,19 @@ async function registerRoutes() {
     });
   });
 
-  app.post("/api/v1/focus", async (request, reply) => {
-    const body = request.body as { agentId?: unknown; webNotifyPermission?: unknown };
-    const agentId = body?.agentId;
-
-    // Track browser notification permission state from the client
-    if (typeof body?.webNotifyPermission === "string") {
-      const perm = body.webNotifyPermission;
-      if (perm === "granted" || perm === "denied" || perm === "default") {
-        focusTracker.setWebNotifyPermission(perm);
-      }
+  app.post("/api/v1/notifications/ack", async (request, reply) => {
+    const body = request.body as { notificationId?: unknown };
+    if (typeof body?.notificationId !== "string") {
+      return reply.code(400).send({ error: "notificationId must be a string." });
     }
+    const found = ackWebNotification(body.notificationId);
+    app.log.debug({ notificationId: body.notificationId, found }, "Web notification ack received");
+    return reply.code(204).send();
+  });
+
+  app.post("/api/v1/focus", async (request, reply) => {
+    const body = request.body as { agentId?: unknown };
+    const agentId = body?.agentId;
 
     if (agentId === null || agentId === undefined) {
       // User is no longer focused on any agent — clear all focus immediately

--- a/apps/web/src/hooks/use-agent-focus.ts
+++ b/apps/web/src/hooks/use-agent-focus.ts
@@ -1,16 +1,12 @@
 import { useEffect, useRef } from "react";
 import type { AuthState } from "@/components/app/types";
-import { getNotificationPermission } from "@/lib/web-notifications";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 
 /**
  * Sends periodic focus heartbeats to the server so it knows the user is
  * actively viewing a specific agent. The server uses this to suppress
- * redundant Slack notifications.
- *
- * Also reports the browser notification permission state so the server
- * can decide whether to use web notifications or fall back to Slack.
+ * redundant notifications when the user is already looking at the agent.
  *
  * Heartbeats are only sent when:
  * - The user is authenticated
@@ -35,10 +31,7 @@ export function useAgentFocus(
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          agentId,
-          webNotifyPermission: getNotificationPermission(),
-        }),
+        body: JSON.stringify({ agentId }),
         keepalive: true,
       }).catch(() => {});
     };

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -16,7 +16,7 @@ type UiEvent =
   | { type: "feedback.created"; agentId: string }
   | { type: "feedback.updated"; agentId: string }
   | { type: "job.changed" }
-  | { type: "notification"; agentId: string; agentName: string; eventType: string; message: string };
+  | { type: "notification"; notificationId: string; agentId: string; agentName: string; eventType: string; message: string };
 
 export function useSSE(
   authState: AuthState,
@@ -112,7 +112,16 @@ export function useSSE(
         }
 
         if (payload.type === "notification") {
-          showWebNotification(payload);
+          const shown = showWebNotification(payload);
+          if (shown) {
+            void fetch("/api/v1/notifications/ack", {
+              method: "POST",
+              credentials: "include",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ notificationId: payload.notificationId }),
+              keepalive: true,
+            }).catch(() => {});
+          }
           return;
         }
       } catch {}

--- a/apps/web/src/lib/web-notifications.ts
+++ b/apps/web/src/lib/web-notifications.ts
@@ -7,14 +7,15 @@ const EVENT_LABELS: Record<string, string> = {
 /**
  * Show a browser notification for an agent event.
  * Only fires when the Notification API is available and permission is granted.
+ * Returns true if a notification was attempted (permission granted), false otherwise.
  */
 export function showWebNotification(payload: {
   agentName: string;
   eventType: string;
   message: string;
-}): void {
-  if (typeof Notification === "undefined") return;
-  if (Notification.permission !== "granted") return;
+}): boolean {
+  if (typeof Notification === "undefined") return false;
+  if (Notification.permission !== "granted") return false;
 
   const verb = EVENT_LABELS[payload.eventType] ?? payload.eventType;
   const title = `${payload.agentName} ${verb}`;
@@ -24,6 +25,8 @@ export function showWebNotification(payload: {
     tag: `dispatch-${payload.agentName}-${payload.eventType}`,
     icon: getAppIconUrl(),
   });
+
+  return true;
 }
 
 /** Derive the app icon URL from the current page's apple-touch-icon link. */

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -1,7 +1,75 @@
 import { test, expect } from "@playwright/test";
+import http from "http";
 import { createAgentViaAPI, setAgentLatestEventViaAPI } from "./helpers";
 
-const authHeader = { Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}` };
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
+const authHeader = { Authorization: `Bearer ${AUTH_TOKEN}` };
+const devPort = process.env.E2E_PORT ?? "8788";
+const protocol = process.env.TLS_CERT ? "https" : "http";
+const SSE_BASE_URL = `${protocol}://127.0.0.1:${devPort}`;
+
+type SSEEvent = { type: string; [key: string]: unknown };
+
+/** Open a raw HTTP SSE connection (EventSource isn't available in Node). */
+function openSSEStream(baseURL: string): {
+  events: SSEEvent[];
+  ready: Promise<void>;
+  close: () => void;
+} {
+  const events: SSEEvent[] = [];
+  const url = new URL("/api/v1/events", baseURL);
+  let req: http.ClientRequest | null = null;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    req = http.get(
+      url,
+      { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } },
+      (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`SSE stream returned ${res.statusCode}`));
+          return;
+        }
+        let buffer = "";
+        res.on("data", (chunk: Buffer) => {
+          buffer += chunk.toString();
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop()!;
+          for (const part of parts) {
+            const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
+            if (!dataLine) continue;
+            try {
+              const payload = JSON.parse(dataLine.slice(6));
+              events.push(payload);
+              if (payload.type === "snapshot") resolve();
+            } catch {}
+          }
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+  });
+
+  return { events, ready, close: () => req?.destroy() };
+}
+
+/** Wait until events array contains at least `count` events matching predicate. */
+async function waitForEvents(
+  events: SSEEvent[],
+  predicate: (e: SSEEvent) => boolean,
+  count: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (events.filter(predicate).length >= count) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  const matched = events.filter(predicate).length;
+  throw new Error(
+    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms).`,
+  );
+}
 
 test.describe("Web notification settings API", () => {
   test("GET /api/v1/notifications/settings returns web notification fields", async ({ request }) => {
@@ -152,5 +220,194 @@ test.describe("Web notification ack endpoint", () => {
       data: { notificationId: 123 },
     });
     expect(res.status()).toBe(400);
+  });
+});
+
+test.describe("Web notification SSE delivery and ack flow", () => {
+  test("SSE notification event includes notificationId when web notifications are enabled", async ({ request }) => {
+    // Enable web notifications for "done"
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    // Open SSE stream so the server sees a connected client
+    const sse = openSSEStream(SSE_BASE_URL);
+    await sse.ready;
+
+    try {
+      // Create an agent and trigger a "done" event
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Task completed",
+      });
+
+      // Wait for the notification event in the SSE stream
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "notification",
+        1,
+        5000,
+      );
+
+      const notification = sse.events.find((e) => e.type === "notification");
+      expect(notification).toBeDefined();
+      expect(notification!.notificationId).toBeDefined();
+      expect(typeof notification!.notificationId).toBe("string");
+      expect(notification!.agentName).toBeDefined();
+      expect(notification!.eventType).toBe("done");
+      expect(notification!.message).toBe("Task completed");
+    } finally {
+      sse.close();
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+
+  test("acking a notification prevents Slack fallback (ack returns 204)", async ({ request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    const sse = openSSEStream(SSE_BASE_URL);
+    await sse.ready;
+
+    try {
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Ack test",
+      });
+
+      await waitForEvents(
+        sse.events,
+        (e) => e.type === "notification",
+        1,
+        5000,
+      );
+
+      const notification = sse.events.find((e) => e.type === "notification");
+      expect(notification).toBeDefined();
+
+      // Ack the notification — this should cancel the Slack fallback timer
+      const ackRes = await request.post("/api/v1/notifications/ack", {
+        headers: authHeader,
+        data: { notificationId: notification!.notificationId },
+      });
+      expect(ackRes.status()).toBe(204);
+    } finally {
+      sse.close();
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+
+  test("no notification SSE event for unconfigured event types", async ({ request }) => {
+    // Enable web notifications for "done" only
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    const sse = openSSEStream(SSE_BASE_URL);
+    await sse.ready;
+
+    try {
+      const agent = await createAgentViaAPI(request);
+
+      // Trigger a "blocked" event — not in configured events
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "blocked",
+        message: "Something went wrong",
+      });
+
+      // Wait a bit and verify no notification event was sent
+      // (we should see the agent.upsert but no notification)
+      await new Promise((r) => setTimeout(r, 1500));
+      const notifications = sse.events.filter((e) => e.type === "notification");
+      expect(notifications).toHaveLength(0);
+    } finally {
+      sse.close();
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+
+  test("no notification SSE event when web notifications are disabled", async ({ request }) => {
+    // Ensure web notifications are disabled
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: false },
+    });
+
+    const sse = openSSEStream(SSE_BASE_URL);
+    await sse.ready;
+
+    try {
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Should not notify",
+      });
+
+      // Wait and verify no notification event
+      await new Promise((r) => setTimeout(r, 1500));
+      const notifications = sse.events.filter((e) => e.type === "notification");
+      expect(notifications).toHaveLength(0);
+    } finally {
+      sse.close();
+    }
+  });
+
+  test("focused agent does not trigger notification SSE event", async ({ request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    const sse = openSSEStream(SSE_BASE_URL);
+    await sse.ready;
+
+    try {
+      const agent = await createAgentViaAPI(request);
+
+      // Report focus on this agent
+      await request.post("/api/v1/focus", {
+        headers: authHeader,
+        data: { agentId: agent.id },
+      });
+
+      // Trigger a "done" event — should be suppressed because agent is focused
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Focused agent done",
+      });
+
+      // Wait and verify no notification event
+      await new Promise((r) => setTimeout(r, 1500));
+      const notifications = sse.events.filter((e) => e.type === "notification");
+      expect(notifications).toHaveLength(0);
+    } finally {
+      sse.close();
+      // Clear focus
+      await request.post("/api/v1/focus", {
+        headers: authHeader,
+        data: { agentId: null },
+      });
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
   });
 });

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -85,12 +85,6 @@ test.describe("Web notification SSE events", () => {
       data: { webNotifyEnabled: true, webNotifyEvents: ["done", "waiting_user", "blocked"] },
     });
 
-    // Report browser permission as granted via focus heartbeat
-    await request.post("/api/v1/focus", {
-      headers: authHeader,
-      data: { agentId: null, webNotifyPermission: "granted" },
-    });
-
     // Create an agent and set it to "done"
     const agent = await createAgentViaAPI(request);
     await setAgentLatestEventViaAPI(request, agent.id, {
@@ -135,31 +129,28 @@ test.describe("Web notification SSE events", () => {
   });
 });
 
-test.describe("Focus heartbeat includes notification permission", () => {
-  test("POST /api/v1/focus accepts webNotifyPermission field", async ({ request }) => {
-    const res = await request.post("/api/v1/focus", {
+test.describe("Web notification ack endpoint", () => {
+  test("POST /api/v1/notifications/ack accepts a valid notificationId", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/ack", {
       headers: authHeader,
-      data: { agentId: null, webNotifyPermission: "granted" },
+      data: { notificationId: "test-notification-id" },
     });
     expect(res.status()).toBe(204);
   });
 
-  test("POST /api/v1/focus accepts all valid permission values", async ({ request }) => {
-    for (const perm of ["granted", "denied", "default"]) {
-      const res = await request.post("/api/v1/focus", {
-        headers: authHeader,
-        data: { agentId: null, webNotifyPermission: perm },
-      });
-      expect(res.status()).toBe(204);
-    }
+  test("POST /api/v1/notifications/ack rejects missing notificationId", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/ack", {
+      headers: authHeader,
+      data: {},
+    });
+    expect(res.status()).toBe(400);
   });
 
-  test("POST /api/v1/focus ignores invalid permission values", async ({ request }) => {
-    const res = await request.post("/api/v1/focus", {
+  test("POST /api/v1/notifications/ack rejects non-string notificationId", async ({ request }) => {
+    const res = await request.post("/api/v1/notifications/ack", {
       headers: authHeader,
-      data: { agentId: null, webNotifyPermission: "invalid" },
+      data: { notificationId: 123 },
     });
-    // Should still succeed — invalid values are silently ignored
-    expect(res.status()).toBe(204);
+    expect(res.status()).toBe(400);
   });
 });

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from "@playwright/test";
 import http from "http";
-import { createAgentViaAPI, setAgentLatestEventViaAPI, loadApp } from "./helpers";
+import {
+  createAgentViaAPI,
+  setAgentLatestEventViaAPI,
+  loadApp,
+} from "./helpers";
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
 const authHeader = { Authorization: `Bearer ${AUTH_TOKEN}` };
@@ -47,7 +51,7 @@ function openSSEStream(baseURL: string): {
           }
         });
         res.on("error", reject);
-      },
+      }
     );
     req.on("error", reject);
   });
@@ -60,7 +64,7 @@ async function waitForEvents(
   events: SSEEvent[],
   predicate: (e: SSEEvent) => boolean,
   count: number,
-  timeoutMs = 5000,
+  timeoutMs = 5000
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -69,7 +73,7 @@ async function waitForEvents(
   }
   const matched = events.filter(predicate).length;
   throw new Error(
-    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms).`,
+    `Timed out waiting for ${count} matching events (got ${matched} in ${timeoutMs}ms).`
   );
 }
 
@@ -281,7 +285,7 @@ test.describe("Web notification SSE delivery and ack flow", () => {
         sse.events,
         (e) => e.type === "notification",
         1,
-        5000,
+        5000
       );
 
       const notification = sse.events.find((e) => e.type === "notification");
@@ -326,7 +330,7 @@ test.describe("Web notification SSE delivery and ack flow", () => {
         sse.events,
         (e) => e.type === "notification",
         1,
-        5000,
+        5000
       );
 
       const notification = sse.events.find((e) => e.type === "notification");
@@ -342,12 +346,17 @@ test.describe("Web notification SSE delivery and ack flow", () => {
       sse.close();
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });
 
-  test("no notification SSE event for unconfigured event types", async ({ request }) => {
+  test("no notification SSE event for unconfigured event types", async ({
+    request,
+  }) => {
     // Enable web notifications for "done" only
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -375,12 +384,17 @@ test.describe("Web notification SSE delivery and ack flow", () => {
       sse.close();
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });
 
-  test("no notification SSE event when web notifications are disabled", async ({ request }) => {
+  test("no notification SSE event when web notifications are disabled", async ({
+    request,
+  }) => {
     // Ensure web notifications are disabled
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -406,7 +420,9 @@ test.describe("Web notification SSE delivery and ack flow", () => {
     }
   });
 
-  test("focused agent does not trigger notification SSE event", async ({ request }) => {
+  test("focused agent does not trigger notification SSE event", async ({
+    request,
+  }) => {
     // Enable web notifications
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -444,14 +460,20 @@ test.describe("Web notification SSE delivery and ack flow", () => {
       });
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });
 });
 
 test.describe("Browser notification ack flow (mocked Notification API)", () => {
-  test("client acks when Notification permission is granted", async ({ page, request }) => {
+  test("client acks when Notification permission is granted", async ({
+    page,
+    request,
+  }) => {
     // Enable web notifications
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -459,27 +481,39 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
     });
 
     // Mock the Notification API with permission "granted"
-    const notifications: Array<{ title: string; body: string; tag: string }> = [];
+    const notifications: Array<{ title: string; body: string; tag: string }> =
+      [];
     await page.addInitScript(() => {
-      (window as unknown as Record<string, unknown>).Notification = class MockNotification {
-        static permission = "granted";
-        static requestPermission = async () => "granted" as NotificationPermission;
-        constructor(title: string, options?: { body?: string; tag?: string; icon?: string }) {
-          (window as unknown as Record<string, unknown[]>).__mockNotifications ??= [];
-          (window as unknown as Record<string, unknown[]>).__mockNotifications.push({
-            title,
-            body: options?.body ?? "",
-            tag: options?.tag ?? "",
-          });
-        }
-      };
+      (window as unknown as Record<string, unknown>).Notification =
+        class MockNotification {
+          static permission = "granted";
+          static requestPermission = async () =>
+            "granted" as NotificationPermission;
+          constructor(
+            title: string,
+            options?: { body?: string; tag?: string; icon?: string }
+          ) {
+            (
+              window as unknown as Record<string, unknown[]>
+            ).__mockNotifications ??= [];
+            (
+              window as unknown as Record<string, unknown[]>
+            ).__mockNotifications.push({
+              title,
+              body: options?.body ?? "",
+              tag: options?.tag ?? "",
+            });
+          }
+        };
       (window as unknown as Record<string, unknown[]>).__mockNotifications = [];
     });
 
     // Intercept ack requests
     const ackRequests: Array<{ notificationId: string }> = [];
     await page.route("**/api/v1/notifications/ack", async (route) => {
-      const postData = route.request().postDataJSON() as { notificationId: string };
+      const postData = route.request().postDataJSON() as {
+        notificationId: string;
+      };
       ackRequests.push(postData);
       await route.continue();
     });
@@ -499,7 +533,8 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
 
       // Verify a Notification was created in the browser
       const mockNotifications = await page.evaluate(
-        () => (window as unknown as Record<string, unknown[]>).__mockNotifications
+        () =>
+          (window as unknown as Record<string, unknown[]>).__mockNotifications
       );
       expect(mockNotifications.length).toBeGreaterThanOrEqual(1);
       const notif = mockNotifications[0] as { title: string; body: string };
@@ -512,12 +547,18 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
     } finally {
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });
 
-  test("client does not ack when Notification permission is denied", async ({ page, request }) => {
+  test("client does not ack when Notification permission is denied", async ({
+    page,
+    request,
+  }) => {
     // Enable web notifications
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -526,20 +567,24 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
 
     // Mock the Notification API with permission "denied"
     await page.addInitScript(() => {
-      (window as unknown as Record<string, unknown>).Notification = class MockNotification {
-        static permission = "denied";
-        static requestPermission = async () => "denied" as NotificationPermission;
-        constructor() {
-          // Should never be called when permission is denied
-          throw new Error("Notification created with denied permission");
-        }
-      };
+      (window as unknown as Record<string, unknown>).Notification =
+        class MockNotification {
+          static permission = "denied";
+          static requestPermission = async () =>
+            "denied" as NotificationPermission;
+          constructor() {
+            // Should never be called when permission is denied
+            throw new Error("Notification created with denied permission");
+          }
+        };
     });
 
     // Intercept ack requests
     const ackRequests: Array<{ notificationId: string }> = [];
     await page.route("**/api/v1/notifications/ack", async (route) => {
-      const postData = route.request().postDataJSON() as { notificationId: string };
+      const postData = route.request().postDataJSON() as {
+        notificationId: string;
+      };
       ackRequests.push(postData);
       await route.continue();
     });
@@ -562,12 +607,18 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
     } finally {
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });
 
-  test("client does not ack when Notification API is unavailable", async ({ page, request }) => {
+  test("client does not ack when Notification API is unavailable", async ({
+    page,
+    request,
+  }) => {
     // Enable web notifications
     await request.post("/api/v1/notifications/settings", {
       headers: authHeader,
@@ -582,7 +633,9 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
     // Intercept ack requests
     const ackRequests: Array<{ notificationId: string }> = [];
     await page.route("**/api/v1/notifications/ack", async (route) => {
-      const postData = route.request().postDataJSON() as { notificationId: string };
+      const postData = route.request().postDataJSON() as {
+        notificationId: string;
+      };
       ackRequests.push(postData);
       await route.continue();
     });
@@ -603,7 +656,10 @@ test.describe("Browser notification ack flow (mocked Notification API)", () => {
     } finally {
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
-        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+        data: {
+          webNotifyEnabled: false,
+          webNotifyEvents: ["done", "waiting_user", "blocked"],
+        },
       });
     }
   });

--- a/e2e/web-notifications.spec.ts
+++ b/e2e/web-notifications.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import http from "http";
-import { createAgentViaAPI, setAgentLatestEventViaAPI } from "./helpers";
+import { createAgentViaAPI, setAgentLatestEventViaAPI, loadApp } from "./helpers";
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
 const authHeader = { Authorization: `Bearer ${AUTH_TOKEN}` };
@@ -404,6 +404,165 @@ test.describe("Web notification SSE delivery and ack flow", () => {
         headers: authHeader,
         data: { agentId: null },
       });
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+});
+
+test.describe("Browser notification ack flow (mocked Notification API)", () => {
+  test("client acks when Notification permission is granted", async ({ page, request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    // Mock the Notification API with permission "granted"
+    const notifications: Array<{ title: string; body: string; tag: string }> = [];
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).Notification = class MockNotification {
+        static permission = "granted";
+        static requestPermission = async () => "granted" as NotificationPermission;
+        constructor(title: string, options?: { body?: string; tag?: string; icon?: string }) {
+          (window as unknown as Record<string, unknown[]>).__mockNotifications ??= [];
+          (window as unknown as Record<string, unknown[]>).__mockNotifications.push({
+            title,
+            body: options?.body ?? "",
+            tag: options?.tag ?? "",
+          });
+        }
+      };
+      (window as unknown as Record<string, unknown[]>).__mockNotifications = [];
+    });
+
+    // Intercept ack requests
+    const ackRequests: Array<{ notificationId: string }> = [];
+    await page.route("**/api/v1/notifications/ack", async (route) => {
+      const postData = route.request().postDataJSON() as { notificationId: string };
+      ackRequests.push(postData);
+      await route.continue();
+    });
+
+    try {
+      await loadApp(page);
+
+      // Create an agent and trigger a "done" event
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Permission granted test",
+      });
+
+      // Wait for the client to receive the SSE event and send an ack
+      await page.waitForTimeout(3000);
+
+      // Verify a Notification was created in the browser
+      const mockNotifications = await page.evaluate(
+        () => (window as unknown as Record<string, unknown[]>).__mockNotifications
+      );
+      expect(mockNotifications.length).toBeGreaterThanOrEqual(1);
+      const notif = mockNotifications[0] as { title: string; body: string };
+      expect(notif.body).toBe("Permission granted test");
+
+      // Verify the ack was sent back to the server
+      expect(ackRequests.length).toBeGreaterThanOrEqual(1);
+      expect(ackRequests[0].notificationId).toBeDefined();
+      expect(typeof ackRequests[0].notificationId).toBe("string");
+    } finally {
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+
+  test("client does not ack when Notification permission is denied", async ({ page, request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    // Mock the Notification API with permission "denied"
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).Notification = class MockNotification {
+        static permission = "denied";
+        static requestPermission = async () => "denied" as NotificationPermission;
+        constructor() {
+          // Should never be called when permission is denied
+          throw new Error("Notification created with denied permission");
+        }
+      };
+    });
+
+    // Intercept ack requests
+    const ackRequests: Array<{ notificationId: string }> = [];
+    await page.route("**/api/v1/notifications/ack", async (route) => {
+      const postData = route.request().postDataJSON() as { notificationId: string };
+      ackRequests.push(postData);
+      await route.continue();
+    });
+
+    try {
+      await loadApp(page);
+
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "Permission denied test",
+      });
+
+      // Wait long enough for an ack to arrive if one were sent
+      await page.waitForTimeout(3000);
+
+      // No ack should have been sent — permission denied means
+      // showWebNotification returns false
+      expect(ackRequests).toHaveLength(0);
+    } finally {
+      await request.post("/api/v1/notifications/settings", {
+        headers: authHeader,
+        data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },
+      });
+    }
+  });
+
+  test("client does not ack when Notification API is unavailable", async ({ page, request }) => {
+    // Enable web notifications
+    await request.post("/api/v1/notifications/settings", {
+      headers: authHeader,
+      data: { webNotifyEnabled: true, webNotifyEvents: ["done"] },
+    });
+
+    // Remove the Notification API entirely (simulates iOS Safari without PWA)
+    await page.addInitScript(() => {
+      delete (window as unknown as Record<string, unknown>).Notification;
+    });
+
+    // Intercept ack requests
+    const ackRequests: Array<{ notificationId: string }> = [];
+    await page.route("**/api/v1/notifications/ack", async (route) => {
+      const postData = route.request().postDataJSON() as { notificationId: string };
+      ackRequests.push(postData);
+      await route.continue();
+    });
+
+    try {
+      await loadApp(page);
+
+      const agent = await createAgentViaAPI(request);
+      await setAgentLatestEventViaAPI(request, agent.id, {
+        type: "done",
+        message: "No API test",
+      });
+
+      await page.waitForTimeout(3000);
+
+      // No ack — Notification API doesn't exist
+      expect(ackRequests).toHaveLength(0);
+    } finally {
       await request.post("/api/v1/notifications/settings", {
         headers: authHeader,
         data: { webNotifyEnabled: false, webNotifyEvents: ["done", "waiting_user", "blocked"] },


### PR DESCRIPTION
## Summary
- Replace predictive permission-tracking for web notifications with a reactive ack-based system
- Server broadcasts notification via SSE with a unique ID, waits 3s for any client to ack, falls back to Slack if no ack arrives
- Removes `webNotifyPermission` tracking from FocusTracker and focus heartbeats — delivery confirmation is now the source of truth

## Problem
The previous approach tracked browser notification permission via focus heartbeats and predicted whether to send web or Slack notifications. This had several issues:
- **Permission state collision**: multiple clients' heartbeats overwrote each other — last writer wins
- **Aggressive Slack suppression**: if any one client reported `granted`, Slack was suppressed for all clients, even those that couldn't show the notification
- **Duplicate notifications**: all connected SSE clients received and showed the notification

## How it works now
1. Agent emits a terminal event (done/blocked/waiting_user)
2. Focus check: if user is focused on the agent → suppress everything (unchanged)
3. If web notifications enabled + SSE client connected → broadcast notification with unique ID, start 3s timer
4. Client receives SSE event, attempts `new Notification()`, POSTs ack if permission was granted
5. If any client acks → Slack suppressed. If no ack within 3s → Slack fires as fallback

## Test plan
- [x] Type checks pass (`pnpm run check`)
- [x] Web finalization passes (`pnpm run finalize:web`)
- [x] All 122 E2E tests pass
- [x] New ack endpoint tests added (valid ID, missing ID, non-string ID)
- [x] Existing web notification tests updated (removed permission heartbeat dependency)