### PR TITLE
feat(web): sound cues for agent status changes + lift SSE to dashboard root

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,8 @@ import { api } from "@/lib/api";
 import { useAuthContext } from "@/contexts/auth-context";
 import { useHealth } from "@/hooks/use-health";
 import { useLayout } from "@/hooks/use-layout";
+import { useSSE } from "@/hooks/use-sse";
+import { useAgentSoundCues } from "@/hooks/use-agent-sound-cues";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useTheme } from "@/hooks/use-theme";
@@ -122,6 +124,12 @@ export function DashboardLayout(): JSX.Element {
   }, [instanceName]);
 
   useEffect(() => initEnergyMetrics(), []);
+
+  // SSE + sound cues live at the dashboard root so events flow on every
+  // route, not just /agents. The hooks only write to the React Query cache,
+  // so they don't depend on any view-local state.
+  useSSE("authenticated");
+  useAgentSoundCues();
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -39,7 +39,6 @@ import { cn } from "@/lib/utils";
 import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
-import { useSSE } from "@/hooks/use-sse";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
@@ -114,8 +113,6 @@ export function AgentsView({
 }: AgentsViewProps): JSX.Element {
   const navigate = useNavigate();
   const { agentId: routeAgentId, itemId, summaryAgentId } = useParams();
-  const selectedAgentIdRef = useRef<string | null>(routeAgentId ?? null);
-  selectedAgentIdRef.current = routeAgentId ?? null;
 
   const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<
     string | null
@@ -131,8 +128,6 @@ export function AgentsView({
     connectedAgent,
     overflowAgentId,
     setOverflowAgentId,
-    streamingAgentIds,
-    setStreamingAgentIds,
     agentVisualState,
     resortAgents,
   } = useAgents(
@@ -209,9 +204,6 @@ export function AgentsView({
     resortAgents();
   }, [connectedAgentId, resortAgents]);
 
-  const connectedAgentIdRef = useRef<string | null>(null);
-  connectedAgentIdRef.current = connectedAgentId;
-
   const focusedAgentId =
     connState === "connected" || connState === "reconnecting"
       ? (connectedAgentId ?? validatedSelectedAgentId)
@@ -230,25 +222,14 @@ export function AgentsView({
     openLightbox,
     mediaViewportRef,
     refreshMedia,
-    markSeenInCache,
   } = useMedia(focusedAgentId, mediaPanelOpen);
 
-  const focusedAgentHasStream = focusedAgentId
-    ? streamingAgentIds.has(focusedAgentId)
-    : false;
+  const focusedAgentHasStream = focusedAgent?.hasStream ?? false;
   const focusedAgentStreamUrl = focusedAgentId
     ? `/api/v1/agents/${focusedAgentId}/stream`
     : null;
 
   useAgentFocus(focusedAgentId, "authenticated");
-
-  useSSE(
-    "authenticated",
-    connectedAgentIdRef,
-    selectedAgentIdRef,
-    setStreamingAgentIds,
-    markSeenInCache
-  );
 
   const prevLeftOpenRef = useRef(leftPanelOpen);
   const prevMediaOpenRef = useRef(mediaPanelOpen);

--- a/apps/web/src/components/app/notification-settings.tsx
+++ b/apps/web/src/components/app/notification-settings.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
+import { soundCuesEnabledAtom } from "@/lib/store";
+import { CUE_INTENTS, playCueForIntent } from "@/lib/sound-cues";
 import {
   getNotificationPermission,
   requestNotificationPermission,
@@ -34,6 +38,47 @@ const EVENT_OPTIONS: Array<{
     description: "Agent hit an error or obstacle",
   },
 ];
+
+function SoundCuesSection(): JSX.Element {
+  const [enabled, setEnabled] = useAtom(soundCuesEnabledAtom);
+  return (
+    <div>
+      <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Sound Cues
+      </h3>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Soft tone on agent status changes. This device only.
+      </p>
+      <div className="max-w-lg space-y-3">
+        <label className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50">
+          <Checkbox
+            checked={enabled}
+            onCheckedChange={(checked) => setEnabled(checked === true)}
+            data-testid="sound-cues-enabled"
+          />
+          <div className="text-sm font-medium text-foreground">Enable</div>
+        </label>
+        {enabled && (
+          <div className="grid grid-cols-2 gap-2 pl-1">
+            {CUE_INTENTS.map(({ intent, label }) => (
+              <Button
+                key={intent}
+                variant="default"
+                size="sm"
+                onClick={() => playCueForIntent(intent)}
+                data-testid={`sound-preview-${intent}`}
+                className="gap-1.5"
+              >
+                <Play className="h-3 w-3" />
+                {label}
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function NotificationSettings(): JSX.Element {
   // Slack settings
@@ -308,8 +353,10 @@ export function NotificationSettings(): JSX.Element {
 
   return (
     <div className="flex flex-col gap-8 overflow-y-auto p-6">
+      <SoundCuesSection />
+
       {/* Browser Notifications */}
-      <div>
+      <div className="border-t border-border pt-8">
         <h3 className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
           Browser Notifications
         </h3>

--- a/apps/web/src/hooks/use-agent-sound-cues.ts
+++ b/apps/web/src/hooks/use-agent-sound-cues.ts
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { useAtomValue } from "jotai";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Agent } from "@/components/app/types";
+import { soundCuesEnabledAtom } from "@/lib/store";
+import { playCueForIntent, type CueIntent } from "@/lib/sound-cues";
+
+const INTENT_FOR_EVENT: Record<string, CueIntent | undefined> = {
+  done: "done",
+  blocked: "blocked",
+  waiting_user: "waiting_user",
+};
+
+type Snapshot = { eventKey: string; reviewStatus: string };
+
+/**
+ * Plays a sound cue when an agent transitions into one of the notable
+ * terminal-ish states: done, blocked, waiting_user, or review complete.
+ *
+ * - Subscribes to the React Query ["agents"] cache; never re-renders the host.
+ * - Skips the very first observation so a snapshot/reconnect doesn't fire a
+ *   wall of sound for state that already existed before the page loaded.
+ * - When both a review completion and a latestEvent transition happen on the
+ *   same tick (a persona agent finishing its review usually fires both),
+ *   only the review cue plays.
+ */
+export function useAgentSoundCues(): void {
+  const enabled = useAtomValue(soundCuesEnabledAtom);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const lastByAgent = new Map<string, Snapshot>();
+    let seeded = false;
+
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (event.type !== "updated") return;
+      const key = event.query.queryKey;
+      if (!Array.isArray(key) || key[0] !== "agents") return;
+      const data = event.query.state.data as Agent[] | undefined;
+      if (!data) return;
+
+      const next = new Map<string, Snapshot>();
+
+      for (const agent of data) {
+        const eventKey = agent.latestEvent
+          ? `${agent.latestEvent.type}:${agent.latestEvent.updatedAt}`
+          : "";
+        const reviewStatus = agent.review?.status ?? "";
+        next.set(agent.id, { eventKey, reviewStatus });
+
+        if (!seeded) continue;
+
+        const prev = lastByAgent.get(agent.id);
+
+        if (prev?.reviewStatus !== "complete" && reviewStatus === "complete") {
+          playCueForIntent("review_finished");
+          continue;
+        }
+
+        if (prev?.eventKey !== eventKey) {
+          const intent = INTENT_FOR_EVENT[agent.latestEvent?.type ?? ""];
+          if (intent) playCueForIntent(intent);
+        }
+      }
+
+      lastByAgent.clear();
+      for (const [k, v] of next) lastByAgent.set(k, v);
+      seeded = true;
+    });
+
+    return () => unsubscribe();
+  }, [enabled, queryClient]);
+}

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -19,9 +19,6 @@ export function useAgents(
   connectedAgentIdRef.current = connectedAgentId;
 
   const [overflowAgentId, setOverflowAgentId] = useState<string | null>(null);
-  const [streamingAgentIds, setStreamingAgentIds] = useState<Set<string>>(
-    new Set()
-  );
 
   const { data: agents = [], isSuccess: agentsLoaded } = useQuery<Agent[]>({
     queryKey: ["agents"],
@@ -79,8 +76,6 @@ export function useAgents(
       connectedAgent,
       overflowAgentId,
       setOverflowAgentId,
-      streamingAgentIds,
-      setStreamingAgentIds,
       agentVisualState,
       resortAgents,
     }),
@@ -91,7 +86,6 @@ export function useAgents(
       selectedAgent,
       connectedAgent,
       overflowAgentId,
-      streamingAgentIds,
       agentVisualState,
       resortAgents,
     ]

--- a/apps/web/src/hooks/use-media.ts
+++ b/apps/web/src/hooks/use-media.ts
@@ -224,7 +224,6 @@ export function useMedia(
       openLightbox,
       mediaViewportRef: mediaViewportRef as RefObject<HTMLDivElement>,
       refreshMedia,
-      markSeenInCache,
     }),
     [
       mediaFiles,
@@ -235,7 +234,6 @@ export function useMedia(
       setLightboxIndex,
       openLightbox,
       refreshMedia,
-      markSeenInCache,
     ]
   );
 }

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { type Agent, type AuthState } from "@/components/app/types";
+import {
+  type Agent,
+  type AuthState,
+  type MediaFile,
+} from "@/components/app/types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
 import { showWebNotification } from "@/lib/web-notifications";
@@ -25,13 +29,19 @@ type UiEvent =
       message: string;
     };
 
-export function useSSE(
-  authState: AuthState,
-  connectedAgentIdRef: React.RefObject<string | null>,
-  selectedAgentIdRef: React.RefObject<string | null>,
-  setStreamingAgentIds: React.Dispatch<React.SetStateAction<Set<string>>>,
-  markSeenInCache: (agentId: string, keys: Set<string>) => void
+function patchAgentHasStream(
+  queryClient: ReturnType<typeof useQueryClient>,
+  agentId: string,
+  hasStream: boolean
 ): void {
+  queryClient.setQueryData<Agent[]>(["agents"], (old) =>
+    old?.map((a) =>
+      a.id === agentId && a.hasStream !== hasStream ? { ...a, hasStream } : a
+    )
+  );
+}
+
+export function useSSE(authState: AuthState): void {
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
 
@@ -45,9 +55,6 @@ export function useSSE(
           queryClient.setQueryData<Agent[]>(
             ["agents"],
             sortAgentsByCreatedAtDesc(payload.agents)
-          );
-          setStreamingAgentIds(
-            new Set(payload.agents.filter((a) => a.hasStream).map((a) => a.id))
           );
           // A snapshot means a fresh SSE connection (initial or reconnect).
           // Invalidate job queries so they refetch — the snapshot only
@@ -87,27 +94,26 @@ export function useSSE(
         }
 
         if (payload.type === "stream.started") {
-          setStreamingAgentIds((current) => {
-            if (current.has(payload.agentId)) return current;
-            const next = new Set(current);
-            next.add(payload.agentId);
-            return next;
-          });
+          patchAgentHasStream(queryClient, payload.agentId, true);
           return;
         }
 
         if (payload.type === "stream.stopped") {
-          setStreamingAgentIds((current) => {
-            if (!current.has(payload.agentId)) return current;
-            const next = new Set(current);
-            next.delete(payload.agentId);
-            return next;
-          });
+          patchAgentHasStream(queryClient, payload.agentId, false);
           return;
         }
 
         if (payload.type === "media.seen") {
-          markSeenInCache(payload.agentId, new Set(payload.keys));
+          const seen = new Set(payload.keys);
+          queryClient.setQueryData<MediaFile[]>(
+            ["media", payload.agentId],
+            (old) =>
+              old?.map((file) =>
+                seen.has(`${file.name}:${file.updatedAt}`) && !file.seen
+                  ? { ...file, seen: true }
+                  : file
+              )
+          );
           return;
         }
 
@@ -177,12 +183,5 @@ export function useSSE(
       document.removeEventListener("visibilitychange", onVisChange);
       closeSSE();
     };
-  }, [
-    authState,
-    connectedAgentIdRef,
-    markSeenInCache,
-    queryClient,
-    selectedAgentIdRef,
-    setStreamingAgentIds,
-  ]);
+  }, [authState, queryClient]);
 }

--- a/apps/web/src/lib/sound-cues.ts
+++ b/apps/web/src/lib/sound-cues.ts
@@ -1,0 +1,171 @@
+/**
+ * Synthesized audio cues for agent events. Uses Web Audio API to generate
+ * tones at runtime (no asset files). Each cue is a small sequence of
+ * envelope-shaped oscillators tuned to feel tactile, not alarming.
+ */
+
+let ctx: AudioContext | null = null;
+let unlocked = false;
+
+function getContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (!ctx) {
+    const Ctor =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+  }
+  return ctx;
+}
+
+/**
+ * iOS Safari keeps the AudioContext suspended until a user gesture, and even
+ * after resume() it sometimes drops the first scheduled audio. Playing a 1-frame
+ * silent buffer during the gesture fully primes the output graph so subsequent
+ * scheduled tones are audible. Safe to call repeatedly.
+ */
+function unlockAudio(): void {
+  const c = getContext();
+  if (!c) return;
+  if (c.state === "suspended") void c.resume();
+  if (unlocked) return;
+  try {
+    const buffer = c.createBuffer(1, 1, 22050);
+    const source = c.createBufferSource();
+    source.buffer = buffer;
+    source.connect(c.destination);
+    source.start(0);
+    unlocked = true;
+  } catch {
+    // ignore — will retry on next gesture
+  }
+}
+
+if (typeof window !== "undefined") {
+  const handler = () => unlockAudio();
+  window.addEventListener("pointerdown", handler);
+  window.addEventListener("touchstart", handler, { passive: true });
+  window.addEventListener("keydown", handler);
+}
+
+type Tone = {
+  freq: number;
+  startSec: number;
+  durSec: number;
+  type?: OscillatorType;
+  gain?: number;
+};
+
+function playTones(tones: Tone[], masterGain = 0.18): void {
+  unlockAudio();
+  const c = getContext();
+  if (!c) return;
+  // Small lookahead so iOS Safari has time to actually start the context
+  // when this call is the first audio after a resume().
+  const now = c.currentTime + 0.02;
+  const master = c.createGain();
+  master.gain.value = masterGain;
+  master.connect(c.destination);
+  for (const t of tones) {
+    const osc = c.createOscillator();
+    const env = c.createGain();
+    osc.type = t.type ?? "sine";
+    osc.frequency.value = t.freq;
+    const peak = t.gain ?? 1;
+    const start = now + t.startSec;
+    const end = start + t.durSec;
+    env.gain.setValueAtTime(0.0001, start);
+    env.gain.exponentialRampToValueAtTime(peak, start + 0.012);
+    env.gain.exponentialRampToValueAtTime(0.0001, end);
+    osc.connect(env);
+    env.connect(master);
+    osc.start(start);
+    osc.stop(end + 0.04);
+  }
+}
+
+export type CueIntent = "done" | "blocked" | "waiting_user" | "review_finished";
+
+type SoundCue = {
+  id: string;
+  intent: CueIntent;
+  play: () => void;
+};
+
+const SOUND_CUES: SoundCue[] = [
+  {
+    id: "done-bloom",
+    intent: "done",
+    play: () =>
+      playTones([
+        { freq: 523.25, startSec: 0, durSec: 0.2 },
+        { freq: 783.99, startSec: 0.1, durSec: 0.26 },
+      ]),
+  },
+  {
+    id: "blocked-thud",
+    intent: "blocked",
+    play: () =>
+      playTones(
+        [
+          { freq: 246.94, startSec: 0, durSec: 0.18, type: "triangle" },
+          { freq: 196.0, startSec: 0.12, durSec: 0.3, type: "triangle" },
+        ],
+        0.2
+      ),
+  },
+  {
+    id: "waiting-nudge",
+    intent: "waiting_user",
+    play: () =>
+      playTones([
+        { freq: 659.25, startSec: 0, durSec: 0.14 },
+        { freq: 659.25, startSec: 0.2, durSec: 0.16, gain: 0.7 },
+      ]),
+  },
+  {
+    id: "review-chord",
+    intent: "review_finished",
+    play: () =>
+      playTones(
+        [
+          { freq: 523.25, startSec: 0.0, durSec: 0.45 },
+          { freq: 659.25, startSec: 0.06, durSec: 0.4 },
+          { freq: 783.99, startSec: 0.12, durSec: 0.34 },
+        ],
+        0.13
+      ),
+  },
+];
+
+export const CUE_INTENTS: Array<{
+  intent: CueIntent;
+  label: string;
+  description: string;
+}> = [
+  { intent: "done", label: "Done", description: "Agent finished its task." },
+  {
+    intent: "waiting_user",
+    label: "Waiting for input",
+    description: "Agent needs your response.",
+  },
+  {
+    intent: "blocked",
+    label: "Blocked",
+    description: "Agent hit an error or obstacle.",
+  },
+  {
+    intent: "review_finished",
+    label: "Review finished",
+    description: "Persona agent submitted its verdict.",
+  },
+];
+
+const cueByIntent = new Map(SOUND_CUES.map((c) => [c.intent, c]));
+
+/** Play the cue for an event intent. */
+export function playCueForIntent(intent: CueIntent): void {
+  cueByIntent.get(intent)?.play();
+}

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -41,3 +41,7 @@ export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">(
   "dispatch:mediaSidebarTab",
   "pins"
 );
+export const soundCuesEnabledAtom = atomWithLocalStorage(
+  "dispatch:soundCuesEnabled",
+  true
+);


### PR DESCRIPTION
## Summary

Plays a soft synthesized tone when an agent transitions to one of four notable states:

- `done` → rising perfect fifth (C5 → G5)
- `waiting_user` → soft double-tap on E5
- `blocked` → descending minor third (B3 → G3)
- `review.status === "complete"` → overlapping major triad (C5 + E5 + G5)

Default **on**, per-device toggle in **Settings → Notifications → Sound Cues**. Pure Web Audio API synthesis, no asset files. iOS Safari is unlocked via the standard 1-frame silent-buffer trick during the first user gesture.

This PR also lifts `useSSE` from `AgentsView` up to `DashboardLayout` so events flow on every route, not just `/agents` — meaning sound cues and live agent state updates work from Settings, Activity, etc. As part of that lift, `streamingAgentIds` (a `useState<Set<string>>` mirror) is removed in favor of patching `agent.hasStream` directly in the React Query cache. Same data, one source of truth.

## What's included

**New**
- `apps/web/src/lib/sound-cues.ts` — Web Audio synth + cue palette + iOS unlock
- `apps/web/src/hooks/use-agent-sound-cues.ts` — React Query cache subscriber that plays cues on agent transitions

**UI**
- `notification-settings.tsx` — new Sound Cues section at the top with toggle + 4 preview buttons
- `store.ts` — `soundCuesEnabledAtom` (Jotai + localStorage, per-device)

**Architectural cleanup**
- `use-sse.ts` — signature reduced to `useSSE(authState)`; `stream.started/stopped` patch `agent.hasStream`; `media.seen` cache write inlined
- `use-agents.ts` — drops `streamingAgentIds` state and exports
- `use-media.ts` — `markSeenInCache` no longer in public return (still used internally by IntersectionObserver)
- `agents-view.tsx` — derives `focusedAgentHasStream` from `focusedAgent?.hasStream`; drops dead refs and the lifted hook calls
- `App.tsx` — mounts `useSSE` and `useAgentSoundCues` in `DashboardLayout`

## Behavior notes

- Skips the very first cache observation so a snapshot/reconnect doesn't fire a wall of sound for state that already existed
- When a persona agent transitions to `review_finished` *and* fires `done` in the same tick, only the review cue plays (dedup)
- iOS silent switch and OS-level mute are respected — Web Audio cannot bypass them; sound requires media volume + ringer on
- The setting is per-device only (no server sync) — different browsers/devices each have their own toggle state

## Test plan

- [ ] Open `/settings/notifications` — Sound Cues section appears at top with toggle ON by default
- [ ] Click each of the 4 preview buttons (Done / Waiting for input / Blocked / Review finished) — distinct audible tone
- [ ] Toggle off → preview buttons disappear; toggle back on → they reappear
- [ ] Setting persists across page reloads (localStorage)
- [ ] Navigate `/agents` → `/settings` → `/activity` → `/agents` — no console errors, EventSource (`/api/v1/events`) stays open across navigations
- [ ] Trigger an agent state change (run an agent task to completion) — done cue plays even when on Settings or Activity, not just `/agents`
- [ ] Stream indicators on agent cards still render correctly (regression check after `streamingAgentIds` removal)
- [ ] Media "seen" badges still dim when scrolling media into view (regression check after `markSeenInCache` refactor)
- [ ] iPad / iPhone Safari: with media volume up and silent switch off, preview buttons play tones