### PR TITLE
fix(web): add horizontal padding to terminal host

### DIFF
--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -56,7 +56,7 @@ export const TerminalPane = memo(function TerminalPane({
           showReconnectOverlay && "blur-[1.5px]"
         )}
       >
-        <div className="h-full" ref={terminalHostRef} />
+        <div className="h-full px-2" ref={terminalHostRef} />
       </div>
 
       {showEmptyState ? (


### PR DESCRIPTION
## Summary

- The xterm host sat flush against the container's left edge while FitAddon's whole-cell rounding left a small gap on the right, making the terminal text look visibly lopsided.
- Added symmetric `px-2` (8px each side) to the xterm host `div` in `terminal-pane.tsx` so both sides get equal breathing room on desktop and mobile.

## Validation

- `pnpm run check` — passes
- `pnpm run finalize:web` — passes (vite build OK)
- `pnpm run test:e2e` — 138 passed, 6 skipped, 0 failed
- Visual validation on live dev stack at desktop (1440w) and mobile (390w), both sidebars open and collapsed
- `frontend-ux-review` persona: approve, no findings

## Test plan

- [ ] Visually confirm terminal text has symmetric left/right padding on desktop with both sidebars open
- [ ] Confirm behavior on mobile (terminal not butted against viewport edges)
- [ ] Confirm xterm selection and click targeting at the far-left column still work correctly