### PR TITLE
feat(web): round sidebar inner edges and add vertical breathing room

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -498,7 +498,7 @@ export function AgentsView({
 
   return (
     <div className="h-full min-h-0 overflow-hidden text-foreground">
-      <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
+      <div className="flex h-full min-h-0 min-w-0 overflow-hidden py-2">
         <GlassSidebar
           open={isMobile ? mobileLeftOpen : leftOpen}
           onOpenChange={(open) => {
@@ -570,12 +570,7 @@ export function AgentsView({
           </SidebarShell>
         </GlassSidebar>
 
-        <main
-          className={cn(
-            "min-h-0 min-w-0 flex-1 overflow-hidden",
-            mediaOpen && !isMobile && "border-r-2 border-border"
-          )}
-        >
+        <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <div
             className={cn(
               "grid h-full min-h-0 min-w-0 transition-[grid-template-rows] duration-300 ease-in-out",

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -30,6 +30,7 @@ import {
 import { PinsPanel } from "@/components/app/pins-panel";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
+import { glassPanel } from "@/lib/glass";
 import { cn } from "@/lib/utils";
 
 const ACCEPTED_EXTENSIONS =
@@ -403,7 +404,7 @@ export function MediaSidebarContent({
     <aside
       data-testid="media-sidebar"
       className={cn(
-        "flex h-full min-h-0 w-full flex-col border-l border-white/[0.12] bg-[hsl(var(--card))] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]",
+        "flex h-full min-h-0 w-full flex-col text-foreground",
         className
       )}
     >
@@ -525,7 +526,7 @@ export function MediaSidebar({
         hasStream={hasStream}
         onRequestClose={() => setMediaOpen(false)}
         closeButtonIcon="chevron"
-        className="w-[360px]"
+        className={cn("w-[360px] rounded-l-lg border-l", glassPanel)}
       />
     </div>
   );

--- a/apps/web/src/components/ui/glass-sidebar.tsx
+++ b/apps/web/src/components/ui/glass-sidebar.tsx
@@ -43,6 +43,7 @@ function DesktopSidebar({
   "open" | "side" | "width" | "className" | "children"
 >) {
   const borderSide = side === "left" ? "border-r" : "border-l";
+  const innerRadius = side === "left" ? "rounded-r-lg" : "rounded-l-lg";
 
   return (
     <div
@@ -51,7 +52,7 @@ function DesktopSidebar({
     >
       <div
         className={cn(
-          `flex h-full min-h-0 flex-col ${borderSide} text-foreground`,
+          `flex h-full min-h-0 flex-col ${borderSide} ${innerRadius} text-foreground`,
           glassPanel,
           className
         )}

--- a/apps/web/src/layouts/dashboard-sections.tsx
+++ b/apps/web/src/layouts/dashboard-sections.tsx
@@ -54,7 +54,7 @@ function SectionShell({
 
   return (
     <div className="h-full min-h-0 overflow-hidden text-foreground">
-      <div className="flex h-full min-h-0 min-w-0 overflow-hidden">
+      <div className="flex h-full min-h-0 min-w-0 overflow-hidden py-2">
         <GlassSidebar
           open={isMobile ? mobileLeftOpen : leftOpen}
           onOpenChange={(open) => {


### PR DESCRIPTION
## Summary

- Inner edges of the desktop left/right sidebars now have rounded top/bottom corners (`rounded-r-lg` on the left, `rounded-l-lg` on the right).
- Added 8px top/bottom padding on the sidebar/main flex container so the panels float with a little breathing room.
- Unified the `MediaSidebar` to use the shared `glassPanel` token so its border opacity and top+bottom inset highlights match the left sidebar exactly.
- Dropped the `border-r-2 border-border` on `<main>` that was drawing a flat vertical line flush against the right sidebar's rounded edge.
- Moved the glass + rounded styles onto the desktop `MediaSidebar` wrapper's `className` prop so the mobile slide-over (rendered inside `GlassSidebar` mobile mode) stays flat and full-screen.

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run finalize:web` passes (production build)
- [x] Playwright: desktop — both sidebars show matching rounded inner corners, matching border/inset-shadow styles (confirmed via computed styles)
- [x] Playwright: mobile (414px) — right media slide-over renders full-screen with `border-radius: 0px`
- [ ] Verify on a real iPad / narrow window after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)