### PR TITLE
docs: refresh in-app Media & Sharing section

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -9,36 +9,41 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`fd68e1345965eb71b448bf9f69e76faffc4f40c1` — HEAD at the start of the 2026-04-19 Jobs-section run (before the PR that lands this file). The PR that lands this file will advance the SHA once merged; the next run should diff from whatever HEAD is when it reads the file.
+`8eb091116fb689ea972054fe6eb7ebd1fd288a39` — HEAD at the start of the 2026-04-19 Media & Sharing run (before the PR that lands this file). The PR that lands this file will advance the SHA once merged; the next run should diff from whatever HEAD is when it reads the file.
 
 ## next_focus
 
-**Audit the `docs-pane` "Media & Sharing" section against `registerShareTool` and friends.**
+**Audit the docs-pane "Notifications" section against the actual notification surfaces.**
 
-Media drift has been in the backlog since 2026-04-18 and is now the oldest unaudited docs-pane section. The current copy only describes file-path sharing and `source: "simulator"`, but `dispatch_share` has grown other surfaces that agents genuinely use.
+This is the oldest unaudited docs-pane section, and the backlog has been pointing at it for two runs now. Current copy covers Slack webhook setup and the three configurable agent events (done / waiting_user / blocked), plus focus-aware suppression. The likely gaps:
 
