### PR TITLE
Expose dispatch_rename_session to job agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_notify`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_rename_session`, `dispatch_notify`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`.
 
 ### Repo-specific tools
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_rename_session`, `dispatch_notify`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `list_agents`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`.
 
 ### Repo-specific tools
 

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -2108,7 +2108,7 @@ export class AgentManager {
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
     const launchGuidance = jobRunId
-      ? `[dispatch:${agentId}] Dispatch job startup rules: You are running a Dispatch job run (${jobRunId}). Do not use normal agent lifecycle tools such as dispatch_event; job agents have a dedicated MCP route. Use job_log for progress, use repo tools when relevant, and call a job terminal tool when the job is complete, failed, or needs input. ` +
+      ? `[dispatch:${agentId}] Dispatch job startup rules: You are running a Dispatch job run (${jobRunId}). Job agents have a dedicated MCP route. Use dispatch_event to keep the agent status current in the UI, use job_log for task-level run progress, use repo tools when relevant, and call a job terminal tool when the job is complete, failed, or needs input. ` +
         (suggestSessionRename
           ? "If your session still has the default generated name, wait until you understand the task, then call dispatch_rename_session once with a short topic/goal/feature name. Use the session name as a stable label for the run, not as a live status update. "
           : "")

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -3630,6 +3630,15 @@ export class AgentManager {
     }
 
     const trimmed = agentName?.trim();
+    if (opts.jobRunId) {
+      const jobNameSuffix = `-${opts.jobRunId.slice(0, 8)}`;
+      return (
+        !!trimmed &&
+        trimmed.startsWith("job-") &&
+        trimmed.endsWith(jobNameSuffix)
+      );
+    }
+
     return trimmed === `agent-${agentId.slice(-6)}`;
   }
 

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -2108,7 +2108,10 @@ export class AgentManager {
     // Lean startup guidance shared by both agent types. Full behavioral specs live in
     // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
     const launchGuidance = jobRunId
-      ? `[dispatch:${agentId}] Dispatch job startup rules: You are running a Dispatch job run (${jobRunId}). Do not use normal agent lifecycle tools such as dispatch_event; job agents have a dedicated MCP route. Use job_log for progress, use repo tools when relevant, and call a job terminal tool when the job is complete, failed, or needs input.`
+      ? `[dispatch:${agentId}] Dispatch job startup rules: You are running a Dispatch job run (${jobRunId}). Do not use normal agent lifecycle tools such as dispatch_event; job agents have a dedicated MCP route. Use job_log for progress, use repo tools when relevant, and call a job terminal tool when the job is complete, failed, or needs input. ` +
+        (suggestSessionRename
+          ? "If your session still has the default generated name, wait until you understand the task, then call dispatch_rename_session once with a short topic/goal/feature name. Use the session name as a stable label for the run, not as a live status update. "
+          : "")
       : `[dispatch:${agentId}] ` +
         "Dispatch startup rules: " +
         "If the user has not explicitly asked for a change, fix, review, or investigation target, do not start repo work or infer a task from branch/worktree context alone; ask what they want done. " +
@@ -3622,7 +3625,7 @@ export class AgentManager {
     agentId: string,
     opts: { persona?: string | null; jobRunId?: string }
   ): boolean {
-    if (opts.persona || opts.jobRunId) {
+    if (opts.persona) {
       return false;
     }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1617,6 +1617,7 @@ async function registerRoutes() {
       repoRoot,
       worktreeRoot,
       sendNotify: mcpSendNotify,
+      upsertEvent: mcpUpsertEvent,
       renameSession: mcpRenameSession,
       shareMedia: mcpShareMedia,
       upsertPin: mcpUpsertPin,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1617,6 +1617,7 @@ async function registerRoutes() {
       repoRoot,
       worktreeRoot,
       sendNotify: mcpSendNotify,
+      renameSession: mcpRenameSession,
       shareMedia: mcpShareMedia,
       upsertPin: mcpUpsertPin,
       deletePin: mcpDeletePin,

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -162,6 +162,7 @@ const AGENT_TOOLS = new Set([
 const JOB_TOOLS = new Set([
   "create_pr",
   "get_pr_status",
+  "dispatch_rename_session",
   "dispatch_notify",
   "dispatch_pin",
   "dispatch_share",

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -162,6 +162,7 @@ const AGENT_TOOLS = new Set([
 const JOB_TOOLS = new Set([
   "create_pr",
   "get_pr_status",
+  "dispatch_event",
   "dispatch_rename_session",
   "dispatch_notify",
   "dispatch_pin",

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -17,6 +17,7 @@ import {
   expect,
   beforeAll,
   afterAll,
+  afterEach,
   beforeEach,
   vi,
 } from "vitest";
@@ -530,6 +531,22 @@ describe("AgentManager", () => {
       );
       expect(setupScript).not.toContain("Autonomous Review is enabled");
       expect(setupScript).toContain("Dispatch job startup rules");
+    });
+
+    it("should include rename guidance for job agents with default names", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        type: "codex",
+        jobRunId: "run_abc123",
+        useWorktree: false,
+      });
+
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
+      expect(setupScript).toContain("dispatch_rename_session");
+      expect(setupScript).toContain("short topic/goal/feature name");
     });
 
     it("should generate a setup script with worktree steps when useWorktree is true", async () => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -537,6 +537,7 @@ describe("AgentManager", () => {
       const agent = await manager.createAgent({
         cwd: "/tmp",
         type: "codex",
+        name: "job-rename-test-run_abc1",
         jobRunId: "run_abc123",
         useWorktree: false,
       });

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -545,6 +545,10 @@ describe("AgentManager", () => {
         `/tmp/dispatch_setup_${agent.id}.sh`,
         "utf-8"
       );
+      expect(setupScript).toContain(
+        "Use dispatch_event to keep the agent status current in the UI"
+      );
+      expect(setupScript).toContain("use job_log for task-level run progress");
       expect(setupScript).toContain("dispatch_rename_session");
       expect(setupScript).toContain("short topic/goal/feature name");
     });

--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -91,6 +91,7 @@ beforeEach(async () => {
   await pool.query("DELETE FROM jobs");
   await pool.query("DELETE FROM agents WHERE id LIKE 'agt_cb_%'");
   vi.mocked(mockLog.warn).mockClear();
+  vi.mocked(mockAgentManager.createAgent).mockReset();
 });
 
 describe("JobService", () => {
@@ -250,6 +251,69 @@ describe("JobService", () => {
   });
 
   describe("error paths", () => {
+    it("runJob creates a job agent with the production-generated default name", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+      const store = new JobStore(pool);
+
+      const job = await makeJob(store, {
+        name: "Rename Test",
+        directory: "/tmp/test-rename",
+      });
+
+      vi.mocked(mockAgentManager.createAgent).mockImplementation(async () => {
+        const createdAt = new Date().toISOString();
+        await pool.query(
+          `INSERT INTO agents (id, name, type, status, cwd, codex_args, full_access)
+           VALUES ('agt_job_rename', 'job-Rename_Test-placeholder', 'claude', 'running', '/tmp/test-rename', '[]'::jsonb, false)`
+        );
+        return {
+          id: "agt_job_rename",
+          name: "job-Rename_Test-placeholder",
+          type: "claude",
+          status: "running",
+          cwd: "/tmp/test-rename",
+          tmuxSession: null,
+          createdAt,
+          updatedAt: createdAt,
+          metadata: null,
+          codexArgs: [],
+          claudeArgs: [],
+          opencodeArgs: [],
+          latestEvent: null,
+          fullAccess: false,
+          useWorktree: false,
+          worktreePath: null,
+          worktreeBranch: null,
+          setupPhase: null,
+          parentAgentId: null,
+          persona: null,
+          autoReview: false,
+          baseBranch: null,
+        } as Awaited<ReturnType<AgentManager["createAgent"]>>;
+      });
+
+      const result = await service.runJob({
+        name: "Rename Test",
+        directory: "/tmp/test-rename",
+        wait: false,
+      });
+
+      expect(result.status).toBe("running");
+      expect(mockAgentManager.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobRunId: result.runId,
+          name: `job-Rename_Test-${result.runId.slice(0, 8)}`,
+        })
+      );
+
+      service.stopAllSchedulers();
+    });
+
     it("runJob throws when job has no prompt", async () => {
       const service = new JobService(
         pool,

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -183,4 +183,48 @@ describe("MCP auth integration", () => {
     expect(jobResponse.statusCode).toBe(404);
     expect(jobResponse.json()).toEqual({ error: "Agent not found." });
   });
+
+  it("exposes dispatch_rename_session on the job-scoped MCP route", async () => {
+    await pool.query(
+      `INSERT INTO agents (id, name, type, status, cwd, full_access)
+       VALUES ('agt_jobrename', 'job-rename-test', 'codex', 'running', '/tmp', false)`
+    );
+    await pool.query(
+      `INSERT INTO jobs (
+          id, directory, name, enabled, agent_type, use_worktree, full_access,
+          schedule, timeout_ms, needs_input_timeout_ms, auto_archive
+        )
+        VALUES (
+          'job_rename', '/tmp', 'Rename Job', true, 'codex', false, false,
+          null, 1800000, 1800000, true
+        )`
+    );
+    await pool.query(
+      `INSERT INTO job_runs (
+          id, job_id, status, started_at, status_updated_at, agent_id
+        )
+        VALUES (
+          'run_jobrename', 'job_rename', 'running', NOW(), NOW(), 'agt_jobrename'
+        )`
+    );
+
+    const authTokenResult = await pool.query<{ value: string }>(
+      "SELECT value FROM settings WHERE key = 'auth_token'"
+    );
+    const authToken = authTokenResult.rows[0]!.value;
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/mcp/jobs/run_jobrename/agt_jobrename",
+      headers: {
+        authorization: `Bearer ${createJobMcpToken(authToken, "run_jobrename", "agt_jobrename")}`,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("dispatch_rename_session");
+  });
 });

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -184,7 +184,7 @@ describe("MCP auth integration", () => {
     expect(jobResponse.json()).toEqual({ error: "Agent not found." });
   });
 
-  it("exposes dispatch_rename_session on the job-scoped MCP route", async () => {
+  it("exposes dispatch_event and dispatch_rename_session on the job-scoped MCP route", async () => {
     await pool.query(
       `INSERT INTO agents (id, name, type, status, cwd, full_access)
        VALUES ('agt_jobrename', 'job-rename-test', 'codex', 'running', '/tmp', false)`
@@ -225,6 +225,7 @@ describe("MCP auth integration", () => {
     });
 
     expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("dispatch_event");
     expect(response.body).toContain("dispatch_rename_session");
   });
 });

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -92,7 +92,7 @@ Job agents are given a narrowed MCP toolset (see `JOB_TOOLS` in `apps/server/src
 | `job_needs_input` | Pause the run and ask a human a question.   |
 | `job_log`         | Append a progress log to a named task.      |
 
-Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_notify`.
+Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_rename_session` / `dispatch_notify`.
 
 ## UI
 

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -92,7 +92,7 @@ Job agents are given a narrowed MCP toolset (see `JOB_TOOLS` in `apps/server/src
 | `job_needs_input` | Pause the run and ask a human a question.   |
 | `job_log`         | Append a progress log to a named task.      |
 
-Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_rename_session` / `dispatch_notify`.
+Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_event` / `dispatch_rename_session` / `dispatch_notify`.
 
 ## UI
 


### PR DESCRIPTION
## Summary
- expose `dispatch_rename_session` to job-scoped MCP sessions
- pass the rename handler through the job MCP route and add job startup rename guidance
- add regression coverage and update job-agent docs

## Testing
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`