### PR TITLE
Simplify sidebar navigation interactions

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,7 +66,6 @@ import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
-import { useTemporaryState } from "@/hooks/use-temporary-state";
 import {
   AGENT_TYPES,
   type AgentType,
@@ -664,12 +663,6 @@ export function DashboardLayout(): JSX.Element {
     return "bg-status-waiting";
   };
 
-  const [pulsingNavItem, setPulsingNavItem] = useTemporaryState<string | null>(
-    null,
-    260
-  );
-  const [pendingNavPulse, setPendingNavPulse] = useState<string | null>(null);
-
   const currentNavItem = (() => {
     if (location.pathname.startsWith("/jobs")) return "jobs";
     if (location.pathname.startsWith("/activity")) return "activity";
@@ -694,34 +687,6 @@ export function DashboardLayout(): JSX.Element {
       setMobileLeftOpen(true);
     }
   }, [currentNavItem, isMobile, setMobileLeftOpen, setMobileMediaOpen]);
-
-  useEffect(() => {
-    if (!pendingNavPulse || pendingNavPulse !== currentNavItem) return;
-    setPulsingNavItem(pendingNavPulse);
-    setPendingNavPulse(null);
-  }, [currentNavItem, pendingNavPulse, setPulsingNavItem]);
-
-  const triggerNavAnimation = useCallback(
-    (navItem: string) => {
-      if (navItem === currentNavItem) {
-        setPulsingNavItem(navItem);
-        return;
-      }
-      setPendingNavPulse(navItem);
-    },
-    [currentNavItem, setPulsingNavItem]
-  );
-
-  // ── Navigation callbacks ────────────────────────────────────────────
-  const handleSidebarNavigate = useCallback(
-    (section: NavSection) => {
-      if (section === "agents") navigate("/");
-      else if (section === "jobs") navigate("/jobs");
-      else if (section === "activity") navigate("/activity");
-      else if (section === "settings") navigate("/settings");
-    },
-    [navigate]
-  );
 
   // ── Settings state ────────────────────────────────────────────────────
   const {
@@ -785,17 +750,12 @@ export function DashboardLayout(): JSX.Element {
           >
             <SidebarShell
               activeSection={currentNavItem as NavSection}
-              onNavigate={(section) => {
-                handleSidebarNavigate(section);
-              }}
               onRequestClose={
                 isMobile
                   ? () => setMobileLeftOpen(false)
                   : () => setLeftOpen(false)
               }
               closeButtonIcon={isMobile ? "x" : "chevron"}
-              pulsingNavItem={pulsingNavItem}
-              triggerNavAnimation={triggerNavAnimation}
             >
               {currentNavItem === "agents" && (
                 <AgentListContent

--- a/apps/web/src/components/app/sidebar-shell.tsx
+++ b/apps/web/src/components/app/sidebar-shell.tsx
@@ -7,14 +7,9 @@ import {
   X,
 } from "lucide-react";
 import React from "react";
+import { NavLink } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { cn } from "@/lib/utils";
@@ -23,16 +18,10 @@ export type NavSection = "agents" | "jobs" | "activity" | "settings";
 
 type SidebarNavBarProps = {
   activeSection: NavSection;
-  onNavigate: (section: NavSection) => void;
-  pulsingNavItem?: string | null;
-  triggerNavAnimation?: (navItem: string) => void;
 };
 
 export function SidebarNavBar({
   activeSection,
-  onNavigate,
-  pulsingNavItem,
-  triggerNavAnimation,
 }: SidebarNavBarProps): JSX.Element {
   const navButtonClassName = (navItem: string, active = false): string =>
     cn(
@@ -40,69 +29,48 @@ export function SidebarNavBar({
       active ? "text-primary hover:text-primary/80" : "text-muted-foreground"
     );
 
-  const triggerNavAnimationForKey = (
-    event: React.KeyboardEvent<HTMLButtonElement>,
-    navItem: string
-  ): void => {
-    if (event.key === "Enter" || event.key === " ") {
-      triggerNavAnimation?.(navItem);
-    }
-  };
-
-  const items: Array<{ id: NavSection; icon: typeof Bot; label: string }> = [
-    { id: "agents", icon: Bot, label: "Agents" },
-    { id: "jobs", icon: AlarmClock, label: "Jobs" },
-    { id: "activity", icon: Activity, label: "Activity" },
-    { id: "settings", icon: Settings, label: "Settings" },
+  const items: Array<{
+    id: NavSection;
+    icon: typeof Bot;
+    label: string;
+    to: string;
+  }> = [
+    { id: "agents", icon: Bot, label: "Agents", to: "/" },
+    { id: "jobs", icon: AlarmClock, label: "Jobs", to: "/jobs" },
+    { id: "activity", icon: Activity, label: "Activity", to: "/activity" },
+    { id: "settings", icon: Settings, label: "Settings", to: "/settings" },
   ];
 
   return (
-    <TooltipProvider delayDuration={120}>
-      <div className="flex items-center justify-around border-t border-white/[0.12] py-3 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
-        {items.map(({ id, icon: Icon, label }) => (
-          <Tooltip key={id}>
-            <TooltipTrigger asChild>
-              <button
-                onPointerDown={() => triggerNavAnimation?.(id)}
-                onKeyDown={(event) => triggerNavAnimationForKey(event, id)}
-                onClick={() => onNavigate(id)}
-                aria-label={label}
-                data-testid={`${id}-button`}
-                className={cn(
-                  navButtonClassName(id, activeSection === id),
-                  pulsingNavItem === id && "animate-sidebar-nav-pulse"
-                )}
-              >
-                <span className="flex items-center justify-center">
-                  <Icon className="h-5 w-5" />
-                </span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>{label}</TooltipContent>
-          </Tooltip>
-        ))}
-      </div>
-    </TooltipProvider>
+    <div className="flex items-center justify-around border-t border-white/[0.12] py-3 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
+      {items.map(({ id, icon: Icon, label, to }) => (
+        <NavLink
+          key={id}
+          to={to}
+          aria-label={label}
+          data-testid={`${id}-button`}
+          className={navButtonClassName(id, activeSection === id)}
+        >
+          <span className="flex items-center justify-center">
+            <Icon className="h-5 w-5" />
+          </span>
+        </NavLink>
+      ))}
+    </div>
   );
 }
 
 type SidebarShellProps = {
   activeSection: NavSection;
-  onNavigate: (section: NavSection) => void;
   onRequestClose?: () => void;
   closeButtonIcon?: "chevron" | "x";
-  pulsingNavItem?: string | null;
-  triggerNavAnimation?: (navItem: string) => void;
   children: React.ReactNode;
 };
 
 export function SidebarShell({
   activeSection,
-  onNavigate,
   onRequestClose,
   closeButtonIcon = "x",
-  pulsingNavItem,
-  triggerNavAnimation,
   children,
 }: SidebarShellProps): JSX.Element {
   const { iconColor } = useIconColor();
@@ -154,12 +122,7 @@ export function SidebarShell({
 
       <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
 
-      <SidebarNavBar
-        activeSection={activeSection}
-        onNavigate={onNavigate}
-        pulsingNavItem={pulsingNavItem}
-        triggerNavAnimation={triggerNavAnimation}
-      />
+      <SidebarNavBar activeSection={activeSection} />
     </aside>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -804,39 +804,6 @@ html[data-theme="matrix"] [role="button"] {
   animation: persona-reviewing-pulse 2s ease-in-out infinite;
 }
 
-@keyframes sidebar-nav-pulse {
-  0% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
-    background-color: transparent;
-  }
-  18% {
-    transform: scale(0.9);
-    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
-  }
-  58% {
-    transform: scale(1.3);
-    box-shadow: 0 0 0 8px hsl(var(--primary) / 0.18);
-    background-color: hsl(var(--primary) / 0.12);
-  }
-  82% {
-    transform: scale(1.06);
-    box-shadow: 0 0 0 4px hsl(var(--primary) / 0.08);
-    background-color: hsl(var(--primary) / 0.06);
-  }
-  100% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
-    background-color: transparent;
-  }
-}
-
-.animate-sidebar-nav-pulse {
-  animation: sidebar-nav-pulse 260ms cubic-bezier(0.22, 1, 0.36, 1);
-  transform-origin: center;
-  will-change: transform, box-shadow, background-color;
-}
-
 /* Persona reviewing row — subtle left-border shimmer */
 @keyframes persona-reviewing-shimmer {
   0% {


### PR DESCRIPTION
## Summary
- convert the sidebar nav icons to declarative route links
- remove the tooltip wrappers and nav animation state/callbacks
- drop the sidebar nav pulse CSS so the nav only uses hover/active color states

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e