### PR TITLE
docs: steer agents to repo dev MCP tools

### DIFF
--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -11,7 +11,7 @@ Your job is to test the described feature from an end-user perspective using Pla
 ## Approach
 
 1. Read the context to understand what was built and what flows to test.
-2. Use `get_parent_context` to find the parent agent's pinned validation URLs and shared media. Reuse the existing validation stack instead of starting one yourself.
+2. Use `get_parent_context` to find the parent agent's pinned validation URLs and shared media. Reuse the existing validation stack when a usable URL is available. If the parent context does not include a workable validation target, stop and report that gap in your review status instead of trying to manage infra yourself.
 3. Use Playwright to navigate the app and interact with the new feature.
 4. Take screenshots at key points using `dispatch_share` to document what you see.
 5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.

--- a/.dispatch/personas/e2e-tester.md
+++ b/.dispatch/personas/e2e-tester.md
@@ -11,7 +11,7 @@ Your job is to test the described feature from an end-user perspective using Pla
 ## Approach
 
 1. Read the context to understand what was built and what flows to test.
-2. Start the dev environment using `dispatch-dev up` (or use an existing one).
+2. Use `get_parent_context` to find the parent agent's pinned validation URLs and shared media. Reuse the existing validation stack instead of starting one yourself.
 3. Use Playwright to navigate the app and interact with the new feature.
 4. Take screenshots at key points using `dispatch_share` to document what you see.
 5. For each issue found, call `dispatch_feedback` with a description and reference any screenshots via `mediaRef`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,30 +63,18 @@ Before marking any task as done, run the following checks and fix any failures:
 
 - **NEVER run `pnpm run dev` directly** in your terminal — it will block your session and killing it can kill your agent process.
 - **NEVER use `pkill`, `killall`, or `lsof | xargs kill`** to manage dev servers — these can kill your own agent process.
-- Use `dispatch-dev` to manage dev environments. It spins up an isolated DB, API server, and Vite frontend, all on auto-selected free ports.
-- When `DISPATCH_AGENT_ID` is set (normal agent sessions), the suffix is derived automatically. Otherwise pass `--suffix <name>` or let the script generate one.
+- Use the repo MCP tools to manage dev environments: `repo_dev_up`, `repo_dev_restart`, `repo_dev_down`, `repo_dev_status`, and `repo_dev_logs`. They spin up an isolated DB, API server, and Vite frontend on auto-selected free ports.
 - If you start a validation stack for user review, do not tear it down automatically at the end of the turn unless the user explicitly asks.
-  ```bash
-  dispatch-dev up                             # start isolated DB + API server + Vite
-  dispatch-dev up --cwd /path/to/dir          # start from a specific directory
-  dispatch-dev up --no-db                     # skip DB (use existing DATABASE_URL)
-  dispatch-dev down                           # tear down everything
-  dispatch-dev restart                        # restart the environment
-  dispatch-dev status                         # check what's running
-  dispatch-dev logs                           # API server logs
-  dispatch-dev logs --vite                    # Vite server logs
-  dispatch-dev url                            # print the API server URL
-  ```
-- `dispatch-dev up` auto-selects free ports and prints the URLs — just use the printed URLs.
+- `repo_dev_up` auto-selects free ports and prints the URLs — just use the printed URLs.
 
 ## Backend Testing Safety
 
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
-- When backend changes need local validation, use `dispatch-dev up` and point validation tooling to the printed URL.
+- When backend changes need local validation, use `repo_dev_up` and point validation tooling to the printed URL.
 - Only operate on production (`:6767`) when explicitly requested by the user.
 
 ## Development Database
 
 - Production uses the `dispatch` database. Never connect to it from dev servers.
-- `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
+- `repo_dev_up` creates an isolated Postgres container with its own port — no manual `DATABASE_URL` setup needed.
 - Migrations run automatically on API server start.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Before marking any task as done, run the following checks and fix any failures:
 ## Web Finalization
 
 - If any files under `apps/web/` changed, run `pnpm run finalize:web` before marking the task complete.
-- After running `pnpm run finalize:web`, verify the served app via `dispatch-dev` when the task affects UI/theme/rendering behavior.
+- After running `pnpm run finalize:web`, verify the served app via the repo MCP dev tools when the task affects UI/theme/rendering behavior.
 - After UI/theme/rendering validation on an isolated dev stack, leave that stack running for the user to inspect unless they explicitly ask you to tear it down.
 - In the final response, include the exact local URLs/ports for the running validation stack and the cleanup command(s) needed to stop it later.
 
@@ -96,30 +96,21 @@ Before marking any task as done, run the following checks and fix any failures:
 
 - **NEVER run `pnpm run dev` directly** in your terminal — it will block your session and killing it can kill your agent process.
 - **NEVER use `pkill`, `killall`, or `lsof | xargs kill`** to manage dev servers — these can kill your own agent process.
-- Use `dispatch-dev` to manage dev environments. It spins up an isolated DB, API server, and Vite frontend, all on auto-selected free ports. The suffix is derived from `DISPATCH_AGENT_ID` automatically in agent sessions.
-- **Prefer `dispatch-dev restart` over `down` + `up`** when you need to pick up code changes. Restart reuses the same ports and DB — no wasted time recreating containers. Only use `down` when the user asks or you're done for good.
+- Use the repo MCP dev tools to manage dev environments: `repo_dev_up`, `repo_dev_restart`, `repo_dev_down`, `repo_dev_status`, and `repo_dev_logs`. They spin up an isolated DB, API server, and Vite frontend on auto-selected free ports.
+- **Prefer `repo_dev_restart` over `repo_dev_down` + `repo_dev_up`** when you need to pick up code changes. Restart reuses the same ports and DB — no wasted time recreating containers. Only use `repo_dev_down` when the user asks or you're done for good.
 - If you start a validation stack for user review, do not tear it down automatically at the end of the turn unless the user explicitly asks.
-  ```bash
-  dispatch-dev up                             # first start: DB + API server + Vite
-  dispatch-dev restart                        # pick up code changes (reuses ports/DB)
-  dispatch-dev status                         # check what's running
-  dispatch-dev logs                           # API server logs
-  dispatch-dev logs --vite                    # Vite server logs
-  dispatch-dev url                            # print the API server URL
-  dispatch-dev down                           # full teardown (removes DB container)
-  ```
-- `dispatch-dev up` auto-selects free ports and prints the URLs — just use the printed URLs.
+- `repo_dev_up` auto-selects free ports and prints the URLs — just use the printed URLs.
 
 ## Backend Testing Safety
 
 - Treat `127.0.0.1:6767` as production by default; do not stop or kill the existing production server for ad-hoc testing.
-- When backend changes need local validation, use `dispatch-dev up` and point validation tooling to the printed URL.
+- When backend changes need local validation, use `repo_dev_up` and point validation tooling to the printed URL.
 - Only operate on production (`:6767`) when explicitly requested by the user.
 
 ## Development Database
 
 - Production uses the `dispatch` database. Never connect to it from dev servers.
-- `dispatch-dev up` creates an isolated Postgres container with its own port — no manual DATABASE_URL setup needed.
+- `repo_dev_up` creates an isolated Postgres container with its own port — no manual `DATABASE_URL` setup needed.
 - Migrations run automatically on API server start.
 
 ## Agent Pins


### PR DESCRIPTION
## Summary
- update agent-facing guidance to refer to repo dev MCP tools instead of `dispatch-dev`
- align the e2e tester persona with its actual tool access by reusing parent-provided validation context
- keep the underlying implementation unchanged in this docs-only PR

## Testing
- pnpm run check
- pnpm run test:e2e