### PR TITLE
fix(web): wait for late service worker updatefound before reload

### DIFF
--- a/apps/web/src/components/app/update-available-toast.tsx
+++ b/apps/web/src/components/app/update-available-toast.tsx
@@ -50,7 +50,7 @@ export function UpdateAvailableToast(): JSX.Element | null {
 
   const handleReload = (): void => {
     setReloading(true);
-    reloadApp().catch(() => {
+    reloadApp({ waitForUpdate: true }).catch(() => {
       setReloading(false);
     });
   };

--- a/apps/web/src/hooks/use-release-stream.ts
+++ b/apps/web/src/hooks/use-release-stream.ts
@@ -102,7 +102,7 @@ export function useReleaseStream(): UseReleaseStreamResult {
             setJob((prev) =>
               prev ? { ...prev, phase: "done", tag: data.tag } : prev
             );
-            setTimeout(() => reloadApp(), 1500);
+            setTimeout(() => reloadApp({ waitForUpdate: true }), 1500);
           }
         }
       } catch {

--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,18 +1,64 @@
-async function waitForWorkerActivation(
+function isControllingWorker(
   worker: ServiceWorker,
+  registration: ServiceWorkerRegistration
+): boolean {
+  const active = registration.active;
+  const controller = navigator.serviceWorker.controller;
+  const workerScript = worker.scriptURL;
+  return Boolean(
+    active &&
+    active.scriptURL === workerScript &&
+    (!controller || controller.scriptURL === workerScript)
+  );
+}
+
+async function waitForWorkerControl(
+  worker: ServiceWorker,
+  registration: ServiceWorkerRegistration,
   timeoutMs: number
 ): Promise<void> {
-  if (worker.state === "activated") return;
+  if (isControllingWorker(worker, registration)) return;
   await new Promise<void>((resolve) => {
+    const hasExistingController = navigator.serviceWorker.controller !== null;
     const handleChange = (): void => {
-      if (worker.state === "activated" || worker.state === "redundant") {
-        worker.removeEventListener("statechange", handleChange);
+      if (worker.state === "redundant") {
+        cleanup();
+        resolve();
+        return;
+      }
+      if (isControllingWorker(worker, registration)) {
+        cleanup();
+        resolve();
+        return;
+      }
+      // On a first install there may be no existing controller to swap out,
+      // so the best available signal is that the fetched worker activated.
+      if (!hasExistingController && worker.state === "activated") {
+        cleanup();
         resolve();
       }
     };
-    worker.addEventListener("statechange", handleChange);
-    setTimeout(() => {
+    const handleControllerChange = (): void => {
+      if (isControllingWorker(worker, registration)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const cleanup = (): void => {
+      clearTimeout(timer);
       worker.removeEventListener("statechange", handleChange);
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        handleControllerChange
+      );
+    };
+    worker.addEventListener("statechange", handleChange);
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      handleControllerChange
+    );
+    const timer = setTimeout(() => {
+      cleanup();
       resolve();
     }, timeoutMs);
   });
@@ -36,9 +82,9 @@ export async function reloadApp(): Promise<void> {
             registration.waiting.postMessage({ type: "SKIP_WAITING" });
           }
           // vite-plugin-pwa's "activated" handler auto-reloads when the new
-          // SW activates. We wait so our fallback reload below doesn't fire
-          // before the new SW is in control.
-          await waitForWorkerActivation(pending, 3000);
+          // SW activates. We wait for the worker to actually control this page
+          // so our fallback reload below doesn't race the controller handoff.
+          await waitForWorkerControl(pending, registration, 10_000);
         }
       }
     } catch {

--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,19 +1,48 @@
-type UpdateSW = (reloadPage?: boolean) => Promise<void>;
-
-let updateSW: UpdateSW | null = null;
-
-export function setUpdateSW(fn: UpdateSW): void {
-  updateSW = fn;
+async function waitForWorkerActivation(
+  worker: ServiceWorker,
+  timeoutMs: number
+): Promise<void> {
+  if (worker.state === "activated") return;
+  await new Promise<void>((resolve) => {
+    const handleChange = (): void => {
+      if (worker.state === "activated" || worker.state === "redundant") {
+        worker.removeEventListener("statechange", handleChange);
+        resolve();
+      }
+    };
+    worker.addEventListener("statechange", handleChange);
+    setTimeout(() => {
+      worker.removeEventListener("statechange", handleChange);
+      resolve();
+    }, timeoutMs);
+  });
 }
 
 export async function reloadApp(): Promise<void> {
-  if (updateSW) {
+  // vite-plugin-pwa's updateSW(true) is a no-op in autoUpdate mode and
+  // neither mode triggers registration.update() on demand. Without this,
+  // clicking Reload reloads before a new SW has installed, so the old
+  // precached bundle is served and the toast reappears.
+  if ("serviceWorker" in navigator) {
     try {
-      await updateSW(true);
-      return;
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (registration) {
+        await registration.update();
+        const pending = registration.installing ?? registration.waiting;
+        if (pending) {
+          // autoUpdate sets skipWaiting:true so "waiting" is unusual, but
+          // poke it anyway for edge-case timings.
+          if (registration.waiting) {
+            registration.waiting.postMessage({ type: "SKIP_WAITING" });
+          }
+          // vite-plugin-pwa's "activated" handler auto-reloads when the new
+          // SW activates. We wait so our fallback reload below doesn't fire
+          // before the new SW is in control.
+          await waitForWorkerActivation(pending, 3000);
+        }
+      }
     } catch {
-      // Fall through to a hard reload if the SW update path fails so the
-      // user isn't left with a stuck Reload button.
+      // fall through
     }
   }
   window.location.reload();

--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -97,12 +97,16 @@ async function waitForWorkerControl(
   });
 }
 
-export async function reloadApp(): Promise<void> {
+type ReloadAppOptions = {
+  waitForUpdate?: boolean;
+};
+
+export async function reloadApp(options: ReloadAppOptions = {}): Promise<void> {
   // vite-plugin-pwa's updateSW(true) is a no-op in autoUpdate mode and
   // neither mode triggers registration.update() on demand. Without this,
   // clicking Reload reloads before a new SW has installed, so the old
   // precached bundle is served and the toast reappears.
-  if ("serviceWorker" in navigator) {
+  if (options.waitForUpdate && "serviceWorker" in navigator) {
     try {
       const registration = await navigator.serviceWorker.getRegistration();
       if (registration) {

--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -12,6 +12,39 @@ function isControllingWorker(
   );
 }
 
+function getPendingWorker(
+  registration: ServiceWorkerRegistration
+): ServiceWorker | null {
+  return registration.installing ?? registration.waiting ?? null;
+}
+
+async function waitForPendingWorker(
+  registration: ServiceWorkerRegistration,
+  timeoutMs: number
+): Promise<ServiceWorker | null> {
+  const existing = getPendingWorker(registration);
+  if (existing) return existing;
+  return await new Promise<ServiceWorker | null>((resolve) => {
+    const handleUpdateFound = (): void => {
+      const pending = getPendingWorker(registration);
+      if (pending) {
+        cleanup();
+        resolve(pending);
+      }
+    };
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      registration.removeEventListener("updatefound", handleUpdateFound);
+    };
+    registration.addEventListener("updatefound", handleUpdateFound);
+    const timer = setTimeout(() => {
+      const pending = getPendingWorker(registration);
+      cleanup();
+      resolve(pending);
+    }, timeoutMs);
+  });
+}
+
 async function waitForWorkerControl(
   worker: ServiceWorker,
   registration: ServiceWorkerRegistration,
@@ -74,7 +107,7 @@ export async function reloadApp(): Promise<void> {
       const registration = await navigator.serviceWorker.getRegistration();
       if (registration) {
         await registration.update();
-        const pending = registration.installing ?? registration.waiting;
+        const pending = await waitForPendingWorker(registration, 3_000);
         if (pending) {
           // autoUpdate sets skipWaiting:true so "waiting" is unusual, but
           // poke it anyway for edge-case timings.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
-import { setUpdateSW } from "./lib/reload";
 import "./index.css";
 
 // Detect iPad PWA (standalone mode on iPad-class device) and apply targeted
@@ -37,7 +36,7 @@ if (import.meta.env.PROD) {
   // (the PWA plugin is only loaded in production builds).
   const pwaModule = "virtual:pwa-register";
   void import(/* @vite-ignore */ pwaModule).then(({ registerSW }) => {
-    const updateSW = registerSW({
+    registerSW({
       immediate: true,
       onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
         if (registration) {
@@ -47,7 +46,6 @@ if (import.meta.env.PROD) {
         }
       },
     });
-    setUpdateSW(updateSW);
   });
 } else if ("serviceWorker" in navigator) {
   void navigator.serviceWorker.getRegistrations().then((registrations) => {


### PR DESCRIPTION
## Summary
- fix a remaining race in the update-toast reload path by waiting for `registration.updatefound` after calling `registration.update()`
- continue waiting for the new worker to take control of the page before reloading
- avoid the stale-controller hard refresh path when the browser reports the update asynchronously a moment after `update()` resolves

## Why
The merged reload fix already handled the `controllerchange` handoff, but it still sampled `registration.installing ?? registration.waiting` only once immediately after `await registration.update()`. In real clients the browser can resolve `update()` first and dispatch `updatefound` slightly later. In that case the app reloaded the old controller before the new worker had even appeared, and the update toast could reappear forever on repeated Reload clicks.

## Test plan
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- Playwright validation with a mocked SW sequence where `registration.update()` resolves first, `updatefound` arrives later, and `controllerchange` happens last; confirm reload waits for the late `updatefound` + controller handoff and the toast is not visible after reload