### PR TITLE
feat(web): rewrite localhost in pinned URLs to the current host

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run"
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.9.0",
@@ -59,6 +60,7 @@
     "tailwindcss": "^3.4.15",
     "typescript-eslint": "^8.56.1",
     "vite": "^5.4.21",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -11,11 +11,13 @@ import { FrontTruncatedValue } from "@/components/app/agent-meta";
 import { type AgentPin } from "@/components/app/types";
 import { Markdown } from "@/components/ui/markdown";
 import { useCopyText } from "@/hooks/use-copy";
+import { useRewriteLocalhostPins } from "@/hooks/use-rewrite-localhost-pins";
 import {
   getSafariExternalHref,
   isStandaloneIOSApp,
 } from "@/lib/external-links";
 import { splitPinValues } from "@/lib/pins";
+import { rewritePinUrl } from "@/lib/rewrite-pin-url";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 const SAFE_URL_RE = /^https?:\/\//i;
@@ -227,15 +229,23 @@ function PinValueRow({
   value: string;
   workspaceRoot: string | null;
 }): JSX.Element {
+  const { enabled: rewriteLocalhost } = useRewriteLocalhostPins();
+
   if (type === "markdown") {
     return <MarkdownPinBody value={value} />;
   }
 
+  const rewrittenValue =
+    rewriteLocalhost && type === "url"
+      ? rewritePinUrl(value, window.location.host)
+      : value;
   const filenameValue =
-    type === "filename" ? trimFilenameForDisplay(value, workspaceRoot) : null;
+    type === "filename"
+      ? trimFilenameForDisplay(rewrittenValue, workspaceRoot)
+      : null;
   const { display, tooltip, href, badge, icon } = resolveDisplayValue(
     type,
-    filenameValue?.display ?? value
+    filenameValue?.display ?? rewrittenValue
   );
   const tooltipValue = filenameValue?.tooltip ?? tooltip;
   const showSafariButton = Boolean(href) && isStandaloneIOSApp();

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -18,13 +18,16 @@ import { UpdatesSection } from "@/components/app/release-manager";
 import { SecuritySettings } from "@/components/app/security-settings";
 import { ServiceStatus } from "@/components/app/service-status";
 import { type ServiceState } from "@/components/app/types";
+import { Checkbox } from "@/components/ui/checkbox";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useReleaseStream } from "@/hooks/use-release-stream";
+import { useRewriteLocalhostPins } from "@/hooks/use-rewrite-localhost-pins";
 import { type ThemeId, THEMES } from "@/hooks/use-theme";
 import { Input } from "@/components/ui/input";
 import { type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
+import { extractHostname } from "@/lib/rewrite-pin-url";
 import { cn } from "@/lib/utils";
 
 type SettingsSection =
@@ -156,6 +159,46 @@ function InstanceNameSettings(): JSX.Element {
 }
 
 // AppSettings (About) has been merged into UpdatesSection in release-manager.tsx
+
+function RewriteLocalhostPinsSettings(): JSX.Element {
+  const { enabled, setEnabled } = useRewriteLocalhostPins();
+  const host =
+    typeof window === "undefined" ? "" : extractHostname(window.location.host);
+
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Pin links
+      </div>
+      <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
+        Rewrite{" "}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+          localhost
+        </code>{" "}
+        in pinned URLs to{" "}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+          {host}
+        </code>
+        . Saved on this device.
+      </p>
+      <label
+        className={cn(
+          "flex max-w-lg items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors",
+          "cursor-pointer hover:bg-muted/50"
+        )}
+      >
+        <Checkbox
+          checked={enabled}
+          onCheckedChange={(v) => setEnabled(v === true)}
+          data-testid="rewrite-localhost-pins-toggle"
+        />
+        <div className="min-w-0 text-sm font-medium text-foreground">
+          Rewrite localhost in pins
+        </div>
+      </label>
+    </div>
+  );
+}
 
 type WorktreeLocation = "sibling" | "nested";
 
