### PR TITLE
docs: sync README + docs with current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ dispatch/
 │   │   │   ├── agents/        # agent manager, lifecycle, token harvesting
 │   │   │   ├── db/            # PostgreSQL migrations and queries
 │   │   │   ├── jobs/          # job scheduler, runner, reporting
-│   │   │   ├── notifications/ # Slack notifier
-│   │   │   ├── personas/      # persona loader
-│   │   │   ├── shared/        # shared utilities (git, github, mcp, run-command)
+│   │   │   ├── notifications/ # Slack + job notifiers
+│   │   │   ├── personas/      # persona loader, review-diff builder
+│   │   │   ├── shared/        # shared utilities — git/, github/, mcp/, lib/ (run-command)
 │   │   │   └── terminal/      # tmux terminal bridge
 │   │   └── test/              # unit tests (vitest)
 │   └── web/                   # Vite React frontend (@dispatch/web)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
-> 5. Copy `.env.example` to `.env`. The defaults work for local-only use. Set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections. Authentication is handled automatically — the server generates a secure token on first run and stores it in the database.
+> 5. Copy `.env.example` to `.env`. The defaults work for local-only use. Set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections. On first visit to the web UI you will be prompted to set a password; sessions are stored as signed HTTP cookies.
 > 6. Register as a system service:
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
 >    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs `node apps/server/dist/main.js` with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.
@@ -42,7 +42,9 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
   - media pane for screenshots, video, and live Playwright browser streaming
   - real-time agent status events via SSE
   - agent pins for surfacing key info (URLs, ports, PRs, files) in the sidebar
-  - iOS Simulator device assignment per agent
+  - iOS Simulator screenshot capture via `dispatch_share` (`source: "simulator"`, `xcrun simctl`)
+  - in-app browser notifications (with Slack fallback if no browser client acks)
+  - in-app docs pane covering features and MCP tools
 
 ## Prerequisites
 
