### PR TITLE
Make worktree badge clickable to copy path

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -438,21 +438,34 @@ export function AgentCard({
                               onClick={() =>
                                 agent.cwd && copyWorktreePath(agent.cwd)
                               }
-                              className="group h-auto gap-1 rounded-full border border-border bg-muted/35 px-2 py-0.5 text-[10px] font-normal text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                              aria-label={
+                                worktreePathCopied
+                                  ? "Worktree path copied"
+                                  : `Copy worktree path: ${agent.cwd}`
+                              }
+                              className="group relative h-auto gap-1 rounded-full border border-border bg-muted/35 px-2 py-0.5 text-[10px] font-normal text-muted-foreground before:absolute before:inset-x-0 before:-inset-y-1.5 before:content-[''] hover:bg-muted/60 hover:text-foreground"
                             >
                               {worktreePathCopied ? (
                                 <Check className="h-3 w-3 text-status-done" />
                               ) : (
                                 <>
-                                  <FolderTree className="h-3 w-3 group-hover:hidden" />
-                                  <Copy className="hidden h-3 w-3 group-hover:block" />
+                                  <FolderTree className="h-3 w-3 group-hover:hidden group-focus-visible:hidden" />
+                                  <Copy className="hidden h-3 w-3 group-hover:block group-focus-visible:block" />
                                 </>
                               )}
                               <span>Worktree</span>
+                              <span className="sr-only" aria-live="polite">
+                                {worktreePathCopied
+                                  ? "Worktree path copied"
+                                  : ""}
+                              </span>
                             </Button>
                           </TooltipTrigger>
                           <TooltipContent className="max-w-[420px] break-all">
                             {agent.cwd}
+                            <div className="mt-1 text-[10px] opacity-70">
+                              Click to copy
+                            </div>
                           </TooltipContent>
                         </Tooltip>
                       ) : (

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import {
   AlertTriangle,
   Archive,
+  Check,
   ChevronDown,
   AlarmClock,
+  Copy,
   Folder,
   FolderGit2,
+  FolderTree,
   GitBranch,
   Loader2,
   Play,
@@ -33,6 +36,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AnimatePresence, motion } from "framer-motion";
+import { useCopyText } from "@/hooks/use-copy";
 import { type AgentType } from "@/lib/agent-types";
 import { cn } from "@/lib/utils";
 
@@ -137,6 +141,7 @@ export function AgentCard({
   const isStopped = state === "stopped";
   const isExpanded = expandedAgentId === agent.id;
   const fullAccessEnabled = isFullAccessEnabled(agent);
+  const [worktreePathCopied, copyWorktreePath] = useCopyText();
   const needsAttention = agent.status === "error";
   const isJobAgent = agent.name.startsWith("job-");
   const sidebarBaseBranch = agent.baseBranch ?? "main";
@@ -424,12 +429,27 @@ export function AgentCard({
                       </>
                     )}
                     <div className="flex items-center justify-between gap-2 pt-1">
-                      {agent.gitContext?.isWorktree ? (
+                      {agent.gitContext?.isWorktree && agent.cwd ? (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <div className="inline-flex items-center rounded-full border border-border bg-muted/35 px-2 py-0.5 text-[10px] text-muted-foreground">
-                              Worktree
-                            </div>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                agent.cwd && copyWorktreePath(agent.cwd)
+                              }
+                              className="group h-auto gap-1 rounded-full border border-border bg-muted/35 px-2 py-0.5 text-[10px] font-normal text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                            >
+                              {worktreePathCopied ? (
+                                <Check className="h-3 w-3 text-status-done" />
+                              ) : (
+                                <>
+                                  <FolderTree className="h-3 w-3 group-hover:hidden" />
+                                  <Copy className="hidden h-3 w-3 group-hover:block" />
+                                </>
+                              )}
+                              <span>Worktree</span>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent className="max-w-[420px] break-all">
                             {agent.cwd}


### PR DESCRIPTION
## Summary

- Worktree badge in the agent card sidebar is now a clickable button that copies the worktree path (`agent.cwd`) to the clipboard.
- Added a `FolderTree` icon so the badge matches the height of the neighboring "Full access" / "Sandboxed" badge.
- Icon changes to `Copy` on hover (CSS-only via `group-hover`) to hint at the interaction.
- After a successful copy, the icon briefly (2s) becomes a green `Check` (`text-status-done`); label stays "Worktree" so the button doesn't resize.
- Uses the shared `useCopyText` hook and the shadcn `<Button>` component (variant="ghost", size="sm") with badge-style className overrides.
- Tooltip continues to show the full `cwd` path on hover.

## Test plan

- [x] `pnpm run check` (type check)
- [x] `pnpm run finalize:web` (type check + production build)
- [x] `pnpm run test:e2e` — 130 passed
- [x] Manually verified in an isolated dev stack: hover swaps `FolderTree → Copy`; click copies path and shows green `Check` for ~2s; tooltip still shows cwd; badge heights match `Full access`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)