### PR TITLE
feat: add terminal agent type

### DIFF
--- a/apps/server/src/agent-type-settings.ts
+++ b/apps/server/src/agent-type-settings.ts
@@ -2,8 +2,19 @@ import type { Pool } from "pg";
 
 import { getSetting, setSetting } from "./db/settings.js";
 
-export const AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export const AGENT_TYPES = ["codex", "claude", "opencode", "terminal"] as const;
 export type AgentType = (typeof AGENT_TYPES)[number];
+
+// Agent types that run an AI CLI — eligible for jobs, review assignment, and
+// persona launches. Terminal agents are excluded because they don't run a CLI.
+export const CLI_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
+
+export function isCliAgentType(value: unknown): value is CliAgentType {
+  return (
+    typeof value === "string" && CLI_AGENT_TYPES.includes(value as CliAgentType)
+  );
+}
 
 const ENABLED_AGENT_TYPES_KEY = "enabled_agent_types";
 

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -787,9 +787,10 @@ export class AgentManager {
         agent.type === "terminal"
           ? {
               type: "idle",
-              message: shouldResume
-                ? "Terminal session resumed."
-                : "Terminal session started.",
+              // Terminal agents don't track a CLI session id, so `shouldResume`
+              // is always false here — but reaching startAgent means the agent
+              // was previously stopped, which is definitionally a resume.
+              message: "Terminal session resumed.",
             }
           : {
               type: "working",

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -39,7 +39,7 @@ type AgentStatus =
   | "archiving"
   | "error"
   | "unknown";
-type AgentType = "codex" | "claude" | "opencode";
+type AgentType = "codex" | "claude" | "opencode" | "terminal";
 type AgentLatestEventType =
   | "working"
   | "blocked"
@@ -131,7 +131,7 @@ export type AgentRecord = {
 };
 
 const CLI_BY_AGENT_TYPE: Record<
-  AgentType,
+  Exclude<AgentType, "terminal">,
   keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">
 > = {
   codex: "codexBin",
@@ -567,10 +567,12 @@ export class AgentManager {
         `UPDATE agents SET status = 'running', cwd = $2, worktree_path = $3, worktree_branch = $4, setup_phase = NULL, updated_at = NOW() WHERE id = $1`,
         [id, effectiveCwd, worktreePath, worktreeBranch]
       );
-      await this.setSystemLatestEvent(id, {
-        type: "working",
-        message: "Session started.",
-      });
+      await this.setSystemLatestEvent(
+        id,
+        type === "terminal"
+          ? { type: "idle", message: "Terminal session started." }
+          : { type: "working", message: "Session started." }
+      );
     } else {
       try {
         await this.ensureNoExistingSession(tmuxSession);
@@ -698,10 +700,12 @@ export class AgentManager {
       [id, result.effectiveCwd, result.worktreePath, result.worktreeBranch]
     );
 
-    await this.setSystemLatestEvent(id, {
-      type: "working",
-      message: "Session started.",
-    });
+    await this.setSystemLatestEvent(
+      id,
+      agent.type === "terminal"
+        ? { type: "idle", message: "Terminal session started." }
+        : { type: "working", message: "Session started." }
+    );
 
     // Clean up setup script
     const setupScriptPath = `/tmp/dispatch_setup_${id}.sh`;
@@ -778,10 +782,20 @@ export class AgentManager {
         agent.autoReview ?? false
       );
       await this.setAgentStatus(id, "running", null, tmuxSession);
-      await this.setSystemLatestEvent(id, {
-        type: "working",
-        message: shouldResume ? "Session resumed." : "Session started.",
-      });
+      await this.setSystemLatestEvent(
+        id,
+        agent.type === "terminal"
+          ? {
+              type: "idle",
+              message: shouldResume
+                ? "Terminal session resumed."
+                : "Terminal session started.",
+            }
+          : {
+              type: "working",
+              message: shouldResume ? "Session resumed." : "Session started.",
+            }
+      );
     } catch (error) {
       const message = this.errorMessage(error);
       await this.setAgentStatus(id, "error", message, tmuxSession);
@@ -2228,6 +2242,13 @@ export class AgentManager {
     }
 
     const envPrefix = envPrefixParts.join(" ");
+
+    // Terminal agents have no CLI to launch — drop the user into a login shell
+    // in the chosen cwd/worktree. No MCP hookups, no session id tracking.
+    if (type === "terminal") {
+      return `${envPrefix} "\${SHELL:-/bin/bash}" -l`;
+    }
+
     const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
     const dispatchMcpUrl = this.dispatchMcpUrl(agentId, jobRunId);
     const dispatchMcpToken = jobRunId
@@ -4227,30 +4248,39 @@ export class AgentManager {
         `    else`,
         `      info "No .env file found — skipping"`,
         `    fi`,
-        ``,
-        `    # --- Install dependencies ---`,
-        `    ${curlPhase("deps")}`,
-        `    phase "Installing dependencies"`,
-        `    cd "$WT_PATH"`,
-        `    if [ -f "pnpm-lock.yaml" ]; then`,
-        `      info "Detected pnpm-lock.yaml"`,
-        `      pnpm install 2>&1 || warn "pnpm install failed (continuing anyway)"`,
-        `      ok "Dependencies installed"`,
-        `    elif [ -f "yarn.lock" ]; then`,
-        `      info "Detected yarn.lock"`,
-        `      yarn install 2>&1 || warn "yarn install failed (continuing anyway)"`,
-        `      ok "Dependencies installed"`,
-        `    elif [ -f "package-lock.json" ]; then`,
-        `      info "Detected package-lock.json"`,
-        `      npm install 2>&1 || warn "npm install failed (continuing anyway)"`,
-        `      ok "Dependencies installed"`,
-        `    elif [ -f "bun.lockb" ]; then`,
-        `      info "Detected bun.lockb"`,
-        `      bun install 2>&1 || warn "bun install failed (continuing anyway)"`,
-        `      ok "Dependencies installed"`,
-        `    else`,
-        `      info "No lockfile found — skipping dependency install"`,
-        `    fi`,
+        ``
+      );
+
+      if (agentType !== "terminal") {
+        lines.push(
+          `    # --- Install dependencies ---`,
+          `    ${curlPhase("deps")}`,
+          `    phase "Installing dependencies"`,
+          `    cd "$WT_PATH"`,
+          `    if [ -f "pnpm-lock.yaml" ]; then`,
+          `      info "Detected pnpm-lock.yaml"`,
+          `      pnpm install 2>&1 || warn "pnpm install failed (continuing anyway)"`,
+          `      ok "Dependencies installed"`,
+          `    elif [ -f "yarn.lock" ]; then`,
+          `      info "Detected yarn.lock"`,
+          `      yarn install 2>&1 || warn "yarn install failed (continuing anyway)"`,
+          `      ok "Dependencies installed"`,
+          `    elif [ -f "package-lock.json" ]; then`,
+          `      info "Detected package-lock.json"`,
+          `      npm install 2>&1 || warn "npm install failed (continuing anyway)"`,
+          `      ok "Dependencies installed"`,
+          `    elif [ -f "bun.lockb" ]; then`,
+          `      info "Detected bun.lockb"`,
+          `      bun install 2>&1 || warn "bun install failed (continuing anyway)"`,
+          `      ok "Dependencies installed"`,
+          `    else`,
+          `      info "No lockfile found — skipping dependency install"`,
+          `    fi`,
+          ``
+        );
+      }
+
+      lines.push(
         `  else`,
         `    warn "Worktree creation failed — using original directory"`,
         `  fi`,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -94,7 +94,9 @@ import { FocusTracker } from "./focus-tracker.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import {
   AGENT_TYPES,
+  CLI_AGENT_TYPES,
   getEnabledAgentTypes,
+  isCliAgentType,
   setEnabledAgentTypes,
 } from "./agent-type-settings.js";
 import { isPinType, validatePinValue } from "./pins.js";
@@ -1209,7 +1211,7 @@ const AddJobBodySchema = JobEnableDisableBodySchema.extend({
   schedule: z.string().nullable().optional(),
   timeoutMs: z.number().int().positive().optional(),
   needsInputTimeoutMs: z.number().int().positive().optional(),
-  agentType: z.enum(AGENT_TYPES).optional(),
+  agentType: z.enum(CLI_AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
   baseBranch: z.string().nullable().optional(),
   branchName: z.string().nullable().optional(),
@@ -3291,17 +3293,20 @@ async function registerRoutes() {
     const id = params.id ?? "";
     const body = request.body as { reviewAgentType?: unknown } | null;
 
-    let reviewAgentType: (typeof AGENT_TYPES)[number] | null;
+    let reviewAgentType: (typeof CLI_AGENT_TYPES)[number] | null;
     if (body?.reviewAgentType === null || body?.reviewAgentType === undefined) {
       reviewAgentType = null;
     } else if (
       typeof body.reviewAgentType === "string" &&
-      AGENT_TYPES.includes(body.reviewAgentType as (typeof AGENT_TYPES)[number])
+      CLI_AGENT_TYPES.includes(
+        body.reviewAgentType as (typeof CLI_AGENT_TYPES)[number]
+      )
     ) {
-      reviewAgentType = body.reviewAgentType as (typeof AGENT_TYPES)[number];
+      reviewAgentType =
+        body.reviewAgentType as (typeof CLI_AGENT_TYPES)[number];
     } else {
       return reply.code(400).send({
-        error: `reviewAgentType must be null or one of ${AGENT_TYPES.join(", ")}.`,
+        error: `reviewAgentType must be null or one of ${CLI_AGENT_TYPES.join(", ")}.`,
       });
     }
 
@@ -3691,10 +3696,12 @@ async function registerRoutes() {
       body.type !== undefined &&
       body.type !== "codex" &&
       body.type !== "claude" &&
-      body.type !== "opencode"
+      body.type !== "opencode" &&
+      body.type !== "terminal"
     ) {
       return reply.code(400).send({
-        error: "type must be codex, claude, or opencode when provided.",
+        error:
+          "type must be codex, claude, opencode, or terminal when provided.",
       });
     }
 
@@ -3758,7 +3765,9 @@ async function registerRoutes() {
         ? "claude"
         : body.type === "opencode"
           ? "opencode"
-          : "codex";
+          : body.type === "terminal"
+            ? "terminal"
+            : "codex";
     const enabledAgentTypes = await getEnabledAgentTypes(pool);
     if (!enabledAgentTypes.includes(agentType)) {
       return reply
@@ -5550,20 +5559,23 @@ async function mcpLaunchPersona(
   opts: {
     persona: string;
     context: string;
-    agentType?: (typeof AGENT_TYPES)[number];
+    agentType?: (typeof CLI_AGENT_TYPES)[number];
     allowRecheck?: boolean;
   }
 ): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
   const parent = await agentManager.getAgent(agentId);
   if (!parent) throw new Error("Parent agent not found.");
 
-  const personaAgentType =
-    opts.agentType ??
-    parent.reviewAgentType ??
-    (parent.type === "claude" || parent.type === "opencode"
+  const fallbackReviewType = isCliAgentType(parent.reviewAgentType)
+    ? parent.reviewAgentType
+    : null;
+  const fallbackParentType =
+    parent.type === "claude" || parent.type === "opencode"
       ? parent.type
-      : "codex");
-  if (!AGENT_TYPES.includes(personaAgentType)) {
+      : "codex";
+  const personaAgentType: (typeof CLI_AGENT_TYPES)[number] =
+    opts.agentType ?? fallbackReviewType ?? fallbackParentType;
+  if (!CLI_AGENT_TYPES.includes(personaAgentType)) {
     throw new Error(`Unsupported persona agent type "${personaAgentType}".`);
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3775,6 +3775,11 @@ async function registerRoutes() {
         .send({ error: `${agentType} agents are disabled in settings.` });
     }
 
+    // Terminal agents have no CLI to drive, so full-access / auto-review /
+    // initial-prompt are inert. Normalize them here so the stored record
+    // matches what the runtime honors and future side-effects keyed off these
+    // fields don't silently misfire for terminal agents.
+    const isTerminalAgent = agentType === "terminal";
     const fullAccessArg =
       agentType === "claude"
         ? CLAUDE_FULL_ACCESS_ARG
@@ -3782,7 +3787,7 @@ async function registerRoutes() {
           ? CODEX_FULL_ACCESS_ARG
           : null;
     const resolvedAgentArgs =
-      body.fullAccess === true && fullAccessArg
+      !isTerminalAgent && body.fullAccess === true && fullAccessArg
         ? Array.from(new Set([...(agentArgs ?? []), fullAccessArg]))
         : agentArgs;
 
@@ -3799,7 +3804,7 @@ async function registerRoutes() {
         type: agentType,
         cwd: body.cwd,
         agentArgs: resolvedAgentArgs,
-        fullAccess: body.fullAccess === true,
+        fullAccess: !isTerminalAgent && body.fullAccess === true,
         useWorktree:
           typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
         worktreeBranch:
@@ -3818,9 +3823,9 @@ async function registerRoutes() {
           typeof body.personaContext === "string"
             ? body.personaContext
             : undefined,
-        autoReview: body.autoReview === true,
+        autoReview: !isTerminalAgent && body.autoReview === true,
         initialPrompt:
-          typeof body.initialPrompt === "string"
+          !isTerminalAgent && typeof body.initialPrompt === "string"
             ? body.initialPrompt.trim() || undefined
             : undefined,
       });

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -144,6 +144,7 @@ export function AgentCard({
   const [worktreePathCopied, copyWorktreePath] = useCopyText();
   const needsAttention = agent.status === "error";
   const isJobAgent = agent.name.startsWith("job-");
+  const isTerminalAgent = agent.type === "terminal";
   const sidebarBaseBranch = agent.baseBranch ?? "main";
 
   return (
@@ -182,7 +183,11 @@ export function AgentCard({
                 <AgentTypeIcon
                   type={agent.type}
                   eventType={
-                    agent.status === "running" ? agent.latestEvent?.type : null
+                    isTerminalAgent
+                      ? null
+                      : agent.status === "running"
+                        ? agent.latestEvent?.type
+                        : null
                   }
                 />
                 <span className="truncate">{agent.name}</span>
@@ -306,7 +311,7 @@ export function AgentCard({
           </div>
         ) : null}
 
-        {agent.latestEvent ? (
+        {agent.latestEvent && !isTerminalAgent ? (
           isExpanded ? (
             <div className="mt-1 text-xs text-muted-foreground">
               <div className="flex items-baseline">
@@ -471,21 +476,25 @@ export function AgentCard({
                       ) : (
                         <span />
                       )}
-                      <div
-                        className={cn(
-                          "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px]",
-                          fullAccessEnabled
-                            ? "border border-status-waiting/35 bg-status-waiting/10 text-status-waiting"
-                            : "border border-border bg-muted/40 text-muted-foreground"
-                        )}
-                      >
-                        {fullAccessEnabled ? (
-                          <AlertTriangle className="h-3 w-3" />
-                        ) : null}
-                        <span>
-                          {fullAccessEnabled ? "Full access" : "Sandboxed"}
-                        </span>
-                      </div>
+                      {isTerminalAgent ? (
+                        <span />
+                      ) : (
+                        <div
+                          className={cn(
+                            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px]",
+                            fullAccessEnabled
+                              ? "border border-status-waiting/35 bg-status-waiting/10 text-status-waiting"
+                              : "border border-border bg-muted/40 text-muted-foreground"
+                          )}
+                        >
+                          {fullAccessEnabled ? (
+                            <AlertTriangle className="h-3 w-3" />
+                          ) : null}
+                          <span>
+                            {fullAccessEnabled ? "Full access" : "Sandboxed"}
+                          </span>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -511,37 +520,41 @@ export function AgentCard({
               </div>
               {!agent.persona ? (
                 <div className="flex flex-col gap-3 px-0 pb-1">
-                  <ParentFeedbackPanel
-                    parentAgentId={agent.id}
-                    sendTerminalInput={sendTerminalInput}
-                    isConnected={connectedAgentId === agent.id}
-                    onRequestClose={onRequestClose}
-                    closeOnSessionAction={closeOnSessionAction}
-                    onOpenDetail={onOpenFeedbackDetail}
-                    activeDetailItemId={
-                      feedbackDetailState?.parentAgentId === agent.id &&
-                      "itemId" in feedbackDetailState
-                        ? feedbackDetailState.itemId
-                        : null
-                    }
-                    childAgents={childAgents}
-                    selectedAgentId={selectedAgentId}
-                    agentVisualState={getVisualState}
-                    detachTerminal={detachTerminal}
-                    attachToAgent={attachToAgent}
-                  />
+                  {isTerminalAgent ? null : (
+                    <ParentFeedbackPanel
+                      parentAgentId={agent.id}
+                      sendTerminalInput={sendTerminalInput}
+                      isConnected={connectedAgentId === agent.id}
+                      onRequestClose={onRequestClose}
+                      closeOnSessionAction={closeOnSessionAction}
+                      onOpenDetail={onOpenFeedbackDetail}
+                      activeDetailItemId={
+                        feedbackDetailState?.parentAgentId === agent.id &&
+                        "itemId" in feedbackDetailState
+                          ? feedbackDetailState.itemId
+                          : null
+                      }
+                      childAgents={childAgents}
+                      selectedAgentId={selectedAgentId}
+                      agentVisualState={getVisualState}
+                      detachTerminal={detachTerminal}
+                      attachToAgent={attachToAgent}
+                    />
+                  )}
                   <div className="flex min-h-9 items-center justify-between gap-2 pt-2">
                     <div className="min-h-9 min-w-0 flex items-center">
-                      <PersonaLauncher
-                        agent={agent}
-                        enabledAgentTypes={enabledAgentTypes}
-                        sendTerminalInput={sendTerminalInput}
-                        disabled={
-                          connectedAgentId !== agent.id ||
-                          isStopped ||
-                          agent.status === "archiving"
-                        }
-                      />
+                      {isTerminalAgent ? null : (
+                        <PersonaLauncher
+                          agent={agent}
+                          enabledAgentTypes={enabledAgentTypes}
+                          sendTerminalInput={sendTerminalInput}
+                          disabled={
+                            connectedAgentId !== agent.id ||
+                            isStopped ||
+                            agent.status === "archiving"
+                          }
+                        />
+                      )}
                       {/* Keep review visible for every parent agent; lifecycle controls stay on the right. */}
                     </div>
                     <div className="flex h-9 shrink-0 items-center gap-[18px]">

--- a/apps/web/src/components/app/agent-type-icon.tsx
+++ b/apps/web/src/components/app/agent-type-icon.tsx
@@ -1,3 +1,4 @@
+import { Terminal as TerminalIcon } from "lucide-react";
 import { siClaude } from "simple-icons";
 
 import { cn } from "@/lib/utils";
@@ -24,12 +25,15 @@ const CODEX_LOGO_PATH =
 
 function normalizeAgentType(
   type?: string | null
-): "codex" | "claude" | "opencode" | "unknown" {
+): "codex" | "claude" | "opencode" | "terminal" | "unknown" {
   if (type === "claude") {
     return "claude";
   }
   if (type === "opencode") {
     return "opencode";
+  }
+  if (type === "terminal") {
+    return "terminal";
   }
   if (type === "codex" || !type) {
     return "codex";
@@ -48,7 +52,9 @@ export function AgentTypeIcon({
       ? "Claude"
       : normalizedType === "opencode"
         ? "OpenCode"
-        : "Codex";
+        : normalizedType === "terminal"
+          ? "Terminal"
+          : "Codex";
   const statusClass = eventType ? eventColorClass[eventType] : "";
   const baseClass = statusClass
     ? "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors duration-300"
@@ -67,6 +73,18 @@ export function AgentTypeIcon({
         aria-label={`${label} agent`}
       >
         OC
+      </span>
+    );
+  }
+
+  if (normalizedType === "terminal") {
+    return (
+      <span
+        className={cn(baseClass, statusClass, className)}
+        title={`${label} agent`}
+        aria-label={`${label} agent`}
+      >
+        <TerminalIcon className="h-3.5 w-3.5" aria-hidden="true" />
       </span>
     );
   }

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -489,46 +489,50 @@ function CreateAgentDialogContent({
                   ) : null}
                 </div>
 
-                <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-                  <Checkbox
-                    checked={createFullAccess}
-                    onCheckedChange={() =>
-                      setCreateFullAccess((current) => !current)
-                    }
-                    className="mt-0.5"
-                    title="Toggle full access"
-                  />
-                  <span className="space-y-1">
-                    <span className="block text-sm font-medium text-foreground">
-                      Start in full access mode
-                    </span>
-                    <span className="block text-xs text-muted-foreground">
-                      Starts the selected agent with its most permissive
-                      supported execution mode.
-                    </span>
-                  </span>
-                </label>
+                {createType !== "terminal" ? (
+                  <>
+                    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                      <Checkbox
+                        checked={createFullAccess}
+                        onCheckedChange={() =>
+                          setCreateFullAccess((current) => !current)
+                        }
+                        className="mt-0.5"
+                        title="Toggle full access"
+                      />
+                      <span className="space-y-1">
+                        <span className="block text-sm font-medium text-foreground">
+                          Start in full access mode
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          Starts the selected agent with its most permissive
+                          supported execution mode.
+                        </span>
+                      </span>
+                    </label>
 
-                <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-                  <Checkbox
-                    checked={createAutoReview}
-                    onCheckedChange={() =>
-                      setCreateAutoReview((current) => !current)
-                    }
-                    className="mt-0.5"
-                    title="Toggle autonomous review"
-                    data-testid="create-agent-auto-review"
-                  />
-                  <span className="space-y-1">
-                    <span className="block text-sm font-medium text-foreground">
-                      Autonomous Review
-                    </span>
-                    <span className="block text-xs text-muted-foreground">
-                      Agent will launch one review agent and address feedback
-                      before completing.
-                    </span>
-                  </span>
-                </label>
+                    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                      <Checkbox
+                        checked={createAutoReview}
+                        onCheckedChange={() =>
+                          setCreateAutoReview((current) => !current)
+                        }
+                        className="mt-0.5"
+                        title="Toggle autonomous review"
+                        data-testid="create-agent-auto-review"
+                      />
+                      <span className="space-y-1">
+                        <span className="block text-sm font-medium text-foreground">
+                          Autonomous Review
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          Agent will launch one review agent and address
+                          feedback before completing.
+                        </span>
+                      </span>
+                    </label>
+                  </>
+                ) : null}
               </div>
             </div>
             <div className="flex justify-end gap-2 pt-3">
@@ -541,16 +545,18 @@ function CreateAgentDialogContent({
               >
                 Cancel
               </Button>
-              <Button
-                type="button"
-                variant="default"
-                tabIndex={0}
-                disabled={creating || !createCwd.trim()}
-                data-testid="create-agent-with-prompt"
-                onClick={() => setStep("prompt")}
-              >
-                Create with prompt
-              </Button>
+              {createType !== "terminal" ? (
+                <Button
+                  type="button"
+                  variant="default"
+                  tabIndex={0}
+                  disabled={creating || !createCwd.trim()}
+                  data-testid="create-agent-with-prompt"
+                  onClick={() => setStep("prompt")}
+                >
+                  Create with prompt
+                </Button>
+              ) : null}
               <Button
                 type="submit"
                 variant="primary"

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -62,7 +62,12 @@ import {
 } from "@/components/ui/chart";
 import { StatCard } from "@/components/app/stat-card";
 import { formatRelativeTime } from "@/lib/format";
-import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  type CliAgentType,
+  isCliAgentType,
+} from "@/lib/agent-types";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
 
@@ -1120,8 +1125,9 @@ function AddJobFlow({
   const [timeoutMinutes, setTimeoutMinutes] = useState("30");
   const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] =
     useState("1440");
-  const [agentType, setAgentType] = useState<AgentType>(
-    enabledAgentTypes[0] ?? "codex"
+  const jobAgentTypes = enabledAgentTypes.filter(isCliAgentType);
+  const [agentType, setAgentType] = useState<CliAgentType>(
+    jobAgentTypes[0] ?? "codex"
   );
   const [fullAccess, setFullAccess] = useState(false);
   const [useWorktree, setUseWorktree] = useState(false);
@@ -1237,13 +1243,13 @@ function AddJobFlow({
                 </label>
                 <Select
                   value={agentType}
-                  onValueChange={(value) => setAgentType(value as AgentType)}
+                  onValueChange={(value) => setAgentType(value as CliAgentType)}
                 >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {enabledAgentTypes.map((type) => (
+                    {jobAgentTypes.map((type) => (
                       <SelectItem key={type} value={type}>
                         {AGENT_TYPE_LABELS[type]}
                       </SelectItem>
@@ -1839,7 +1845,7 @@ function SettingsTab({
   const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] = useState(
     minutesFromMs(job.needsInputTimeoutMs)
   );
-  const [agentType, setAgentType] = useState<AgentType>(job.agentType);
+  const [agentType, setAgentType] = useState<CliAgentType>(job.agentType);
   const [fullAccess, setFullAccess] = useState(job.fullAccess);
   const [useWorktree, setUseWorktree] = useState(job.useWorktree);
   const [baseBranch, setBaseBranch] = useState(job.baseBranch ?? "main");
@@ -1948,13 +1954,13 @@ function SettingsTab({
             <label className="text-sm text-muted-foreground">Agent type</label>
             <Select
               value={agentType}
-              onValueChange={(value) => setAgentType(value as AgentType)}
+              onValueChange={(value) => setAgentType(value as CliAgentType)}
             >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {enabledAgentTypes.map((type) => (
+                {enabledAgentTypes.filter(isCliAgentType).map((type) => (
                   <SelectItem key={type} value={type}>
                     {AGENT_TYPE_LABELS[type]}
                   </SelectItem>

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -11,7 +11,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api";
-import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  isCliAgentType,
+} from "@/lib/agent-types";
 
 type PersonaSummary = {
   slug: string;
@@ -43,7 +47,9 @@ export function PersonaLauncher({
     },
   });
   const hasPersonas = personas.length > 0;
-  const showReviewAgentTypePicker = enabledAgentTypes.length > 1;
+  // Terminal agents can't run personas — exclude from review type options.
+  const reviewerTypes = enabledAgentTypes.filter(isCliAgentType);
+  const showReviewAgentTypePicker = reviewerTypes.length > 1;
 
   if (!hasPersonas) {
     return null;
@@ -146,7 +152,7 @@ export function PersonaLauncher({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {enabledAgentTypes.map((agentType) => (
+            {reviewerTypes.map((agentType) => (
               <DropdownMenuItem
                 key={agentType}
                 className="text-foreground"

--- a/apps/web/src/lib/agent-types.ts
+++ b/apps/web/src/lib/agent-types.ts
@@ -1,4 +1,4 @@
-export const AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export const AGENT_TYPES = ["codex", "claude", "opencode", "terminal"] as const;
 
 export type AgentType = (typeof AGENT_TYPES)[number];
 
@@ -6,7 +6,17 @@ export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   codex: "Codex",
   claude: "Claude",
   opencode: "OpenCode",
+  terminal: "Terminal",
 };
+
+// Agent types that run an AI CLI — eligible for reviews, jobs, and personas.
+// Terminal agents are excluded because there's no CLI to drive them.
+export const CLI_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
+
+export function isCliAgentType(value: string): value is CliAgentType {
+  return CLI_AGENT_TYPES.includes(value as CliAgentType);
+}
 
 export function isAgentType(value: string): value is AgentType {
   return AGENT_TYPES.includes(value as AgentType);

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "@playwright/test";
+import {
+  cleanupE2EAgents,
+  loadApp,
+  setEnabledAgentTypesViaAPI,
+} from "./helpers";
+
+const authHeader = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
+
+type AgentRecord = {
+  id: string;
+  type: string;
+  fullAccess: boolean;
+  autoReview: boolean;
+  agentArgs: string[];
+  latestEvent: { type: string; message: string } | null;
+};
+
+test.describe("Terminal agent type", () => {
+  // Earlier specs in the run may disable agent types via settings; re-enable
+  // so these tests are order-independent.
+  test.beforeEach(async ({ request }) => {
+    await setEnabledAgentTypesViaAPI(request, [
+      "codex",
+      "claude",
+      "opencode",
+      "terminal",
+    ]);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("POST /api/v1/agents accepts type=terminal and seeds an idle event", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/v1/agents", {
+      headers: authHeader,
+      data: {
+        name: `e2e-agent-terminal-${Date.now()}`,
+        type: "terminal",
+        cwd: "/tmp",
+        useWorktree: false,
+      },
+    });
+    expect(res.status()).toBe(201);
+
+    const { agent } = (await res.json()) as { agent: AgentRecord };
+    expect(agent.type).toBe("terminal");
+    // Created via the inert test runtime — initial event should be idle,
+    // not "working" like the CLI types.
+    expect(agent.latestEvent?.type).toBe("idle");
+  });
+
+  test("POST /api/v1/agents normalizes inert fields when type=terminal", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/v1/agents", {
+      headers: authHeader,
+      data: {
+        name: `e2e-agent-terminal-${Date.now()}`,
+        type: "terminal",
+        cwd: "/tmp",
+        useWorktree: false,
+        fullAccess: true,
+        autoReview: true,
+        initialPrompt: "should be ignored",
+      },
+    });
+    expect(res.status()).toBe(201);
+
+    const { agent } = (await res.json()) as { agent: AgentRecord };
+    expect(agent.fullAccess).toBe(false);
+    expect(agent.autoReview).toBe(false);
+    // No full-access flag should be injected for terminal.
+    expect(agent.agentArgs).toEqual([]);
+  });
+
+  test("POST /api/v1/agents rejects unknown type", async ({ request }) => {
+    const res = await request.post("/api/v1/agents", {
+      headers: authHeader,
+      data: { type: "not-a-real-type", cwd: "/tmp", useWorktree: false },
+    });
+    expect(res.status()).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("terminal");
+  });
+
+  test("PATCH review-agent-type rejects terminal", async ({ request }) => {
+    const create = await request.post("/api/v1/agents", {
+      headers: authHeader,
+      data: {
+        name: `e2e-agent-terminal-parent-${Date.now()}`,
+        type: "codex",
+        cwd: "/tmp",
+        useWorktree: false,
+      },
+    });
+    const { agent } = (await create.json()) as { agent: { id: string } };
+
+    const patch = await request.patch(
+      `/api/v1/agents/${agent.id}/review-agent-type`,
+      {
+        headers: authHeader,
+        data: { reviewAgentType: "terminal" },
+      }
+    );
+    expect(patch.status()).toBe(400);
+
+    const body = (await patch.json()) as { error: string };
+    expect(body.error).toContain("reviewAgentType");
+  });
+
+  test("create dialog hides inert fields when terminal is selected", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    const form = page.getByTestId("create-agent-form");
+    await expect(form).toBeVisible();
+
+    // Full access + auto review + "Create with prompt" are all visible for
+    // the default CLI type.
+    await expect(form.getByText("Start in full access mode")).toBeVisible();
+    await expect(form.getByText("Autonomous Review")).toBeVisible();
+    await expect(page.getByTestId("create-agent-with-prompt")).toBeVisible();
+
+    // Switch to terminal.
+    const typeTrigger = form.getByRole("combobox").first();
+    await typeTrigger.click();
+    await page.getByRole("option", { name: "Terminal" }).click();
+    await expect(typeTrigger).toContainText("Terminal");
+
+    // All three inert controls should be gone; worktree checkbox stays.
+    await expect(form.getByText("Start in full access mode")).not.toBeVisible();
+    await expect(form.getByText("Autonomous Review")).not.toBeVisible();
+    await expect(
+      page.getByTestId("create-agent-with-prompt")
+    ).not.toBeVisible();
+    await expect(page.getByTestId("create-agent-worktree")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Terminal** agent type that launches a plain login shell in tmux instead of an AI CLI — lets you drop into a bare terminal inside Dispatch without the overhead of Codex/Claude/OpenCode.

- Worktree + .env copy still run when enabled; deps install, MCP config, autonomous review, and initial prompts are skipped.
- Resume re-launches a fresh shell in the same cwd/worktree (shell state itself isn't preserved — the worktree is the durable artifact).
- UI hides full-access, autonomous-review, initial-prompt, the event chip, the review/persona controls, and the sandbox badge for terminal agents. Icon is lucide `Terminal`.
- Introduces `CLI_AGENT_TYPES` so jobs, persona launches, and review-agent assignment can't pick terminal by accident.

## Test plan

- [x] `pnpm run check` — server + web typecheck pass
- [x] `pnpm run finalize:web` — build succeeds
- [x] `pnpm run test` — 391/13 unit tests pass
- [x] `pnpm run test:e2e` — 138 e2e tests pass
- [x] Live dev stack (`repo_dev_up --live`): create terminal agent → real zsh prompt → `echo hi` works
- [x] Pause → Resume: fresh shell relaunched in same `/tmp` cwd
- [x] Codex dialog regression: full-access, auto-review, "Create with prompt" still present