-Concrete pointers for the next run:
+- **Agent-initiated notifications via `dispatch_notify`.** Agents can call this built-in MCP tool directly (it's listed in `AGENT_TOOLS` / `JOB_TOOLS` / `PERSONA_TOOLS` in `apps/server/src/shared/mcp/server.ts`). It supports `title`, `message`, `level` (info / success / warning / error), and `respectFocus`, and is rate-limited to 5/min. Currently zero mention in the Notifications section.
+- **Job notifications.** `JobNotifyConfig` on `JobRecord` (`onComplete` / `onError` / `onNeedsInput`) is wired through to Slack via `jobService.onRunStateChange` in `apps/server/src/jobs/service.ts`. The Jobs section doesn't describe it either — a cross-link from Notifications → Jobs (or a new subsection in Notifications) would close this gap.
+- **Focus tracker accuracy.** `apps/server/src/focus-tracker.ts` is the source of truth for the focus-aware suppression claim — confirm the "terminal open" framing still matches (it may now track broader "viewing this agent" signals).
+- **Per-event toggle plumbing.** Verify the three event types the docs list (done / waiting_user / blocked) still match whatever the settings pane actually exposes. Cross-check `apps/web/src/components/app/settings-pane.tsx` (search "Notifications") and the persisted config shape.
+- **Slack webhook setup flow.** The "Send test" button copy and location should still be accurate.
 
-- Primary target: `apps/web/src/components/app/docs-pane.tsx` — the section with `id: "media"`.
+Concrete pointers:
+
+- Primary target: `apps/web/src/components/app/docs-pane.tsx` — section with `id: "notifications"`.
 - Cross-check against:
-  - `apps/server/src/shared/mcp/server.ts` — find `registerShareTool` and the `dispatch_share` input schema. Confirm the current set of accepted parameters (path, `content`, `name`, `description`, `source`, `simulatorUdid`, `update`) and what's supported per source.
-  - Supported MIME/formats list — verify against whatever validator `registerShareTool` uses (PNG/JPG/GIF/WebP/MP4/PDF and text extensions). The docs currently say "PNG, JPG, GIF, WebP images, MP4 video, and text files" — check PDF support and any newer formats.
-  - `dispatch_list_media` — if the Media section should mention this built-in tool (agents can list media shared with or by them).
-  - Media sidebar UX: `apps/web/src/components/app/media-sidebar.tsx` changed on 2026-04-19 — skim to confirm the "reverse chronological + badge for new items" claim is still accurate.
-- New subsection the docs should probably gain: **"Sharing text snippets"** — `content` + `name` path, separate from file-path sharing. And **"Updating shared media"** — the `update` parameter that replaces a previously-shared file in place.
+  - `apps/server/src/notifications/slack.ts` — Slack send path and any level → color/emoji mapping.
+  - `apps/server/src/focus-tracker.ts` — focus signal semantics.
+  - `apps/server/src/jobs/service.ts` — `onRunStateChange` / `JobNotifyConfig`.
+  - `apps/server/src/shared/mcp/server.ts` — the `dispatch_notify` tool registration (grep `registerNotifyTool`).
+  - `apps/web/src/components/app/settings-pane.tsx` — Notifications settings UI.
 
-Scope the PR to this one section plus whatever the git diff since `last_audited_sha` demands.
+Scope the PR to this one section plus whatever `git diff <last_audited_sha>..HEAD` turns up.
 
 ## backlog
 
 Items noticed during prior passes but left for later runs. Pick the most relevant one when `next_focus` is empty or already done.
 
-- **docs-pane "Jobs" section — lifecycle handoff files** — the 2026-04-19 Jobs run seeded the Jobs section with the four lifecycle tools (`job_log` / `job_complete` / `job_failed` / `job_needs_input`) and basic run lifecycle, but did not document the `.dispatch/job-state/<job>.md` handoff convention. That's not a server feature — it's a pattern individual jobs adopt — but the docs could mention it under "Run lifecycle" as a recommended way for agents inside a recurring job to pass context between runs. Check the docs-audit.md and any other `.dispatch/job-state/*.md` files that exist at the time for concrete examples.
-- **docs-pane "Jobs" section — notify config** — `JobNotifyConfig` on `JobRecord` (`onComplete` / `onError` / `onNeedsInput`) is currently undocumented in the new Jobs section. The config is wired through to Slack via `jobService.onRunStateChange`; a "Notifications" subsection in Jobs (or a cross-link to the Notifications docs) would be worth adding once the Notifications section itself is refreshed.
+- **docs-pane "Jobs" section — lifecycle handoff files** — the 2026-04-19 Jobs run seeded the Jobs section with the four lifecycle tools (`job_log` / `job_complete` / `job_failed` / `job_needs_input`) and basic run lifecycle, but did not document the `.dispatch/job-state/<job>.md` handoff convention. That's not a server feature — it's a pattern individual jobs adopt — but the docs could mention it under "Run lifecycle" as a recommended way for agents inside a recurring job to pass context between runs. Check `docs-audit.md` and any other `.dispatch/job-state/*.md` files that exist at the time for concrete examples.
+- **docs-pane "Jobs" section — notify config** — `JobNotifyConfig` on `JobRecord` (`onComplete` / `onError` / `onNeedsInput`) is currently undocumented in the new Jobs section. The config is wired through to Slack via `jobService.onRunStateChange`; a "Notifications" subsection in Jobs (or a cross-link to the Notifications docs) would be worth adding once the Notifications section itself is refreshed. **Coupled to the next_focus above — address together if the Notifications pass surfaces it clearly.**
 - **docs-pane "Jobs" section — timeouts** — `timeoutMs` and `needsInputTimeoutMs` are configurable per job (defaults 30 min / 24 h in `apps/server/src/jobs/service.ts`). The current copy mentions "subject to a separate needs-input timeout" but does not call out that either value is configurable. A short bullet would close this.
 - **docs-pane "Status Events" section** — event types are in sync today (`AGENT_LATEST_EVENT_TYPES` in `apps/server/src/server.ts`: working/blocked/waiting_user/done/idle). Re-check when new event types are added.
-- **docs-pane "Media & Sharing" section** — **assigned to the 2026-04-19+ next_focus.** See above.
-- **docs-pane "Notifications" section** — verify Slack event toggles and focus-aware suppression match `apps/server/src/notifications/slack.ts` and `apps/server/src/focus-tracker.ts`. Also: `dispatch_notify` (built-in tool agents can call directly) is rate-limited to 5/min and supports a `respectFocus` flag — the Notifications docs should mention this path, not just agent-event-driven notifications.
+- **docs-pane "Media & Sharing" section** — audited 2026-04-19; see History. Re-check when `registerShareTool` or `isMediaFile` in `apps/server/src/server.ts` gain new supported extensions (the current docs list is hand-maintained), or when the Share-file upload UI changes.
 - **docs-pane Reviewers section — Autonomous Review flow** — the Agents pass documented the "Autonomous Review" checkbox on create-agent-dialog.tsx, but the Reviewers section never explains how auto-review actually works end-to-end (which persona is launched, when, what the parent agent sees, how addressing feedback works). Worth a "Autonomous review" subsection that ties the two features together.
 - **docs-pane "Worktrees" — deps auto-install** — `setupWorktree` in `apps/server/src/agents/manager.ts` (search `setupWorktree`) auto-installs deps by detecting `pnpm-lock.yaml` / `yarn.lock` / `package-lock.json` / `bun.lockb`. The Automatic-worktree-creation bullet in docs-pane only mentions `.env` copying; a one-sentence mention of the lockfile-driven install would round it out.
 - **`docs/03-api-spec.md`** — spot-check for new routes added in the last 30 days. Recent migrations (0012 auto-review, 0013 review agent type, 0014 base branch, 0015 jobs base branch + auto-archive) imply the agents and jobs POST body schemas have grown. The actual on-demand run endpoint is `POST /api/v1/jobs/run` (body: `{ name, directory, wait?, triggerSource? }`) — spec may pre-date that.
@@ -60,11 +65,12 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **Agent lifecycle has two axes: status and phase.** `status` (`creating`/`running`/…/`archiving`) and `setup_phase` / `archive_phase` are distinct. Docs that mention "phase" without qualifying which one are a drift risk.
 - **Persona prompt assembly strips legacy placeholders.** `apps/server/src/personas/loader.ts` strips `{{context}}` and `{{diff}}` from persona bodies and appends its own context/diff/feedback-guidance sections. Anywhere the docs describe persona file contents, cross-check against `assemblePersonaPrompt`.
 - **Job-related state lives in multiple places.** A "Job" has fields on the DB row (`use_worktree`, `base_branch`, `auto_archive`, …), on the `JobRecord` TS type, in the add-job form state (`keepAgent` inverts to `autoArchive`), and in the `buildJobPrompt` preamble that is sent to the agent on every run. When auditing a Jobs claim, trace the field from the UI form → `AddJobConfig` / `JobConfigUpdate` → `JobStore.createJob` / `updateJob` → `JobRecord` → `buildRunConfig` / `buildJobPrompt`. The UI labels (e.g. "Keep agent") do not always match the DB column name (`auto_archive`).
+- **Media formats are gated by two separate allow-lists.** The accepted extensions for `dispatch_share` live in `isMediaFile` / `TEXT_EXTENSIONS` / `DOCUMENT_EXTENSIONS` in `apps/server/src/server.ts`, while the upload-button `accept=` list lives in `ACCEPTED_EXTENSIONS` in `apps/web/src/components/app/media-sidebar.tsx`. They should stay in sync; drift between them creates a confusing UX where an agent can share a format the UI refuses to upload (or vice versa). Diff both when touching either.
 
 ## Notes for the next run
 
 - If `next_focus` feels too big for one night, split it and push half back into `backlog` with a concrete description.
-- Treat each run as one focused slice. Recent passes (Agents, Repo Tools, Reviewers, Worktrees, Jobs) all fit comfortably in one PR each. Aim for that size.
+- Treat each run as one focused slice. Recent passes (Agents, Repo Tools, Reviewers, Worktrees, Jobs, Media) all fit comfortably in one PR each. Aim for that size.
 - If you notice something that isn't drift but is genuinely missing (e.g. a new feature with no docs anywhere), add it to `backlog` with enough detail that a future run can act on it without re-discovering the context.
 
 ## History
@@ -74,3 +80,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-04-18** (Reviewers) — Audited docs-pane "Reviewers" section against `PERSONA_TOOLS` and the review tooling in `apps/server/src/shared/mcp/server.ts` + the loader in `apps/server/src/personas/loader.ts`. Removed the stale `{{context}}`/`{{diff}}` placeholder example (the loader now strips them and auto-appends context/diff/feedback-guidance). Added a "Review lifecycle" subsection covering `review_status` with its `reviewing`/`complete` statuses and `approve`/`request_changes` verdicts. Added a paragraph noting that persona agents also have `dispatch_pin`, `dispatch_share`, and `get_parent_context`. Split "Feedback findings" into "Submitting findings" + "Review lifecycle".
 - **2026-04-18** (Worktrees) — Audited docs-pane "Worktrees" section against `apps/server/src/shared/git/worktree.ts`, `apps/server/src/agents/manager.ts` (archive flow + `setupWorktree`), `apps/web/src/components/app/settings-pane.tsx`, and `create-agent-dialog.tsx`. Flipped the reversed "Worktree location" default — code default is `sibling` (`../repo-branch-name`), not `.dispatch/worktrees/`. Automatic-creation, archive-cleanup (auto/keep/force), and parallel-agents claims all matched reality. Deps auto-install omission pushed to backlog.
 - **2026-04-19** (Jobs) — Seeded a new docs-pane "Jobs" section between "Repo Tools" and "Worktrees". Covers creating a job (all form fields including Name / Working directory / Prompt / Schedule / Agent type / Full access / Use worktree + base branch / Keep agent after run completes / Enable on schedule), on-demand runs (Run now + `triggerSource: "manual"`), run lifecycle (`job_log` / `job_complete` / `job_failed` / `job_needs_input` plus the seven run statuses), and history/status. Used `Briefcase` icon, added `"jobs"` to the `DocsSection` union. Lifecycle handoff-file convention and `JobNotifyConfig` / configurable timeouts deferred to backlog.
+- **2026-04-19** (Media & Sharing) — Audited docs-pane "Media & Sharing" section against `registerShareTool` / `mcpShareMedia` / `isMediaFile` in `apps/server/src/server.ts` and the sidebar UI in `apps/web/src/components/app/media-sidebar.tsx`. Added PDF to the supported formats list and called out the full text-extension family. Split "Sharing media" into three subsections: file-path sharing, text-snippet sharing (`content` + `name`, 32KB cap), and in-place updates via the `update` parameter. Fleshed out Simulator subsection with `simulatorUdid` defaulting to booted. Added a "Listing shared media" subsection for `dispatch_list_media`. Added a paragraph to the Media sidebar section describing the "Share file" upload button (`source: "user"`) and noting the "most recent 50" limit on the list endpoint.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -750,12 +750,35 @@ issues caused or worsened by this diff.`}</CodeBlock>
         </P>
 
         <Section>
-          <H3>Sharing media</H3>
+          <H3>Sharing files</H3>
           <P>
-            Agents call the <Code>dispatch_share</Code> tool to publish media.
-            It accepts a file path or raw text content, along with a
-            description. Supported formats include PNG, JPG, GIF, WebP images,
-            MP4 video, and text files.
+            Agents call the <Code>dispatch_share</Code> tool with a{" "}
+            <Code>filePath</Code> and a <Code>description</Code> to publish an
+            existing file. Supported formats are PNG, JPG, GIF, WebP, MP4, PDF,
+            and a wide range of text file extensions (txt, md, json, yaml, ts,
+            py, go, rs, sh, sql, and many others).
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Sharing text snippets</H3>
+          <P>
+            Instead of writing a scratch file first, agents can pass the text
+            directly as <Code>content</Code> along with a <Code>name</Code> that
+            has an appropriate extension (e.g. <Code>snippet.ts</Code>). Content
+            is capped at 32KB — for anything larger, write the file and use{" "}
+            <Code>filePath</Code>.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Updating shared media</H3>
+          <P>
+            Every <Code>dispatch_share</Code> call returns a{" "}
+            <Code>fileName</Code>. Pass that back as the <Code>update</Code>{" "}
+            parameter on a later call to replace the existing file in place
+            instead of creating a new entry — useful for iterating on a
+            screenshot or snippet without cluttering the sidebar.
           </P>
         </Section>
 
@@ -763,9 +786,10 @@ issues caused or worsened by this diff.`}</CodeBlock>
           <H3>Simulator screenshots</H3>
           <P>
             When <Code>dispatch_share</Code> is called with{" "}