@@ -191,7 +193,8 @@ These tools only work inside running agent sessions (they require agent-scoped M
 - [New Machine Setup](docs/12-new-machine-setup.md) — first-time macOS setup guide
 - [Theming](docs/14-theming.md) — how to add and customize color themes
 - [Personas and Feedback](docs/15-personas-and-feedback.md) — automated code review via persona agents
-- [Notifications](docs/16-notifications.md) — Slack webhook integration
+- [Notifications](docs/16-notifications.md) — in-app and Slack notifications
+- [Jobs](docs/17-jobs.md) — scheduled/on-demand agent tasks with structured reports
 
 ## Issue Tracking
 

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -63,9 +63,13 @@
   "agentArgs": ["--model", "opus"],
   "useWorktree": true,
   "worktreeBranch": "fix-auth-bug",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "autoReview": false,
+  "initialPrompt": "Start by reading CONTRIBUTING.md..."
 }
 ```
+
+`type` defaults to `codex` if omitted. `autoReview` queues a persona review to run automatically when the agent reaches a terminal state. `initialPrompt` is piped into the agent CLI as its first user turn.
 
 For persona agents (launched via `dispatch_launch_persona`):
 
@@ -226,25 +230,35 @@ Query params: `project`, `type`, `sort` (`recent` | `oldest`), `limit`, `offset`
 
 ## Notifications
 
-| Method | Path                      | Description                                   |
-| ------ | ------------------------- | --------------------------------------------- |
-| GET    | `/notifications/settings` | Get Slack webhook URL and enabled event types |
-| POST   | `/notifications/settings` | Update webhook URL and event configuration    |
-| POST   | `/notifications/test`     | Send a test message to the configured webhook |
-| POST   | `/notifications/ack`      | Acknowledge a web notification by ID          |
+| Method | Path                      | Description                                                                         |
+| ------ | ------------------------- | ----------------------------------------------------------------------------------- |
+| GET    | `/notifications/settings` | Get Slack webhook URL, enabled Slack event types, and web notification config       |
+| POST   | `/notifications/settings` | Update any subset of webhook URL, event lists, or web-notify toggle                 |
+| POST   | `/notifications/test`     | Send a test message to the configured (or provided) webhook                         |
+| POST   | `/notifications/ack`      | Acknowledge a web notification by ID (suppresses the Slack fallback for that event) |
 
 ### `POST /notifications/settings`
 
+All fields are optional — the request updates only the fields it contains.
+
 ```json
 {
-  "slackWebhookUrl": "https://hooks.slack.com/services/...",
-  "events": {
-    "done": true,
-    "waiting_user": true,
-    "blocked": false
-  }
+  "webhookUrl": "https://hooks.slack.com/services/T.../B.../xxx",
+  "notifyEvents": ["done", "waiting_user"],
+  "webNotifyEnabled": true,
+  "webNotifyEvents": ["done", "waiting_user", "blocked"]
 }
 ```
+
+`notifyEvents` and `webNotifyEvents` are arrays of event-type strings (`done`, `waiting_user`, `blocked`). When a notable agent event fires, Dispatch first attempts an in-app notification via the SSE event stream; if no browser client acks within ~3s it falls back to the Slack webhook (provided the event is enabled there).
+
+### `POST /notifications/ack`
+
+```json
+{ "notificationId": "<id from the SSE event>" }
+```
+
+Returns `204` regardless of whether the notification was still pending.
 
 ## Settings
 

--- a/docs/16-notifications.md
+++ b/docs/16-notifications.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-Dispatch sends Slack notifications when agents need attention, so you don't have to watch the dashboard. Notifications are event-driven and focus-aware — you only get notified about agents you're not actively viewing.
+Dispatch can notify you when an agent reaches a notable state (`done`, `waiting_user`, `blocked`) via two channels:
+
+- **In-app browser notifications** — broadcast over the SSE stream (`GET /api/v1/events`) and surfaced by the connected web client as a native browser notification.
+- **Slack webhooks** — fallback when no browser client acknowledges within ~3 seconds, or whenever web notifications are disabled.
+
+Notifications are focus-aware — the agent you are actively viewing is suppressed.
 
 ## Slack Setup
 
@@ -11,15 +16,23 @@ Dispatch sends Slack notifications when agents need attention, so you don't have
 3. Paste the webhook URL.
 4. Use **Send test** to verify the integration.
 
+The URL must start with `https://hooks.slack.com/`; other URLs are rejected to prevent SSRF.
+
+## Web Notifications
+
+Web notifications are broadcast over the SSE event stream whenever at least one browser client is connected. The client acknowledges delivery via `POST /api/v1/notifications/ack` with the `notificationId` from the event; a successful ack suppresses the Slack fallback. If no ack arrives within 3 seconds, Dispatch falls back to Slack (assuming Slack is configured and the event type is enabled there).
+
+Web notifications have their own enable toggle and event list, independent of Slack.
+
 ## Configurable Events
 
-You can enable or disable notifications for each event type:
+Each channel has its own list of event types to notify on. Defaults:
 
-| Event          | Default  | Description                          |
-| -------------- | -------- | ------------------------------------ |
-| `done`         | Enabled  | Agent finished its task              |
-| `waiting_user` | Enabled  | Agent needs your input or a decision |
-| `blocked`      | Disabled | Agent hit an error it can't resolve  |
+| Event          | Slack default | Description                          |
+| -------------- | ------------- | ------------------------------------ |
+| `done`         | Enabled       | Agent finished its task              |
+| `waiting_user` | Enabled       | Agent needs your input or a decision |
+| `blocked`      | Disabled      | Agent hit an error it can't resolve  |
 
 ## Focus-Aware Suppression
 
@@ -37,21 +50,30 @@ Slack messages include:
 
 ## API Endpoints
 
-| Method | Path                             | Description                             |
-| ------ | -------------------------------- | --------------------------------------- |
-| GET    | `/api/v1/notifications/settings` | Get webhook URL and enabled events      |
-| POST   | `/api/v1/notifications/settings` | Update webhook URL and event config     |
-| POST   | `/api/v1/notifications/test`     | Send test message to configured webhook |
+| Method | Path                             | Description                                                        |
+| ------ | -------------------------------- | ------------------------------------------------------------------ |
+| GET    | `/api/v1/notifications/settings` | Get webhook URL, Slack event list, and web notification config     |
+| POST   | `/api/v1/notifications/settings` | Update any subset of webhook URL, event lists, or web notify state |
+| POST   | `/api/v1/notifications/test`     | Send test message to the configured (or provided) webhook          |
+| POST   | `/api/v1/notifications/ack`      | Acknowledge an in-app notification by `notificationId`             |
 
 ### `POST /api/v1/notifications/settings`
 
