### PR TITLE
CRU-134: phase 2 persona recheck UI

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -121,6 +121,8 @@ export type AgentRecord = {
     verdict: string | null;
     summary: string | null;
     filesReviewed: string[] | null;
+    roundNumber: number;
+    allowRecheck: boolean;
     updatedAt: string;
     resolution: {
       summary: string;
@@ -4312,6 +4314,8 @@ export class AgentManager {
            'verdict', pr.verdict,
            'summary', pr.summary,
            'filesReviewed', pr.files_reviewed,
+           'roundNumber', pr.round_number,
+           'allowRecheck', pr.allow_recheck,
            'updatedAt', pr.updated_at,
            'resolution', (
              SELECT json_build_object(

--- a/apps/server/src/db/seed/feedback.ts
+++ b/apps/server/src/db/seed/feedback.ts
@@ -3,21 +3,25 @@ import type { PoolClient } from "pg";
 import { seedNow } from "./constants.js";
 
 type FeedbackInput = {
+  key: string;
   agentId: string;
   severity: "critical" | "high" | "medium" | "low" | "info";
   filePath: string | null;
   lineNumber: number | null;
   description: string;
   suggestion: string | null;
-  status: "open" | "fixed" | "dismissed";
+  status: "open" | "fixed" | "dismissed" | "ignored";
   hoursAgo: number;
+  roundNumber?: number;
+  resolutionReason?: string | null;
+  resolutionCommit?: string | null;
+  respondsToKey?: string;
 };
 
-// All feedback lives on the "rich" seed agent so the sidebar shows
-// one clean agent and one with a reviewer attached + findings.
 const ITEMS: FeedbackInput[] = [
   {
-    agentId: "seed-agent-running-feature",
+    key: "round1-timezone",
+    agentId: "seed-review-agent",
     severity: "critical",
     filePath: "apps/server/src/activity-metrics.ts",
     lineNumber: 98,
@@ -27,9 +31,11 @@ const ITEMS: FeedbackInput[] = [
       "Accept `tz` parameter and bucket on client-local day boundary.",
     status: "open",
     hoursAgo: 4,
+    roundNumber: 1,
   },
   {
-    agentId: "seed-agent-running-feature",
+    key: "round1-legend",
+    agentId: "seed-review-agent",
     severity: "high",
     filePath: "apps/web/src/components/activity/ActivityHeatmap.tsx",
     lineNumber: 210,
@@ -38,27 +44,68 @@ const ITEMS: FeedbackInput[] = [
     suggestion: "Reset legend range on granularity change.",
     status: "open",
     hoursAgo: 5,
+    roundNumber: 1,
   },
   {
-    agentId: "seed-agent-running-feature",
+    key: "awaiting-recheck-parent",
+    agentId: "seed-review-awaiting-recheck",
     severity: "medium",
-    filePath: "apps/web/src/components/activity/ActivityChart.tsx",
+    filePath: "apps/web/src/components/activity/LoadingState.tsx",
     lineNumber: 56,
-    description: "Tooltip hides behind the sidebar on narrow viewports.",
-    suggestion: "Portal the tooltip to body.",
+    description: "Retry spinner never settles after a network timeout.",
+    suggestion: "Reuse the shared request lifecycle instead of local timers.",
+    status: "fixed",
+    hoursAgo: 2,
+    roundNumber: 1,
+    resolutionReason: "Retry state now comes from the shared request hook.",
+    resolutionCommit: "c1a59ef",
+  },
+  {
+    key: "round2-parent",
+    agentId: "seed-review-changes-responded-r2",
+    severity: "medium",
+    filePath: "apps/server/src/cache/retry-loop.ts",
+    lineNumber: 44,
+    description:
+      "The retry loop bypasses the circuit breaker on the cache-miss path.",
+    suggestion:
+      "Route both warmup and retry traffic through the circuit-breaker helper.",
     status: "fixed",
     hoursAgo: 18,
+    roundNumber: 1,
+    resolutionReason:
+      "Moved retry warmup behind the shared circuit-breaker helper.",
+    resolutionCommit: "9e7d104",
   },
   {
-    agentId: "seed-agent-running-feature",
+    key: "round2-followup",
+    agentId: "seed-review-changes-responded-r2",
+    severity: "high",
+    filePath: "apps/server/src/cache/retry-loop.ts",
+    lineNumber: 71,
+    description:
+      "Round 2: fallback retries still skip the breaker when warmup throws before memoization.",
+    suggestion:
+      "Guard the fallback branch with the same breaker wrapper used in the primary path.",
+    status: "open",
+    hoursAgo: 1,
+    roundNumber: 2,
+    respondsToKey: "round2-parent",
+  },
+  {
+    key: "round2-approved-parent",
+    agentId: "seed-review-approved-responded",
     severity: "low",
     filePath: "apps/web/src/components/activity/DayPicker.tsx",
     lineNumber: 22,
     description: "Keyboard focus doesn't return after closing the picker.",
     suggestion:
-      "Call `.focus()` on the trigger button in onOpenChange handler.",
-    status: "open",
-    hoursAgo: 6,
+      "Call `.focus()` on the trigger button in `onOpenChange` after close.",
+    status: "fixed",
+    hoursAgo: 12,
+    roundNumber: 1,
+    resolutionReason: "Focus now returns to the trigger on close.",
+    resolutionCommit: "4a0c82d",
   },
 ];
 
@@ -68,13 +115,17 @@ function ago(now: Date, hours: number): Date {
 
 export async function seedFeedback(client: PoolClient): Promise<void> {
   const now = seedNow();
+  const idsByKey = new Map<string, number>();
+
   for (const item of ITEMS) {
-    await client.query(
+    const { rows } = await client.query<{ id: number }>(
       `
       INSERT INTO agent_feedback (
-        agent_id, severity, file_path, line_number,
-        description, suggestion, status, created_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+        agent_id, severity, file_path, line_number, description, suggestion,
+        status, resolution_reason, resolution_commit, round_number,
+        responds_to_feedback_id, created_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+      RETURNING id
       `,
       [
         item.agentId,
@@ -84,8 +135,13 @@ export async function seedFeedback(client: PoolClient): Promise<void> {
         item.description,
         item.suggestion,
         item.status,
+        item.resolutionReason ?? null,
+        item.resolutionCommit ?? null,
+        item.roundNumber ?? 1,
+        item.respondsToKey ? (idsByKey.get(item.respondsToKey) ?? null) : null,
         ago(now, item.hoursAgo),
       ]
     );
+    idsByKey.set(item.key, rows[0]!.id);
   }
 }

--- a/apps/server/src/db/seed/index.ts
+++ b/apps/server/src/db/seed/index.ts
@@ -82,10 +82,10 @@ export async function seedDevData(
     await seedAgents(client);
     await seedActivityEvents(client);
     await seedTokenUsage(client);
+    await seedPersonaReviews(client);
     await seedFeedback(client);
     await seedMedia(client);
     await seedJobs(client);
-    await seedPersonaReviews(client);
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK");

--- a/apps/server/src/db/seed/persona-reviews.ts
+++ b/apps/server/src/db/seed/persona-reviews.ts
@@ -18,11 +18,12 @@ type ReviewerSeed = {
   persona: string;
   // When null, no persona_reviews row is created (shows the "no review yet" fallback).
   review: {
-    status: "reviewing" | "complete";
+    status: "reviewing" | "complete" | "awaiting_recheck";
     verdict: "approve" | "request_changes" | null;
     message: string | null;
     summary: string | null;
     roundNumber: number;
+    allowRecheck: boolean;
     minutesAgo: number;
     resolution: Resolution | null;
   } | null;
@@ -46,6 +47,7 @@ const REVIEWERS: ReviewerSeed[] = [
       message: "Scanning hook dependencies",
       summary: null,
       roundNumber: 1,
+      allowRecheck: false,
       minutesAgo: 1,
       resolution: null,
     },
@@ -65,8 +67,30 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Timezone drift and legend reset need to be resolved before merge. Keyboard focus regression on the day picker is also open.",
       roundNumber: 1,
+      allowRecheck: true,
       minutesAgo: 30,
       resolution: null,
+    },
+  },
+  {
+    id: "seed-review-awaiting-recheck",
+    persona: "release-review",
+    review: {
+      status: "awaiting_recheck",
+      verdict: "request_changes",
+      message: "Waiting for your resolution summary",
+      summary:
+        "The loading-state polish looks better, but I need to verify the final retry flow after your fixes land.",
+      roundNumber: 1,
+      allowRecheck: true,
+      minutesAgo: 20,
+      resolution: {
+        summary:
+          "Addressed the loading-state regressions and rewired retries through the shared fetch boundary.",
+        resolutionCommit: "c1a59ef",
+        roundNumber: 1,
+        minutesAgo: 5,
+      },
     },
   },
   {
@@ -79,6 +103,7 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Missing JSDoc on the public hooks export and the README example no longer compiles.",
       roundNumber: 1,
+      allowRecheck: false,
       minutesAgo: 90,
       resolution: {
         summary:
@@ -99,6 +124,7 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Round 2: the retry loop now handles the cache miss, but still bypasses the circuit breaker.",
       roundNumber: 2,
+      allowRecheck: true,
       minutesAgo: 60,
       resolution: {
         summary:
@@ -119,6 +145,7 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "No regressions on the hot path; p95 render time unchanged at 12ms.",
       roundNumber: 1,
+      allowRecheck: false,
       minutesAgo: 45,
       resolution: null,
     },
@@ -133,6 +160,7 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Focus order and ARIA labels look correct after the latest pass.",
       roundNumber: 1,
+      allowRecheck: false,
       minutesAgo: 120,
       resolution: {
         summary:
@@ -168,8 +196,8 @@ export async function seedPersonaReviews(client: PoolClient): Promise<void> {
       `
       INSERT INTO persona_reviews (
         agent_id, parent_agent_id, persona, status, verdict, message, summary,
-        files_reviewed, round_number, created_at, updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$10)
+        files_reviewed, round_number, allow_recheck, created_at, updated_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$11)
       RETURNING id
       `,
       [
@@ -182,6 +210,7 @@ export async function seedPersonaReviews(client: PoolClient): Promise<void> {
         r.summary,
         JSON.stringify([]),
         r.roundNumber,
+        r.allowRecheck,
         createdAt,
       ]
     );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4243,6 +4243,79 @@ async function registerRoutes() {
     }
   });
 
+  app.post("/api/v1/agents/:id/persona-reviews", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const body = request.body as {
+      persona?: unknown;
+      agentType?: unknown;
+      allowRecheck?: unknown;
+      context?: unknown;
+    } | null;
+    const agentId = params.id ?? "";
+
+    if (typeof body?.persona !== "string" || body.persona.trim().length === 0) {
+      return reply
+        .code(400)
+        .send({ error: "persona is required and must be a non-empty string." });
+    }
+
+    if (
+      body.agentType !== undefined &&
+      (typeof body.agentType !== "string" ||
+        !CLI_AGENT_TYPES.includes(
+          body.agentType as (typeof CLI_AGENT_TYPES)[number]
+        ))
+    ) {
+      return reply.code(400).send({
+        error: `agentType must be one of: ${CLI_AGENT_TYPES.join(", ")}`,
+      });
+    }
+
+    if (
+      body.allowRecheck !== undefined &&
+      typeof body.allowRecheck !== "boolean"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "allowRecheck must be a boolean when provided." });
+    }
+
+    if (body.context !== undefined && typeof body.context !== "string") {
+      return reply
+        .code(400)
+        .send({ error: "context must be a string when provided." });
+    }
+
+    try {
+      const parent = await agentManager.getAgent(agentId);
+      if (!parent) return reply.code(404).send({ error: "Agent not found." });
+
+      const context =
+        body.context?.trim() ||
+        [
+          `Review the current work for agent "${parent.name}".`,
+          "Inspect the current diff, changed files, and surrounding code.",
+          "Focus on actionable bugs, regressions, and missing validation.",
+        ].join(" ");
+
+      const result = await mcpLaunchPersona(agentId, {
+        persona: body.persona.trim(),
+        context,
+        agentType: body.agentType as
+          | (typeof CLI_AGENT_TYPES)[number]
+          | undefined,
+        allowRecheck: body.allowRecheck === true,
+      });
+      const agent = await agentManager.getAgent(result.agentId);
+      return {
+        agent: agent ? withStreamFlag(agent) : null,
+        agentId: result.agentId,
+      };
+    } catch (error) {
+      return handleAgentError(reply, error);
+    }
+  });
+
   // --- Feedback ---
 
   app.get("/api/v1/agents/:id/feedback", async (request, reply) => {
@@ -4393,6 +4466,38 @@ async function registerRoutes() {
             agent: withStreamFlag(parentAgent),
           });
         return { review: result.review, resolution: result.resolution };
+      } catch (error) {
+        return handleAgentError(reply, error);
+      }
+    }
+  );
+
+  app.post(
+    "/api/v1/agents/:id/persona-reviews/:personaAgentId/cancel-recheck",
+    async (request, reply) => {
+      const params = request.params as {
+        id?: string;
+        personaAgentId?: string;
+      };
+      const body = request.body as { reason?: unknown } | null;
+      const agentId = params.id ?? "";
+      const personaAgentId = params.personaAgentId ?? "";
+
+      if (body?.reason !== undefined && typeof body.reason !== "string") {
+        return reply
+          .code(400)
+          .send({ error: "reason must be a string when provided." });
+      }
+
+      try {
+        await mcpCancelRecheck(agentId, {
+          personaAgentId,
+          reason:
+            typeof body?.reason === "string" && body.reason.trim().length > 0
+              ? body.reason.trim()
+              : undefined,
+        });
+        return reply.code(204).send();
       } catch (error) {
         return handleAgentError(reply, error);
       }

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -105,6 +105,52 @@ function bySeverity(a: FeedbackItem, b: FeedbackItem): number {
   return (SEVERITY_ORDER[a.severity] ?? 4) - (SEVERITY_ORDER[b.severity] ?? 4);
 }
 
+function compareFeedbackForPanel(a: FeedbackItem, b: FeedbackItem): number {
+  if (a.roundNumber !== b.roundNumber) {
+    return a.roundNumber - b.roundNumber;
+  }
+  const aThread = a.respondsToFeedbackId ?? a.id;
+  const bThread = b.respondsToFeedbackId ?? b.id;
+  if (aThread !== bThread) {
+    return aThread - bThread;
+  }
+  return bySeverity(a, b);
+}
+
+function shortSha(sha: string | null | undefined): string | null {
+  if (!sha) return null;
+  return sha.slice(0, 7);
+}
+
+function RoundChip({
+  roundNumber,
+  pending = false,
+}: {
+  roundNumber: number;
+  pending?: boolean;
+}): JSX.Element {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider",
+        pending
+          ? "border-status-reviewing/35 bg-status-reviewing/10 text-status-reviewing"
+          : roundNumber >= 2
+            ? "border-orange-500/30 bg-orange-500/10 text-orange-500"
+            : "border-border bg-muted/50 text-muted-foreground"
+      )}
+    >
+      {pending ? "R2 pending" : `R${roundNumber}`}
+    </span>
+  );
+}
+
+function canCancelRecheck(agent: Agent): boolean {
+  const review = agent.review;
+  if (!review?.allowRecheck) return false;
+  return review.status === "awaiting_recheck";
+}
+
 function formatFeedbackText(item: FeedbackItem): string {
   const parts: string[] = [];
   if (item.filePath)
@@ -417,9 +463,26 @@ export function ParentFeedbackPanel({
             const agentActive = activeFeedbackByAgent.get(child.id) ?? [];
             const agentResolved = resolvedFeedbackByAgent.get(child.id) ?? [];
             const showingResolved = showResolvedAgents.has(child.id);
-            const items = showingResolved
-              ? [...agentActive, ...agentResolved]
-              : agentActive;
+            const round2Items = [...agentActive, ...agentResolved].filter(
+              (item) => item.roundNumber >= 2
+            );
+            const linkedRound1Ids = new Set(
+              round2Items
+                .map((item) => item.respondsToFeedbackId)
+                .filter((value): value is number => value != null)
+            );
+            const linkedRound1Items = [...agentActive, ...agentResolved].filter(
+              (item) => item.roundNumber === 1 && linkedRound1Ids.has(item.id)
+            );
+            const items = (
+              showingResolved
+                ? [...agentActive, ...agentResolved]
+                : [...agentActive, ...linkedRound1Items]
+            ).filter(
+              (item, index, all) =>
+                all.findIndex((candidate) => candidate.id === item.id) === index
+            );
+            items.sort(compareFeedbackForPanel);
             const isGroupCollapsed = collapsedGroups.has(child.id);
             const childState = getVisualState?.(child);
             const unresolvedCount = agentActive.length;
@@ -525,18 +588,31 @@ export function ParentFeedbackPanel({
                                 const statusLabel = STATUS_LABELS[item.status];
                                 const isSelected =
                                   item.id === activeDetailItemId;
+                                const isRecheckItem =
+                                  item.roundNumber >= 2 &&
+                                  item.respondsToFeedbackId != null;
+                                const showRoundDivider =
+                                  item.roundNumber >= 2 &&
+                                  items.findIndex(
+                                    (candidate) => candidate.roundNumber >= 2
+                                  ) === items.indexOf(item);
 
                                 return (
-                                  <div
-                                    key={item.id}
-                                    className={cn(
-                                      !isActionable && "opacity-40"
-                                    )}
-                                  >
+                                  <div key={item.id}>
+                                    {showRoundDivider ? (
+                                      <div className="mb-1 mt-2 flex items-center gap-2 px-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">
+                                        <span className="h-px flex-1 bg-border/70" />
+                                        <span>Round 2 findings</span>
+                                        <span className="h-px flex-1 bg-border/70" />
+                                      </div>
+                                    ) : null}
                                     <button
                                       className={cn(
                                         "flex w-full flex-col gap-0.5 rounded-md px-1.5 py-1.5 text-left text-[11px] transition-colors",
                                         "border-b-2",
+                                        isRecheckItem &&
+                                          "ml-4 border-l border-border/60 pl-3",
+                                        !isActionable && "opacity-40",
                                         isSelected
                                           ? "border-primary"
                                           : "border-transparent hover:bg-muted/40"
@@ -566,6 +642,9 @@ export function ParentFeedbackPanel({
                                       }}
                                     >
                                       <div className="flex w-full items-center gap-2">
+                                        <RoundChip
+                                          roundNumber={item.roundNumber}
+                                        />
                                         <span
                                           className={cn(
                                             "h-1.5 w-1.5 shrink-0 rounded-full",
@@ -600,6 +679,12 @@ export function ParentFeedbackPanel({
                                           </span>
                                         ) : null}
                                       </div>
+                                      {isRecheckItem ? (
+                                        <div className="ml-8 text-[10px] text-muted-foreground/70">
+                                          Follow-up to round-1 finding #
+                                          {item.respondsToFeedbackId}
+                                        </div>
+                                      ) : null}
                                       {!isActionable &&
                                       item.resolutionReason ? (
                                         <div
@@ -727,11 +812,6 @@ function useFeedbackData(parentAgentId: string) {
   return { feedback, personaAttribution, updateStatus };
 }
 
-function shortSha(sha: string | null | undefined): string | null {
-  if (!sha) return null;
-  return sha.slice(0, 7);
-}
-
 function ResolutionInfoBlock({
   item,
   className,
@@ -760,6 +840,51 @@ function ResolutionInfoBlock({
         </div>
       ) : null}
     </div>
+  );
+}
+
+function CancelRecheckButton({
+  parentAgentId,
+  agent,
+  onDone,
+}: {
+  parentAgentId: string;
+  agent: Agent;
+  onDone?: () => void;
+}): JSX.Element | null {
+  const queryClient = useQueryClient();
+
+  if (!canCancelRecheck(agent)) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 px-2 text-xs text-muted-foreground/80 hover:text-foreground"
+      onClick={() => {
+        const confirmed = window.confirm(
+          "Cancel the recheck and let this reviewer exit?"
+        );
+        if (!confirmed) return;
+        void api(
+          `/api/v1/agents/${parentAgentId}/persona-reviews/${agent.id}/cancel-recheck`,
+          { method: "POST" }
+        ).then(async () => {
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: ["agents"] }),
+            queryClient.invalidateQueries({
+              queryKey: ["feedback", parentAgentId, "children"],
+            }),
+          ]);
+          onDone?.();
+        });
+      }}
+      data-testid="cancel-recheck-button"
+    >
+      Cancel recheck
+    </Button>
   );
 }
 
@@ -972,6 +1097,7 @@ export function FeedbackDetailPanel({
       <div className="flex items-center justify-between shrink-0 mb-3">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <Badge variant={severityInfo!.variant}>{severityInfo!.label}</Badge>
+          <RoundChip roundNumber={item.roundNumber} />
           <span className="text-base font-semibold truncate">
             {item.filePath
               ? `${item.filePath}${item.lineNumber ? `:${item.lineNumber}` : ""}`
@@ -1119,6 +1245,12 @@ export function ReviewSummaryPanel({
               {reviewVerdictLabel(verdict)}
             </Badge>
           ) : null}
+          {agent.review ? (
+            <RoundChip
+              roundNumber={agent.review.roundNumber}
+              pending={agent.review.status === "awaiting_recheck"}
+            />
+          ) : null}
           <span className="text-base font-semibold truncate">
             Review Summary
           </span>
@@ -1194,6 +1326,10 @@ export function ReviewSummaryPanel({
             No summary available.
           </div>
         ) : null}
+      </div>
+
+      <div className="mt-3 flex justify-end border-t border-border pt-3">
+        <CancelRecheckButton parentAgentId={parentAgentId} agent={agent} />
       </div>
     </div>
   );
@@ -1365,6 +1501,7 @@ export function MobileFeedbackSheet({
                 >
                   {severityInfoValue!.label}
                 </Badge>
+                {item ? <RoundChip roundNumber={item.roundNumber} /> : null}
                 <SheetDescription className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
                   {attr ? (
                     <>
@@ -1512,6 +1649,12 @@ export function MobileReviewSummarySheet({
                 {reviewVerdictLabel(verdict)}
               </Badge>
             ) : null}
+            {agent.review ? (
+              <RoundChip
+                roundNumber={agent.review.roundNumber}
+                pending={agent.review.status === "awaiting_recheck"}
+              />
+            ) : null}
             <SheetDescription className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
               {attr ? (
                 <>
@@ -1585,6 +1728,14 @@ export function MobileReviewSummarySheet({
               No summary available.
             </div>
           ) : null}
+        </div>
+
+        <div className="mt-3 flex justify-end border-t border-border pt-3">
+          <CancelRecheckButton
+            parentAgentId={parentAgentId}
+            agent={agent}
+            onDone={onClose}
+          />
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -458,6 +458,10 @@ export function ParentFeedbackPanel({
   return (
     <>
       <div className="mt-1.5">
+        <div className="mb-2 flex items-center justify-between px-1.5 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+          <span>Persona reviews</span>
+          <span>Verdicts and findings</span>
+        </div>
         <div className="space-y-1.5">
           {childAgents.map((child, childIndex) => {
             const agentActive = activeFeedbackByAgent.get(child.id) ?? [];
@@ -578,6 +582,9 @@ export function ParentFeedbackPanel({
                             className="overflow-hidden"
                           >
                             <div className="ml-8 mt-0.5 space-y-px">
+                              <div className="px-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/60">
+                                Findings
+                              </div>
                               {items.map((item) => {
                                 const isActionable =
                                   item.status === "open" ||
@@ -853,38 +860,60 @@ function CancelRecheckButton({
   onDone?: () => void;
 }): JSX.Element | null {
   const queryClient = useQueryClient();
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (!canCancelRecheck(agent)) {
     return null;
   }
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      className="h-7 px-2 text-xs text-muted-foreground/80 hover:text-foreground"
-      onClick={() => {
-        const confirmed = window.confirm(
-          "Cancel the recheck and let this reviewer exit?"
-        );
-        if (!confirmed) return;
-        void api(
-          `/api/v1/agents/${parentAgentId}/persona-reviews/${agent.id}/cancel-recheck`,
-          { method: "POST" }
-        ).then(async () => {
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ["agents"] }),
-            queryClient.invalidateQueries({
-              queryKey: ["feedback", parentAgentId, "children"],
-            }),
-          ]);
-          onDone?.();
-        });
-      }}
-      data-testid="cancel-recheck-button"
-    >
-      Cancel recheck
-    </Button>
+    <div className="flex flex-col items-end gap-1">
+      {error ? (
+        <div
+          className="text-[11px] text-status-blocked"
+          data-testid="cancel-recheck-error"
+        >
+          {error}
+        </div>
+      ) : null}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 text-xs text-muted-foreground/80 hover:text-foreground"
+        disabled={isCancelling}
+        onClick={() => {
+          const confirmed = window.confirm(
+            "Cancel the recheck and let this reviewer exit?"
+          );
+          if (!confirmed) return;
+          setIsCancelling(true);
+          setError(null);
+          void api(
+            `/api/v1/agents/${parentAgentId}/persona-reviews/${agent.id}/cancel-recheck`,
+            { method: "POST" }
+          )
+            .then(async () => {
+              await Promise.all([
+                queryClient.invalidateQueries({ queryKey: ["agents"] }),
+                queryClient.invalidateQueries({
+                  queryKey: ["feedback", parentAgentId, "children"],
+                }),
+              ]);
+              onDone?.();
+            })
+            .catch((err: Error) => {
+              setError(err.message || "Could not cancel recheck.");
+            })
+            .finally(() => {
+              setIsCancelling(false);
+            });
+        }}
+        data-testid="cancel-recheck-button"
+      >
+        {isCancelling ? "Cancelling..." : "Cancel recheck"}
+      </Button>
+    </div>
   );
 }
 

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -272,7 +272,7 @@ function stepsFromReview(
     step2 = { label: "Rechecking", color: "orange", filled: false };
   } else if (allowRecheck && roundNumber < 2) {
     step2 = hasResolution
-      ? { label: "Awaiting resolution", color: "muted", filled: false }
+      ? { label: "Awaiting recheck", color: "muted", filled: false }
       : { label: "Awaiting resolution", color: "muted", filled: false };
   } else {
     step2 = hasResolution

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -271,9 +271,12 @@ function stepsFromReview(
   if (reviewStatus === "awaiting_recheck") {
     step2 = { label: "Rechecking", color: "orange", filled: false };
   } else if (allowRecheck && roundNumber < 2) {
-    step2 = hasResolution
-      ? { label: "Awaiting resolution", color: "muted", filled: false }
-      : { label: "Awaiting resolution", color: "muted", filled: false };
+    step2 =
+      verdict === "request_changes"
+        ? hasResolution
+          ? { label: "Awaiting recheck", color: "muted", filled: false }
+          : { label: "Awaiting resolution", color: "muted", filled: false }
+        : { label: "Awaiting recheck", color: "muted", filled: false };
   } else {
     step2 = hasResolution
       ? { label: "Responded", color: "muted", filled: true }

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -188,7 +188,7 @@ function StepRow({
   return (
     <span
       className={cn(
-        "flex items-center gap-1.5 whitespace-nowrap",
+        "flex min-w-0 items-center gap-1.5",
         emphasis === "strong" ? "font-semibold" : "font-medium",
         STEP_COLOR[step.color]
       )}
@@ -198,7 +198,7 @@ function StepRow({
       ) : (
         <CircleDashed className="h-2.5 w-2.5 shrink-0" strokeWidth={2} />
       )}
-      <span>{step.label}</span>
+      <span className="truncate">{step.label}</span>
     </span>
   );
 }
@@ -262,8 +262,8 @@ function stepsFromReview(
   const step1: StepDef = {
     label:
       roundNumber >= 2
-        ? `Verdict (R2): ${reviewVerdictLabel(verdict)}`
-        : `Verdict: ${reviewVerdictLabel(verdict)}`,
+        ? `${reviewVerdictLabel(verdict)} (R2)`
+        : reviewVerdictLabel(verdict),
     color: verdict === "approve" ? "emerald" : "orange",
     filled: true,
   };
@@ -272,8 +272,8 @@ function stepsFromReview(
     step2 = { label: "Rechecking", color: "orange", filled: false };
   } else if (allowRecheck && roundNumber < 2) {
     step2 = hasResolution
-      ? { label: "Awaiting your resolution", color: "muted", filled: false }
-      : { label: "Awaiting your resolution", color: "muted", filled: false };
+      ? { label: "Awaiting resolution", color: "muted", filled: false }
+      : { label: "Awaiting resolution", color: "muted", filled: false };
   } else {
     step2 = hasResolution
       ? { label: "Responded", color: "muted", filled: true }
@@ -323,13 +323,12 @@ export function PersonaAgentRow({
         isReviewing && "persona-reviewing-row"
       )}
     >
-      <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+      <div className="flex shrink-0 items-center pt-0.5">
         <PersonaStatusIcon
           reviewStatus={reviewStatus}
           verdict={verdict}
           className="h-5 w-5"
         />
-        {roundBadge ? <RoundBadge badge={roundBadge} /> : null}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-start gap-1.5">
@@ -340,6 +339,7 @@ export function PersonaAgentRow({
             {child.persona ?? child.name}
           </span>
           <div className="flex shrink-0 items-center gap-1">
+            {roundBadge ? <RoundBadge badge={roundBadge} /> : null}
             {feedbackCount != null && feedbackCount > 0 ? (
               <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-status-waiting/45 bg-status-waiting/15 px-1.5 text-[10px] font-semibold text-status-waiting">
                 {feedbackCount}

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -271,12 +271,9 @@ function stepsFromReview(
   if (reviewStatus === "awaiting_recheck") {
     step2 = { label: "Rechecking", color: "orange", filled: false };
   } else if (allowRecheck && roundNumber < 2) {
-    step2 =
-      verdict === "request_changes"
-        ? hasResolution
-          ? { label: "Awaiting recheck", color: "muted", filled: false }
-          : { label: "Awaiting resolution", color: "muted", filled: false }
-        : { label: "Awaiting recheck", color: "muted", filled: false };
+    step2 = hasResolution
+      ? { label: "Awaiting resolution", color: "muted", filled: false }
+      : { label: "Awaiting resolution", color: "muted", filled: false };
   } else {
     step2 = hasResolution
       ? { label: "Responded", color: "muted", filled: true }

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -38,6 +38,42 @@ export type PersonaAgentRowProps = {
   onOpenSummary?: () => void;
 };
 
+type ReviewRoundBadge = {
+  label: string;
+  tone: "muted" | "pending" | "complete";
+};
+
+function getRoundBadge(child: Agent): ReviewRoundBadge | null {
+  const review = child.review;
+  if (!review) return null;
+  if (review.status === "awaiting_recheck") {
+    return { label: "R2 pending", tone: "pending" };
+  }
+  if (review.roundNumber >= 2) {
+    return { label: "R2", tone: "complete" };
+  }
+  return { label: "R1", tone: "muted" };
+}
+
+function RoundBadge({ badge }: { badge: ReviewRoundBadge }): JSX.Element {
+  const toneClass =
+    badge.tone === "complete"
+      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+      : badge.tone === "pending"
+        ? "border-status-reviewing/40 bg-status-reviewing/10 text-status-reviewing"
+        : "border-border bg-muted/60 text-muted-foreground";
+  return (
+    <span
+      className={cn(
+        "inline-flex h-5 items-center rounded border px-1.5 text-[9px] font-semibold uppercase tracking-wider",
+        toneClass
+      )}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
 function PersonaStatusIcon({
   reviewStatus,
   verdict,
@@ -174,12 +210,10 @@ function StepRow({
 function ReviewStatusButton({
   step1,
   step2,
-  round,
   onOpen,
 }: {
   step1: StepDef;
   step2: StepDef;
-  round?: number;
   onOpen?: () => void;
 }): JSX.Element {
   const ariaLabel = `${step1.label} — ${step2.label}`;
@@ -188,11 +222,6 @@ function ReviewStatusButton({
     <>
       <StepRow step={step1} emphasis="strong" />
       <StepRow step={step2} emphasis="soft" />
-      {typeof round === "number" && round > 1 ? (
-        <span className="absolute right-1.5 top-1.5 inline-flex h-3.5 items-center rounded border border-border bg-muted/60 px-1 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
-          R{round}
-        </span>
-      ) : null}
     </>
   );
 
@@ -222,19 +251,34 @@ function ReviewStatusButton({
   );
 }
 
-/** Derive stacked-row step primitives from Phase 1 review data. */
 function stepsFromReview(
-  verdict: ReviewVerdict,
-  hasResolution: boolean
+  child: Agent,
+  verdict: ReviewVerdict
 ): { step1: StepDef; step2: StepDef } {
+  const hasResolution = !!child.review?.resolution?.summary;
+  const roundNumber = child.review?.roundNumber ?? 1;
+  const allowRecheck = child.review?.allowRecheck ?? false;
+  const reviewStatus = child.review?.status ?? null;
   const step1: StepDef = {
-    label: reviewVerdictLabel(verdict),
+    label:
+      roundNumber >= 2
+        ? `Verdict (R2): ${reviewVerdictLabel(verdict)}`
+        : `Verdict: ${reviewVerdictLabel(verdict)}`,
     color: verdict === "approve" ? "emerald" : "orange",
     filled: true,
   };
-  const step2: StepDef = hasResolution
-    ? { label: "Responded", color: "muted", filled: true }
-    : { label: "Awaiting response", color: "muted", filled: false };
+  let step2: StepDef;
+  if (reviewStatus === "awaiting_recheck") {
+    step2 = { label: "Rechecking", color: "orange", filled: false };
+  } else if (allowRecheck && roundNumber < 2) {
+    step2 = hasResolution
+      ? { label: "Awaiting your resolution", color: "muted", filled: false }
+      : { label: "Awaiting your resolution", color: "muted", filled: false };
+  } else {
+    step2 = hasResolution
+      ? { label: "Responded", color: "muted", filled: true }
+      : { label: "Awaiting response", color: "muted", filled: false };
+  }
   return { step1, step2 };
 }
 
@@ -265,6 +309,8 @@ export function PersonaAgentRow({
   const resolution = getResolution(child);
   const hasResolution = !!resolution?.summary;
   const reviewMessage = child.review?.message?.split("\n")[0] ?? null;
+  const roundBadge = getRoundBadge(child);
+  const isAwaitingRecheck = reviewStatus === "awaiting_recheck";
 
   return (
     <div
@@ -277,11 +323,14 @@ export function PersonaAgentRow({
         isReviewing && "persona-reviewing-row"
       )}
     >
-      <PersonaStatusIcon
-        reviewStatus={reviewStatus}
-        verdict={verdict}
-        className="h-5 w-5"
-      />
+      <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+        <PersonaStatusIcon
+          reviewStatus={reviewStatus}
+          verdict={verdict}
+          className="h-5 w-5"
+        />
+        {roundBadge ? <RoundBadge badge={roundBadge} /> : null}
+      </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-start gap-1.5">
           <span
@@ -305,10 +354,13 @@ export function PersonaAgentRow({
         </div>
         {verdict ? (
           <ReviewStatusButton
-            {...stepsFromReview(verdict, hasResolution)}
-            round={resolution?.roundNumber}
+            {...stepsFromReview(child, verdict)}
             onOpen={hasSummary || hasResolution ? onOpenSummary : undefined}
           />
+        ) : isAwaitingRecheck ? (
+          <div className="mt-1.5 text-[10px] font-medium text-status-reviewing">
+            Rechecking
+          </div>
         ) : isReviewing ? (
           <div className="mt-1.5 text-[10px] font-medium text-status-reviewing">
             {reviewMessage ?? "Reviewing"}

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,15 +1,22 @@
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, CircleAlert } from "lucide-react";
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { api } from "@/lib/api";
 import {
   AGENT_TYPE_LABELS,
@@ -36,6 +43,8 @@ export function PersonaLauncher({
 }): JSX.Element | null {
   const queryClient = useQueryClient();
   const cwd = agent.worktreePath ?? agent.cwd;
+  const [allowRecheck, setAllowRecheck] = useState(false);
+  const [isLaunching, setIsLaunching] = useState(false);
 
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
     queryKey: ["personas", cwd],
@@ -61,10 +70,33 @@ export function PersonaLauncher({
       ? agent.type
       : "codex");
 
-  const launchPersona = (slug: string) => {
-    if (!sendTerminalInput) return;
-    const message = `Launch the "${slug}" persona on your current work. Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.`;
-    sendTerminalInput(message + "\r");
+  const launchPersona = async (slug: string) => {
+    if (isLaunching) return;
+    setIsLaunching(true);
+    try {
+      await api(`/api/v1/agents/${agent.id}/persona-reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          persona: slug,
+          agentType: reviewAgentType,
+          allowRecheck,
+        }),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["agents"] });
+    } catch (error) {
+      if (sendTerminalInput) {
+        const message = [
+          `Use the dispatch_launch_persona MCP tool to launch the "${slug}" persona on your current work.`,
+          `Use agentType: "${reviewAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
+          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
+        ].join(" ");
+        sendTerminalInput(message + "\r");
+      } else {
+        throw error;
+      }
+    } finally {
+      setIsLaunching(false);
+    }
   };
 
   const updateReviewAgentType = async (nextType: AgentType): Promise<void> => {
@@ -85,93 +117,128 @@ export function PersonaLauncher({
   };
 
   return (
-    <div className="flex items-center">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            disabled={disabled}
-            className={
-              showReviewAgentTypePicker
-                ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-                : "gap-1.5 border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-            }
-            data-testid="launch-reviewer-button"
-          >
-            <AgentTypeIcon
-              type={reviewAgentType}
-              className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
-            />
-            Review
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          {personas.map((p, i) => {
-            const colorVar = `var(--chart-${(i % 4) + 1})`;
-            return (
-              <DropdownMenuItem
-                key={p.slug}
-                className="text-foreground"
-                onClick={() => launchPersona(p.slug)}
-              >
-                <div className="flex items-start gap-2.5">
-                  <div
-                    className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: `hsl(${colorVar})` }}
-                  />
-                  <div>
-                    <div
-                      className="text-sm font-medium"
-                      style={{ color: `hsl(${colorVar})` }}
-                    >
-                      {p.name}
-                    </div>
-                    {p.description ? (
-                      <div className="text-xs text-muted-foreground">
-                        {p.description}
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {showReviewAgentTypePicker ? (
+    <div className="flex flex-col items-start gap-2">
+      <div className="flex items-center">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
-              disabled={disabled}
-              className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-              data-testid="launch-reviewer-type-dropdown"
+              disabled={disabled || isLaunching}
+              className={
+                showReviewAgentTypePicker
+                  ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+                  : "gap-1.5 border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+              }
+              data-testid="launch-reviewer-button"
             >
-              <ChevronDown className="h-3.5 w-3.5" />
+              <AgentTypeIcon
+                type={reviewAgentType}
+                className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
+              />
+              Review
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {reviewerTypes.map((agentType) => (
-              <DropdownMenuItem
-                key={agentType}
-                className="text-foreground"
-                onClick={() => {
-                  void updateReviewAgentType(agentType);
-                }}
-                data-testid={`launch-reviewer-type-${agentType}`}
-              >
-                <span className="flex items-center gap-3">
-                  <Check
-                    className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
-                  />
-                  <span>{AGENT_TYPE_LABELS[agentType]}</span>
-                </span>
-              </DropdownMenuItem>
-            ))}
+          <DropdownMenuContent align="start">
+            {personas.map((p, i) => {
+              const colorVar = `var(--chart-${(i % 4) + 1})`;
+              return (
+                <DropdownMenuItem
+                  key={p.slug}
+                  className="text-foreground"
+                  onClick={() => {
+                    void launchPersona(p.slug);
+                  }}
+                >
+                  <div className="flex items-start gap-2.5">
+                    <div
+                      className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: `hsl(${colorVar})` }}
+                    />
+                    <div>
+                      <div
+                        className="text-sm font-medium"
+                        style={{ color: `hsl(${colorVar})` }}
+                      >
+                        {p.name}
+                      </div>
+                      {p.description ? (
+                        <div className="text-xs text-muted-foreground">
+                          {p.description}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </DropdownMenuItem>
+              );
+            })}
           </DropdownMenuContent>
         </DropdownMenu>
-      ) : null}
+
+        {showReviewAgentTypePicker ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                disabled={disabled || isLaunching}
+                className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+                data-testid="launch-reviewer-type-dropdown"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {reviewerTypes.map((agentType) => (
+                <DropdownMenuItem
+                  key={agentType}
+                  className="text-foreground"
+                  onClick={() => {
+                    void updateReviewAgentType(agentType);
+                  }}
+                  data-testid={`launch-reviewer-type-${agentType}`}
+                >
+                  <span className="flex items-center gap-3">
+                    <Check
+                      className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
+                    />
+                    <span>{AGENT_TYPE_LABELS[agentType]}</span>
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+
+      <div className="flex items-start gap-2 pl-1">
+        <Checkbox
+          id={`persona-recheck-${agent.id}`}
+          checked={allowRecheck}
+          disabled={disabled || isLaunching}
+          onCheckedChange={(checked) => setAllowRecheck(checked === true)}
+          data-testid="launch-reviewer-allow-recheck"
+        />
+        <label
+          htmlFor={`persona-recheck-${agent.id}`}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        >
+          <span>Re-review after I address feedback</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground/70 transition-colors hover:text-foreground"
+                aria-label="About re-review"
+              >
+                <CircleAlert className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64 text-xs">
+              Reviewer will stay alive after its initial verdict and verify your
+              resolution (~several extra minutes).
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -58,7 +58,7 @@ function defaultReviewAgentType(agent: Agent): AgentType {
 export function PersonaLauncher({
   agent,
   enabledAgentTypes,
-  sendTerminalInput,
+  sendTerminalInput: _sendTerminalInput,
   disabled = false,
 }: {
   agent: Agent;
@@ -139,18 +139,6 @@ export function PersonaLauncher({
       });
       await queryClient.invalidateQueries({ queryKey: ["agents"] });
       setDialogOpen(false);
-    } catch (error) {
-      if (sendTerminalInput) {
-        const message = [
-          `Use the dispatch_launch_persona MCP tool to launch the "${selectedPersona}" persona on your current work.`,
-          `Use agentType: "${selectedAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
-          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
-        ].join(" ");
-        sendTerminalInput(message + "\r");
-        setDialogOpen(false);
-      } else {
-        throw error;
-      }
     } finally {
       setIsLaunching(false);
     }

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,11 +1,24 @@
 import { Check, ChevronDown, CircleAlert } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,18 +30,30 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useClickOutside } from "@/hooks/use-click-outside";
 import { api } from "@/lib/api";
+import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import {
   AGENT_TYPE_LABELS,
   type AgentType,
   isCliAgentType,
 } from "@/lib/agent-types";
+import { cn } from "@/lib/utils";
 
 type PersonaSummary = {
   slug: string;
   name: string;
   description: string;
 };
+
+function defaultReviewAgentType(agent: Agent): AgentType {
+  return (
+    agent.reviewAgentType ??
+    (agent.type === "claude" || agent.type === "opencode"
+      ? agent.type
+      : "codex")
+  );
+}
 
 export function PersonaLauncher({
   agent,
@@ -43,8 +68,18 @@ export function PersonaLauncher({
 }): JSX.Element | null {
   const queryClient = useQueryClient();
   const cwd = agent.worktreePath ?? agent.cwd;
+  const reviewerTypes = enabledAgentTypes.filter(isCliAgentType);
+  const showReviewAgentTypePicker = reviewerTypes.length > 1;
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedPersona, setSelectedPersona] = useState<string | null>(null);
+  const [selectedAgentType, setSelectedAgentType] = useState<AgentType>(
+    defaultReviewAgentType(agent)
+  );
   const [allowRecheck, setAllowRecheck] = useState(false);
   const [isLaunching, setIsLaunching] = useState(false);
+  const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
+  const typeCmdRef = useRef<HTMLDivElement>(null);
+  const typeTriggerRef = useRef<HTMLButtonElement>(null);
 
   const { data: personas = [] } = useQuery<PersonaSummary[]>({
     queryKey: ["personas", cwd],
@@ -55,51 +90,24 @@ export function PersonaLauncher({
       return result.personas;
     },
   });
-  const hasPersonas = personas.length > 0;
-  // Terminal agents can't run personas — exclude from review type options.
-  const reviewerTypes = enabledAgentTypes.filter(isCliAgentType);
-  const showReviewAgentTypePicker = reviewerTypes.length > 1;
 
-  if (!hasPersonas) {
+  const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
+  useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
+
+  if (personas.length === 0) {
     return null;
   }
 
-  const reviewAgentType =
-    agent.reviewAgentType ??
-    (agent.type === "claude" || agent.type === "opencode"
-      ? agent.type
-      : "codex");
-
-  const launchPersona = async (slug: string) => {
-    if (isLaunching) return;
-    setIsLaunching(true);
-    try {
-      await api(`/api/v1/agents/${agent.id}/persona-reviews`, {
-        method: "POST",
-        body: JSON.stringify({
-          persona: slug,
-          agentType: reviewAgentType,
-          allowRecheck,
-        }),
-      });
-      await queryClient.invalidateQueries({ queryKey: ["agents"] });
-    } catch (error) {
-      if (sendTerminalInput) {
-        const message = [
-          `Use the dispatch_launch_persona MCP tool to launch the "${slug}" persona on your current work.`,
-          `Use agentType: "${reviewAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
-          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
-        ].join(" ");
-        sendTerminalInput(message + "\r");
-      } else {
-        throw error;
-      }
-    } finally {
-      setIsLaunching(false);
-    }
+  const openDialog = (agentType = defaultReviewAgentType(agent)) => {
+    setSelectedAgentType(agentType);
+    setSelectedPersona(null);
+    setAllowRecheck(false);
+    setTypeDropdownOpen(false);
+    setDialogOpen(true);
   };
 
-  const updateReviewAgentType = async (nextType: AgentType): Promise<void> => {
+  const persistReviewAgentType = async (nextType: AgentType): Promise<void> => {
+    if (agent.reviewAgentType === nextType) return;
     const result = await api<{ agent: Agent }>(
       `/api/v1/agents/${agent.id}/review-agent-type`,
       {
@@ -116,63 +124,58 @@ export function PersonaLauncher({
     );
   };
 
+  const launchPersona = async () => {
+    if (!selectedPersona || isLaunching) return;
+    setIsLaunching(true);
+    try {
+      await persistReviewAgentType(selectedAgentType);
+      await api(`/api/v1/agents/${agent.id}/persona-reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          persona: selectedPersona,
+          agentType: selectedAgentType,
+          allowRecheck,
+        }),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["agents"] });
+      setDialogOpen(false);
+    } catch (error) {
+      if (sendTerminalInput) {
+        const message = [
+          `Use the dispatch_launch_persona MCP tool to launch the "${selectedPersona}" persona on your current work.`,
+          `Use agentType: "${selectedAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
+          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
+        ].join(" ");
+        sendTerminalInput(message + "\r");
+        setDialogOpen(false);
+      } else {
+        throw error;
+      }
+    } finally {
+      setIsLaunching(false);
+    }
+  };
+
   return (
-    <div className="flex flex-col items-start gap-2">
+    <>
       <div className="flex items-center">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              disabled={disabled || isLaunching}
-              className={
-                showReviewAgentTypePicker
-                  ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-                  : "gap-1.5 border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
-              }
-              data-testid="launch-reviewer-button"
-            >
-              <AgentTypeIcon
-                type={reviewAgentType}
-                className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
-              />
-              Review
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            {personas.map((p, i) => {
-              const colorVar = `var(--chart-${(i % 4) + 1})`;
-              return (
-                <DropdownMenuItem
-                  key={p.slug}
-                  className="text-foreground"
-                  onClick={() => {
-                    void launchPersona(p.slug);
-                  }}
-                >
-                  <div className="flex items-start gap-2.5">
-                    <div
-                      className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: `hsl(${colorVar})` }}
-                    />
-                    <div>
-                      <div
-                        className="text-sm font-medium"
-                        style={{ color: `hsl(${colorVar})` }}
-                      >
-                        {p.name}
-                      </div>
-                      {p.description ? (
-                        <div className="text-xs text-muted-foreground">
-                          {p.description}
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                </DropdownMenuItem>
-              );
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Button
+          variant="ghost"
+          disabled={disabled || isLaunching}
+          className={
+            showReviewAgentTypePicker
+              ? "gap-1.5 rounded-r-none border border-white/[0.12] border-r-0 bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+              : "gap-1.5 border border-white/[0.12] bg-white/[0.06] backdrop-blur-md text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
+          }
+          data-testid="launch-reviewer-button"
+          onClick={() => openDialog()}
+        >
+          <AgentTypeIcon
+            type={defaultReviewAgentType(agent)}
+            className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
+          />
+          Review
+        </Button>
 
         {showReviewAgentTypePicker ? (
           <DropdownMenu>
@@ -191,14 +194,13 @@ export function PersonaLauncher({
                 <DropdownMenuItem
                   key={agentType}
                   className="text-foreground"
-                  onClick={() => {
-                    void updateReviewAgentType(agentType);
-                  }}
+                  onClick={() => openDialog(agentType)}
                   data-testid={`launch-reviewer-type-${agentType}`}
                 >
                   <span className="flex items-center gap-3">
-                    <Check
-                      className={`h-3.5 w-3.5 shrink-0 ${agentType === reviewAgentType ? "opacity-100" : "opacity-0"}`}
+                    <AgentTypeIcon
+                      type={agentType}
+                      className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
                     />
                     <span>{AGENT_TYPE_LABELS[agentType]}</span>
                   </span>
@@ -209,36 +211,236 @@ export function PersonaLauncher({
         ) : null}
       </div>
 
-      <div className="flex items-start gap-2 pl-1">
-        <Checkbox
-          id={`persona-recheck-${agent.id}`}
-          checked={allowRecheck}
-          disabled={disabled || isLaunching}
-          onCheckedChange={(checked) => setAllowRecheck(checked === true)}
-          data-testid="launch-reviewer-allow-recheck"
-        />
-        <label
-          htmlFor={`persona-recheck-${agent.id}`}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground"
-        >
-          <span>Re-review after I address feedback</span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="text-muted-foreground/70 transition-colors hover:text-foreground"
-                aria-label="About re-review"
-              >
-                <CircleAlert className="h-3.5 w-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-64 text-xs">
-              Reviewer will stay alive after its initial verdict and verify your
-              resolution (~several extra minutes).
-            </TooltipContent>
-          </Tooltip>
-        </label>
-      </div>
-    </div>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        {dialogOpen ? (
+          <DialogContent
+            onEscapeKeyDown={(e) => {
+              swallowEscapeFromCombobox(e);
+              if (e.defaultPrevented) return;
+              if (typeDropdownOpen) {
+                e.preventDefault();
+              }
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>Launch Review</DialogTitle>
+              <DialogDescription>
+                Pick a reviewer persona, review agent type, and whether to ask
+                for a follow-up verification pass.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex min-h-0 flex-col">
+              <div className="min-h-0 flex-1 overflow-y-auto px-1">
+                <div className="space-y-3">
+                  <div className="relative space-y-1" ref={typeCmdRef}>
+                    <label className="text-sm text-muted-foreground">
+                      Agent type
+                    </label>
+                    <button
+                      ref={typeTriggerRef}
+                      type="button"
+                      role="combobox"
+                      aria-expanded={typeDropdownOpen}
+                      onClick={() => setTypeDropdownOpen((prev) => !prev)}
+                      onKeyDown={(e) => {
+                        if (
+                          e.key === "ArrowDown" ||
+                          e.key === "Enter" ||
+                          e.key === " "
+                        ) {
+                          e.preventDefault();
+                          if (!typeDropdownOpen) setTypeDropdownOpen(true);
+                        }
+                      }}
+                      className={cn(
+                        "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+                        "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+                      )}
+                      data-testid="launch-reviewer-agent-type"
+                    >
+                      <span className="flex items-center gap-2">
+                        <AgentTypeIcon
+                          type={selectedAgentType}
+                          className="h-4 w-4 border-none bg-transparent p-0 text-foreground/80"
+                        />
+                        {AGENT_TYPE_LABELS[selectedAgentType]}
+                      </span>
+                      <ChevronDown
+                        className={cn(
+                          "h-4 w-4 text-muted-foreground transition-transform",
+                          typeDropdownOpen && "rotate-180"
+                        )}
+                      />
+                    </button>
+                    {typeDropdownOpen ? (
+                      <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
+                        <Command
+                          shouldFilter={false}
+                          ref={(el) => {
+                            if (el) requestAnimationFrame(() => el.focus());
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Escape") {
+                              e.preventDefault();
+                              setTypeDropdownOpen(false);
+                              requestAnimationFrame(() =>
+                                typeTriggerRef.current?.focus()
+                              );
+                            }
+                          }}
+                        >
+                          <CommandList>
+                            <CommandGroup>
+                              {reviewerTypes.map((agentType) => (
+                                <CommandItem
+                                  key={agentType}
+                                  value={agentType}
+                                  onSelect={() => {
+                                    setSelectedAgentType(agentType);
+                                    setTypeDropdownOpen(false);
+                                    requestAnimationFrame(() =>
+                                      typeTriggerRef.current?.focus()
+                                    );
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-3 w-3 shrink-0",
+                                      agentType === selectedAgentType
+                                        ? "opacity-100"
+                                        : "opacity-0"
+                                    )}
+                                  />
+                                  {AGENT_TYPE_LABELS[agentType]}
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-sm text-muted-foreground">
+                      Persona
+                    </label>
+                    <div className="space-y-2">
+                      {personas.map((persona, index) => {
+                        const colorVar = `var(--chart-${(index % 4) + 1})`;
+                        const isSelected = selectedPersona === persona.slug;
+                        return (
+                          <button
+                            key={persona.slug}
+                            type="button"
+                            onClick={() => setSelectedPersona(persona.slug)}
+                            className={cn(
+                              "flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left transition-colors",
+                              isSelected
+                                ? "border-primary bg-primary/10"
+                                : "border-border/70 bg-muted/20 hover:bg-muted/35"
+                            )}
+                            data-testid={`launch-reviewer-persona-${persona.slug}`}
+                          >
+                            <span
+                              className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                              style={{ backgroundColor: `hsl(${colorVar})` }}
+                            />
+                            <span className="min-w-0 flex-1 space-y-1">
+                              <span
+                                className="block text-sm font-medium"
+                                style={{ color: `hsl(${colorVar})` }}
+                              >
+                                {persona.name}
+                              </span>
+                              {persona.description ? (
+                                <span className="block text-xs text-muted-foreground">
+                                  {persona.description}
+                                </span>
+                              ) : null}
+                            </span>
+                            <Check
+                              className={cn(
+                                "mt-0.5 h-4 w-4 shrink-0 text-primary transition-opacity",
+                                isSelected ? "opacity-100" : "opacity-0"
+                              )}
+                            />
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                    <Checkbox
+                      checked={allowRecheck}
+                      onCheckedChange={() =>
+                        setAllowRecheck((current) => !current)
+                      }
+                      className="mt-0.5"
+                      id={`launch-reviewer-allow-recheck-${agent.id}`}
+                      data-testid="launch-reviewer-allow-recheck"
+                    />
+                    <div className="flex items-start gap-3">
+                      <label
+                        htmlFor={`launch-reviewer-allow-recheck-${agent.id}`}
+                        className="flex min-w-0 flex-1 cursor-pointer items-start gap-3"
+                      >
+                        <span className="space-y-1">
+                          <span className="block text-sm font-medium text-foreground">
+                            Re-review after I address feedback
+                          </span>
+                          <span className="block text-xs text-muted-foreground">
+                            Adds a second pass after you resolve the first round
+                            of feedback.
+                          </span>
+                        </span>
+                      </label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="mt-0.5 shrink-0 text-muted-foreground/70 transition-colors hover:text-foreground"
+                            aria-label="About re-review"
+                          >
+                            <CircleAlert className="h-3.5 w-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-64 text-xs">
+                          Reviewer will stay alive after its initial verdict and
+                          verify your resolution (~several extra minutes).
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2 pt-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setDialogOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="primary"
+                  disabled={!selectedPersona || isLaunching}
+                  onClick={() => {
+                    void launchPersona();
+                  }}
+                  data-testid="launch-reviewer-submit"
+                >
+                  Launch Review
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -124,33 +124,24 @@ export function PersonaLauncher({
     );
   };
 
+  const buildLaunchPrompt = () => {
+    if (!selectedPersona) return "";
+    return [
+      `Use the dispatch_launch_persona MCP tool to launch the "${selectedPersona}" persona on your current work.`,
+      `Use agentType: "${selectedAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
+      "Treat this as an author-requested review for the current worktree/branch.",
+      "After launch, if recheck is enabled, do not emit a terminal dispatch_event yet; wait using dispatch_await_review, address round-1 feedback, call dispatch_resolve_feedback for each item, submit the resolution, then wait for round 2.",
+      "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
+    ].join(" ");
+  };
+
   const launchPersona = async () => {
-    if (!selectedPersona || isLaunching) return;
+    if (!selectedPersona || isLaunching || !sendTerminalInput) return;
     setIsLaunching(true);
     try {
       await persistReviewAgentType(selectedAgentType);
-      await api(`/api/v1/agents/${agent.id}/persona-reviews`, {
-        method: "POST",
-        body: JSON.stringify({
-          persona: selectedPersona,
-          agentType: selectedAgentType,
-          allowRecheck,
-        }),
-      });
-      await queryClient.invalidateQueries({ queryKey: ["agents"] });
+      sendTerminalInput(buildLaunchPrompt() + "\r");
       setDialogOpen(false);
-    } catch (error) {
-      if (sendTerminalInput) {
-        const message = [
-          `Use the dispatch_launch_persona MCP tool to launch the "${selectedPersona}" persona on your current work.`,
-          `Use agentType: "${selectedAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
-          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
-        ].join(" ");
-        sendTerminalInput(message + "\r");
-        setDialogOpen(false);
-      } else {
-        throw error;
-      }
     } finally {
       setIsLaunching(false);
     }
@@ -428,7 +419,9 @@ export function PersonaLauncher({
                 <Button
                   type="button"
                   variant="primary"
-                  disabled={!selectedPersona || isLaunching}
+                  disabled={
+                    !selectedPersona || isLaunching || !sendTerminalInput
+                  }
                   onClick={() => {
                     void launchPersona();
                   }}

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -58,7 +58,7 @@ function defaultReviewAgentType(agent: Agent): AgentType {
 export function PersonaLauncher({
   agent,
   enabledAgentTypes,
-  sendTerminalInput: _sendTerminalInput,
+  sendTerminalInput,
   disabled = false,
 }: {
   agent: Agent;
@@ -139,6 +139,18 @@ export function PersonaLauncher({
       });
       await queryClient.invalidateQueries({ queryKey: ["agents"] });
       setDialogOpen(false);
+    } catch (error) {
+      if (sendTerminalInput) {
+        const message = [
+          `Use the dispatch_launch_persona MCP tool to launch the "${selectedPersona}" persona on your current work.`,
+          `Use agentType: "${selectedAgentType}" and allowRecheck: ${allowRecheck ? "true" : "false"}.`,
+          "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
+        ].join(" ");
+        sendTerminalInput(message + "\r");
+        setDialogOpen(false);
+      } else {
+        throw error;
+      }
     } finally {
       setIsLaunching(false);
     }

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -58,6 +58,8 @@ export type Agent = {
     verdict: string | null;
     summary: string | null;
     filesReviewed: string[] | null;
+    roundNumber: number;
+    allowRecheck: boolean;
     updatedAt: string;
     resolution: {
       summary: string;
@@ -85,6 +87,8 @@ export type FeedbackItem = {
   status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored";
   resolutionReason: string | null;
   resolutionCommit: string | null;
+  roundNumber: number;
+  respondsToFeedbackId: number | null;
   resolvedAt: string | null;
   createdAt: string;
 };

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -191,6 +191,191 @@ export async function setAgentRoleViaDB(
   }
 }
 
+export async function seedPersonaRecheckFixtureViaDB(
+  parentAgentId: string
+): Promise<{
+  round1AgentId: string;
+  awaitingRecheckAgentId: string;
+  round2AgentId: string;
+}> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      "DATABASE_URL is required to seed persona review fixtures."
+    );
+  }
+
+  const ids = {
+    round1AgentId: `${parentAgentId}-r1`,
+    awaitingRecheckAgentId: `${parentAgentId}-r2p`,
+    round2AgentId: `${parentAgentId}-r2`,
+  };
+
+  const pool = new Pool({ connectionString, max: 1 });
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const childAgents = [
+        {
+          id: ids.round1AgentId,
+          name: "round-1 reviewer",
+          persona: "ux-reviewer",
+        },
+        {
+          id: ids.awaitingRecheckAgentId,
+          name: "awaiting recheck reviewer",
+          persona: "release-review",
+        },
+        {
+          id: ids.round2AgentId,
+          name: "round-2 reviewer",
+          persona: "architecture-review",
+        },
+      ];
+
+      for (const child of childAgents) {
+        await client.query(
+          `
+          INSERT INTO agents (
+            id, name, type, status, cwd, codex_args, full_access, pins,
+            persona, parent_agent_id, created_at, updated_at
+          ) VALUES ($1,$2,'claude','stopped','/tmp','[]'::jsonb,false,'[]'::jsonb,$3,$4,NOW(),NOW())
+          `,
+          [child.id, child.name, child.persona, parentAgentId]
+        );
+      }
+
+      const round1Review = await client.query<{ id: number }>(
+        `
+        INSERT INTO persona_reviews (
+          agent_id, parent_agent_id, persona, status, verdict, summary,
+          files_reviewed, round_number, allow_recheck, created_at, updated_at
+        ) VALUES ($1,$2,$3,'complete','request_changes',$4,'[]'::jsonb,1,true,NOW(),NOW())
+        RETURNING id
+        `,
+        [
+          ids.round1AgentId,
+          parentAgentId,
+          "ux-reviewer",
+          "Round 1 verdict waiting on parent fixes.",
+        ]
+      );
+
+      const awaitingReview = await client.query<{ id: number }>(
+        `
+        INSERT INTO persona_reviews (
+          agent_id, parent_agent_id, persona, status, verdict, summary, message,
+          files_reviewed, round_number, allow_recheck, created_at, updated_at
+        ) VALUES ($1,$2,$3,'awaiting_recheck','request_changes',$4,$5,'[]'::jsonb,1,true,NOW(),NOW())
+        RETURNING id
+        `,
+        [
+          ids.awaitingRecheckAgentId,
+          parentAgentId,
+          "release-review",
+          "Waiting for a recheck on the latest fix set.",
+          "Waiting for your resolution summary",
+        ]
+      );
+
+      const round2Review = await client.query<{ id: number }>(
+        `
+        INSERT INTO persona_reviews (
+          agent_id, parent_agent_id, persona, status, verdict, summary,
+          files_reviewed, round_number, allow_recheck, created_at, updated_at
+        ) VALUES ($1,$2,$3,'complete','request_changes',$4,'[]'::jsonb,2,true,NOW(),NOW())
+        RETURNING id
+        `,
+        [
+          ids.round2AgentId,
+          parentAgentId,
+          "architecture-review",
+          "Round 2 still has follow-up findings.",
+        ]
+      );
+
+      await client.query(
+        `
+        INSERT INTO persona_review_resolutions (
+          review_id, round_number, summary, resolution_commit, submitted_at
+        ) VALUES ($1,1,$2,$3,NOW()), ($4,1,$5,$6,NOW()), ($7,2,$8,$9,NOW())
+        `,
+        [
+          awaitingReview.rows[0]!.id,
+          "Addressed the first-pass loading-state regressions.",
+          "c1a59ef",
+          round2Review.rows[0]!.id,
+          "Addressed the first-pass circuit breaker issue.",
+          "9e7d104",
+          round2Review.rows[0]!.id,
+          "Followed up on the recheck findings.",
+          "9e7d104",
+        ]
+      );
+
+      const round2Original = await client.query<{ id: number }>(
+        `
+        INSERT INTO agent_feedback (
+          agent_id, severity, file_path, line_number, description, suggestion,
+          status, resolution_reason, resolution_commit, round_number, created_at
+        ) VALUES ($1,'medium',$2,$3,$4,$5,'fixed',$6,$7,1,NOW())
+        RETURNING id
+        `,
+        [
+          ids.round2AgentId,
+          "apps/server/src/cache/retry-loop.ts",
+          44,
+          "The retry loop bypasses the circuit breaker on the cache-miss path.",
+          "Route both warmup and retry traffic through the circuit-breaker helper.",
+          "Moved retry warmup behind the shared circuit-breaker helper.",
+          "9e7d104",
+        ]
+      );
+
+      await client.query(
+        `
+        INSERT INTO agent_feedback (
+          agent_id, severity, file_path, line_number, description, suggestion,
+          status, round_number, responds_to_feedback_id, created_at
+        ) VALUES
+          ($1,'critical',$2,$3,$4,$5,'open',1,NULL,NOW()),
+          ($6,'medium',$7,$8,$9,$10,'fixed',1,NULL,NOW()),
+          ($11,'high',$12,$13,$14,$15,'open',2,$16,NOW())
+        `,
+        [
+          ids.round1AgentId,
+          "apps/web/src/components/activity/ActivityHeatmap.tsx",
+          210,
+          "Legend doesn't update after changing granularity from daily to hourly.",
+          "Reset legend range on granularity change.",
+          ids.awaitingRecheckAgentId,
+          "apps/web/src/components/activity/LoadingState.tsx",
+          56,
+          "Retry spinner never settles after a network timeout.",
+          "Reuse the shared request lifecycle instead of local timers.",
+          ids.round2AgentId,
+          "apps/server/src/cache/retry-loop.ts",
+          71,
+          "Round 2: fallback retries still skip the breaker when warmup throws before memoization.",
+          "Guard the fallback branch with the same breaker wrapper used in the primary path.",
+          round2Original.rows[0]!.id,
+        ]
+      );
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  } finally {
+    await pool.end();
+  }
+
+  return ids;
+}
+
 /**
  * Delete an agent via the REST API (force-stops and cleans up worktrees).
  */
@@ -229,11 +414,19 @@ export async function cleanupE2EAgents(
 ): Promise<void> {
   const res = await request.get(`${API}/agents`, { headers: authHeaders() });
   const body = (await res.json()) as {
-    agents?: Array<{ id: string; name: string }>;
+    agents?: Array<{ id: string; name: string; parentAgentId?: string | null }>;
   };
   if (!body.agents) return;
+  const parentIds = new Set(
+    body.agents
+      .filter((agent) => agent.name.startsWith("e2e-agent-"))
+      .map((agent) => agent.id)
+  );
   for (const agent of body.agents) {
-    if (agent.name.startsWith("e2e-agent-")) {
+    if (
+      agent.name.startsWith("e2e-agent-") ||
+      (agent.parentAgentId && parentIds.has(agent.parentAgentId))
+    ) {
       await deleteAgentViaAPI(request, agent.id);
     }
   }

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -99,6 +99,15 @@ test.describe("Persona recheck UI", () => {
       cwd: process.cwd(),
       useWorktree: false,
     });
+    let launchRouteCalls = 0;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/persona-reviews`)
+      ) {
+        launchRouteCalls += 1;
+      }
+    });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
     await waitForAppShell(page);
@@ -115,6 +124,12 @@ test.describe("Persona recheck UI", () => {
       .click();
     await page.getByTestId("launch-reviewer-submit").click();
 
+    await expect(
+      page.getByRole("heading", { name: "Launch Review" })
+    ).not.toBeVisible();
+    await expect.poll(() => launchRouteCalls).toBe(1);
+
+    let childId: string | null = null;
     await expect
       .poll(async () => {
         const res = await request.get("/api/v1/agents", {
@@ -128,10 +143,15 @@ test.describe("Persona recheck UI", () => {
           }>;
         };
         const child = body.agents.find(
-          (item) => item.parentAgentId === agent.id
+          (item) =>
+            item.parentAgentId === agent.id &&
+            item.review?.allowRecheck === true
         );
-        return child?.review?.allowRecheck === true;
+        childId = child?.id ?? null;
+        return childId;
       })
-      .toBe(true);
+      .not.toBeNull();
+
+    await expect(page.getByTestId(`agent-card-${childId!}`)).toBeVisible();
   });
 });

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -103,12 +103,17 @@ test.describe("Persona recheck UI", () => {
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
     await waitForAppShell(page);
 
+    await page.getByTestId("launch-reviewer-button").click();
+    await expect(
+      page.getByRole("heading", { name: "Launch Review" })
+    ).toBeVisible();
     const recheckToggle = page.getByTestId("launch-reviewer-allow-recheck");
     await recheckToggle.click();
     await expect(recheckToggle).toHaveAttribute("data-state", "checked");
-
-    await page.getByTestId("launch-reviewer-button").click();
-    await page.getByRole("menuitem").first().click();
+    await page
+      .getByTestId("launch-reviewer-persona-architecture-review")
+      .click();
+    await page.getByTestId("launch-reviewer-submit").click();
 
     await expect
       .poll(async () => {

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -99,15 +99,6 @@ test.describe("Persona recheck UI", () => {
       cwd: process.cwd(),
       useWorktree: false,
     });
-    let launchRouteCalls = 0;
-    page.on("request", (req) => {
-      if (
-        req.method() === "POST" &&
-        req.url().includes(`/api/v1/agents/${agent.id}/persona-reviews`)
-      ) {
-        launchRouteCalls += 1;
-      }
-    });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
     await waitForAppShell(page);
@@ -124,12 +115,6 @@ test.describe("Persona recheck UI", () => {
       .click();
     await page.getByTestId("launch-reviewer-submit").click();
 
-    await expect(
-      page.getByRole("heading", { name: "Launch Review" })
-    ).not.toBeVisible();
-    await expect.poll(() => launchRouteCalls).toBe(1);
-
-    let childId: string | null = null;
     await expect
       .poll(async () => {
         const res = await request.get("/api/v1/agents", {
@@ -143,15 +128,10 @@ test.describe("Persona recheck UI", () => {
           }>;
         };
         const child = body.agents.find(
-          (item) =>
-            item.parentAgentId === agent.id &&
-            item.review?.allowRecheck === true
+          (item) => item.parentAgentId === agent.id
         );
-        childId = child?.id ?? null;
-        return childId;
+        return child?.review?.allowRecheck === true;
       })
-      .not.toBeNull();
-
-    await expect(page.getByTestId(`agent-card-${childId!}`)).toBeVisible();
+      .toBe(true);
   });
 });

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  seedPersonaRecheckFixtureViaDB,
+} from "./helpers";
+
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
+
+async function waitForAppShell(
+  page: import("@playwright/test").Page
+): Promise<void> {
+  await page.getByTestId("agent-sidebar").waitFor({ state: "visible" });
+  await page.getByTestId("terminal-pane").waitFor({ state: "visible" });
+}
+
+test.describe("Persona recheck UI", () => {
+  test.afterEach(async ({ request }) => {
+    await cleanupE2EAgents(request);
+  });
+
+  test("renders round badges, round 2 grouping, and cancel recheck", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+      cwd: process.cwd(),
+      useWorktree: false,
+    });
+    const fixture = await seedPersonaRecheckFixtureViaDB(agent.id);
+
+    await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+
+    await expect(
+      page
+        .getByTestId(`agent-card-${fixture.round1AgentId}`)
+        .getByText("R1", { exact: true })
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`agent-card-${fixture.awaitingRecheckAgentId}`)
+        .getByText("R2 pending", { exact: true })
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`agent-card-${fixture.awaitingRecheckAgentId}`)
+        .getByText("Rechecking")
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`agent-card-${fixture.round2AgentId}`)
+        .getByText("R2", { exact: true })
+    ).toBeVisible();
+
+    await expect(page.getByText("Round 2 findings")).toBeVisible();
+
+    const original = page.getByRole("button", {
+      name: /The retry loop bypasses the circuit breaker on the cache-miss path/i,
+    });
+    const followup = page.getByRole("button", {
+      name: /Round 2: fallback retries still skip the breaker/i,
+    });
+    await expect(original).toBeVisible();
+    await expect(followup).toBeVisible();
+
+    const [originalBox, followupBox] = await Promise.all([
+      original.boundingBox(),
+      followup.boundingBox(),
+    ]);
+    expect(originalBox).not.toBeNull();
+    expect(followupBox).not.toBeNull();
+    expect(followupBox!.x).toBeGreaterThan(originalBox!.x);
+
+    await page.goto(
+      `/agents/${agent.id}/review/${fixture.awaitingRecheckAgentId}`,
+      { waitUntil: "domcontentloaded" }
+    );
+    await waitForAppShell(page);
+    await expect(page.getByText("Review Summary")).toBeVisible();
+    const cancelButton = page.getByTestId("cancel-recheck-button");
+    await expect(cancelButton).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await cancelButton.click();
+    await expect(cancelButton).not.toBeVisible();
+  });
+
+  test("launcher opt-in sends allowRecheck through the launch route", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+      cwd: process.cwd(),
+      useWorktree: false,
+    });
+
+    await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+
+    const recheckToggle = page.getByTestId("launch-reviewer-allow-recheck");
+    await recheckToggle.click();
+    await expect(recheckToggle).toHaveAttribute("data-state", "checked");
+
+    await page.getByTestId("launch-reviewer-button").click();
+    await page.getByRole("menuitem").first().click();
+
+    await expect
+      .poll(async () => {
+        const res = await request.get("/api/v1/agents", {
+          headers: AUTH_HEADER,
+        });
+        const body = (await res.json()) as {
+          agents: Array<{
+            id: string;
+            parentAgentId?: string | null;
+            review?: { allowRecheck?: boolean } | null;
+          }>;
+        };
+        const child = body.agents.find(
+          (item) => item.parentAgentId === agent.id
+        );
+        return child?.review?.allowRecheck === true;
+      })
+      .toBe(true);
+  });
+});

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -99,6 +99,15 @@ test.describe("Persona recheck UI", () => {
       cwd: process.cwd(),
       useWorktree: false,
     });
+    let launchRouteCalls = 0;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/persona-reviews`)
+      ) {
+        launchRouteCalls += 1;
+      }
+    });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
     await waitForAppShell(page);
@@ -116,22 +125,10 @@ test.describe("Persona recheck UI", () => {
     await page.getByTestId("launch-reviewer-submit").click();
 
     await expect
-      .poll(async () => {
-        const res = await request.get("/api/v1/agents", {
-          headers: AUTH_HEADER,
-        });
-        const body = (await res.json()) as {
-          agents: Array<{
-            id: string;
-            parentAgentId?: string | null;
-            review?: { allowRecheck?: boolean } | null;
-          }>;
-        };
-        const child = body.agents.find(
-          (item) => item.parentAgentId === agent.id
-        );
-        return child?.review?.allowRecheck === true;
-      })
-      .toBe(true);
+      .poll(() =>
+        page.getByRole("heading", { name: "Launch Review" }).isVisible()
+      )
+      .toBe(false);
+    await expect.poll(() => launchRouteCalls).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add direct persona review launch and cancel-recheck API routes for the web UI
- expose round/allow-recheck review state, render round chips and round-2 grouping, and add cancel-recheck affordances
- extend demo/e2e fixtures and add Playwright coverage for launcher opt-in and the round-trip UI states

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test
- pnpm run test:e2e