### PR TITLE
fix: launchd wrapper ABI self-heal + README nvm prereq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,6 @@ jobs:
         env:
           TEST_DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/postgres
 
-      - name: Build
-        run: pnpm run build
-
       - name: Stop Postgres
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true
@@ -80,7 +77,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version and tag
+      # Bump versions before building so __APP_VERSION__ (stamped into the web
+      # bundle from package.json) matches the released tag. Commit/tag/push
+      # happens later, after the build succeeds.
+      - name: Bump version and generate release notes
         id: version
         run: |
           mkdir -p release-notes
@@ -102,21 +102,27 @@ jobs:
               -f target_commitish="main" \
               --jq '.body' > release-notes/current.md
           fi
-          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
-          git commit -m "Release ${NEW_VERSION}"
-          # Pull in any commits that landed on main during the CI run
-          git pull --rebase origin main
-          git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
-          # Push branch first, then tag separately — if the branch push
-          # fails we don't leave an orphan tag on the remote.
-          git push origin main
-          git push origin "${NEW_VERSION}"
           echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build
+        run: pnpm run build
+
       - name: Pack release artifact
         run: bin/pack-release --output dispatch-release.tar.gz
+
+      - name: Commit, tag, and push
+        run: |
+          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
+          git commit -m "Release ${{ steps.version.outputs.tag }}"
+          # Pull in any commits that landed on main during the CI run
+          git pull --rebase origin main
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          # Push branch first, then tag separately — if the branch push
+          # fails we don't leave an orphan tag on the remote.
+          git push origin main
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create GitHub release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           TEST_DATABASE_URL: postgres://dispatch:dispatch@127.0.0.1:${{ steps.postgres.outputs.port }}/postgres
 
+      - name: Build
+        run: pnpm run build
+
       - name: Stop Postgres
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true
@@ -77,10 +80,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Bump versions before building so __APP_VERSION__ (stamped into the web
-      # bundle from package.json) matches the released tag. Commit/tag/push
-      # happens later, after the build succeeds.
-      - name: Bump version and generate release notes
+      - name: Bump version and tag
         id: version
         run: |
           mkdir -p release-notes
@@ -102,35 +102,21 @@ jobs:
               -f target_commitish="main" \
               --jq '.body' > release-notes/current.md
           fi
+          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
+          git commit -m "Release ${NEW_VERSION}"
+          # Pull in any commits that landed on main during the CI run
+          git pull --rebase origin main
+          git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
+          # Push branch first, then tag separately — if the branch push
+          # fails we don't leave an orphan tag on the remote.
+          git push origin main
+          git push origin "${NEW_VERSION}"
           echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: pnpm run build
-
       - name: Pack release artifact
         run: bin/pack-release --output dispatch-release.tar.gz
-
-      - name: Commit, tag, and push
-        run: |
-          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
-          git commit -m "Release ${{ steps.version.outputs.tag }}"
-          # Pull in any commits that landed on main during the CI run
-          git pull --rebase origin main
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          # Push branch first, then tag separately — if the branch push
-          # fails we don't leave an orphan tag on the remote.
-          git push origin main
-          git push origin "${{ steps.version.outputs.tag }}"
-
-      # Leave the self-hosted runner in a predictable state if the release
-      # step failed mid-flight (rebase-in-progress, packed artifact on disk).
-      - name: Clean up after failure
-        if: failure()
-        run: |
-          git rebase --abort 2>/dev/null || true
-          rm -f dispatch-release.tar.gz
 
       - name: Create GitHub release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,14 @@ jobs:
           git push origin main
           git push origin "${{ steps.version.outputs.tag }}"
 
+      # Leave the self-hosted runner in a predictable state if the release
+      # step failed mid-flight (rebase-in-progress, packed artifact on disk).
+      - name: Clean up after failure
+        if: failure()
+        run: |
+          git rebase --abort 2>/dev/null || true
+          rm -f dispatch-release.tar.gz
+
       - name: Create GitHub release
         run: |
           gh release create ${{ steps.version.outputs.tag }} \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > Clone https://github.com/selfcontained/dispatch.git and install it as a persistent service on this machine. Steps:
 >
 > 1. Clone the repo to `~/.dispatch/server`.
-> 2. Install system dependencies: **Node.js 22+**, **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
+> 2. Install system dependencies: **nvm**, **Node.js 22+** (installed via nvm — required by `bin/install-launchd`), **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
 > 5. Copy `.env.example` to `.env`. The defaults work for local-only use. Set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections. On first visit to the web UI you will be prompted to set a password; sessions are stored as signed HTTP cookies.
@@ -49,14 +49,15 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 
 ## Prerequisites
 
-| Dependency                 | Purpose                               | macOS                        | Linux                                 |
-| -------------------------- | ------------------------------------- | ---------------------------- | ------------------------------------- |
-| **Build tools**            | Compile native npm modules (node-pty) | `xcode-select --install`     | `apt install build-essential python3` |
-| **Node.js 22+**            | Runtime                               | `nvm install 22`             | `nvm install 22`                      |
-| **pnpm**                   | Package manager                       | `npm i -g pnpm`              | `npm i -g pnpm`                       |
-| **PostgreSQL 14+**         | Database                              | `brew install postgresql@17` | `apt install postgresql`              |
-| **tmux**                   | Agent session management              | `brew install tmux`          | `apt install tmux`                    |
-| **At least one agent CLI** | The agents Dispatch runs              | See below                    | See below                             |
+| Dependency                 | Purpose                                                                          | macOS                                                              | Linux                                                              |
+| -------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| **Build tools**            | Compile native npm modules (node-pty)                                            | `xcode-select --install`                                           | `apt install build-essential python3`                              |
+| **nvm**                    | Node version manager (required by `bin/install-launchd` and the launchd wrapper) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) |
+| **Node.js 22+**            | Runtime                                                                          | `nvm install 22`                                                   | `nvm install 22`                                                   |
+| **pnpm**                   | Package manager                                                                  | `npm i -g pnpm`                                                    | `npm i -g pnpm`                                                    |
+| **PostgreSQL 14+**         | Database                                                                         | `brew install postgresql@17`                                       | `apt install postgresql`                                           |
+| **tmux**                   | Agent session management                                                         | `brew install tmux`                                                | `apt install tmux`                                                 |
+| **At least one agent CLI** | The agents Dispatch runs                                                         | See below                                                          | See below                                                          |
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 > Clone https://github.com/selfcontained/dispatch.git and install it as a persistent service on this machine. Steps:
 >
 > 1. Clone the repo to `~/.dispatch/server`.
