### PR TITLE
fix(web): wait for new SW to actually control page before reload

### DIFF
--- a/apps/web/src/lib/reload.ts
+++ b/apps/web/src/lib/reload.ts
@@ -1,17 +1,3 @@
-function isControllingWorker(
-  worker: ServiceWorker,
-  registration: ServiceWorkerRegistration
-): boolean {
-  const active = registration.active;
-  const controller = navigator.serviceWorker.controller;
-  const workerScript = worker.scriptURL;
-  return Boolean(
-    active &&
-    active.scriptURL === workerScript &&
-    (!controller || controller.scriptURL === workerScript)
-  );
-}
-
 function getPendingWorker(
   registration: ServiceWorkerRegistration
 ): ServiceWorker | null {
@@ -45,55 +31,43 @@ async function waitForPendingWorker(
   });
 }
 
+// The new worker takes over in two steps: it becomes registration.active
+// (skipWaiting → activated), then — with clientsClaim, which vite-plugin-pwa's
+// autoUpdate mode enables — it claims this page and becomes the controller.
+// Compare ServiceWorker instances, not scriptURL: Workbox's SW has a stable
+// URL (/sw.js) so the old and new workers share the same scriptURL string,
+// and a URL equality check returns true the moment any active worker exists
+// — including the old one.
 async function waitForWorkerControl(
   worker: ServiceWorker,
-  registration: ServiceWorkerRegistration,
   timeoutMs: number
 ): Promise<void> {
-  if (isControllingWorker(worker, registration)) return;
+  if (navigator.serviceWorker.controller === worker) return;
   await new Promise<void>((resolve) => {
-    const hasExistingController = navigator.serviceWorker.controller !== null;
-    const handleChange = (): void => {
-      if (worker.state === "redundant") {
-        cleanup();
-        resolve();
-        return;
-      }
-      if (isControllingWorker(worker, registration)) {
-        cleanup();
-        resolve();
-        return;
-      }
-      // On a first install there may be no existing controller to swap out,
-      // so the best available signal is that the fetched worker activated.
-      if (!hasExistingController && worker.state === "activated") {
-        cleanup();
-        resolve();
-      }
+    const settle = (): void => {
+      cleanup();
+      resolve();
     };
     const handleControllerChange = (): void => {
-      if (isControllingWorker(worker, registration)) {
-        cleanup();
-        resolve();
-      }
+      if (navigator.serviceWorker.controller === worker) settle();
+    };
+    const handleStateChange = (): void => {
+      if (worker.state === "redundant") settle();
     };
     const cleanup = (): void => {
       clearTimeout(timer);
-      worker.removeEventListener("statechange", handleChange);
       navigator.serviceWorker.removeEventListener(
         "controllerchange",
         handleControllerChange
       );
+      worker.removeEventListener("statechange", handleStateChange);
     };
-    worker.addEventListener("statechange", handleChange);
     navigator.serviceWorker.addEventListener(
       "controllerchange",
       handleControllerChange
     );
-    const timer = setTimeout(() => {
-      cleanup();
-      resolve();
-    }, timeoutMs);
+    worker.addEventListener("statechange", handleStateChange);
+    const timer = setTimeout(settle, timeoutMs);
   });
 }
 
@@ -118,10 +92,7 @@ export async function reloadApp(options: ReloadAppOptions = {}): Promise<void> {
           if (registration.waiting) {
             registration.waiting.postMessage({ type: "SKIP_WAITING" });
           }
-          // vite-plugin-pwa's "activated" handler auto-reloads when the new
-          // SW activates. We wait for the worker to actually control this page
-          // so our fallback reload below doesn't race the controller handoff.
-          await waitForWorkerControl(pending, registration, 10_000);
+          await waitForWorkerControl(pending, 10_000);
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

The update toast reappeared on every reload — even a hard refresh — and only went away when dismissed manually.

`reloadApp`'s `isControllingWorker` compared `scriptURL` strings, but Workbox's generated service worker has a stable URL (`/sw.js`), so the old active SW, the current controller, and the newly-`installing` SW all match. The check returned `true` immediately, `waitForWorkerControl` resolved in the same tick, and `window.location.reload()` fired before the new SW had claimed the page. The old SW then served the old cached `index.html`, the page ran with the old `BUILD_VERSION`, and the toast reappeared. Safari/iOS PWA compounds this — there is no SW-bypassing hard refresh — so repeated reloads stayed stuck in the stale-bundle loop.

Fix: compare `ServiceWorker` instances, not script URLs. The same worker object moves through `installing → waiting → active`, so `registration.active === worker` only turns true when the *new* worker activates, and `navigator.serviceWorker.controller === worker` confirms it's controlling this page. Drive the wait off the `controllerchange` event so we only reload once the handover has actually happened.

## Test plan

- [x] `pnpm run check` — passes
- [x] `pnpm run finalize:web` — build succeeds, 9 precache entries generated
- [x] Playwright: mounted toast with forced mismatch (`__dispatchReportVersion('9.9.9')`) — toast renders; reset to matching version — toast unmounts
- [ ] Deploy an update and confirm a single Reload click on an old client loads the new bundle without the toast reappearing (requires a real production deploy to verify, since the SW path does not run in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)