### PR TITLE
fix(web): swap Enter/Keyboard and align Esc-Tab row with arrows in mobile toolbar

### DIFF
--- a/apps/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/apps/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -77,15 +77,15 @@ export function MobileTerminalToolbar({
               size="sm"
               variant="default"
               className="h-full w-full px-2 text-xs"
-              aria-label="Send Enter"
-              onClick={() => sendKey("\r")}
+              aria-label="Open text input"
+              onClick={openInput}
             >
-              Enter
+              <Keyboard className="h-5 w-5" strokeWidth={2} />
             </Button>
           </div>
 
-          <div className="flex shrink-0 flex-col items-center justify-center gap-2">
-            <div className="flex justify-center gap-2">
+          <div className="flex shrink-0 flex-col items-stretch justify-center gap-2">
+            <div className="flex w-full justify-between">
               <Button
                 type="button"
                 size="sm"
@@ -175,10 +175,10 @@ export function MobileTerminalToolbar({
               size="sm"
               variant="default"
               className="h-full w-full px-2 text-xs"
-              aria-label="Open text input"
-              onClick={openInput}
+              aria-label="Send Enter"
+              onClick={() => sendKey("\r")}
             >
-              <Keyboard className="h-5 w-5" strokeWidth={2} />
+              Enter
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Swap the Enter and Keyboard (text-input) buttons between the outer flex-1 slots in the mobile terminal toolbar — Keyboard now on the left, Enter on the right.
- Align the Esc/Ctrl/Tab row with the arrow row: middle column changed to `items-stretch`, top row changed to `flex w-full justify-between`. Esc's left edge now lines up with ←, and Tab's right edge lines up with →.
- No logic changes — `sendKey`, `toggleCtrl`, `openInput`, `submitInput`, and the full-screen input modal are untouched.

## Files changed
- `apps/web/src/components/app/mobile-terminal-toolbar.tsx`

## Test plan
- [x] `pnpm run check` passes
- [x] `pnpm run finalize:web` passes
- [x] Playwright at 390×844 confirms the layout
- [x] frontend-ux-review persona approved
- [ ] Manual: open the terminal view on a mobile viewport, confirm Keyboard opens the modal and Enter sends a newline