### PR TITLE
docs: fix Reviewers section drift in in-app docs

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -9,20 +9,21 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`fbfeb475515ef41d4174f2b6f1d299c3f1ffbe99` — HEAD at the start of the 2026-04-18 Repo Tools run. The PR that lands this file will advance the SHA once merged; the next run should diff from wherever HEAD is when it reads the file.
+`ecf3cffc084d0477e5e62a70fa74444f528cfe5c` — HEAD at the start of the 2026-04-18 Reviewers run. The PR that lands this file will advance the SHA once merged; the next run should diff from wherever HEAD is when it reads the file.
 
 ## next_focus
 
-**Audit the `docs-pane.tsx` "Reviewers" section against the persona launch + review-status flow in `apps/server/src/shared/mcp/server.ts` and `apps/server/src/agents/manager.ts`.**
+**Audit the `docs-pane.tsx` "Worktrees" section against `apps/server/src/shared/git/worktree.ts`, the create-agent worktree flow in `create-agent-dialog.tsx`, and the archive/cleanup phases in `apps/server/src/agents/manager.ts` (`worktree-check` / `worktree-cleanup`).**
 
 Concrete pointers for the next run:
 
-- `apps/web/src/components/app/docs-pane.tsx` — the "Reviewers" section (search for `id: "personas"`).
+- `apps/web/src/components/app/docs-pane.tsx` — the "Worktrees" section (search for `id: "worktrees"`).
 - Cross-check against:
-  - `apps/server/src/shared/mcp/server.ts` — the `review_status` tool accepts a `verdict` of `"approve" | "request_changes"` and a `status` of `"reviewing" | "complete"`. The docs describe severity but never mention verdict/status. `PERSONA_TOOLS` also includes `get_parent_context` — worth a sentence.
-  - `apps/server/src/agents/manager.ts` — the `AgentRecord.review` shape (review_status / verdict fields) and how review outcomes surface in the UI.
-  - `apps/server/src/personas/` loader — confirm the `feedbackFormat` values still supported (docs say it defaults to `findings`; verify nothing new has been added).
-- Worth confirming the "How personas work" narrative still matches — persona agents now also have `dispatch_pin` and `dispatch_share` (see `PERSONA_TOOLS` in `server.ts:180-186`), which the docs don't call out.
+  - `apps/server/src/shared/git/worktree.ts` — worktree creation, branch selection, location (sibling vs nested).
+  - `apps/web/src/components/app/create-agent-dialog.tsx` — the UI the docs describe: base-branch picker, custom branch name, worktree location setting.
+  - `apps/server/src/agents/manager.ts` — search for `worktree-check` and `worktree-cleanup` (archive phases). The docs should describe what happens when an agent finishes: uncommitted/unpushed work detection, archive vs. delete.
+  - Settings page for the sibling/nested toggle — confirm the copy in docs still matches what the UI shows.
+- Also worth a sentence on how `baseBranch` is surfaced (recent migration `0014_base-branch.sql`).
 
 Scope the PR to this one section plus whatever the git diff since `last_audited_sha` demands.
 
