### PR TITLE
feat(web): restyle review agent row with stacked status button

### DIFF
--- a/apps/server/src/db/seed/persona-reviews.ts
+++ b/apps/server/src/db/seed/persona-reviews.ts
@@ -2,51 +2,210 @@ import type { PoolClient } from "pg";
 
 import { seedNow } from "./constants.js";
 
-// One persona review attached to the "rich" sidebar agent so the review
-// attribution UI has something to render. The reviewer itself is a child
-// agent (parent_agent_id points at the sidebar agent) so it stays nested
-// rather than showing as a separate top-level entry.
-const REVIEW = {
-  id: "seed-review-agent",
-  parent: "seed-agent-running-feature",
-  persona: "ux-reviewer",
-  status: "complete" as const,
-  verdict: "request_changes" as const,
-  summary:
-    "Timezone drift and legend reset need to be resolved before merge. Keyboard focus regression on the day picker is also open.",
-  minutesAgo: 30,
+// All reviewer children live under the "rich" sidebar agent so the whole
+// matrix of review states is visible when it's expanded.
+const PARENT = "seed-agent-running-feature";
+
+type Resolution = {
+  summary: string;
+  resolutionCommit: string | null;
+  roundNumber: number;
+  minutesAgo: number;
 };
+
+type ReviewerSeed = {
+  id: string;
+  persona: string;
+  // When null, no persona_reviews row is created (shows the "no review yet" fallback).
+  review: {
+    status: "reviewing" | "complete";
+    verdict: "approve" | "request_changes" | null;
+    message: string | null;
+    summary: string | null;
+    roundNumber: number;
+    minutesAgo: number;
+    resolution: Resolution | null;
+  } | null;
+};
+
+// Covers every UI combination the sidebar can render:
+//   · no review yet (CircleDashed)
+//   · reviewing in progress (blue spinner)
+//   · approved, awaiting response
+//   · approved, responded
+//   · changes requested, awaiting response (existing demo case)
+//   · changes requested, responded (round 1)
+//   · changes requested, responded (round 2 — shows R2 badge)
+const REVIEWERS: ReviewerSeed[] = [
+  {
+    id: "seed-review-reviewing",
+    persona: "code-quality-review",
+    review: {
+      status: "reviewing",
+      verdict: null,
+      message: "Scanning hook dependencies",
+      summary: null,
+      roundNumber: 1,
+      minutesAgo: 1,
+      resolution: null,
+    },
+  },
+  {
+    id: "seed-review-no-review",
+    persona: "backend-security-review",
+    review: null,
+  },
+  {
+    id: "seed-review-agent",
+    persona: "ux-reviewer",
+    review: {
+      status: "complete",
+      verdict: "request_changes",
+      message: null,
+      summary:
+        "Timezone drift and legend reset need to be resolved before merge. Keyboard focus regression on the day picker is also open.",
+      roundNumber: 1,
+      minutesAgo: 30,
+      resolution: null,
+    },
+  },
+  {
+    id: "seed-review-changes-responded",
+    persona: "docs-review",
+    review: {
+      status: "complete",
+      verdict: "request_changes",
+      message: null,
+      summary:
+        "Missing JSDoc on the public hooks export and the README example no longer compiles.",
+      roundNumber: 1,
+      minutesAgo: 90,
+      resolution: {
+        summary:
+          "Added JSDoc on exported hooks and regenerated the README example against the new API.",
+        resolutionCommit: "b3f2a1c",
+        roundNumber: 1,
+        minutesAgo: 20,
+      },
+    },
+  },
+  {
+    id: "seed-review-changes-responded-r2",
+    persona: "architecture-review",
+    review: {
+      status: "complete",
+      verdict: "request_changes",
+      message: null,
+      summary:
+        "Round 2: the retry loop now handles the cache miss, but still bypasses the circuit breaker.",
+      roundNumber: 2,
+      minutesAgo: 60,
+      resolution: {
+        summary:
+          "Routed retries through the circuit breaker and moved cache warmup behind the same guard.",
+        resolutionCommit: "9e7d104",
+        roundNumber: 2,
+        minutesAgo: 10,
+      },
+    },
+  },
+  {
+    id: "seed-review-approved-awaiting",
+    persona: "perf-review",
+    review: {
+      status: "complete",
+      verdict: "approve",
+      message: null,
+      summary:
+        "No regressions on the hot path; p95 render time unchanged at 12ms.",
+      roundNumber: 1,
+      minutesAgo: 45,
+      resolution: null,
+    },
+  },
+  {
+    id: "seed-review-approved-responded",
+    persona: "a11y-review",
+    review: {
+      status: "complete",
+      verdict: "approve",
+      message: null,
+      summary:
+        "Focus order and ARIA labels look correct after the latest pass.",
+      roundNumber: 1,
+      minutesAgo: 120,
+      resolution: {
+        summary:
+          "Confirmed against the NVDA + VoiceOver runbook before merging.",
+        resolutionCommit: "4a0c82d",
+        roundNumber: 1,
+        minutesAgo: 15,
+      },
+    },
+  },
+];
 
 export async function seedPersonaReviews(client: PoolClient): Promise<void> {
   const now = seedNow();
-  // Insert the reviewer's child agent row so the FK from persona_reviews is valid.
-  await client.query(
-    `
-    INSERT INTO agents (
-      id, name, type, status, cwd, codex_args, full_access, pins,
-      persona, parent_agent_id, created_at, updated_at
-    ) VALUES ($1,$2,'claude','stopped','/tmp/dispatch-demo','[]'::jsonb,false,'[]'::jsonb,$3,$4, NOW(), NOW())
-    `,
-    [REVIEW.id, `${REVIEW.persona} review`, REVIEW.persona, REVIEW.parent]
-  );
 
-  const createdAt = new Date(now.getTime() - REVIEW.minutesAgo * 60_000);
-  await client.query(
-    `
-    INSERT INTO persona_reviews (
-      agent_id, parent_agent_id, persona, status, verdict, summary, files_reviewed,
-      created_at, updated_at
-    ) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$8)
-    `,
-    [
-      REVIEW.id,
-      REVIEW.parent,
-      REVIEW.persona,
-      REVIEW.status,
-      REVIEW.verdict,
-      REVIEW.summary,
-      JSON.stringify([]),
-      createdAt,
-    ]
-  );
+  for (const reviewer of REVIEWERS) {
+    // Insert the reviewer's child agent row so the FK from persona_reviews is valid.
+    await client.query(
+      `
+      INSERT INTO agents (
+        id, name, type, status, cwd, codex_args, full_access, pins,
+        persona, parent_agent_id, created_at, updated_at
+      ) VALUES ($1,$2,'claude','stopped','/tmp/dispatch-demo','[]'::jsonb,false,'[]'::jsonb,$3,$4, NOW(), NOW())
+      `,
+      [reviewer.id, `${reviewer.persona} review`, reviewer.persona, PARENT]
+    );
+
+    if (!reviewer.review) continue;
+
+    const r = reviewer.review;
+    const createdAt = new Date(now.getTime() - r.minutesAgo * 60_000);
+    const { rows } = await client.query<{ id: number }>(
+      `
+      INSERT INTO persona_reviews (
+        agent_id, parent_agent_id, persona, status, verdict, message, summary,
+        files_reviewed, round_number, created_at, updated_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$10)
+      RETURNING id
+      `,
+      [
+        reviewer.id,
+        PARENT,
+        reviewer.persona,
+        r.status,
+        r.verdict,
+        r.message,
+        r.summary,
+        JSON.stringify([]),
+        r.roundNumber,
+        createdAt,
+      ]
+    );
+
+    if (r.resolution) {
+      const reviewId = rows[0]?.id;
+      if (reviewId == null) continue;
+      const submittedAt = new Date(
+        now.getTime() - r.resolution.minutesAgo * 60_000
+      );
+      await client.query(
+        `
+        INSERT INTO persona_review_resolutions (
+          review_id, round_number, summary, resolution_commit, submitted_at
+        ) VALUES ($1,$2,$3,$4,$5)
+        `,
+        [
+          reviewId,
+          r.resolution.roundNumber,
+          r.resolution.summary,
+          r.resolution.resolutionCommit,
+          submittedAt,
+        ]
+      );
+    }
+  }
 }

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -1,4 +1,12 @@
-import { Check, Eye, ListChecks, Terminal, X, XCircle } from "lucide-react";
+import {
+  CircleDashed,
+  Flag,
+  ListChecks,
+  Loader2,
+  Terminal,
+  ThumbsUp,
+  X,
+} from "lucide-react";
 
 import {
   reviewVerdictLabel,
@@ -39,28 +47,24 @@ function PersonaStatusIcon({
   verdict?: ReviewVerdict;
   className?: string;
 }): JSX.Element {
-  // Review complete — show verdict icon
   if (reviewStatus === "complete" && verdict) {
     return <PersonaVerdictIcon verdict={verdict} className={className} />;
   }
 
-  // Actively reviewing — pulsing eye
   if (reviewStatus === "reviewing") {
     return (
       <span
         className={cn(
           "inline-flex shrink-0 items-center justify-center rounded-full",
-          "border border-status-working/50 bg-status-working/15 text-status-working",
-          "animate-persona-reviewing",
+          "border border-blue-500/50 bg-blue-500/15 text-blue-500",
           className
         )}
       >
-        <Eye className="h-3 w-3" />
+        <Loader2 className="h-3 w-3 animate-spin" />
       </span>
     );
   }
 
-  // No review record yet — default icon
   return (
     <span
       className={cn(
@@ -69,7 +73,7 @@ function PersonaStatusIcon({
         className
       )}
     >
-      <Eye className="h-3 w-3" />
+      <CircleDashed className="h-3 w-3" />
     </span>
   );
 }
@@ -89,11 +93,10 @@ function PersonaVerdictIcon({
           className
         )}
       >
-        <Check className="h-3 w-3" />
+        <ThumbsUp className="h-3 w-3" />
       </span>
     );
   }
-  // request_changes or unknown
   return (
     <span
       className={cn(
@@ -101,7 +104,7 @@ function PersonaVerdictIcon({
         className
       )}
     >
-      <XCircle className="h-3 w-3" />
+      <Flag className="h-3 w-3" />
     </span>
   );
 }
@@ -139,13 +142,19 @@ type StepDef = {
   filled: boolean;
 };
 
-function StepperStep({ step }: { step: StepDef }): JSX.Element {
+function StepRow({
+  step,
+  emphasis,
+}: {
+  step: StepDef;
+  emphasis: "strong" | "soft";
+}): JSX.Element {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap font-semibold",
-        STEP_COLOR[step.color],
-        !step.filled && "opacity-60"
+        "flex items-center gap-1.5 whitespace-nowrap",
+        emphasis === "strong" ? "font-semibold" : "font-medium",
+        STEP_COLOR[step.color]
       )}
     >
       <span
@@ -160,81 +169,70 @@ function StepperStep({ step }: { step: StepDef }): JSX.Element {
 }
 
 /**
- * Two-step pill showing reviewer verdict and parent-response state.
- * Pure presentation — caller derives step primitives from the source data.
+ * Stacked two-row button showing reviewer verdict and parent-response state.
+ * Scales to multi-round cycles by letting each row grow independently.
  */
-function ReviewStepper({
+function ReviewStatusButton({
   step1,
   step2,
-  connector,
   round,
   onOpen,
 }: {
   step1: StepDef;
   step2: StepDef;
-  connector: "solid" | "dashed";
   round?: number;
   onOpen?: () => void;
 }): JSX.Element {
-  const pillClass = cn(
-    "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-border/70 bg-background/40 px-2 py-0.5 text-[10px] transition-colors",
-    onOpen && "cursor-pointer hover:bg-muted/40"
+  const frameClass = cn(
+    "mt-2 flex w-full flex-col items-stretch gap-1 rounded-md border border-border bg-muted/40 px-2 py-1.5 text-left text-[10px] transition-colors",
+    onOpen && "cursor-pointer hover:bg-muted/70 hover:border-border/80"
   );
 
-  const inner = (
-    <>
-      <StepperStep step={step1} />
-      <span
-        aria-hidden
-        className={cn(
-          "h-0 w-3 shrink-0 border-t",
-          connector === "solid"
-            ? "border-border"
-            : "border-dashed border-border/60"
-        )}
-      />
-      <StepperStep step={step2} />
-    </>
-  );
+  const ariaLabel = `${step1.label} — ${step2.label}`;
 
   const badge =
     typeof round === "number" && round > 1 ? (
-      <span className="inline-flex h-4 items-center rounded border border-border bg-muted/40 px-1 text-[9.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <span className="absolute right-1.5 top-1.5 inline-flex h-3.5 items-center rounded border border-border bg-muted/60 px-1 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
         R{round}
       </span>
     ) : null;
 
-  const ariaLabel = `${step1.label} — ${step2.label}`;
-
-  return (
-    <span className="inline-flex items-center gap-1">
+  const inner = (
+    <>
+      <StepRow step={step1} emphasis="strong" />
+      <StepRow step={step2} emphasis="soft" />
       {badge}
-      {onOpen ? (
-        <button
-          data-agent-control="true"
-          className={pillClass}
-          aria-label={ariaLabel}
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpen();
-          }}
-        >
-          {inner}
-        </button>
-      ) : (
-        <span className={pillClass} aria-label={ariaLabel}>
-          {inner}
-        </span>
-      )}
+    </>
+  );
+
+  if (onOpen) {
+    return (
+      <button
+        data-agent-control="true"
+        type="button"
+        className={cn("relative", frameClass)}
+        aria-label={ariaLabel}
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpen();
+        }}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <span className={cn("relative", frameClass)} aria-label={ariaLabel}>
+      {inner}
     </span>
   );
 }
 
-/** Derive stepper step primitives from Phase 1 review data. */
+/** Derive stacked-row step primitives from Phase 1 review data. */
 function stepsFromReview(
   verdict: ReviewVerdict,
   hasResolution: boolean
-): { step1: StepDef; step2: StepDef; connector: "solid" | "dashed" } {
+): { step1: StepDef; step2: StepDef } {
   const step1: StepDef = {
     label: reviewVerdictLabel(verdict),
     color: verdict === "approve" ? "emerald" : "orange",
@@ -243,8 +241,7 @@ function stepsFromReview(
   const step2: StepDef = hasResolution
     ? { label: "Responded", color: "muted", filled: true }
     : { label: "Awaiting response", color: "muted", filled: false };
-  const connector: "solid" | "dashed" = hasResolution ? "solid" : "dashed";
-  return { step1, step2, connector };
+  return { step1, step2 };
 }
 
 export function PersonaAgentRow({
@@ -279,9 +276,8 @@ export function PersonaAgentRow({
     <div
       data-testid={`agent-card-${child.id}`}
       className={cn(
-        "flex items-start gap-2.5 px-2.5 py-2 transition-colors duration-200",
+        "flex items-start gap-2.5 px-2.5 py-2.5 transition-colors duration-200",
         hasFeedback && "cursor-pointer hover:bg-muted/50",
-        childIsStopped && child.status !== "error" && "opacity-50",
         isSelected && "bg-muted/35",
         (isSelected || isReviewing) && "rounded-lg",
         isReviewing && "persona-reviewing-row"
@@ -313,23 +309,24 @@ export function PersonaAgentRow({
             ) : null}
           </div>
         </div>
-        <div className="mt-1 flex items-center gap-1 text-[10px]">
-          {verdict ? (
-            <ReviewStepper
-              {...stepsFromReview(verdict, hasResolution)}
-              onOpen={hasSummary || hasResolution ? onOpenSummary : undefined}
-            />
-          ) : isReviewing ? (
-            <span className="font-medium text-status-working">
-              {reviewMessage ?? "Reviewing"}
-            </span>
-          ) : child.status === "running" ? (
-            <span className="font-medium text-muted-foreground">Starting</span>
-          ) : null}
-        </div>
+        {verdict ? (
+          <ReviewStatusButton
+            {...stepsFromReview(verdict, hasResolution)}
+            round={resolution?.roundNumber}
+            onOpen={hasSummary || hasResolution ? onOpenSummary : undefined}
+          />
+        ) : isReviewing ? (
+          <div className="mt-1.5 text-[10px] font-medium text-blue-500">
+            {reviewMessage ?? "Reviewing"}
+          </div>
+        ) : child.status === "running" ? (
+          <div className="mt-1.5 text-[10px] font-medium text-muted-foreground">
+            Starting
+          </div>
+        ) : null}
         {child.status === "error" ? (
           <div
-            className="mt-1 truncate text-[10px] text-status-blocked/90"
+            className="mt-1.5 truncate text-[10px] text-status-blocked/90"
             title={child.lastError ?? undefined}
           >
             {child.lastError?.split("\n")[0] ?? "Error"}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -853,20 +853,6 @@ html[data-theme="matrix"] [role="button"] {
   color: hsl(var(--status-waiting)); /* yellow for meta */
 }
 
-/* Persona reviewing animation — subtle pulse on the status icon */
-@keyframes persona-reviewing-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-.animate-persona-reviewing {
-  animation: persona-reviewing-pulse 2s ease-in-out infinite;
-}
-
 @keyframes sidebar-nav-pulse {
   0% {
     transform: scale(1);
@@ -957,9 +943,6 @@ html[data-hidden] .dispatch-activity-bar {
   will-change: auto;
 }
 html[data-hidden] .animate-spin {
-  animation-play-state: paused;
-}
-html[data-hidden] .animate-persona-reviewing {
   animation-play-state: paused;
 }
 html[data-hidden] .persona-reviewing-row::before {


### PR DESCRIPTION
## Summary

Rebuilds the review agent item in the sidebar. The old inline stepper pill overflowed at sidebar width, had cramped vertical spacing, blended into the dark background (didn't read as a control), and used an error-shaped icon (`XCircle`) for *changes requested*.

- `PersonaAgentRow` now renders the verdict + response as a **stacked two-row button** in a bordered container. Rows scale independently and an `R2` badge surfaces when `resolution.roundNumber > 1`, so multi-round reviews read cleanly.
- Leading status icons:
  - `Flag` (orange) — changes requested
  - `ThumbsUp` (emerald) — approved
  - `Loader2` with `animate-spin` on **blue** — reviewing (distinct from approved; `--status-working` is in the green hue range across themes)
  - `CircleDashed` (muted) — no review record yet
- Drops the `opacity-50` dim on stopped reviewer children — finished reviews stay fully legible.
- Removes the unused `animate-persona-reviewing` keyframes.
- Seeds **7 reviewer children** on the rich demo agent (`seed-agent-running-feature`) so every state combo — reviewing, no-review, approved ± responded, changes-requested ± responded, R2 — is visible in `dispatch-dev` out of the box.

Options were explored on `/design-lab` (9 layout variants × 2 verdict states, plus icon grids); stacked-rows was the pick because it scales to multi-round cycles, keeps labels full-size, and gives the button-shape the dark theme needs. `design-lab.tsx` is restored to its empty canvas.

## Test plan

- [x] `pnpm run check` (server + web tsc)
- [x] `pnpm run finalize:web` (production Vite build)
- [x] `pnpm run test:e2e` — 138 passed, 6 skipped
- [x] Live validation in `dispatch-dev` — all seven seeded combos render as expected
- [ ] Visual review of the seven combos in a reviewer's local stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)