### PR TITLE
fix(web): show update toast only for deployed versions

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -693,7 +693,8 @@ type ReleaseStreamEvent =
   | { type: "log.rewind"; count: number }
   | { type: "phase"; phase: ReleasePhase; error?: string }
   | { type: "runUrl"; url: string }
-  | { type: "tag"; tag: string };
+  | { type: "tag"; tag: string }
+  | { type: "deployed"; tag: string | null };
 
 let activeReleaseJob: ReleaseJob | null = null;
 let activeAssistedUpdateLaunch = false;
@@ -2333,6 +2334,12 @@ async function registerRoutes() {
       job: activeReleaseJob,
     };
     stream.write(`data: ${JSON.stringify(snapshot)}\n\n`);
+    const releaseRecord = await readReleaseStore();
+    const deployed: ReleaseStreamEvent = {
+      type: "deployed",
+      tag: releaseRecord?.tag ?? null,
+    };
+    stream.write(`data: ${JSON.stringify(deployed)}\n\n`);
 
     stream.on("close", () => {
       clearInterval(heartbeat);

--- a/apps/web/src/components/app/update-available-toast.tsx
+++ b/apps/web/src/components/app/update-available-toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUpdateAvailable } from "@/hooks/use-update-available";
@@ -6,6 +6,16 @@ import { reloadApp } from "@/lib/reload";
 import { cn } from "@/lib/utils";
 
 const DISMISS_KEY = "dispatch:update-toast:dismissed-version";
+
+function isEditableElement(element: Element | null): element is HTMLElement {
+  if (!(element instanceof HTMLElement)) return false;
+  if (element.isContentEditable) return true;
+  return matches(element, ["input", "textarea", "select"]);
+}
+
+function matches(element: HTMLElement, selectors: string[]): boolean {
+  return selectors.some((selector) => element.matches(selector));
+}
 
 function readDismissed(): string | null {
   try {
@@ -29,6 +39,7 @@ export function UpdateAvailableToast(): JSX.Element | null {
     readDismissed()
   );
   const [reloading, setReloading] = useState(false);
+  const hadFocusedEditableRef = useRef(false);
 
   useEffect(() => {
     if (
@@ -44,6 +55,25 @@ export function UpdateAvailableToast(): JSX.Element | null {
   if (dismissedVersion === serverVersion) return null;
 
   const handleReload = (): void => {
+    const activeElement = document.activeElement;
+    const hadFocusedEditable =
+      hadFocusedEditableRef.current || isEditableElement(activeElement);
+    hadFocusedEditableRef.current = false;
+
+    if (
+      window.location.pathname.startsWith("/settings") &&
+      hadFocusedEditable &&
+      !window.confirm(
+        "You have a settings field open. Reloading now may discard unsaved changes. Reload anyway?"
+      )
+    ) {
+      return;
+    }
+
+    if (isEditableElement(activeElement)) {
+      activeElement.blur();
+    }
+
     setReloading(true);
     reloadApp({ waitForUpdate: true }).catch(() => {
       setReloading(false);
@@ -82,7 +112,9 @@ export function UpdateAvailableToast(): JSX.Element | null {
             "absolute top-1 right-1 z-10",
             "h-11 w-11 md:h-8 md:w-8 inline-flex items-center justify-center rounded-md",
             "text-muted-foreground hover:text-foreground hover:bg-muted",
-            "transition-colors"
+            "transition-colors focus-visible:outline-none",
+            "focus-visible:ring-2 focus-visible:ring-ring",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-card"
           )}
         >
           <X className="h-4 w-4" />
@@ -105,6 +137,11 @@ export function UpdateAvailableToast(): JSX.Element | null {
           </div>
         </div>
         <Button
+          onPointerDownCapture={() => {
+            hadFocusedEditableRef.current = isEditableElement(
+              document.activeElement
+            );
+          }}
           onClick={handleReload}
           disabled={reloading}
           className="h-11 w-full shrink-0 md:h-8 md:w-auto"

--- a/apps/web/src/components/app/update-available-toast.tsx
+++ b/apps/web/src/components/app/update-available-toast.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
 import { RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUpdateAvailable } from "@/hooks/use-update-available";
@@ -26,7 +25,6 @@ function writeDismissed(version: string): void {
 
 export function UpdateAvailableToast(): JSX.Element | null {
   const { available, serverVersion } = useUpdateAvailable();
-  const location = useLocation();
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(() =>
     readDismissed()
   );
@@ -44,9 +42,6 @@ export function UpdateAvailableToast(): JSX.Element | null {
 
   if (!available || !serverVersion) return null;
   if (dismissedVersion === serverVersion) return null;
-  // Release manager lives under /settings and owns its own update flow + reload
-  // CTA, so hide the passive toast there to avoid duplication.
-  if (location.pathname.startsWith("/settings")) return null;
 
   const handleReload = (): void => {
     setReloading(true);
@@ -63,10 +58,10 @@ export function UpdateAvailableToast(): JSX.Element | null {
   return (
     <div
       className={cn(
-        "fixed z-50 left-1/2 -translate-x-1/2 top-4",
-        "pt-[env(safe-area-inset-top)]",
+        "fixed z-50 left-1/2 -translate-x-1/2 bottom-4",
+        "pb-[env(safe-area-inset-bottom)]",
         "md:left-auto md:translate-x-0 md:right-4 md:bottom-4 md:top-auto",
-        "md:pt-0 md:pb-[env(safe-area-inset-bottom)]",
+        "md:pt-0",
         "w-[calc(100vw-2rem)] max-w-sm md:w-auto md:max-w-lg"
       )}
     >

--- a/apps/web/src/hooks/use-update-available.ts
+++ b/apps/web/src/hooks/use-update-available.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/app-version";
 
 type ReleaseStreamEvent =
-  | { type: "tag"; tag: string }
+  | { type: "deployed"; tag: string | null }
   | { type: string; [key: string]: unknown };
 
 export type UpdateAvailableState = {
@@ -30,9 +30,14 @@ export function useUpdateAvailable(): UpdateAvailableState {
     es.onmessage = (event) => {
       try {
         const parsed = JSON.parse(event.data as string) as ReleaseStreamEvent;
-        if (parsed.type === "tag" && typeof parsed.tag === "string") {
-          const stripped = parsed.tag.replace(/^v/, "");
-          setServerVersion((prev) => (prev === stripped ? prev : stripped));
+        if (parsed.type === "deployed") {
+          const nextVersion =
+            typeof parsed.tag === "string"
+              ? parsed.tag.replace(/^v/, "")
+              : null;
+          setServerVersion((prev) =>
+            prev === nextVersion ? prev : nextVersion
+          );
         }
       } catch {
         /* ignore malformed payloads */


### PR DESCRIPTION
## Summary
- stop treating release creation `tag` events as deployed server-version updates
- send a `deployed` event from the release stream based on the current release store state
- show the update toast on settings pages and keep it at the bottom on mobile so it does not cover the sidebar toggle

## Context
The update toast was surfacing as soon as a new release was created, even when the current server had not installed that release yet. The web client was listening to `/api/v1/release/stream` `tag` events, but those events mean "a release was created", not "this server is now running that version".

This change adds a `deployed` release-stream event that reflects the server's current deployed tag and updates the toast logic to listen to that deployed signal instead. The existing `X-Dispatch-Version` header path still works as before.

## Test plan
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test`
- `pnpm run test:e2e`
- Playwright validation on `/settings/updates` confirming a `tag` event alone does not show the toast, while a `deployed` event does and is visible on settings pages