### PR TITLE
feat(server): schema for review round-trip loop (CRU-131)

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -193,6 +193,8 @@ export type PersonaReviewRecord = {
   summary: string | null;
   filesReviewed: string[] | null;
   lastReviewedCommit: string | null;
+  roundNumber: number;
+  allowRecheck: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -210,6 +212,8 @@ export type FeedbackRecord = {
   resolutionReason: string | null;
   resolutionCommit: string | null;
   resolvedAt: string | null;
+  roundNumber: number;
+  respondsToFeedbackId: number | null;
   createdAt: string;
 };
 
@@ -2398,20 +2402,24 @@ export class AgentManager {
     parentAgentId: string;
     persona: string;
     lastReviewedCommit?: string | null;
+    allowRecheck?: boolean;
   }): Promise<PersonaReviewRecord> {
     const result = await this.pool.query<PersonaReviewRecord>(
-      `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, last_reviewed_commit)
-       VALUES ($1, $2, $3, $4)
+      `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, last_reviewed_commit, allow_recheck)
+       VALUES ($1, $2, $3, $4, COALESCE($5, false))
        RETURNING id, agent_id AS "agentId", parent_agent_id AS "parentAgentId",
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
                  last_reviewed_commit AS "lastReviewedCommit",
+                 round_number AS "roundNumber",
+                 allow_recheck AS "allowRecheck",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [
         input.agentId,
         input.parentAgentId,
         input.persona,
         input.lastReviewedCommit ?? null,
+        input.allowRecheck ?? null,
       ]
     );
     return result.rows[0]!;
@@ -2436,6 +2444,8 @@ export class AgentManager {
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
                  last_reviewed_commit AS "lastReviewedCommit",
+                 round_number AS "roundNumber",
+                 allow_recheck AS "allowRecheck",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [agentId, input.status, input.message ?? null]
     );
