### PR TITLE
docs: fix Repo Tools section drift in in-app docs

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -9,19 +9,20 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`8d7e3fb97069eccda7ac9bc3de920832177cae23` — HEAD at the start of the 2026-04-18 run. The PR that lands this file will advance the SHA once merged; the next run should diff from wherever HEAD is when it reads the file.
+`fbfeb475515ef41d4174f2b6f1d299c3f1ffbe99` — HEAD at the start of the 2026-04-18 Repo Tools run. The PR that lands this file will advance the SHA once merged; the next run should diff from wherever HEAD is when it reads the file.
 
 ## next_focus
 
-**Audit the `docs-pane.tsx` "Repo Tools" section against `apps/server/src/shared/mcp/repo-tools.ts` and the `.dispatch/tools.json` schema.**
+**Audit the `docs-pane.tsx` "Reviewers" section against the persona launch + review-status flow in `apps/server/src/shared/mcp/server.ts` and `apps/server/src/agents/manager.ts`.**
 
-This was the top backlog item after the Agents pass. Focus points:
+Concrete pointers for the next run:
 
-- `apps/web/src/components/app/docs-pane.tsx` — the "Repo Tools" section (search for `id: "tools"`).
+- `apps/web/src/components/app/docs-pane.tsx` — the "Reviewers" section (search for `id: "personas"`).
 - Cross-check against:
-  - `apps/server/src/shared/mcp/repo-tools.ts` — schema for `.dispatch/tools.json`, including any `scope` field (job-only tools) that the docs don't currently mention.
-  - `apps/server/src/shared/mcp/server.ts` — the built-in tools list the docs enumerate (`create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_share`, `dispatch_feedback`, `dispatch_get_feedback`, `dispatch_launch_persona`). Verify the list is complete and the short descriptions are accurate. In particular, the docs list `dispatch_pin` in `CLAUDE.md` but not in the docs-pane — worth checking whether it belongs under Built-in tools.
-  - `apps/server/test/repo-tools.test.ts` — captures the supported param shapes.
+  - `apps/server/src/shared/mcp/server.ts` — the `review_status` tool accepts a `verdict` of `"approve" | "request_changes"` and a `status` of `"reviewing" | "complete"`. The docs describe severity but never mention verdict/status. `PERSONA_TOOLS` also includes `get_parent_context` — worth a sentence.
+  - `apps/server/src/agents/manager.ts` — the `AgentRecord.review` shape (review_status / verdict fields) and how review outcomes surface in the UI.
+  - `apps/server/src/personas/` loader — confirm the `feedbackFormat` values still supported (docs say it defaults to `findings`; verify nothing new has been added).
+- Worth confirming the "How personas work" narrative still matches — persona agents now also have `dispatch_pin` and `dispatch_share` (see `PERSONA_TOOLS` in `server.ts:180-186`), which the docs don't call out.
 
 Scope the PR to this one section plus whatever the git diff since `last_audited_sha` demands.
 
