### PR TITLE
fix(web): wait for new SW to install before reloading from update toast

### DIFF
--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,19 +1,48 @@
-type UpdateSW = (reloadPage?: boolean) => Promise<void>;
-
-let updateSW: UpdateSW | null = null;
-
-export function setUpdateSW(fn: UpdateSW): void {
-  updateSW = fn;
+// Wait for a worker to finish installing/activating so the reload that follows
+// picks up the new precache instead of serving the old one.
+async function waitForWorkerActivation(
+  worker: ServiceWorker,
+  timeoutMs: number
+): Promise<void> {
+  if (worker.state === "activated") return;
+  await new Promise<void>((resolve) => {
+    const handleChange = (): void => {
+      if (worker.state === "activated" || worker.state === "redundant") {
+        worker.removeEventListener("statechange", handleChange);
+        resolve();
+      }
+    };
+    worker.addEventListener("statechange", handleChange);
+    setTimeout(() => {
+      worker.removeEventListener("statechange", handleChange);
+      resolve();
+    }, timeoutMs);
+  });
 }
 
 export async function reloadApp(): Promise<void> {
-  if (updateSW) {
+  // Force the service worker to check for a new version and wait for it to
+  // install before reloading. Without this, autoUpdate's periodic update loop
+  // may not have noticed the new SW yet, so the reload serves the old
+  // precached bundle and the "update available" toast reappears immediately.
+  if ("serviceWorker" in navigator) {
     try {
-      await updateSW(true);
-      return;
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (registration) {
+        await registration.update();
+        const pending = registration.installing ?? registration.waiting;
+        if (pending) {
+          // vite-plugin-pwa's autoUpdate already sets skipWaiting:true in the
+          // SW itself, so a "waiting" worker is unusual — but post the message
+          // anyway as a safety net for edge-case timings.
+          if (registration.waiting) {
+            registration.waiting.postMessage({ type: "SKIP_WAITING" });
+          }
+          await waitForWorkerActivation(pending, 3000);
+        }
+      }
     } catch {
-      // Fall through to a hard reload if the SW update path fails so the
-      // user isn't left with a stuck Reload button.
+      // fall through to plain reload
     }
   }
   window.location.reload();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
-import { setUpdateSW } from "./lib/reload";
 import "./index.css";
 
 // Detect iPad PWA (standalone mode on iPad-class device) and apply targeted
@@ -37,7 +36,7 @@ if (import.meta.env.PROD) {
   // (the PWA plugin is only loaded in production builds).
   const pwaModule = "virtual:pwa-register";
   void import(/* @vite-ignore */ pwaModule).then(({ registerSW }) => {
-    const updateSW = registerSW({
+    registerSW({
       immediate: true,
       onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
         if (registration) {
@@ -47,7 +46,6 @@ if (import.meta.env.PROD) {
         }
       },
     });
-    setUpdateSW(updateSW);
   });
 } else if ("serviceWorker" in navigator) {
   void navigator.serviceWorker.getRegistrations().then((registrations) => {


### PR DESCRIPTION
## Summary

Clicking "Reload" on the update-available toast was reloading the page before the new service worker finished installing. The reload kept serving the old precached bundle, so `__APP_VERSION__` was still the old value and the toast immediately re-appeared on the just-reloaded page — exactly the "I'm supposedly up to date, stop nagging me" bug that @bmharris hit after updating to v0.17.0.

## Root cause

`vite-plugin-pwa` is configured with `registerType: "autoUpdate"` and a 5-min periodic `registration.update()` check. In that mode, its `updateSW(true)` helper does its own `registration.update()` + `skipWaiting` + reload sequence, but doesn't reliably wait for the *installation* to complete before firing `window.location.reload()`. If the periodic check hadn't yet detected the new version when the user clicked Reload, the reload happens *before* the new precache is in the SW — so the reload serves the old bundle.

## Fix

`reloadApp()` now:
1. Calls `registration.update()` and awaits it.
2. If a worker is `installing` or `waiting`, listens for `statechange` and waits up to 3s for it to reach `activated` (belt-and-suspenders: also posts `SKIP_WAITING` to any waiting worker, even though autoUpdate normally handles that).
3. *Then* reloads — the reload now consumes the freshly precached bundle.

Also drops the `setUpdateSW` plumbing from `main.tsx`; we no longer call `updateSW(true)` so it's dead code. The periodic 5-min `registration.update()` inside `onRegisteredSW` is unchanged.

## Test plan

- [x] `pnpm run check` — pass
- [x] `pnpm run finalize:web` — pass
- [ ] Manual verification: cut a new release after this lands, hit Reload from the toast on a pre-existing tab, confirm the toast does not reappear post-reload.