### PR TITLE
fix(web): wait for new SW to install before reloading from update toast

### DIFF
--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,18 +1,64 @@
-async function waitForWorkerActivation(
+function isControllingWorker(
   worker: ServiceWorker,
+  registration: ServiceWorkerRegistration
+): boolean {
+  const active = registration.active;
+  const controller = navigator.serviceWorker.controller;
+  const workerScript = worker.scriptURL;
+  return Boolean(
+    active &&
+    active.scriptURL === workerScript &&
+    (!controller || controller.scriptURL === workerScript)
+  );
+}
+
+async function waitForWorkerControl(
+  worker: ServiceWorker,
+  registration: ServiceWorkerRegistration,
   timeoutMs: number
 ): Promise<void> {
-  if (worker.state === "activated") return;
+  if (isControllingWorker(worker, registration)) return;
   await new Promise<void>((resolve) => {
+    const hasExistingController = navigator.serviceWorker.controller !== null;
     const handleChange = (): void => {
-      if (worker.state === "activated" || worker.state === "redundant") {
-        worker.removeEventListener("statechange", handleChange);
+      if (worker.state === "redundant") {
+        cleanup();
+        resolve();
+        return;
+      }
+      if (isControllingWorker(worker, registration)) {
+        cleanup();
+        resolve();
+        return;
+      }
+      // On a first install there may be no existing controller to swap out,
+      // so the best available signal is that the fetched worker activated.
+      if (!hasExistingController && worker.state === "activated") {
+        cleanup();
         resolve();
       }
     };
-    worker.addEventListener("statechange", handleChange);
-    setTimeout(() => {
+    const handleControllerChange = (): void => {
+      if (isControllingWorker(worker, registration)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const cleanup = (): void => {
+      clearTimeout(timer);
       worker.removeEventListener("statechange", handleChange);
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        handleControllerChange
+      );
+    };
+    worker.addEventListener("statechange", handleChange);
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      handleControllerChange
+    );
+    const timer = setTimeout(() => {
+      cleanup();
       resolve();
     }, timeoutMs);
   });
@@ -36,9 +82,9 @@ export async function reloadApp(): Promise<void> {
             registration.waiting.postMessage({ type: "SKIP_WAITING" });
           }
           // vite-plugin-pwa's "activated" handler auto-reloads when the new
-          // SW activates. We wait so our fallback reload below doesn't fire
-          // before the new SW is in control.
-          await waitForWorkerActivation(pending, 3000);
+          // SW activates. We wait for the worker to actually control this page
+          // so our fallback reload below doesn't race the controller handoff.
+          await waitForWorkerControl(pending, registration, 10_000);
         }
       }
     } catch {

--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,19 +1,48 @@
-type UpdateSW = (reloadPage?: boolean) => Promise<void>;
-
-let updateSW: UpdateSW | null = null;
-
-export function setUpdateSW(fn: UpdateSW): void {
-  updateSW = fn;
+async function waitForWorkerActivation(
+  worker: ServiceWorker,
+  timeoutMs: number
+): Promise<void> {
+  if (worker.state === "activated") return;
+  await new Promise<void>((resolve) => {
+    const handleChange = (): void => {
+      if (worker.state === "activated" || worker.state === "redundant") {
+        worker.removeEventListener("statechange", handleChange);
+        resolve();
+      }
+    };
+    worker.addEventListener("statechange", handleChange);
+    setTimeout(() => {
+      worker.removeEventListener("statechange", handleChange);
+      resolve();
+    }, timeoutMs);
+  });
 }
 
 export async function reloadApp(): Promise<void> {
-  if (updateSW) {
+  // vite-plugin-pwa's updateSW(true) is a no-op in autoUpdate mode and
+  // neither mode triggers registration.update() on demand. Without this,
+  // clicking Reload reloads before a new SW has installed, so the old
+  // precached bundle is served and the toast reappears.
+  if ("serviceWorker" in navigator) {
     try {
-      await updateSW(true);
-      return;
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (registration) {
+        await registration.update();
+        const pending = registration.installing ?? registration.waiting;
+        if (pending) {
+          // autoUpdate sets skipWaiting:true so "waiting" is unusual, but
+          // poke it anyway for edge-case timings.
+          if (registration.waiting) {
+            registration.waiting.postMessage({ type: "SKIP_WAITING" });
+          }
+          // vite-plugin-pwa's "activated" handler auto-reloads when the new
+          // SW activates. We wait so our fallback reload below doesn't fire
+          // before the new SW is in control.
+          await waitForWorkerActivation(pending, 3000);
+        }
+      }
     } catch {
-      // Fall through to a hard reload if the SW update path fails so the
-      // user isn't left with a stuck Reload button.
+      // fall through
     }
   }
   window.location.reload();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
-import { setUpdateSW } from "./lib/reload";
 import "./index.css";
 
 // Detect iPad PWA (standalone mode on iPad-class device) and apply targeted
@@ -37,7 +36,7 @@ if (import.meta.env.PROD) {
   // (the PWA plugin is only loaded in production builds).
   const pwaModule = "virtual:pwa-register";
   void import(/* @vite-ignore */ pwaModule).then(({ registerSW }) => {
-    const updateSW = registerSW({
+    registerSW({
       immediate: true,
       onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
         if (registration) {
@@ -47,7 +46,6 @@ if (import.meta.env.PROD) {
         }
       },
     });
-    setUpdateSW(updateSW);
   });
 } else if ("serviceWorker" in navigator) {
   void navigator.serviceWorker.getRegistrations().then((registrations) => {


### PR DESCRIPTION
## Summary
- replace the update-toast reload path so it asks the existing service worker registration to check for updates on demand
- wait briefly for an installing or waiting worker to activate before falling back to `window.location.reload()`
- remove the `setUpdateSW` plumbing from `main.tsx` because `updateSW(true)` is a no-op under `registerType: "autoUpdate"`

## Why
`vite-plugin-pwa`'s `updateSW(true)` only sends `SKIP_WAITING` when it is not in auto-update mode. In this app's `autoUpdate` configuration, clicking Reload could fall through to a hard page refresh before the browser had installed a new service worker, so the old precached bundle loaded again and the update toast immediately reappeared.

## Test plan
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- manual Playwright validation on an isolated dev stack by triggering the update toast, clicking Reload, and confirming the mocked service worker activation completed before the page reload and the toast did not remain visible after reload
- manual verify after the next real release: leave a tab open across a deploy, click Reload from the update toast, and confirm the toast does not reappear after the refresh