@@ -616,6 +659,9 @@ export function SettingsContent({
                 iconColorError={iconColorError}
                 clearIconColorError={clearIconColorError}
               />
+            </div>
+            <div className="border-t border-border p-4 md:p-6">
+              <RewriteLocalhostPinsSettings />
             </div>
             <div className="border-t border-border">
               <SecuritySettings onLogout={onLogout} />

--- a/apps/web/src/hooks/use-rewrite-localhost-pins.ts
+++ b/apps/web/src/hooks/use-rewrite-localhost-pins.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "dispatch:rewrite_localhost_pins";
+
+function readStored(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+export function useRewriteLocalhostPins(): {
+  enabled: boolean;
+  setEnabled: (value: boolean) => void;
+} {
+  const [enabled, setEnabledState] = useState<boolean>(readStored);
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      setEnabledState(event.newValue === "true");
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const setEnabled = useCallback((value: boolean) => {
+    window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+    setEnabledState(value);
+  }, []);
+
+  return { enabled, setEnabled };
+}

--- a/apps/web/src/lib/rewrite-pin-url.test.ts
+++ b/apps/web/src/lib/rewrite-pin-url.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { extractHostname, rewritePinUrl } from "./rewrite-pin-url";
+
+describe("rewritePinUrl", () => {
+  const target = "dispatch.example.com";
+
+  it.each([
+    ["http://localhost:5173", "http://dispatch.example.com:5173/"],
+    ["http://127.0.0.1:5173", "http://dispatch.example.com:5173/"],
+    ["http://0.0.0.0:8080", "http://dispatch.example.com:8080/"],
+    ["http://[::1]:5173", "http://dispatch.example.com:5173/"],
+  ])("rewrites loopback host %s", (input, expected) => {
+    expect(rewritePinUrl(input, target)).toBe(expected);
+  });
+
+  it("preserves path, query, and fragment", () => {
+    expect(
+      rewritePinUrl("http://localhost:5173/foo/bar?x=1&y=2#section", target)
+    ).toBe("http://dispatch.example.com:5173/foo/bar?x=1&y=2#section");
+  });
+
+  it("preserves https scheme and default port", () => {
+    expect(rewritePinUrl("https://localhost/dashboard", target)).toBe(
+      "https://dispatch.example.com/dashboard"
+    );
+  });
+
+  it("leaves non-loopback hosts alone", () => {
+    expect(rewritePinUrl("http://example.com:5173", target)).toBe(
+      "http://example.com:5173"
+    );
+  });
+
+  it("returns malformed input unchanged", () => {
+    expect(rewritePinUrl("not a url", target)).toBe("not a url");
+    expect(rewritePinUrl("", target)).toBe("");
+  });
+
+  it("accepts a targetHost with port and strips it", () => {
+    // Only the hostname portion should be used; pin's own port wins.
+    expect(
+      rewritePinUrl("http://localhost:5173", "dispatch.example.com:3000")
+    ).toBe("http://dispatch.example.com:5173/");
+  });
+});
+
+describe("extractHostname", () => {
+  it("returns bare hostname when port is absent", () => {
+    expect(extractHostname("example.com")).toBe("example.com");
+  });
+
+  it("strips the port from host:port", () => {
+    expect(extractHostname("example.com:8080")).toBe("example.com");
+  });
+
+  it("unwraps IPv6 bracket notation", () => {
+    expect(extractHostname("[::1]:8080")).toBe("[::1]");
+  });
+
+  it("passes unparseable input through", () => {
+    expect(extractHostname("")).toBe("");
+  });
+});

--- a/apps/web/src/lib/rewrite-pin-url.ts
+++ b/apps/web/src/lib/rewrite-pin-url.ts
@@ -1,0 +1,33 @@
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "[::1]",
+]);
+
+export function extractHostname(targetHost: string): string {
+  try {
+    return new URL(`http://${targetHost}`).hostname;
+  } catch {
+    return targetHost;
+  }
+}
+
+/**
+ * If `value` parses as a URL with a loopback host, swap in the hostname from
+ * `targetHost` (typically `window.location.host`). The URL's original port,
+ * path, query, and fragment are preserved. Non-loopback or unparseable inputs
+ * pass through unchanged.
+ */
+export function rewritePinUrl(value: string, targetHost: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return value;
+  }
+  if (!LOOPBACK_HOSTS.has(url.hostname)) return value;
+  url.hostname = extractHostname(targetHost);
+  return url.toString();
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:migrate": "pnpm --filter @dispatch/server db:migrate",
     "check": "pnpm --filter @dispatch/server check && pnpm run check:web",
     "ci": "pnpm run format && pnpm run check && pnpm run lint:web && pnpm run build && pnpm run test && pnpm run test:e2e",
-    "test": "pnpm --filter @dispatch/server test",
+    "test": "pnpm --filter @dispatch/server test && pnpm --filter @dispatch/web test",
     "test:watch": "pnpm --filter @dispatch/server test:watch",
     "test:e2e": "bash scripts/e2e-isolated.sh",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@24.12.0)(happy-dom@18.0.1)(terser@5.46.1)
 
 packages:
   "@alloc/quick-lru@5.2.0":
