### PR TITLE
feat(server): resolution capture for persona feedback (CRU-128)

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -3325,19 +3325,25 @@ export class AgentManager {
       );
     }
     const result = await this.pool.query<FeedbackRecord>(
+      // resolution_reason / resolution_commit use COALESCE so that a later
+      // fixed/ignored call with a null reason (allowed for 'fixed') does not
+      // erase the audit-trail captured on the first resolving call.
+      // resolved_at is set only on the first transition into fixed/ignored so
+      // benign re-calls don't drift the timestamp forward.
       `UPDATE agent_feedback
        SET status = $2,
            resolution_reason = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN $4
+             WHEN $2 IN ('fixed', 'ignored') THEN COALESCE($4, resolution_reason)
              ELSE resolution_reason
            END,
            resolution_commit = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN $5
+             WHEN $2 IN ('fixed', 'ignored') THEN COALESCE($5, resolution_commit)
              ELSE resolution_commit
            END,
            resolved_at = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN NOW()
-             ELSE NULL
+             WHEN $2 IN ('fixed', 'ignored') AND resolved_at IS NULL THEN NOW()
+             WHEN $2 NOT IN ('fixed', 'ignored') THEN NULL
+             ELSE resolved_at
            END
        WHERE id = $1 AND agent_id = $3
        RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
@@ -3365,19 +3371,21 @@ export class AgentManager {
       );
     }
     const result = await this.pool.query<FeedbackRecord>(
+      // See updateFeedbackStatus for the COALESCE / first-transition rationale.
       `UPDATE agent_feedback af
        SET status = $2,
            resolution_reason = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN $4
+             WHEN $2 IN ('fixed', 'ignored') THEN COALESCE($4, af.resolution_reason)
              ELSE af.resolution_reason
            END,
            resolution_commit = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN $5
+             WHEN $2 IN ('fixed', 'ignored') THEN COALESCE($5, af.resolution_commit)
              ELSE af.resolution_commit
            END,
            resolved_at = CASE
-             WHEN $2 IN ('fixed', 'ignored') THEN NOW()
-             ELSE NULL
+             WHEN $2 IN ('fixed', 'ignored') AND af.resolved_at IS NULL THEN NOW()
+             WHEN $2 NOT IN ('fixed', 'ignored') THEN NULL
+             ELSE af.resolved_at
            END
        FROM agents a
        WHERE af.id = $1 AND af.agent_id = a.id AND a.parent_agent_id = $3

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -186,6 +186,7 @@ export type PersonaReviewRecord = {
   verdict: string | null;
   summary: string | null;
   filesReviewed: string[] | null;
+  lastReviewedCommit: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -200,7 +201,19 @@ export type FeedbackRecord = {
   suggestion: string | null;
   mediaRef: string | null;
   status: string;
+  resolutionReason: string | null;
+  resolutionCommit: string | null;
+  resolvedAt: string | null;
   createdAt: string;
+};
+
+export type PersonaReviewResolutionRecord = {
+  id: number;
+  reviewId: number;
+  roundNumber: number;
+  summary: string;
+  resolutionCommit: string | null;
+  submittedAt: string;
 };
 
 type AgentLatestEventInput = {
@@ -2375,15 +2388,22 @@ export class AgentManager {
     agentId: string;
     parentAgentId: string;
     persona: string;
+    lastReviewedCommit?: string | null;
   }): Promise<PersonaReviewRecord> {
     const result = await this.pool.query<PersonaReviewRecord>(
-      `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona)
-       VALUES ($1, $2, $3)
+      `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, last_reviewed_commit)
+       VALUES ($1, $2, $3, $4)
        RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
+                 last_reviewed_commit AS "lastReviewedCommit",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
-      [input.agentId, input.parentAgentId, input.persona]
+      [
+        input.agentId,
+        input.parentAgentId,
+        input.persona,
+        input.lastReviewedCommit ?? null,
+      ]
     );
     return result.rows[0]!;
   }
@@ -2406,6 +2426,7 @@ export class AgentManager {
        RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
+                 last_reviewed_commit AS "lastReviewedCommit",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [agentId, input.status, input.message ?? null]
     );
@@ -2421,6 +2442,7 @@ export class AgentManager {
       summary: string;
       filesReviewed?: string[];
       message?: string;
+      lastReviewedCommit?: string | null;
     }
   ): Promise<PersonaReviewRecord> {
     const VALID_VERDICTS = ["approve", "request_changes"];
@@ -2452,11 +2474,14 @@ export class AgentManager {
     const result = await this.pool.query<PersonaReviewRecord>(
       `UPDATE persona_reviews
        SET status = 'complete', verdict = $2, summary = $3,
-           files_reviewed = $4::jsonb, message = $5, updated_at = NOW()
+           files_reviewed = $4::jsonb, message = $5,
+           last_reviewed_commit = COALESCE($6, last_reviewed_commit),
+           updated_at = NOW()
        WHERE agent_id = $1
        RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
+                 last_reviewed_commit AS "lastReviewedCommit",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [
         agentId,
@@ -2464,6 +2489,7 @@ export class AgentManager {
         input.summary,
         JSON.stringify(input.filesReviewed ?? []),
         input.message ?? null,
+        input.lastReviewedCommit ?? null,
       ]
     );
     if (result.rowCount === 0)
@@ -2476,6 +2502,7 @@ export class AgentManager {
       `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
+              last_reviewed_commit AS "lastReviewedCommit",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews WHERE agent_id = $1`,
       [agentId]
@@ -2490,6 +2517,7 @@ export class AgentManager {
       `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
+              last_reviewed_commit AS "lastReviewedCommit",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews WHERE parent_agent_id = $1
        ORDER BY created_at`,
@@ -2505,6 +2533,7 @@ export class AgentManager {
       `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
+              last_reviewed_commit AS "lastReviewedCommit",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews
        WHERE created_at >= NOW() - make_interval(days => $1)
@@ -2520,7 +2549,11 @@ export class AgentManager {
     const result = await this.pool.query<FeedbackRecord & { persona: string }>(
       `SELECT f.id, f.agent_id AS "agentId", a.persona, f.severity, f.file_path AS "filePath",
               f.line_number AS "lineNumber", f.description, f.suggestion,
-              f.media_ref AS "mediaRef", f.status, f.created_at AS "createdAt"
+              f.media_ref AS "mediaRef", f.status,
+              f.resolution_reason AS "resolutionReason",
+              f.resolution_commit AS "resolutionCommit",
+              f.resolved_at AS "resolvedAt",
+              f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
        WHERE f.created_at >= NOW() - make_interval(days => $1)
@@ -3175,7 +3208,11 @@ export class AgentManager {
       `INSERT INTO agent_feedback (agent_id, severity, file_path, line_number, description, suggestion, media_ref)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
-                 description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"`,
+                 description, suggestion, media_ref AS "mediaRef", status,
+                 resolution_reason AS "resolutionReason",
+                 resolution_commit AS "resolutionCommit",
+                 resolved_at AS "resolvedAt",
+                 created_at AS "createdAt"`,
       [
         agentId,
         feedback.severity ?? "info",
@@ -3192,7 +3229,11 @@ export class AgentManager {
   async listFeedback(agentId: string): Promise<FeedbackRecord[]> {
     const result = await this.pool.query<FeedbackRecord>(
       `SELECT id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
-              description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"
+              description, suggestion, media_ref AS "mediaRef", status,
+              resolution_reason AS "resolutionReason",
+              resolution_commit AS "resolutionCommit",
+              resolved_at AS "resolvedAt",
+              created_at AS "createdAt"
        FROM agent_feedback WHERE agent_id = $1 ORDER BY created_at ASC`,
       [agentId]
     );
@@ -3202,7 +3243,11 @@ export class AgentManager {
   async listFeedbackByParent(parentAgentId: string): Promise<FeedbackRecord[]> {
     const result = await this.pool.query<FeedbackRecord>(
       `SELECT f.id, f.agent_id AS "agentId", f.severity, f.file_path AS "filePath", f.line_number AS "lineNumber",
-              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status, f.created_at AS "createdAt"
+              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status,
+              f.resolution_reason AS "resolutionReason",
+              f.resolution_commit AS "resolutionCommit",
+              f.resolved_at AS "resolvedAt",
+              f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
        WHERE a.parent_agent_id = $1
@@ -3233,7 +3278,11 @@ export class AgentManager {
 
     const result = await this.pool.query<FeedbackRecord & { persona: string }>(
       `SELECT f.id, f.agent_id AS "agentId", a.persona, f.severity, f.file_path AS "filePath", f.line_number AS "lineNumber",
-              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status, f.created_at AS "createdAt"
+              f.description, f.suggestion, f.media_ref AS "mediaRef", f.status,
+              f.resolution_reason AS "resolutionReason",
+              f.resolution_commit AS "resolutionCommit",
+              f.resolved_at AS "resolvedAt",
+              f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
        ${whereClause}
@@ -3265,14 +3314,39 @@ export class AgentManager {
   async updateFeedbackStatus(
     feedbackId: number,
     agentId: string,
-    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
+    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored",
+    options: { reason?: string | null; resolutionCommit?: string | null } = {}
   ): Promise<FeedbackRecord | null> {
+    const reason = options.reason ?? null;
+    if (status === "ignored" && !(reason && reason.trim().length > 0)) {
+      throw new AgentError(
+        "A reason is required when marking feedback as ignored.",
+        400
+      );
+    }
     const result = await this.pool.query<FeedbackRecord>(
-      `UPDATE agent_feedback SET status = $2
+      `UPDATE agent_feedback
+       SET status = $2,
+           resolution_reason = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN $4
+             ELSE resolution_reason
+           END,
+           resolution_commit = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN $5
+             ELSE resolution_commit
+           END,
+           resolved_at = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN NOW()
+             ELSE NULL
+           END
        WHERE id = $1 AND agent_id = $3
        RETURNING id, agent_id AS "agentId", severity, file_path AS "filePath", line_number AS "lineNumber",
-                 description, suggestion, media_ref AS "mediaRef", status, created_at AS "createdAt"`,
-      [feedbackId, status, agentId]
+                 description, suggestion, media_ref AS "mediaRef", status,
+                 resolution_reason AS "resolutionReason",
+                 resolution_commit AS "resolutionCommit",
+                 resolved_at AS "resolvedAt",
+                 created_at AS "createdAt"`,
+      [feedbackId, status, agentId, reason, options.resolutionCommit ?? null]
     );
     return result.rows[0] ?? null;
   }
@@ -3280,18 +3354,174 @@ export class AgentManager {
   async updateFeedbackStatusByParent(
     feedbackId: number,
     parentAgentId: string,
-    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored"
+    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored",
+    options: { reason?: string | null; resolutionCommit?: string | null } = {}
   ): Promise<FeedbackRecord | null> {
+    const reason = options.reason ?? null;
+    if (status === "ignored" && !(reason && reason.trim().length > 0)) {
+      throw new AgentError(
+        "A reason is required when marking feedback as ignored.",
+        400
+      );
+    }
     const result = await this.pool.query<FeedbackRecord>(
-      `UPDATE agent_feedback af SET status = $2
+      `UPDATE agent_feedback af
+       SET status = $2,
+           resolution_reason = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN $4
+             ELSE af.resolution_reason
+           END,
+           resolution_commit = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN $5
+             ELSE af.resolution_commit
+           END,
+           resolved_at = CASE
+             WHEN $2 IN ('fixed', 'ignored') THEN NOW()
+             ELSE NULL
+           END
        FROM agents a
        WHERE af.id = $1 AND af.agent_id = a.id AND a.parent_agent_id = $3
        RETURNING af.id, af.agent_id AS "agentId", af.severity, af.file_path AS "filePath",
                  af.line_number AS "lineNumber", af.description, af.suggestion,
-                 af.media_ref AS "mediaRef", af.status, af.created_at AS "createdAt"`,
-      [feedbackId, status, parentAgentId]
+                 af.media_ref AS "mediaRef", af.status,
+                 af.resolution_reason AS "resolutionReason",
+                 af.resolution_commit AS "resolutionCommit",
+                 af.resolved_at AS "resolvedAt",
+                 af.created_at AS "createdAt"`,
+      [
+        feedbackId,
+        status,
+        parentAgentId,
+        reason,
+        options.resolutionCommit ?? null,
+      ]
     );
     return result.rows[0] ?? null;
+  }
+
+  async submitReviewResolution(input: {
+    parentAgentId: string;
+    personaAgentId: string;
+    summary: string;
+    resolutionCommit?: string | null;
+  }): Promise<{
+    review: PersonaReviewRecord;
+    resolution: PersonaReviewResolutionRecord;
+  }> {
+    const summary = input.summary.trim();
+    if (summary.length === 0) {
+      throw new AgentError("summary is required.", 400);
+    }
+    if (summary.length > 10_000) {
+      throw new AgentError("summary exceeds 10,000 character limit.", 400);
+    }
+
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+
+      const reviewResult = await client.query<PersonaReviewRecord>(
+        `SELECT id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
+                persona, status, message, verdict, summary,
+                files_reviewed AS "filesReviewed",
+                last_reviewed_commit AS "lastReviewedCommit",
+                created_at AS "createdAt", updated_at AS "updatedAt"
+         FROM persona_reviews
+         WHERE agent_id = $1 AND parent_agent_id = $2
+         FOR UPDATE`,
+        [input.personaAgentId, input.parentAgentId]
+      );
+      const review = reviewResult.rows[0];
+      if (!review) {
+        throw new AgentError(
+          `No persona review found for agent ${input.personaAgentId} under parent ${input.parentAgentId}.`,
+          404
+        );
+      }
+      if (review.status !== "complete") {
+        throw new AgentError(
+          `Review must be in status 'complete' to submit a resolution (current: ${review.status}).`,
+          409
+        );
+      }
+
+      const openOrUnresolved = await client.query<{
+        id: number;
+        status: string;
+        resolution_reason: string | null;
+      }>(
+        `SELECT id, status, resolution_reason
+         FROM agent_feedback
+         WHERE agent_id = $1
+         ORDER BY id ASC`,
+        [input.personaAgentId]
+      );
+      const openIds: number[] = [];
+      const ignoredMissingReason: number[] = [];
+      for (const row of openOrUnresolved.rows) {
+        if (row.status === "open") {
+          openIds.push(row.id);
+        } else if (
+          row.status === "ignored" &&
+          !(row.resolution_reason && row.resolution_reason.trim().length > 0)
+        ) {
+          ignoredMissingReason.push(row.id);
+        }
+      }
+      if (openIds.length > 0) {
+        throw new AgentError(
+          `Cannot submit resolution — feedback items still open: ${openIds.join(", ")}.`,
+          409
+        );
+      }
+      if (ignoredMissingReason.length > 0) {
+        throw new AgentError(
+          `Cannot submit resolution — ignored feedback items missing a reason: ${ignoredMissingReason.join(", ")}.`,
+          409
+        );
+      }
+
+      const roundNumber = 1;
+      const inserted = await client.query<PersonaReviewResolutionRecord>(
+        `INSERT INTO persona_review_resolutions
+           (review_id, round_number, summary, resolution_commit)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (review_id, round_number) DO UPDATE
+           SET summary = EXCLUDED.summary,
+               resolution_commit = EXCLUDED.resolution_commit,
+               submitted_at = NOW()
+         RETURNING id,
+                   review_id AS "reviewId",
+                   round_number AS "roundNumber",
+                   summary,
+                   resolution_commit AS "resolutionCommit",
+                   submitted_at AS "submittedAt"`,
+        [review.id, roundNumber, summary, input.resolutionCommit ?? null]
+      );
+
+      await client.query("COMMIT");
+      return { review, resolution: inserted.rows[0]! };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getReviewResolutions(
+    reviewId: number
+  ): Promise<PersonaReviewResolutionRecord[]> {
+    const result = await this.pool.query<PersonaReviewResolutionRecord>(
+      `SELECT id, review_id AS "reviewId", round_number AS "roundNumber",
+              summary, resolution_commit AS "resolutionCommit",
+              submitted_at AS "submittedAt"
+       FROM persona_review_resolutions
+       WHERE review_id = $1
+       ORDER BY round_number ASC, submitted_at ASC`,
+      [reviewId]
+    );
+    return result.rows;
   }
 
   private baseAgentSelectSql(): string {

--- a/apps/server/src/db/migrations/0016_feedback-resolution-capture.sql
+++ b/apps/server/src/db/migrations/0016_feedback-resolution-capture.sql
@@ -1,0 +1,26 @@
+-- Phase 1 of the review round-trip feature (CRU-128).
+-- Captures resolution metadata on feedback items and introduces a
+-- parent "resolution" record per review. No round-trip loop yet —
+-- round_number defaults to 1 so Phase 2 (CRU-131) can layer on
+-- additional rounds without a table migration.
+
+ALTER TABLE agent_feedback
+  ADD COLUMN IF NOT EXISTS resolution_reason TEXT,
+  ADD COLUMN IF NOT EXISTS resolution_commit TEXT,
+  ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ;
+
+ALTER TABLE persona_reviews
+  ADD COLUMN IF NOT EXISTS last_reviewed_commit TEXT;
+
+CREATE TABLE IF NOT EXISTS persona_review_resolutions (
+  id SERIAL PRIMARY KEY,
+  review_id INT NOT NULL REFERENCES persona_reviews(id) ON DELETE CASCADE,
+  round_number INT NOT NULL DEFAULT 1,
+  summary TEXT NOT NULL,
+  resolution_commit TEXT,
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (review_id, round_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_persona_review_resolutions_review_id
+  ON persona_review_resolutions(review_id);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4069,6 +4069,11 @@ async function registerRoutes() {
 
       let reason: string | null = null;
       if (typeof body.reason === "string") {
+        if (body.reason.length > 10_000) {
+          return reply
+            .code(400)
+            .send({ error: "reason exceeds 10,000 character limit." });
+        }
         reason = body.reason;
       } else if (body.reason !== undefined && body.reason !== null) {
         return reply
@@ -4084,8 +4089,13 @@ async function registerRoutes() {
 
       try {
         const agentId = params.id ?? "";
-        const agent = await agentManager.getAgent(agentId);
-        const resolutionCommit = agent ? await resolveHeadSha(agent.cwd) : null;
+        // Only compute HEAD when the update will actually record a
+        // resolution; updateFeedbackStatus discards it otherwise.
+        const isResolving =
+          body.status === "fixed" || body.status === "ignored";
+        const agent = isResolving ? await agentManager.getAgent(agentId) : null;
+        const resolutionCommit =
+          isResolving && agent ? await resolveHeadSha(agent.cwd) : null;
         const updated = await agentManager.updateFeedbackStatus(
           feedbackId,
           agentId,
@@ -4126,11 +4136,9 @@ async function registerRoutes() {
         typeof body?.summary !== "string" ||
         body.summary.trim().length === 0
       ) {
-        return reply
-          .code(400)
-          .send({
-            error: "summary is required and must be a non-empty string.",
-          });
+        return reply.code(400).send({
+          error: "summary is required and must be a non-empty string.",
+        });
       }
 
       try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -78,6 +78,7 @@ import { createPool } from "./db/client.js";
 import { runMigrations } from "./db/migrate.js";
 import { deleteSetting, getSetting, setSetting } from "./db/settings.js";
 import { runCommand } from "./shared/lib/run-command.js";
+import { resolveHeadSha } from "./shared/git/worktree.js";
 import { handleMcpRequest } from "./shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import { StreamManager } from "./stream-manager.js";
@@ -1696,6 +1697,7 @@ async function registerRoutes() {
       launchPersona: mcpLaunchPersona,
       getFeedback: mcpGetFeedback,
       resolveFeedback: mcpResolveFeedback,
+      submitResolution: mcpSubmitResolution,
       upsertPin: mcpUpsertPin,
       deletePin: mcpDeletePin,
       getParentContext: mcpGetParentContext,
@@ -4038,7 +4040,10 @@ async function registerRoutes() {
     "/api/v1/agents/:id/feedback/:feedbackId",
     async (request, reply) => {
       const params = request.params as { id?: string; feedbackId?: string };
-      const body = request.body as { status?: unknown };
+      const body = request.body as {
+        status?: unknown;
+        reason?: unknown;
+      } | null;
       const feedbackId = parseInt(params.feedbackId ?? "", 10);
 
       if (isNaN(feedbackId)) {
@@ -4062,8 +4067,25 @@ async function registerRoutes() {
         });
       }
 
+      let reason: string | null = null;
+      if (typeof body.reason === "string") {
+        reason = body.reason;
+      } else if (body.reason !== undefined && body.reason !== null) {
+        return reply
+          .code(400)
+          .send({ error: "reason must be a string if provided." });
+      }
+
+      if (body.status === "ignored" && !(reason && reason.trim().length > 0)) {
+        return reply.code(400).send({
+          error: "A reason is required when marking feedback as ignored.",
+        });
+      }
+
       try {
         const agentId = params.id ?? "";
+        const agent = await agentManager.getAgent(agentId);
+        const resolutionCommit = agent ? await resolveHeadSha(agent.cwd) : null;
         const updated = await agentManager.updateFeedbackStatus(
           feedbackId,
           agentId,
@@ -4072,7 +4094,8 @@ async function registerRoutes() {
             | "dismissed"
             | "forwarded"
             | "fixed"
-            | "ignored"
+            | "ignored",
+          { reason, resolutionCommit }
         );
         if (!updated)
           return reply.code(404).send({ error: "Feedback not found." });
@@ -4082,6 +4105,59 @@ async function registerRoutes() {
           feedback: updated,
         });
         return { feedback: updated };
+      } catch (error) {
+        return handleAgentError(reply, error);
+      }
+    }
+  );
+
+  app.post(
+    "/api/v1/agents/:id/persona-reviews/:personaAgentId/resolution",
+    async (request, reply) => {
+      const params = request.params as {
+        id?: string;
+        personaAgentId?: string;
+      };
+      const body = request.body as { summary?: unknown } | null;
+      const agentId = params.id ?? "";
+      const personaAgentId = params.personaAgentId ?? "";
+
+      if (
+        typeof body?.summary !== "string" ||
+        body.summary.trim().length === 0
+      ) {
+        return reply
+          .code(400)
+          .send({
+            error: "summary is required and must be a non-empty string.",
+          });
+      }
+
+      try {
+        const parent = await agentManager.getAgent(agentId);
+        if (!parent) return reply.code(404).send({ error: "Agent not found." });
+        const resolutionCommit = await resolveHeadSha(parent.cwd);
+        const result = await agentManager.submitReviewResolution({
+          parentAgentId: agentId,
+          personaAgentId,
+          summary: body.summary,
+          resolutionCommit,
+        });
+        const [child, parentAgent] = await Promise.all([
+          agentManager.getAgent(personaAgentId),
+          agentManager.getAgent(agentId),
+        ]);
+        if (child)
+          uiEventBroker.publish({
+            type: "agent.upsert",
+            agent: withStreamFlag(child),
+          });
+        if (parentAgent)
+          uiEventBroker.publish({
+            type: "agent.upsert",
+            agent: withStreamFlag(parentAgent),
+          });
+        return { review: result.review, resolution: result.resolution };
       } catch (error) {
         return handleAgentError(reply, error);
       }
@@ -5165,12 +5241,16 @@ async function mcpGetFeedback(
 async function mcpResolveFeedback(
   agentId: string,
   feedbackId: number,
-  status: "fixed" | "ignored"
+  status: "fixed" | "ignored",
+  options: { reason?: string | null } = {}
 ): Promise<import("./agents/manager.js").FeedbackRecord> {
+  const parent = await agentManager.getAgent(agentId);
+  const resolutionCommit = parent ? await resolveHeadSha(parent.cwd) : null;
   const record = await agentManager.updateFeedbackStatusByParent(
     feedbackId,
     agentId,
-    status
+    status,
+    { reason: options.reason ?? null, resolutionCommit }
   );
   if (!record)
     throw new Error(
@@ -5182,6 +5262,39 @@ async function mcpResolveFeedback(
     feedback: record,
   });
   return record;
+}
+
+async function mcpSubmitResolution(
+  agentId: string,
+  input: { personaAgentId: string; summary: string }
+): Promise<{
+  review: import("./agents/manager.js").PersonaReviewRecord;
+  resolution: import("./agents/manager.js").PersonaReviewResolutionRecord;
+}> {
+  const parent = await agentManager.getAgent(agentId);
+  if (!parent) throw new Error("Agent not found.");
+  const resolutionCommit = await resolveHeadSha(parent.cwd);
+  const result = await agentManager.submitReviewResolution({
+    parentAgentId: agentId,
+    personaAgentId: input.personaAgentId,
+    summary: input.summary,
+    resolutionCommit,
+  });
+  const [child, parentAgent] = await Promise.all([
+    agentManager.getAgent(input.personaAgentId),
+    agentManager.getAgent(agentId),
+  ]);
+  if (child)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(child),
+    });
+  if (parentAgent)
+    uiEventBroker.publish({
+      type: "agent.upsert",
+      agent: withStreamFlag(parentAgent),
+    });
+  return result;
 }
 
 async function mcpUpsertPin(
@@ -5236,7 +5349,14 @@ async function mcpCompleteReview(
     message?: string;
   }
 ): Promise<void> {
-  const review = await agentManager.completePersonaReview(agentId, input);
+  const personaAgent = await agentManager.getAgent(agentId);
+  const lastReviewedCommit = personaAgent
+    ? await resolveHeadSha(personaAgent.cwd)
+    : null;
+  const review = await agentManager.completePersonaReview(agentId, {
+    ...input,
+    lastReviewedCommit,
+  });
   const [child, parent] = await Promise.all([
     agentManager.getAgent(agentId),
     agentManager.getAgent(review.parentAgentId),
@@ -5433,11 +5553,14 @@ async function mcpLaunchPersona(
     cliSessionId,
   });
 
-  // Create the persona review record
+  // Create the persona review record. Capture parent HEAD at launch time so
+  // Phase 2 can diff round-1 findings against what the reviewer saw.
+  const launchCommit = await resolveHeadSha(parentCwd);
   await agentManager.createPersonaReview({
     agentId: agent.id,
     parentAgentId: agentId,
     persona: opts.persona,
+    lastReviewedCommit: launchCommit,
   });
 
   // Re-fetch so the SSE event includes the review subquery data

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -56,6 +56,18 @@ export class GitWorktreeError extends Error {
   }
 }
 
+export async function resolveHeadSha(cwd: string): Promise<string | null> {
+  try {
+    const result = await runCommand("git", ["-C", cwd, "rev-parse", "HEAD"], {
+      allowedExitCodes: [0, 128],
+    });
+    if (result.exitCode !== 0 || !result.stdout) return null;
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function createGitWorktree(
   input: CreateGitWorktreeInput,
   commandRunner: CommandRunner = runCommand

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -983,9 +983,10 @@ async function createDispatchMcpServer(
             ),
           reason: z
             .string()
+            .max(10_000)
             .optional()
             .describe(
-              "Why you chose this resolution. REQUIRED when status is 'ignored'. Optional but encouraged for 'fixed'."
+              "Why you chose this resolution. REQUIRED when status is 'ignored'. Optional but encouraged for 'fixed'. Max 10,000 characters."
             ),
         },
       },

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -153,6 +153,7 @@ const AGENT_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
+  "dispatch_submit_resolution",
   "get_activity_summary",
   "get_agent_history",
   "get_feedback_summary",
@@ -287,8 +288,23 @@ export type McpRequestContext = {
   resolveFeedback?: (
     agentId: string,
     feedbackId: number,
-    status: "fixed" | "ignored"
+    status: "fixed" | "ignored",
+    options?: { reason?: string | null }
   ) => Promise<FeedbackItem>;
+  submitResolution?: (
+    agentId: string,
+    input: { personaAgentId: string; summary: string }
+  ) => Promise<{
+    review: { id: number; agentId: string; status: string };
+    resolution: {
+      id: number;
+      reviewId: number;
+      roundNumber: number;
+      summary: string;
+      resolutionCommit: string | null;
+      submittedAt: string;
+    };
+  }>;
   upsertPin?: (
     agentId: string,
     pin: { label: string; value: string; type: string }
@@ -953,7 +969,7 @@ async function createDispatchMcpServer(
       "dispatch_resolve_feedback",
       {
         description:
-          "Resolve a persona feedback item by marking it as fixed or ignored. Use after retrieving feedback with dispatch_get_feedback to update the status of individual items.",
+          "Mark a persona feedback item as fixed or ignored. If status is 'ignored', you must include a `reason` explaining why. If status is 'fixed', `reason` is optional but encouraged when the fix is non-obvious. The server records the current HEAD commit at the time of the call as the resolution commit.",
         inputSchema: {
           feedbackId: z
             .number()
@@ -965,6 +981,12 @@ async function createDispatchMcpServer(
             .describe(
               "Resolution status: 'fixed' if addressed, 'ignored' if not applicable."
             ),
+          reason: z
+            .string()
+            .optional()
+            .describe(
+              "Why you chose this resolution. REQUIRED when status is 'ignored'. Optional but encouraged for 'fixed'."
+            ),
         },
       },
       async (args) => {
@@ -972,7 +994,8 @@ async function createDispatchMcpServer(
           const result = await resolveFeedback(
             agentId,
             args.feedbackId,
-            args.status
+            args.status,
+            { reason: args.reason ?? null }
           );
           return {
             content: [
@@ -981,6 +1004,57 @@ async function createDispatchMcpServer(
                 text: `Feedback #${result.id} marked as ${result.status}.`,
               },
             ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_submit_resolution ────────────────────────────────────
+  if (
+    allowed.has("dispatch_submit_resolution") &&
+    context.agent &&
+    context.submitResolution
+  ) {
+    const agentId = context.agent.id;
+    const submitResolution = context.submitResolution;
+
+    server.registerTool(
+      "dispatch_submit_resolution",
+      {
+        description:
+          "Call this after you have resolved every feedback item from a persona review. `summary` is required — 1–3 sentences describing what you addressed and what you chose to leave alone. In v1 this records your narrative response. Once the full round-trip ships, this call also triggers the reviewer's recheck pass. Rejected if any feedback item is still 'open' or if any 'ignored' item is missing a reason.",
+        inputSchema: {
+          personaAgentId: z
+            .string()
+            .describe(
+              "The persona agent ID whose review you are resolving (the agent you launched via dispatch_launch_persona)."
+            ),
+          summary: z
+            .string()
+            .min(1)
+            .max(10_000)
+            .describe(
+              "1–3 sentence narrative summary of what you addressed and what you left alone."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await submitResolution(agentId, {
+            personaAgentId: args.personaAgentId,
+            summary: args.summary,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Resolution submitted for review #${result.review.id} (round ${result.resolution.roundNumber}).`,
+              },
+            ],
+            structuredContent: result,
           };
         } catch (error) {
           return toToolError(error);

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -1355,7 +1355,8 @@ describe("AgentManager", () => {
       const result = await manager.updateFeedbackStatusByParent(
         feedback.id,
         parentB.id,
-        "ignored"
+        "ignored",
+        { reason: "not my problem" }
       );
       expect(result).toBeNull();
     });

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -696,9 +696,15 @@ function useFeedbackData(parentAgentId: string) {
 
   const updateStatus = useCallback(
     async (item: FeedbackItem, status: string) => {
+      const body: { status: string; reason?: string } = { status };
+      // Server requires a reason when ignoring. Until CRU-129 adds the
+      // inline prompt, stamp a generic reason so the UI button works.
+      if (status === "ignored") {
+        body.reason = "User's choice";
+      }
       await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
         method: "PATCH",
-        body: JSON.stringify({ status }),
+        body: JSON.stringify(body),
       });
       const update = (f: FeedbackItem) =>
         f.id === item.id


### PR DESCRIPTION
## Summary

Phase 1 of the review round-trip flow ([CRU-127](https://linear.app/crumbstream/issue/CRU-127/review-round-trip-flow-opt-in-reviewer-verification-pass) / [CRU-128](https://linear.app/crumbstream/issue/CRU-128/phase-1-schema-backend-for-resolution-capture)). Captures an explicit "why" on every resolved feedback item and a parent-supplied summary per review, laying the audit-trail foundation that Phase 2's round-trip loop will build on.

- **Migration 0016** — adds `resolution_reason`, `resolution_commit`, `resolved_at` to `agent_feedback`; `last_reviewed_commit` to `persona_reviews`; and a new `persona_review_resolutions` table. The resolutions table is created with `round_number` defaulting to 1 so Phase 2 (CRU-131) can layer on additional rounds without another table migration.
- **`dispatch_resolve_feedback`** (and HTTP `PATCH /api/v1/agents/:id/feedback/:feedbackId`) — accept an optional `reason`. Rejects `ignored` items without one. Records HEAD at the call site as `resolution_commit`.
- **`dispatch_submit_resolution`** (new) and HTTP `POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution` — parent submits a 1–3 sentence summary once every feedback item is resolved. Server rejects if any item is still `open` or any `ignored` item is missing a reason.
- Capture parent HEAD on persona launch and on `dispatch_complete_review` so Phase 2 can diff round-1 findings against the reviewed snapshot.

Out of scope for this PR: UI surfacing (CRU-129) and a dedicated test suite for the new paths (CRU-130).

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run test` — 325 passed, 11 skipped, no regressions (updated one existing test that called `updateFeedbackStatusByParent` with `ignored` and no reason)
- [x] `pnpm run test:e2e` — 138 passed, 6 skipped
- [ ] Phase 1 dedicated unit tests land in CRU-130
- [ ] UI validation lands in CRU-129