### PR TITLE
fix(web): restore mobile layout for section routes

### DIFF
--- a/apps/web/src/layouts/dashboard-sections.tsx
+++ b/apps/web/src/layouts/dashboard-sections.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { BarChart3, History } from "lucide-react";
+import { BarChart3, History, PanelRightOpen } from "lucide-react";
 
 import { AgentsView } from "@/components/app/agents-view";
 import { ActivityPane } from "@/components/app/activity-pane";
@@ -18,6 +18,7 @@ import { type NavSection, SidebarShell } from "@/components/app/sidebar-shell";
 import { type ServiceState } from "@/components/app/types";
 import { DesignLab } from "@/components/app/design-lab";
 import { GlassSidebar } from "@/components/ui/glass-sidebar";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useDashboardContext } from "@/App";
 import { agentRoute } from "@/lib/agent-routes";
@@ -45,6 +46,7 @@ function SectionShell({
     setLeftOpen,
     setMobileLeftOpen,
     setMobileMediaOpen,
+    handleSetLeftPanelOpen,
     pulsingNavItem,
     triggerNavAnimation,
     handleSidebarNavigate,
@@ -84,11 +86,27 @@ function SectionShell({
           </SidebarShell>
         </GlassSidebar>
 
-        <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)]">
-            <div className={cn("min-h-0 min-w-0", !leftPanelOpen && "pt-14")}>
-              {children}
+        <main className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+          {!leftPanelOpen ? (
+            <div className="pointer-events-none absolute left-3 top-3 z-10">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="pointer-events-auto"
+                onClick={() => handleSetLeftPanelOpen(true)}
+                title="Open sidebar"
+              >
+                <PanelRightOpen className="h-4 w-4" />
+              </Button>
             </div>
+          ) : null}
+          <div
+            className={cn(
+              "flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
+              !leftPanelOpen && "pt-14"
+            )}
+          >
+            {children}
           </div>
         </main>
       </div>
@@ -124,7 +142,8 @@ export function AgentsRoute(): JSX.Element {
 
 export function JobsRoute(): JSX.Element {
   const navigate = useNavigate();
-  const { agents, enabledAgentTypes, isMobile } = useDashboardContext();
+  const { agents, enabledAgentTypes, isMobile, setMobileLeftOpen } =
+    useDashboardContext();
   const openAgent = useCallback(
     async (agent: (typeof agents)[number]) => {
       navigate(agentRoute(agent.id));
@@ -142,7 +161,9 @@ export function JobsRoute(): JSX.Element {
       <SectionShell
         activeSection="jobs"
         sidebar={
-          <JobListContent onItemSelect={isMobile ? () => void 0 : undefined} />
+          <JobListContent
+            onItemSelect={isMobile ? () => setMobileLeftOpen(false) : undefined}
+          />
         }
       >
         <JobDetailPane />

--- a/e2e/mobile-layout.spec.ts
+++ b/e2e/mobile-layout.spec.ts
@@ -1,0 +1,102 @@
+import {
+  test,
+  expect,
+  type Page,
+  type APIRequestContext,
+} from "@playwright/test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
+
+async function gotoMobile(page: Page, path: string): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await page.locator("main").waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function seedJob(request: APIRequestContext): Promise<void> {
+  const dir = join(tmpdir(), `dispatch-e2e-mobile-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  await request.post("/api/v1/jobs", {
+    headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+    data: {
+      name: "mobile-layout-e2e",
+      directory: dir,
+      prompt: "noop",
+      schedule: "0 * * * *",
+      timeoutMs: 120000,
+      needsInputTimeoutMs: 86400000,
+    },
+  });
+}
+
+test.describe("Mobile layout", () => {
+  test("tapping a job row on mobile closes the sidebar and reveals the detail pane", async ({
+    page,
+    request,
+  }) => {
+    await seedJob(request);
+    await gotoMobile(page, "/jobs");
+
+    await page.getByTitle("Open sidebar").click();
+    const sidebar = page.getByRole("dialog", { name: "Navigation sidebar" });
+    await expect(sidebar.getByTitle("Close sidebar")).toBeVisible();
+
+    const firstRow = page.locator('[data-testid^="job-row-"]').first();
+    await firstRow.waitFor({ state: "visible", timeout: 5_000 });
+    await firstRow.click();
+
+    await expect(page).toHaveURL(/\/jobs\/[^/]+$/);
+
+    // Mobile sidebar is a slide-over; it slides off to the left (x < 0) when closed.
+    await expect
+      .poll(
+        async () =>
+          sidebar.evaluate((el) => Math.round(el.getBoundingClientRect().left)),
+        { timeout: 2_000 }
+      )
+      .toBeLessThan(0);
+
+    // The open-sidebar affordance is back once the detail is shown.
+    await expect(page.getByTitle("Open sidebar")).toBeVisible();
+  });
+
+  test("activity history fills the viewport and scrolls", async ({ page }) => {
+    await gotoMobile(page, "/activity/history");
+
+    // Open-sidebar button should be rendered when the mobile sidebar is closed.
+    await expect(page.getByTitle("Open sidebar")).toBeVisible();
+
+    // The content wrapper inside <main> should fill most of the viewport.
+    // Regression: the wrapper previously collapsed to ~300px because flex-1
+    // was applied to a non-flex parent.
+    const contentHeight = await page
+      .locator("main > div")
+      .last()
+      .evaluate((el) => el.clientHeight);
+    expect(contentHeight).toBeGreaterThan(MOBILE_VIEWPORT.height - 80);
+  });
+
+  test("settings detail exposes an open-sidebar button on mobile", async ({
+    page,
+  }) => {
+    await gotoMobile(page, "/settings/general");
+
+    const openButton = page.getByTitle("Open sidebar");
+    await expect(openButton).toBeVisible();
+
+    await openButton.click();
+    const sidebar = page.getByRole("dialog", { name: "Navigation sidebar" });
+    await expect(sidebar.getByTitle("Close sidebar")).toBeVisible();
+    await expect
+      .poll(async () =>
+        sidebar.evaluate((el) => Math.round(el.getBoundingClientRect().left))
+      )
+      .toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Three regressions in mobile navigation introduced by the route-driven workspace refactor:

- **Jobs**: Tapping a job row left the full-screen sidebar open, so the detail pane was hidden. `JobsRoute` was passing `onItemSelect={() => void 0}`; it now closes the mobile sidebar.
- **Settings / Activity / Design-Lab**: Once the mobile sidebar closed there was no affordance to reopen it. `SectionShell` reserved `pt-14` space for a button that was never rendered. Added the same absolute `PanelRightOpen` button used by `agents-view.tsx`.
- **Activity History didn't scroll**: The `SectionShell` content wrapper wasn't a flex container, so `flex-1` / `h-full` inside the route children collapsed. The Activity pane rendered at ~307px instead of filling the viewport. Wrapper is now `flex h-full min-h-0 min-w-0 flex-col overflow-hidden`.

## Test plan

- [x] `pnpm run check` (type check)
- [x] `pnpm run finalize:web`
- [x] `pnpm run test:e2e` (139 passed, 6 skipped)
- [x] New `e2e/mobile-layout.spec.ts` asserts the three regressions
- [x] Manual Playwright validation at 390×844 and 1280×800

🤖 Generated with [Claude Code](https://claude.com/claude-code)