-            <Code>source: "simulator"</Code>, it automatically captures a
-            screenshot from the iOS Simulator using <Code>xcrun simctl</Code>.
-            This is useful for agents validating mobile UI changes.
+            <Code>source: "simulator"</Code>, it captures a screenshot from the
+            iOS Simulator using <Code>xcrun simctl</Code> and shares the
+            resulting PNG. <Code>simulatorUdid</Code> selects a specific
+            simulator; it defaults to the booted one.
           </P>
         </Section>
 
@@ -780,12 +804,29 @@ issues caused or worsened by this diff.`}</CodeBlock>
         </Section>
 
         <Section>
+          <H3>Listing shared media</H3>
+          <P>
+            Agents can call <Code>dispatch_list_media</Code> to enumerate the
+            files they (or the user) have shared in the current session. An
+            optional <Code>source</Code> filter narrows the results — e.g.{" "}
+            <Code>"user"</Code>, <Code>"screenshot"</Code>, <Code>"text"</Code>,{" "}
+            <Code>"simulator"</Code>, or <Code>"stream"</Code>.
+          </P>
+        </Section>
+
+        <Section>
           <H3>Media sidebar</H3>
           <P>
             Click any agent's media count badge to open the sidebar. Media items
-            are shown in reverse chronological order. Click an item to open the
-            full-screen lightbox. New items since your last visit are marked
-            with a badge.
+            are shown in reverse chronological order (most recent 50). Click an
+            item to open the full-screen lightbox. New items since your last
+            visit are marked with a badge.
+          </P>
+          <P>
+            The <strong>Share file</strong> button at the top of the sidebar
+            lets you upload a file directly to the agent's media stream (stored
+            with <Code>source: "user"</Code>). Tell the agent afterward so it
+            knows to look.
           </P>
         </Section>
       </>


### PR DESCRIPTION
## Summary

Nightly docs-audit run — focused slice on the in-app "Media & Sharing" docs section (`apps/web/src/components/app/docs-pane.tsx`, `id: "media"`).

**What was audited:** the Media & Sharing section vs. the actual `dispatch_share` / `dispatch_list_media` MCP tools and the media sidebar UI (`apps/server/src/server.ts` `registerShareTool` / `mcpShareMedia` / `isMediaFile`, and `apps/web/src/components/app/media-sidebar.tsx`).

**What changed in the docs:**

- Added PDF to the supported formats list and called out the full text-extension family (the section previously listed only images + mp4 + "text files").
- Split "Sharing media" into three subsections: file-path sharing, **text-snippet sharing** (`content` + `name`, 32KB cap), and **in-place updates** via the `update` parameter. Both new subsections document real `dispatch_share` behavior that was undocumented.
- Fleshed out the Simulator subsection with `simulatorUdid` (defaults to `booted`).
- Added a "Listing shared media" subsection for `dispatch_list_media` (previously unmentioned).
- Extended the Media sidebar subsection with a paragraph describing the **Share file** upload button (`source: "user"`), and noted the "most recent 50" cap on the list endpoint.

**State file:** `.dispatch/job-state/docs-audit.md` rewritten — `last_audited_sha` advanced to current HEAD, `next_focus` pointed at the docs-pane Notifications section (oldest unaudited, likely missing `dispatch_notify` and `JobNotifyConfig` coverage), and a new `drift_patterns` entry added about the media format allow-lists living in two places (server `isMediaFile` vs. web `ACCEPTED_EXTENSIONS`).

**Deferred:** nothing new beyond what's now queued under `backlog` / `next_focus`.

## Test plan

- [x] `pnpm exec prettier --check apps/web/src/components/app/docs-pane.tsx .dispatch/job-state/docs-audit.md` — clean
- [x] `pnpm run check` (server + web `tsc --noEmit`) — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)