### PR TITLE
fix(web): keep parent agent expanded when child review is active

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -283,10 +283,10 @@ export function AgentsView({
 
   useEffect(() => {
     if (!validatedSelectedAgentId) return;
-    setExpandedAgentId((current) =>
-      current === validatedSelectedAgentId ? current : validatedSelectedAgentId
-    );
-  }, [validatedSelectedAgentId]);
+    const selected = agents.find((a) => a.id === validatedSelectedAgentId);
+    const target = selected?.parentAgentId ?? validatedSelectedAgentId;
+    setExpandedAgentId((current) => (current === target ? current : target));
+  }, [agents, validatedSelectedAgentId]);
 
   useEffect(() => {
     if (!routeAgentId) return;


### PR DESCRIPTION
## Summary

When a child review agent was attached/connected in the terminal (or its URL was opened directly), the parent agent's sidebar item collapsed because the `validatedSelectedAgentId` effect unconditionally set `expandedAgentId` to the selected agent.

For child review agents, we now expand the **parent** instead, so the parent stays open with the active child visible underneath.

- `apps/web/src/components/app/agents-view.tsx`: when the selected agent has a `parentAgentId`, expand the parent rather than the selected child.

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run finalize:web` passes
- [x] Playwright: navigated directly to a child review URL (`/agents/seed-review-changes-responded-r2`) and confirmed the parent agent sidebar item ("add activity heatmap") stays expanded with all child reviews visible
- [ ] Manually verify clicking a child review row from the sidebar does not collapse the parent