@@ -30,11 +31,11 @@ Scope the PR to this one section plus whatever the git diff since `last_audited_
 
 Items noticed during prior passes but left for later runs. Pick the most relevant one when `next_focus` is empty or already done.
 
-- **docs-pane "Worktrees" section** — cross-check against `apps/server/src/shared/git/worktree.ts` and the worktree cleanup flow in `apps/server/src/agents/manager.ts` (`worktree-check` / `worktree-cleanup` archive phases). Confirm the "sibling vs nested" Settings toggle copy still matches the UI.
-- **docs-pane "Status Events" section** — event types are in sync today (`AGENT_LATEST_EVENT_TYPES` in `apps/server/src/server.ts:243`: working/blocked/waiting_user/done/idle). Re-check when new event types are added.
-- **docs-pane "Media & Sharing" section** — 2026-04-18 Repo Tools pass noted that `dispatch_share` supports `content`, `name`, `update`, and `simulatorUdid` params (see `registerShareTool` in `apps/server/src/shared/mcp/server.ts`). Docs currently only describe `source: "simulator"`. Worth a "Sharing text snippets" or "Updating shared media" bullet.
-- **docs-pane "Notifications" section** — verify Slack event toggles and focus-aware suppression match `apps/server/src/notifications/slack.ts` and `apps/server/src/focus-tracker.ts`. Also: `dispatch_notify` (new built-in tool agents can call directly) is rate-limited to 5/min and supports a `respectFocus` flag — the Notifications docs should mention this path, not just agent-event-driven notifications.
+- **docs-pane "Status Events" section** — event types are in sync today (`AGENT_LATEST_EVENT_TYPES` in `apps/server/src/server.ts`: working/blocked/waiting_user/done/idle). Re-check when new event types are added.
+- **docs-pane "Media & Sharing" section** — `dispatch_share` supports `content`, `name`, `update`, and `simulatorUdid` params (see `registerShareTool` in `apps/server/src/shared/mcp/server.ts`). Docs currently only describe `source: "simulator"`. Worth a "Sharing text snippets" or "Updating shared media" bullet.
+- **docs-pane "Notifications" section** — verify Slack event toggles and focus-aware suppression match `apps/server/src/notifications/slack.ts` and `apps/server/src/focus-tracker.ts`. Also: `dispatch_notify` (built-in tool agents can call directly) is rate-limited to 5/min and supports a `respectFocus` flag — the Notifications docs should mention this path, not just agent-event-driven notifications.
 - **New in-app section: Jobs** — jobs are a major feature with no in-app docs page. The Repo Tools pass added a mention of the job-only built-in tools (`job_complete`, `job_failed`, `job_needs_input`, `job_log`) but there's still no page explaining how jobs differ from manually-launched agents, how they're scheduled, or how `.dispatch/job-state/*.md` handoff files work. Consider adding a "Jobs" section.
+- **docs-pane Reviewers section — Autonomous Review flow** — the Agents pass documented the "Autonomous Review" checkbox on create-agent-dialog.tsx, but the Reviewers section never explains how auto-review actually works end-to-end (which persona is launched, when, what the parent agent sees, how addressing feedback works). Worth a "Autonomous review" subsection that ties the two features together.
 - **`docs/03-api-spec.md`** — spot-check for new routes added in the last 30 days. Recent migrations (0012 auto-review, 0013 review agent type, 0014 base branch) imply the agents POST body schema has grown.
 - **`docs/04-agent-lifecycle.md`** — verify it still matches `AgentStatus` / `SetupPhase` / `ArchivePhase` in `apps/server/src/agents/manager.ts`. The values are: status ∈ {creating, running, stopping, stopped, archiving, error, unknown}; setupPhase ∈ {worktree, env, deps, session, null}; archivePhase ∈ {stopping, worktree-check, worktree-cleanup, finalizing, null}.
 - **`docs/10-operations-runbook.md`** — verify service management commands match current `bin/dispatch-server` / `bin/dispatch-deploy` flags.
@@ -47,19 +48,21 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **User-facing docs drift fastest.** When the app's behavior changes, the in-app docs-pane content is the first thing to notice. It's also the easiest to update in the same PR as the code change (a reviewer can flag stale copy), but in practice it often isn't — so this audit is where it catches up.
 - **The built-in MCP tool list sprawls without touching the docs.** The 2026-04-18 Repo Tools pass found the docs-pane listed 7 built-in tools; `AGENT_TOOLS` in `apps/server/src/shared/mcp/server.ts` actually has 17. Each new tool gets added to `AGENT_TOOLS` / `JOB_TOOLS` / `PERSONA_TOOLS` but almost never to `docs-pane.tsx`. Grep for `AGENT_TOOLS = new Set` and diff against the `Built-in tools` list in `docs-pane.tsx` whenever touching this area.
 - **The create-agent dialog accretes options silently.** The 2026-04-18 pass found that the dialog had gained an "Autonomous Review" checkbox and a two-step "Create with prompt" flow (initial prompt textarea) without any change to `docs-pane.tsx`. When `create-agent-dialog.tsx` gains a field, the "Creating an agent" bullet list needs a matching entry. Grep `create-agent-dialog.tsx` for `<Checkbox` and `<label` to catch new form fields quickly.
-- **Status indicator colors are theme-driven via CSS vars (`--status-working`, `--status-blocked`, `--status-waiting`, `--status-done`).** Don't trust any hard-coded color-name claim in the docs — resolve the actual hue from `apps/web/src/index.css` (search for `--status-working`). 2026-04-18 found the docs had working/done backwards (they'd been copy-pasted from some earlier palette).
-- **MCP tool sets change by agent type.** The AGENT / JOB / PERSONA tool lists in `apps/server/src/shared/mcp/server.ts` evolve independently. Any doc that enumerates tools for one role is at risk of drifting from the other two. The Repo Tools pass added a one-paragraph note about per-agent-type subsets instead of re-listing all three — keep it that way.
-- **Repo tool prefix is `repo_`, not `repo.`.** MCP clients don't support dots in tool names, so dots in configured names are sanitized to underscores (`repo-tools.ts:161-162`). Docs had `repo.lint` wrong for a long stretch; grep for `repo\.` in docs when reviewing tool-prefix claims.
+- **Status indicator colors are theme-driven via CSS vars (`--status-working`, `--status-blocked`, `--status-waiting`, `--status-done`).** Don't trust any hard-coded color-name claim in the docs — resolve the actual hue from `apps/web/src/index.css`. 2026-04-18 found the docs had working/done backwards (they'd been copy-pasted from some earlier palette).
+- **MCP tool sets change by agent type.** The AGENT / JOB / PERSONA tool lists in `apps/server/src/shared/mcp/server.ts` evolve independently. Any doc that enumerates tools for one role is at risk of drifting from the other two. The Reviewers pass enumerated the persona-only tools (`review_status`, `get_parent_context`) directly; keep that specific-to-role pattern rather than re-listing the full set.
+- **Repo tool prefix is `repo_`, not `repo.`.** MCP clients don't support dots in tool names, so dots in configured names are sanitized to underscores (`repo-tools.ts`). Docs had `repo.lint` wrong for a long stretch; grep for `repo\.` in docs when reviewing tool-prefix claims.
 - **Job configuration semantics have changed.** Jobs were once file-based (`.dispatch/jobs/*.md`) and are now DB-backed (migration `0011_drop-jobs-file-path-column.sql`). Older docs and comments may still reference the file-based model.
 - **Agent lifecycle has two axes: status and phase.** `status` (`creating`/`running`/…/`archiving`) and `setup_phase` / `archive_phase` are distinct. Docs that mention "phase" without qualifying which one are a drift risk.
+- **Persona prompt assembly strips legacy placeholders.** `apps/server/src/personas/loader.ts` strips `{{context}}` and `{{diff}}` from persona bodies and appends its own context/diff/feedback-guidance sections. The Reviewers pass on 2026-04-18 found the docs were still telling users to add those placeholders. Anywhere the docs describe persona file contents, cross-check against `assemblePersonaPrompt`.
 
 ## Notes for the next run
 
 - If `next_focus` feels too big for one night, split it and push half back into `backlog` with a concrete description.
-- Treat each run as one focused slice. The Agents pass on 2026-04-18 fit comfortably in one PR; the Repo Tools pass did too. Aim for that size.
+- Treat each run as one focused slice. The Agents, Repo Tools, and Reviewers passes on 2026-04-18 all fit comfortably in one PR each. Aim for that size.
 - If you notice something that isn't drift but is genuinely missing (e.g. a new feature with no docs anywhere), add it to `backlog` with enough detail that a future run can act on it without re-discovering the context.
 
 ## History
 
 - **2026-04-18** (Agents) — Audited docs-pane "Agents" section. Fixed status-indicator color mapping (working/done were swapped in the docs), added Autonomous Review checkbox and Create-with-prompt flow to the "Creating an agent" bullets, clarified the auto-naming behavior of the Name field.
 - **2026-04-18** (Repo Tools) — Audited docs-pane "Repo Tools" section against `repo-tools.ts` and `server.ts`. Fixed the tool prefix from `repo.` → `repo_` (and added a note about dot-to-underscore sanitization), documented the `scope` field for job/reviewer-only tools, expanded the built-in tool list from 7 → 14 entries, and added a one-paragraph note that persona and job agents see different built-in tool subsets.
+- **2026-04-18** (Reviewers) — Audited docs-pane "Reviewers" section against `PERSONA_TOOLS` and the review tooling in `apps/server/src/shared/mcp/server.ts` + the loader in `apps/server/src/personas/loader.ts`. Removed the stale `{{context}}`/`{{diff}}` placeholder example (the loader now strips them and auto-appends context/diff/feedback-guidance). Added a "Review lifecycle" subsection covering `review_status` with its `reviewing`/`complete` statuses and `approve`/`request_changes` verdicts. Added a paragraph noting that persona agents also have `dispatch_pin`, `dispatch_share`, and `get_parent_context`. Split "Feedback findings" into "Submitting findings" + "Review lifecycle".

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -481,10 +481,17 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <P>
             An agent calls the built-in <Code>dispatch_launch_persona</Code>{" "}
             tool, passing the persona name and a context briefing. Dispatch
-            loads the persona definition from the repo, spawns a new child agent
-            with the persona's instructions and a diff of the current branch,
-            and the child reviews the work and submits findings via{" "}
-            <Code>dispatch_feedback</Code>.
+            loads the persona definition from the repo and spawns a new child
+            agent with the persona's instructions, the parent's context, and a
+            diff of the current branch. The child then reviews the work, submits
+            findings via <Code>dispatch_feedback</Code>, and reports progress
+            through the review lifecycle with <Code>review_status</Code>.
+          </P>
+          <P>
+            Persona agents also have <Code>dispatch_pin</Code> and{" "}
+            <Code>dispatch_share</Code> for surfacing files or screenshots, and{" "}
+            <Code>get_parent_context</Code> to retrieve the parent agent's pins
+            and shared media (for example, a dev server URL to test against).
           </P>
         </Section>
 
@@ -494,9 +501,10 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             Each repo defines its own personas as markdown files in{" "}
             <Code>.dispatch/personas/</Code>. The filename (without extension)
             becomes the persona slug used when launching. Files use YAML
-            frontmatter for metadata and the body contains instructions with{" "}
-            <Code>{"{{context}}"}</Code> and <Code>{"{{diff}}"}</Code>{" "}
-            placeholders that Dispatch fills in at launch time.
+            frontmatter for metadata and the body is the persona's instructions.
+            Dispatch automatically appends the parent agent's context and the
+            current diff, plus a standard block of feedback guidance — persona
+            files should not include their own context or diff placeholders.
           </P>
           <CodeBlock>{`
 # .dispatch/personas/security-review.md
@@ -506,14 +514,9 @@ description: Reviews code for security vulnerabilities
 feedbackFormat: findings
 ---
 
-You are a security reviewer. Analyze the following changes
-for vulnerabilities, injection risks, and auth issues.
-
-## Context
-{{context}}
-
-## Diff
-{{diff}}`}</CodeBlock>
+You are a security reviewer. Analyze the changes below for
+vulnerabilities, injection risks, and auth issues. Flag only
+issues caused or worsened by this diff.`}</CodeBlock>
           <P>
             The <Code>name</Code> and <Code>description</Code> fields are shown
             in the persona picker UI. The <Code>feedbackFormat</Code> field is
@@ -522,7 +525,7 @@ for vulnerabilities, injection risks, and auth issues.
         </Section>
 
         <Section>
-          <H3>Feedback findings</H3>
+          <H3>Submitting findings</H3>
           <P>
             Persona agents submit findings with the{" "}
             <Code>dispatch_feedback</Code> tool. Each finding includes a
@@ -531,6 +534,19 @@ for vulnerabilities, injection risks, and auth issues.
             description, and optionally a file path, line number, and suggested
             fix. Findings appear in the Feedback panel where you can review and
             resolve them.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Review lifecycle</H3>
+          <P>
+            Persona agents report progress with the <Code>review_status</Code>{" "}
+            tool. They call it with <Code>status: "reviewing"</Code> and a short
+            message when they start, then with <Code>status: "complete"</Code> —
+            along with a <Code>verdict</Code> of <Code>approve</Code> or{" "}
+            <Code>request_changes</Code> and a <Code>summary</Code> — when they
+            finish. The verdict and summary show up on the review agent's card
+            in the UI.
           </P>
         </Section>
       </>


### PR DESCRIPTION
## Summary

Reviewers docs-pane audit pass. The docs-pane "Reviewers" section had drifted from the actual persona launch + review flow.

- Removed the stale `{{context}}` / `{{diff}}` placeholders from the example persona file. The loader in `apps/server/src/personas/loader.ts` strips these and auto-appends the parent's context, the current diff, and a standard block of feedback guidance — persona files shouldn't include their own placeholders.
- Added a "Review lifecycle" subsection covering `review_status` (with `reviewing`/`complete` statuses and `approve`/`request_changes` verdicts). This tool wasn't mentioned anywhere before.
- Added a paragraph noting that persona agents also have `dispatch_pin`, `dispatch_share`, and `get_parent_context` — previously they were only credited with `dispatch_feedback`.
- Split "Feedback findings" into "Submitting findings" + "Review lifecycle".

## State file

`.dispatch/job-state/docs-audit.md` is updated in the same commit. Next run's `next_focus` is the docs-pane **Worktrees** section, cross-checked against `apps/server/src/shared/git/worktree.ts`, `create-agent-dialog.tsx`, and the archive phases in `apps/server/src/agents/manager.ts`.

## Test plan

- [x] `pnpm run check` (backend + web tsc) passes.
- [x] Prettier run on touched files; no formatting drift.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)