### PR TITLE
Adjust mobile terminal key sizing

### DIFF
--- a/apps/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/apps/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -113,7 +113,7 @@ export function MobileTerminalToolbar({
             type="button"
             size="sm"
             variant="default"
-            className="h-8 shrink-0 px-3 text-xs"
+            className="h-8 min-w-0 flex-1 px-3 text-xs"
             aria-label="Send Enter"
             onClick={() => sendKey("\r")}
           >
@@ -123,7 +123,7 @@ export function MobileTerminalToolbar({
             type="button"
             size="sm"
             variant="default"
-            className="h-8 min-w-0 flex-1 px-3 text-xs"
+            className="h-8 shrink-0 px-4 text-xs"
             aria-label="Open text input"
             onClick={openInput}
           >


### PR DESCRIPTION
## Summary
- widen the mobile terminal Enter shortcut so it takes the remaining row space
- reduce the keyboard shortcut button to a compact padded width around the icon
- validate the mobile terminal toolbar in the browser and rerun required checks

## Testing
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e