### PR TITLE
fix(web): render dark terminal palette in Light theme

### DIFF
--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -45,7 +45,7 @@ export const TerminalPane = memo(function TerminalPane({
   return (
     <div
       data-testid="terminal-pane"
-      className="relative h-full min-h-0 overflow-hidden bg-terminal-bg"
+      className="relative h-full min-h-0 overflow-hidden bg-background"
     >
       <div
         className={cn(
@@ -62,7 +62,7 @@ export const TerminalPane = memo(function TerminalPane({
       {showEmptyState ? (
         <div
           data-testid="terminal-empty-state"
-          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+          className="absolute inset-0 z-20 grid place-items-center bg-background"
         >
           <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-8 w-8" />
@@ -74,7 +74,7 @@ export const TerminalPane = memo(function TerminalPane({
       {showInertState ? (
         <div
           data-testid="terminal-inert-state"
-          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+          className="absolute inset-0 z-20 grid place-items-center bg-background"
         >
           <div className="flex max-w-xl flex-col items-center gap-3 px-6 text-center text-muted-foreground">
             <TerminalSquare className="h-9 w-9 text-status-waiting" />
@@ -92,7 +92,7 @@ export const TerminalPane = memo(function TerminalPane({
       {archivePhase ? (
         <div
           data-testid="terminal-archive-state"
-          className="absolute inset-0 z-20 grid place-items-center bg-terminal-bg"
+          className="absolute inset-0 z-20 grid place-items-center bg-background"
         >
           <div className="flex max-w-md flex-col items-center gap-3 px-6 text-center text-muted-foreground">
             <Archive className="h-9 w-9 text-orange-400" />

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -121,8 +121,8 @@ export const TerminalPane = memo(function TerminalPane({
       ) : null}
 
       {showReconnectOverlay ? (
-        <div className="absolute inset-0 z-30 grid place-items-center bg-black/70 backdrop-blur-sm">
-          <div className="flex flex-col items-center gap-2 text-sm text-white">
+        <div className="absolute inset-0 z-30 grid place-items-center bg-background/80 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-2 text-sm text-foreground">
             <ActivityBars size={28} />
             <span>{statusMessage}</span>
           </div>

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -96,32 +96,6 @@ const SOLARIZED_DARK: TerminalPalette = {
   brightWhite: "#fdf6e3",
 };
 
-const LIGHT: TerminalPalette = {
-  minimumContrastRatio: 4.5,
-  foreground: "#1f2328",
-  background: "#eff2f5",
-  cursor: "#1f2328",
-  cursorAccent: "#eff2f5",
-  selectionBackground: "#d1d9e0",
-  selectionInactiveBackground: "#dae0e7",
-  black: "#1f2328",
-  red: "#c7243a",
-  green: "#2a7e4f",
-  yellow: "#9a6700",
-  blue: "#0842a0",
-  magenta: "#8b3fc7",
-  cyan: "#0f7b8a",
-  white: "#59636e",
-  brightBlack: "#818b98",
-  brightRed: "#b91c33",
-  brightGreen: "#1a6b3c",
-  brightYellow: "#8a5d00",
-  brightBlue: "#0842a0",
-  brightMagenta: "#7132a8",
-  brightCyan: "#0b6674",
-  brightWhite: "#393f46",
-};
-
 /** Vaporwave — neon pink, cyan & purple on deep purple-black */
 const VAPORWAVE: TerminalPalette = {
   foreground: "#e0d0f0",
@@ -220,7 +194,7 @@ export const THEMES: ThemeDefinition[] = [
     label: "Light",
     description: "Primer-inspired IDE light theme",
     swatches: ["#e6eaef", "#0d7d4d", "#1f2328", "#d1d9e0"],
-    terminal: LIGHT,
+    terminal: MONOKAI,
   },
   {
     id: "matrix",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -38,7 +38,6 @@
 
   /* Surface & terminal */
   --surface: 50 15% 5%;
-  --terminal-bg: 0 0% 8%;
   --log-stream-bg: 48 10% 10%;
   --log-stream-foreground: 145 44% 78%;
   --log-stream-muted-foreground: 42 10% 64%;
@@ -78,7 +77,6 @@
   --chart-6: 150 57% 49%;
 
   --surface: 225 16% 7%;
-  --terminal-bg: 225 16% 7%;
   --log-stream-bg: 222 16% 10%;
   --log-stream-foreground: 164 52% 76%;
   --log-stream-muted-foreground: 220 8% 67%;
@@ -118,7 +116,6 @@
   --chart-6: 45 80% 48%;
 
   --surface: 0 0% 2%;
-  --terminal-bg: 0 0% 0%;
   --log-stream-bg: 0 0% 5%;
   --log-stream-foreground: 153 55% 74%;
   --log-stream-muted-foreground: 0 0% 58%;
@@ -158,7 +155,6 @@
   --chart-6: 68 80% 25%;
 
   --surface: 192 100% 8%;
-  --terminal-bg: 192 100% 11%;
   --log-stream-bg: 192 62% 13%;
   --log-stream-foreground: 182 21% 71%;
   --log-stream-muted-foreground: 194 14% 48%;
@@ -198,7 +194,6 @@
   --chart-6: 142 60% 30%;
 
   --surface: 207 22% 90%;
-  --terminal-bg: 210 23% 95%;
   --log-stream-bg: 210 29% 97%;
   --log-stream-foreground: 153 63% 26%;
   --log-stream-muted-foreground: 211 11% 39%;
@@ -238,7 +233,6 @@
   --chart-6: 160 100% 40%;
 
   --surface: 262 52% 4%;
-  --terminal-bg: 262 52% 6%;
   --log-stream-bg: 262 38% 10%;
   --log-stream-foreground: 181 78% 78%;
   --log-stream-muted-foreground: 270 20% 58%;
@@ -278,7 +272,6 @@
   --chart-6: 150 57% 49%;
 
   --surface: 0 0% 2%;
-  --terminal-bg: 0 0% 0%;
   --log-stream-bg: 220 12% 6%;
   --log-stream-foreground: 194 90% 74%;
   --log-stream-muted-foreground: 220 8% 60%;
@@ -318,7 +311,6 @@
   --chart-6: 46 40% 44%;
 
   --surface: 145 24% 2%;
-  --terminal-bg: 150 20% 1.5%;
   --log-stream-bg: 145 32% 4%;
   --log-stream-foreground: 139 94% 82%;
   --log-stream-muted-foreground: 138 25% 58%;
@@ -358,7 +350,6 @@
   --chart-6: 222 18% 55%;
 
   --surface: 220 12% 4%;
-  --terminal-bg: 0 0% 1%;
   --log-stream-bg: 228 18% 9%;
   --log-stream-foreground: 226 28% 84%;
   --log-stream-muted-foreground: 220 12% 60%;
@@ -554,12 +545,6 @@ html.ipad-pwa .overflow-scroll {
 
 .terminal-font {
   font-family: "JetBrains Mono", Menlo, monospace;
-}
-
-.xterm,
-.xterm .xterm-viewport,
-.xterm .xterm-screen {
-  background-color: hsl(var(--terminal-bg)) !important;
 }
 
 html[data-theme="matrix"] .xterm {

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -13,7 +13,6 @@ export default {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         surface: "hsl(var(--surface))",
-        "terminal-bg": "hsl(var(--terminal-bg))",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",

--- a/docs/14-theming.md
+++ b/docs/14-theming.md
@@ -48,10 +48,11 @@ These control agent state indicators, badges, buttons, and status dots throughou
 
 ### Surface tokens
 
-| Variable        | Purpose                                                                      |
-| --------------- | ---------------------------------------------------------------------------- |
-| `--surface`     | Header, footer, and toolbar background (slightly darker than `--background`) |
-| `--terminal-bg` | Terminal pane and xterm background                                           |
+| Variable    | Purpose                                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
+| `--surface` | Header, footer, and toolbar background (slightly darker than `--background`) |
+
+The terminal pane paints its own background from the theme's `TerminalPalette.background` field (see [Step 2](#step-2-register-the-theme-in-use-themets)). There is no separate CSS variable to keep in sync.
 
 ### Value format
 
@@ -84,7 +85,7 @@ This means you can use standard Tailwind patterns:
 <span className="border-status-blocked/50" />       // 50% opacity border
 ```
 
-The `surface` and `terminal-bg` colors are also available as `bg-surface` and `bg-terminal-bg`.
+The `surface` color is also available as `bg-surface`.
 
 ## How to add a new theme
 
@@ -122,7 +123,6 @@ Add a new `[data-theme="your-theme-id"]` block in `apps/web/src/index.css`. You 
 
   /* Surface tokens */
   --surface: 240 20% 3%;
-  --terminal-bg: 240 20% 3%;
 }
 ```
 
@@ -146,7 +146,9 @@ export type ThemeId = "default" | "cool-navy" | "midnight";
 },
 ```
 
-The `terminal` field is a `TerminalPalette` object with 22 color properties (foreground, background, cursor, 16 ANSI colors, etc.). For dark themes, you can spread `MONOKAI` and override just the background. For themes with a distinctive palette (like Solarized), define a full custom palette. See `SOLARIZED_DARK` and `LIGHT` in `use-theme.ts` for examples.
+The `terminal` field is a `TerminalPalette` object with 22 color properties (foreground, background, cursor, 16 ANSI colors, etc.). For dark themes, you can spread `MONOKAI` and override just the background. For themes with a distinctive palette (like Solarized), define a full custom palette. See `SOLARIZED_DARK` in `use-theme.ts` for an example.
+
+The `Light` theme intentionally reuses `MONOKAI` so terminal output from TUIs like the Claude CLI — which emit truecolor escapes tuned for dark backgrounds and bypass xterm's `minimumContrastRatio` — remains readable. Keep the terminal pane dark when authoring light UI themes.
 
 When the user switches themes, the terminal palette is updated live and the session reconnects so tmux re-sends the viewport with the correct colors.
 
@@ -164,13 +166,12 @@ That's it — the theme picker, localStorage persistence, flash-free loading, an
 - **Primary** is the most prominent accent — used on the Create button, selected states, and focus rings. Pick something that pops against the background.
 - **Status colors** should be visually distinct from each other. They appear as small dots and text labels, so they need good contrast against both `--background` and `--card`.
 - **Border** should be subtle — lightness around 18–22% works well for dark themes.
-- **Terminal background** (`--terminal-bg`) is usually the same as `--background` or `--surface`. The terminal palette's `background` field should match `--terminal-bg`.
-- **Terminal ANSI palette** — each theme defines a full 16-color ANSI palette in its `terminal` field. For dark themes, the Monokai base palette works well — just override the background to match. For light themes or distinctive palettes (Solarized), define all 16 colors. Ensure good contrast between ANSI colors and the terminal background.
+- **Terminal ANSI palette** — each theme defines a full 16-color ANSI palette in its `terminal` field. For dark themes, the Monokai base palette works well — just override the background to match. For themes with a distinctive palette (Solarized), define all 16 colors. Ensure good contrast between ANSI colors and the terminal background. Light UI themes should keep a dark terminal palette (see note above).
 
 ## What NOT to do
 
 - **Don't use hardcoded Tailwind color classes** like `text-emerald-400` or `bg-red-500` for anything that should change with the theme. Use the semantic `status-*` utilities or the base tokens (`primary`, `destructive`, etc.) instead.
-- **Don't use hardcoded hex values** for backgrounds like `bg-[#141414]`. Use `bg-terminal-bg`, `bg-surface`, or `bg-background`.
+- **Don't use hardcoded hex values** for backgrounds like `bg-[#141414]`. Use `bg-surface` or `bg-background`.
 - **Don't wrap CSS var values in `hsl()`** — the bare `H S% L%` format is required for Tailwind opacity support.
 - **Don't forget to define all variables** — a missing variable will cause that color to disappear (transparent) in your theme.
 


### PR DESCRIPTION
## Summary
- The Light theme used a light xterm palette (`#eff2f5` bg), but Claude CLI and other TUIs emit truecolor escapes tuned for dark backgrounds, which xterm's `minimumContrastRatio` doesn't rewrite. Result: pale-gray output on a near-white background, effectively unreadable.
- Match the VSCode convention — keep the UI chrome light while the terminal pane stays dark. Point the `light` theme's terminal palette at `MONOKAI`, drop the `.xterm*` `!important` override that was forcing xterm bg to the UI `--terminal-bg`, and route `TerminalPane`'s chrome/overlays to `bg-background` so the empty/inert/archive states stay readable against the light UI. Removed the now-unused `--terminal-bg` CSS var + Tailwind mapping.

## Test plan
- [x] `pnpm run check`
- [x] `pnpm run finalize:web`
- [x] Playwright: live dev stack + Light theme + real Codex agent — terminal renders with dark Monokai palette, UI chrome stays light, overlay states readable.
- [ ] Dark themes (Mytra, Cool Navy, OLED, etc.) still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)