### PR TITLE
Simplify single-agent action buttons

### DIFF
--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -78,6 +78,7 @@ export function AgentListContent({
     lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
       ? lastUsedAgentType
       : (enabledAgentTypes[0] ?? "codex");
+  const showCreateTypePicker = enabledAgentTypes.length > 1;
 
   return (
     <div data-testid="agent-sidebar" className="flex h-full min-h-0 flex-col">
@@ -89,7 +90,11 @@ export function AgentListContent({
           <Button
             size="sm"
             variant="default"
-            className="rounded-r-none border-r-0 text-muted-foreground hover:text-foreground"
+            className={
+              showCreateTypePicker
+                ? "rounded-r-none border-r-0 text-muted-foreground hover:text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }
             onClick={() => onOpenCreateDialog(defaultCreateType)}
             data-testid="create-agent-button"
           >
@@ -99,31 +104,33 @@ export function AgentListContent({
             />
             Create
           </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="sm"
-                variant="default"
-                className="rounded-l-none border-l border-white/[0.12] px-1 text-muted-foreground hover:text-foreground"
-                data-testid="create-agent-type-dropdown"
-              >
-                <ChevronDown className="h-3.5 w-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {enabledAgentTypes.map((agentType) => (
-                <DropdownMenuItem
-                  key={agentType}
-                  className="text-foreground"
-                  onClick={() => onOpenCreateDialog(agentType)}
-                  data-testid={`create-agent-type-${agentType}`}
+          {showCreateTypePicker ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="rounded-l-none border-l border-white/[0.12] px-1 text-muted-foreground hover:text-foreground"
+                  data-testid="create-agent-type-dropdown"
                 >
-                  <AgentTypeIcon type={agentType} className="mr-2 h-4 w-4" />
-                  {AGENT_TYPE_LABELS[agentType]}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  <ChevronDown className="h-3.5 w-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {enabledAgentTypes.map((agentType) => (
+                  <DropdownMenuItem
+                    key={agentType}
+                    className="text-foreground"
+                    onClick={() => onOpenCreateDialog(agentType)}
+                    data-testid={`create-agent-type-${agentType}`}
+                  >
+                    <AgentTypeIcon type={agentType} className="mr-2 h-4 w-4" />
+                    {AGENT_TYPE_LABELS[agentType]}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
         </div>
       </div>
 

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -43,6 +43,7 @@ export function PersonaLauncher({
     },
   });
   const hasPersonas = personas.length > 0;
+  const showReviewAgentTypePicker = enabledAgentTypes.length > 1;
 
   const reviewAgentType =
     agent.reviewAgentType ??
@@ -80,7 +81,11 @@ export function PersonaLauncher({
           <Button
             variant="ghost"
             disabled={disabled || !hasPersonas}
-            className="gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+            className={
+              showReviewAgentTypePicker
+                ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+                : "gap-1.5 border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+            }
             data-testid="launch-reviewer-button"
           >
             <AgentTypeIcon
@@ -128,37 +133,39 @@ export function PersonaLauncher({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            disabled={disabled || !hasPersonas}
-            className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-            data-testid="launch-reviewer-type-dropdown"
-          >
-            <ChevronDown className="h-3.5 w-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {enabledAgentTypes.map((agentType) => (
-            <DropdownMenuItem
-              key={agentType}
-              className="text-foreground"
-              onClick={() => {
-                void updateReviewAgentType(agentType);
-              }}
-              data-testid={`launch-reviewer-type-${agentType}`}
+      {showReviewAgentTypePicker ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              disabled={disabled || !hasPersonas}
+              className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+              data-testid="launch-reviewer-type-dropdown"
             >
-              <span className="flex items-center gap-3">
-                <Check
-                  className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
-                />
-                <span>{AGENT_TYPE_LABELS[agentType]}</span>
-              </span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {enabledAgentTypes.map((agentType) => (
+              <DropdownMenuItem
+                key={agentType}
+                className="text-foreground"
+                onClick={() => {
+                  void updateReviewAgentType(agentType);
+                }}
+                data-testid={`launch-reviewer-type-${agentType}`}
+              >
+                <span className="flex items-center gap-3">
+                  <Check
+                    className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
+                  />
+                  <span>{AGENT_TYPE_LABELS[agentType]}</span>
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -45,6 +45,10 @@ export function PersonaLauncher({
   const hasPersonas = personas.length > 0;
   const showReviewAgentTypePicker = enabledAgentTypes.length > 1;
 
+  if (!hasPersonas) {
+    return null;
+  }
+
   const reviewAgentType =
     agent.reviewAgentType ??
     (agent.type === "claude" || agent.type === "opencode"
@@ -80,7 +84,7 @@ export function PersonaLauncher({
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            disabled={disabled || !hasPersonas}
+            disabled={disabled}
             className={
               showReviewAgentTypePicker
                 ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
@@ -96,40 +100,36 @@ export function PersonaLauncher({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
-          {hasPersonas ? (
-            personas.map((p, i) => {
-              const colorVar = `var(--chart-${(i % 4) + 1})`;
-              return (
-                <DropdownMenuItem
-                  key={p.slug}
-                  className="text-foreground"
-                  onClick={() => launchPersona(p.slug)}
-                >
-                  <div className="flex items-start gap-2.5">
+          {personas.map((p, i) => {
+            const colorVar = `var(--chart-${(i % 4) + 1})`;
+            return (
+              <DropdownMenuItem
+                key={p.slug}
+                className="text-foreground"
+                onClick={() => launchPersona(p.slug)}
+              >
+                <div className="flex items-start gap-2.5">
+                  <div
+                    className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: `hsl(${colorVar})` }}
+                  />
+                  <div>
                     <div
-                      className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: `hsl(${colorVar})` }}
-                    />
-                    <div>
-                      <div
-                        className="text-sm font-medium"
-                        style={{ color: `hsl(${colorVar})` }}
-                      >
-                        {p.name}
-                      </div>
-                      {p.description ? (
-                        <div className="text-xs text-muted-foreground">
-                          {p.description}
-                        </div>
-                      ) : null}
+                      className="text-sm font-medium"
+                      style={{ color: `hsl(${colorVar})` }}
+                    >
+                      {p.name}
                     </div>
+                    {p.description ? (
+                      <div className="text-xs text-muted-foreground">
+                        {p.description}
+                      </div>
+                    ) : null}
                   </div>
-                </DropdownMenuItem>
-              );
-            })
-          ) : (
-            <DropdownMenuItem disabled>No reviewers available</DropdownMenuItem>
-          )}
+                </div>
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -138,7 +138,7 @@ export function PersonaLauncher({
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
-              disabled={disabled || !hasPersonas}
+              disabled={disabled}
               className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
               data-testid="launch-reviewer-type-dropdown"
             >

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
-import { loadApp, setEnabledAgentTypesViaAPI } from "./helpers";
+import {
+  createAgentViaAPI,
+  loadApp,
+  setEnabledAgentTypesViaAPI,
+} from "./helpers";
 
 test.describe("Settings pane", () => {
   test.afterEach(async ({ request }) => {
@@ -83,5 +87,30 @@ test.describe("Settings pane", () => {
     await expect(
       page.getByRole("option", { name: "Claude" })
     ).not.toBeVisible();
+  });
+
+  test("single enabled agent type removes split buttons", async ({
+    page,
+    request,
+  }) => {
+    await setEnabledAgentTypesViaAPI(request, ["codex"]);
+    const agent = await createAgentViaAPI(request, {
+      type: "codex",
+      cwd: "/tmp",
+    });
+
+    await loadApp(page);
+
+    await expect(page.getByTestId("create-agent-button")).toBeVisible();
+    await expect(page.getByTestId("create-agent-type-dropdown")).toHaveCount(0);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await expect(agentCard).toBeVisible();
+    await agentCard.getByTestId(`agent-expand-toggle-${agent.id}`).click();
+
+    await expect(agentCard.getByTestId("launch-reviewer-button")).toBeVisible();
+    await expect(
+      agentCard.getByTestId("launch-reviewer-type-dropdown")
+    ).toHaveCount(0);
   });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -96,7 +96,7 @@ test.describe("Settings pane", () => {
     await setEnabledAgentTypesViaAPI(request, ["codex"]);
     const agent = await createAgentViaAPI(request, {
       type: "codex",
-      cwd: "/tmp",
+      cwd: process.cwd(),
     });
 
     await loadApp(page);


### PR DESCRIPTION
## Summary
- hide the create-agent split button when only one agent type is enabled
- hide the reviewer agent-type split button when only one agent type is enabled
- add E2E coverage for the single-agent-type UI state

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- Playwright validation against isolated dispatch-dev stack