### PR TITLE
Inline API and DB status in settings sidebar footer

### DIFF
--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -539,7 +539,7 @@ export function SettingsNavContent({
         ))}
       </nav>
       <div className="border-t border-border px-4 pb-3 pt-4">
-        <div className="flex flex-row justify-around text-xs text-muted-foreground">
+        <div className="flex justify-around text-xs text-muted-foreground">
           <ServiceStatus
             icon={<Server className="h-3.5 w-3.5" />}
             label="API"

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -539,10 +539,7 @@ export function SettingsNavContent({
         ))}
       </nav>
       <div className="border-t border-border px-4 pb-3 pt-4">
-        <div className="mb-3 text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-          System
-        </div>
-        <div className="space-y-2 text-xs text-muted-foreground">
+        <div className="flex flex-row justify-around text-xs text-muted-foreground">
           <ServiceStatus
             icon={<Server className="h-3.5 w-3.5" />}
             label="API"


### PR DESCRIPTION
## Summary
- Replace the stacked `System` section in the settings sidebar footer with a single flex row so the API and DB status indicators sit side-by-side.
- Drop the now-redundant `System` label.

## Test plan
- [x] `pnpm run check` (backend + web type check)
- [x] `pnpm run finalize:web` (type check + production build)
- [x] Playwright: loaded `/settings`, confirmed API and DB render side-by-side under the sidebar footer with no "System" heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)