@@ -3423,11 +3426,31 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  "@vitest/expect@2.1.9":
+    resolution:
+      {
+        integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==,
+      }
+
   "@vitest/expect@4.1.2":
     resolution:
       {
         integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==,
       }
+
+  "@vitest/mocker@2.1.9":
+    resolution:
+      {
+        integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   "@vitest/mocker@4.1.2":
     resolution:
@@ -3443,10 +3466,22 @@ packages:
       vite:
         optional: true
 
+  "@vitest/pretty-format@2.1.9":
+    resolution:
+      {
+        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
+      }
+
   "@vitest/pretty-format@4.1.2":
     resolution:
       {
         integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==,
+      }
+
+  "@vitest/runner@2.1.9":
+    resolution:
+      {
+        integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==,
       }
 
   "@vitest/runner@4.1.2":
@@ -3455,16 +3490,34 @@ packages:
         integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==,
       }
 
+  "@vitest/snapshot@2.1.9":
+    resolution:
+      {
+        integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==,
+      }
+
   "@vitest/snapshot@4.1.2":
     resolution:
       {
         integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==,
       }
 
+  "@vitest/spy@2.1.9":
+    resolution:
+      {
+        integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==,
+      }
+
   "@vitest/spy@4.1.2":
     resolution:
       {
         integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==,
+      }
+
+  "@vitest/utils@2.1.9":
+    resolution:
+      {
+        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
       }
 
   "@vitest/utils@4.1.2":
@@ -3846,6 +3899,13 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  cac@6.7.14:
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: ">=8" }
+
   call-bind-apply-helpers@1.0.2:
     resolution:
       {
@@ -3893,6 +3953,13 @@ packages:
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
 
+  chai@5.3.3:
+    resolution:
+      {
+        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+      }
+    engines: { node: ">=18" }
+
   chai@6.2.2:
     resolution:
       {
@@ -3930,6 +3997,13 @@ packages:
       {
         integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
       }
+
+  check-error@2.1.3:
+    resolution:
+      {
+        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
+      }
+    engines: { node: ">= 16" }
 
   chokidar@3.6.0:
     resolution:
@@ -4276,6 +4350,13 @@ packages:
         integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
       }
 
+  deep-eql@5.0.2:
+    resolution:
+      {
+        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+      }
+    engines: { node: ">=6" }
+
   deep-is@0.1.4:
     resolution:
       {
@@ -4442,6 +4523,12 @@ packages:
         integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==,
       }
     engines: { node: ">= 0.4" }
+
+  es-module-lexer@1.7.0:
+    resolution:
+      {
+        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+      }
 
   es-module-lexer@2.0.0:
     resolution:
@@ -5826,6 +5913,12 @@ packages:
       }
     hasBin: true
 
+  loupe@3.2.1:
+    resolution:
+      {
+        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
+      }
+
   lru-cache@11.2.7:
     resolution:
       {
@@ -6481,11 +6574,24 @@ packages:
         integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==,
       }
 
+  pathe@1.1.2:
+    resolution:
+      {
+        integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
+      }
+
   pathe@2.0.3:
     resolution:
       {
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
       }
+
+  pathval@2.0.1:
+    resolution:
+      {
+        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+      }
+    engines: { node: ">= 14.16" }
 
   pg-cloudflare@1.3.0:
     resolution:
@@ -7471,6 +7577,12 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  std-env@3.10.0:
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+      }
+
   std-env@4.0.0:
     resolution:
       {
@@ -7695,6 +7807,12 @@ packages:
         integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
       }
 