@@ -2491,6 +2501,8 @@ export class AgentManager {
                  persona, status, message, verdict, summary,
                  files_reviewed AS "filesReviewed",
                  last_reviewed_commit AS "lastReviewedCommit",
+                 round_number AS "roundNumber",
+                 allow_recheck AS "allowRecheck",
                  created_at AS "createdAt", updated_at AS "updatedAt"`,
       [
         agentId,
@@ -2512,6 +2524,8 @@ export class AgentManager {
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
               last_reviewed_commit AS "lastReviewedCommit",
+              round_number AS "roundNumber",
+              allow_recheck AS "allowRecheck",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews WHERE agent_id = $1`,
       [agentId]
@@ -2527,6 +2541,8 @@ export class AgentManager {
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
               last_reviewed_commit AS "lastReviewedCommit",
+              round_number AS "roundNumber",
+              allow_recheck AS "allowRecheck",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews WHERE parent_agent_id = $1
        ORDER BY created_at`,
@@ -2543,6 +2559,8 @@ export class AgentManager {
               persona, status, message, verdict, summary,
               files_reviewed AS "filesReviewed",
               last_reviewed_commit AS "lastReviewedCommit",
+              round_number AS "roundNumber",
+              allow_recheck AS "allowRecheck",
               created_at AS "createdAt", updated_at AS "updatedAt"
        FROM persona_reviews
        WHERE created_at >= NOW() - make_interval(days => $1)
@@ -2562,6 +2580,8 @@ export class AgentManager {
               f.resolution_reason AS "resolutionReason",
               f.resolution_commit AS "resolutionCommit",
               f.resolved_at AS "resolvedAt",
+              f.round_number AS "roundNumber",
+              f.responds_to_feedback_id AS "respondsToFeedbackId",
               f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
@@ -3221,6 +3241,8 @@ export class AgentManager {
                  resolution_reason AS "resolutionReason",
                  resolution_commit AS "resolutionCommit",
                  resolved_at AS "resolvedAt",
+                 round_number AS "roundNumber",
+                 responds_to_feedback_id AS "respondsToFeedbackId",
                  created_at AS "createdAt"`,
       [
         agentId,
@@ -3242,6 +3264,8 @@ export class AgentManager {
               resolution_reason AS "resolutionReason",
               resolution_commit AS "resolutionCommit",
               resolved_at AS "resolvedAt",
+              round_number AS "roundNumber",
+              responds_to_feedback_id AS "respondsToFeedbackId",
               created_at AS "createdAt"
        FROM agent_feedback WHERE agent_id = $1 ORDER BY created_at ASC`,
       [agentId]
@@ -3256,6 +3280,8 @@ export class AgentManager {
               f.resolution_reason AS "resolutionReason",
               f.resolution_commit AS "resolutionCommit",
               f.resolved_at AS "resolvedAt",
+              f.round_number AS "roundNumber",
+              f.responds_to_feedback_id AS "respondsToFeedbackId",
               f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
@@ -3291,6 +3317,8 @@ export class AgentManager {
               f.resolution_reason AS "resolutionReason",
               f.resolution_commit AS "resolutionCommit",
               f.resolved_at AS "resolvedAt",
+              f.round_number AS "roundNumber",
+              f.responds_to_feedback_id AS "respondsToFeedbackId",
               f.created_at AS "createdAt"
        FROM agent_feedback f
        JOIN agents a ON a.id = f.agent_id
@@ -3360,6 +3388,8 @@ export class AgentManager {
                  resolution_reason AS "resolutionReason",
                  resolution_commit AS "resolutionCommit",
                  resolved_at AS "resolvedAt",
+                 round_number AS "roundNumber",
+                 responds_to_feedback_id AS "respondsToFeedbackId",
                  created_at AS "createdAt"`,
       [feedbackId, status, agentId, reason, options.resolutionCommit ?? null]
     );
@@ -3404,6 +3434,8 @@ export class AgentManager {
                  af.resolution_reason AS "resolutionReason",
                  af.resolution_commit AS "resolutionCommit",
                  af.resolved_at AS "resolvedAt",
+                 af.round_number AS "roundNumber",
+                 af.responds_to_feedback_id AS "respondsToFeedbackId",
                  af.created_at AS "createdAt"`,
       [
         feedbackId,
@@ -3442,6 +3474,8 @@ export class AgentManager {
                 persona, status, message, verdict, summary,
                 files_reviewed AS "filesReviewed",
                 last_reviewed_commit AS "lastReviewedCommit",
+                round_number AS "roundNumber",
+                allow_recheck AS "allowRecheck",
                 created_at AS "createdAt", updated_at AS "updatedAt"
          FROM persona_reviews
          WHERE agent_id = $1 AND parent_agent_id = $2

--- a/apps/server/src/db/migrations/0017_persona-review-round-trip.sql
+++ b/apps/server/src/db/migrations/0017_persona-review-round-trip.sql
@@ -1,0 +1,31 @@
+-- Phase 2 of the review round-trip feature (CRU-131).
+-- Adds round tracking and the allow_recheck opt-in so a single reviewer
+-- session can span an initial review and a follow-up recheck pass.
+-- No status transitions are introduced here — this migration is pure
+-- schema readiness for the backend ticket that lights up the loop.
+
+-- Up Migration
+
+ALTER TABLE persona_reviews
+  ADD COLUMN IF NOT EXISTS round_number INT NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS allow_recheck BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE agent_feedback
+  ADD COLUMN IF NOT EXISTS round_number INT NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS responds_to_feedback_id INT
+    REFERENCES agent_feedback(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_feedback_responds_to
+  ON agent_feedback(responds_to_feedback_id);
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_agent_feedback_responds_to;
+
+ALTER TABLE agent_feedback
+  DROP COLUMN IF EXISTS responds_to_feedback_id,
+  DROP COLUMN IF EXISTS round_number;
+
+ALTER TABLE persona_reviews
+  DROP COLUMN IF EXISTS allow_recheck,
+  DROP COLUMN IF EXISTS round_number;


### PR DESCRIPTION
Phase 2 of the review round-trip feature (CRU-127). Pure schema readiness — no new transitions into `awaiting_recheck` or round-2 writes are wired up yet. Builds on Phase 1 (CRU-128 / migration 0016).

## Migration `0017_persona-review-round-trip.sql`

- `persona_reviews`:
  - `round_number INT NOT NULL DEFAULT 1`
  - `allow_recheck BOOLEAN NOT NULL DEFAULT false`
- `agent_feedback`:
  - `round_number INT NOT NULL DEFAULT 1`
  - `responds_to_feedback_id INT REFERENCES agent_feedback(id) ON DELETE SET NULL`
  - index `idx_agent_feedback_responds_to` on `responds_to_feedback_id`
- Includes a `-- Down Migration` block that drops the index, FK-bearing column, and the four new columns. Phase 1 columns (`resolution_reason`, `resolution_commit`, `resolved_at`, `last_reviewed_commit`, `persona_review_resolutions`) are left untouched.
- No check-constraint change needed for the new `awaiting_recheck` persona-review status — status is validated in app code, not Postgres. That value is not yet written anywhere in this PR.

## Manager query helpers (`apps/server/src/agents/manager.ts`)

- `PersonaReviewRecord` gains `roundNumber` + `allowRecheck`; `FeedbackRecord` gains `roundNumber` + `respondsToFeedbackId`.
- All `SELECT` / `RETURNING` clauses that hydrate those record types now surface the new columns.
- `createPersonaReview` accepts an optional `allowRecheck` param. All other writers rely on the DB defaults so existing behavior is unchanged.

## Notes

- The Phase 1 migration already created `persona_review_resolutions` in its final shape (no temp summary column), so the "backfill and drop" step from the ticket description is a no-op here.
- Next migration number was chosen by checking prod `pgmigrations` (last applied: `0016_feedback-resolution-capture`).

## Test plan

- [x] `pnpm run check` — typecheck clean (backend + web).
- [x] `pnpm run test` — 372 unit tests pass.
- [x] `pnpm run test:e2e` — 138 E2E tests pass.
- [x] Manual verification: ran `node-pg-migrate` up then down against a throwaway DB. New columns/index appear with correct types + defaults, default-inserting into `agent_feedback` yields `round_number=1` / `responds_to_feedback_id=null`, and a single-step rollback removes all Phase 2 artifacts while preserving Phase 1 columns.