### PR TITLE
fix(web): polish review row per frontend-ux review (#383 follow-up)

### DIFF
--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -56,7 +56,7 @@ function PersonaStatusIcon({
       <span
         className={cn(
           "inline-flex shrink-0 items-center justify-center rounded-full",
-          "border border-blue-500/50 bg-blue-500/15 text-blue-500",
+          "border border-status-reviewing/50 bg-status-reviewing/15 text-status-reviewing",
           className
         )}
       >
@@ -157,12 +157,11 @@ function StepRow({
         STEP_COLOR[step.color]
       )}
     >
-      <span
-        className={cn(
-          "h-1.5 w-1.5 shrink-0 rounded-full",
-          step.filled ? "bg-current" : "border border-current bg-transparent"
-        )}
-      />
+      {step.filled ? (
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current" />
+      ) : (
+        <CircleDashed className="h-2.5 w-2.5 shrink-0" strokeWidth={2} />
+      )}
       <span>{step.label}</span>
     </span>
   );
@@ -183,25 +182,17 @@ function ReviewStatusButton({
   round?: number;
   onOpen?: () => void;
 }): JSX.Element {
-  const frameClass = cn(
-    "mt-2 flex w-full flex-col items-stretch gap-1 rounded-md border border-border bg-muted/40 px-2 py-1.5 text-left text-[10px] transition-colors",
-    onOpen && "cursor-pointer hover:bg-muted/70 hover:border-border/80"
-  );
-
   const ariaLabel = `${step1.label} — ${step2.label}`;
-
-  const badge =
-    typeof round === "number" && round > 1 ? (
-      <span className="absolute right-1.5 top-1.5 inline-flex h-3.5 items-center rounded border border-border bg-muted/60 px-1 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
-        R{round}
-      </span>
-    ) : null;
 
   const inner = (
     <>
       <StepRow step={step1} emphasis="strong" />
       <StepRow step={step2} emphasis="soft" />
-      {badge}
+      {typeof round === "number" && round > 1 ? (
+        <span className="absolute right-1.5 top-1.5 inline-flex h-3.5 items-center rounded border border-border bg-muted/60 px-1 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+          R{round}
+        </span>
+      ) : null}
     </>
   );
 
@@ -210,7 +201,7 @@ function ReviewStatusButton({
       <button
         data-agent-control="true"
         type="button"
-        className={cn("relative", frameClass)}
+        className="relative mt-1.5 flex w-full cursor-pointer flex-col items-stretch gap-0.5 rounded-md border border-border bg-muted/40 px-2 py-1 text-left text-[10px] transition-colors hover:border-border/80 hover:bg-muted/70"
         aria-label={ariaLabel}
         onClick={(e) => {
           e.stopPropagation();
@@ -222,7 +213,10 @@ function ReviewStatusButton({
     );
   }
   return (
-    <span className={cn("relative", frameClass)} aria-label={ariaLabel}>
+    <span
+      className="relative mt-1.5 flex w-full flex-col items-stretch gap-0.5 text-[10px]"
+      aria-label={ariaLabel}
+    >
       {inner}
     </span>
   );
@@ -316,7 +310,7 @@ export function PersonaAgentRow({
             onOpen={hasSummary || hasResolution ? onOpenSummary : undefined}
           />
         ) : isReviewing ? (
-          <div className="mt-1.5 text-[10px] font-medium text-blue-500">
+          <div className="mt-1.5 text-[10px] font-medium text-status-reviewing">
             {reviewMessage ?? "Reviewing"}
           </div>
         ) : child.status === "running" ? (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -27,6 +27,7 @@
   --status-waiting: 45 96% 64%;
   --status-done: 198 93% 60%;
   --status-idle: 240 4% 46%;
+  --status-reviewing: 210 80% 62%;
 
   /* Chart colors */
   --chart-1: 158 64% 52%; /* teal — input tokens */
@@ -68,6 +69,7 @@
   --status-waiting: 55 87% 63%;
   --status-done: 207 100% 67%;
   --status-idle: 220 8% 50%;
+  --status-reviewing: 270 80% 72%;
 
   --chart-1: 207 100% 67%;
   --chart-2: 55 87% 63%;
@@ -107,6 +109,7 @@
   --status-waiting: 45 93% 58%;
   --status-done: 198 93% 60%;
   --status-idle: 0 0% 35%;
+  --status-reviewing: 210 90% 65%;
 
   --chart-1: 160 72% 52%;
   --chart-2: 45 93% 58%;
@@ -146,6 +149,7 @@
   --status-waiting: 45 100% 35%;
   --status-done: 205 82% 45%;
   --status-idle: 194 14% 40%;
+  --status-reviewing: 285 65% 62%;
 
   --chart-1: 205 82% 45%;
   --chart-2: 45 100% 35%;
@@ -185,6 +189,7 @@
   --status-waiting: 46 97% 42%;
   --status-done: 217 91% 50%;
   --status-idle: 220 8% 52%;
+  --status-reviewing: 262 72% 50%;
 
   --chart-1: 217 91% 50%;
   --chart-2: 46 97% 42%;
@@ -224,6 +229,7 @@
   --status-waiting: 57 100% 79%;
   --status-done: 191 99% 50%;
   --status-idle: 262 20% 45%;
+  --status-reviewing: 268 80% 72%;
 
   --chart-1: 191 99% 50%;
   --chart-2: 57 100% 79%;
@@ -263,6 +269,7 @@
   --status-waiting: 55 87% 63%;
   --status-done: 207 100% 67%;
   --status-idle: 220 8% 40%;
+  --status-reviewing: 270 80% 74%;
 
   --chart-1: 207 100% 67%;
   --chart-2: 55 87% 63%;
@@ -302,6 +309,7 @@
   --status-waiting: 46 52% 54%;
   --status-done: 153 76% 64%;
   --status-idle: 132 12% 40%;
+  --status-reviewing: 185 80% 62%;
 
   --chart-1: 136 100% 71%;
   --chart-2: 46 52% 54%;
@@ -341,6 +349,7 @@
   --status-waiting: 233 28% 73%;
   --status-done: 229 57% 71%;
   --status-idle: 222 8% 44%;
+  --status-reviewing: 290 70% 74%;
 
   --chart-1: 244 100% 69%;
   --chart-2: 229 57% 71%;

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -35,6 +35,7 @@ export default {
           waiting: "hsl(var(--status-waiting) / <alpha-value>)",
           done: "hsl(var(--status-done) / <alpha-value>)",
           idle: "hsl(var(--status-idle) / <alpha-value>)",
+          reviewing: "hsl(var(--status-reviewing) / <alpha-value>)",
         },
         chart: {
           1: "hsl(var(--chart-1) / <alpha-value>)",


### PR DESCRIPTION
## Summary

Follow-up to #383 addressing four low-severity items from the frontend-ux persona review.

### 1 · Reviewing color adapts to theme (was hardcoded `blue-500`)

The leading spinner and "Reviewing…" text now use a new `--status-reviewing` CSS token, registered in `tailwind.config.ts` as `status-reviewing` and tuned per theme so the hue stays clearly distinct from both the approved emerald and each theme's primary:

| Theme | `--status-reviewing` | Reads as |
|---|---|---|
| default | `210 80% 62%` | azure |
| cool-navy | `270 80% 72%` | purple (primary is blue) |
| oled-black | `210 90% 65%` | azure |
| solarized-dark | `285 65% 62%` | violet (primary is blue) |
| light | `262 72% 50%` | indigo-violet |
| vaporwave | `268 80% 72%` | purple (primary is pink) |
| midnight | `270 80% 74%` | lavender (primary is blue) |
| matrix | `185 80% 62%` | teal-cyan (distinct from greens) |
| mytra | `290 70% 74%` | magenta-purple (primary is indigo) |

### 2 · Tighter stacked button

`ReviewStatusButton`: `mt-2 → mt-1.5`, `py-1.5 → py-1`, inner `gap-1 → gap-0.5`. Shaves ~8–10px per reviewer row so parents with many reviewers don't push neighbors off the sidebar.

### 3 · Non-interactive span no longer mimics a button

When `onOpen` is unset (verdict with no summary and no resolution), the span variant renders as plain stacked rows with no border/bg/hover — only the interactive `<button>` variant gets the frame.

### 4 · Awaiting-response dot → `CircleDashed` icon

The 1px hollow ring was low-contrast against `bg-muted/40`. Swapped for the `CircleDashed` lucide icon, matching the "no review yet" status icon and scanning faster at 10px.

## Test plan

- [x] `pnpm run check` (server + web tsc)
- [x] `pnpm run finalize:web` (Vite production build)
- [x] `pnpm run test:e2e` — 138 passed, 6 skipped
- [x] Visual validation in default, Matrix, and Solarized Dark themes — reviewing color now reads as its own state in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)