### PR TITLE
test(server): resolution capture unit + integration coverage (CRU-130)

### DIFF
--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -1377,6 +1377,519 @@ describe("AgentManager", () => {
     });
   });
 
+  // CRU-128 / CRU-130 — resolution capture (reason, resolution_commit,
+  // resolved_at, persona_review_resolutions, last_reviewed_commit).
+  describe("resolution capture", () => {
+    async function seedParentChild() {
+      const parent = await manager.createAgent({
+        name: "parent",
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+      const child = await manager.createAgent({
+        name: "child",
+        cwd: "/tmp",
+        useWorktree: false,
+        persona: "security-review",
+        parentAgentId: parent.id,
+      });
+      return { parent, child };
+    }
+
+    describe("updateFeedbackStatus (direct)", () => {
+      it("rejects ignored without a reason", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        await expect(
+          manager.updateFeedbackStatus(feedback.id, child.id, "ignored")
+        ).rejects.toThrow(/reason is required/);
+      });
+
+      it("rejects ignored with a whitespace-only reason", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        await expect(
+          manager.updateFeedbackStatus(feedback.id, child.id, "ignored", {
+            reason: "   ",
+          })
+        ).rejects.toThrow(/reason is required/);
+      });
+
+      it("persists reason, commit, and resolved_at when ignored with a reason", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const before = Date.now();
+        const updated = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "ignored",
+          { reason: "Out of scope", resolutionCommit: "abc1234" }
+        );
+        const after = Date.now();
+
+        expect(updated).not.toBeNull();
+        expect(updated!.status).toBe("ignored");
+        expect(updated!.resolutionReason).toBe("Out of scope");
+        expect(updated!.resolutionCommit).toBe("abc1234");
+        expect(updated!.resolvedAt).toBeTruthy();
+        const resolvedMs = new Date(
+          updated!.resolvedAt as unknown as string
+        ).getTime();
+        expect(resolvedMs).toBeGreaterThanOrEqual(before - 1000);
+        expect(resolvedMs).toBeLessThanOrEqual(after + 1000);
+      });
+
+      it("accepts fixed without a reason and records commit + resolved_at", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const updated = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "fixed",
+          { resolutionCommit: "deadbeef" }
+        );
+
+        expect(updated!.status).toBe("fixed");
+        expect(updated!.resolutionReason).toBeNull();
+        expect(updated!.resolutionCommit).toBe("deadbeef");
+        expect(updated!.resolvedAt).toBeTruthy();
+      });
+
+      it("persists reason when fixed with a reason", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const updated = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "fixed",
+          { reason: "Patched in request middleware" }
+        );
+
+        expect(updated!.status).toBe("fixed");
+        expect(updated!.resolutionReason).toBe("Patched in request middleware");
+      });
+
+      it("preserves reason on a benign re-resolve with no reason", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        await manager.updateFeedbackStatus(feedback.id, child.id, "ignored", {
+          reason: "Won't fix",
+          resolutionCommit: "sha1",
+        });
+        // Re-resolve as fixed without passing reason/commit — the original
+        // audit trail must be preserved (COALESCE behavior).
+        const second = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "fixed"
+        );
+
+        expect(second!.status).toBe("fixed");
+        expect(second!.resolutionReason).toBe("Won't fix");
+        expect(second!.resolutionCommit).toBe("sha1");
+      });
+
+      it("does not drift resolved_at on a benign re-resolve", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const first = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "fixed"
+        );
+        const firstResolvedAt = first!.resolvedAt;
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const second = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "ignored",
+          { reason: "changed my mind" }
+        );
+
+        expect(
+          new Date(second!.resolvedAt as unknown as string).getTime()
+        ).toBe(new Date(firstResolvedAt as unknown as string).getTime());
+      });
+
+      it("clears resolved_at when reverting to open", async () => {
+        const { child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        await manager.updateFeedbackStatus(feedback.id, child.id, "fixed");
+        const reopened = await manager.updateFeedbackStatus(
+          feedback.id,
+          child.id,
+          "open"
+        );
+
+        expect(reopened!.status).toBe("open");
+        expect(reopened!.resolvedAt).toBeNull();
+      });
+    });
+
+    describe("updateFeedbackStatusByParent (reason validation + commit)", () => {
+      it("rejects ignored without a reason", async () => {
+        const { parent, child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        await expect(
+          manager.updateFeedbackStatusByParent(
+            feedback.id,
+            parent.id,
+            "ignored"
+          )
+        ).rejects.toThrow(/reason is required/);
+      });
+
+      it("persists reason and resolution_commit when a parent ignores", async () => {
+        const { parent, child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const updated = await manager.updateFeedbackStatusByParent(
+          feedback.id,
+          parent.id,
+          "ignored",
+          {
+            reason: "Not applicable to this flow",
+            resolutionCommit: "f00dbabe",
+          }
+        );
+
+        expect(updated!.status).toBe("ignored");
+        expect(updated!.resolutionReason).toBe("Not applicable to this flow");
+        expect(updated!.resolutionCommit).toBe("f00dbabe");
+        expect(updated!.resolvedAt).toBeTruthy();
+      });
+
+      it("accepts fixed without a reason when parent resolves", async () => {
+        const { parent, child } = await seedParentChild();
+        const feedback = await manager.submitFeedback(child.id, {
+          description: "finding",
+        });
+
+        const updated = await manager.updateFeedbackStatusByParent(
+          feedback.id,
+          parent.id,
+          "fixed",
+          { resolutionCommit: "cafef00d" }
+        );
+
+        expect(updated!.status).toBe("fixed");
+        expect(updated!.resolutionCommit).toBe("cafef00d");
+        expect(updated!.resolvedAt).toBeTruthy();
+      });
+    });
+
+    describe("submitReviewResolution", () => {
+      async function seedCompletedReview(): Promise<{
+        parent: Awaited<ReturnType<typeof manager.createAgent>>;
+        child: Awaited<ReturnType<typeof manager.createAgent>>;
+      }> {
+        const { parent, child } = await seedParentChild();
+        await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+          lastReviewedCommit: "launchsha",
+        });
+        await manager.completePersonaReview(child.id, {
+          verdict: "approve",
+          summary: "All good",
+        });
+        return { parent, child };
+      }
+
+      it("rejects an empty summary", async () => {
+        const { parent, child } = await seedCompletedReview();
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "",
+          })
+        ).rejects.toThrow(/summary is required/);
+      });
+
+      it("rejects a whitespace-only summary", async () => {
+        const { parent, child } = await seedCompletedReview();
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "   \n\t ",
+          })
+        ).rejects.toThrow(/summary is required/);
+      });
+
+      it("rejects a summary above the 10,000 character limit", async () => {
+        const { parent, child } = await seedCompletedReview();
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "x".repeat(10_001),
+          })
+        ).rejects.toThrow(/10,000 character/);
+      });
+
+      it("rejects when the review is not in 'complete' state", async () => {
+        const { parent, child } = await seedParentChild();
+        // Create but do NOT complete the review — status stays 'reviewing'.
+        await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+        });
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "Addressed everything",
+          })
+        ).rejects.toThrow(/must be in status 'complete'/);
+      });
+
+      it("rejects when there are still open feedback items", async () => {
+        const { parent, child } = await seedCompletedReview();
+        const openItem = await manager.submitFeedback(child.id, {
+          description: "unresolved",
+        });
+        // Also add a resolved item to confirm only the open ones are reported.
+        const fixedItem = await manager.submitFeedback(child.id, {
+          description: "done",
+        });
+        await manager.updateFeedbackStatus(fixedItem.id, child.id, "fixed");
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "Addressed some",
+          })
+        ).rejects.toThrow(
+          new RegExp(`feedback items still open: ${openItem.id}`)
+        );
+      });
+
+      it("rejects when an ignored item is missing a reason", async () => {
+        const { parent, child } = await seedCompletedReview();
+        const item = await manager.submitFeedback(child.id, {
+          description: "maybe later",
+        });
+        // Insert a bare 'ignored' row directly — bypass the resolve API guard
+        // to prove submitReviewResolution enforces the reason rule itself.
+        await pool.query(
+          "UPDATE agent_feedback SET status = 'ignored', resolution_reason = NULL WHERE id = $1",
+          [item.id]
+        );
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "Covered the rest",
+          })
+        ).rejects.toThrow(
+          new RegExp(`ignored feedback items missing a reason: ${item.id}`)
+        );
+      });
+
+      it("returns 404 when there is no review for the parent/child pair", async () => {
+        const { parent, child } = await seedParentChild();
+        // No createPersonaReview call.
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "nothing to resolve against",
+          })
+        ).rejects.toThrow(/No persona review found/);
+      });
+
+      it("persists summary and resolution_commit on the happy path", async () => {
+        const { parent, child } = await seedCompletedReview();
+        const item = await manager.submitFeedback(child.id, {
+          description: "a thing",
+        });
+        await manager.updateFeedbackStatus(item.id, child.id, "ignored", {
+          reason: "rejected by design",
+        });
+
+        const result = await manager.submitReviewResolution({
+          parentAgentId: parent.id,
+          personaAgentId: child.id,
+          summary: "Accepted one, rejected one.",
+          resolutionCommit: "headsha1",
+        });
+
+        expect(result.resolution.summary).toBe("Accepted one, rejected one.");
+        expect(result.resolution.resolutionCommit).toBe("headsha1");
+        expect(result.resolution.roundNumber).toBe(1);
+
+        // Confirm via a separate read path so the test also covers read APIs.
+        const resolutions = await manager.getReviewResolutions(
+          result.review.id
+        );
+        expect(resolutions).toHaveLength(1);
+        expect(resolutions[0].summary).toBe("Accepted one, rejected one.");
+        expect(resolutions[0].resolutionCommit).toBe("headsha1");
+      });
+
+      it("upserts on repeat submit, replacing summary + commit", async () => {
+        const { parent, child } = await seedCompletedReview();
+
+        const first = await manager.submitReviewResolution({
+          parentAgentId: parent.id,
+          personaAgentId: child.id,
+          summary: "v1",
+          resolutionCommit: "sha-v1",
+        });
+        const second = await manager.submitReviewResolution({
+          parentAgentId: parent.id,
+          personaAgentId: child.id,
+          summary: "v2 — revised",
+          resolutionCommit: "sha-v2",
+        });
+
+        expect(second.resolution.id).toBe(first.resolution.id);
+        const resolutions = await manager.getReviewResolutions(
+          second.review.id
+        );
+        expect(resolutions).toHaveLength(1);
+        expect(resolutions[0].summary).toBe("v2 — revised");
+        expect(resolutions[0].resolutionCommit).toBe("sha-v2");
+      });
+
+      it("trims leading/trailing whitespace from the stored summary", async () => {
+        const { parent, child } = await seedCompletedReview();
+
+        const result = await manager.submitReviewResolution({
+          parentAgentId: parent.id,
+          personaAgentId: child.id,
+          summary: "   padded summary   \n",
+        });
+
+        expect(result.resolution.summary).toBe("padded summary");
+      });
+
+      it("does not persist any resolution when a precondition fails", async () => {
+        const { parent, child } = await seedCompletedReview();
+        await manager.submitFeedback(child.id, { description: "still open" });
+
+        await expect(
+          manager.submitReviewResolution({
+            parentAgentId: parent.id,
+            personaAgentId: child.id,
+            summary: "optimistic",
+          })
+        ).rejects.toThrow();
+
+        const review = await manager.getPersonaReview(child.id);
+        const resolutions = await manager.getReviewResolutions(review!.id);
+        expect(resolutions).toHaveLength(0);
+      });
+    });
+
+    describe("persona review last_reviewed_commit", () => {
+      it("stores the launch commit on createPersonaReview", async () => {
+        const { parent, child } = await seedParentChild();
+
+        const review = await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+          lastReviewedCommit: "launchsha",
+        });
+
+        expect(review.lastReviewedCommit).toBe("launchsha");
+        const refetched = await manager.getPersonaReview(child.id);
+        expect(refetched!.lastReviewedCommit).toBe("launchsha");
+      });
+
+      it("defaults to null when no commit is supplied at launch", async () => {
+        const { parent, child } = await seedParentChild();
+
+        const review = await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+        });
+
+        expect(review.lastReviewedCommit).toBeNull();
+      });
+
+      it("updates last_reviewed_commit on completePersonaReview", async () => {
+        const { parent, child } = await seedParentChild();
+        await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+          lastReviewedCommit: "launchsha",
+        });
+
+        const completed = await manager.completePersonaReview(child.id, {
+          verdict: "approve",
+          summary: "fine",
+          lastReviewedCommit: "completesha",
+        });
+
+        expect(completed.lastReviewedCommit).toBe("completesha");
+      });
+
+      it("preserves last_reviewed_commit via COALESCE when completion omits it", async () => {
+        const { parent, child } = await seedParentChild();
+        await manager.createPersonaReview({
+          agentId: child.id,
+          parentAgentId: parent.id,
+          persona: "security-review",
+          lastReviewedCommit: "launchsha",
+        });
+
+        const completed = await manager.completePersonaReview(child.id, {
+          verdict: "approve",
+          summary: "fine",
+          // no lastReviewedCommit
+        });
+
+        expect(completed.lastReviewedCommit).toBe("launchsha");
+      });
+    });
+  });
+
   describe("listRecentPersonaReviews", () => {
     it("should return reviews created within the time window", async () => {
       const parent = await manager.createAgent({

--- a/apps/server/test/resolution-capture-integration.test.ts
+++ b/apps/server/test/resolution-capture-integration.test.ts
@@ -288,6 +288,20 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId — resolution capture",
       "cafef00dcafef00dcafef00dcafef00dcafef00d"
     );
   });
+
+  it("requires authentication", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { "content-type": "application/json" },
+      payload: { status: "fixed" },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
 });
 
 describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution", () => {
@@ -347,6 +361,22 @@ describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution", (
 
     expect(response.statusCode).toBe(400);
     expect(response.json().error).toMatch(/summary is required/i);
+  });
+
+  // Exercises the manager-level 10k cap through handleAgentError so a refactor
+  // that drops the cap or swallows its throw surfaces as an HTTP-layer failure.
+  it("rejects a summary above the 10,000 character limit", async () => {
+    const { parentId, childId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "x".repeat(10_001) },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/10,000 character/);
   });
 
   it("rejects with 409 when feedback items are still open", async () => {
@@ -416,6 +446,28 @@ describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution", (
 
     expect(response.statusCode).toBe(404);
     expect(response.json().error).toMatch(/Agent not found/i);
+  });
+
+  // The "no persona_reviews row" 404 path throws from inside the transactional
+  // block in submitReviewResolution. Exercising it at the HTTP layer ensures
+  // handleAgentError translates the inner AgentError(..., 404) correctly.
+  it("returns 404 when no persona_reviews row exists for the parent/child pair", async () => {
+    const parentId = await insertAgent();
+    const childId = await insertAgent({
+      parentAgentId: parentId,
+      persona: "security-review",
+    });
+    // Note: no insertPersonaReview call — both agents exist but the review row is missing.
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "nothing to resolve against" },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error).toMatch(/No persona review found/i);
   });
 
   it("persists summary + HEAD sha on the happy path", async () => {

--- a/apps/server/test/resolution-capture-integration.test.ts
+++ b/apps/server/test/resolution-capture-integration.test.ts
@@ -1,0 +1,461 @@
+/**
+ * HTTP integration tests for CRU-128 resolution capture (CRU-130).
+ *
+ * Exercises the real Fastify routes that back the new MCP tools so we catch
+ * endpoint-level validation drift (status codes, body shapes, auth) in addition
+ * to the AgentManager unit tests.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { FastifyInstance } from "fastify";
+import type { Pool } from "pg";
+
+import {
+  setupTestDb,
+  teardownTestDb,
+  runTestMigrations,
+  getTestDatabaseUrl,
+} from "./db/setup.js";
+
+// Hoisted mock state — readable by any runCommand caller (resolveHeadSha, etc.)
+const mockState = vi.hoisted(() => ({
+  headSha: "cafef00dcafef00dcafef00dcafef00dcafef00d",
+}));
+
+vi.mock("../src/shared/lib/run-command.js", () => ({
+  runCommand: vi.fn(async (_cmd: string, args: string[]) => {
+    if (
+      args?.[0] === "-C" &&
+      args?.[2] === "rev-parse" &&
+      args?.[3] === "HEAD"
+    ) {
+      return { exitCode: 0, stdout: mockState.headSha, stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  }),
+}));
+
+let pool: Pool;
+let app: FastifyInstance;
+let createSession: typeof import("../src/auth.js").createSession;
+let sessionCookie: string;
+
+// See mcp-auth-integration.test.ts — the MCP SDK's StreamableHTTP transport
+// schedules a 500 ms drain that fires a destroySoon that Fastify inject()
+// sockets don't implement. Swallow only that specific teardown error.
+const uncaughtExceptionFilter = (err: Error): void => {
+  if (
+    err instanceof TypeError &&
+    err.message.includes("destroySoon is not a function")
+  ) {
+    return;
+  }
+  throw err;
+};
+
+beforeAll(async () => {
+  process.prependListener("uncaughtException", uncaughtExceptionFilter);
+
+  pool = await setupTestDb();
+  await runTestMigrations();
+
+  process.env.DATABASE_URL = getTestDatabaseUrl();
+  process.env.DISPATCH_AGENT_RUNTIME = "inert";
+  process.env.DISPATCH_PORT = "6769";
+  process.env.DISPATCH_HOST = "127.0.0.1";
+
+  const auth = await import("../src/auth.js");
+  ({ createSession } = auth);
+
+  const serverModule = await import("../src/server.js");
+  app = await serverModule.initializeApp({
+    runMigrations: false,
+    reconcileState: false,
+  });
+
+  const setupResponse = await app.inject({
+    method: "POST",
+    url: "/api/v1/auth/setup",
+    payload: { password: "hunter2hunter2" },
+  });
+  expect(setupResponse.statusCode).toBe(200);
+});
+
+afterAll(async () => {
+  const serverModule = await import("../src/server.js");
+  await serverModule.closeApp();
+  delete process.env.DISPATCH_AGENT_RUNTIME;
+  delete process.env.DATABASE_URL;
+  delete process.env.DISPATCH_PORT;
+  delete process.env.DISPATCH_HOST;
+  await teardownTestDb();
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  process.off("uncaughtException", uncaughtExceptionFilter);
+});
+
+beforeEach(async () => {
+  await pool.query("DELETE FROM agent_feedback");
+  // persona_review_resolutions cascades from persona_reviews, which cascades
+  // from agents, but delete explicitly for clarity/order-independence.
+  await pool.query("DELETE FROM persona_review_resolutions");
+  await pool.query("DELETE FROM persona_reviews");
+  await pool.query("DELETE FROM agent_events");
+  await pool.query("DELETE FROM agents");
+  await pool.query("DELETE FROM sessions");
+  const session = await createSession(pool);
+  const signed = (
+    app as FastifyInstance & { signCookie: (value: string) => string }
+  ).signCookie(session);
+  sessionCookie = `dispatch_session=${signed}`;
+  mockState.headSha = "cafef00dcafef00dcafef00dcafef00dcafef00d";
+});
+
+let agentCounter = 0;
+function nextAgentId(): string {
+  agentCounter += 1;
+  // agt_ + 12 hex chars — matches production format the MCP auth checks expect
+  return `agt_${agentCounter.toString(16).padStart(12, "0")}`;
+}
+
+async function insertAgent(
+  overrides: {
+    parentAgentId?: string;
+    persona?: string;
+  } = {}
+): Promise<string> {
+  const id = nextAgentId();
+  await pool.query(
+    `INSERT INTO agents (id, name, type, status, cwd, parent_agent_id, persona)
+     VALUES ($1, $2, 'codex', 'running', '/tmp', $3, $4)`,
+    [
+      id,
+      `agent-${id.slice(-6)}`,
+      overrides.parentAgentId ?? null,
+      overrides.persona ?? null,
+    ]
+  );
+  return id;
+}
+
+async function insertFeedback(
+  childId: string,
+  description = "finding"
+): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO agent_feedback (agent_id, severity, description)
+     VALUES ($1, 'info', $2)
+     RETURNING id`,
+    [childId, description]
+  );
+  return result.rows[0]!.id;
+}
+
+async function insertPersonaReview(
+  childId: string,
+  parentId: string,
+  status: "reviewing" | "complete" = "complete"
+): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, status, verdict, summary)
+     VALUES ($1, $2, 'security-review', $3,
+             CASE WHEN $3 = 'complete' THEN 'approve' ELSE NULL END,
+             CASE WHEN $3 = 'complete' THEN 'done' ELSE NULL END)
+     RETURNING id`,
+    [childId, parentId, status]
+  );
+  return result.rows[0]!.id;
+}
+
+describe("PATCH /api/v1/agents/:id/feedback/:feedbackId — resolution capture", () => {
+  it("rejects non-string reason", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "fixed", reason: 123 },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/reason must be a string/);
+  });
+
+  it("rejects a reason that exceeds the 10,000 character limit", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "ignored", reason: "x".repeat(10_001) },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/10,000 character/);
+  });
+
+  it("rejects ignored without a reason (400)", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "ignored" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/reason is required/i);
+  });
+
+  it("accepts ignored with a reason and records reason + commit + resolved_at", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "ignored", reason: "Out of scope for this release." },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json().feedback;
+    expect(body.status).toBe("ignored");
+    expect(body.resolutionReason).toBe("Out of scope for this release.");
+    expect(body.resolutionCommit).toBe(mockState.headSha);
+    expect(body.resolvedAt).toBeTruthy();
+  });
+
+  it("accepts fixed without a reason and still records the resolution commit", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "fixed" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json().feedback;
+    expect(body.status).toBe("fixed");
+    expect(body.resolutionReason).toBeNull();
+    expect(body.resolutionCommit).toBe(mockState.headSha);
+  });
+
+  it("does not compute a resolution commit when reverting to 'open'", async () => {
+    const childId = await insertAgent();
+    const feedbackId = await insertFeedback(childId);
+    // Pre-resolve so there's state to revert.
+    const first = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "fixed" },
+    });
+    expect(first.statusCode).toBe(200);
+
+    // Change the mock SHA — if the server wrongly computed HEAD on a revert,
+    // the new SHA would leak through.
+    mockState.headSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    const reopen = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${childId}/feedback/${feedbackId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { status: "open" },
+    });
+
+    expect(reopen.statusCode).toBe(200);
+    const body = reopen.json().feedback;
+    expect(body.status).toBe("open");
+    expect(body.resolvedAt).toBeNull();
+    // First-resolve commit preserved because the endpoint only touches
+    // resolution metadata on transitions into fixed/ignored.
+    expect(body.resolutionCommit).toBe(
+      "cafef00dcafef00dcafef00dcafef00dcafef00d"
+    );
+  });
+});
+
+describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution", () => {
+  async function seed(
+    opts: { reviewStatus?: "reviewing" | "complete" } = {}
+  ): Promise<{ parentId: string; childId: string; reviewId: number }> {
+    const parentId = await insertAgent();
+    const childId = await insertAgent({
+      parentAgentId: parentId,
+      persona: "security-review",
+    });
+    const reviewId = await insertPersonaReview(
+      childId,
+      parentId,
+      opts.reviewStatus ?? "complete"
+    );
+    return { parentId, childId, reviewId };
+  }
+
+  it("rejects an empty summary with 400", async () => {
+    const { parentId, childId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/summary is required/i);
+  });
+
+  it("rejects a whitespace-only summary with 400", async () => {
+    const { parentId, childId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "   \n" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/summary is required/i);
+  });
+
+  it("rejects non-string summary with 400", async () => {
+    const { parentId, childId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: 42 },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/summary is required/i);
+  });
+
+  it("rejects with 409 when feedback items are still open", async () => {
+    const { parentId, childId } = await seed();
+    const openId = await insertFeedback(childId, "still open");
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "I addressed some of it." },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toMatch(
+      new RegExp(`feedback items still open: ${openId}`)
+    );
+  });
+
+  it("rejects with 409 when an ignored item is missing a reason", async () => {
+    const { parentId, childId } = await seed();
+    const feedbackId = await insertFeedback(childId);
+    // Mark ignored in the DB without a reason to simulate bypassing the
+    // resolve tool's guard.
+    await pool.query(
+      "UPDATE agent_feedback SET status = 'ignored', resolution_reason = NULL WHERE id = $1",
+      [feedbackId]
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "Covered the rest." },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toMatch(
+      new RegExp(`ignored feedback items missing a reason: ${feedbackId}`)
+    );
+  });
+
+  it("rejects with 409 when the review is not in 'complete' state", async () => {
+    const { parentId, childId } = await seed({ reviewStatus: "reviewing" });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "Something." },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toMatch(/must be in status 'complete'/);
+  });
+
+  it("returns 404 when the parent agent does not exist", async () => {
+    const parentId = "agt_000000000000";
+    const childId = await insertAgent({ persona: "security-review" });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "whatever" },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error).toMatch(/Agent not found/i);
+  });
+
+  it("persists summary + HEAD sha on the happy path", async () => {
+    const { parentId, childId, reviewId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { summary: "Fixed 2, rejected 1 with reasons." },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.resolution.summary).toBe("Fixed 2, rejected 1 with reasons.");
+    expect(body.resolution.resolutionCommit).toBe(mockState.headSha);
+    expect(body.resolution.roundNumber).toBe(1);
+    expect(body.resolution.reviewId).toBe(reviewId);
+
+    // Confirm row is actually persisted.
+    const dbRows = await pool.query(
+      "SELECT summary, resolution_commit, round_number FROM persona_review_resolutions WHERE review_id = $1",
+      [reviewId]
+    );
+    expect(dbRows.rowCount).toBe(1);
+    expect(dbRows.rows[0].summary).toBe("Fixed 2, rejected 1 with reasons.");
+    expect(dbRows.rows[0].resolution_commit).toBe(mockState.headSha);
+    expect(dbRows.rows[0].round_number).toBe(1);
+  });
+
+  it("requires authentication", async () => {
+    const { parentId, childId } = await seed();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${parentId}/persona-reviews/${childId}/resolution`,
+      headers: { "content-type": "application/json" },
+      payload: { summary: "anything" },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 test coverage for the review round-trip flow (parent of [CRU-127](https://linear.app/crumbstream/issue/CRU-127)). Backs the resolution-capture implementation landed in #372 / [CRU-128](https://linear.app/crumbstream/issue/CRU-128) with unit + HTTP integration tests so every new guard has a regression net.

No production code changed — tests only.

## Coverage

**Unit (`apps/server/test/db/agent-manager.test.ts`, additive):**

- `updateFeedbackStatus` / `updateFeedbackStatusByParent`
  - `ignored` rejects without a reason (empty, whitespace-only)
  - `fixed` accepted with or without a reason
  - `resolution_reason`, `resolution_commit`, `resolved_at` persisted
  - Benign re-resolve preserves the original audit trail (COALESCE)
  - `resolved_at` does not drift on repeat calls; cleared on revert to `open`
- `submitReviewResolution`
  - Empty / whitespace / over-length (10k) summary
  - Review not in `complete` state
  - Still-open items surface the offending IDs
  - Ignored-without-reason items surface the offending IDs
  - Missing review returns 404
  - Happy path: summary + resolution commit + `round_number=1`
  - Idempotent upsert replaces summary + commit on repeat submit
  - Summary is trimmed on persist
  - Failing preconditions leave no partial rows
- `persona_reviews.last_reviewed_commit`
  - Set on `createPersonaReview`; defaults to null
  - Updated on `completePersonaReview`; COALESCE preserves when omitted

**HTTP integration (`apps/server/test/resolution-capture-integration.test.ts`, new file):**

- `PATCH /api/v1/agents/:id/feedback/:feedbackId`
  - Reason must be a string; 10k cap
  - `ignored` without reason → 400
  - Happy paths for `fixed` / `ignored` record reason + HEAD sha
  - Reverting to `open` does not recompute resolution commit
- `POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution`
  - Summary validation (missing / whitespace / non-string) → 400
  - Still-open items → 409 with IDs
  - Ignored items missing a reason → 409 with IDs
  - Review not `complete` → 409
  - Parent not found → 404
  - Happy path persists summary + HEAD sha, row readable via DB
  - Unauthenticated requests → 401

Follows the `mcp-auth-integration.test.ts` pattern: inert runtime, isolated test DB, `runCommand` mocked so `resolveHeadSha` returns a controlled value.

## Test plan

- [x] `pnpm run check` (backend + web tsc)
- [x] `pnpm run test` — 366 passed, 11 skipped (pre-existing)
- [x] New suite alone: 39 unit + integration tests all green
- [ ] `pnpm run test:e2e` — not re-run; no production code changed, no E2E assertions touched