### PR TITLE
fix(web): ActivityBars review follow-up — light-theme contrast + small-size hardening

### DIFF
--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -122,7 +122,7 @@ export const TerminalPane = memo(function TerminalPane({
 
       {showReconnectOverlay ? (
         <div className="absolute inset-0 z-30 grid place-items-center bg-black/70 backdrop-blur-sm">
-          <div className="flex flex-col items-center gap-2 text-sm text-foreground">
+          <div className="flex flex-col items-center gap-2 text-sm text-white">
             <ActivityBars size={28} />
             <span>{statusMessage}</span>
           </div>

--- a/apps/web/src/components/ui/activity-bars.tsx
+++ b/apps/web/src/components/ui/activity-bars.tsx
@@ -23,8 +23,8 @@ export function ActivityBars({
 
   return (
     <div
-      className={cn("flex items-center justify-center", className)}
-      style={{ gap, height: size, width: size }}
+      className={cn("flex shrink-0 items-center", className)}
+      style={{ gap, height: size }}
       role="status"
       aria-label="Loading"
     >


### PR DESCRIPTION
Follow-up to #357 (merged). These two fixes were from the frontend-ux review but landed after the merge, so they go out as a separate PR.

## Summary

- **Reconnect overlay contrast in light theme** — the overlay uses `bg-black/70` (dark in every theme), but `text-foreground` resolves to near-black under the `light` theme, composing to ~1.8:1 contrast on the dark scrim. Changed to `text-white` — the `ActivityBars` carry the color; the text just needs to stay legible.

- **ActivityBars hardening below size≈12** — the component's container was a fixed `size × size` pixel box, so at very small sizes the flex children (bars at `max(2, size/8)` + gaps) overflowed and flex-shrunk toward invisible. Dropped `width: size` (and the now-redundant `justify-center`), added `shrink-0`. The container now sizes intrinsically to its content. Visually identical at every current usage — the bars+gaps were always the visible extent.

## Test plan

- [ ] Settings theme → Light → trigger a terminal reconnect → "Reconnecting…" text reads clearly on the scrim
- [ ] All existing ActivityBars usages (release pages, jobs pane, agent cards, dialogs, terminal reconnect) render unchanged
- [ ] `pnpm run check` passes