+  tinyexec@0.3.2:
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
+
   tinyexec@1.0.4:
     resolution:
       {
@@ -7709,10 +7827,31 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
+  tinypool@1.1.1:
+    resolution:
+      {
+        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+
+  tinyrainbow@1.2.0:
+    resolution:
+      {
+        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
+      }
+    engines: { node: ">=14.0.0" }
+
   tinyrainbow@3.1.0:
     resolution:
       {
         integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  tinyspy@3.0.2:
+    resolution:
+      {
+        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
       }
     engines: { node: ">=14.0.0" }
 
@@ -8042,6 +8181,14 @@ packages:
         integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==,
       }
 
+  vite-node@2.1.9:
+    resolution:
+      {
+        integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+    hasBin: true
+
   vite-plugin-pwa@1.2.0:
     resolution:
       {
@@ -8132,6 +8279,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution:
+      {
+        integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@types/node": ^18.0.0 || >=20.0.0
+      "@vitest/browser": 2.1.9
+      "@vitest/ui": 2.1.9
+      happy-dom: "*"
+      jsdom: "*"
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.2:
@@ -10451,6 +10626,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@vitest/expect@2.1.9":
+    dependencies:
+      "@vitest/spy": 2.1.9
+      "@vitest/utils": 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   "@vitest/expect@4.1.2":
     dependencies:
       "@standard-schema/spec": 1.1.0
@@ -10460,6 +10642,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  "@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))":
+    dependencies:
+      "@vitest/spy": 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.12.0)(terser@5.46.1)
+
   "@vitest/mocker@4.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
       "@vitest/spy": 4.1.2
@@ -10468,14 +10658,29 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  "@vitest/pretty-format@2.1.9":
+    dependencies:
+      tinyrainbow: 1.2.0
+
   "@vitest/pretty-format@4.1.2":
     dependencies:
       tinyrainbow: 3.1.0
+
+  "@vitest/runner@2.1.9":
+    dependencies:
+      "@vitest/utils": 2.1.9
+      pathe: 1.1.2
 
   "@vitest/runner@4.1.2":
     dependencies:
       "@vitest/utils": 4.1.2
       pathe: 2.0.3
+
+  "@vitest/snapshot@2.1.9":
+    dependencies:
+      "@vitest/pretty-format": 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
 
   "@vitest/snapshot@4.1.2":
     dependencies:
@@ -10484,7 +10689,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  "@vitest/spy@2.1.9":
+    dependencies:
+      tinyspy: 3.0.2
+
   "@vitest/spy@4.1.2": {}
+
+  "@vitest/utils@2.1.9":
+    dependencies:
+      "@vitest/pretty-format": 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   "@vitest/utils@4.1.2":
     dependencies:
@@ -10728,6 +10943,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -10753,6 +10970,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -10767,6 +10992,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -10944,6 +11171,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -11084,6 +11313,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -12000,6 +12231,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
@@ -12554,7 +12787,11 @@ snapshots:
 
   path-to-regexp@8.4.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -13227,6 +13464,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -13408,6 +13647,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -13415,7 +13656,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13632,6 +13879,24 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@2.1.9(@types/node@24.12.0)(terser@5.46.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.12.0)(terser@5.46.1)
+    transitivePeerDependencies:
+      - "@types/node"
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-pwa@1.2.0(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
@@ -13668,6 +13933,42 @@ snapshots:
       terser: 5.46.1
       tsx: 4.21.0
       yaml: 2.8.3
+
+  vitest@2.1.9(@types/node@24.12.0)(happy-dom@18.0.1)(terser@5.46.1):
+    dependencies:
+      "@vitest/expect": 2.1.9
+      "@vitest/mocker": 2.1.9(vite@5.4.21(@types/node@24.12.0)(terser@5.46.1))
+      "@vitest/pretty-format": 2.1.9
+      "@vitest/runner": 2.1.9
+      "@vitest/snapshot": 2.1.9
+      "@vitest/spy": 2.1.9
+      "@vitest/utils": 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.12.0)(terser@5.46.1)
+      vite-node: 2.1.9(@types/node@24.12.0)(terser@5.46.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@types/node": 24.12.0
+      happy-dom: 18.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@4.1.2(@types/node@24.12.0)(happy-dom@18.0.1)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds an opt-in, per-client display transform that rewrites loopback hosts (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) in pinned `url` values to match the host the browser used to reach Dispatch. A pin like `http://localhost:5173` created on the server now works when clicked from a remote client (Tailscale, LAN IP, public hostname).
- Setting lives in `localStorage` (`dispatch:rewrite_localhost_pins`), default **off**, exposed under Settings → General → Pin links. Each device opts in independently.
- Server, MCP tools, SSE payloads, and DB state are untouched — pins stay canonical in the data layer; this is purely a client-side render transform.
- Adds vitest to `apps/web` (none previously) so the pure helper has regression coverage (13 cases).

## Test plan

- [x] `pnpm run check` — server + web tsc
- [x] `pnpm run finalize:web` — web type check + production build
- [x] `pnpm run test` — 325 server + 13 web unit tests pass
- [x] `pnpm run test:e2e` — 139 passed, 6 skipped
- [x] Manual browser validation: toggle renders and persists across reloads; helper rewrites every loopback form (including IPv6 `[::1]`) when run against a local pin value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)