@@ -30,32 +31,35 @@ Scope the PR to this one section plus whatever the git diff since `last_audited_
 Items noticed during prior passes but left for later runs. Pick the most relevant one when `next_focus` is empty or already done.
 
 - **docs-pane "Worktrees" section** — cross-check against `apps/server/src/shared/git/worktree.ts` and the worktree cleanup flow in `apps/server/src/agents/manager.ts` (`worktree-check` / `worktree-cleanup` archive phases). Confirm the "sibling vs nested" Settings toggle copy still matches the UI.
-- **docs-pane "Reviewers" section** — verify persona launch flow (`dispatch_launch_persona` in `apps/server/src/shared/mcp/server.ts`) and feedback status values. The docs describe severity but not verdict/status values; see `review_status` / `verdict` fields on `AgentRecord.review` in `apps/server/src/agents/manager.ts`.
 - **docs-pane "Status Events" section** — event types are in sync today (`AGENT_LATEST_EVENT_TYPES` in `apps/server/src/server.ts:243`: working/blocked/waiting_user/done/idle). Re-check when new event types are added.
-- **docs-pane "Media & Sharing" section** — cross-check the `dispatch_share` input schema including the `content` / `source` / `update` params. Docs mention `source: "simulator"` but not the `content` / `update` parameters.
-- **docs-pane "Notifications" section** — verify Slack event toggles and focus-aware suppression match `apps/server/src/notifications/slack.ts` and `apps/server/src/focus-tracker.ts`.
-- **New in-app section: Jobs** — jobs are a major feature with no in-app docs page. The 2026-04-18 Agents pass noticed an `isJobAgent` badge in `agent-card.tsx` but there's no user-facing doc that explains how jobs differ from manually-launched agents. Consider adding a "Jobs" section.
+- **docs-pane "Media & Sharing" section** — 2026-04-18 Repo Tools pass noted that `dispatch_share` supports `content`, `name`, `update`, and `simulatorUdid` params (see `registerShareTool` in `apps/server/src/shared/mcp/server.ts`). Docs currently only describe `source: "simulator"`. Worth a "Sharing text snippets" or "Updating shared media" bullet.
+- **docs-pane "Notifications" section** — verify Slack event toggles and focus-aware suppression match `apps/server/src/notifications/slack.ts` and `apps/server/src/focus-tracker.ts`. Also: `dispatch_notify` (new built-in tool agents can call directly) is rate-limited to 5/min and supports a `respectFocus` flag — the Notifications docs should mention this path, not just agent-event-driven notifications.
+- **New in-app section: Jobs** — jobs are a major feature with no in-app docs page. The Repo Tools pass added a mention of the job-only built-in tools (`job_complete`, `job_failed`, `job_needs_input`, `job_log`) but there's still no page explaining how jobs differ from manually-launched agents, how they're scheduled, or how `.dispatch/job-state/*.md` handoff files work. Consider adding a "Jobs" section.
 - **`docs/03-api-spec.md`** — spot-check for new routes added in the last 30 days. Recent migrations (0012 auto-review, 0013 review agent type, 0014 base branch) imply the agents POST body schema has grown.
 - **`docs/04-agent-lifecycle.md`** — verify it still matches `AgentStatus` / `SetupPhase` / `ArchivePhase` in `apps/server/src/agents/manager.ts`. The values are: status ∈ {creating, running, stopping, stopped, archiving, error, unknown}; setupPhase ∈ {worktree, env, deps, session, null}; archivePhase ∈ {stopping, worktree-check, worktree-cleanup, finalizing, null}.
 - **`docs/10-operations-runbook.md`** — verify service management commands match current `bin/dispatch-server` / `bin/dispatch-deploy` flags.
+- **README.md MCP tools summary** — the README likely lists built-in MCP tools and may be out of date for the same reasons the docs-pane was. Worth a spot check after the next `next_focus` is done.
 
 ## drift_patterns
 
 Observations about where docs tend to go stale. Each run should add new observations and prune ones that no longer apply.
 
 - **User-facing docs drift fastest.** When the app's behavior changes, the in-app docs-pane content is the first thing to notice. It's also the easiest to update in the same PR as the code change (a reviewer can flag stale copy), but in practice it often isn't — so this audit is where it catches up.
+- **The built-in MCP tool list sprawls without touching the docs.** The 2026-04-18 Repo Tools pass found the docs-pane listed 7 built-in tools; `AGENT_TOOLS` in `apps/server/src/shared/mcp/server.ts` actually has 17. Each new tool gets added to `AGENT_TOOLS` / `JOB_TOOLS` / `PERSONA_TOOLS` but almost never to `docs-pane.tsx`. Grep for `AGENT_TOOLS = new Set` and diff against the `Built-in tools` list in `docs-pane.tsx` whenever touching this area.
 - **The create-agent dialog accretes options silently.** The 2026-04-18 pass found that the dialog had gained an "Autonomous Review" checkbox and a two-step "Create with prompt" flow (initial prompt textarea) without any change to `docs-pane.tsx`. When `create-agent-dialog.tsx` gains a field, the "Creating an agent" bullet list needs a matching entry. Grep `create-agent-dialog.tsx` for `<Checkbox` and `<label` to catch new form fields quickly.
 - **Status indicator colors are theme-driven via CSS vars (`--status-working`, `--status-blocked`, `--status-waiting`, `--status-done`).** Don't trust any hard-coded color-name claim in the docs — resolve the actual hue from `apps/web/src/index.css` (search for `--status-working`). 2026-04-18 found the docs had working/done backwards (they'd been copy-pasted from some earlier palette).
-- **MCP tool sets change by agent type.** The AGENT / JOB / PERSONA tool lists in `apps/server/src/shared/mcp/server.ts` evolve independently. Any doc that enumerates tools for one role is at risk of drifting from the other two. Prefer linking to the source of truth over re-listing.
+- **MCP tool sets change by agent type.** The AGENT / JOB / PERSONA tool lists in `apps/server/src/shared/mcp/server.ts` evolve independently. Any doc that enumerates tools for one role is at risk of drifting from the other two. The Repo Tools pass added a one-paragraph note about per-agent-type subsets instead of re-listing all three — keep it that way.
+- **Repo tool prefix is `repo_`, not `repo.`.** MCP clients don't support dots in tool names, so dots in configured names are sanitized to underscores (`repo-tools.ts:161-162`). Docs had `repo.lint` wrong for a long stretch; grep for `repo\.` in docs when reviewing tool-prefix claims.
 - **Job configuration semantics have changed.** Jobs were once file-based (`.dispatch/jobs/*.md`) and are now DB-backed (migration `0011_drop-jobs-file-path-column.sql`). Older docs and comments may still reference the file-based model.
 - **Agent lifecycle has two axes: status and phase.** `status` (`creating`/`running`/…/`archiving`) and `setup_phase` / `archive_phase` are distinct. Docs that mention "phase" without qualifying which one are a drift risk.
 
 ## Notes for the next run
 
 - If `next_focus` feels too big for one night, split it and push half back into `backlog` with a concrete description.
-- Treat each run as one focused slice. The Agents pass on 2026-04-18 fit comfortably in one PR; aim for that size.
+- Treat each run as one focused slice. The Agents pass on 2026-04-18 fit comfortably in one PR; the Repo Tools pass did too. Aim for that size.
 - If you notice something that isn't drift but is genuinely missing (e.g. a new feature with no docs anywhere), add it to `backlog` with enough detail that a future run can act on it without re-discovering the context.
 
 ## History
 
-- **2026-04-18** — Audited docs-pane "Agents" section. Fixed status-indicator color mapping (working/done were swapped in the docs), added Autonomous Review checkbox and Create-with-prompt flow to the "Creating an agent" bullets, clarified the auto-naming behavior of the Name field. Did not touch any secondary docs.
+- **2026-04-18** (Agents) — Audited docs-pane "Agents" section. Fixed status-indicator color mapping (working/done were swapped in the docs), added Autonomous Review checkbox and Create-with-prompt flow to the "Creating an agent" bullets, clarified the auto-naming behavior of the Name field.
+- **2026-04-18** (Repo Tools) — Audited docs-pane "Repo Tools" section against `repo-tools.ts` and `server.ts`. Fixed the tool prefix from `repo.` → `repo_` (and added a note about dot-to-underscore sanitization), documented the `scope` field for job/reviewer-only tools, expanded the built-in tool list from 7 → 14 entries, and added a one-paragraph note that persona and job agents see different built-in tool subsets.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -201,9 +201,10 @@ const SECTIONS: SectionDef[] = [
           <H3>Defining tools</H3>
           <P>
             Each tool has a name, a description, and a command to run. Dispatch
-            automatically prefixes tool names with <Code>repo.</Code> when
-            exposing them to agents. The command executes in the repo root when
-            called.
+            automatically prefixes tool names with <Code>repo_</Code> when
+            exposing them to agents (any dots in the configured name are
+            sanitized to underscores, since MCP clients don't support dots in
+            tool names). The command executes in the repo root when called.
           </P>
           <CodeBlock>{`
 // .dispatch/tools.json
@@ -228,8 +229,8 @@ const SECTIONS: SectionDef[] = [
 }`}</CodeBlock>
           <P>
             The tools above would be available to agents as{" "}
-            <Code>repo.lint</Code>, <Code>repo.test</Code>, and{" "}
-            <Code>repo.db_reset</Code>.
+            <Code>repo_lint</Code>, <Code>repo_test</Code>, and{" "}
+            <Code>repo_db_reset</Code>.
           </P>
         </Section>
 
@@ -262,7 +263,7 @@ const SECTIONS: SectionDef[] = [
   ]
 }`}</CodeBlock>
           <P>
-            When an agent calls <Code>repo.dev_up</Code> with{" "}
+            When an agent calls <Code>repo_dev_up</Code> with{" "}
             <Code>{'{ cwd: "/path", live: true }'}</Code>, Dispatch runs{" "}
             <Code>./bin/dev up --cwd /path --live</Code>. Parameters that are
             omitted or false are skipped.
@@ -270,10 +271,34 @@ const SECTIONS: SectionDef[] = [
         </Section>
 
         <Section>
+          <H3>Limiting tool scope</H3>
+          <P>
+            By default a repo tool is exposed to every agent type. Add an
+            optional <Code>scope</Code> array to restrict where a tool shows up.
+            Valid scopes are <Code>"agent"</Code> (standard agents),{" "}
+            <Code>"reviewer"</Code> (persona reviewers), and <Code>"job"</Code>{" "}
+            (scheduled job runs). Useful for job-only maintenance commands that
+            shouldn't clutter a regular agent's toolset.
+          </P>
+          <CodeBlock>{`
+{
+  "name": "list_dev_containers",
+  "description": "List running dispatch-dev Postgres containers.",
+  "command": ["docker", "ps", "--filter", "name=dispatch-postgres-"],
+  "scope": ["job"]
+}`}</CodeBlock>
+        </Section>
+
+        <Section>
           <H3>Built-in tools</H3>
           <P>
             Dispatch also provides built-in tools that are always available,
-            regardless of repo configuration:
+            regardless of repo configuration. Standard agents see the set below.
+            Persona reviewers and scheduled jobs get tailored subsets — for
+            example, persona agents get <Code>review_status</Code> and{" "}
+            <Code>get_parent_context</Code>, and jobs get{" "}
+            <Code>job_complete</Code>, <Code>job_failed</Code>,{" "}
+            <Code>job_needs_input</Code>, and <Code>job_log</Code>.
           </P>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
             <li>
@@ -283,26 +308,54 @@ const SECTIONS: SectionDef[] = [
             <li>
               <Code>get_pr_status</Code> — check CI status on a pull request
             </li>
-
             <li>
               <Code>dispatch_event</Code> — report agent status (working,
-              blocked, done)
+              blocked, waiting_user, done, idle)
             </li>
             <li>
-              <Code>dispatch_share</Code> — publish a screenshot or image to the
-              session's media stream
+              <Code>dispatch_rename_session</Code> — rename the current agent
+              session
+            </li>
+            <li>
+              <Code>dispatch_notify</Code> — send a Slack notification (rate
+              limited, supports mrkdwn)
+            </li>
+            <li>
+              <Code>dispatch_pin</Code> — pin a label/value pair to the sidebar
+              (URLs, ports, filenames, PRs, markdown summaries)
+            </li>
+            <li>
+              <Code>dispatch_share</Code> — publish a screenshot, image, video,
+              or text snippet to the session's media stream
+            </li>
+            <li>
+              <Code>dispatch_list_media</Code> — list media shared with or by
+              the current agent
             </li>
             <li>
               <Code>dispatch_feedback</Code> — submit a structured finding with
               severity, file reference, and suggestion
             </li>
             <li>
-              <Code>dispatch_get_feedback</Code> — retrieve feedback findings
-              for the current session
+              <Code>list_personas</Code> — list persona reviewers defined for
+              the current repo
             </li>
             <li>
               <Code>dispatch_launch_persona</Code> — launch a persona agent as a
               child of the current session
+            </li>
+            <li>
+              <Code>dispatch_get_feedback</Code> — retrieve feedback submitted
+              by child persona agents
+            </li>
+            <li>
+              <Code>dispatch_resolve_feedback</Code> — mark a feedback item as
+              fixed or ignored
+            </li>
+            <li>
+              <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,{" "}
+              <Code>get_feedback_summary</Code> — analytics queries over recent
+              Dispatch activity
             </li>
           </ul>
         </Section>


### PR DESCRIPTION
## Summary

Recurring docs-audit pass. next_focus from the prior run pointed at the in-app docs-pane "Repo Tools" section; audited it against `apps/server/src/shared/mcp/repo-tools.ts` and `apps/server/src/shared/mcp/server.ts`.

Three substantive drifts fixed:

- **Tool prefix** was documented as `repo.` but the code uses `repo_` (MCP clients don't support dots, so dots in configured names are sanitized to underscores — see `repo-tools.ts:161-162`). Updated the example and the trailing commentary.
- **`scope` field** was completely undocumented despite being in active use in `.dispatch/tools.json` for job-only tools. Added a new "Limiting tool scope" subsection.
- **Built-in tools list** had drifted from 7 → 14 entries. `AGENT_TOOLS` in `server.ts` now includes `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_list_media`, `list_personas`, `dispatch_resolve_feedback`, and the `get_activity_summary` / `get_agent_history` / `get_feedback_summary` analytics tools — none of which were listed. Also added a one-paragraph note that persona and job agents see different built-in tool subsets, so the list stays honest without re-enumerating each role.

State file rewritten: `next_focus` now points the next run at the **Reviewers** section (the `review_status` tool has `verdict`/`status` values that are still undocumented). Backlog trimmed and updated with concrete follow-ups for Worktrees, Media & Sharing, Notifications, and a missing "Jobs" section.

## Test plan

- [x] `pnpm run format:write` — no additional drift in untouched files
- [x] `pnpm run check` — backend + web type checks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)