### PR TITLE
Prefer managed flow for assisted updates

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -143,6 +143,8 @@ const CLI_BY_AGENT_TYPE: Record<
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
+const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
+const DISPATCH_SERVER_AUTH_TOKEN_ENV = "DISPATCH_SERVER_AUTH_TOKEN";
 
 type WorktreeLocation = "sibling" | "nested";
 
@@ -635,6 +637,7 @@ export class AgentManager {
         // Build the agent command that the setup script will exec into
         const agentCommand = this.buildAgentCommand(
           type,
+          role,
           agentArgs,
           mediaDir,
           tmuxSession,
@@ -830,6 +833,7 @@ export class AgentManager {
         agent.name,
         agent.persona,
         agent.type,
+        agent.role,
         agent.agentArgs ?? [],
         agent.fullAccess ?? false,
         cliSessionId ?? undefined,
@@ -2048,6 +2052,7 @@ export class AgentManager {
     agentName: string,
     persona: string | null,
     type: AgentType,
+    role: AgentRole,
     agentArgs: string[],
     fullAccess: boolean,
     cliSessionId?: string,
@@ -2062,6 +2067,7 @@ export class AgentManager {
     await mkdir(mediaDir, { recursive: true });
     const agentCommand = this.buildAgentCommand(
       type,
+      role,
       agentArgs,
       mediaDir,
       sessionName,
@@ -2202,6 +2208,7 @@ export class AgentManager {
 
   private buildAgentCommand(
     type: AgentType,
+    role: AgentRole,
     args: string[],
     mediaDir: string,
     sessionName: string,
@@ -2256,6 +2263,17 @@ export class AgentManager {
       // Prevents cwd drift back to the original repo root during long conversations.
       `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`,
     ];
+
+    if (role === "assisted_update") {
+      envPrefixParts.push(
+        `${DISPATCH_API_URL_ENV}=${this.shellEscape(
+          `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}`
+        )}`,
+        `${DISPATCH_SERVER_AUTH_TOKEN_ENV}=${this.shellEscape(
+          this.config.authToken
+        )}`
+      );
+    }
 
     // Forward the clipboard display to agent sessions so CLI tools can read
     // images pasted via the browser clipboard (xclip needs a DISPLAY).

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -141,6 +141,9 @@ const CLI_BY_AGENT_TYPE: Record<
   opencode: "opencodeBin",
 };
 
+const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
+const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
+
 type WorktreeLocation = "sibling" | "nested";
 
 type CreateAgentInput = {
@@ -508,8 +511,17 @@ export class AgentManager {
     const id = this.newAgentId();
     const type: AgentType = input.type ?? "codex";
     const role: AgentRole = input.role ?? "standard";
-    const agentArgs = input.agentArgs ?? [];
     const fullAccess = input.fullAccess ?? false;
+    const fullAccessArg =
+      type === "claude"
+        ? CLAUDE_FULL_ACCESS_ARG
+        : type === "codex"
+          ? CODEX_FULL_ACCESS_ARG
+          : null;
+    const agentArgs =
+      fullAccess && fullAccessArg
+        ? Array.from(new Set([...(input.agentArgs ?? []), fullAccessArg]))
+        : (input.agentArgs ?? []);
     const name = input.name?.trim() || `agent-${id.slice(-6)}`;
     const tmuxSession = this.toSessionName(id, name);
     const mediaDir = path.join(this.config.mediaRoot, id);

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -18,7 +18,11 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Pool } from "pg";
 
 import type { AppConfig } from "../config.js";
-import { createAgentMcpToken, createJobMcpToken } from "../auth.js";
+import {
+  createAgentMcpToken,
+  createJobMcpToken,
+  createReleaseUpdateToken,
+} from "../auth.js";
 import {
   createGitWorktree,
   cleanupGitWorktree,
@@ -144,7 +148,7 @@ const CLI_BY_AGENT_TYPE: Record<
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
-const DISPATCH_SERVER_AUTH_TOKEN_ENV = "DISPATCH_SERVER_AUTH_TOKEN";
+const DISPATCH_RELEASE_UPDATE_TOKEN_ENV = "DISPATCH_RELEASE_UPDATE_TOKEN";
 
 type WorktreeLocation = "sibling" | "nested";
 
@@ -2269,8 +2273,8 @@ export class AgentManager {
         `${DISPATCH_API_URL_ENV}=${this.shellEscape(
           `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}`
         )}`,
-        `${DISPATCH_SERVER_AUTH_TOKEN_ENV}=${this.shellEscape(
-          this.config.authToken
+        `${DISPATCH_RELEASE_UPDATE_TOKEN_ENV}=${this.shellEscape(
+          createReleaseUpdateToken(this.config.authToken, agentId)
         )}`
       );
     }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -27,11 +27,28 @@ function validateMcpScopeToken(
   token: string,
   expectedScope: string
 ): boolean {
-  const expected = createMcpScopeToken(secret, expectedScope);
-  const actualBuffer = Buffer.from(token, "utf-8");
-  const expectedBuffer = Buffer.from(expected, "utf-8");
+  const actualScope = getValidMcpScope(secret, token);
+  if (!actualScope) return false;
+  const actualBuffer = Buffer.from(actualScope, "utf-8");
+  const expectedBuffer = Buffer.from(expectedScope, "utf-8");
   if (actualBuffer.length !== expectedBuffer.length) return false;
   return crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function getValidMcpScope(secret: string, token: string): string | null {
+  const [payload, signature] = token.split(".");
+  if (!payload || !signature) return null;
+  let scope: string;
+  try {
+    scope = Buffer.from(payload, "base64url").toString("utf-8");
+  } catch {
+    return null;
+  }
+  const expected = createMcpScopeToken(secret, scope);
+  const actualBuffer = Buffer.from(token, "utf-8");
+  const expectedBuffer = Buffer.from(expected, "utf-8");
+  if (actualBuffer.length !== expectedBuffer.length) return null;
+  return crypto.timingSafeEqual(actualBuffer, expectedBuffer) ? scope : null;
 }
 
 export async function isPasswordSet(pool: Pool): Promise<boolean> {
@@ -142,7 +159,11 @@ export function shouldAcceptApiBearerToken(
   token: string,
   serverAuthToken: string
 ): boolean {
-  return token === serverAuthToken;
+  return (
+    token === serverAuthToken ||
+    (url === "/api/v1/release/update" &&
+      getReleaseUpdateAgentId(serverAuthToken, token) !== null)
+  );
 }
 
 export function createAgentMcpToken(secret: string, agentId: string): string {
@@ -172,6 +193,31 @@ export function validateJobMcpToken(
   agentId: string
 ): boolean {
   return validateMcpScopeToken(secret, token, `job:${runId}:${agentId}`);
+}
+
+export function createReleaseUpdateToken(
+  secret: string,
+  agentId: string
+): string {
+  return createMcpScopeToken(secret, `release-update:${agentId}`);
+}
+
+export function validateReleaseUpdateToken(
+  secret: string,
+  token: string,
+  agentId: string
+): boolean {
+  return validateMcpScopeToken(secret, token, `release-update:${agentId}`);
+}
+
+export function getReleaseUpdateAgentId(
+  secret: string,
+  token: string
+): string | null {
+  const scope = getValidMcpScope(secret, token);
+  if (!scope?.startsWith("release-update:")) return null;
+  const agentId = scope.slice("release-update:".length);
+  return agentId.length > 0 ? agentId : null;
 }
 
 /**

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -69,6 +69,7 @@ import {
   cleanExpiredSessions,
   getOrCreateAuthToken,
   getOrCreateCookieSecret,
+  getReleaseUpdateAgentId,
   isScopedMcpRoute,
   shouldAcceptApiBearerToken,
   validateAgentMcpToken,
@@ -745,7 +746,7 @@ Update details:
 - Production checkout: ${serverDir}
 - Health endpoint: ${dispatchHealthUrl()}
 - Dispatch API base URL: $DISPATCH_API_URL
-- Dispatch API bearer token env: $DISPATCH_SERVER_AUTH_TOKEN
+- Dispatch API update token env: $DISPATCH_RELEASE_UPDATE_TOKEN
 - Main service log: ~/.dispatch/logs/dispatch.log
 - Failure log path: ~/.dispatch/logs/last-release-failure.log
 - Service restart command: ${serviceCommand}
@@ -761,7 +762,7 @@ Guardrails:
 Suggested workflow:
 1. Capture the current repo/tag/service state.
 2. Trigger the existing managed Dispatch update flow first by calling the built-in update endpoint the UI uses with the provided bearer token, for example:
-   \`curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN" -d '{"tag":"${input.tag}"}'\`
+   \`curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_RELEASE_UPDATE_TOKEN" -d '{"tag":"${input.tag}"}'\`
 3. Monitor restart and health until success or failure is clear.
 4. If the managed flow request fails or the service does not come back, inspect launchd/systemd state and recent logs before deciding on recovery.
 5. Reuse existing Dispatch service scripts/commands where they already encode the normal update behavior; do not manually reproduce the normal update sequence unless the managed path has already failed and you are in explicit recovery mode.
@@ -2170,6 +2171,7 @@ async function registerRoutes() {
 
   app.post("/api/v1/release/update", async (request, reply) => {
     const body = request.body as { tag?: unknown } | undefined;
+    const bearerToken = getBearerToken(request);
 
     if (
       !body?.tag ||
@@ -2182,6 +2184,22 @@ async function registerRoutes() {
     }
 
     const tag = body.tag as string;
+    const releaseUpdateAgentId = bearerToken
+      ? getReleaseUpdateAgentId(config.authToken, bearerToken)
+      : null;
+
+    if (releaseUpdateAgentId) {
+      const agent = await agentManager.getAgent(releaseUpdateAgentId);
+      if (
+        !agent ||
+        agent.role !== "assisted_update" ||
+        agent.cwd !== serverDir
+      ) {
+        return reply
+          .code(403)
+          .send({ error: "Invalid assisted update token." });
+      }
+    }
 
     // Only one release/update at a time
     if (

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -695,6 +695,7 @@ type ReleaseStreamEvent =
   | { type: "tag"; tag: string };
 
 let activeReleaseJob: ReleaseJob | null = null;
+let activeAssistedUpdateLaunch = false;
 const releaseStreamClients = new Set<NodeJS.WritableStream>();
 
 const serverDir =
@@ -757,7 +758,7 @@ Guardrails:
 
 Suggested workflow:
 1. Capture the current repo/tag/service state.
-2. Prefer the existing managed Dispatch update flow first by calling the same built-in update endpoint the UI uses (\`POST /api/v1/release/update\` with tag ${input.tag}) instead of reproducing deploy steps by hand.
+2. Prefer the existing managed Dispatch update flow first. If you have a valid Dispatch API bearer token or the server has no password set, you can call the built-in update endpoint the UI uses (\`POST /api/v1/release/update\` with tag ${input.tag}); otherwise use the local Dispatch scripts/commands that already implement the normal update behavior.
 3. Monitor restart and health until success or failure is clear.
 4. If the managed flow fails or the service does not come back, inspect launchd/systemd state and recent logs.
 5. Reuse existing Dispatch service scripts/commands where they already encode the normal update behavior; only fall back to manual git/install/build/restart steps if those managed paths are unavailable or already failed.
@@ -2240,14 +2241,22 @@ async function registerRoutes() {
         .send({ error: "A release or update is already in progress." });
     }
 
-    if (await hasActiveAssistedUpdateAgent()) {
+    if (activeAssistedUpdateLaunch) {
       return reply.code(409).send({
         error:
-          "An assisted update agent is already active for the production checkout.",
+          "An assisted update agent is already being created for the production checkout.",
       });
     }
 
+    activeAssistedUpdateLaunch = true;
     try {
+      if (await hasActiveAssistedUpdateAgent()) {
+        return reply.code(409).send({
+          error:
+            "An assisted update agent is already active for the production checkout.",
+        });
+      }
+
       const record = await readReleaseStore().catch(() => null);
       const worktreeLocationRaw = await getSetting(pool, WORKTREE_LOCATION_KEY);
       const worktreeLocation: WorktreeLocation =
@@ -2278,6 +2287,8 @@ async function registerRoutes() {
       return reply.code(201).send({ agent: withStreamFlag(agent) });
     } catch (error) {
       return handleAgentError(reply, error);
+    } finally {
+      activeAssistedUpdateLaunch = false;
     }
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -757,12 +757,13 @@ Guardrails:
 
 Suggested workflow:
 1. Capture the current repo/tag/service state.
-2. Perform the update to ${input.tag}.
+2. Prefer the existing managed Dispatch update flow first by calling the same built-in update endpoint the UI uses (\`POST /api/v1/release/update\` with tag ${input.tag}) instead of reproducing deploy steps by hand.
 3. Monitor restart and health until success or failure is clear.
-4. If unhealthy, inspect launchd/systemd state and recent logs.
-5. Retry one clean restart if that is the safest next step.
-6. If still broken, identify the last confirmed healthy tag from repo/service history, roll back to it, and verify health.
-7. Summarize outcome, root cause, commands run, and any remaining risk.
+4. If the managed flow fails or the service does not come back, inspect launchd/systemd state and recent logs.
+5. Reuse existing Dispatch service scripts/commands where they already encode the normal update behavior; only fall back to manual git/install/build/restart steps if those managed paths are unavailable or already failed.
+6. Retry one clean restart if that is the safest next step.
+7. If still broken, identify the last confirmed healthy tag from repo/service history, roll back to it, and verify health.
+8. Summarize outcome, root cause, commands run, and any remaining risk.
 `.trim();
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -744,6 +744,8 @@ Update details:
 - Target tag: ${input.tag}
 - Production checkout: ${serverDir}
 - Health endpoint: ${dispatchHealthUrl()}
+- Dispatch API base URL: $DISPATCH_API_URL
+- Dispatch API bearer token env: $DISPATCH_SERVER_AUTH_TOKEN
 - Main service log: ~/.dispatch/logs/dispatch.log
 - Failure log path: ~/.dispatch/logs/last-release-failure.log
 - Service restart command: ${serviceCommand}
@@ -758,10 +760,11 @@ Guardrails:
 
 Suggested workflow:
 1. Capture the current repo/tag/service state.
-2. Prefer the existing managed Dispatch update flow first. If you have a valid Dispatch API bearer token or the server has no password set, you can call the built-in update endpoint the UI uses (\`POST /api/v1/release/update\` with tag ${input.tag}); otherwise use the local Dispatch scripts/commands that already implement the normal update behavior.
+2. Trigger the existing managed Dispatch update flow first by calling the built-in update endpoint the UI uses with the provided bearer token, for example:
+   \`curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN" -d '{"tag":"${input.tag}"}'\`
 3. Monitor restart and health until success or failure is clear.
-4. If the managed flow fails or the service does not come back, inspect launchd/systemd state and recent logs.
-5. Reuse existing Dispatch service scripts/commands where they already encode the normal update behavior; only fall back to manual git/install/build/restart steps if those managed paths are unavailable or already failed.
+4. If the managed flow request fails or the service does not come back, inspect launchd/systemd state and recent logs before deciding on recovery.
+5. Reuse existing Dispatch service scripts/commands where they already encode the normal update behavior; do not manually reproduce the normal update sequence unless the managed path has already failed and you are in explicit recovery mode.
 6. Retry one clean restart if that is the safest next step.
 7. If still broken, identify the last confirmed healthy tag from repo/service history, roll back to it, and verify health.
 8. Summarize outcome, root cause, commands run, and any remaining risk.

--- a/apps/server/test/auth.test.ts
+++ b/apps/server/test/auth.test.ts
@@ -17,9 +17,12 @@ import {
   isScopedMcpRoute,
   shouldAcceptApiBearerToken,
   createAgentMcpToken,
+  createReleaseUpdateToken,
+  getReleaseUpdateAgentId,
   validateAgentMcpToken,
   createJobMcpToken,
   validateJobMcpToken,
+  validateReleaseUpdateToken,
 } from "../src/auth.js";
 
 let pool: Pool;
@@ -173,6 +176,19 @@ describe("auth token and cookie secret", () => {
     ).toBe(false);
   });
 
+  it("creates release-update tokens scoped to a single agent", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+    const token = createReleaseUpdateToken(secret, "agt_123456abcdef");
+
+    expect(validateReleaseUpdateToken(secret, token, "agt_123456abcdef")).toBe(
+      true
+    );
+    expect(validateReleaseUpdateToken(secret, token, "agt_otheragent")).toBe(
+      false
+    );
+    expect(getReleaseUpdateAgentId(secret, token)).toBe("agt_123456abcdef");
+  });
+
   it("does not let scoped MCP bearer tokens through the global auth gate", async () => {
     const secret = await getOrCreateAuthToken(pool);
     const agentToken = createAgentMcpToken(secret, "agt_123456abcdef");
@@ -197,6 +213,19 @@ describe("auth token and cookie secret", () => {
     expect(
       shouldAcceptApiBearerToken("/api/v1/agents", agentToken, secret)
     ).toBe(false);
+  });
+
+  it("only accepts release-update scoped tokens on the update endpoint", async () => {
+    const secret = await getOrCreateAuthToken(pool);
+    const token = createReleaseUpdateToken(secret, "agt_123456abcdef");
+
+    expect(
+      shouldAcceptApiBearerToken("/api/v1/release/update", token, secret)
+    ).toBe(true);
+    expect(shouldAcceptApiBearerToken("/api/v1/agents", token, secret)).toBe(
+      false
+    );
+    expect(shouldAcceptApiBearerToken("/api/mcp", token, secret)).toBe(false);
   });
 
   it("identifies only agent and job MCP routes as scoped routes", () => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -197,6 +197,20 @@ describe("AgentManager", () => {
         useWorktree: false,
       });
       expect(agent.fullAccess).toBe(true);
+      expect(agent.agentArgs).toContain(
+        "--dangerously-bypass-approvals-and-sandbox"
+      );
+    });
+
+    it("should append the claude full access flag for direct launches", async () => {
+      const agent = await manager.createAgent({
+        type: "claude",
+        cwd: "/tmp",
+        fullAccess: true,
+        useWorktree: false,
+      });
+      expect(agent.fullAccess).toBe(true);
+      expect(agent.agentArgs).toContain("--dangerously-skip-permissions");
     });
 
     it("should persist autoReview", async () => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -171,6 +171,33 @@ describe("AgentManager", () => {
       expect(agent.role).toBe("assisted_update");
     });
 
+    it("should inject explicit update API auth and instructions for assisted update agents", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        role: "assisted_update",
+        type: "codex",
+        useWorktree: false,
+        initialPrompt: [
+          "You are running an assisted Dispatch update on the host machine.",
+          "Trigger the existing managed Dispatch update flow first by calling the built-in update endpoint the UI uses with the provided bearer token.",
+          `curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN" -d '{\"tag\":\"v9.9.9\"}'`,
+        ].join("\n"),
+      });
+
+      const setupScript = await readFile(
+        `/tmp/dispatch_setup_${agent.id}.sh`,
+        "utf-8"
+      );
+      expect(setupScript).toContain("DISPATCH_API_URL=");
+      expect(setupScript).toContain("DISPATCH_SERVER_AUTH_TOKEN=");
+      expect(setupScript).toContain(
+        'curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update"'
+      );
+      expect(setupScript).toContain(
+        "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN"
+      );
+    });
+
     it("should persist reviewAgentType when provided", async () => {
       const agent = await manager.createAgent({
         type: "codex",

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -180,7 +180,7 @@ describe("AgentManager", () => {
         initialPrompt: [
           "You are running an assisted Dispatch update on the host machine.",
           "Trigger the existing managed Dispatch update flow first by calling the built-in update endpoint the UI uses with the provided bearer token.",
-          `curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN" -d '{\"tag\":\"v9.9.9\"}'`,
+          `curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update" -H "Content-Type: application/json" -H "Authorization: Bearer $DISPATCH_RELEASE_UPDATE_TOKEN" -d '{\"tag\":\"v9.9.9\"}'`,
         ].join("\n"),
       });
 
@@ -189,12 +189,12 @@ describe("AgentManager", () => {
         "utf-8"
       );
       expect(setupScript).toContain("DISPATCH_API_URL=");
-      expect(setupScript).toContain("DISPATCH_SERVER_AUTH_TOKEN=");
+      expect(setupScript).toContain("DISPATCH_RELEASE_UPDATE_TOKEN=");
       expect(setupScript).toContain(
         'curl -sf -X POST "$DISPATCH_API_URL/api/v1/release/update"'
       );
       expect(setupScript).toContain(
-        "Authorization: Bearer $DISPATCH_SERVER_AUTH_TOKEN"
+        "Authorization: Bearer $DISPATCH_RELEASE_UPDATE_TOKEN"
       );
     });
 


### PR DESCRIPTION
## Summary
- launch assisted update agents with the runtime's full-access permission flag
- steer assisted update prompts toward the existing managed update endpoint before manual recovery steps
- cover the direct-launch full-access behavior with agent manager tests

## Testing
- pnpm run check
- pnpm run test
- pnpm run test:e2e