### PR TITLE
feat(web): surface resolution reasons and parent summary (CRU-129)

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -112,6 +112,12 @@ export type AgentRecord = {
     summary: string | null;
     filesReviewed: string[] | null;
     updatedAt: string;
+    resolution: {
+      summary: string;
+      resolutionCommit: string | null;
+      submittedAt: string;
+      roundNumber: number;
+    } | null;
   } | null;
   baseBranch: string | null;
   autoReview: boolean;
@@ -3581,7 +3587,19 @@ export class AgentManager {
            'verdict', pr.verdict,
            'summary', pr.summary,
            'filesReviewed', pr.files_reviewed,
-           'updatedAt', pr.updated_at
+           'updatedAt', pr.updated_at,
+           'resolution', (
+             SELECT json_build_object(
+               'summary', prr.summary,
+               'resolutionCommit', prr.resolution_commit,
+               'submittedAt', prr.submitted_at,
+               'roundNumber', prr.round_number
+             )
+             FROM persona_review_resolutions prr
+             WHERE prr.review_id = pr.id
+             ORDER BY prr.round_number DESC, prr.submitted_at DESC
+             LIMIT 1
+           )
          ) FROM persona_reviews pr WHERE pr.agent_id = agents.id LIMIT 1
         ) AS "review",
         created_at AS "createdAt",

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -429,6 +429,7 @@ export function ParentFeedbackPanel({
             const canTriage = isConnected && !!sendTerminalInput;
             const childVerdict = getVerdict(child);
             const childSummary = getReviewSummary(child);
+            const childResolution = child.review?.resolution ?? null;
             const handleTriage =
               unresolvedCount > 0
                 ? () => {
@@ -502,6 +503,27 @@ export function ParentFeedbackPanel({
                     />
                   </div>
                 ) : null}
+                {childResolution ? (
+                  <div
+                    className="ml-8 mt-1 rounded-md border border-border/60 bg-muted/20 p-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                      Parent's response
+                    </div>
+                    <div className="whitespace-pre-wrap break-words text-xs text-foreground">
+                      {childResolution.summary}
+                    </div>
+                    {childResolution.resolutionCommit ? (
+                      <div className="mt-1 text-[10px] text-muted-foreground/70">
+                        at{" "}
+                        <span className="font-mono text-muted-foreground">
+                          {shortSha(childResolution.resolutionCommit)}
+                        </span>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
                 <AnimatePresence initial={false}>
                   {!isGroupCollapsed && hasAnyFeedback
                     ? (() => {
@@ -535,7 +557,7 @@ export function ParentFeedbackPanel({
                                   >
                                     <button
                                       className={cn(
-                                        "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-[11px] transition-colors",
+                                        "flex w-full flex-col gap-0.5 rounded-md px-1.5 py-1.5 text-left text-[11px] transition-colors",
                                         "border-b-2",
                                         isSelected
                                           ? "border-primary"
@@ -565,38 +587,48 @@ export function ParentFeedbackPanel({
                                         });
                                       }}
                                     >
-                                      <span
-                                        className={cn(
-                                          "h-1.5 w-1.5 shrink-0 rounded-full",
-                                          dotColor
-                                        )}
-                                      />
-                                      <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
-                                        <FrontTruncatedValue
-                                          value={
-                                            item.filePath
-                                              ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}`
-                                              : "—"
-                                          }
-                                          mono
-                                        />
-                                      </div>
-                                      <span className="min-w-0 flex-1 truncate text-foreground">
-                                        {item.description}
-                                      </span>
-                                      {statusLabel && !isActionable ? (
+                                      <div className="flex w-full items-center gap-2">
                                         <span
                                           className={cn(
-                                            "shrink-0",
-                                            statusLabel.color
+                                            "h-1.5 w-1.5 shrink-0 rounded-full",
+                                            dotColor
                                           )}
-                                          title={statusLabel.label}
-                                        >
-                                          <StatusIcon
-                                            status={item.status}
-                                            className={statusLabel.color}
+                                        />
+                                        <div className="min-w-0 overflow-hidden font-mono text-muted-foreground">
+                                          <FrontTruncatedValue
+                                            value={
+                                              item.filePath
+                                                ? `${item.filePath.split("/").pop()}${item.lineNumber ? `:${item.lineNumber}` : ""}`
+                                                : "—"
+                                            }
+                                            mono
                                           />
+                                        </div>
+                                        <span className="min-w-0 flex-1 truncate text-foreground">
+                                          {item.description}
                                         </span>
+                                        {statusLabel && !isActionable ? (
+                                          <span
+                                            className={cn(
+                                              "shrink-0",
+                                              statusLabel.color
+                                            )}
+                                            title={statusLabel.label}
+                                          >
+                                            <StatusIcon
+                                              status={item.status}
+                                              className={statusLabel.color}
+                                            />
+                                          </span>
+                                        ) : null}
+                                      </div>
+                                      {item.resolutionReason ? (
+                                        <div
+                                          className="ml-4 truncate pl-0.5 text-[10px] italic text-muted-foreground/70"
+                                          title={item.resolutionReason}
+                                        >
+                                          {item.resolutionReason}
+                                        </div>
                                       ) : null}
                                     </button>
                                   </div>
@@ -695,30 +727,131 @@ function useFeedbackData(parentAgentId: string) {
   }, [allAgents, parentAgentId, personas]);
 
   const updateStatus = useCallback(
-    async (item: FeedbackItem, status: string) => {
+    async (item: FeedbackItem, status: string, reason?: string) => {
       const body: { status: string; reason?: string } = { status };
-      // Server requires a reason when ignoring. Until CRU-129 adds the
-      // inline prompt, stamp a generic reason so the UI button works.
-      if (status === "ignored") {
-        body.reason = "User's choice";
-      }
-      await api(`/api/v1/agents/${item.agentId}/feedback/${item.id}`, {
-        method: "PATCH",
-        body: JSON.stringify(body),
-      });
-      const update = (f: FeedbackItem) =>
-        f.id === item.id
-          ? { ...f, status: status as FeedbackItem["status"] }
-          : f;
+      if (reason !== undefined) body.reason = reason;
+      const response = await api<{ feedback: FeedbackItem }>(
+        `/api/v1/agents/${item.agentId}/feedback/${item.id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(body),
+        }
+      );
       queryClient.setQueryData<FeedbackItem[]>(
         ["feedback", parentAgentId, "children"],
-        (old) => old?.map(update)
+        (old) => old?.map((f) => (f.id === item.id ? response.feedback : f))
       );
     },
     [queryClient, parentAgentId]
   );
 
   return { feedback, personaAttribution, updateStatus };
+}
+
+function shortSha(sha: string | null | undefined): string | null {
+  if (!sha) return null;
+  return sha.slice(0, 7);
+}
+
+function ResolutionInfoBlock({
+  item,
+  className,
+}: {
+  item: FeedbackItem;
+  className?: string;
+}): JSX.Element | null {
+  if (!item.resolutionReason && !item.resolutionCommit) return null;
+  const sha = shortSha(item.resolutionCommit);
+  return (
+    <div className={cn("space-y-1", className)}>
+      {item.resolutionReason ? (
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+            Resolution reason
+          </div>
+          <div className="text-sm text-muted-foreground whitespace-pre-wrap break-words">
+            {item.resolutionReason}
+          </div>
+        </div>
+      ) : null}
+      {sha ? (
+        <div className="text-[10px] text-muted-foreground/70">
+          Resolved at commit{" "}
+          <span className="font-mono text-muted-foreground">{sha}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function IgnoreReasonInput({
+  onCancel,
+  onSubmit,
+  size = "default",
+}: {
+  onCancel: () => void;
+  onSubmit: (reason: string) => void;
+  size?: "sm" | "default";
+}): JSX.Element {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0;
+  const submit = () => {
+    if (canSubmit) onSubmit(trimmed);
+  };
+  const inputClass =
+    size === "sm" ? "h-7 px-2 text-[11px]" : "h-8 px-2.5 text-xs";
+  const btnClass =
+    size === "sm" ? "h-7 px-2 text-[11px]" : "h-8 px-2.5 text-xs";
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-md border border-border bg-background/60 p-1"
+      )}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        placeholder="Why ignore? (required)"
+        className={cn(
+          "min-w-0 flex-1 bg-transparent text-foreground placeholder:text-muted-foreground/60 outline-none",
+          inputClass
+        )}
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        className={btnClass + " text-muted-foreground/60 hover:text-foreground"}
+        onClick={onCancel}
+      >
+        Cancel
+      </Button>
+      <Button
+        variant="default"
+        size="sm"
+        className={btnClass}
+        disabled={!canSubmit}
+        onClick={submit}
+      >
+        Ignore
+      </Button>
+    </div>
+  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -800,9 +933,12 @@ export function FeedbackDetailPanel({
     [copyText]
   );
 
+  const [ignoreTarget, setIgnoreTarget] = useState<number | null>(null);
+
   const handleResolve = useCallback(
-    (feedbackItem: FeedbackItem, status: string) => {
-      void updateStatus(feedbackItem, status);
+    (feedbackItem: FeedbackItem, status: string, reason?: string) => {
+      void updateStatus(feedbackItem, status, reason);
+      setIgnoreTarget(null);
       // Advance within the same persona group
       const samePersona = activeItems.filter(
         (f) => f.agentId === feedbackItem.agentId
@@ -921,21 +1057,36 @@ export function FeedbackDetailPanel({
             </Markdown>
           </div>
         ) : null}
+
+        {!isActionable ? <ResolutionInfoBlock item={item} /> : null}
       </div>
 
       {/* Actions footer */}
       <div className="shrink-0 pt-2 border-t border-border mt-2">
-        <FeedbackActions
-          item={item}
-          isConnected={isConnected}
-          onForward={(mode) => forward(item, mode)}
-          onCopy={() => handleCopy(item)}
-          copied={copied && copiedItemId === item.id}
-          onUpdateStatus={(s) => handleResolve(item, s)}
-          isActionable={isActionable}
-          statusLabel={STATUS_LABELS[item.status]}
-          size="default"
-        />
+        {ignoreTarget === item.id ? (
+          <IgnoreReasonInput
+            onCancel={() => setIgnoreTarget(null)}
+            onSubmit={(reason) => handleResolve(item, "ignored", reason)}
+          />
+        ) : (
+          <FeedbackActions
+            item={item}
+            isConnected={isConnected}
+            onForward={(mode) => forward(item, mode)}
+            onCopy={() => handleCopy(item)}
+            copied={copied && copiedItemId === item.id}
+            onUpdateStatus={(s) => {
+              if (s === "ignored") {
+                setIgnoreTarget(item.id);
+              } else {
+                handleResolve(item, s);
+              }
+            }}
+            isActionable={isActionable}
+            statusLabel={STATUS_LABELS[item.status]}
+            size="default"
+          />
+        )}
       </div>
     </div>
   );
@@ -960,6 +1111,7 @@ export function ReviewSummaryPanel({
   const verdict = getVerdict(agent);
   const summary = getReviewSummary(agent);
   const filesReviewed = getFilesReviewed(agent);
+  const resolution = agent.review?.resolution ?? null;
   const attr = personaAttribution.get(agent.id);
 
   return (
@@ -1029,6 +1181,25 @@ export function ReviewSummaryPanel({
                 </div>
               ))}
             </div>
+          </div>
+        ) : null}
+
+        {resolution ? (
+          <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+              Parent's response
+            </div>
+            <Markdown className="text-sm text-foreground">
+              {resolution.summary}
+            </Markdown>
+            {resolution.resolutionCommit ? (
+              <div className="mt-2 text-[10px] text-muted-foreground/70">
+                Submitted at commit{" "}
+                <span className="font-mono text-muted-foreground">
+                  {shortSha(resolution.resolutionCommit)}
+                </span>
+              </div>
+            ) : null}
           </div>
         ) : null}
 
@@ -1117,9 +1288,12 @@ export function MobileFeedbackSheet({
     [copyText]
   );
 
+  const [ignoreTarget, setIgnoreTarget] = useState<number | null>(null);
+
   const handleResolve = useCallback(
-    (feedbackItem: FeedbackItem, status: string) => {
-      void updateStatus(feedbackItem, status);
+    (feedbackItem: FeedbackItem, status: string, reason?: string) => {
+      void updateStatus(feedbackItem, status, reason);
+      setIgnoreTarget(null);
       const samePersona = activeItems.filter(
         (f) => f.agentId === feedbackItem.agentId
       );
@@ -1243,20 +1417,34 @@ export function MobileFeedbackSheet({
                   </Markdown>
                 </div>
               ) : null}
+              {!isActionable ? <ResolutionInfoBlock item={item} /> : null}
             </div>
 
             <div className="shrink-0 pt-2 border-t border-border">
-              <FeedbackActions
-                item={item}
-                isConnected={isConnected}
-                onForward={(mode) => forward(item, mode)}
-                onCopy={() => handleCopy(item)}
-                copied={copied && copiedItemId === item.id}
-                onUpdateStatus={(s) => handleResolve(item, s)}
-                isActionable={!!isActionable}
-                statusLabel={STATUS_LABELS[item.status]}
-                size="default"
-              />
+              {ignoreTarget === item.id ? (
+                <IgnoreReasonInput
+                  onCancel={() => setIgnoreTarget(null)}
+                  onSubmit={(reason) => handleResolve(item, "ignored", reason)}
+                />
+              ) : (
+                <FeedbackActions
+                  item={item}
+                  isConnected={isConnected}
+                  onForward={(mode) => forward(item, mode)}
+                  onCopy={() => handleCopy(item)}
+                  copied={copied && copiedItemId === item.id}
+                  onUpdateStatus={(s) => {
+                    if (s === "ignored") {
+                      setIgnoreTarget(item.id);
+                    } else {
+                      handleResolve(item, s);
+                    }
+                  }}
+                  isActionable={!!isActionable}
+                  statusLabel={STATUS_LABELS[item.status]}
+                  size="default"
+                />
+              )}
             </div>
           </>
         ) : (
@@ -1298,6 +1486,7 @@ export function MobileReviewSummarySheet({
   const verdict = getVerdict(agent);
   const summary = getReviewSummary(agent);
   const filesReviewed = getFilesReviewed(agent);
+  const resolution = agent.review?.resolution ?? null;
   const attr = personaAttribution.get(agent.id);
 
   return (
@@ -1379,6 +1568,25 @@ export function MobileReviewSummarySheet({
                   </div>
                 ))}
               </div>
+            </div>
+          ) : null}
+
+          {resolution ? (
+            <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
+                Parent's response
+              </div>
+              <Markdown className="text-sm text-foreground">
+                {resolution.summary}
+              </Markdown>
+              {resolution.resolutionCommit ? (
+                <div className="mt-2 text-[10px] text-muted-foreground/70">
+                  Submitted at commit{" "}
+                  <span className="font-mono text-muted-foreground">
+                    {shortSha(resolution.resolutionCommit)}
+                  </span>
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -511,9 +511,9 @@ export function ParentFeedbackPanel({
                     <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
                       Parent's response
                     </div>
-                    <div className="whitespace-pre-wrap break-words text-xs text-foreground">
+                    <Markdown className="text-xs text-foreground">
                       {childResolution.summary}
-                    </div>
+                    </Markdown>
                     {childResolution.resolutionCommit ? (
                       <div className="mt-1 text-[10px] text-muted-foreground/70">
                         at{" "}
@@ -622,7 +622,8 @@ export function ParentFeedbackPanel({
                                           </span>
                                         ) : null}
                                       </div>
-                                      {item.resolutionReason ? (
+                                      {!isActionable &&
+                                      item.resolutionReason ? (
                                         <div
                                           className="ml-4 truncate pl-0.5 text-[10px] italic text-muted-foreground/70"
                                           title={item.resolutionReason}
@@ -804,9 +805,8 @@ function IgnoreReasonInput({
     if (canSubmit) onSubmit(trimmed);
   };
   const inputClass =
-    size === "sm" ? "h-7 px-2 text-[11px]" : "h-8 px-2.5 text-xs";
-  const btnClass =
-    size === "sm" ? "h-7 px-2 text-[11px]" : "h-8 px-2.5 text-xs";
+    size === "sm" ? "h-7 px-2 text-[11px]" : "h-11 px-3 text-sm";
+  const btnClass = size === "sm" ? "h-7 px-2 text-[11px]" : "h-11 px-3 text-sm";
   return (
     <div
       className={cn(
@@ -819,11 +819,15 @@ function IgnoreReasonInput({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
+          // stopPropagation so the outer panel/sheet Esc handler doesn't
+          // also fire and close the whole panel on cancel.
           if (e.key === "Enter") {
             e.preventDefault();
+            e.stopPropagation();
             submit();
           } else if (e.key === "Escape") {
             e.preventDefault();
+            e.stopPropagation();
             onCancel();
           }
         }}
@@ -970,12 +974,15 @@ export function FeedbackDetailPanel({
   const isActionable = item.status === "open" || item.status === "forwarded";
   const severityInfo = SEVERITY_LABELS[item.severity] ?? SEVERITY_LABELS.info;
   const attr = personaAttribution.get(item.agentId);
+  const isIgnoring = ignoreTarget === item.id;
 
   return (
     <div
       ref={panelRef}
       tabIndex={-1}
       onKeyDown={(e) => {
+        // Skip when the inline ignore input is open — it owns Esc to cancel.
+        if (isIgnoring) return;
         if (e.key === "Escape") {
           e.stopPropagation();
           onClose();
@@ -1011,7 +1018,7 @@ export function FeedbackDetailPanel({
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0"
-            disabled={!prevItem}
+            disabled={!prevItem || isIgnoring}
             onClick={() => prevItem && onNavigate(prevItem.id)}
           >
             <ChevronLeft className="h-4 w-4" />
@@ -1020,7 +1027,7 @@ export function FeedbackDetailPanel({
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0"
-            disabled={!nextItem}
+            disabled={!nextItem || isIgnoring}
             onClick={() => nextItem && onNavigate(nextItem.id)}
           >
             <ChevronRight className="h-4 w-4" />
@@ -1029,6 +1036,7 @@ export function FeedbackDetailPanel({
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0 ml-4 opacity-70 hover:opacity-100"
+            disabled={isIgnoring}
             onClick={onClose}
           >
             <X className="h-4 w-4" />
@@ -1317,12 +1325,15 @@ export function MobileFeedbackSheet({
   const attr = item ? personaAttribution.get(item.agentId) : undefined;
   const isActionable =
     item && (item.status === "open" || item.status === "forwarded");
+  const isIgnoring = !!item && ignoreTarget === item.id;
 
   return (
     <Sheet
       open
       onOpenChange={(open) => {
-        if (!open) onClose();
+        // Block the overlay/Esc close path from the Radix Sheet while the
+        // inline reason input is open so the user doesn't lose their place.
+        if (!open && !isIgnoring) onClose();
       }}
     >
       <SheetContent
@@ -1343,7 +1354,7 @@ export function MobileFeedbackSheet({
                   variant="ghost"
                   size="sm"
                   className="h-8 w-8 p-0"
-                  disabled={!prevItem}
+                  disabled={!prevItem || isIgnoring}
                   onClick={() => prevItem && onNavigate(prevItem.id)}
                 >
                   <ChevronLeft className="h-4 w-4" />
@@ -1352,7 +1363,7 @@ export function MobileFeedbackSheet({
                   variant="ghost"
                   size="sm"
                   className="h-8 w-8 p-0"
-                  disabled={!nextItem}
+                  disabled={!nextItem || isIgnoring}
                   onClick={() => nextItem && onNavigate(nextItem.id)}
                 >
                   <ChevronRight className="h-4 w-4" />
@@ -1362,6 +1373,7 @@ export function MobileFeedbackSheet({
                 variant="ghost"
                 size="sm"
                 className="h-8 w-8 p-0 opacity-70 hover:opacity-100"
+                disabled={isIgnoring}
                 onClick={onClose}
               >
                 <X className="h-4 w-4" />

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -429,7 +429,6 @@ export function ParentFeedbackPanel({
             const canTriage = isConnected && !!sendTerminalInput;
             const childVerdict = getVerdict(child);
             const childSummary = getReviewSummary(child);
-            const childResolution = child.review?.resolution ?? null;
             const handleTriage =
               unresolvedCount > 0
                 ? () => {
@@ -501,27 +500,6 @@ export function ParentFeedbackPanel({
                         });
                       }}
                     />
-                  </div>
-                ) : null}
-                {childResolution ? (
-                  <div
-                    className="ml-8 mt-1 rounded-md border border-border/60 bg-muted/20 p-2"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground/80 mb-1">
-                      Parent's response
-                    </div>
-                    <Markdown className="text-xs text-foreground">
-                      {childResolution.summary}
-                    </Markdown>
-                    {childResolution.resolutionCommit ? (
-                      <div className="mt-1 text-[10px] text-muted-foreground/70">
-                        at{" "}
-                        <span className="font-mono text-muted-foreground">
-                          {shortSha(childResolution.resolutionCommit)}
-                        </span>
-                      </div>
-                    ) : null}
                   </div>
                 ) : null}
                 <AnimatePresence initial={false}>

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -121,6 +121,10 @@ export function getFilesReviewed(child: Agent): string[] | undefined {
   return Array.isArray(f) ? f : undefined;
 }
 
+export function getResolution(child: Agent) {
+  return child.review?.resolution ?? undefined;
+}
+
 export function PersonaAgentRow({
   child,
   childIndex,
@@ -145,6 +149,8 @@ export function PersonaAgentRow({
   const isReviewing = reviewStatus === "reviewing";
   const verdict = getVerdict(child);
   const hasSummary = !!getReviewSummary(child);
+  const resolution = getResolution(child);
+  const hasResolution = !!resolution?.summary;
   const reviewMessage = child.review?.message?.split("\n")[0] ?? null;
 
   return (
@@ -186,7 +192,24 @@ export function PersonaAgentRow({
           </div>
         </div>
         <div className="mt-1 flex items-center gap-1.5 text-[10px]">
-          {verdict ? (
+          {hasResolution ? (
+            (hasSummary || resolution?.summary) && onOpenSummary ? (
+              <button
+                data-agent-control="true"
+                className="font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/40 underline-offset-2 transition-colors hover:text-foreground hover:decoration-solid"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenSummary();
+                }}
+              >
+                Resolution submitted
+              </button>
+            ) : (
+              <span className="font-medium text-muted-foreground">
+                Resolution submitted
+              </span>
+            )
+          ) : verdict ? (
             hasSummary && onOpenSummary ? (
               <button
                 data-agent-control="true"

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -193,7 +193,7 @@ export function PersonaAgentRow({
         </div>
         <div className="mt-1 flex items-center gap-1.5 text-[10px]">
           {hasResolution ? (
-            (hasSummary || resolution?.summary) && onOpenSummary ? (
+            onOpenSummary ? (
               <button
                 data-agent-control="true"
                 className="font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/40 underline-offset-2 transition-colors hover:text-foreground hover:decoration-solid"

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -125,6 +125,128 @@ export function getResolution(child: Agent) {
   return child.review?.resolution ?? undefined;
 }
 
+type StepColor = "orange" | "emerald" | "muted";
+
+const STEP_COLOR: Record<StepColor, string> = {
+  orange: "text-orange-500",
+  emerald: "text-emerald-500",
+  muted: "text-muted-foreground",
+};
+
+type StepDef = {
+  label: string;
+  color: StepColor;
+  filled: boolean;
+};
+
+function StepperStep({ step }: { step: StepDef }): JSX.Element {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 whitespace-nowrap font-semibold",
+        STEP_COLOR[step.color],
+        !step.filled && "opacity-60"
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 shrink-0 rounded-full",
+          step.filled ? "bg-current" : "border border-current bg-transparent"
+        )}
+      />
+      <span>{step.label}</span>
+    </span>
+  );
+}
+
+/**
+ * Two-step pill showing reviewer verdict and parent-response state.
+ * Pure presentation — caller derives step primitives from the source data.
+ */
+function ReviewStepper({
+  step1,
+  step2,
+  connector,
+  round,
+  onOpen,
+}: {
+  step1: StepDef;
+  step2: StepDef;
+  connector: "solid" | "dashed";
+  round?: number;
+  onOpen?: () => void;
+}): JSX.Element {
+  const pillClass = cn(
+    "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-border/70 bg-background/40 px-2 py-0.5 text-[10px] transition-colors",
+    onOpen && "cursor-pointer hover:bg-muted/40"
+  );
+
+  const inner = (
+    <>
+      <StepperStep step={step1} />
+      <span
+        aria-hidden
+        className={cn(
+          "h-0 w-3 shrink-0 border-t",
+          connector === "solid"
+            ? "border-border"
+            : "border-dashed border-border/60"
+        )}
+      />
+      <StepperStep step={step2} />
+    </>
+  );
+
+  const badge =
+    typeof round === "number" && round > 1 ? (
+      <span className="inline-flex h-4 items-center rounded border border-border bg-muted/40 px-1 text-[9.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+        R{round}
+      </span>
+    ) : null;
+
+  const ariaLabel = `${step1.label} — ${step2.label}`;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      {badge}
+      {onOpen ? (
+        <button
+          data-agent-control="true"
+          className={pillClass}
+          aria-label={ariaLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpen();
+          }}
+        >
+          {inner}
+        </button>
+      ) : (
+        <span className={pillClass} aria-label={ariaLabel}>
+          {inner}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** Derive stepper step primitives from Phase 1 review data. */
+function stepsFromReview(
+  verdict: ReviewVerdict,
+  hasResolution: boolean
+): { step1: StepDef; step2: StepDef; connector: "solid" | "dashed" } {
+  const step1: StepDef = {
+    label: reviewVerdictLabel(verdict),
+    color: verdict === "approve" ? "emerald" : "orange",
+    filled: true,
+  };
+  const step2: StepDef = hasResolution
+    ? { label: "Responded", color: "muted", filled: true }
+    : { label: "Awaiting response", color: "muted", filled: false };
+  const connector: "solid" | "dashed" = hasResolution ? "solid" : "dashed";
+  return { step1, step2, connector };
+}
+
 export function PersonaAgentRow({
   child,
   childIndex,
@@ -191,51 +313,12 @@ export function PersonaAgentRow({
             ) : null}
           </div>
         </div>
-        <div className="mt-1 flex items-center gap-1.5 text-[10px]">
-          {hasResolution ? (
-            onOpenSummary ? (
-              <button
-                data-agent-control="true"
-                className="font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/40 underline-offset-2 transition-colors hover:text-foreground hover:decoration-solid"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenSummary();
-                }}
-              >
-                Resolution submitted
-              </button>
-            ) : (
-              <span className="font-medium text-muted-foreground">
-                Resolution submitted
-              </span>
-            )
-          ) : verdict ? (
-            hasSummary && onOpenSummary ? (
-              <button
-                data-agent-control="true"
-                className={cn(
-                  "font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid transition-colors",
-                  verdict === "approve"
-                    ? "text-emerald-500 decoration-emerald-500/40 hover:decoration-emerald-500"
-                    : "text-orange-500 decoration-orange-500/40 hover:decoration-orange-500"
-                )}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenSummary();
-                }}
-              >
-                {reviewVerdictLabel(verdict)}
-              </button>
-            ) : (
-              <span
-                className={cn(
-                  "font-medium",
-                  verdict === "approve" ? "text-emerald-500" : "text-orange-500"
-                )}
-              >
-                {reviewVerdictLabel(verdict)}
-              </span>
-            )
+        <div className="mt-1 flex items-center gap-1 text-[10px]">
+          {verdict ? (
+            <ReviewStepper
+              {...stepsFromReview(verdict, hasResolution)}
+              onOpen={hasSummary || hasResolution ? onOpenSummary : undefined}
+            />
           ) : isReviewing ? (
             <span className="font-medium text-status-working">
               {reviewMessage ?? "Reviewing"}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -58,6 +58,12 @@ export type Agent = {
     summary: string | null;
     filesReviewed: string[] | null;
     updatedAt: string;
+    resolution: {
+      summary: string;
+      resolutionCommit: string | null;
+      submittedAt: string;
+      roundNumber: number;
+    } | null;
   } | null;
   baseBranch?: string | null;
   autoReview?: boolean;
@@ -76,6 +82,9 @@ export type FeedbackItem = {
   suggestion: string | null;
   mediaRef: string | null;
   status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored";
+  resolutionReason: string | null;
+  resolutionCommit: string | null;
+  resolvedAt: string | null;
   createdAt: string;
 };
 


### PR DESCRIPTION
## Summary

Phase 1 UI for the review round-trip feature — renders the resolution metadata that CRU-128 landed on the backend.

- **Feedback items with `resolution_reason`** render the reason inline (compact italic under description in the list; full block in the detail/mobile panels) plus a short commit SHA from `resolution_commit` when present.
- **Manual Ignore** is now an inline reason prompt in the detail & mobile panels (replaces the action row), removing the `"User's choice"` placeholder that CRU-128 shipped as a stopgap. Reason is required before the item can be resolved.
- **Parent's response** block renders inside each persona card in the feedback panel and in the persona review summary panel/sheet once `persona_review_resolutions` has a summary for the review.
- **`PersonaAgentRow`** shows "Resolution submitted" in place of the verdict label once the parent has submitted a resolution.
- The agent query now pulls the latest review resolution into the existing review subquery so the UI reads it without an extra fetch; `FeedbackItem` gains `resolutionReason` / `resolutionCommit` / `resolvedAt` to match CRU-128's payload.

Linear: https://linear.app/crumbstream/issue/CRU-129

## Test plan

- [x] `pnpm run check` (backend + web tsc)
- [x] `pnpm run finalize:web` (web tsc + vite build)
- [x] `pnpm run test` (server vitest + web vitest)
- [x] `pnpm run test:e2e` (Playwright — 138 passed)
- [x] Playwright validation of three states (a) open items, (b) items with reasons, (c) resolution submitted with Parent's response block — screenshots shared
- [x] End-to-end manual Ignore reason prompt: submitted reason "Legend bug being tracked in follow-up ticket CRU-200." and verified server persisted `resolution_reason`