### PR TITLE
Suppress noisy migration timestamp logs

### DIFF
--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -14,10 +14,15 @@ const migrationsDir = __dirname.includes("/dist/")
 
 // Arbitrary fixed key for pg_advisory_lock to prevent concurrent migrations.
 const MIGRATION_LOCK_ID = 8675309;
+const TIMESTAMP_PARSE_NOISE_RE = /^Can't determine timestamp for \d+$/;
 
 export interface MigrationOptions {
   databaseUrl?: string;
   count?: number;
+}
+
+export function shouldLogMigrationMessage(msg: string): boolean {
+  return !TIMESTAMP_PARSE_NOISE_RE.test(msg);
 }
 
 export async function runMigrations(
@@ -42,7 +47,11 @@ export async function runMigrations(
       direction: "up",
       migrationsTable: "pgmigrations",
       count: opts.count,
-      log: (msg) => console.log(`[migrate] ${msg}`),
+      log: (msg) => {
+        if (shouldLogMigrationMessage(msg)) {
+          console.log(`[migrate] ${msg}`);
+        }
+      },
     });
 
     console.log("Migrations completed.");

--- a/apps/server/test/db/migrate.test.ts
+++ b/apps/server/test/db/migrate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldLogMigrationMessage } from "../../src/db/migrate.js";
+
+describe("migration log filtering", () => {
+  it("suppresses node-pg-migrate timestamp parse noise for numeric prefixes", () => {
+    expect(
+      shouldLogMigrationMessage("Can't determine timestamp for 0001")
+    ).toBe(false);
+  });
+
+  it("keeps real migration messages", () => {
+    expect(shouldLogMigrationMessage("Running migration 0001_baseline")).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- suppress `node-pg-migrate` timestamp-parse noise for sequential numeric migration prefixes
- keep other migration log lines unchanged
- add a focused test for the filter behavior

## Verification
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`