-> 2. Install system dependencies: **nvm**, **Node.js 22+** (installed via nvm — required by `bin/install-launchd`), **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
+> 2. Install system dependencies: **nvm**, **Node.js 22+** (installed via nvm — Dispatch's service-management scripts require nvm), **PostgreSQL** (14+), **tmux**, **pnpm**, and build tools for native npm modules (Xcode CLI Tools on macOS, `build-essential`/`python3`/`xclip`/`xvfb` on Linux).
 > 3. Start PostgreSQL and create the database: `createdb dispatch && psql dispatch -c "CREATE ROLE dispatch WITH LOGIN PASSWORD 'dispatch'; GRANT ALL ON DATABASE dispatch TO dispatch; GRANT ALL ON SCHEMA public TO dispatch;"`.
 > 4. `pnpm install && pnpm run build`
 > 5. Copy `.env.example` to `.env`. The defaults work for local-only use. Set `DISPATCH_HOST=0.0.0.0` only when this machine should accept remote connections. On first visit to the web UI you will be prompted to set a password; sessions are stored as signed HTTP cookies.
@@ -49,15 +49,15 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 
 ## Prerequisites
 
-| Dependency                 | Purpose                                                                          | macOS                                                              | Linux                                                              |
-| -------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| **Build tools**            | Compile native npm modules (node-pty)                                            | `xcode-select --install`                                           | `apt install build-essential python3`                              |
-| **nvm**                    | Node version manager (required by `bin/install-launchd` and the launchd wrapper) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) |
-| **Node.js 22+**            | Runtime                                                                          | `nvm install 22`                                                   | `nvm install 22`                                                   |
-| **pnpm**                   | Package manager                                                                  | `npm i -g pnpm`                                                    | `npm i -g pnpm`                                                    |
-| **PostgreSQL 14+**         | Database                                                                         | `brew install postgresql@17`                                       | `apt install postgresql`                                           |
-| **tmux**                   | Agent session management                                                         | `brew install tmux`                                                | `apt install tmux`                                                 |
-| **At least one agent CLI** | The agents Dispatch runs                                                         | See below                                                          | See below                                                          |
+| Dependency                 | Purpose                                                                                                                                                  | macOS                                                              | Linux                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| **Build tools**            | Compile native npm modules (node-pty)                                                                                                                    | `xcode-select --install`                                           | `apt install build-essential python3`                              |
+| **nvm**                    | Node version manager (required by Dispatch's service-management scripts: `bin/install-launchd`, `bin/dispatch-server`, `bin/preflight`, launchd wrapper) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) | [install.sh](https://github.com/nvm-sh/nvm#install--update-script) |
+| **Node.js 22+**            | Runtime                                                                                                                                                  | `nvm install 22`                                                   | `nvm install 22`                                                   |
+| **pnpm**                   | Package manager                                                                                                                                          | `npm i -g pnpm`                                                    | `npm i -g pnpm`                                                    |
+| **PostgreSQL 14+**         | Database                                                                                                                                                 | `brew install postgresql@17`                                       | `apt install postgresql`                                           |
+| **tmux**                   | Agent session management                                                                                                                                 | `brew install tmux`                                                | `apt install tmux`                                                 |
+| **At least one agent CLI** | The agents Dispatch runs                                                                                                                                 | See below                                                          | See below                                                          |
 
 ### Optional
 

--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -11,5 +11,17 @@
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Self-heal native-module ABI mismatch (e.g. after a Node upgrade). The check
+# takes a few ms on the happy path; a rebuild only runs when something's wrong.
+ABI_CHECK=$(cd "$ROOT_DIR/apps/server" && node -e "require('node-pty')" 2>&1) || true
+if echo "$ABI_CHECK" | grep -q "NODE_MODULE_VERSION"; then
+  echo "==> native module ABI mismatch detected, rebuilding..." >&2
+  if ! (cd "$ROOT_DIR" && pnpm -r rebuild); then
+    echo "error: pnpm rebuild failed — dispatch cannot start" >&2
+    echo "$ABI_CHECK" >&2
+    exit 1
+  fi
+fi
+
 cd "$ROOT_DIR"
 exec node "$ROOT_DIR/apps/server/dist/main.js"

--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -21,6 +21,14 @@ if echo "$ABI_CHECK" | grep -q "NODE_MODULE_VERSION"; then
     echo "$ABI_CHECK" >&2
     exit 1
   fi
+  # Re-probe so we don't let launchd's KeepAlive spin on a stuck rebuild loop
+  # if pnpm exited 0 but the mismatch somehow persists.
+  ABI_RECHECK=$(cd "$ROOT_DIR/apps/server" && node -e "require('node-pty')" 2>&1) || true
+  if echo "$ABI_RECHECK" | grep -q "NODE_MODULE_VERSION"; then
+    echo "error: ABI mismatch persists after pnpm rebuild — dispatch cannot start" >&2
+    echo "$ABI_RECHECK" >&2
+    exit 1
+  fi
 fi
 
 cd "$ROOT_DIR"


### PR DESCRIPTION
## Summary

Two narrow fixes from a fresh Quick Install run. (Originally three — the third, a release.yml reorder to fix the "update available" banner on fresh installs, has been dropped because CRU-138 deletes the whole `__APP_VERSION__` mechanism and replaces it with `vite-plugin-pwa` prompt mode.)

- **Launchd wrapper self-heals native-module ABI mismatch.** After a host Node upgrade, existing `node-pty` is compiled against the old ABI, and launchd cycle-restarts a broken server. `bin/dispatch-launchd-wrapper` now probes `require('node-pty')`, runs `pnpm -r rebuild` on `NODE_MODULE_VERSION` mismatch, re-probes, and exits 1 with a clear error if the mismatch persists. Happy-path cost is a few ms.

- **README lists nvm as a prereq.** `bin/install-launchd`, `bin/dispatch-server`, `bin/preflight`, and the launchd wrapper all `load_nvm` and fail hard if nvm isn't installed. Prereq table and Quick Install prompt now call this out explicitly.

## Related

- CRU-138 — Simplify update-toast plumbing by switching vite-plugin-pwa to prompt mode. Supersedes the release.yml fix that was originally part of this PR.

## Test plan

- [ ] `pnpm run check` passes (done locally).
- [ ] On a host that has been upgraded past the Node version Dispatch was last deployed against, `launchctl kickstart com.dispatch.server` triggers the rebuild branch and the server comes up.
- [ ] Fresh Quick Install prompt now mentions nvm so the agent doing the install installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)