### PR TITLE
feat(jobs): on-demand runs, base branch, and keep-agent toggle

### DIFF
--- a/apps/server/src/db/migrations/0015_jobs-base-branch-auto-archive.sql
+++ b/apps/server/src/db/migrations/0015_jobs-base-branch-auto-archive.sql
@@ -1,0 +1,5 @@
+-- Jobs: add base_branch (fork-from branch for worktree jobs) and auto_archive
+-- (opt-out for the auto-archive-on-terminal-run behavior).
+
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS base_branch TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS auto_archive BOOLEAN NOT NULL DEFAULT TRUE;

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -40,8 +40,10 @@ export type AddJobInput = {
   needsInputTimeoutMs?: number;
   agentType?: JobAgentType;
   useWorktree?: boolean;
+  baseBranch?: string | null;
   branchName?: string | null;
   fullAccess?: boolean;
+  autoArchive?: boolean;
   enabled?: boolean;
 };
 
@@ -137,6 +139,7 @@ export class JobService {
         agentArgs: buildAgentArgs(job.agentType, prompt, job.fullAccess),
         fullAccess: job.fullAccess,
         useWorktree: job.useWorktree,
+        baseBranch: job.baseBranch ?? undefined,
         worktreeBranch: job.branchName ?? undefined,
         jobRunId: run.id,
       });
@@ -243,8 +246,10 @@ export class JobService {
         input.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
       agentType: input.agentType ?? "claude",
       useWorktree: input.useWorktree ?? false,
+      baseBranch: input.baseBranch ?? null,
       branchName: input.branchName ?? null,
       fullAccess: input.fullAccess ?? false,
+      autoArchive: input.autoArchive ?? true,
       enabled: input.enabled ?? false,
     });
 
