### PR TITLE
feat(web): ActivityBars loading indicator + matching reconnect scan

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -10,7 +10,6 @@ import {
   FolderGit2,
   FolderTree,
   GitBranch,
-  Loader2,
   Play,
   Pause,
 } from "lucide-react";
@@ -28,6 +27,7 @@ import {
 } from "@/components/app/feedback-panel";
 import { PersonaLauncher } from "@/components/app/persona-launcher";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -274,7 +274,7 @@ export function AgentCard({
 
         {agent.status === "creating" && agent.setupPhase ? (
           <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-status-working">
-            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+            <ActivityBars size={12} className="shrink-0" />
             <span className="truncate font-medium">
               {agent.setupPhase === "worktree"
                 ? "Creating worktree…"
@@ -291,7 +291,7 @@ export function AgentCard({
 
         {agent.status === "archiving" ? (
           <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-orange-400">
-            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+            <ActivityBars size={12} className="shrink-0" />
             <span className="truncate font-medium">
               {agent.archivePhase === "stopping"
                 ? "Stopping agent…"

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -637,7 +637,7 @@ export function AgentsView({
               ) : null}
               {connState === "reconnecting" ? (
                 <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
-                  <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
+                  <div className="dispatch-reconnect-scan h-full w-1/3 will-change-transform bg-[linear-gradient(to_right,transparent,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)),transparent)] saturate-[1.35] brightness-[1.05] animate-[reconnect-scan_1350ms_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:translate-x-[140%]" />
                 </div>
               ) : null}
               <TerminalPane

--- a/apps/web/src/components/app/app-header.tsx
+++ b/apps/web/src/components/app/app-header.tsx
@@ -82,7 +82,7 @@ export function AppHeader({
 
       {showReconnectIndicator ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden">
-          <div className="dispatch-reconnect-scan h-full w-1/3 bg-gradient-to-r from-transparent via-status-waiting to-transparent" />
+          <div className="dispatch-reconnect-scan h-full w-1/3 will-change-transform bg-[linear-gradient(to_right,transparent,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)),transparent)] saturate-[1.35] brightness-[1.05] animate-[reconnect-scan_1350ms_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:translate-x-[140%]" />
         </div>
       ) : null}
     </header>

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -7,15 +7,10 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  Check,
-  ChevronDown,
-  GitBranch,
-  Loader2,
-  ChevronLeft,
-} from "lucide-react";
+import { Check, ChevronDown, GitBranch, ChevronLeft } from "lucide-react";
 
 import { PathInput } from "@/components/app/path-input";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -590,7 +585,10 @@ export function CreateAgentDialog({
                           >
                             {createBaseBranch}
                             {branchesLoading ? (
-                              <Loader2 className="ml-2 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                              <ActivityBars
+                                size={14}
+                                className="ml-2 shrink-0"
+                              />
                             ) : (
                               <ChevronDown
                                 className={cn(
@@ -622,7 +620,7 @@ export function CreateAgentDialog({
                                   {branchesLoading ? (
                                     <CommandLoading>
                                       <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
-                                        <Loader2 className="h-3 w-3 animate-spin" />
+                                        <ActivityBars size={12} />
                                         Loading branches...
                                       </div>
                                     </CommandLoading>
@@ -744,7 +742,7 @@ export function CreateAgentDialog({
                   data-testid="create-agent-submit"
                 >
                   {creating ? (
-                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    <ActivityBars size={16} className="mr-1.5" />
                   ) : null}
                   Create
                 </Button>
@@ -806,7 +804,7 @@ export function CreateAgentDialog({
                     data-testid="create-agent-prompt-submit"
                   >
                     {creating ? (
-                      <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                      <ActivityBars size={16} className="mr-1.5" />
                     ) : null}
                     Create
                   </Button>

--- a/apps/web/src/components/app/delete-agent-dialog.tsx
+++ b/apps/web/src/components/app/delete-agent-dialog.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { AlertTriangle, Archive, GitBranch, Loader2 } from "lucide-react";
+import { AlertTriangle, Archive, GitBranch } from "lucide-react";
 
 import { type Agent } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -208,9 +209,7 @@ export function DeleteAgentDialog({
               data-testid="delete-agent-force-worktree"
               className="h-auto w-full min-w-0 whitespace-normal py-2 text-center"
             >
-              {deleting ? (
-                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              ) : null}
+              {deleting ? <ActivityBars size={16} className="mr-1.5" /> : null}
               Archive and remove worktree
             </Button>
           </div>
@@ -245,7 +244,7 @@ export function DeleteAgentDialog({
             onClick={() => void handleConfirmDelete()}
           >
             {loading || deleting ? (
-              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              <ActivityBars size={16} className="mr-1.5" />
             ) : (
               <Archive className="mr-1.5 h-4 w-4" />
             )}

--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,442 +1,709 @@
-/**
- * Design Lab — a comparison page for exploring depth/elevation styles.
- *
- * Renders mock Dispatch components (agent cards, sidebar, status badges, a modal,
- * nav bar, data rows) in four style treatments side by side:
- *   1. Current (flat baseline)
- *   2. Soft Elevation (layered shadows, hover lift)
- *   3. Layered Glass (backdrop blur, translucent panels)
- *   4. Editorial (depth via typography & spacing contrast)
- *
- * All styles are scoped via wrapper classNames — nothing leaks into the app.
- */
+import { useEffect, useState } from "react";
+import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
 
-import { useState, useEffect } from "react";
+// -- Keyframes ----------------------------------------------------------------
 
-// -- Fake data ----------------------------------------------------------------
-const agents = [
-  {
-    name: "PR Review Bot",
-    status: "working" as const,
-    model: "Claude Sonnet",
-    branch: "feat/auth-refactor",
-    elapsed: "4m 32s",
-  },
-  {
-    name: "E2E Test Runner",
-    status: "done" as const,
-    model: "Claude Sonnet",
-    branch: "main",
-    elapsed: "12m 08s",
-  },
-  {
-    name: "Migration Agent",
-    status: "blocked" as const,
-    model: "Claude Opus",
-    branch: "fix/db-schema",
-    elapsed: "1m 47s",
-  },
-  {
-    name: "Deploy Monitor",
-    status: "idle" as const,
-    model: "Claude Haiku",
-    branch: "main",
-    elapsed: "--",
-  },
+const SPINNER_KEYFRAMES = `
+@keyframes dl-material-dash {
+  0%   { stroke-dasharray: 1, 63; stroke-dashoffset: 0; }
+  50%  { stroke-dasharray: 44, 63; stroke-dashoffset: -16; }
+  100% { stroke-dasharray: 44, 63; stroke-dashoffset: -60; }
+}
+@keyframes dl-pulse-dot {
+  0%, 80%, 100% { transform: scale(0.5); opacity: 0.4; }
+  40%           { transform: scale(1);   opacity: 1; }
+}
+@keyframes dl-bar-pulse {
+  0%, 100% { transform: scaleY(0.35); }
+  50%      { transform: scaleY(1); }
+}
+/* Activity Bars: wave left→right, bounces off the right end, right→left,
+   rests. Bar 3 briefly holds at peak during the turnaround. */
+@keyframes dl-bar-wave-0 {
+  0%, 5%, 25%, 67%, 87%, 100% { transform: scaleY(0.22); }
+  10%, 20%, 72%, 82%          { transform: scaleY(0.55); }
+  15%, 77%                    { transform: scaleY(1); }
+}
+@keyframes dl-bar-wave-1 {
+  0%, 13%, 33%, 59%, 79%, 100% { transform: scaleY(0.22); }
+  18%, 28%, 64%, 74%           { transform: scaleY(0.55); }
+  23%, 69%                     { transform: scaleY(1); }
+}
+@keyframes dl-bar-wave-2 {
+  0%, 21%, 41%, 51%, 71%, 100% { transform: scaleY(0.22); }
+  26%, 36%, 56%, 66%           { transform: scaleY(0.55); }
+  31%, 61%                     { transform: scaleY(1); }
+}
+@keyframes dl-bar-wave-3 {
+  0%, 29%, 44%, 47%, 63%, 100% { transform: scaleY(0.22); }
+  34%, 50%, 58%                { transform: scaleY(0.55); }
+  39%, 53%                     { transform: scaleY(1); }
+}
+@keyframes dl-indeterminate-bar {
+  0%   { transform: translateX(-100%) scaleX(0.4); }
+  50%  { transform: translateX(0%)    scaleX(0.6); }
+  100% { transform: translateX(100%)  scaleX(0.4); }
+}
+`;
+
+// -- Color system -------------------------------------------------------------
+
+type ColorVariant = "mono" | "gradient" | "multi";
+
+const THEME_COLOR = {
+  primary: "hsl(var(--primary))",
+  working: "hsl(var(--status-working))",
+  done: "hsl(var(--status-done))",
+  waiting: "hsl(var(--status-waiting))",
+  blocked: "hsl(var(--status-blocked))",
+} as const;
+
+// Multi sequence picks distinct theme colors, ordered to avoid clashing hues.
+const MULTI_SEQUENCE = [
+  THEME_COLOR.primary,
+  THEME_COLOR.done,
+  THEME_COLOR.working,
+  THEME_COLOR.waiting,
+  THEME_COLOR.blocked,
 ];
 
-const statusColors: Record<string, string> = {
-  working: "bg-status-working/15 text-status-working border-status-working/40",
-  done: "bg-status-done/15 text-status-done border-status-done/35",
-  blocked: "bg-status-blocked/15 text-status-blocked border-status-blocked/40",
-  idle: "bg-muted text-muted-foreground border-border",
-};
+// 3-stop gradient for the "gradient" variant — visible even on short arcs.
+const GRADIENT_STOPS = [
+  THEME_COLOR.primary,
+  THEME_COLOR.done,
+  THEME_COLOR.working,
+];
 
-const statusDots: Record<string, string> = {
-  working: "bg-status-working",
-  done: "bg-status-done",
-  blocked: "bg-status-blocked",
-  idle: "bg-muted-foreground/50",
-};
+// Conic gradient string — used where we want a full rainbow around a full 360°.
+function conicGradient(stops: string[], from = "0deg"): string {
+  const ring = [...stops, stops[0]]; // close the loop
+  const pieces = ring
+    .map((c, i) => `${c} ${((i / (ring.length - 1)) * 360).toFixed(0)}deg`)
+    .join(", ");
+  return `conic-gradient(from ${from}, ${pieces})`;
+}
 
-// -- Style definitions --------------------------------------------------------
-interface StyleDef {
+function multiColorAt(index: number): string {
+  return MULTI_SEQUENCE[index % MULTI_SEQUENCE.length]!;
+}
+
+// -- Spinner components -------------------------------------------------------
+
+interface SpinnerProps {
+  size?: number;
+  variant: ColorVariant;
+  className?: string;
+}
+
+function ringMask(size: number, thickness: number): string {
+  const inner = Math.max(0, size / 2 - thickness);
+  return `radial-gradient(circle at center, transparent ${inner}px, black ${inner + 0.5}px, black ${size / 2}px)`;
+}
+
+function ringMaskStyle(size: number, thickness: number): React.CSSProperties {
+  const m = ringMask(size, thickness);
+  return { WebkitMask: m, mask: m };
+}
+
+function MaterialArcSpinner({ size = 32, variant, className }: SpinnerProps) {
+  // Mono keeps the classic Material dash-and-rotate arc.
+  if (variant === "mono") {
+    const stroke = Math.max(1.5, size / 10);
+    return (
+      <svg
+        className={`animate-spin ${className ?? ""}`}
+        style={{
+          width: size,
+          height: size,
+          animationDuration: "1.4s",
+          color: THEME_COLOR.primary,
+        }}
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          style={{
+            animation: "dl-material-dash 1.4s ease-in-out infinite",
+            transformOrigin: "center",
+          }}
+        />
+      </svg>
+    );
+  }
+
+  // Gradient / multi render as a conic-gradient ring with an arc cut out.
+  // A second `mask-image` fades one portion of the ring so it still reads as an arc.
+  const thickness = Math.max(2, size / 9);
+  const stops = variant === "gradient" ? GRADIENT_STOPS : MULTI_SEQUENCE;
+  const bg = conicGradient([...stops, stops[0]!]);
+  return (
+    <div
+      className={`animate-spin rounded-full ${className ?? ""}`}
+      style={{
+        width: size,
+        height: size,
+        background: bg,
+        animationDuration: "1.1s",
+        ...ringMaskStyle(size, thickness),
+      }}
+    />
+  );
+}
+
+function DualRingSpinner({ size = 32, variant, className }: SpinnerProps) {
+  const outerThickness = Math.max(2, size / 10);
+  const innerThickness = Math.max(1.5, size / 12);
+  const innerSize = Math.round(size * 0.55);
+
+  if (variant === "mono") {
+    const stroke = Math.max(1.5, size / 12);
+    return (
+      <div
+        className={`relative ${className ?? ""}`}
+        style={{ width: size, height: size, color: THEME_COLOR.primary }}
+      >
+        <svg
+          className="absolute inset-0 animate-spin"
+          style={{ animationDuration: "1.1s" }}
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeOpacity="0.18"
+            strokeWidth={stroke}
+          />
+          <path
+            d="M 12 2 A 10 10 0 0 1 22 12"
+            stroke="currentColor"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            fill="none"
+          />
+        </svg>
+        <svg
+          className="absolute inset-0 animate-spin"
+          style={{ animationDuration: "0.8s", animationDirection: "reverse" }}
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <path
+            d="M 12 6 A 6 6 0 0 1 18 12"
+            stroke="currentColor"
+            strokeOpacity="0.55"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            fill="none"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  const outerColors =
+    variant === "gradient"
+      ? [THEME_COLOR.primary, THEME_COLOR.done, THEME_COLOR.primary]
+      : [
+          THEME_COLOR.primary,
+          THEME_COLOR.done,
+          THEME_COLOR.working,
+          THEME_COLOR.waiting,
+          THEME_COLOR.primary,
+        ];
+  const innerColors =
+    variant === "gradient"
+      ? [THEME_COLOR.done, THEME_COLOR.primary, THEME_COLOR.done]
+      : [
+          THEME_COLOR.waiting,
+          THEME_COLOR.blocked,
+          THEME_COLOR.working,
+          THEME_COLOR.waiting,
+        ];
+
+  return (
+    <div
+      className={`relative ${className ?? ""}`}
+      style={{ width: size, height: size }}
+    >
+      <div
+        className="absolute inset-0 animate-spin rounded-full"
+        style={{
+          background: conicGradient(outerColors),
+          animationDuration: "1.1s",
+          ...ringMaskStyle(size, outerThickness),
+        }}
+      />
+      <div
+        className="absolute animate-spin rounded-full"
+        style={{
+          width: innerSize,
+          height: innerSize,
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          background: conicGradient(innerColors, "90deg"),
+          animationDuration: "0.8s",
+          animationDirection: "reverse",
+          ...ringMaskStyle(innerSize, innerThickness),
+        }}
+      />
+    </div>
+  );
+}
+
+function OrbitSpinner({ size = 32, variant, className }: SpinnerProps) {
+  const dot = Math.max(2, size / 6);
+
+  const dotStyle = (index: number, opacity: number): React.CSSProperties => {
+    if (variant === "mono") {
+      return { backgroundColor: THEME_COLOR.primary, opacity };
+    }
+    if (variant === "gradient") {
+      // Each dot is a radial gradient from primary to done — opacity still trails.
+      return {
+        backgroundImage: `radial-gradient(circle at 30% 30%, ${THEME_COLOR.primary}, ${THEME_COLOR.done})`,
+        opacity,
+      };
+    }
+    // multi: each dot gets a distinct theme color.
+    return { backgroundColor: multiColorAt(index) };
+  };
+
+  return (
+    <div
+      className={`relative animate-spin ${className ?? ""}`}
+      style={{ width: size, height: size, animationDuration: "1s" }}
+    >
+      <div
+        className="absolute rounded-full"
+        style={{
+          width: dot,
+          height: dot,
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          ...dotStyle(0, 1),
+        }}
+      />
+      <div
+        className="absolute rounded-full"
+        style={{
+          width: dot,
+          height: dot,
+          bottom: "10%",
+          right: "10%",
+          ...dotStyle(1, 0.6),
+        }}
+      />
+      <div
+        className="absolute rounded-full"
+        style={{
+          width: dot,
+          height: dot,
+          bottom: "10%",
+          left: "10%",
+          ...dotStyle(2, 0.3),
+        }}
+      />
+    </div>
+  );
+}
+
+function PulseDotsSpinner({ size = 32, variant, className }: SpinnerProps) {
+  const dot = Math.max(3, size / 4);
+  const gap = Math.max(2, size / 8);
+
+  const dotStyle = (i: number): React.CSSProperties => {
+    if (variant === "mono") return { backgroundColor: THEME_COLOR.primary };
+    if (variant === "multi") return { backgroundColor: multiColorAt(i) };
+    // gradient: each dot gets a radial gradient sampled from a different point
+    // along the primary→done transition — so the row reads as a smooth sweep.
+    const starts = [THEME_COLOR.primary, THEME_COLOR.done, THEME_COLOR.working];
+    const ends = [THEME_COLOR.done, THEME_COLOR.working, THEME_COLOR.primary];
+    return {
+      backgroundImage: `radial-gradient(circle at 30% 30%, ${starts[i]}, ${ends[i]})`,
+    };
+  };
+
+  return (
+    <div
+      className={`flex items-center ${className ?? ""}`}
+      style={{ gap, height: size }}
+    >
+      {[0, 0.16, 0.32].map((delay, i) => (
+        <div
+          key={delay}
+          className="rounded-full"
+          style={{
+            width: dot,
+            height: dot,
+            animation: "dl-pulse-dot 1.2s ease-in-out infinite",
+            animationDelay: `${delay}s`,
+            ...dotStyle(i),
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RadarSpinner({ size = 32, variant, className }: SpinnerProps) {
+  // A rotating conic "sweep" — transparent on the back side, color-rich on the
+  // leading edge so it feels like a scanner.
+  const thickness = Math.max(2, size / 9);
+
+  const sweep =
+    variant === "mono"
+      ? `conic-gradient(from 0deg, transparent 0deg, ${THEME_COLOR.primary} 270deg, ${THEME_COLOR.primary} 360deg)`
+      : variant === "gradient"
+        ? `conic-gradient(from 0deg, transparent 0deg, ${THEME_COLOR.primary} 120deg, ${THEME_COLOR.done} 240deg, ${THEME_COLOR.working} 360deg)`
+        : `conic-gradient(from 0deg, transparent 0deg, ${THEME_COLOR.blocked} 60deg, ${THEME_COLOR.waiting} 150deg, ${THEME_COLOR.working} 240deg, ${THEME_COLOR.done} 320deg, ${THEME_COLOR.primary} 360deg)`;
+
+  return (
+    <div
+      className={`relative ${className ?? ""}`}
+      style={{ width: size, height: size }}
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          border: `${Math.max(1, thickness * 0.4)}px solid ${THEME_COLOR.primary}`,
+          opacity: 0.12,
+        }}
+      />
+      <div
+        className="absolute inset-0 animate-spin rounded-full"
+        style={{
+          background: sweep,
+          animationDuration: "1.1s",
+          ...ringMaskStyle(size, thickness),
+        }}
+      />
+    </div>
+  );
+}
+
+function ActivityBarsSpinner({ size = 32, variant, className }: SpinnerProps) {
+  const bar = Math.max(2, size / 8);
+  const gap = Math.max(1, size / 12);
+
+  // Rainbow palette specific to this spinner — avoids the primary/done hue
+  // collision several themes have, so each bar reads as a distinct color.
+  const RAINBOW = [
+    THEME_COLOR.blocked,
+    THEME_COLOR.waiting,
+    THEME_COLOR.working,
+    THEME_COLOR.done,
+  ];
+
+  const barStyle = (i: number): React.CSSProperties => {
+    if (variant === "mono") return { backgroundColor: THEME_COLOR.primary };
+    if (variant === "multi") {
+      return {
+        backgroundColor: RAINBOW[i % RAINBOW.length],
+        filter: "saturate(1.35) brightness(1.05)",
+      };
+    }
+    // gradient: 4 evenly-distributed stops (0 / 33 / 66 / 100%).
+    return {
+      backgroundImage: `linear-gradient(to top, ${RAINBOW.join(", ")})`,
+      filter: "saturate(1.35) brightness(1.05)",
+    };
+  };
+
+  return (
+    <div
+      className={`flex items-center ${className ?? ""}`}
+      style={{ gap, height: size, width: size }}
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="rounded-full"
+          style={{
+            width: bar,
+            height: "100%",
+            transformOrigin: "center",
+            animation: `dl-bar-wave-${i} 2.4s ease-in-out infinite`,
+            ...barStyle(i),
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ConicRingSpinner({ size = 32, variant, className }: SpinnerProps) {
+  const thickness = Math.max(2, size / 8);
+
+  const bg =
+    variant === "mono"
+      ? `conic-gradient(from 0deg, transparent 0deg, ${THEME_COLOR.primary} 300deg, transparent 360deg)`
+      : variant === "gradient"
+        ? conicGradient([
+            THEME_COLOR.primary,
+            THEME_COLOR.done,
+            THEME_COLOR.working,
+            THEME_COLOR.done,
+            THEME_COLOR.primary,
+          ])
+        : conicGradient([
+            THEME_COLOR.primary,
+            THEME_COLOR.done,
+            THEME_COLOR.working,
+            THEME_COLOR.waiting,
+            THEME_COLOR.blocked,
+            THEME_COLOR.primary,
+          ]);
+
+  return (
+    <div
+      className={`animate-spin rounded-full ${className ?? ""}`}
+      style={{
+        width: size,
+        height: size,
+        background: bg,
+        animationDuration: "1.4s",
+        ...ringMaskStyle(size, thickness),
+      }}
+    />
+  );
+}
+
+// -- Spinner registry ---------------------------------------------------------
+
+interface SpinnerDef {
   id: string;
   label: string;
-  subtitle: string;
-  wrapper: string;
-  card: string;
-  cardHover: string;
-  sidebar: string;
-  badge: string;
-  modal: string;
-  modalBackdrop: string;
-  button: string;
-  buttonPrimary: string;
-  input: string;
-  navItem: string;
-  navItemActive: string;
-  heading: string;
-  subtext: string;
-  dataRow: string;
-  dataRowHover: string;
-  separator: string;
+  description: string;
+  Component: React.FC<SpinnerProps>;
 }
 
-const styles: StyleDef[] = [
-  // 1. Current flat style
+const spinners: SpinnerDef[] = [
   {
-    id: "current",
-    label: "Current",
-    subtitle: "Flat surfaces, thin borders, minimal shadows",
-    wrapper: "bg-background",
-    card: "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
-    cardHover: "hover:bg-muted/50",
-    sidebar: "border-r border-border bg-card",
-    badge:
-      "rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide",
-    modal: "rounded-xl border border-border bg-card p-6",
-    modalBackdrop: "bg-black/50",
-    button:
-      "rounded-md border border-border bg-muted text-foreground px-3 py-2 text-sm font-medium hover:bg-muted/80",
-    buttonPrimary:
-      "rounded-md bg-primary text-primary-foreground px-3 py-2 text-sm font-medium hover:bg-primary/90",
-    input:
-      "rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground",
-    navItem:
-      "rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 hover:text-foreground",
-    navItemActive: "rounded-md px-3 py-2 text-sm bg-muted text-foreground",
-    heading: "text-lg font-semibold text-foreground",
-    subtext: "text-sm text-muted-foreground",
-    dataRow: "border-b border-border px-4 py-3",
-    dataRowHover: "hover:bg-muted/40",
-    separator: "border-t border-border",
+    id: "conic-ring",
+    label: "Conic Ring",
+    description:
+      "Solid ring filled with a rotating conic gradient. Shows every color at once — strongest for gradient / multi modes.",
+    Component: ConicRingSpinner,
   },
-  // 2. Soft Elevation
   {
-    id: "elevation",
-    label: "Soft Elevation",
-    subtitle: "Raised surfaces, glow halos, hover lift, inset inputs",
-    wrapper: "bg-background",
-    card: "rounded-xl border border-white/[0.06] bg-card text-card-foreground shadow-[0_2px_4px_rgba(0,0,0,0.4),0_8px_24px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.04)_inset]",
-    cardHover:
-      "hover:shadow-[0_4px_12px_rgba(0,0,0,0.5),0_16px_48px_rgba(0,0,0,0.35),0_0_24px_hsl(var(--primary)/0.06)] hover:-translate-y-1 transition-all duration-200",
-    sidebar:
-      "border-r border-white/[0.04] bg-[hsl(var(--card))] shadow-[4px_0_16px_rgba(0,0,0,0.3),1px_0_0_rgba(255,255,255,0.03)]",
-    badge:
-      "rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide shadow-[0_1px_4px_rgba(0,0,0,0.3)]",
-    modal:
-      "rounded-2xl border border-white/[0.08] bg-card p-6 shadow-[0_12px_48px_rgba(0,0,0,0.6),0_4px_16px_rgba(0,0,0,0.4),0_0_0_1px_rgba(255,255,255,0.06)_inset,0_0_80px_hsl(var(--primary)/0.05)]",
-    modalBackdrop: "bg-black/65",
-    button:
-      "rounded-lg border border-white/[0.06] bg-muted text-foreground px-3 py-2 text-sm font-medium shadow-[0_2px_6px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.03)_inset] hover:shadow-[0_4px_12px_rgba(0,0,0,0.35)] hover:-translate-y-0.5 active:translate-y-0 active:shadow-[0_1px_2px_rgba(0,0,0,0.3)] transition-all duration-150",
-    buttonPrimary:
-      "rounded-lg bg-primary text-primary-foreground px-3 py-2 text-sm font-medium shadow-[0_2px_8px_rgba(0,0,0,0.3),0_0_16px_hsl(var(--primary)/0.15),0_1px_0_rgba(255,255,255,0.1)_inset] hover:shadow-[0_4px_16px_rgba(0,0,0,0.35),0_0_24px_hsl(var(--primary)/0.25)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-150",
-    input:
-      "rounded-lg border border-white/[0.04] bg-[hsl(var(--background))] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground shadow-[inset_0_2px_6px_rgba(0,0,0,0.35),inset_0_0_0_1px_rgba(0,0,0,0.15)] focus:shadow-[inset_0_2px_6px_rgba(0,0,0,0.35),0_0_0_2px_hsl(var(--ring)/0.35)]",
-    navItem:
-      "rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 hover:text-foreground hover:shadow-[0_2px_8px_rgba(0,0,0,0.2)] transition-all duration-150",
-    navItemActive:
-      "rounded-lg px-3 py-2 text-sm bg-muted text-foreground shadow-[0_2px_8px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.06)]",
-    heading: "text-lg font-semibold text-foreground",
-    subtext: "text-sm text-muted-foreground",
-    dataRow: "border-b border-white/[0.04] px-4 py-3",
-    dataRowHover:
-      "hover:bg-white/[0.02] hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] transition-all duration-150",
-    separator: "border-t border-white/[0.04]",
+    id: "material-arc",
+    label: "Material Arc",
+    description:
+      "Rotating circle whose stroke grows and shrinks — classic Material feel.",
+    Component: MaterialArcSpinner,
   },
-  // 3. Layered Glass
   {
-    id: "glass",
-    label: "Layered Glass",
-    subtitle:
-      "Frosted blur, translucent panels, luminous borders, glowing accents",
-    wrapper:
-      "bg-background bg-[radial-gradient(ellipse_at_top,hsl(var(--primary)/0.08),transparent_60%),radial-gradient(ellipse_at_bottom_right,hsl(var(--status-done)/0.06),transparent_50%)]",
-    card: "rounded-xl border border-white/[0.12] bg-white/[0.04] backdrop-blur-xl text-card-foreground shadow-[0_4px_24px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.08)]",
-    cardHover:
-      "hover:border-white/[0.18] hover:bg-white/[0.07] hover:shadow-[0_4px_24px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.12),0_0_20px_hsl(var(--primary)/0.06)] transition-all duration-250",
-    sidebar:
-      "border-r border-white/[0.1] bg-white/[0.03] backdrop-blur-2xl shadow-[inset_-1px_0_0_rgba(255,255,255,0.06)]",
-    badge:
-      "rounded-full border border-white/[0.12] px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide bg-white/[0.06] backdrop-blur-md shadow-[0_1px_4px_rgba(0,0,0,0.2)]",
-    modal:
-      "rounded-2xl border border-white/[0.15] bg-white/[0.06] backdrop-blur-2xl p-6 shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.12),0_0_40px_hsl(var(--primary)/0.06)]",
-    modalBackdrop: "bg-black/50 backdrop-blur-md",
-    button:
-      "rounded-lg border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-foreground px-3 py-2 text-sm font-medium shadow-[0_1px_4px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-white/[0.1] hover:border-white/[0.18] transition-all duration-150",
-    buttonPrimary:
-      "rounded-lg bg-primary/80 backdrop-blur-md text-primary-foreground px-3 py-2 text-sm font-medium border border-white/[0.15] shadow-[0_2px_8px_rgba(0,0,0,0.25),0_0_20px_hsl(var(--primary)/0.25),inset_0_1px_0_rgba(255,255,255,0.15)] hover:shadow-[0_2px_8px_rgba(0,0,0,0.25),0_0_32px_hsl(var(--primary)/0.35)] hover:bg-primary/90 transition-all duration-150",
-    input:
-      "rounded-lg border border-white/[0.1] bg-black/20 backdrop-blur-md px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/70 shadow-[inset_0_1px_4px_rgba(0,0,0,0.2)] focus:border-white/[0.2] focus:shadow-[inset_0_1px_4px_rgba(0,0,0,0.2),0_0_0_2px_hsl(var(--ring)/0.25)]",
-    navItem:
-      "rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-all duration-150",
-    navItemActive:
-      "rounded-lg px-3 py-2 text-sm bg-white/[0.08] text-foreground border border-white/[0.1] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]",
-    heading:
-      "text-lg font-semibold text-foreground drop-shadow-[0_1px_2px_rgba(0,0,0,0.3)]",
-    subtext: "text-sm text-muted-foreground/80",
-    dataRow: "border-b border-white/[0.06] px-4 py-3",
-    dataRowHover: "hover:bg-white/[0.04] transition-colors duration-150",
-    separator: "border-t border-white/[0.08]",
+    id: "dual-ring",
+    label: "Dual Ring",
+    description:
+      "Two arcs counter-rotating at different speeds. Feels mechanical.",
+    Component: DualRingSpinner,
   },
-  // 4. Editorial
   {
-    id: "editorial",
-    label: "Editorial",
-    subtitle: "Bold type hierarchy, generous spacing, depth through contrast",
-    wrapper: "bg-[hsl(var(--surface))]",
-    card: "rounded-2xl bg-card text-card-foreground border-0",
-    cardHover:
-      "hover:bg-[hsl(var(--muted)/0.5)] transition-colors duration-200",
-    sidebar: "bg-[hsl(var(--background))] border-r-0 shadow-none",
-    badge:
-      "rounded-md border-0 bg-muted px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-[0.15em]",
-    modal:
-      "rounded-3xl border-0 bg-card p-10 shadow-[0_32px_80px_rgba(0,0,0,0.6)]",
-    modalBackdrop: "bg-black/75",
-    button:
-      "rounded-xl border-0 bg-muted text-foreground px-5 py-3 text-sm font-semibold tracking-wide hover:bg-muted/80 transition-colors duration-150",
-    buttonPrimary:
-      "rounded-xl border-0 bg-primary text-primary-foreground px-5 py-3 text-sm font-semibold tracking-wide hover:bg-primary/90 transition-colors duration-150",
-    input:
-      "rounded-xl border-2 border-transparent bg-muted/40 px-5 py-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:bg-muted/60 focus:border-primary/30 focus:ring-0 transition-all duration-150",
-    navItem:
-      "rounded-xl px-4 py-3 text-sm font-medium text-muted-foreground/70 hover:text-foreground transition-colors duration-150",
-    navItemActive:
-      "rounded-xl px-4 py-3 text-sm font-black text-foreground border-l-2 border-primary",
-    heading: "text-2xl font-black tracking-tight text-foreground",
-    subtext:
-      "text-xs text-muted-foreground/60 font-light tracking-[0.08em] uppercase",
-    dataRow: "px-6 py-5",
-    dataRowHover: "hover:bg-muted/15 transition-colors duration-150",
-    separator: "border-t border-white/[0.04]",
+    id: "orbit",
+    label: "Orbit",
+    description: "Three dots orbiting with trailing opacity. Playful, agent-y.",
+    Component: OrbitSpinner,
+  },
+  {
+    id: "pulse-dots",
+    label: "Pulse Dots",
+    description:
+      "Staggered fade across three dots. Reads well inline in text like 'Loading…'.",
+    Component: PulseDotsSpinner,
+  },
+  {
+    id: "radar",
+    label: "Radar Sweep",
+    description:
+      "Gradient arc sweeping a faded track. Feels like it's scanning for something.",
+    Component: RadarSpinner,
+  },
+  {
+    id: "activity-bars",
+    label: "Activity Bars",
+    description:
+      "Wave travels right, bounces off the end, returns, rests. Considered, not urgent.",
+    Component: ActivityBarsSpinner,
   },
 ];
 
-// -- Mock Components ----------------------------------------------------------
+// -- UI pieces ---------------------------------------------------------------
 
-function StatusBadge({ status, style }: { status: string; style: StyleDef }) {
+function SpinnerCell({
+  def,
+  variant,
+}: {
+  def: SpinnerDef;
+  variant: ColorVariant;
+}) {
+  const { Component, label, description } = def;
   return (
-    <span className={`${style.badge} ${statusColors[status]}`}>{status}</span>
+    <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-4">
+      <div>
+        <div className="text-sm font-semibold text-foreground">{label}</div>
+        <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+          {description}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-center rounded-lg bg-muted/40 p-6">
+        <Component size={56} variant={variant} />
+      </div>
+
+      <div className="flex items-center justify-around rounded-lg bg-muted/25 p-3">
+        <div className="flex flex-col items-center gap-1.5">
+          <Component size={16} variant={variant} />
+          <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+            sm
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-1.5">
+          <Component size={24} variant={variant} />
+          <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+            md
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-1.5">
+          <Component size={40} variant={variant} />
+          <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+            lg
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <button className="inline-flex items-center gap-2 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium">
+          <Component size={14} variant={variant} />
+          Loading
+        </button>
+        <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+          <Component size={14} variant={variant} />
+          Loading jobs…
+        </div>
+      </div>
+    </div>
   );
 }
 
-function AgentCard({
-  agent,
-  style,
+function IndeterminateBar({ variant }: { variant: ColorVariant }) {
+  const background =
+    variant === "mono"
+      ? THEME_COLOR.primary
+      : variant === "gradient"
+        ? `linear-gradient(to right, ${THEME_COLOR.primary}, ${THEME_COLOR.done})`
+        : `linear-gradient(to right, ${THEME_COLOR.primary}, ${THEME_COLOR.done}, ${THEME_COLOR.working}, ${THEME_COLOR.waiting})`;
+  return (
+    <div className="relative h-1 w-full overflow-hidden rounded-full bg-muted">
+      <div
+        className="absolute inset-y-0 left-0 w-1/3 rounded-full"
+        style={{
+          background,
+          animation: "dl-indeterminate-bar 1.6s ease-in-out infinite",
+        }}
+      />
+    </div>
+  );
+}
+
+function ThemePicker({
+  theme,
+  setTheme,
 }: {
-  agent: (typeof agents)[0];
-  style: StyleDef;
+  theme: ThemeId;
+  setTheme: (id: ThemeId) => void;
 }) {
   return (
-    <div className={`${style.card} ${style.cardHover} p-4 cursor-pointer`}>
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <div className={`w-2 h-2 rounded-full ${statusDots[agent.status]}`} />
-          <span className="text-sm font-medium text-foreground">
-            {agent.name}
-          </span>
-        </div>
-        <StatusBadge status={agent.status} style={style} />
-      </div>
-      <div className="flex items-center gap-3 text-xs text-muted-foreground">
-        <span>{agent.model}</span>
-        <span className="opacity-40">|</span>
-        <span className="font-mono">{agent.branch}</span>
-        <span className="ml-auto tabular-nums">{agent.elapsed}</span>
-      </div>
-    </div>
-  );
-}
-
-function MockSidebar({ style }: { style: StyleDef }) {
-  return (
-    <div
-      className={`${style.sidebar} w-64 p-3 flex flex-col gap-1 rounded-l-xl`}
-    >
-      <div className="flex items-center gap-2 px-3 py-2 mb-3">
-        <div className="w-5 h-5 rounded bg-primary/80" />
-        <span className="text-sm font-semibold text-foreground">Dispatch</span>
-      </div>
-      <div className="px-3 mb-2">
-        <span className={style.subtext}>Navigation</span>
-      </div>
-      {["Agents", "Jobs", "Activity", "Settings"].map((item, i) => (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-muted-foreground uppercase tracking-wide mr-1">
+        Theme
+      </span>
+      {THEMES.map((t) => (
         <button
-          key={item}
-          className={`text-left ${i === 0 ? style.navItemActive : style.navItem}`}
+          key={t.id}
+          onClick={() => setTheme(t.id)}
+          className={`group flex items-center gap-2 rounded-lg border px-2.5 py-1.5 text-xs transition-colors ${
+            theme === t.id
+              ? "border-primary bg-primary/10 text-foreground"
+              : "border-border bg-card text-muted-foreground hover:text-foreground"
+          }`}
+          title={t.description}
         >
-          {item}
+          <span className="flex gap-0.5">
+            {t.swatches.slice(0, 3).map((swatch, i) => (
+              <span
+                key={i}
+                className="h-3 w-3 rounded-sm border border-black/20"
+                style={{ backgroundColor: swatch }}
+              />
+            ))}
+          </span>
+          {t.label}
         </button>
       ))}
-      <div className={`${style.separator} my-3`} />
-      <div className="px-3 mb-2">
-        <span className={style.subtext}>System</span>
-      </div>
-      <div className="flex items-center gap-2 px-3 py-1.5">
-        <div className="w-1.5 h-1.5 rounded-full bg-status-working" />
-        <span className="text-xs text-muted-foreground">API</span>
-        <span className="text-xs text-status-working ml-auto">ok</span>
-      </div>
-      <div className="flex items-center gap-2 px-3 py-1.5">
-        <div className="w-1.5 h-1.5 rounded-full bg-status-working" />
-        <span className="text-xs text-muted-foreground">DB</span>
-        <span className="text-xs text-status-working ml-auto">ok</span>
-      </div>
     </div>
   );
 }
 
-function MockModal({ style }: { style: StyleDef }) {
-  return (
-    <div className="relative">
-      <div className={`absolute inset-0 rounded-xl ${style.modalBackdrop}`} />
-      <div className="relative flex items-center justify-center py-12 px-8">
-        <div className={`${style.modal} w-full max-w-sm`}>
-          <h3 className={`${style.heading} mb-1`}>Create Agent</h3>
-          <p className={`${style.subtext} mb-5`}>
-            Configure a new agent session.
-          </p>
-          <div className="space-y-3 mb-5">
-            <input
-              className={`${style.input} w-full`}
-              placeholder="Agent name"
-            />
-            <input
-              className={`${style.input} w-full`}
-              placeholder="~/path/to/project"
-            />
-          </div>
-          <div className="flex justify-end gap-2">
-            <button className={style.button}>Cancel</button>
-            <button className={style.buttonPrimary}>Create</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MockDataTable({ style }: { style: StyleDef }) {
-  const rows = [
-    {
-      name: "Nightly E2E",
-      schedule: "0 2 * * *",
-      lastRun: "2h ago",
-      status: "done",
-    },
-    {
-      name: "PR Triage",
-      schedule: "*/30 * * * *",
-      lastRun: "12m ago",
-      status: "working",
-    },
-    {
-      name: "Stale Branch Cleanup",
-      schedule: "0 9 * * 1",
-      lastRun: "3d ago",
-      status: "blocked",
-    },
+function VariantPicker({
+  variant,
+  setVariant,
+}: {
+  variant: ColorVariant;
+  setVariant: (v: ColorVariant) => void;
+}) {
+  const options: { id: ColorVariant; label: string; hint: string }[] = [
+    { id: "mono", label: "Mono", hint: "Primary color only" },
+    { id: "gradient", label: "Gradient", hint: "Primary → Done" },
+    { id: "multi", label: "Multi", hint: "All status colors" },
   ];
   return (
-    <div className={`${style.card} overflow-hidden`}>
-      <div className="px-4 py-3">
-        <span className={style.heading}>Jobs</span>
-      </div>
-      <div className={style.separator} />
-      <div
-        className={`${style.dataRow} flex items-center text-xs font-medium text-muted-foreground uppercase tracking-wider`}
-      >
-        <span className="flex-1">Name</span>
-        <span className="w-32">Schedule</span>
-        <span className="w-24">Last Run</span>
-        <span className="w-20 text-right">Status</span>
-      </div>
-      {rows.map((row) => (
-        <div
-          key={row.name}
-          className={`${style.dataRow} ${style.dataRowHover} flex items-center text-sm cursor-pointer`}
-        >
-          <span className="flex-1 font-medium text-foreground">{row.name}</span>
-          <span className="w-32 font-mono text-xs text-muted-foreground">
-            {row.schedule}
-          </span>
-          <span className="w-24 text-muted-foreground">{row.lastRun}</span>
-          <span className="w-20 text-right">
-            <StatusBadge status={row.status} style={style} />
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// -- Full variant preview -----------------------------------------------------
-
-function VariantPreview({ style }: { style: StyleDef }) {
-  return (
-    <div
-      className={`${style.wrapper} rounded-xl border border-border/30 overflow-hidden`}
-    >
-      <div className="px-6 py-4 border-b border-border/30">
-        <h2 className="text-xl font-bold text-foreground">{style.label}</h2>
-        <p className={style.subtext}>{style.subtitle}</p>
-      </div>
-
-      <div className="flex min-h-[520px]">
-        <MockSidebar style={style} />
-        <div className="flex-1 p-5 space-y-5 overflow-hidden">
-          <div>
-            <h3 className={`${style.heading} mb-3`}>Agent Cards</h3>
-            <div className="grid grid-cols-2 gap-3">
-              {agents.map((a) => (
-                <AgentCard key={a.name} agent={a} style={style} />
-              ))}
-            </div>
-          </div>
-
-          <MockDataTable style={style} />
-
-          <div>
-            <h3 className={`${style.heading} mb-3`}>Controls</h3>
-            <div className="flex items-center gap-3 flex-wrap">
-              <button className={style.button}>Default</button>
-              <button className={style.buttonPrimary}>Primary</button>
-              <input
-                className={`${style.input} w-48`}
-                placeholder="Search agents..."
-              />
-              {(["working", "done", "blocked", "idle"] as const).map((s) => (
-                <StatusBadge key={s} status={s} style={style} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="border-t border-border/30">
-        <div className="px-6 py-3">
-          <h3 className={`${style.heading} mb-0`}>Modal</h3>
-        </div>
-        <MockModal style={style} />
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground uppercase tracking-wide mr-1">
+        Color
+      </span>
+      <div className="inline-flex rounded-lg border border-border bg-card p-0.5">
+        {options.map((o) => (
+          <button
+            key={o.id}
+            onClick={() => setVariant(o.id)}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              variant === o.id
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            title={o.hint}
+          >
+            {o.label}
+          </button>
+        ))}
       </div>
     </div>
   );
 }
 
-// -- Main page ----------------------------------------------------------------
+// -- Main page ---------------------------------------------------------------
 
 export function DesignLab() {
-  const [selected, setSelected] = useState<string | null>(null);
-  const visibleStyles = selected
-    ? styles.filter((s) => s.id === selected)
-    : styles;
+  const { theme, setTheme } = useTheme();
+  const [variant, setVariant] = useState<ColorVariant>("gradient");
 
   useEffect(() => {
     const style = document.createElement("style");
     style.textContent =
-      "html, body, #root { overflow: auto !important; height: auto !important; }";
+      "html, body, #root { overflow: auto !important; height: auto !important; }" +
+      SPINNER_KEYFRAMES;
     document.head.appendChild(style);
     return () => {
       style.remove();
@@ -444,47 +711,45 @@ export function DesignLab() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-surface p-8">
-      <div className="max-w-[1600px] mx-auto mb-8">
-        <h1 className="text-3xl font-bold tracking-tight text-foreground mb-2">
-          Design Lab
-        </h1>
-        <p className="text-muted-foreground mb-6">
-          Comparing depth & elevation treatments for Dispatch. Each variant
-          renders the same mock components with different visual styles.
-        </p>
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-[1400px] mx-auto">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground mb-1">
+            Loading Spinners
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Candidate replacements for the current{" "}
+            <code className="text-xs bg-muted rounded px-1 py-0.5">
+              Loader2
+            </code>{" "}
+            spinner. Try different themes and color variants to find the
+            combination that fits.
+          </p>
+        </header>
 
-        <div className="flex gap-2 flex-wrap">
-          <button
-            onClick={() => setSelected(null)}
-            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-              selected === null
-                ? "bg-primary text-primary-foreground"
-                : "bg-muted text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            All
-          </button>
-          {styles.map((s) => (
-            <button
-              key={s.id}
-              onClick={() => setSelected(selected === s.id ? null : s.id)}
-              className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                selected === s.id
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {s.label}
-            </button>
+        <div className="sticky top-0 z-10 -mx-2 mb-8 rounded-xl border border-border bg-background/80 backdrop-blur px-4 py-3 flex items-center gap-6 flex-wrap">
+          <ThemePicker theme={theme} setTheme={setTheme} />
+          <VariantPicker variant={variant} setVariant={setVariant} />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-8">
+          {spinners.map((def) => (
+            <SpinnerCell key={def.id} def={def} variant={variant} />
           ))}
         </div>
-      </div>
 
-      <div className="max-w-[1600px] mx-auto space-y-10">
-        {visibleStyles.map((s) => (
-          <VariantPreview key={s.id} style={s} />
-        ))}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="mb-3">
+            <div className="text-sm font-semibold text-foreground">
+              Indeterminate Bar
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Alternative for list/table loading states — a top-of-pane bar
+              instead of a centered spinner.
+            </p>
+          </div>
+          <IndeterminateBar variant={variant} />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -8,8 +8,6 @@ import {
   Clock,
   GitBranch,
   History,
-  Loader2,
-  LoaderCircle,
   MessageSquareText,
   Play,
   Settings,
@@ -149,7 +147,7 @@ function statusIcon(status: JobRunStatus | null): JSX.Element | null {
   if (status === "failed" || status === "timed_out" || status === "crashed")
     return <XCircle className="h-3.5 w-3.5" />;
   if (status === "started" || status === "running" || status === "needs_input")
-    return <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin" />;
+    return <ActivityBars size={14} className="shrink-0" />;
   return null;
 }
 
@@ -1356,7 +1354,7 @@ function AddJobFlow({
             }).catch((error) => setSubmitError(errorMessage(error)));
           }}
         >
-          {isAdding ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {isAdding ? <ActivityBars size={16} className="mr-2" /> : null}
           Add job
         </Button>
       </div>
@@ -1927,9 +1925,7 @@ function SettingsTab({
                 });
             }}
           >
-            {isUpdating ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : null}
+            {isUpdating ? <ActivityBars size={16} className="mr-2" /> : null}
             Save
           </Button>
         </div>
@@ -2017,7 +2013,7 @@ function RemoveJobDialog({
               onClick={onConfirm}
             >
               {isRemoving ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <ActivityBars size={16} className="mr-2" />
               ) : (
                 <Trash2 className="mr-2 h-4 w-4" />
               )}
@@ -2100,9 +2096,7 @@ function PromptTab({
                 });
             }}
           >
-            {isUpdating ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : null}
+            {isUpdating ? <ActivityBars size={16} className="mr-2" /> : null}
             Save prompt
           </Button>
         </div>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -23,6 +23,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { PathInput } from "@/components/app/path-input";
 import { type Agent } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -383,7 +384,7 @@ export function JobListContent({
           </div>
         ) : isLoading ? (
           <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" /> Loading jobs...
+            <ActivityBars size={16} /> Loading jobs...
           </div>
         ) : jobs.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground">
@@ -673,7 +674,7 @@ function JobsOverview({
         {/* Loading */}
         {statsLoading && !metrics && (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <ActivityBars size={20} />
           </div>
         )}
 
@@ -2128,7 +2129,7 @@ function HistoryTab({
     <ScrollArea className="mt-4 min-h-0 h-full pr-1">
       {loading ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" /> Loading history...
+          <ActivityBars size={16} /> Loading history...
         </div>
       ) : runs.length === 0 ? (
         <div className="text-sm text-muted-foreground">No runs yet.</div>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -10,7 +10,6 @@ import {
   ChevronRight,
   ExternalLink,
   FileText,
-  Loader2,
   MonitorPlay,
   X,
   Image,
@@ -29,6 +28,7 @@ import {
   stripTimestamp,
 } from "@/components/app/media-lightbox";
 import { PinsPanel } from "@/components/app/pins-panel";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -198,7 +198,7 @@ function MediaContent({
               onClick={triggerFilePicker}
             >
               {uploading ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
+                <ActivityBars size={12} />
               ) : uploadSuccess ? (
                 <Check className="h-3 w-3" />
               ) : (

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -4,10 +4,10 @@ import {
   CheckCircle2,
   ChevronDown,
   GitBranch,
-  Loader2,
   X,
 } from "lucide-react";
 
+import { ActivityBars } from "@/components/ui/activity-bars";
 import {
   Command,
   CommandGroup,
@@ -282,7 +282,7 @@ export function PathInput({
       {showValidation ? (
         <div className="flex h-5 items-center justify-end gap-1.5 text-xs">
           {validating ? (
-            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+            <ActivityBars size={12} />
           ) : pathValidation ? (
             pathValidation.isDirectory ? (
               <>

--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -8,6 +8,7 @@ import {
   Zap,
 } from "lucide-react";
 import { OperationTakeover } from "@/components/app/release-manager";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import type {
   ReleaseInfo,
@@ -226,7 +227,7 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
 
         {infoLoading && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <ActivityBars size={14} />
             Loading...
           </div>
         )}
@@ -346,7 +347,7 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
 
         {releasesLoading && releases.length === 0 && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <ActivityBars size={14} />
             Loading...
           </div>
         )}

--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from "react";
 import {
   CheckCircle2,
   ExternalLink,
-  Loader2,
   ShieldCheck,
   Sparkles,
   Zap,
@@ -384,7 +383,7 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
                       disabled={promotingTag === r.tag}
                     >
                       {promotingTag === r.tag ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
+                        <ActivityBars size={12} />
                       ) : (
                         "Promote"
                       )}

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -5,11 +5,11 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
-  Loader2,
   RefreshCw,
   Trash2,
   XCircle,
 } from "lucide-react";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import {
@@ -343,7 +343,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
 
         {infoLoading && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <ActivityBars size={14} />
             Checking...
           </div>
         )}

--- a/apps/web/src/components/app/release-shared.tsx
+++ b/apps/web/src/components/app/release-shared.tsx
@@ -1,4 +1,3 @@
-import { Loader2 } from "lucide-react";
 import type { ReleaseJob, ReleasePhase } from "@/hooks/use-release-stream";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { LogStream } from "@/components/ui/log-stream";
@@ -64,7 +63,7 @@ export function PhaseProgress({
                   {PHASE_LABELS[phase as ReleasePhase] ?? phase}
                 </span>
                 {current && isRestarting && phase === "restarting" && (
-                  <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                  <ActivityBars size={12} />
                 )}
               </div>
             );

--- a/apps/web/src/components/app/release-shared.tsx
+++ b/apps/web/src/components/app/release-shared.tsx
@@ -1,5 +1,6 @@
 import { Loader2 } from "lucide-react";
 import type { ReleaseJob, ReleasePhase } from "@/hooks/use-release-stream";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { LogStream } from "@/components/ui/log-stream";
 import { cn } from "@/lib/utils";
 
@@ -96,7 +97,7 @@ export function OperationLog({
           ))}
         {(isRestarting || postRestartPolling) && !job.log.length && (
           <div className="flex items-center gap-2 text-[hsl(var(--log-stream-muted-foreground))]">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <ActivityBars size={14} />
             Waiting for Dispatch to restart...
           </div>
         )}

--- a/apps/web/src/components/app/stop-agent-dialog.tsx
+++ b/apps/web/src/components/app/stop-agent-dialog.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from "react";
-import { Loader2, Pause } from "lucide-react";
+import { Pause } from "lucide-react";
 
 import { type Agent } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -78,7 +79,7 @@ export function StopAgentDialog({
             onClick={() => void handleConfirmStop()}
           >
             {stopping ? (
-              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              <ActivityBars size={16} className="mr-1.5" />
             ) : (
               <Pause className="mr-1.5 h-4 w-4" />
             )}

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -1,5 +1,5 @@
 import { memo, type RefCallback, useEffect, useState } from "react";
-import { Archive, Loader2, TerminalSquare } from "lucide-react";
+import { Archive, TerminalSquare } from "lucide-react";
 
 import { type Agent, type ConnState } from "@/components/app/types";
 import { ActivityBars } from "@/components/ui/activity-bars";
@@ -100,7 +100,7 @@ export const TerminalPane = memo(function TerminalPane({
               Archiving agent
             </p>
             <div className="flex items-center gap-2 text-sm text-orange-400">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <ActivityBars size={16} />
               <span>
                 {archivePhase === "stopping"
                   ? "Stopping agent…"

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -2,6 +2,7 @@ import { memo, type RefCallback, useEffect, useState } from "react";
 import { Archive, Loader2, TerminalSquare } from "lucide-react";
 
 import { type Agent, type ConnState } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { cn } from "@/lib/utils";
 
 type TerminalPaneProps = {
@@ -121,8 +122,8 @@ export const TerminalPane = memo(function TerminalPane({
 
       {showReconnectOverlay ? (
         <div className="absolute inset-0 z-30 grid place-items-center bg-black/70 backdrop-blur-sm">
-          <div className="flex flex-col items-center gap-2 text-sm text-status-waiting">
-            <Loader2 className="h-5 w-5 animate-spin" />
+          <div className="flex flex-col items-center gap-2 text-sm text-foreground">
+            <ActivityBars size={28} />
             <span>{statusMessage}</span>
           </div>
         </div>

--- a/apps/web/src/components/ui/activity-bars.tsx
+++ b/apps/web/src/components/ui/activity-bars.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils";
+
+export interface ActivityBarsProps {
+  size?: number;
+  className?: string;
+}
+
+// Listed as static strings so Tailwind's JIT picks them up.
+// Keyframes `dispatch-bar-wave-*` are defined in index.css.
+const BAR_ANIMATION_CLASSES = [
+  "animate-[dispatch-bar-wave-0_2.4s_ease-in-out_infinite]",
+  "animate-[dispatch-bar-wave-1_2.4s_ease-in-out_infinite]",
+  "animate-[dispatch-bar-wave-2_2.4s_ease-in-out_infinite]",
+  "animate-[dispatch-bar-wave-3_2.4s_ease-in-out_infinite]",
+] as const;
+
+export function ActivityBars({
+  size = 24,
+  className,
+}: ActivityBarsProps): JSX.Element {
+  const bar = Math.max(2, size / 8);
+  const gap = Math.max(1, size / 12);
+
+  return (
+    <div
+      className={cn("flex items-center", className)}
+      style={{ gap, height: size, width: size }}
+      role="status"
+      aria-label="Loading"
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className={cn(
+            "dispatch-activity-bar rounded-full origin-center will-change-transform",
+            "bg-[linear-gradient(to_top,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)))]",
+            "saturate-[1.35] brightness-[1.05]",
+            "motion-reduce:animate-none motion-reduce:scale-y-[0.55]",
+            BAR_ANIMATION_CLASSES[i]
+          )}
+          style={{ width: bar, height: "100%" }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/activity-bars.tsx
+++ b/apps/web/src/components/ui/activity-bars.tsx
@@ -23,7 +23,7 @@ export function ActivityBars({
 
   return (
     <div
-      className={cn("flex items-center", className)}
+      className={cn("flex items-center justify-center", className)}
       style={{ gap, height: size, width: size }}
       role="status"
       aria-label="Loading"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -638,15 +638,93 @@ html[data-theme="matrix"] [role="button"] {
   }
 }
 
-.dispatch-reconnect-scan {
-  animation: reconnect-scan 1350ms ease-in-out infinite;
-  will-change: transform;
-}
+/* `.dispatch-reconnect-scan` is a marker class — the animation, gradient,
+   and reduced-motion behavior are Tailwind utilities on the element. This
+   class only exists so the `html[data-hidden]` rule below can pause it. */
 
-@media (prefers-reduced-motion: reduce) {
-  .dispatch-reconnect-scan {
-    animation: none;
-    transform: translateX(140%);
+/* Activity Bars loading indicator — wave travels left→right, bounces
+   off the right end, travels right→left, then rests. Bar 3 (rightmost)
+   briefly holds at peak during the turnaround, giving the bounce a
+   natural feel. Keyframes must live in CSS; the gradient, filter,
+   sizing, animation binding, and reduced-motion handling are all
+   Tailwind utilities in the ActivityBars component. */
+@keyframes dispatch-bar-wave-0 {
+  0%,
+  5%,
+  25%,
+  67%,
+  87%,
+  100% {
+    transform: scaleY(0.22);
+  }
+  10%,
+  20%,
+  72%,
+  82% {
+    transform: scaleY(0.55);
+  }
+  15%,
+  77% {
+    transform: scaleY(1);
+  }
+}
+@keyframes dispatch-bar-wave-1 {
+  0%,
+  13%,
+  33%,
+  59%,
+  79%,
+  100% {
+    transform: scaleY(0.22);
+  }
+  18%,
+  28%,
+  64%,
+  74% {
+    transform: scaleY(0.55);
+  }
+  23%,
+  69% {
+    transform: scaleY(1);
+  }
+}
+@keyframes dispatch-bar-wave-2 {
+  0%,
+  21%,
+  41%,
+  51%,
+  71%,
+  100% {
+    transform: scaleY(0.22);
+  }
+  26%,
+  36%,
+  56%,
+  66% {
+    transform: scaleY(0.55);
+  }
+  31%,
+  61% {
+    transform: scaleY(1);
+  }
+}
+@keyframes dispatch-bar-wave-3 {
+  0%,
+  29%,
+  44%,
+  47%,
+  63%,
+  100% {
+    transform: scaleY(0.22);
+  }
+  34%,
+  50%,
+  58% {
+    transform: scaleY(0.55);
+  }
+  39%,
+  53% {
+    transform: scaleY(1);
   }
 }
 
@@ -863,6 +941,10 @@ html[data-theme="matrix"] [role="button"] {
 
 /* Pause GPU-composited animations when the page is hidden to reduce energy */
 html[data-hidden] .dispatch-reconnect-scan {
+  animation-play-state: paused;
+  will-change: auto;
+}
+html[data-hidden] .dispatch-activity-bar {
   animation-play-state: paused;
   will-change: auto;
 }


### PR DESCRIPTION
## Summary

- Adds a shared `ActivityBars` loading indicator and uses it for the terminal reconnect overlay (replacing the old `Loader2` spinner)
- Recolors the reconnect scan line in the app header and terminal pane to use the same 4-stop status rainbow, so both indicators share a visual language
- Rewrites the `/design-lab` page as a spinner comparison playground with a theme picker and color-mode toggle (mono / gradient / multi)

## What it looks like

Four rounded pill bars with a vertical gradient (`status-blocked` → `status-waiting` → `status-working` → `status-done`, saturation boosted). The wave travels right, bar 3 peaks at the turnaround, collapses to rest with a brief hold, then rises for the reverse wave back left, then a ~400ms pause. Cycle is 2.4s.

Keyframes live in `index.css` (unavoidable — Tailwind can't define arbitrary keyframes per element). Everything else — gradient, filter, animation binding, sizing, reduced-motion — is Tailwind utilities in the component. Custom classes (`dispatch-activity-bar`, `dispatch-reconnect-scan`) exist only as marker hooks for the existing `html[data-hidden]` pause-on-tab-hidden optimization.

## Files

- `apps/web/src/components/ui/activity-bars.tsx` — new shared component
- `apps/web/src/index.css` — 4 keyframes; old reconnect-scan raw CSS removed (gradient/animation now in JSX)
- `apps/web/src/components/app/terminal-pane.tsx` — reconnect overlay now uses `<ActivityBars size={28} />`
- `apps/web/src/components/app/app-header.tsx`, `agents-view.tsx` — scan line uses rainbow gradient + Tailwind-based animation binding
- `apps/web/src/components/app/design-lab.tsx` — rewritten as spinner comparison (theme switcher, mono/gradient/multi toggle, 6 candidates)

## Test plan

- [ ] Visit `/design-lab` → Activity Bars shows rounded pills in gradient/multi/mono variants at sm/md/lg sizes
- [ ] Switch themes on `/design-lab` → bar colors update to match each theme's status palette
- [ ] Trigger a terminal reconnect (disconnect network / restart backend) → overlay shows `ActivityBars` in place of old spinner; scan line above terminal is rainbow
- [ ] Verify motion in `prefers-reduced-motion` browser — bars hold at a static scale, no animation
- [ ] Switch tabs away and back — animations don't run while tab is hidden (existing optimization preserved)
- [ ] `pnpm run check` passes
- [ ] `pnpm run finalize:web` passes
- [ ] `pnpm run test:e2e` passes (running in background)