+All fields optional — only provided fields are updated.
+
 ```json
 {
-  "slackWebhookUrl": "https://hooks.slack.com/services/T.../B.../xxx",
-  "events": {
-    "done": true,
-    "waiting_user": true,
-    "blocked": false
-  }
+  "webhookUrl": "https://hooks.slack.com/services/T.../B.../xxx",
+  "notifyEvents": ["done", "waiting_user"],
+  "webNotifyEnabled": true,
+  "webNotifyEvents": ["done", "waiting_user", "blocked"]
 }
 ```
+
+### `POST /api/v1/notifications/ack`
+
+```json
+{ "notificationId": "<id from the SSE event>" }
+```
+
+Returns `204` whether or not the notification was still pending.

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -1,0 +1,99 @@
+# Jobs
+
+## Overview
+
+A **job** is a named, repo-scoped agent task that can run on a schedule or on demand. Each invocation is a **run**, which spawns a fresh agent with the job's prompt, posts structured progress via MCP, and returns a terminal `JobReport`.
+
+Jobs are the right mechanism for recurring work (nightly PR triage, release babysitting, janitorial cleanup) and for one-shot tasks where you want a machine-readable outcome instead of a free-form chat transcript.
+
+## Data Model
+
+Jobs are uniquely identified by (`directory`, `name`). Each job has:
+
+| Field                 | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `name`                | Display/slug name, unique within its `directory`                                     |
+| `directory`           | Absolute path of the repo the job runs against                                       |
+| `prompt`              | User-supplied prompt used as the agent's first turn                                  |
+| `schedule`            | Cron expression (optional). Jobs without a schedule can still be triggered manually. |
+| `agentType`           | One of `claude`, `codex`, `opencode`                                                 |
+| `useWorktree`         | If true, the run gets its own git worktree (default)                                 |
+| `branchName`          | Branch for the worktree (optional)                                                   |
+| `fullAccess`          | Pass the agent CLI's full-access/bypass-approvals flag                               |
+| `timeoutMs`           | Max wall-clock for a run (default 30 min)                                            |
+| `needsInputTimeoutMs` | Max time a run may sit in `needs_input` (default 24 h)                               |
+| `enabled`             | If false, the cron schedule is skipped but manual runs still work                    |
+
+## Run Lifecycle
+
+States: `started` → `running` → (`completed` | `failed` | `needs_input` | `timed_out` | `crashed`).
+
+- The runner creates an agent named `job-<slug>-<runId[:8]>` and waits for a terminal MCP call from it (`job_complete` or `job_failed`).
+- A run that calls `job_needs_input` transitions to `needs_input` and pauses. Answering it (via the UI or deleting the run) resumes or ends it; an unanswered `needs_input` times out per `needsInputTimeoutMs`.
+- Only one run per job can be active at a time. The DB enforces this via a unique index on (jobId, active status).
+
+## Report Shape
+
+The MCP tools `job_complete` / `job_failed` require a report:
+
+```json
+{
+  "status": "completed",
+  "summary": "Processed 3 pull requests.",
+  "tasks": [
+    {
+      "name": "triage-pr-123",
+      "status": "success",
+      "summary": "Re-ran CI, posted comment"
+    },
+    {
+      "name": "triage-pr-124",
+      "status": "error",
+      "summary": "Rebase failed",
+      "errors": [
+        { "message": "Merge conflict in server.ts", "recoverable": false }
+      ]
+    }
+  ]
+}
+```
+
+`job_log` appends a structured log line (level: `debug|info|warn|error`) onto the named task, creating it if needed. Use it for progress updates between terminal calls.
+
+Report size limits: 1 MB total, 100 tasks, 500 logs per task, 10 KB summary and error-message strings, 5 KB log-message strings.
+
+## Notifications
+
+Jobs emit their own Slack messages (distinct from the per-agent notifications in [docs/16-notifications.md](16-notifications.md)) on the following events, each with an independent webhook URL list:
+
+- `onComplete` — run finished with `status: completed`
+- `onError` — run ended as `failed`, `timed_out`, or `crashed`
+- `onNeedsInput` — run is waiting on human input
+
+The job agent's `latest-event` notifications are suppressed so you do not double-notify on completion.
+
+## API
+
+See [docs/03-api-spec.md](03-api-spec.md#jobs) for the full endpoint reference. The relevant endpoints are:
+
+- `GET /api/v1/jobs` / `POST|PATCH|DELETE /api/v1/jobs`
+- `POST /api/v1/jobs/enable` / `POST /api/v1/jobs/disable`
+- `POST /api/v1/jobs/run` — trigger manually (`{ name, directory, wait? }`)
+- `GET /api/v1/jobs/stats` / `GET /api/v1/jobs/history`
+
+## MCP Tools (job-scope only)
+
+Job agents are given a narrowed MCP toolset (see `JOB_TOOLS` in `apps/server/src/shared/mcp/server.ts`). The job-lifecycle tools are:
+
+| Tool              | Purpose                                     |
+| ----------------- | ------------------------------------------- |
+| `job_complete`    | Terminal success. Submits the final report. |
+| `job_failed`      | Terminal failure. Submits the final report. |
+| `job_needs_input` | Pause the run and ask a human a question.   |
+| `job_log`         | Append a progress log to a named task.      |
+
+Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_notify`.
+
+## UI
+
+The jobs pane (`/jobs`) lists every configured job with its latest run status. Drill-down views show run history, per-run reports, and the MCP log stream. A run blocked on `needs_input` exposes an answer box that resumes the agent.


### PR DESCRIPTION
## Summary

Documentation audit: compared every concrete claim in `README.md`, `CLAUDE.md`, and `docs/*.md` against the actual codebase and fixed inaccuracies. Also added a dedicated Jobs reference.

## Changes by file

### `README.md`
- Features list: removed the inaccurate *"iOS Simulator device assignment per agent"* bullet — Dispatch has no per-agent simulator UI; it captures from the booted simulator via `dispatch_share` (`source: "simulator"`). Rewrote as *"iOS Simulator screenshot capture via `dispatch_share`"*.
- Features list: added in-app browser notifications (with Slack fallback) and the docs pane, both of which previously weren't mentioned.
- Quick Install step 5: fixed the auth description. Authentication is **not** automatic — the web UI prompts for a password on first visit; the auto-generated value is the agent-to-server MCP auth token, not the user login.
- Docs index: added `docs/17-jobs.md`.

### `docs/03-api-spec.md`
- `POST /notifications/settings`: replaced the wrong body shape (`slackWebhookUrl`, `events: { done: true, ... }`) with the real one (`webhookUrl`, `notifyEvents` array, plus `webNotifyEnabled` / `webNotifyEvents`). Clarified the in-app → Slack fallback flow.
- `POST /agents`: added the `autoReview` and `initialPrompt` fields that the route accepts (and a short description of each).

### `docs/16-notifications.md`
- Added a section describing in-app browser notifications, the SSE broadcast, and the `/notifications/ack` suppression mechanism.
- Fixed the `POST /notifications/settings` body example to match the actual handler.
- Documented the `POST /notifications/ack` endpoint.

### `CLAUDE.md`
- Project-structure tree: corrected the `notifications/`, `personas/`, and `shared/` lines to reflect actual file layout (`notifications/` has `slack.ts` + `job-notifier.ts`; `personas/` has `loader.ts` + `review-diff.ts`; `shared/` has `git/`, `github/`, `lib/`, `mcp/` subdirs).

### `docs/17-jobs.md` (new)
Concise reference for the Jobs feature: data model, run lifecycle, report shape and size limits, job-level notifications, API summary, and the job-scoped MCP tool set.

## Test plan

- [x] `pnpm run format` passes
- [x] All `docs/*.md` links in README resolve to files in the tree
- [x] Every file path / function name / MCP tool name mentioned in updated docs verified against the codebase
- [ ] Reviewer sanity-check: confirm no behavioural change is needed to match the updated docs (these updates follow the code, not the other way around)

🤖 Generated with [Claude Code](https://claude.com/claude-code)