@@ -275,6 +280,7 @@ export class JobService {
     const config: Parameters<JobStore["updateJobConfig"]>[1] = {};
     const displayName = normalizeOptionalString(input.displayName);
     const branchName = normalizeNullableString(input.branchName);
+    const baseBranch = normalizeNullableString(input.baseBranch);
     if (displayName !== undefined && displayName !== existing.name) {
       const conflict = await this.store.getJobByDirectoryAndName(
         input.directory,
@@ -294,8 +300,10 @@ export class JobService {
       config.needsInputTimeoutMs = input.needsInputTimeoutMs;
     if (input.agentType !== undefined) config.agentType = input.agentType;
     if (input.useWorktree !== undefined) config.useWorktree = input.useWorktree;
+    if (baseBranch !== undefined) config.baseBranch = baseBranch;
     if (branchName !== undefined) config.branchName = branchName;
     if (input.fullAccess !== undefined) config.fullAccess = input.fullAccess;
+    if (input.autoArchive !== undefined) config.autoArchive = input.autoArchive;
     if (input.enabled !== undefined) config.enabled = input.enabled;
 
     const updated = await this.store.updateJobConfig(existing.id, config);
@@ -715,6 +723,7 @@ function buildRunConfig(
       job.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
     notify: job.notify ?? { onComplete: [], onError: [], onNeedsInput: [] },
     triggerSource,
+    autoArchive: job.autoArchive,
   };
 }
 

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -38,8 +38,10 @@ export type JobRecord = {
   enabled: boolean;
   agentType: JobAgentType;
   useWorktree: boolean;
+  baseBranch: string | null;
   branchName: string | null;
   fullAccess: boolean;
+  autoArchive: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -82,6 +84,7 @@ export type JobRunConfig = {
   needsInputTimeoutMs: number;
   notify: JobNotifyConfig;
   triggerSource?: "manual" | "scheduled";
+  autoArchive?: boolean;
 };
 
 export type JobConfigUpdate = {
@@ -92,8 +95,10 @@ export type JobConfigUpdate = {
   needsInputTimeoutMs?: number;
   agentType?: JobAgentType;
   useWorktree?: boolean;
+  baseBranch?: string | null;
   branchName?: string | null;
   fullAccess?: boolean;
+  autoArchive?: boolean;
   enabled?: boolean;
 };
 
@@ -109,16 +114,18 @@ export class JobStore {
     needsInputTimeoutMs: number;
     agentType: JobAgentType;
     useWorktree: boolean;
+    baseBranch: string | null;
     branchName: string | null;
     fullAccess: boolean;
+    autoArchive: boolean;
     enabled: boolean;
   }): Promise<JobRecord> {
     const id = randomUUID();
     try {
       const result = await this.pool.query(
         `
-        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, branch_name, enabled)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, base_branch, branch_name, auto_archive, enabled)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
         RETURNING ${this.jobColumns()}
         `,
         [
@@ -132,7 +139,9 @@ export class JobStore {
           input.fullAccess,
           input.agentType,
           input.useWorktree,
+          input.baseBranch,
           input.branchName,
+          input.autoArchive,
           input.enabled,
         ]
       );
@@ -360,8 +369,10 @@ export class JobStore {
         j.enabled,
         j.agent_type AS "agentType",
         j.use_worktree AS "useWorktree",
+        j.base_branch AS "baseBranch",
         j.branch_name AS "branchName",
         j.full_access AS "fullAccess",
+        j.auto_archive AS "autoArchive",
         j.created_at AS "createdAt",
         j.updated_at AS "updatedAt",
         lr.id AS "lastRunId",
@@ -532,6 +543,8 @@ export class JobStore {
             branch_name = CASE WHEN $11 THEN $12 ELSE branch_name END,
             full_access = COALESCE($13, full_access),
             enabled = COALESCE($14, enabled),
+            base_branch = CASE WHEN $15 THEN $16 ELSE base_branch END,
+            auto_archive = COALESCE($17, auto_archive),
             updated_at = NOW()
         WHERE id = $1
         RETURNING ${this.jobColumns()}
@@ -551,6 +564,9 @@ export class JobStore {
           input.branchName ?? null,
           input.fullAccess,
           input.enabled,
+          Object.prototype.hasOwnProperty.call(input, "baseBranch"),
+          input.baseBranch ?? null,
+          input.autoArchive,
         ]
       );
       if (!result.rows[0]) throw new Error(`Job ${jobId} not found.`);
@@ -629,8 +645,10 @@ export class JobStore {
       enabled,
       agent_type AS "agentType",
       use_worktree AS "useWorktree",
+      base_branch AS "baseBranch",
       branch_name AS "branchName",
       full_access AS "fullAccess",
+      auto_archive AS "autoArchive",
       created_at AS "createdAt",
       updated_at AS "updatedAt"
     `;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -133,7 +133,13 @@ jobService.onRunStateChange((run) => {
   });
   // Auto-archive job agents when the run reaches a terminal state.
   // needs_input is excluded — user may need to interact with the agent.
-  if (JOB_TERMINAL_STATUSES.has(run.status) && run.agentId) {
+  // Jobs with autoArchive=false keep the agent around for post-run follow-up.
+  const shouldAutoArchive = run.config?.autoArchive ?? true;
+  if (
+    JOB_TERMINAL_STATUSES.has(run.status) &&
+    run.agentId &&
+    shouldAutoArchive
+  ) {
     void autoArchiveJobAgent(run.agentId).catch((err) => {
       app.log.warn(
         { err, agentId: run.agentId },
@@ -1201,8 +1207,10 @@ const AddJobBodySchema = JobEnableDisableBodySchema.extend({
   needsInputTimeoutMs: z.number().int().positive().optional(),
   agentType: z.enum(AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
+  baseBranch: z.string().nullable().optional(),
   branchName: z.string().nullable().optional(),
   fullAccess: z.boolean().optional(),
+  autoArchive: z.boolean().optional(),
   enabled: z.boolean().optional(),
 });
 const JobHistoryParamsSchema = z.object({

--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -59,7 +59,9 @@ function makeJob(
     fullAccess: false,
     agentType: "claude",
     useWorktree: false,
+    baseBranch: null,
     branchName: null,
+    autoArchive: true,
     enabled: false,
   });
 }

--- a/apps/server/test/jobs/store-phase2.test.ts
+++ b/apps/server/test/jobs/store-phase2.test.ts
@@ -24,7 +24,9 @@ const jobDefaults = {
   fullAccess: false,
   agentType: "claude" as const,
   useWorktree: false,
+  baseBranch: null,
   branchName: null,
+  autoArchive: true,
   enabled: false,
 };
 

--- a/apps/server/test/jobs/store.test.ts
+++ b/apps/server/test/jobs/store.test.ts
@@ -35,7 +35,9 @@ describe("JobStore", () => {
       fullAccess: false,
       agentType: "claude",
       useWorktree: false,
+      baseBranch: null,
       branchName: null,
+      autoArchive: true,
       enabled: false,
     });
     const run = await store.createRun(job.id, {

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -20,10 +20,10 @@ export type BranchSelectProps = {
   cwd: string;
   baseBranch: string;
   /**
-   * Fired when the user picks a branch AND when the fetched branch list
-   * doesn't include the current `baseBranch` (falls back to the first
-   * returned branch or "main"). The latter keeps the combobox honest if a
-   * previously-saved branch has been renamed/deleted on the remote.
+   * Fired when the user picks a branch. The component never overwrites
+   * `baseBranch` on its own — if a saved branch is missing from the
+   * fetched list we keep it in the dropdown with a visible flag and let
+   * the user choose a replacement.
    */
   onBaseBranchChange: (value: string) => void;
   worktreeBranch: string;
@@ -45,6 +45,7 @@ export function BranchSelect({
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [branchesLoading, setBranchesLoading] = useState(false);
   const [fetchedForCwd, setFetchedForCwd] = useState<string | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const cmdRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -55,22 +56,22 @@ export function BranchSelect({
     const trimmed = cwd.trim();
     if (!trimmed) return;
     setBranchesLoading(true);
-    setRemoteBranches([]);
+    setFetchError(null);
     try {
       const result = await api<{ branches: string[] }>(
         `/api/v1/git/branches?cwd=${encodeURIComponent(trimmed)}`
       );
       setRemoteBranches(result.branches);
-      if (!result.branches.includes(baseBranch)) {
-        onBaseBranchChange(result.branches[0] ?? "main");
-      }
-    } catch {
+    } catch (error) {
       setRemoteBranches([]);
+      setFetchError(
+        error instanceof Error ? error.message : "Couldn't load branches."
+      );
     } finally {
       setBranchesLoading(false);
       setFetchedForCwd(trimmed);
     }
-  }, [cwd, baseBranch, onBaseBranchChange]);
+  }, [cwd]);
 
   const openDropdown = useCallback(() => {
     setDropdownOpen(true);
@@ -80,13 +81,23 @@ export function BranchSelect({
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [fetchBranches, fetchedForCwd, cwd, setDropdownOpen]);
 
-  const allBranches = useMemo(
-    () =>
-      remoteBranches.includes("main")
-        ? remoteBranches
-        : ["main", ...remoteBranches],
-    [remoteBranches]
-  );
+  // Keep the saved baseBranch selectable even if the fetched list doesn't
+  // include it (branch renamed/deleted upstream). We flag it visually in
+  // the dropdown rather than silently overwrite it.
+  const allBranches = useMemo(() => {
+    const base = remoteBranches.includes("main")
+      ? remoteBranches
+      : ["main", ...remoteBranches];
+    if (baseBranch && !base.includes(baseBranch)) return [baseBranch, ...base];
+    return base;
+  }, [remoteBranches, baseBranch]);
+
+  const savedBranchMissing =
+    !branchesLoading &&
+    !!baseBranch &&
+    !!fetchedForCwd &&
+    remoteBranches.length > 0 &&
+    !remoteBranches.includes(baseBranch);
 
   return (
     <div className="space-y-2">
@@ -154,35 +165,63 @@ export function BranchSelect({
                 ) : null}
                 <CommandEmpty>No matching branches.</CommandEmpty>
                 <CommandGroup>
-                  {allBranches.map((branch) => (
-                    <CommandItem
-                      key={branch}
-                      value={branch}
-                      data-testid={`${testIdPrefix}-base-branch-option`}
-                      className="font-mono"
-                      onSelect={() => {
-                        onBaseBranchChange(branch);
-                        setDropdownOpen(false);
-                        requestAnimationFrame(() =>
-                          triggerRef.current?.focus()
-                        );
-                      }}
-                    >
-                      <Check
-                        className={cn(
-                          "mr-2 h-3 w-3 shrink-0",
-                          branch === baseBranch ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                      {branch}
-                    </CommandItem>
-                  ))}
+                  {allBranches.map((branch) => {
+                    const isMissing =
+                      branch === baseBranch &&
+                      remoteBranches.length > 0 &&
+                      !remoteBranches.includes(branch);
+                    return (
+                      <CommandItem
+                        key={branch}
+                        value={branch}
+                        data-testid={`${testIdPrefix}-base-branch-option`}
+                        className="font-mono"
+                        onSelect={() => {
+                          onBaseBranchChange(branch);
+                          setDropdownOpen(false);
+                          requestAnimationFrame(() =>
+                            triggerRef.current?.focus()
+                          );
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-3 w-3 shrink-0",
+                            branch === baseBranch ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        {branch}
+                        {isMissing ? (
+                          <span className="ml-2 text-[10px] uppercase tracking-wide text-status-waiting">
+                            not found
+                          </span>
+                        ) : null}
+                      </CommandItem>
+                    );
+                  })}
                 </CommandGroup>
               </CommandList>
             </Command>
           </div>
         ) : null}
       </div>
+      {fetchError ? (
+        <div className="flex items-center gap-2 text-xs text-status-blocked">
+          <span className="truncate">Couldn't load branches.</span>
+          <button
+            type="button"
+            onClick={() => void fetchBranches()}
+            className="underline underline-offset-2 hover:no-underline"
+          >
+            Retry
+          </button>
+        </div>
+      ) : savedBranchMissing ? (
+        <div className="text-xs text-status-waiting">
+          Saved branch <span className="font-mono">{baseBranch}</span> no longer
+          exists on the remote — pick a new one.
+        </div>
+      ) : null}
       <Input
         value={worktreeBranch}
         onChange={(event) => onWorktreeBranchChange(event.target.value)}

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+import { ActivityBars } from "@/components/ui/activity-bars";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandLoading,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void
+): void {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [ref, isOpen, onClose]);
+}
+
+export type BranchSelectProps = {
+  cwd: string;
+  baseBranch: string;
+  onBaseBranchChange: (value: string) => void;
+  worktreeBranch: string;
+  onWorktreeBranchChange: (value: string) => void;
+  testIdPrefix?: string;
+  worktreeBranchPlaceholder?: string;
+  onDropdownOpenChange?: (open: boolean) => void;
+};
+
+export function BranchSelect({
+  cwd,
+  baseBranch,
+  onBaseBranchChange,
+  worktreeBranch,
+  onWorktreeBranchChange,
+  testIdPrefix = "branch-select",
+  worktreeBranchPlaceholder = "branch name (auto-generated if empty)",
+  onDropdownOpenChange,
+}: BranchSelectProps): JSX.Element {
+  const [dropdownOpen, setDropdownOpenState] = useState(false);
+  const setDropdownOpen = useCallback(
+    (next: boolean) => {
+      setDropdownOpenState(next);
+      onDropdownOpenChange?.(next);
+    },
+    [onDropdownOpenChange]
+  );
+  const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+  const [fetchedForCwd, setFetchedForCwd] = useState<string | null>(null);
+  const cmdRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const closeDropdown = useCallback(
+    () => setDropdownOpen(false),
+    [setDropdownOpen]
+  );
+  useClickOutside(cmdRef, dropdownOpen, closeDropdown);
+
+  const fetchBranches = useCallback(async () => {
+    const trimmed = cwd.trim();
+    if (!trimmed) return;
+    setBranchesLoading(true);
+    setRemoteBranches([]);
+    try {
+      const result = await api<{ branches: string[] }>(
+        `/api/v1/git/branches?cwd=${encodeURIComponent(trimmed)}`
+      );
+      setRemoteBranches(result.branches);
+      if (!result.branches.includes(baseBranch)) {
+        onBaseBranchChange(result.branches[0] ?? "main");
+      }
+    } catch {
+      setRemoteBranches([]);
+    } finally {
+      setBranchesLoading(false);
+      setFetchedForCwd(trimmed);
+    }
+  }, [cwd, baseBranch, onBaseBranchChange]);
+
+  const openDropdown = useCallback(() => {
+    setDropdownOpen(true);
+    if (fetchedForCwd !== cwd.trim()) {
+      void fetchBranches();
+    }
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [fetchBranches, fetchedForCwd, cwd, setDropdownOpen]);
+
+  const allBranches = useMemo(
+    () =>
+      remoteBranches.includes("main")
+        ? remoteBranches
+        : ["main", ...remoteBranches],
+    [remoteBranches]
+  );
+
+  return (
+    <div className="space-y-2">
+      <div className="relative" ref={cmdRef}>
+        <label className="mb-1 block text-xs text-muted-foreground">
+          Base branch
+        </label>
+        <button
+          ref={triggerRef}
+          type="button"
+          role="combobox"
+          tabIndex={0}
+          aria-expanded={dropdownOpen}
+          data-testid={`${testIdPrefix}-base-branch`}
+          onClick={() =>
+            dropdownOpen ? setDropdownOpen(false) : openDropdown()
+          }
+          onKeyDown={(e) => {
+            if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              if (!dropdownOpen) openDropdown();
+            }
+          }}
+          className={cn(
+            "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 font-mono text-xs shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+            "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+          )}
+        >
+          {baseBranch}
+          {branchesLoading ? (
+            <ActivityBars size={14} className="ml-2 shrink-0" />
+          ) : (
+            <ChevronDown
+              className={cn(
+                "ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                dropdownOpen && "rotate-180"
+              )}
+            />
+          )}
+        </button>
+        {dropdownOpen ? (
+          <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
+            <Command
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setDropdownOpen(false);
+                  requestAnimationFrame(() => triggerRef.current?.focus());
+                }
+              }}
+            >
+              <CommandInput
+                ref={inputRef}
+                placeholder="Search branches..."
+                className="font-mono text-xs"
+              />
+              <CommandList>
+                {branchesLoading ? (
+                  <CommandLoading>
+                    <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+                      <ActivityBars size={12} />
+                      Loading branches...
+                    </div>
+                  </CommandLoading>
+                ) : null}
+                <CommandEmpty>No matching branches.</CommandEmpty>
+                <CommandGroup>
+                  {allBranches.map((branch) => (
+                    <CommandItem
+                      key={branch}
+                      value={branch}
+                      data-testid={`${testIdPrefix}-base-branch-option`}
+                      className="font-mono"
+                      onSelect={() => {
+                        onBaseBranchChange(branch);
+                        setDropdownOpen(false);
+                        requestAnimationFrame(() =>
+                          triggerRef.current?.focus()
+                        );
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-3 w-3 shrink-0",
+                          branch === baseBranch ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      {branch}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </div>
+        ) : null}
+      </div>
+      <Input
+        value={worktreeBranch}
+        onChange={(event) => onWorktreeBranchChange(event.target.value)}
+        placeholder={worktreeBranchPlaceholder}
+        data-testid={`${testIdPrefix}-worktree-branch`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
 
 import { ActivityBars } from "@/components/ui/activity-bars";
@@ -12,35 +12,24 @@ import {
   CommandLoading,
 } from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
+import { useClickOutside } from "@/hooks/use-click-outside";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
-
-function useClickOutside(
-  ref: React.RefObject<HTMLElement | null>,
-  isOpen: boolean,
-  onClose: () => void
-): void {
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [ref, isOpen, onClose]);
-}
 
 export type BranchSelectProps = {
   cwd: string;
   baseBranch: string;
+  /**
+   * Fired when the user picks a branch AND when the fetched branch list
+   * doesn't include the current `baseBranch` (falls back to the first
+   * returned branch or "main"). The latter keeps the combobox honest if a
+   * previously-saved branch has been renamed/deleted on the remote.
+   */
   onBaseBranchChange: (value: string) => void;
   worktreeBranch: string;
   onWorktreeBranchChange: (value: string) => void;
   testIdPrefix?: string;
   worktreeBranchPlaceholder?: string;
-  onDropdownOpenChange?: (open: boolean) => void;
 };
 
 export function BranchSelect({
@@ -51,26 +40,15 @@ export function BranchSelect({
   onWorktreeBranchChange,
   testIdPrefix = "branch-select",
   worktreeBranchPlaceholder = "branch name (auto-generated if empty)",
-  onDropdownOpenChange,
 }: BranchSelectProps): JSX.Element {
-  const [dropdownOpen, setDropdownOpenState] = useState(false);
-  const setDropdownOpen = useCallback(
-    (next: boolean) => {
-      setDropdownOpenState(next);
-      onDropdownOpenChange?.(next);
-    },
-    [onDropdownOpenChange]
-  );
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [branchesLoading, setBranchesLoading] = useState(false);
   const [fetchedForCwd, setFetchedForCwd] = useState<string | null>(null);
   const cmdRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const closeDropdown = useCallback(
-    () => setDropdownOpen(false),
-    [setDropdownOpen]
-  );
+  const closeDropdown = useCallback(() => setDropdownOpen(false), []);
   useClickOutside(cmdRef, dropdownOpen, closeDropdown);
 
   const fetchBranches = useCallback(async () => {
@@ -155,6 +133,9 @@ export function BranchSelect({
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
                   e.preventDefault();
+                  // Stop propagation so a surrounding Radix Dialog doesn't
+                  // interpret the Escape as a close-dialog request.
+                  e.stopPropagation();
                   setDropdownOpen(false);
                   requestAnimationFrame(() => triggerRef.current?.focus());
                 }

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -133,9 +133,6 @@ export function BranchSelect({
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
                   e.preventDefault();
-                  // Stop propagation so a surrounding Radix Dialog doesn't
-                  // interpret the Escape as a close-dialog request.
-                  e.stopPropagation();
                   setDropdownOpen(false);
                   requestAnimationFrame(() => triggerRef.current?.focus());
                 }

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -3,24 +3,21 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 import { Check, ChevronDown, GitBranch, ChevronLeft } from "lucide-react";
 
+import { BranchSelect } from "@/components/app/branch-select";
 import { PathInput } from "@/components/app/path-input";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
-  CommandInput,
   CommandItem,
   CommandList,
-  CommandLoading,
 } from "@/components/ui/command";
 import {
   Dialog,
@@ -286,56 +283,6 @@ export function CreateAgentDialog({
   useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
 
   const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
-  const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
-  const [branchesLoading, setBranchesLoading] = useState(false);
-  const [branchesFetchedForCwd, setBranchesFetchedForCwd] = useState<
-    string | null
-  >(null);
-  const branchCmdRef = useRef<HTMLDivElement>(null);
-  const branchTriggerRef = useRef<HTMLButtonElement>(null);
-  const branchInputRef = useRef<HTMLInputElement>(null);
-  const closeBranchDropdown = useCallback(
-    () => setBranchDropdownOpen(false),
-    []
-  );
-  useClickOutside(branchCmdRef, branchDropdownOpen, closeBranchDropdown);
-
-  const fetchBranches = useCallback(async () => {
-    const cwd = createCwd.trim();
-    if (!cwd) return;
-    setBranchesLoading(true);
-    setRemoteBranches([]);
-    try {
-      const result = await api<{ branches: string[] }>(
-        `/api/v1/git/branches?cwd=${encodeURIComponent(cwd)}`
-      );
-      setRemoteBranches(result.branches);
-      if (!result.branches.includes(createBaseBranch)) {
-        setCreateBaseBranch(result.branches[0] ?? "main");
-      }
-    } catch {
-      setRemoteBranches([]);
-    } finally {
-      setBranchesLoading(false);
-      setBranchesFetchedForCwd(cwd);
-    }
-  }, [createBaseBranch, createCwd, setCreateBaseBranch]);
-
-  const openBranchDropdown = useCallback(() => {
-    setBranchDropdownOpen(true);
-    if (branchesFetchedForCwd !== createCwd.trim()) {
-      void fetchBranches();
-    }
-    requestAnimationFrame(() => branchInputRef.current?.focus());
-  }, [branchesFetchedForCwd, createCwd, fetchBranches]);
-
-  const allBranches = useMemo(
-    () =>
-      remoteBranches.includes("main")
-        ? remoteBranches
-        : ["main", ...remoteBranches],
-    [remoteBranches]
-  );
 
   const handleRemoveCwdHistory = useCallback((cwd: string) => {
     setCwdHistory(removeCwdFromHistory(cwd));
@@ -551,122 +498,15 @@ export function CreateAgentDialog({
                       </span>
                     </label>
                     {createUseWorktree ? (
-                      <div className="ml-8 w-[calc(100%-2rem)] space-y-2">
-                        <div className="relative" ref={branchCmdRef}>
-                          <label className="mb-1 block text-xs text-muted-foreground">
-                            Base branch
-                          </label>
-                          <button
-                            ref={branchTriggerRef}
-                            type="button"
-                            role="combobox"
-                            tabIndex={0}
-                            aria-expanded={branchDropdownOpen}
-                            data-testid="create-agent-base-branch"
-                            onClick={() =>
-                              branchDropdownOpen
-                                ? setBranchDropdownOpen(false)
-                                : openBranchDropdown()
-                            }
-                            onKeyDown={(e) => {
-                              if (
-                                e.key === "ArrowDown" ||
-                                e.key === "Enter" ||
-                                e.key === " "
-                              ) {
-                                e.preventDefault();
-                                if (!branchDropdownOpen) openBranchDropdown();
-                              }
-                            }}
-                            className={cn(
-                              "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 font-mono text-xs shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
-                              "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
-                            )}
-                          >
-                            {createBaseBranch}
-                            {branchesLoading ? (
-                              <ActivityBars
-                                size={14}
-                                className="ml-2 shrink-0"
-                              />
-                            ) : (
-                              <ChevronDown
-                                className={cn(
-                                  "ml-2 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                                  branchDropdownOpen && "rotate-180"
-                                )}
-                              />
-                            )}
-                          </button>
-                          {branchDropdownOpen ? (
-                            <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
-                              <Command
-                                onKeyDown={(e) => {
-                                  if (e.key === "Escape") {
-                                    e.preventDefault();
-                                    setBranchDropdownOpen(false);
-                                    requestAnimationFrame(() =>
-                                      branchTriggerRef.current?.focus()
-                                    );
-                                  }
-                                }}
-                              >
-                                <CommandInput
-                                  ref={branchInputRef}
-                                  placeholder="Search branches..."
-                                  className="font-mono text-xs"
-                                />
-                                <CommandList>
-                                  {branchesLoading ? (
-                                    <CommandLoading>
-                                      <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
-                                        <ActivityBars size={12} />
-                                        Loading branches...
-                                      </div>
-                                    </CommandLoading>
-                                  ) : null}
-                                  <CommandEmpty>
-                                    No matching branches.
-                                  </CommandEmpty>
-                                  <CommandGroup>
-                                    {allBranches.map((branch) => (
-                                      <CommandItem
-                                        key={branch}
-                                        value={branch}
-                                        data-testid="create-agent-base-branch-option"
-                                        className="font-mono"
-                                        onSelect={() => {
-                                          setCreateBaseBranch(branch);
-                                          setBranchDropdownOpen(false);
-                                          requestAnimationFrame(() =>
-                                            branchTriggerRef.current?.focus()
-                                          );
-                                        }}
-                                      >
-                                        <Check
-                                          className={cn(
-                                            "mr-2 h-3 w-3 shrink-0",
-                                            branch === createBaseBranch
-                                              ? "opacity-100"
-                                              : "opacity-0"
-                                          )}
-                                        />
-                                        {branch}
-                                      </CommandItem>
-                                    ))}
-                                  </CommandGroup>
-                                </CommandList>
-                              </Command>
-                            </div>
-                          ) : null}
-                        </div>
-                        <Input
-                          value={createWorktreeBranch}
-                          onChange={(event) =>
-                            setCreateWorktreeBranch(event.target.value)
-                          }
-                          placeholder="branch name (auto-generated if empty)"
-                          data-testid="create-agent-worktree-branch"
+                      <div className="ml-8 w-[calc(100%-2rem)]">
+                        <BranchSelect
+                          cwd={createCwd}
+                          baseBranch={createBaseBranch}
+                          onBaseBranchChange={setCreateBaseBranch}
+                          worktreeBranch={createWorktreeBranch}
+                          onWorktreeBranchChange={setCreateWorktreeBranch}
+                          testIdPrefix="create-agent"
+                          onDropdownOpenChange={setBranchDropdownOpen}
                         />
                       </div>
                     ) : null}

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { type Agent } from "@/components/app/types";
+import { useClickOutside } from "@/hooks/use-click-outside";
 import {
   AGENT_TYPE_LABELS,
   type AgentType,
@@ -43,23 +44,6 @@ const CWD_HISTORY_MAX = 20;
 const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
 const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
 const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
-
-function useClickOutside(
-  ref: React.RefObject<HTMLElement | null>,
-  isOpen: boolean,
-  onClose: () => void
-): void {
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [ref, isOpen, onClose]);
-}
 
 function readStoredString(key: string): string {
   if (typeof window === "undefined") return "";
@@ -282,8 +266,6 @@ export function CreateAgentDialog({
   const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
   useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
 
-  const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
-
   const handleRemoveCwdHistory = useCallback((cwd: string) => {
     setCwdHistory(removeCwdFromHistory(cwd));
   }, []);
@@ -340,7 +322,7 @@ export function CreateAgentDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
         onEscapeKeyDown={(e) => {
-          if (typeDropdownOpen || branchDropdownOpen) {
+          if (typeDropdownOpen) {
             e.preventDefault();
           }
           if (step === "prompt") {
@@ -506,7 +488,6 @@ export function CreateAgentDialog({
                           worktreeBranch={createWorktreeBranch}
                           onWorktreeBranchChange={setCreateWorktreeBranch}
                           testIdPrefix="create-agent"
-                          onDropdownOpenChange={setBranchDropdownOpen}
                         />
                       </div>
                     ) : null}

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -35,6 +35,7 @@ import {
   isAgentType,
 } from "@/lib/agent-types";
 import { api } from "@/lib/api";
+import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
 
 const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
@@ -322,6 +323,8 @@ export function CreateAgentDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
         onEscapeKeyDown={(e) => {
+          swallowEscapeFromCombobox(e);
+          if (e.defaultPrevented) return;
           if (typeDropdownOpen) {
             e.preventDefault();
           }

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -81,7 +81,7 @@ type JobsContextValue = {
   showDetailPane: boolean;
   tab: DetailTab;
   history: { data?: { runs: JobRun[] }; isLoading: boolean };
-  activeRunAgent: Agent | null;
+  activeRunAgent: { agent: Agent; isActive: boolean } | null;
   jobStats: {
     data?: import("@/hooks/use-jobs").JobStats | null;
     isLoading: boolean;
@@ -226,19 +226,19 @@ function triggerSourceLabel(run: JobRun): string {
 
 function useActiveRun(job: Job | null, agents: Agent[]) {
   return useMemo(() => {
-    if (
-      !job?.lastRunId ||
-      !job.lastRunStatus ||
-      !ACTIVE_RUN_STATUSES.includes(job.lastRunStatus)
-    )
-      return null;
-    return (
+    if (!job?.lastRunId || !job.lastRunStatus) return null;
+    // Active statuses always resolve; terminal statuses only resolve when the
+    // job opted out of auto-archive so the agent should still exist.
+    const isActive = ACTIVE_RUN_STATUSES.includes(job.lastRunStatus);
+    const keepsAgent = !job.autoArchive;
+    if (!isActive && !keepsAgent) return null;
+    const match =
       agents.find(
         (agent) =>
           agent.name.startsWith(`job-${job.name}-`) ||
           agent.name.endsWith(job.lastRunId!.slice(0, 8))
-      ) ?? null
-    );
+      ) ?? null;
+    return match ? { agent: match, isActive } : null;
   }, [agents, job]);
 }
 
@@ -392,8 +392,8 @@ export function JobListContent({
                 No jobs added yet.
               </div>
               <div className="mt-1 text-xs">
-                Added jobs will appear here with schedule, status, and run
-                controls.
+                Added jobs will appear here — run them on a schedule or on
+                demand.
               </div>
             </div>
           </div>
@@ -1119,6 +1119,10 @@ function AddJobFlow({
   const [enableImmediately, setEnableImmediately] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  // Enabled is meaningless without a schedule — reset when the schedule clears.
+  useEffect(() => {
+    if (!schedule.trim() && enableImmediately) setEnableImmediately(false);
+  }, [schedule, enableImmediately]);
   const scheduleError = cronError(schedule, enableImmediately);
   const canAdd =
     !!displayName.trim() &&
@@ -1132,28 +1136,35 @@ function AddJobFlow({
     <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col overflow-hidden p-4 md:p-8">
       <div className="text-lg font-semibold">Create a new job</div>
       <p className="mt-1 text-sm text-muted-foreground">
-        Define a recurring automation with a prompt and schedule.
+        Define an automation with a prompt — on a schedule or on demand.
       </p>
 
       <ScrollArea className="mt-6 min-h-0 flex-1 pr-1">
         <div className="grid min-w-0 gap-4">
           <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
-            <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
-              <span>
-                <span className="block font-medium text-foreground">
-                  Enabled
+            {schedule.trim() ? (
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+                <span>
+                  <span className="block font-medium text-foreground">
+                    Enabled
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Run this job on its schedule after creating it.
+                  </span>
                 </span>
-                <span className="block text-xs text-muted-foreground">
-                  Run this job on its schedule after creating it.
-                </span>
-              </span>
-              <SwitchToggle
-                checked={enableImmediately}
-                onCheckedChange={setEnableImmediately}
-                ariaLabel="Enable job"
-              />
-            </label>
-            <div className="mt-4 grid min-w-0 gap-3 md:grid-cols-2">
+                <SwitchToggle
+                  checked={enableImmediately}
+                  onCheckedChange={setEnableImmediately}
+                  ariaLabel="Enable job"
+                />
+              </label>
+            ) : null}
+            <div
+              className={cn(
+                "grid min-w-0 gap-3 md:grid-cols-2",
+                schedule.trim() ? "mt-4" : ""
+              )}
+            >
               <div className="min-w-0 space-y-1 md:col-span-2">
                 <label
                   className="text-sm text-muted-foreground"
@@ -1268,7 +1279,7 @@ function AddJobFlow({
               <div>
                 <div className="text-sm font-medium">Advanced settings</div>
                 <div className="mt-1 text-xs text-muted-foreground">
-                  Timeouts, worktree behavior, and permissions.
+                  Timeouts, worktree, permissions, and agent lifecycle.
                 </div>
               </div>
               <ChevronDown
@@ -1416,7 +1427,7 @@ function JobDetail({
   historyLoading: boolean;
   selectedRunId: string | null;
   onSelectRun: (runId: string) => void;
-  activeRunAgent: Agent | null;
+  activeRunAgent: { agent: Agent; isActive: boolean } | null;
   onOpenAgent: (agent: Agent) => Promise<void>;
   onRunNow: (job: Job) => Promise<void>;
   onSetEnabled: (job: Job, enabled: boolean) => Promise<void>;
@@ -1455,22 +1466,41 @@ function JobDetail({
           }}
         >
           <Play className="mr-2 h-4 w-4" />
-          Run Now
+          Run now
         </Button>
       </div>
 
       {activeRunAgent ? (
-        <div className="mt-4 rounded-md border border-status-working/40 bg-status-working/10 p-3">
+        <div
+          className={cn(
+            "mt-4 rounded-md border p-3",
+            activeRunAgent.isActive
+              ? "border-status-working/40 bg-status-working/10"
+              : "border-border/70 bg-muted/30"
+          )}
+        >
           <div className="flex flex-wrap items-center gap-3">
             <div className="min-w-0 flex-1">
-              <div className="text-sm font-medium text-status-working">
-                Active run is attached to a live agent session.
+              <div
+                className={cn(
+                  "text-sm font-medium",
+                  activeRunAgent.isActive
+                    ? "text-status-working"
+                    : "text-foreground"
+                )}
+              >
+                {activeRunAgent.isActive
+                  ? "Active run is attached to a live agent session."
+                  : "Agent kept after completion — pick up where the run left off."}
               </div>
               <div className="truncate text-xs text-muted-foreground">
-                {activeRunAgent.name}
+                {activeRunAgent.agent.name}
               </div>
             </div>
-            <Button size="sm" onClick={() => void onOpenAgent(activeRunAgent)}>
+            <Button
+              size="sm"
+              onClick={() => void onOpenAgent(activeRunAgent.agent)}
+            >
               <Terminal className="mr-2 h-4 w-4" />
               Open session
             </Button>
@@ -1488,7 +1518,7 @@ function JobDetail({
               ? `Scheduled next run: ${formatDate(job.nextRun)}.`
               : job.schedule
                 ? "This job is saved but not enabled on a schedule yet."
-                : "This job is on-demand — use Run once to start it."}
+                : "This job is on-demand — use Run now to start it."}
           </div>
           {detailActionError ? (
             <div className="mt-3 rounded border border-status-blocked/30 bg-status-blocked/10 p-2 text-sm text-status-blocked">
@@ -1507,7 +1537,7 @@ function JobDetail({
               }}
             >
               <Play className="mr-2 h-4 w-4" />
-              Run once
+              Run now
             </Button>
             {!job.enabled ? (
               <Button
@@ -1713,8 +1743,8 @@ function JobSkipAutoArchiveOption({
           Keep agent after run completes
         </span>
         <span className="block text-xs text-muted-foreground">
-          Skip auto-archive so you can hop back into the session after the job
-          finishes.
+          The agent stays in your Agents list so you can continue the session
+          after the job finishes.
         </span>
       </span>
     </label>
@@ -1814,6 +1844,10 @@ function SettingsTab({
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [saved, setSaved] = useState(false);
+  // Enabled is meaningless without a schedule — reset when the schedule clears.
+  useEffect(() => {
+    if (!schedule.trim() && enabled) setEnabled(false);
+  }, [schedule, enabled]);
   const scheduleError = cronError(schedule, enabled);
   const canSave =
     !!displayName.trim() &&
@@ -1846,19 +1880,21 @@ function SettingsTab({
         <p className="mt-1 text-xs text-muted-foreground">
           These values are used when the schedule or Run button starts this job.
         </p>
-        <label className="mt-4 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
-          <span>
-            <span className="block font-medium text-foreground">Enabled</span>
-            <span className="block text-xs text-muted-foreground">
-              Run this job on its saved schedule.
+        {schedule.trim() ? (
+          <label className="mt-4 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+            <span>
+              <span className="block font-medium text-foreground">Enabled</span>
+              <span className="block text-xs text-muted-foreground">
+                Run this job on its saved schedule.
+              </span>
             </span>
-          </span>
-          <SwitchToggle
-            checked={enabled}
-            onCheckedChange={setEnabled}
-            ariaLabel="Enable job"
-          />
-        </label>
+            <SwitchToggle
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              ariaLabel="Enable job"
+            />
+          </label>
+        ) : null}
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           <div className="space-y-1 md:col-span-2">
             <label

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -63,6 +63,7 @@ import {
 import { StatCard } from "@/components/app/stat-card";
 import { formatRelativeTime } from "@/lib/format";
 import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
 
 type JobsPaneProps = {
@@ -1068,7 +1069,10 @@ function AddJobDialog({
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md" />
-        <DialogPrimitive.Content className="fixed inset-x-2 bottom-2 top-2 z-50 flex max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-lg border border-white/[0.2] bg-[hsl(var(--card))] backdrop-blur-2xl shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] outline-none md:left-1/2 md:top-1/2 md:h-[min(760px,88vh)] md:w-[min(760px,calc(100vw-2rem))] md:-translate-x-1/2 md:-translate-y-1/2">
+        <DialogPrimitive.Content
+          onEscapeKeyDown={swallowEscapeFromCombobox}
+          className="fixed inset-x-2 bottom-2 top-2 z-50 flex max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-lg border border-white/[0.2] bg-[hsl(var(--card))] backdrop-blur-2xl shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] outline-none md:left-1/2 md:top-1/2 md:h-[min(760px,88vh)] md:w-[min(760px,calc(100vw-2rem))] md:-translate-x-1/2 md:-translate-y-1/2"
+        >
           <DialogPrimitive.Title className="sr-only">
             Add job
           </DialogPrimitive.Title>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -81,7 +81,7 @@ type JobsContextValue = {
   showDetailPane: boolean;
   tab: DetailTab;
   history: { data?: { runs: JobRun[] }; isLoading: boolean };
-  activeRunAgent: { agent: Agent; isActive: boolean } | null;
+  attachedAgent: { agent: Agent; isActive: boolean } | null;
   jobStats: {
     data?: import("@/hooks/use-jobs").JobStats | null;
     isLoading: boolean;
@@ -224,7 +224,7 @@ function triggerSourceLabel(run: JobRun): string {
   return run.config.triggerSource === "scheduled" ? "Scheduled" : "Manual";
 }
 
-function useActiveRun(job: Job | null, agents: Agent[]) {
+function useAttachedJobAgent(job: Job | null, agents: Agent[]) {
   return useMemo(() => {
     if (!job?.lastRunId || !job.lastRunStatus) return null;
     // Active statuses always resolve; terminal statuses only resolve when the
@@ -270,7 +270,7 @@ export function JobsProvider({
       ? routeSection
       : "configure";
   const history = useJobHistory(selectedJob);
-  const activeRunAgent = useActiveRun(selectedJob, agents);
+  const attachedAgent = useAttachedJobAgent(selectedJob, agents);
   const jobStats = useJobStats(open && !selectedJob);
 
   const selectJob = (job: Job) => {
@@ -295,7 +295,7 @@ export function JobsProvider({
     showDetailPane,
     tab,
     history,
-    activeRunAgent,
+    attachedAgent,
     jobStats,
     routeRunId,
     selectJob,
@@ -485,7 +485,7 @@ export function JobDetailPane(): JSX.Element {
     selectedJob,
     tab,
     history,
-    activeRunAgent,
+    attachedAgent,
     jobStats,
     routeRunId,
     navigate,
@@ -524,7 +524,7 @@ export function JobDetailPane(): JSX.Element {
                     : `/jobs/${selectedJob.id}/history`
                 );
               }}
-              activeRunAgent={activeRunAgent}
+              attachedAgent={attachedAgent}
               onOpenAgent={onOpenAgent}
               onRunNow={async (job) => {
                 await runNow.mutateAsync(job);
@@ -1115,15 +1115,13 @@ function AddJobFlow({
   const [useWorktree, setUseWorktree] = useState(false);
   const [baseBranch, setBaseBranch] = useState("main");
   const [branchName, setBranchName] = useState("");
-  const [skipAutoArchive, setSkipAutoArchive] = useState(false);
+  const [keepAgent, setKeepAgent] = useState(false);
   const [enableImmediately, setEnableImmediately] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  // Enabled is meaningless without a schedule — reset when the schedule clears.
-  useEffect(() => {
-    if (!schedule.trim() && enableImmediately) setEnableImmediately(false);
-  }, [schedule, enableImmediately]);
-  const scheduleError = cronError(schedule, enableImmediately);
+  // Enabled is only meaningful when there's a schedule — derive rather than reset.
+  const effectiveEnabled = schedule.trim() ? enableImmediately : false;
+  const scheduleError = cronError(schedule, effectiveEnabled);
   const canAdd =
     !!displayName.trim() &&
     !!directory.trim() &&
@@ -1346,9 +1344,9 @@ function AddJobFlow({
                     checked={fullAccess}
                     onCheckedChange={setFullAccess}
                   />
-                  <JobSkipAutoArchiveOption
-                    checked={skipAutoArchive}
-                    onCheckedChange={setSkipAutoArchive}
+                  <JobKeepAgentOption
+                    checked={keepAgent}
+                    onCheckedChange={setKeepAgent}
                   />
                 </div>
               </div>
@@ -1385,8 +1383,8 @@ function AddJobFlow({
               baseBranch: useWorktree ? baseBranch : null,
               branchName: useWorktree ? branchName : null,
               fullAccess,
-              autoArchive: !skipAutoArchive,
-              enabled: enableImmediately,
+              autoArchive: !keepAgent,
+              enabled: effectiveEnabled,
             }).catch((error) => setSubmitError(errorMessage(error)));
           }}
         >
@@ -1405,7 +1403,7 @@ function JobDetail({
   onTabChange,
   history,
   historyLoading,
-  activeRunAgent,
+  attachedAgent,
   onOpenAgent,
   onRunNow,
   onSetEnabled,
@@ -1427,7 +1425,7 @@ function JobDetail({
   historyLoading: boolean;
   selectedRunId: string | null;
   onSelectRun: (runId: string) => void;
-  activeRunAgent: { agent: Agent; isActive: boolean } | null;
+  attachedAgent: { agent: Agent; isActive: boolean } | null;
   onOpenAgent: (agent: Agent) => Promise<void>;
   onRunNow: (job: Job) => Promise<void>;
   onSetEnabled: (job: Job, enabled: boolean) => Promise<void>;
@@ -1470,11 +1468,11 @@ function JobDetail({
         </Button>
       </div>
 
-      {activeRunAgent ? (
+      {attachedAgent ? (
         <div
           className={cn(
             "mt-4 rounded-md border p-3",
-            activeRunAgent.isActive
+            attachedAgent.isActive
               ? "border-status-working/40 bg-status-working/10"
               : "border-border/70 bg-muted/30"
           )}
@@ -1484,22 +1482,22 @@ function JobDetail({
               <div
                 className={cn(
                   "text-sm font-medium",
-                  activeRunAgent.isActive
+                  attachedAgent.isActive
                     ? "text-status-working"
                     : "text-foreground"
                 )}
               >
-                {activeRunAgent.isActive
+                {attachedAgent.isActive
                   ? "Active run is attached to a live agent session."
                   : "Agent kept after completion — pick up where the run left off."}
               </div>
               <div className="truncate text-xs text-muted-foreground">
-                {activeRunAgent.agent.name}
+                {attachedAgent.agent.name}
               </div>
             </div>
             <Button
               size="sm"
-              onClick={() => void onOpenAgent(activeRunAgent.agent)}
+              onClick={() => void onOpenAgent(attachedAgent.agent)}
             >
               <Terminal className="mr-2 h-4 w-4" />
               Open session
@@ -1723,7 +1721,7 @@ function JobWorktreeOption({
   );
 }
 
-function JobSkipAutoArchiveOption({
+function JobKeepAgentOption({
   checked,
   onCheckedChange,
 }: {
@@ -1838,17 +1836,15 @@ function SettingsTab({
   const [useWorktree, setUseWorktree] = useState(job.useWorktree);
   const [baseBranch, setBaseBranch] = useState(job.baseBranch ?? "main");
   const [branchName, setBranchName] = useState(job.branchName ?? "");
-  const [skipAutoArchive, setSkipAutoArchive] = useState(!job.autoArchive);
+  const [keepAgent, setKeepAgent] = useState(!job.autoArchive);
   const [enabled, setEnabled] = useState(job.enabled);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [saved, setSaved] = useState(false);
-  // Enabled is meaningless without a schedule — reset when the schedule clears.
-  useEffect(() => {
-    if (!schedule.trim() && enabled) setEnabled(false);
-  }, [schedule, enabled]);
-  const scheduleError = cronError(schedule, enabled);
+  // Enabled is only meaningful when there's a schedule — derive rather than reset.
+  const effectiveEnabled = schedule.trim() ? enabled : false;
+  const scheduleError = cronError(schedule, effectiveEnabled);
   const canSave =
     !!displayName.trim() &&
     !scheduleError &&
@@ -1865,7 +1861,7 @@ function SettingsTab({
     setUseWorktree(job.useWorktree);
     setBaseBranch(job.baseBranch ?? "main");
     setBranchName(job.branchName ?? "");
-    setSkipAutoArchive(!job.autoArchive);
+    setKeepAgent(!job.autoArchive);
     setEnabled(job.enabled);
     setSaveError(null);
     setRemoveError(null);
@@ -2002,9 +1998,9 @@ function SettingsTab({
             checked={fullAccess}
             onCheckedChange={setFullAccess}
           />
-          <JobSkipAutoArchiveOption
-            checked={skipAutoArchive}
-            onCheckedChange={setSkipAutoArchive}
+          <JobKeepAgentOption
+            checked={keepAgent}
+            onCheckedChange={setKeepAgent}
           />
         </div>
         {saveError ? (
@@ -2036,8 +2032,8 @@ function SettingsTab({
                 baseBranch: useWorktree ? baseBranch : null,
                 branchName: useWorktree ? branchName : null,
                 fullAccess,
-                autoArchive: !skipAutoArchive,
-                enabled,
+                autoArchive: !keepAgent,
+                enabled: effectiveEnabled,
               })
                 .then(() => {
                   setSaved(true);

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -1213,6 +1213,23 @@ function AddJobFlow({
                     Leave blank for an on-demand job.
                   </div>
                 ) : null}
+                {schedule.trim() ? (
+                  <label className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+                    <span>
+                      <span className="block font-medium text-foreground">
+                        Enabled
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        Run this job on its schedule after creating it.
+                      </span>
+                    </span>
+                    <SwitchToggle
+                      checked={enableImmediately}
+                      onCheckedChange={setEnableImmediately}
+                      ariaLabel="Enable job"
+                    />
+                  </label>
+                ) : null}
               </div>
               <div className="min-w-0 space-y-1">
                 <label className="text-sm text-muted-foreground">
@@ -1234,23 +1251,6 @@ function AddJobFlow({
                   </SelectContent>
                 </Select>
               </div>
-              {schedule.trim() ? (
-                <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
-                  <span>
-                    <span className="block font-medium text-foreground">
-                      Enabled
-                    </span>
-                    <span className="block text-xs text-muted-foreground">
-                      Run this job on its schedule after creating it.
-                    </span>
-                  </span>
-                  <SwitchToggle
-                    checked={enableImmediately}
-                    onCheckedChange={setEnableImmediately}
-                    ariaLabel="Enable job"
-                  />
-                </label>
-              ) : null}
             </div>
           </div>
 
@@ -1926,6 +1926,23 @@ function SettingsTab({
                 Leave blank for an on-demand job.
               </div>
             ) : null}
+            {schedule.trim() ? (
+              <label className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+                <span>
+                  <span className="block font-medium text-foreground">
+                    Enabled
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Run this job on its saved schedule.
+                  </span>
+                </span>
+                <SwitchToggle
+                  checked={enabled}
+                  onCheckedChange={setEnabled}
+                  ariaLabel="Enable job"
+                />
+              </label>
+            ) : null}
           </div>
           <div className="space-y-1">
             <label className="text-sm text-muted-foreground">Agent type</label>
@@ -1945,23 +1962,6 @@ function SettingsTab({
               </SelectContent>
             </Select>
           </div>
-          {schedule.trim() ? (
-            <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
-              <span>
-                <span className="block font-medium text-foreground">
-                  Enabled
-                </span>
-                <span className="block text-xs text-muted-foreground">
-                  Run this job on its saved schedule.
-                </span>
-              </span>
-              <SwitchToggle
-                checked={enabled}
-                onCheckedChange={setEnabled}
-                ariaLabel="Enable job"
-              />
-            </label>
-          ) : null}
           <div className="space-y-1">
             <label
               className="text-sm text-muted-foreground"

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -19,6 +19,7 @@ import {
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { BranchSelect } from "@/components/app/branch-select";
 import { PathInput } from "@/components/app/path-input";
 import { type Agent } from "@/components/app/types";
 import { ActivityBars } from "@/components/ui/activity-bars";
@@ -211,7 +212,7 @@ function shortPath(value: string): string {
 }
 
 function humanSchedule(schedule: string | null): string {
-  if (!schedule) return "No schedule";
+  if (!schedule) return "On demand";
   try {
     return cronstrue.toString(schedule, { use24HourTimeFormat: false });
   } catch {
@@ -449,12 +450,18 @@ export function JobListContent({
                   <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
                     <Clock className="h-3.5 w-3.5 shrink-0" />
                     <span className="truncate">
-                      {job.schedule ? `Cron: ${job.schedule}` : "No schedule"}
+                      {job.schedule ? `Cron: ${job.schedule}` : "On demand"}
                     </span>
-                    <span className="shrink-0 text-muted-foreground/70">•</span>
-                    <span className="shrink-0">
-                      {job.enabled ? "enabled" : "disabled"}
-                    </span>
+                    {job.schedule ? (
+                      <>
+                        <span className="shrink-0 text-muted-foreground/70">
+                          •
+                        </span>
+                        <span className="shrink-0">
+                          {job.enabled ? "enabled" : "disabled"}
+                        </span>
+                      </>
+                    ) : null}
                   </div>
                   {actionError ? (
                     <div className="mt-2 rounded border border-status-blocked/30 bg-status-blocked/10 px-2 py-1 text-xs text-status-blocked">
@@ -659,7 +666,7 @@ function JobsOverview({
           <div className="font-medium text-foreground">No jobs yet</div>
           <div className="mt-1 max-w-sm text-sm">
             Use jobs for recurring maintenance, scheduled checks, and repeatable
-            agent workflows that should run without manual prompting.
+            agent workflows — on a schedule or on demand.
           </div>
         </div>
       </div>
@@ -1106,7 +1113,9 @@ function AddJobFlow({
   );
   const [fullAccess, setFullAccess] = useState(false);
   const [useWorktree, setUseWorktree] = useState(false);
+  const [baseBranch, setBaseBranch] = useState("main");
   const [branchName, setBranchName] = useState("");
+  const [skipAutoArchive, setSkipAutoArchive] = useState(false);
   const [enableImmediately, setEnableImmediately] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -1180,7 +1189,8 @@ function AddJobFlow({
                   className="text-sm text-muted-foreground"
                   htmlFor="job-schedule"
                 >
-                  Cron schedule
+                  Cron schedule{" "}
+                  <span className="text-muted-foreground/70">(optional)</span>
                 </label>
                 <Input
                   id="job-schedule"
@@ -1197,6 +1207,11 @@ function AddJobFlow({
                 {!scheduleError && schedule.trim() ? (
                   <div className="text-xs text-muted-foreground">
                     {humanSchedule(schedule)}
+                  </div>
+                ) : null}
+                {!schedule.trim() ? (
+                  <div className="text-xs text-muted-foreground">
+                    Leave blank for an on-demand job.
                   </div>
                 ) : null}
               </div>
@@ -1308,13 +1323,21 @@ function AddJobFlow({
                   </div>
                   <JobWorktreeOption
                     checked={useWorktree}
+                    cwd={directory}
+                    baseBranch={baseBranch}
                     branchName={branchName}
                     onCheckedChange={setUseWorktree}
+                    onBaseBranchChange={setBaseBranch}
                     onBranchNameChange={setBranchName}
+                    testIdPrefix="job-create"
                   />
                   <JobFullAccessOption
                     checked={fullAccess}
                     onCheckedChange={setFullAccess}
+                  />
+                  <JobSkipAutoArchiveOption
+                    checked={skipAutoArchive}
+                    onCheckedChange={setSkipAutoArchive}
                   />
                 </div>
               </div>
@@ -1348,8 +1371,10 @@ function AddJobFlow({
               needsInputTimeoutMs: msFromMinutes(needsInputTimeoutMinutes),
               agentType,
               useWorktree,
+              baseBranch: useWorktree ? baseBranch : null,
               branchName: useWorktree ? branchName : null,
               fullAccess,
+              autoArchive: !skipAutoArchive,
               enabled: enableImmediately,
             }).catch((error) => setSubmitError(errorMessage(error)));
           }}
@@ -1461,7 +1486,9 @@ function JobDetail({
           <div className="mt-1 text-sm text-muted-foreground">
             {job.enabled && job.nextRun
               ? `Scheduled next run: ${formatDate(job.nextRun)}.`
-              : "This job is saved but not enabled on a schedule yet."}
+              : job.schedule
+                ? "This job is saved but not enabled on a schedule yet."
+                : "This job is on-demand — use Run once to start it."}
           </div>
           {detailActionError ? (
             <div className="mt-3 rounded border border-status-blocked/30 bg-status-blocked/10 p-2 text-sm text-status-blocked">
@@ -1614,14 +1641,22 @@ function TabButton({
 
 function JobWorktreeOption({
   checked,
+  cwd,
+  baseBranch,
   branchName,
   onCheckedChange,
+  onBaseBranchChange,
   onBranchNameChange,
+  testIdPrefix,
 }: {
   checked: boolean;
+  cwd: string;
+  baseBranch: string;
   branchName: string;
   onCheckedChange: (checked: boolean) => void;
+  onBaseBranchChange: (value: string) => void;
   onBranchNameChange: (value: string) => void;
+  testIdPrefix?: string;
 }) {
   return (
     <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
@@ -1644,14 +1679,45 @@ function JobWorktreeOption({
       </label>
       {checked ? (
         <div className="ml-8 w-[calc(100%-2rem)]">
-          <Input
-            value={branchName}
-            onChange={(event) => onBranchNameChange(event.target.value)}
-            placeholder="branch name (auto-generated if empty)"
+          <BranchSelect
+            cwd={cwd}
+            baseBranch={baseBranch}
+            onBaseBranchChange={onBaseBranchChange}
+            worktreeBranch={branchName}
+            onWorktreeBranchChange={onBranchNameChange}
+            testIdPrefix={testIdPrefix ?? "job-worktree"}
           />
         </div>
       ) : null}
     </div>
+  );
+}
+
+function JobSkipAutoArchiveOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Keep agent after run completes"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Keep agent after run completes
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          Skip auto-archive so you can hop back into the session after the job
+          finishes.
+        </span>
+      </span>
+    </label>
   );
 }
 
@@ -1740,7 +1806,9 @@ function SettingsTab({
   const [agentType, setAgentType] = useState<AgentType>(job.agentType);
   const [fullAccess, setFullAccess] = useState(job.fullAccess);
   const [useWorktree, setUseWorktree] = useState(job.useWorktree);
+  const [baseBranch, setBaseBranch] = useState(job.baseBranch ?? "main");
   const [branchName, setBranchName] = useState(job.branchName ?? "");
+  const [skipAutoArchive, setSkipAutoArchive] = useState(!job.autoArchive);
   const [enabled, setEnabled] = useState(job.enabled);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
@@ -1761,7 +1829,9 @@ function SettingsTab({
     setAgentType(job.agentType);
     setFullAccess(job.fullAccess);
     setUseWorktree(job.useWorktree);
+    setBaseBranch(job.baseBranch ?? "main");
     setBranchName(job.branchName ?? "");
+    setSkipAutoArchive(!job.autoArchive);
     setEnabled(job.enabled);
     setSaveError(null);
     setRemoveError(null);
@@ -1808,7 +1878,8 @@ function SettingsTab({
               className="text-sm text-muted-foreground"
               htmlFor={`settings-schedule-${job.id}`}
             >
-              Cron schedule
+              Cron schedule{" "}
+              <span className="text-muted-foreground/70">(optional)</span>
             </label>
             <Input
               id={`settings-schedule-${job.id}`}
@@ -1823,6 +1894,11 @@ function SettingsTab({
             {!scheduleError && schedule.trim() ? (
               <div className="text-xs text-muted-foreground">
                 {humanSchedule(schedule)}
+              </div>
+            ) : null}
+            {!schedule.trim() ? (
+              <div className="text-xs text-muted-foreground">
+                Leave blank for an on-demand job.
               </div>
             ) : null}
           </div>
@@ -1878,13 +1954,21 @@ function SettingsTab({
         <div className="mt-4 grid gap-3">
           <JobWorktreeOption
             checked={useWorktree}
+            cwd={job.directory}
+            baseBranch={baseBranch}
             branchName={branchName}
             onCheckedChange={setUseWorktree}
+            onBaseBranchChange={setBaseBranch}
             onBranchNameChange={setBranchName}
+            testIdPrefix={`job-settings-${job.id}`}
           />
           <JobFullAccessOption
             checked={fullAccess}
             onCheckedChange={setFullAccess}
+          />
+          <JobSkipAutoArchiveOption
+            checked={skipAutoArchive}
+            onCheckedChange={setSkipAutoArchive}
           />
         </div>
         {saveError ? (
@@ -1913,8 +1997,10 @@ function SettingsTab({
                 needsInputTimeoutMs: msFromMinutes(needsInputTimeoutMinutes),
                 agentType,
                 useWorktree,
+                baseBranch: useWorktree ? baseBranch : null,
                 branchName: useWorktree ? branchName : null,
                 fullAccess,
+                autoArchive: !skipAutoArchive,
                 enabled,
               })
                 .then(() => {

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -463,6 +463,14 @@ export function JobListContent({
                         </span>
                       </>
                     ) : null}
+                    {!job.autoArchive ? (
+                      <>
+                        <span className="shrink-0 text-muted-foreground/70">
+                          •
+                        </span>
+                        <span className="shrink-0">keeps agent</span>
+                      </>
+                    ) : null}
                   </div>
                   {actionError ? (
                     <div className="mt-2 rounded border border-status-blocked/30 bg-status-blocked/10 px-2 py-1 text-xs text-status-blocked">
@@ -1144,29 +1152,7 @@ function AddJobFlow({
       <ScrollArea className="mt-6 min-h-0 flex-1 pr-1">
         <div className="grid min-w-0 gap-4">
           <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
-            {schedule.trim() ? (
-              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
-                <span>
-                  <span className="block font-medium text-foreground">
-                    Enabled
-                  </span>
-                  <span className="block text-xs text-muted-foreground">
-                    Run this job on its schedule after creating it.
-                  </span>
-                </span>
-                <SwitchToggle
-                  checked={enableImmediately}
-                  onCheckedChange={setEnableImmediately}
-                  ariaLabel="Enable job"
-                />
-              </label>
-            ) : null}
-            <div
-              className={cn(
-                "grid min-w-0 gap-3 md:grid-cols-2",
-                schedule.trim() ? "mt-4" : ""
-              )}
-            >
+            <div className="grid min-w-0 gap-3 md:grid-cols-2">
               <div className="min-w-0 space-y-1 md:col-span-2">
                 <label
                   className="text-sm text-muted-foreground"
@@ -1248,6 +1234,23 @@ function AddJobFlow({
                   </SelectContent>
                 </Select>
               </div>
+              {schedule.trim() ? (
+                <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
+                  <span>
+                    <span className="block font-medium text-foreground">
+                      Enabled
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      Run this job on its schedule after creating it.
+                    </span>
+                  </span>
+                  <SwitchToggle
+                    checked={enableImmediately}
+                    onCheckedChange={setEnableImmediately}
+                    ariaLabel="Enable job"
+                  />
+                </label>
+              ) : null}
             </div>
           </div>
 
@@ -1281,7 +1284,8 @@ function AddJobFlow({
               <div>
                 <div className="text-sm font-medium">Advanced settings</div>
                 <div className="mt-1 text-xs text-muted-foreground">
-                  Timeouts, worktree, permissions, and agent lifecycle.
+                  Timeouts, worktree, permissions, and whether the agent is kept
+                  after running.
                 </div>
               </div>
               <ChevronDown
@@ -1880,21 +1884,6 @@ function SettingsTab({
         <p className="mt-1 text-xs text-muted-foreground">
           These values are used when the schedule or Run button starts this job.
         </p>
-        {schedule.trim() ? (
-          <label className="mt-4 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
-            <span>
-              <span className="block font-medium text-foreground">Enabled</span>
-              <span className="block text-xs text-muted-foreground">
-                Run this job on its saved schedule.
-              </span>
-            </span>
-            <SwitchToggle
-              checked={enabled}
-              onCheckedChange={setEnabled}
-              ariaLabel="Enable job"
-            />
-          </label>
-        ) : null}
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           <div className="space-y-1 md:col-span-2">
             <label
@@ -1956,6 +1945,23 @@ function SettingsTab({
               </SelectContent>
             </Select>
           </div>
+          {schedule.trim() ? (
+            <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
+              <span>
+                <span className="block font-medium text-foreground">
+                  Enabled
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Run this job on its saved schedule.
+                </span>
+              </span>
+              <SwitchToggle
+                checked={enabled}
+                onCheckedChange={setEnabled}
+                ariaLabel="Enable job"
+              />
+            </label>
+          ) : null}
           <div className="space-y-1">
             <label
               className="text-sm text-muted-foreground"

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -14,25 +14,9 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { useClickOutside } from "@/hooks/use-click-outside";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
-
-function useClickOutside(
-  ref: React.RefObject<HTMLElement | null>,
-  isOpen: boolean,
-  onClose: () => void
-): void {
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [ref, isOpen, onClose]);
-}
 
 type PathInfo = { exists: boolean; isDirectory: boolean; isGitRepo: boolean };
 

--- a/apps/web/src/hooks/use-click-outside.ts
+++ b/apps/web/src/hooks/use-click-outside.ts
@@ -1,0 +1,18 @@
+import { useEffect, type RefObject } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void
+): void {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [ref, isOpen, onClose]);
+}

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -47,8 +47,10 @@ export type Job = {
   enabled: boolean;
   agentType: JobAgentType;
   useWorktree: boolean;
+  baseBranch: string | null;
   branchName: string | null;
   fullAccess: boolean;
+  autoArchive: boolean;
   createdAt: string;
   updatedAt: string;
   lastRunId: string | null;
@@ -93,8 +95,10 @@ export type AddJobConfig = {
   needsInputTimeoutMs?: number;
   agentType?: JobAgentType;
   useWorktree?: boolean;
+  baseBranch?: string | null;
   branchName?: string | null;
   fullAccess?: boolean;
+  autoArchive?: boolean;
   enabled?: boolean;
 };
 

--- a/apps/web/src/lib/dialog-escape.ts
+++ b/apps/web/src/lib/dialog-escape.ts
@@ -1,0 +1,19 @@
+/**
+ * Handler factory for a Radix Dialog `onEscapeKeyDown` prop that prevents
+ * the dialog from closing when the Escape key originated inside a nested
+ * cmdk combobox (e.g. `BranchSelect`). The combobox handles its own
+ * Escape via its React `onKeyDown`, so the dialog must stay put.
+ *
+ * Usage:
+ *   <DialogContent onEscapeKeyDown={swallowEscapeFromCombobox}>…</DialogContent>
+ *
+ * Consumers that need additional escape logic can call this first and
+ * branch on `event.defaultPrevented`.
+ */
+export function swallowEscapeFromCombobox(event: KeyboardEvent): void {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  if (target.closest("[cmdk-root]")) {
+    event.preventDefault();
+  }
+}


### PR DESCRIPTION
## Summary

- Make cron **optional**: scheduleless jobs are treated as "On demand" in the UI (label + card copy). Existing "Run Now" already works on disabled/scheduleless jobs.
- Mirror the regular agent's branch controls on jobs: add `base_branch` alongside the existing `branch_name` (worktree name). Extracts the create-agent-dialog combobox into a reusable `BranchSelect` component used by both forms.
- Add a per-job `auto_archive` flag (default `true`). When false, the agent is kept around after the run terminates so the user can hop into the session — snapshotted onto `JobRunConfig` at run creation.

## Changes

- DB migration `0015_jobs-base-branch-auto-archive.sql` — adds `base_branch TEXT` + `auto_archive BOOLEAN DEFAULT TRUE` (both `IF NOT EXISTS`, idempotent). **Note**: verify the next-free number against prod `pgmigrations` before merging.
- `apps/server/src/jobs/store.ts` — `JobRecord`, `JobConfigUpdate`, `JobRunConfig`, `createJob`, `updateJobConfig`, `jobColumns`, `listJobs` SELECT.
- `apps/server/src/jobs/service.ts` — `AddJobInput`, `createAgent({ baseBranch })` wiring, `buildRunConfig` snapshots `autoArchive`.
- `apps/server/src/server.ts` — `AddJobBodySchema` accepts `baseBranch` + `autoArchive`; auto-archive handler gated on `run.config.autoArchive`.
- `apps/web/src/components/app/branch-select.tsx` — new shared component.
- `apps/web/src/components/app/create-agent-dialog.tsx` — consumes `BranchSelect`; drops inline combobox state.
- `apps/web/src/components/app/jobs-pane.tsx` — add-flow + settings tab add base branch + "Keep agent after run completes"; card shows "On demand" (hides enabled/disabled) for scheduleless jobs.
- `apps/web/src/hooks/use-jobs.ts` — `Job` + `AddJobConfig` extended.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm run test` (Vitest, 325 pass)
- [x] `pnpm run test:e2e` (Playwright, 139 pass)
- [x] `pnpm run finalize:web`
- [x] Playwright smoke on dev stack — Create Job dialog shows "Cron schedule (optional) / Leave blank for an on-demand job", Base branch combobox when worktree is on, and "Keep agent after run completes" toggle.
- [x] API round-trip: `POST /api/v1/jobs` with `baseBranch:"develop", autoArchive:false, schedule:null` persists and returns correctly; existing seeded jobs default to `autoArchive: true`.

## Backwards compatibility

- `auto_archive` defaults to `TRUE`, so existing jobs keep current archive-on-terminal behavior.
- `base_branch` is nullable; server-side `createAgent` already falls back to `"main"`.
- Run-level snapshot on `JobRunConfig`: older runs without `autoArchive` in their config default to `true` at the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)