### PR TITLE
fix(web): center and pad terminal reconnect overlay on mobile

### DIFF
--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -122,7 +122,7 @@ export const TerminalPane = memo(function TerminalPane({
 
       {showReconnectOverlay ? (
         <div className="absolute inset-0 z-30 grid place-items-center bg-background/80 backdrop-blur-sm">
-          <div className="flex flex-col items-center gap-2 text-sm text-foreground">
+          <div className="flex max-w-md flex-col items-center gap-2 px-6 text-center text-sm text-foreground">
             <ActivityBars size={28} />
             <span>{statusMessage}</span>
           </div>


### PR DESCRIPTION
## Summary
- The reconnect overlay's status message ("Connecting to session `<name>`…") ran edge-to-edge on narrow viewports and wrapped left-aligned, because its inner container was missing the `max-w-md px-6 text-center` trio used by the sibling empty/inert/archive overlays in the same component.
- Added those three classes to `apps/web/src/components/app/terminal-pane.tsx:125`. Long session names now wrap with ~24px gutters and centered text, matching the other overlay states.

## Test plan
- [x] `pnpm run check`
- [x] `pnpm run finalize:web`
- [x] Visual check at 390×844 (iPhone-size) in Playwright — message centers with breathing room
- [x] `frontend-ux-review` persona — verdict: approve, zero feedback items

🤖 Generated with [Claude Code](https://claude.com/claude-code)