### PR TITLE
feat(web): decouple managed worktree from new branch creation (CRU-139)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@
   4. Is this truly app-wide and cross-cutting? Only then consider Jotai.
 - `App.tsx` is a composition root, not a feature implementation file. Do not add feature-specific dialog state, selection state, or view toggles there when they can live lower in the tree.
 
+### Persisted UI state (localStorage)
+
+- For UI state that needs to survive reloads, prefer jotai's `atomWithLocalStorage` helper in `apps/web/src/lib/store.ts` over a hand-rolled `useState` + `useEffect` pattern. The helper handles SSR-safety, JSON serialization, read-on-mount, and write-on-change in one place — and it sidesteps the read/write effect-ordering races that come up when persistence keys change at runtime.
+- When the persisted value needs to be keyed by another value (cwd, agent ID, route segment, etc.), use jotai's `atomFamily` to produce one atom per key rather than building a custom prefix scheme on top of plain atoms. Example: `atomFamily((cwd: string) => atomWithLocalStorage(\`dispatch:foo:${cwd}\`, default))`.
+- This is the one place where Jotai is preferred over local state even for feature-specific UI — the persistence machinery belongs in a shared spot, and the atom's identity stays stable across mounts so the value reads back correctly when the dialog/component remounts.
+
 ## Pre-Completion Checks (Mandatory)
 
 Before marking any task as done, run the following checks and fix any failures:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ dispatch/
   4. Is this truly app-wide and cross-cutting? Only then consider Jotai.
 - `App.tsx` is a composition root, not a feature implementation file. Do not add feature-specific dialog state, selection state, or view toggles there when they can live lower in the tree.
 
+### Persisted UI state (localStorage)
+
+- For UI state that needs to survive reloads, prefer jotai's `atomWithLocalStorage` helper in `apps/web/src/lib/store.ts` over a hand-rolled `useState` + `useEffect` pattern. The helper handles SSR-safety, JSON serialization, read-on-mount, and write-on-change in one place — and it sidesteps the read/write effect-ordering races that come up when persistence keys change at runtime.
+- When the persisted value needs to be keyed by another value (cwd, agent ID, route segment, etc.), use jotai's `atomFamily` to produce one atom per key rather than building a custom prefix scheme on top of plain atoms. Example: `atomFamily((cwd: string) => atomWithLocalStorage(\`dispatch:foo:${cwd}\`, default))`.
+- This is the one place where Jotai is preferred over local state even for feature-specific UI — the persistence machinery belongs in a shared spot, and the atom's identity stays stable across mounts so the value reads back correctly when the dialog/component remounts.
+
 ## Pre-Completion Checks (Mandatory)
 
 Before marking any task as done, run the following checks and fix any failures:

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -24,8 +24,10 @@ import {
   createReleaseUpdateToken,
 } from "../auth.js";
 import {
-  createGitWorktree,
+  assertSafeRefName,
   cleanupGitWorktree,
+  createGitWorktree,
+  GitWorktreeError,
 } from "../shared/git/worktree.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { loadRepoHooks } from "../shared/mcp/repo-tools.js";
@@ -544,6 +546,37 @@ export class AgentManager {
     const useWorktree = input.useWorktree !== false;
     const createNewBranch = input.createNewBranch ?? true;
 
+    // Normalize ref names up front. assertSafeRefName trims, rejects empty
+    // values, and forbids any character that isn't alphanumeric / `_./-`/`/` —
+    // which (a) keeps malicious input out of the bash setup script (CRU-139
+    // injection vector) and (b) gives us a single canonical form to persist
+    // and compare against during archive cleanup. Skip when the field wasn't
+    // provided so the existing fallback paths still apply.
+    let normalizedBaseBranch: string | undefined;
+    let normalizedWorktreeBranch: string | undefined;
+    try {
+      if (input.baseBranch !== undefined && input.baseBranch.trim() !== "") {
+        normalizedBaseBranch = assertSafeRefName(
+          input.baseBranch,
+          "baseBranch"
+        );
+      }
+      if (
+        input.worktreeBranch !== undefined &&
+        input.worktreeBranch.trim() !== ""
+      ) {
+        normalizedWorktreeBranch = assertSafeRefName(
+          input.worktreeBranch,
+          "worktreeBranch"
+        );
+      }
+    } catch (err) {
+      if (err instanceof GitWorktreeError) {
+        throw new AgentError(err.message, err.statusCode);
+      }
+      throw err;
+    }
+
     // Compute worktree params for the setup script
     let worktreeBranchName: string | undefined;
     let worktreePathOverride: string | undefined;
@@ -554,11 +587,11 @@ export class AgentManager {
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-+|-+$/g, "");
         worktreeBranchName =
-          input.worktreeBranch?.trim() || `${id}/${slugName || "work"}`;
+          normalizedWorktreeBranch || `${id}/${slugName || "work"}`;
       } else {
         // When checking out an existing branch without creating a new one,
         // the worktree branch is the starting branch itself.
-        worktreeBranchName = input.baseBranch?.trim() || "main";
+        worktreeBranchName = normalizedBaseBranch || "main";
       }
       const worktreeLocation = input.worktreeLocation ?? "sibling";
       if (worktreeLocation === "nested") {
@@ -604,7 +637,7 @@ export class AgentManager {
         input.reviewAgentType ?? null,
         cliSessionId,
         input.autoReview ?? false,
-        input.baseBranch ?? null,
+        normalizedBaseBranch ?? null,
       ]
     );
 
@@ -620,7 +653,7 @@ export class AgentManager {
             cwd: originalCwd,
             name,
             branchName: createNewBranch ? worktreeBranchName : undefined,
-            baseBranch: input.baseBranch,
+            baseBranch: normalizedBaseBranch,
             worktreePath: worktreePathOverride,
             createNewBranch,
           });
@@ -683,7 +716,7 @@ export class AgentManager {
           useWorktree,
           createNewBranch,
           worktreeBranchName,
-          baseBranch: input.baseBranch,
+          baseBranch: normalizedBaseBranch,
           worktreePathOverride,
           agentName: name,
           agentCommand,
@@ -4576,6 +4609,16 @@ export class AgentManager {
     ];
 
     if (useWorktree && worktreeBranchName) {
+      // Defense in depth: refs flowing through this function are interpolated
+      // into a bash script that runs in tmux, so re-validate them here even
+      // though createAgent already normalized them. A failure here is a bug,
+      // not user error.
+      assertSafeRefName(worktreeBranchName, "worktreeBranchName");
+      const effectiveBaseBranch = assertSafeRefName(
+        params.baseBranch || "main",
+        "baseBranch"
+      );
+
       const phaseLabel = createNewBranch
         ? "Creating git worktree"
         : "Creating managed git worktree";
@@ -4591,9 +4634,6 @@ export class AgentManager {
 
       // Determine worktree path arg
       const wtPathArg = worktreePathOverride ? `"${worktreePathOverride}"` : "";
-
-      // We need to compute the worktree path. Use git worktree add directly.
-      const effectiveBaseBranch = params.baseBranch || "main";
       lines.push(
         `REPO_ROOT=$(git -C "${originalCwd}" rev-parse --show-toplevel 2>/dev/null) || {`,
         `  warn "Not a git repository — skipping worktree"`,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -162,6 +162,12 @@ type CreateAgentInput = {
   agentArgs?: string[];
   fullAccess?: boolean;
   useWorktree?: boolean;
+  /**
+   * When true (default), create a new branch for the worktree from
+   * `baseBranch`. When false, check out `baseBranch` directly without
+   * creating a new branch.
+   */
+  createNewBranch?: boolean;
   worktreeBranch?: string;
   baseBranch?: string;
   worktreeLocation?: WorktreeLocation;
@@ -536,17 +542,24 @@ export class AgentManager {
     await mkdir(mediaDir, { recursive: true });
 
     const useWorktree = input.useWorktree !== false;
+    const createNewBranch = input.createNewBranch ?? true;
 
     // Compute worktree params for the setup script
     let worktreeBranchName: string | undefined;
     let worktreePathOverride: string | undefined;
     if (useWorktree) {
-      const slugName = name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "");
-      worktreeBranchName =
-        input.worktreeBranch?.trim() || `${id}/${slugName || "work"}`;
+      if (createNewBranch) {
+        const slugName = name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
+        worktreeBranchName =
+          input.worktreeBranch?.trim() || `${id}/${slugName || "work"}`;
+      } else {
+        // When checking out an existing branch without creating a new one,
+        // the worktree branch is the starting branch itself.
+        worktreeBranchName = input.baseBranch?.trim() || "main";
+      }
       const worktreeLocation = input.worktreeLocation ?? "sibling";
       if (worktreeLocation === "nested") {
         worktreePathOverride = path.join(
@@ -606,9 +619,10 @@ export class AgentManager {
           const result = await createGitWorktree({
             cwd: originalCwd,
             name,
-            branchName: worktreeBranchName,
+            branchName: createNewBranch ? worktreeBranchName : undefined,
             baseBranch: input.baseBranch,
             worktreePath: worktreePathOverride,
+            createNewBranch,
           });
           worktreePath = result.worktreePath;
           worktreeBranch = result.branchName;
@@ -667,6 +681,7 @@ export class AgentManager {
           agentType: type,
           originalCwd,
           useWorktree,
+          createNewBranch,
           worktreeBranchName,
           baseBranch: input.baseBranch,
           worktreePathOverride,
@@ -1085,9 +1100,15 @@ export class AgentManager {
             await publishPhase("worktree-cleanup");
 
             const tCleanup = Date.now();
+            // If the worktree is on the user's original starting branch
+            // (i.e. no dispatch-created branch), don't delete that branch —
+            // it belongs to the user, not to this agent.
+            const dispatchOwnsBranch =
+              !!agent.worktreeBranch &&
+              (!agent.baseBranch || agent.worktreeBranch !== agent.baseBranch);
             await cleanupGitWorktree({
               cwd: agent.worktreePath,
-              deleteBranch: true,
+              deleteBranch: dispatchOwnsBranch,
               force: true,
             });
             durations.worktreeCleanup = Date.now() - tCleanup;
@@ -4478,6 +4499,7 @@ export class AgentManager {
     agentType: AgentType;
     originalCwd: string;
     useWorktree: boolean;
+    createNewBranch: boolean;
     worktreeBranchName?: string;
     baseBranch?: string;
     worktreePathOverride?: string;
@@ -4491,6 +4513,7 @@ export class AgentManager {
       agentType,
       originalCwd,
       useWorktree,
+      createNewBranch,
       worktreeBranchName,
       worktreePathOverride,
       agentName,
@@ -4553,10 +4576,16 @@ export class AgentManager {
     ];
 
     if (useWorktree && worktreeBranchName) {
+      const phaseLabel = createNewBranch
+        ? "Creating git worktree"
+        : "Creating managed git worktree";
+      const branchLine = createNewBranch
+        ? `info "Branch: ${worktreeBranchName}"`
+        : `info "Checking out: ${worktreeBranchName}"`;
       lines.push(
         `# --- Worktree creation ---`,
-        `phase "Creating git worktree"`,
-        `info "Branch: ${worktreeBranchName}"`,
+        `phase "${phaseLabel}"`,
+        branchLine,
         ``
       );
 
@@ -4587,7 +4616,10 @@ export class AgentManager {
         lines.push(`  WT_PATH="${worktreePathOverride}"`);
       } else {
         // Default sibling path: <repoRoot>/../<basename>-<slugified-branch>
-        const sluggedBranch = worktreeBranchName
+        const slugSource = createNewBranch
+          ? worktreeBranchName
+          : effectiveBaseBranch;
+        const sluggedBranch = slugSource
           .replace(/[^a-z0-9]+/gi, "-")
           .replace(/^-+|-+$/g, "")
           .toLowerCase();
@@ -4597,11 +4629,18 @@ export class AgentManager {
         );
       }
 
+      const addCmd = createNewBranch
+        ? `git -C "$REPO_ROOT" worktree add -b "${worktreeBranchName}" "$WT_PATH" "$BASE_REF"`
+        : `git -C "$REPO_ROOT" worktree add "$WT_PATH" "${effectiveBaseBranch}"`;
+      const upstreamLine = createNewBranch
+        ? `    git -C "$WT_PATH" branch --set-upstream-to "$BASE_REF" "${worktreeBranchName}" 2>/dev/null || true`
+        : null;
+
       lines.push(
         ``,
-        `  if git -C "$REPO_ROOT" worktree add -b "${worktreeBranchName}" "$WT_PATH" "$BASE_REF" 2>&1; then`,
+        `  if ${addCmd} 2>&1; then`,
         `    ok "Worktree created at $WT_PATH"`,
-        `    git -C "$WT_PATH" branch --set-upstream-to "$BASE_REF" "${worktreeBranchName}" 2>/dev/null || true`,
+        ...(upstreamLine ? [upstreamLine] : []),
         `    EFFECTIVE_CWD="$WT_PATH"`,
         `    WORKTREE_PATH="\\"$WT_PATH\\""`,
         `    WORKTREE_BRANCH="\\"${worktreeBranchName}\\""`,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -28,6 +28,7 @@ import {
   cleanupGitWorktree,
   createGitWorktree,
   GitWorktreeError,
+  worktreePathSlug,
 } from "../shared/git/worktree.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { loadRepoHooks } from "../shared/mcp/repo-tools.js";
@@ -595,14 +596,13 @@ export class AgentManager {
       }
       const worktreeLocation = input.worktreeLocation ?? "sibling";
       if (worktreeLocation === "nested") {
+        // For nested layout, derive the same hashed slug so two agents on
+        // slug-equivalent existing branches don't pick the same path.
         worktreePathOverride = path.join(
           originalCwd,
           ".dispatch",
           "worktrees",
-          worktreeBranchName
-            .replace(/[^a-z0-9]+/gi, "-")
-            .replace(/^-+|-+$/g, "")
-            .toLowerCase()
+          worktreePathSlug(worktreeBranchName, { createNewBranch })
         );
       }
     }
@@ -666,10 +666,26 @@ export class AgentManager {
           );
           await this.setupWorktree(originalCwd, worktreePath);
         } catch (error) {
+          // The user explicitly asked for an isolated worktree. Don't silently
+          // fall back to running in their primary checkout — surface the
+          // failure and mark the agent as failed so it shows up in the UI
+          // with a clear last_error.
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const lastError = `Worktree creation failed: ${message}`;
           this.logger.warn(
             { err: error, agentId: id },
             "Worktree creation failed for inert agent."
           );
+          await this.setAgentStatus(id, "stopped", lastError);
+          await this.setSystemLatestEvent(id, {
+            type: "blocked",
+            message: lastError,
+          });
+          if (error instanceof GitWorktreeError) {
+            throw new AgentError(lastError, error.statusCode);
+          }
+          throw new AgentError(lastError, 500);
         }
       }
 
@@ -828,6 +844,22 @@ export class AgentManager {
 
   async updateSetupPhase(id: string, phase: SetupPhase): Promise<void> {
     await this.setSetupPhase(id, phase);
+  }
+
+  /**
+   * Called by the tmux setup script when an unrecoverable failure happens
+   * during setup (e.g. `git worktree add` failed). Marks the agent as
+   * stopped with the supplied message in `last_error` so the UI surfaces a
+   * clear reason instead of the agent silently disappearing.
+   */
+  async markSetupFailed(id: string, message: string): Promise<AgentRecord> {
+    const trimmed = message.trim().slice(0, 1000) || "Setup failed.";
+    await this.setAgentStatus(id, "stopped", trimmed);
+    await this.setSystemLatestEvent(id, {
+      type: "blocked",
+      message: trimmed,
+    });
+    return (await this.getAgent(id)) as AgentRecord;
   }
 
   async updateReviewAgentType(
@@ -4564,6 +4596,15 @@ export class AgentManager {
       `-H "Authorization: Bearer ${authToken}" ` +
       `-d '{"phase":"${phase}"}' > /dev/null 2>&1 || true`;
 
+    // Helper to report an unrecoverable setup failure. The bash variable
+    // SETUP_ERROR_MSG is interpolated as a JSON string body so the message
+    // surfaces in the agent's last_error.
+    const curlSetupError = (msgBashVar: string) =>
+      `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/error" ` +
+      `-H "Content-Type: application/json" ` +
+      `-H "Authorization: Bearer ${authToken}" ` +
+      `-d "{\\"message\\":\\"\${${msgBashVar}}\\"}" > /dev/null 2>&1 || true`;
+
     // Helper function for the completion callback
     const curlComplete = (
       cwdVar: string,
@@ -4655,14 +4696,14 @@ export class AgentManager {
       if (worktreePathOverride) {
         lines.push(`  WT_PATH="${worktreePathOverride}"`);
       } else {
-        // Default sibling path: <repoRoot>/../<basename>-<slugified-branch>
+        // Default sibling path: <repoRoot>/../<basename>-<slug>. Use the
+        // shared slug helper so the bash path matches what worktree.ts
+        // computes on the inert path (and includes a hash discriminator
+        // when createNewBranch=false to avoid slug collisions).
         const slugSource = createNewBranch
           ? worktreeBranchName
           : effectiveBaseBranch;
-        const sluggedBranch = slugSource
-          .replace(/[^a-z0-9]+/gi, "-")
-          .replace(/^-+|-+$/g, "")
-          .toLowerCase();
+        const sluggedBranch = worktreePathSlug(slugSource, { createNewBranch });
         lines.push(
           `  REPO_BASENAME=$(basename "$REPO_ROOT")`,
           `  WT_PATH="$(dirname "$REPO_ROOT")/\${REPO_BASENAME}-${sluggedBranch}"`
@@ -4678,7 +4719,8 @@ export class AgentManager {
 
       lines.push(
         ``,
-        `  if ${addCmd} 2>&1; then`,
+        `  WORKTREE_ADD_OUTPUT=$(${addCmd} 2>&1)`,
+        `  if [ $? -eq 0 ]; then`,
         `    ok "Worktree created at $WT_PATH"`,
         ...(upstreamLine ? [upstreamLine] : []),
         `    EFFECTIVE_CWD="$WT_PATH"`,
@@ -4727,7 +4769,16 @@ export class AgentManager {
 
       lines.push(
         `  else`,
-        `    warn "Worktree creation failed — using original directory"`,
+        // The user explicitly asked for an isolated worktree. Don't fall back
+        // to running in the primary checkout — surface the failure to the
+        // server (so last_error shows up in the UI) and exit. The tmux
+        // session-died monitor will reconcile status to stopped.
+        `    fail "Worktree creation failed"`,
+        `    fail "$WORKTREE_ADD_OUTPUT"`,
+        `    SETUP_ERROR_MSG=$(printf "%s" "$WORKTREE_ADD_OUTPUT" | head -c 800 | tr -d "\\n\\r" | sed 's/[\\\\\\"]/\\\\&/g')`,
+        `    if [ -z "$SETUP_ERROR_MSG" ]; then SETUP_ERROR_MSG="git worktree add failed"; fi`,
+        `    ${curlSetupError("SETUP_ERROR_MSG")}`,
+        `    exit 1`,
         `  fi`,
         `fi`,
         ``

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3867,6 +3867,7 @@ async function registerRoutes() {
       codexArgs?: unknown;
       fullAccess?: unknown;
       useWorktree?: unknown;
+      createNewBranch?: unknown;
       worktreeBranch?: unknown;
       baseBranch?: unknown;
       persona?: unknown;
@@ -3920,6 +3921,15 @@ async function registerRoutes() {
       return reply
         .code(400)
         .send({ error: "useWorktree must be a boolean when provided." });
+    }
+
+    if (
+      body.createNewBranch !== undefined &&
+      typeof body.createNewBranch !== "boolean"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "createNewBranch must be a boolean when provided." });
     }
 
     if (body.autoReview !== undefined && typeof body.autoReview !== "boolean") {
@@ -4009,6 +4019,10 @@ async function registerRoutes() {
         fullAccess: !isTerminalAgent && body.fullAccess === true,
         useWorktree:
           typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
+        createNewBranch:
+          typeof body.createNewBranch === "boolean"
+            ? body.createNewBranch
+            : undefined,
         worktreeBranch:
           typeof body.worktreeBranch === "string"
             ? body.worktreeBranch

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4057,6 +4057,25 @@ async function registerRoutes() {
   });
 
   // Setup script callbacks — called by the bash setup script running in tmux
+  app.post("/api/v1/agents/:id/setup/error", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const body = request.body as { message?: unknown };
+    const id = params.id ?? "";
+    const message =
+      typeof body?.message === "string" ? body.message : "Setup failed.";
+
+    try {
+      const agent = await agentManager.markSetupFailed(id, message);
+      uiEventBroker.publish({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
+      return { ok: true };
+    } catch (error) {
+      return handleAgentError(reply, error);
+    }
+  });
+
   app.post("/api/v1/agents/:id/setup/phase", async (request, reply) => {
     const params = request.params as { id?: string };
     const body = request.body as { phase?: unknown };

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -472,19 +472,33 @@ function normalizeRefName(
   fallback: string,
   fieldName: string
 ): string {
-  const normalized = (value?.trim() || fallback).trim();
-  if (!normalized) {
+  const candidate = (value?.trim() || fallback).trim();
+  return assertSafeRefName(candidate, fieldName);
+}
+
+/**
+ * Trim a ref name and ensure it only contains characters that are both valid
+ * in git ref names and safe to interpolate into a shell command (so callers
+ * that splice the result into bash, env vars, etc. don't have to do their own
+ * escaping). Throws `GitWorktreeError(400)` on whitespace, shell
+ * metacharacters, or other unsafe input. Callers that already know the value
+ * is non-empty should pass it through here before persisting or interpolating.
+ */
+export function assertSafeRefName(value: string, fieldName: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
     throw new GitWorktreeError(`${fieldName} must not be empty.`, 400);
   }
-
-  if (/\s/.test(normalized)) {
+  // Allow letters, digits, '_', '.', '-', and '/'. This is a strict subset of
+  // git's own ref-name rules and rules out every shell metacharacter (";",
+  // "\"", "'", "$", backtick, "&", "|", "(", ")", "<", ">", whitespace, etc.).
+  if (!/^[\w./-]+$/.test(trimmed)) {
     throw new GitWorktreeError(
-      `${fieldName} must not contain whitespace.`,
+      `${fieldName} may only contain letters, digits, '.', '_', '-', or '/'.`,
       400
     );
   }
-
-  return normalized;
+  return trimmed;
 }
 
 function slugify(value: string): string {

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -16,6 +16,12 @@ export type CreateGitWorktreeInput = {
   baseBranch?: string;
   updateBase?: boolean;
   worktreePath?: string;
+  /**
+   * When false, check out `baseBranch` directly in the new worktree instead of
+   * creating a new branch from it. The resulting `branchName` in the result is
+   * the base branch. Defaults to true.
+   */
+  createNewBranch?: boolean;
 };
 
 export type CreateGitWorktreeResult = {
@@ -84,17 +90,17 @@ export async function createGitWorktree(
 
   const repoRoot = await resolveRepoRoot(cwd, commandRunner);
   const baseBranch = normalizeRefName(input.baseBranch, "main", "baseBranch");
-  const branchName = normalizeRefName(
-    input.branchName,
-    slugify(name),
-    "branchName"
-  );
+  const createNewBranch = input.createNewBranch ?? true;
+  const branchName = createNewBranch
+    ? normalizeRefName(input.branchName, slugify(name), "branchName")
+    : baseBranch;
+  const worktreePathSlugBase = createNewBranch ? branchName : baseBranch;
   const worktreePath = input.worktreePath?.trim()
     ? path.resolve(input.worktreePath)
     : path.resolve(
         repoRoot,
         "..",
-        `${path.basename(repoRoot)}-${slugify(branchName)}`
+        `${path.basename(repoRoot)}-${slugify(worktreePathSlugBase)}`
       );
 
   if (normalizePath(worktreePath) === normalizePath(repoRoot)) {
@@ -125,25 +131,39 @@ export async function createGitWorktree(
 
   const baseSha = await resolveGitRef(repoRoot, baseRef, commandRunner);
 
-  await ensureBranchDoesNotExist(repoRoot, branchName, commandRunner);
+  if (createNewBranch) {
+    await ensureBranchDoesNotExist(repoRoot, branchName, commandRunner);
 
-  await commandRunner("git", [
-    "-C",
-    repoRoot,
-    "worktree",
-    "add",
-    "-b",
-    branchName,
-    worktreePath,
-    baseRef,
-  ]);
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      branchName,
+      worktreePath,
+      baseRef,
+    ]);
 
-  // Set upstream tracking so archival checks know which branch to compare against
-  await commandRunner(
-    "git",
-    ["-C", worktreePath, "branch", "--set-upstream-to", baseRef, branchName],
-    { allowedExitCodes: [0, 1, 128] }
-  );
+    // Set upstream tracking so archival checks know which branch to compare against
+    await commandRunner(
+      "git",
+      ["-C", worktreePath, "branch", "--set-upstream-to", baseRef, branchName],
+      { allowedExitCodes: [0, 1, 128] }
+    );
+  } else {
+    // Check out the starting branch directly. Use the local branch so git
+    // creates/updates the worktree on the user-facing ref rather than a
+    // detached origin/* ref.
+    await commandRunner("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      worktreePath,
+      baseBranch,
+    ]);
+  }
 
   return {
     repoRoot,

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -17,9 +17,12 @@ export type CreateGitWorktreeInput = {
   updateBase?: boolean;
   worktreePath?: string;
   /**
-   * When false, check out `baseBranch` directly in the new worktree instead of
-   * creating a new branch from it. The resulting `branchName` in the result is
-   * the base branch. Defaults to true.
+   * When true, fork a new branch from `baseBranch` (named `branchName` or a
+   * slug of `name`) and check it out in the worktree. When false (default),
+   * check out `baseBranch` directly without creating a new branch — the
+   * result's `branchName` will be the base branch. Defaults to false so
+   * direct callers don't get implicit branch creation; the agent manager
+   * sets it explicitly to preserve its own authoring-flow default of true.
    */
   createNewBranch?: boolean;
 };
@@ -90,7 +93,7 @@ export async function createGitWorktree(
 
   const repoRoot = await resolveRepoRoot(cwd, commandRunner);
   const baseBranch = normalizeRefName(input.baseBranch, "main", "baseBranch");
-  const createNewBranch = input.createNewBranch ?? true;
+  const createNewBranch = input.createNewBranch ?? false;
   const branchName = createNewBranch
     ? normalizeRefName(input.branchName, slugify(name), "branchName")
     : baseBranch;

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -1,7 +1,27 @@
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { access } from "node:fs/promises";
 
 import { runCommand, type RunCommandResult } from "../lib/run-command.js";
+
+/**
+ * Build a worktree-path slug from a branch name. When the worktree is being
+ * created on an existing branch (createNewBranch=false), the slug includes a
+ * short hash of the full ref so that branches that differ only in
+ * non-alphanumeric punctuation (`feature/x` vs `feature-x`, `release/2026.04`
+ * vs `release-2026-04`) don't collapse to the same on-disk path.
+ */
+export function worktreePathSlug(
+  branchName: string,
+  options: { createNewBranch: boolean }
+): string {
+  const baseSlug = slugify(branchName);
+  if (options.createNewBranch) {
+    return baseSlug;
+  }
+  const hash = createHash("sha1").update(branchName).digest("hex").slice(0, 6);
+  return `${baseSlug}-${hash}`;
+}
 
 type CommandRunner = (
   command: string,
@@ -103,7 +123,7 @@ export async function createGitWorktree(
     : path.resolve(
         repoRoot,
         "..",
-        `${path.basename(repoRoot)}-${slugify(worktreePathSlugBase)}`
+        `${path.basename(repoRoot)}-${worktreePathSlug(worktreePathSlugBase, { createNewBranch })}`
       );
 
   if (normalizePath(worktreePath) === normalizePath(repoRoot)) {

--- a/apps/server/test/db/agent-archive-branch-cleanup.test.ts
+++ b/apps/server/test/db/agent-archive-branch-cleanup.test.ts
@@ -58,7 +58,8 @@ vi.mock("../../src/shared/git/worktree.js", async () => {
   };
 });
 
-const { AgentManager } = await import("../../src/agents/manager.js");
+const { AgentManager, AgentError } =
+  await import("../../src/agents/manager.js");
 
 let pool: Pool;
 
@@ -161,6 +162,51 @@ describe("archive branch cleanup", () => {
       deleteBranch: true,
       force: true,
     });
+  });
+
+  it("normalizes whitespace-padded baseBranch so the ownership check is consistent (review #1159)", async () => {
+    // Regression: persisting `input.baseBranch` raw while the worktree branch
+    // gets trimmed makes the archive heuristic falsely classify the user's
+    // branch as Dispatch-owned. Normalizing both sides up front fixes it.
+    const agent = await manager.createAgent({
+      cwd: "/tmp",
+      useWorktree: true,
+      createNewBranch: false,
+      baseBranch: "  feature/x  ",
+    });
+
+    expect(agent.baseBranch).toBe("feature/x");
+    expect(agent.worktreeBranch).toBe("feature/x");
+
+    await archive(agent.id);
+
+    expect(cleanupGitWorktreeSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupGitWorktreeSpy.mock.calls[0][0]).toMatchObject({
+      deleteBranch: false,
+      force: true,
+    });
+  });
+
+  it("rejects baseBranch values containing shell metacharacters (review #1158)", async () => {
+    await expect(
+      manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: true,
+        createNewBranch: false,
+        baseBranch: 'main"; touch /tmp/pwned; #',
+      })
+    ).rejects.toBeInstanceOf(AgentError);
+  });
+
+  it("rejects worktreeBranch values containing shell metacharacters (review #1158)", async () => {
+    await expect(
+      manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: true,
+        createNewBranch: true,
+        worktreeBranch: "feat$(rm -rf /)",
+      })
+    ).rejects.toBeInstanceOf(AgentError);
   });
 
   it("deletes the branch for legacy agents where baseBranch is unset (no confident way to tell otherwise)", async () => {

--- a/apps/server/test/db/agent-archive-branch-cleanup.test.ts
+++ b/apps/server/test/db/agent-archive-branch-cleanup.test.ts
@@ -209,6 +209,65 @@ describe("archive branch cleanup", () => {
     ).rejects.toBeInstanceOf(AgentError);
   });
 
+  it("fails the agent with a clear last_error when worktree creation fails on the inert path (review #1160)", async () => {
+    const worktreeMod = await import("../../src/shared/git/worktree.js");
+    vi.mocked(worktreeMod.createGitWorktree).mockRejectedValueOnce(
+      new worktreeMod.GitWorktreeError(
+        "branch 'feature/x' is already checked out at /tmp/other",
+        409
+      )
+    );
+
+    try {
+      await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: true,
+        createNewBranch: false,
+        baseBranch: "feature/x",
+      });
+      expect.unreachable("createAgent should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentError);
+      expect((err as InstanceType<typeof AgentError>).statusCode).toBe(409);
+      expect((err as Error).message).toContain("Worktree creation failed");
+    }
+
+    // The agent row exists, is in a terminal "stopped" state, and carries
+    // the failure reason in last_error so the UI can surface it.
+    const rows = await pool.query(
+      "SELECT status, last_error FROM agents WHERE last_error IS NOT NULL"
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0].status).toBe("stopped");
+    expect(rows.rows[0].last_error).toContain("Worktree creation failed");
+    expect(rows.rows[0].last_error).toContain("already checked out");
+
+    // Crucially: cleanupGitWorktree was NOT called, since the worktree was
+    // never created in the first place.
+    expect(cleanupGitWorktreeSpy).not.toHaveBeenCalled();
+  });
+
+  it("exposes markSetupFailed to surface tmux-side worktree failures (review #1160)", async () => {
+    const agent = await manager.createAgent({
+      cwd: "/tmp",
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranch: "feat/auto",
+    });
+
+    await manager.markSetupFailed(
+      agent.id,
+      "git worktree add failed: branch 'feat/auto' is already checked out"
+    );
+
+    const row = await pool.query(
+      "SELECT status, last_error FROM agents WHERE id = $1",
+      [agent.id]
+    );
+    expect(row.rows[0].status).toBe("stopped");
+    expect(row.rows[0].last_error).toContain("git worktree add failed");
+  });
+
   it("deletes the branch for legacy agents where baseBranch is unset (no confident way to tell otherwise)", async () => {
     // Older records created before CRU-139 don't have base_branch populated.
     // The cleanup heuristic should still delete the branch in that case so the

--- a/apps/server/test/db/agent-archive-branch-cleanup.test.ts
+++ b/apps/server/test/db/agent-archive-branch-cleanup.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Verifies that archiving an agent's worktree only deletes the branch that
+ * Dispatch created — never the user's pre-existing starting branch. This is
+ * the safety net for the CRU-139 "managed worktree on an existing branch"
+ * flow: if the agent was created with createNewBranch=false, the worktree is
+ * on the user's own branch (e.g. main, feature/x), and archive cleanup must
+ * not `git branch -D` it.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import type { Pool } from "pg";
+
+import { setupTestDb, teardownTestDb, runTestMigrations } from "./setup.js";
+
+// Silence tmux side effects from AgentManager.
+vi.mock("../../src/shared/lib/run-command.js", () => ({
+  runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+}));
+
+// Stub the worktree helpers so we can (a) skip real git work during archive
+// and (b) observe what AgentManager asks us to do.
+const cleanupGitWorktreeSpy = vi.fn(async () => ({
+  repoRoot: "/tmp/repo",
+  worktreePath: "/tmp/repo-wt",
+  worktreeName: "repo-wt",
+  branchName: null,
+  baseBranch: "main",
+  updatedBaseBranch: false,
+  deletedBranch: false,
+}));
+
+vi.mock("../../src/shared/git/worktree.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/shared/git/worktree.js")
+  >("../../src/shared/git/worktree.js");
+  return {
+    ...actual,
+    cleanupGitWorktree: cleanupGitWorktreeSpy,
+    createGitWorktree: vi.fn(async (input) => ({
+      repoRoot: "/tmp/repo",
+      worktreePath: "/tmp/repo-wt",
+      worktreeName: "repo-wt",
+      branchName:
+        input.createNewBranch === false
+          ? (input.baseBranch ?? "main")
+          : (input.branchName ?? "work"),
+      baseBranch: input.baseBranch ?? "main",
+      baseRef: `origin/${input.baseBranch ?? "main"}`,
+      baseSha: "deadbeef",
+    })),
+  };
+});
+
+const { AgentManager } = await import("../../src/agents/manager.js");
+
+let pool: Pool;
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+  child: () => noopLogger,
+  silent: () => {},
+  level: "silent",
+} as unknown as import("fastify").FastifyBaseLogger;
+
+const inertConfig = {
+  host: "127.0.0.1",
+  port: 6767,
+  databaseUrl: "",
+  authToken: "test-token",
+  mediaRoot: "/tmp/dispatch-test-media",
+  dispatchBinDir: "/tmp",
+  codexBin: "echo",
+  claudeBin: "echo",
+  opencodeBin: "echo",
+  agentRuntime: "inert",
+  sessionPrefix: "dispatch",
+  tls: null,
+} satisfies import("../../src/config.js").AppConfig;
+
+let manager: InstanceType<typeof AgentManager>;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+  await runTestMigrations();
+  manager = new AgentManager(pool, noopLogger, inertConfig);
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await pool.query("DELETE FROM agent_feedback");
+  await pool.query("DELETE FROM media_seen");
+  await pool.query("DELETE FROM media");
+  await pool.query("DELETE FROM agents");
+  cleanupGitWorktreeSpy.mockClear();
+});
+
+async function archive(id: string): Promise<void> {
+  await manager.beginArchive(id, "force");
+  await new Promise<void>((resolve, reject) => {
+    void manager.executeArchive(id, {
+      onPhaseChange: () => {},
+      onComplete: () => resolve(),
+      onError: (err) => reject(err),
+    });
+  });
+}
+
+describe("archive branch cleanup", () => {
+  it("preserves the user's branch when the worktree was started on it (createNewBranch=false)", async () => {
+    const agent = await manager.createAgent({
+      cwd: "/tmp",
+      useWorktree: true,
+      createNewBranch: false,
+      baseBranch: "feature/x",
+    });
+
+    // AgentManager records worktree_branch === base_branch for this flow.
+    expect(agent.worktreeBranch).toBe("feature/x");
+    expect(agent.baseBranch).toBe("feature/x");
+
+    await archive(agent.id);
+
+    expect(cleanupGitWorktreeSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupGitWorktreeSpy.mock.calls[0][0]).toMatchObject({
+      deleteBranch: false,
+      force: true,
+    });
+  });
+
+  it("deletes the dispatch-created branch when archiving an agent that forked a new branch", async () => {
+    const agent = await manager.createAgent({
+      cwd: "/tmp",
+      useWorktree: true,
+      createNewBranch: true,
+      baseBranch: "main",
+      worktreeBranch: "feat/auto-generated",
+    });
+
+    expect(agent.worktreeBranch).toBe("feat/auto-generated");
+    expect(agent.baseBranch).toBe("main");
+
+    await archive(agent.id);
+
+    expect(cleanupGitWorktreeSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupGitWorktreeSpy.mock.calls[0][0]).toMatchObject({
+      deleteBranch: true,
+      force: true,
+    });
+  });
+
+  it("deletes the branch for legacy agents where baseBranch is unset (no confident way to tell otherwise)", async () => {
+    // Older records created before CRU-139 don't have base_branch populated.
+    // The cleanup heuristic should still delete the branch in that case so the
+    // pre-existing behavior is preserved for old rows.
+    const agent = await manager.createAgent({
+      cwd: "/tmp",
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranch: "legacy/branch",
+    });
+
+    // Force base_branch to NULL to simulate a pre-migration row.
+    await pool.query("UPDATE agents SET base_branch = NULL WHERE id = $1", [
+      agent.id,
+    ]);
+
+    await archive(agent.id);
+
+    expect(cleanupGitWorktreeSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupGitWorktreeSpy.mock.calls[0][0]).toMatchObject({
+      deleteBranch: true,
+      force: true,
+    });
+  });
+});

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -781,7 +781,10 @@ describe("AgentManager", () => {
   describe("getTerminalAccess", () => {
     it("should return inert terminal metadata for inert runtime agents", async () => {
       const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
-      const agent = await inertManager.createAgent({ cwd: "/tmp" });
+      const agent = await inertManager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
 
       const access = await inertManager.getTerminalAccess(agent.id);
 
@@ -1020,7 +1023,10 @@ describe("AgentManager", () => {
       const { runCommand } =
         await import("../../src/shared/lib/run-command.js");
       const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
-      const agent = await inertManager.createAgent({ cwd: "/tmp" });
+      const agent = await inertManager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
       vi.mocked(runCommand).mockClear();
 
       const stopped = await inertManager.stopAgent(agent.id, { force: true });

--- a/apps/server/test/git-worktree.test.ts
+++ b/apps/server/test/git-worktree.test.ts
@@ -66,6 +66,54 @@ describe("git worktree services", () => {
     });
   });
 
+  it("checks out an existing branch when createNewBranch is false", async () => {
+    const repoRoot = path.join(tempRoot, "repo");
+    const expectedWorktreePath = path.join(tempRoot, "repo-feature-x");
+    const calls: string[] = [];
+
+    vi.mocked(runCommand).mockImplementation(async (_command, args) => {
+      const key = args.join(" ");
+      calls.push(key);
+
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `-C ${repoRoot} fetch origin feature/x --quiet`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `-C ${repoRoot} rev-parse --verify origin/feature/x`:
+          return { exitCode: 0, stdout: "deadbeef", stderr: "" };
+        case `-C ${repoRoot} worktree add ${expectedWorktreePath} feature/x`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const result = await createGitWorktree({
+      cwd: repoRoot,
+      name: "Review Branch X",
+      baseBranch: "feature/x",
+      createNewBranch: false,
+    });
+
+    // No `-b` flag; checks out the existing branch directly.
+    expect(calls).toContain(
+      `-C ${repoRoot} worktree add ${expectedWorktreePath} feature/x`
+    );
+    // Must not pre-check for a clashing branch — the user's branch is expected
+    // to exist.
+    expect(
+      calls.some((c) => c.includes("show-ref --verify --quiet refs/heads/"))
+    ).toBe(false);
+    // Must not set upstream tracking — we're on the user's branch as-is.
+    expect(calls.some((c) => c.includes("--set-upstream-to"))).toBe(false);
+    // Worktree path slug derives from the base branch when no new branch is
+    // created.
+    expect(result.worktreePath).toBe(expectedWorktreePath);
+    expect(result.branchName).toBe("feature/x");
+    expect(result.baseBranch).toBe("feature/x");
+  });
+
   it("rejects worktree creation when the branch already exists", async () => {
     const repoRoot = path.join(tempRoot, "repo");
 

--- a/apps/server/test/git-worktree.test.ts
+++ b/apps/server/test/git-worktree.test.ts
@@ -67,14 +67,67 @@ describe("git worktree services", () => {
     });
   });
 
+  it("derives a hashed worktree-path slug when createNewBranch is false (review #1161)", async () => {
+    // `feature/x` and `feature-x` slug-collapse to `feature-x` with the
+    // legacy mapping. The hash discriminator added for createNewBranch=false
+    // gives each its own on-disk path.
+    const repoRoot = path.join(tempRoot, "repo");
+    const adds: string[] = [];
+
+    vi.mocked(runCommand).mockImplementation(async (_command, args) => {
+      const key = args.join(" ");
+      if (key.startsWith(`-C ${repoRoot} worktree add `)) {
+        adds.push(key);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      switch (key) {
+        case `-C ${repoRoot} rev-parse --show-toplevel`:
+          return { exitCode: 0, stdout: repoRoot, stderr: "" };
+        case `-C ${repoRoot} fetch origin feature/x --quiet`:
+        case `-C ${repoRoot} fetch origin feature-x --quiet`:
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case `-C ${repoRoot} rev-parse --verify origin/feature/x`:
+        case `-C ${repoRoot} rev-parse --verify origin/feature-x`:
+          return { exitCode: 0, stdout: "deadbeef", stderr: "" };
+        default:
+          throw new Error(`Unexpected command: ${key}`);
+      }
+    });
+
+    const a = await createGitWorktree({
+      cwd: repoRoot,
+      name: "x",
+      baseBranch: "feature/x",
+      createNewBranch: false,
+    });
+    const b = await createGitWorktree({
+      cwd: repoRoot,
+      name: "y",
+      baseBranch: "feature-x",
+      createNewBranch: false,
+    });
+
+    expect(a.worktreePath).not.toBe(b.worktreePath);
+    expect(a.worktreePath).toMatch(/-feature-x-[0-9a-f]{6}$/);
+    expect(b.worktreePath).toMatch(/-feature-x-[0-9a-f]{6}$/);
+  });
+
   it("checks out an existing branch when createNewBranch is false", async () => {
     const repoRoot = path.join(tempRoot, "repo");
-    const expectedWorktreePath = path.join(tempRoot, "repo-feature-x");
+    let recordedWorktreePath: string | null = null;
     const calls: string[] = [];
 
     vi.mocked(runCommand).mockImplementation(async (_command, args) => {
       const key = args.join(" ");
       calls.push(key);
+      const addPrefix = `-C ${repoRoot} worktree add `;
+      if (key.startsWith(addPrefix)) {
+        const rest = key.slice(addPrefix.length);
+        const [pathArg, branchArg] = rest.split(" ");
+        recordedWorktreePath = pathArg;
+        expect(branchArg).toBe("feature/x");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
 
       switch (key) {
         case `-C ${repoRoot} rev-parse --show-toplevel`:
@@ -83,8 +136,6 @@ describe("git worktree services", () => {
           return { exitCode: 0, stdout: "", stderr: "" };
         case `-C ${repoRoot} rev-parse --verify origin/feature/x`:
           return { exitCode: 0, stdout: "deadbeef", stderr: "" };
-        case `-C ${repoRoot} worktree add ${expectedWorktreePath} feature/x`:
-          return { exitCode: 0, stdout: "", stderr: "" };
         default:
           throw new Error(`Unexpected command: ${key}`);
       }
@@ -97,10 +148,12 @@ describe("git worktree services", () => {
       createNewBranch: false,
     });
 
-    // No `-b` flag; checks out the existing branch directly.
-    expect(calls).toContain(
-      `-C ${repoRoot} worktree add ${expectedWorktreePath} feature/x`
+    // Path slug derives from the base branch with a hash discriminator (see
+    // worktreePathSlug). Lock the prefix and the 6-char hex suffix shape.
+    expect(result.worktreePath).toMatch(
+      new RegExp(`^${tempRoot}/repo-feature-x-[0-9a-f]{6}$`)
     );
+    expect(recordedWorktreePath).toBe(result.worktreePath);
     // Must not pre-check for a clashing branch — the user's branch is expected
     // to exist.
     expect(
@@ -108,9 +161,6 @@ describe("git worktree services", () => {
     ).toBe(false);
     // Must not set upstream tracking — we're on the user's branch as-is.
     expect(calls.some((c) => c.includes("--set-upstream-to"))).toBe(false);
-    // Worktree path slug derives from the base branch when no new branch is
-    // created.
-    expect(result.worktreePath).toBe(expectedWorktreePath);
     expect(result.branchName).toBe("feature/x");
     expect(result.baseBranch).toBe("feature/x");
   });

--- a/apps/server/test/git-worktree.test.ts
+++ b/apps/server/test/git-worktree.test.ts
@@ -53,6 +53,7 @@ describe("git worktree services", () => {
     const result = await createGitWorktree({
       cwd: path.join(repoRoot, "nested"),
       name: "Feature Auth Flow",
+      createNewBranch: true,
     });
 
     expect(result).toEqual({
@@ -138,6 +139,7 @@ describe("git worktree services", () => {
       createGitWorktree({
         cwd: repoRoot,
         name: "Existing Branch",
+        createNewBranch: true,
       })
     ).rejects.toMatchObject({
       name: "GitWorktreeError",

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -30,6 +30,12 @@ export type BranchSelectProps = {
   onWorktreeBranchChange: (value: string) => void;
   testIdPrefix?: string;
   worktreeBranchPlaceholder?: string;
+  /** Label rendered above the base branch combobox. Defaults to "Base branch". */
+  baseBranchLabel?: string;
+  /** Optional helper text rendered below the base branch combobox. */
+  baseBranchHelper?: string;
+  /** When false, hide the "new branch name" text input. Defaults to true. */
+  showNewBranchInput?: boolean;
 };
 
 export function BranchSelect({
@@ -40,6 +46,9 @@ export function BranchSelect({
   onWorktreeBranchChange,
   testIdPrefix = "branch-select",
   worktreeBranchPlaceholder = "branch name (auto-generated if empty)",
+  baseBranchLabel = "Base branch",
+  baseBranchHelper,
+  showNewBranchInput = true,
 }: BranchSelectProps): JSX.Element {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
@@ -103,7 +112,7 @@ export function BranchSelect({
     <div className="space-y-2">
       <div className="relative" ref={cmdRef}>
         <label className="mb-1 block text-xs text-muted-foreground">
-          Base branch
+          {baseBranchLabel}
         </label>
         <button
           ref={triggerRef}
@@ -221,13 +230,17 @@ export function BranchSelect({
           Saved branch <span className="font-mono">{baseBranch}</span> no longer
           exists on the remote — pick a new one.
         </div>
+      ) : baseBranchHelper ? (
+        <p className="text-xs text-muted-foreground">{baseBranchHelper}</p>
       ) : null}
-      <Input
-        value={worktreeBranch}
-        onChange={(event) => onWorktreeBranchChange(event.target.value)}
-        placeholder={worktreeBranchPlaceholder}
-        data-testid={`${testIdPrefix}-worktree-branch`}
-      />
+      {showNewBranchInput ? (
+        <Input
+          value={worktreeBranch}
+          onChange={(event) => onWorktreeBranchChange(event.target.value)}
+          placeholder={worktreeBranchPlaceholder}
+          data-testid={`${testIdPrefix}-worktree-branch`}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -44,6 +44,7 @@ const CWD_HISTORY_MAX = 20;
 const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
 const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
 const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
+const CREATE_NEW_BRANCH_PREFIX = "dispatch:createNewBranch:";
 
 function readStoredString(key: string): string {
   if (typeof window === "undefined") return "";
@@ -105,12 +106,14 @@ function useCreateAgentPrefs(cwd: string) {
   const [fullAccess, setFullAccess] = useState(false);
   const [autoReview, setAutoReview] = useState(false);
   const [baseBranch, setBaseBranch] = useState("main");
+  const [createNewBranch, _setCreateNewBranch] = useState(true);
 
   useEffect(() => {
     if (!trimmedCwd) {
       setFullAccess(false);
       setAutoReview(false);
       setBaseBranch("main");
+      _setCreateNewBranch(true);
       return;
     }
     setFullAccess(
@@ -121,6 +124,9 @@ function useCreateAgentPrefs(cwd: string) {
     );
     setBaseBranch(
       readStoredString(`${BASE_BRANCH_PREFIX}${trimmedCwd}`) || "main"
+    );
+    _setCreateNewBranch(
+      readStoredBoolean(`${CREATE_NEW_BRANCH_PREFIX}${trimmedCwd}`, true)
     );
   }, [trimmedCwd]);
 
@@ -148,6 +154,27 @@ function useCreateAgentPrefs(cwd: string) {
     );
   }, [baseBranch, trimmedCwd]);
 
+  // Wrapped setter that writes synchronously on user updates. We don't use a
+  // useEffect-based write here because it would race with the load effect on
+  // a cwd change: both effects fire in the same commit, and the write would
+  // persist the still-stale state from the previous cwd before the loaded
+  // value was committed.
+  const setCreateNewBranch = useCallback(
+    (next: boolean | ((prev: boolean) => boolean)) => {
+      _setCreateNewBranch((prev) => {
+        const value = typeof next === "function" ? next(prev) : next;
+        if (trimmedCwd && typeof window !== "undefined") {
+          window.localStorage.setItem(
+            `${CREATE_NEW_BRANCH_PREFIX}${trimmedCwd}`,
+            String(value)
+          );
+        }
+        return value;
+      });
+    },
+    [trimmedCwd]
+  );
+
   return {
     fullAccess,
     setFullAccess,
@@ -155,6 +182,8 @@ function useCreateAgentPrefs(cwd: string) {
     setAutoReview,
     baseBranch,
     setBaseBranch,
+    createNewBranch,
+    setCreateNewBranch,
   };
 }
 
@@ -215,6 +244,7 @@ function CreateAgentDialogContent({
   );
   const [createUseWorktree, setCreateUseWorktree] = useState(true);
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
+  const [cwdIsGitRepo, setCwdIsGitRepo] = useState<boolean | null>(null);
   const [initialPrompt, setInitialPrompt] = useState("");
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() =>
@@ -227,6 +257,8 @@ function CreateAgentDialogContent({
     setAutoReview: setCreateAutoReview,
     baseBranch: createBaseBranch,
     setBaseBranch: setCreateBaseBranch,
+    createNewBranch,
+    setCreateNewBranch,
   } = useCreateAgentPrefs(createCwd);
 
   useEffect(() => {
@@ -270,6 +302,13 @@ function CreateAgentDialogContent({
     setCwdHistory(removeCwdFromHistory(cwd));
   }, []);
 
+  const handlePathInfoChange = useCallback(
+    (info: { isGitRepo: boolean } | null) => {
+      setCwdIsGitRepo(info ? info.isGitRepo : null);
+    },
+    []
+  );
+
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -278,6 +317,11 @@ function CreateAgentDialogContent({
 
       setCreating(true);
       try {
+        // The managed-worktree section is hidden for non-git cwds; force the
+        // payload to skip worktree creation in that case so the server doesn't
+        // try to run git in a non-repo directory.
+        const submitUseWorktree =
+          cwdIsGitRepo === false ? false : createUseWorktree;
         const payload = await api<{ agent: Agent }>("/api/v1/agents", {
           method: "POST",
           body: JSON.stringify({
@@ -286,10 +330,16 @@ function CreateAgentDialogContent({
             type: createType,
             fullAccess: createFullAccess,
             autoReview: createAutoReview,
-            useWorktree: createUseWorktree,
-            worktreeBranch: createWorktreeBranch.trim() || undefined,
+            useWorktree: submitUseWorktree,
+            createNewBranch: submitUseWorktree ? createNewBranch : undefined,
+            worktreeBranch:
+              submitUseWorktree && createNewBranch
+                ? createWorktreeBranch.trim() || undefined
+                : undefined,
             baseBranch:
-              createBaseBranch !== "main" ? createBaseBranch : undefined,
+              submitUseWorktree && createBaseBranch !== "main"
+                ? createBaseBranch
+                : undefined,
             initialPrompt: initialPrompt.trim() || undefined,
           }),
         });
@@ -310,9 +360,11 @@ function CreateAgentDialogContent({
       createCwd,
       createFullAccess,
       createName,
+      createNewBranch,
       createType,
       createUseWorktree,
       createWorktreeBranch,
+      cwdIsGitRepo,
       initialPrompt,
       onCreated,
     ]
@@ -450,44 +502,135 @@ function CreateAgentDialogContent({
                   label="Working directory"
                   history={cwdHistory}
                   onRemoveHistory={handleRemoveCwdHistory}
+                  onPathInfoChange={handlePathInfoChange}
                   data-testid="create-agent-cwd"
                   historyItemTestId="create-agent-cwd-history-option"
                 />
 
-                <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-                  <label className="flex cursor-pointer items-start gap-3">
-                    <Checkbox
-                      checked={createUseWorktree}
-                      onCheckedChange={() =>
-                        setCreateUseWorktree((current) => !current)
-                      }
-                      className="mt-0.5"
-                      title="Toggle git worktree"
-                      data-testid="create-agent-worktree"
-                    />
-                    <span className="space-y-1">
-                      <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                        <GitBranch className="h-3.5 w-3.5" />
-                        Create git worktree
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        Creates an isolated worktree and branch for this agent.
-                      </span>
-                    </span>
-                  </label>
-                  {createUseWorktree ? (
-                    <div className="ml-8 w-[calc(100%-2rem)]">
-                      <BranchSelect
-                        cwd={createCwd}
-                        baseBranch={createBaseBranch}
-                        onBaseBranchChange={setCreateBaseBranch}
-                        worktreeBranch={createWorktreeBranch}
-                        onWorktreeBranchChange={setCreateWorktreeBranch}
-                        testIdPrefix="create-agent"
-                      />
+                {(() => {
+                  const worktreeAvailable = cwdIsGitRepo !== false;
+                  const worktreeChecked =
+                    worktreeAvailable && createUseWorktree;
+                  return (
+                    <div
+                      className={cn(
+                        "space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 transition-opacity duration-200",
+                        !worktreeAvailable && "opacity-60"
+                      )}
+                      data-testid="create-agent-worktree-section"
+                    >
+                      <label
+                        className={cn(
+                          "flex items-start gap-3",
+                          worktreeAvailable
+                            ? "cursor-pointer"
+                            : "cursor-not-allowed"
+                        )}
+                      >
+                        <Checkbox
+                          checked={worktreeChecked}
+                          onCheckedChange={() =>
+                            setCreateUseWorktree((current) => !current)
+                          }
+                          disabled={!worktreeAvailable}
+                          className="mt-0.5"
+                          title={
+                            worktreeAvailable
+                              ? "Toggle managed git worktree"
+                              : "Not a git repository"
+                          }
+                          data-testid="create-agent-worktree"
+                        />
+                        <span className="space-y-1">
+                          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                            <GitBranch className="h-3.5 w-3.5" />
+                            Create managed git worktree
+                          </span>
+                          <span className="block text-xs text-muted-foreground">
+                            {worktreeAvailable
+                              ? "Creates an isolated worktree for this agent. Dispatch tracks and cleans it up when the agent is archived."
+                              : "Working directory isn't a git repository, so a managed worktree isn't available here."}
+                          </span>
+                        </span>
+                      </label>
+                      <div
+                        className={cn(
+                          "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                          worktreeChecked
+                            ? "grid-rows-[1fr] opacity-100"
+                            : "grid-rows-[0fr] opacity-0"
+                        )}
+                        aria-hidden={!worktreeChecked}
+                      >
+                        <div className="min-h-0 overflow-hidden">
+                          <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
+                            <BranchSelect
+                              cwd={createCwd}
+                              baseBranch={createBaseBranch}
+                              onBaseBranchChange={setCreateBaseBranch}
+                              worktreeBranch={createWorktreeBranch}
+                              onWorktreeBranchChange={setCreateWorktreeBranch}
+                              baseBranchLabel="Starting branch"
+                              baseBranchHelper="The branch to check out in the worktree."
+                              showNewBranchInput={false}
+                              testIdPrefix="create-agent"
+                            />
+                            <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
+                              <label className="flex cursor-pointer items-start gap-3">
+                                <Checkbox
+                                  checked={createNewBranch}
+                                  onCheckedChange={() =>
+                                    setCreateNewBranch((current) => !current)
+                                  }
+                                  className="mt-0.5"
+                                  title="Toggle new branch creation"
+                                  data-testid="create-agent-new-branch"
+                                />
+                                <span className="space-y-1">
+                                  <span className="block text-sm font-medium text-foreground">
+                                    Create a new branch in this worktree
+                                  </span>
+                                  <span className="block text-xs text-muted-foreground">
+                                    Creates a new working branch from the
+                                    starting branch so the agent can make
+                                    isolated changes for later submission.
+                                  </span>
+                                </span>
+                              </label>
+                              <div
+                                className={cn(
+                                  "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                                  createNewBranch
+                                    ? "grid-rows-[1fr] opacity-100"
+                                    : "grid-rows-[0fr] opacity-0"
+                                )}
+                                aria-hidden={!createNewBranch}
+                              >
+                                <div className="min-h-0 overflow-hidden">
+                                  <div className="ml-8 w-[calc(100%-2rem)] space-y-1 pt-1">
+                                    <label className="block text-xs text-muted-foreground">
+                                      New branch name
+                                    </label>
+                                    <Input
+                                      value={createWorktreeBranch}
+                                      onChange={(event) =>
+                                        setCreateWorktreeBranch(
+                                          event.target.value
+                                        )
+                                      }
+                                      placeholder="auto-generated if empty"
+                                      data-testid="create-agent-worktree-branch"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                  ) : null}
-                </div>
+                  );
+                })()}
 
                 {createType !== "terminal" ? (
                   <>

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -261,6 +261,13 @@ function CreateAgentDialogContent({
     setCreateNewBranch,
   } = useCreateAgentPrefs(createCwd);
 
+  // The new-branch name is per-cwd in spirit (a branch named "repo-A-feature"
+  // doesn't make sense in repo B); clear it whenever cwd changes so a name
+  // typed for one repo doesn't leak into another.
+  useEffect(() => {
+    setCreateWorktreeBranch("");
+  }, [createCwd]);
+
   useEffect(() => {
     if (createCwdInitialized) return;
     let cancelled = false;
@@ -561,6 +568,11 @@ function CreateAgentDialogContent({
                             : "grid-rows-[0fr] opacity-0"
                         )}
                         aria-hidden={!worktreeChecked}
+                        // Keep collapsed controls out of focus and pointer
+                        // interaction. Cast for React 18 type defs.
+                        {...(!worktreeChecked
+                          ? ({ inert: "" } as Record<string, string>)
+                          : {})}
                       >
                         <div className="min-h-0 overflow-hidden">
                           <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
@@ -605,9 +617,12 @@ function CreateAgentDialogContent({
                                     : "grid-rows-[0fr] opacity-0"
                                 )}
                                 aria-hidden={!createNewBranch}
+                                {...(!createNewBranch
+                                  ? ({ inert: "" } as Record<string, string>)
+                                  : {})}
                               >
                                 <div className="min-h-0 overflow-hidden">
-                                  <div className="ml-8 w-[calc(100%-2rem)] space-y-1 pt-1">
+                                  <div className="space-y-1 pt-2">
                                     <label className="block text-xs text-muted-foreground">
                                       New branch name
                                     </label>

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -2,9 +2,11 @@ import {
   type FormEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
+import { useAtom } from "jotai";
 import { Check, ChevronDown, GitBranch, ChevronLeft } from "lucide-react";
 
 import { BranchSelect } from "@/components/app/branch-select";
@@ -35,6 +37,7 @@ import {
 } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
+import { createNewBranchPrefAtom } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
 const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
@@ -44,7 +47,6 @@ const CWD_HISTORY_MAX = 20;
 const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
 const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
 const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
-const CREATE_NEW_BRANCH_PREFIX = "dispatch:createNewBranch:";
 
 function readStoredString(key: string): string {
   if (typeof window === "undefined") return "";
@@ -106,14 +108,21 @@ function useCreateAgentPrefs(cwd: string) {
   const [fullAccess, setFullAccess] = useState(false);
   const [autoReview, setAutoReview] = useState(false);
   const [baseBranch, setBaseBranch] = useState("main");
-  const [createNewBranch, _setCreateNewBranch] = useState(true);
+
+  // createNewBranch is per-cwd persisted via a jotai atomFamily — the atom's
+  // identity changes with cwd, so reads/writes route to the correct
+  // localStorage entry without manual load/write effects.
+  const createNewBranchAtom = useMemo(
+    () => createNewBranchPrefAtom(trimmedCwd),
+    [trimmedCwd]
+  );
+  const [createNewBranch, setCreateNewBranch] = useAtom(createNewBranchAtom);
 
   useEffect(() => {
     if (!trimmedCwd) {
       setFullAccess(false);
       setAutoReview(false);
       setBaseBranch("main");
-      _setCreateNewBranch(true);
       return;
     }
     setFullAccess(
@@ -124,9 +133,6 @@ function useCreateAgentPrefs(cwd: string) {
     );
     setBaseBranch(
       readStoredString(`${BASE_BRANCH_PREFIX}${trimmedCwd}`) || "main"
-    );
-    _setCreateNewBranch(
-      readStoredBoolean(`${CREATE_NEW_BRANCH_PREFIX}${trimmedCwd}`, true)
     );
   }, [trimmedCwd]);
 
@@ -153,27 +159,6 @@ function useCreateAgentPrefs(cwd: string) {
       baseBranch
     );
   }, [baseBranch, trimmedCwd]);
-
-  // Wrapped setter that writes synchronously on user updates. We don't use a
-  // useEffect-based write here because it would race with the load effect on
-  // a cwd change: both effects fire in the same commit, and the write would
-  // persist the still-stale state from the previous cwd before the loaded
-  // value was committed.
-  const setCreateNewBranch = useCallback(
-    (next: boolean | ((prev: boolean) => boolean)) => {
-      _setCreateNewBranch((prev) => {
-        const value = typeof next === "function" ? next(prev) : next;
-        if (trimmedCwd && typeof window !== "undefined") {
-          window.localStorage.setItem(
-            `${CREATE_NEW_BRANCH_PREFIX}${trimmedCwd}`,
-            String(value)
-          );
-        }
-        return value;
-      });
-    },
-    [trimmedCwd]
-  );
 
   return {
     fullAccess,
@@ -377,6 +362,9 @@ function CreateAgentDialogContent({
     ]
   );
 
+  const worktreeAvailable = cwdIsGitRepo !== false;
+  const worktreeChecked = worktreeAvailable && createUseWorktree;
+
   return (
     <DialogContent
       onEscapeKeyDown={(e) => {
@@ -514,138 +502,129 @@ function CreateAgentDialogContent({
                   historyItemTestId="create-agent-cwd-history-option"
                 />
 
-                {(() => {
-                  const worktreeAvailable = cwdIsGitRepo !== false;
-                  const worktreeChecked =
-                    worktreeAvailable && createUseWorktree;
-                  return (
-                    <div
-                      className={cn(
-                        "space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 transition-opacity duration-200",
-                        !worktreeAvailable && "opacity-60"
-                      )}
-                      data-testid="create-agent-worktree-section"
-                    >
-                      <label
-                        className={cn(
-                          "flex items-start gap-3",
-                          worktreeAvailable
-                            ? "cursor-pointer"
-                            : "cursor-not-allowed"
-                        )}
-                      >
-                        <Checkbox
-                          checked={worktreeChecked}
-                          onCheckedChange={() =>
-                            setCreateUseWorktree((current) => !current)
-                          }
-                          disabled={!worktreeAvailable}
-                          className="mt-0.5"
-                          title={
-                            worktreeAvailable
-                              ? "Toggle managed git worktree"
-                              : "Not a git repository"
-                          }
-                          data-testid="create-agent-worktree"
+                <div
+                  className={cn(
+                    "space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 transition-opacity duration-200",
+                    !worktreeAvailable && "opacity-60"
+                  )}
+                  data-testid="create-agent-worktree-section"
+                >
+                  <label
+                    className={cn(
+                      "flex items-start gap-3",
+                      worktreeAvailable
+                        ? "cursor-pointer"
+                        : "cursor-not-allowed"
+                    )}
+                  >
+                    <Checkbox
+                      checked={worktreeChecked}
+                      onCheckedChange={() =>
+                        setCreateUseWorktree((current) => !current)
+                      }
+                      disabled={!worktreeAvailable}
+                      className="mt-0.5"
+                      title={
+                        worktreeAvailable
+                          ? "Toggle managed git worktree"
+                          : "Not a git repository"
+                      }
+                      data-testid="create-agent-worktree"
+                    />
+                    <span className="space-y-1">
+                      <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                        <GitBranch className="h-3.5 w-3.5" />
+                        Create managed git worktree
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {worktreeAvailable
+                          ? "Creates an isolated worktree for this agent. Dispatch tracks and cleans it up when the agent is archived."
+                          : "Working directory isn't a git repository, so a managed worktree isn't available here."}
+                      </span>
+                    </span>
+                  </label>
+                  <div
+                    className={cn(
+                      "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                      worktreeChecked
+                        ? "grid-rows-[1fr] opacity-100"
+                        : "grid-rows-[0fr] opacity-0"
+                    )}
+                    aria-hidden={!worktreeChecked}
+                    // Keep collapsed controls out of focus and pointer
+                    // interaction. Cast for React 18 type defs.
+                    {...(!worktreeChecked
+                      ? ({ inert: "" } as Record<string, string>)
+                      : {})}
+                  >
+                    <div className="min-h-0 overflow-hidden">
+                      <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
+                        <BranchSelect
+                          cwd={createCwd}
+                          baseBranch={createBaseBranch}
+                          onBaseBranchChange={setCreateBaseBranch}
+                          worktreeBranch={createWorktreeBranch}
+                          onWorktreeBranchChange={setCreateWorktreeBranch}
+                          baseBranchLabel="Starting branch"
+                          baseBranchHelper="The branch to check out in the worktree."
+                          showNewBranchInput={false}
+                          testIdPrefix="create-agent"
                         />
-                        <span className="space-y-1">
-                          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                            <GitBranch className="h-3.5 w-3.5" />
-                            Create managed git worktree
-                          </span>
-                          <span className="block text-xs text-muted-foreground">
-                            {worktreeAvailable
-                              ? "Creates an isolated worktree for this agent. Dispatch tracks and cleans it up when the agent is archived."
-                              : "Working directory isn't a git repository, so a managed worktree isn't available here."}
-                          </span>
-                        </span>
-                      </label>
-                      <div
-                        className={cn(
-                          "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-                          worktreeChecked
-                            ? "grid-rows-[1fr] opacity-100"
-                            : "grid-rows-[0fr] opacity-0"
-                        )}
-                        aria-hidden={!worktreeChecked}
-                        // Keep collapsed controls out of focus and pointer
-                        // interaction. Cast for React 18 type defs.
-                        {...(!worktreeChecked
-                          ? ({ inert: "" } as Record<string, string>)
-                          : {})}
-                      >
-                        <div className="min-h-0 overflow-hidden">
-                          <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
-                            <BranchSelect
-                              cwd={createCwd}
-                              baseBranch={createBaseBranch}
-                              onBaseBranchChange={setCreateBaseBranch}
-                              worktreeBranch={createWorktreeBranch}
-                              onWorktreeBranchChange={setCreateWorktreeBranch}
-                              baseBranchLabel="Starting branch"
-                              baseBranchHelper="The branch to check out in the worktree."
-                              showNewBranchInput={false}
-                              testIdPrefix="create-agent"
+                        <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
+                          <label className="flex cursor-pointer items-start gap-3">
+                            <Checkbox
+                              checked={createNewBranch}
+                              onCheckedChange={() =>
+                                setCreateNewBranch((current) => !current)
+                              }
+                              className="mt-0.5"
+                              title="Toggle new branch creation"
+                              data-testid="create-agent-new-branch"
                             />
-                            <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
-                              <label className="flex cursor-pointer items-start gap-3">
-                                <Checkbox
-                                  checked={createNewBranch}
-                                  onCheckedChange={() =>
-                                    setCreateNewBranch((current) => !current)
+                            <span className="space-y-1">
+                              <span className="block text-sm font-medium text-foreground">
+                                Create a new branch in this worktree
+                              </span>
+                              <span className="block text-xs text-muted-foreground">
+                                Creates a new working branch from the starting
+                                branch so the agent can make isolated changes
+                                for later submission.
+                              </span>
+                            </span>
+                          </label>
+                          <div
+                            className={cn(
+                              "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                              createNewBranch
+                                ? "grid-rows-[1fr] opacity-100"
+                                : "grid-rows-[0fr] opacity-0"
+                            )}
+                            aria-hidden={!createNewBranch}
+                            {...(!createNewBranch
+                              ? ({ inert: "" } as Record<string, string>)
+                              : {})}
+                          >
+                            <div className="min-h-0 overflow-hidden">
+                              <div className="space-y-1 pt-2">
+                                <label className="block text-xs text-muted-foreground">
+                                  New branch name
+                                </label>
+                                <Input
+                                  value={createWorktreeBranch}
+                                  onChange={(event) =>
+                                    setCreateWorktreeBranch(event.target.value)
                                   }
-                                  className="mt-0.5"
-                                  title="Toggle new branch creation"
-                                  data-testid="create-agent-new-branch"
+                                  placeholder="auto-generated if empty"
+                                  data-testid="create-agent-worktree-branch"
                                 />
-                                <span className="space-y-1">
-                                  <span className="block text-sm font-medium text-foreground">
-                                    Create a new branch in this worktree
-                                  </span>
-                                  <span className="block text-xs text-muted-foreground">
-                                    Creates a new working branch from the
-                                    starting branch so the agent can make
-                                    isolated changes for later submission.
-                                  </span>
-                                </span>
-                              </label>
-                              <div
-                                className={cn(
-                                  "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-                                  createNewBranch
-                                    ? "grid-rows-[1fr] opacity-100"
-                                    : "grid-rows-[0fr] opacity-0"
-                                )}
-                                aria-hidden={!createNewBranch}
-                                {...(!createNewBranch
-                                  ? ({ inert: "" } as Record<string, string>)
-                                  : {})}
-                              >
-                                <div className="min-h-0 overflow-hidden">
-                                  <div className="space-y-1 pt-2">
-                                    <label className="block text-xs text-muted-foreground">
-                                      New branch name
-                                    </label>
-                                    <Input
-                                      value={createWorktreeBranch}
-                                      onChange={(event) =>
-                                        setCreateWorktreeBranch(
-                                          event.target.value
-                                        )
-                                      }
-                                      placeholder="auto-generated if empty"
-                                      data-testid="create-agent-worktree-branch"
-                                    />
-                                  </div>
-                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  );
-                })()}
+                  </div>
+                </div>
 
                 {createType !== "terminal" ? (
                   <>

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -30,6 +30,8 @@ type PathInputProps = {
   history?: string[];
   /** Called when a history entry is removed */
   onRemoveHistory?: (dir: string) => void;
+  /** Called whenever the validated path info changes (null while unknown). */
+  onPathInfoChange?: (info: PathInfo | null) => void;
   /** Label text above the input */
   label?: string;
   /** HTML id for the input */
@@ -48,6 +50,7 @@ export function PathInput({
   showValidation = true,
   history = [],
   onRemoveHistory,
+  onPathInfoChange,
   label,
   id,
   "data-testid": testId,
@@ -76,6 +79,7 @@ export function PathInput({
     const trimmed = value.trim();
     if (!trimmed) {
       setPathValidation(null);
+      onPathInfoChange?.(null);
       return;
     }
     if (!showValidation) return;
@@ -85,20 +89,25 @@ export function PathInput({
         `/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`
       )
         .then((result) => {
-          setPathValidation({
+          const info: PathInfo = {
             exists: result.exists,
             isDirectory: result.isDirectory,
             isGitRepo: result.isGitRepo,
-          });
+          };
+          setPathValidation(info);
+          onPathInfoChange?.(info);
         })
-        .catch(() => setPathValidation(null))
+        .catch(() => {
+          setPathValidation(null);
+          onPathInfoChange?.(null);
+        })
         .finally(() => setValidating(false));
     }, 400);
     return () => {
       clearTimeout(timer);
       setValidating(false);
     };
-  }, [value, showValidation]);
+  }, [value, showValidation, onPathInfoChange]);
 
   // Debounced inline ghost completion
   useEffect(() => {

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -30,7 +30,12 @@ type PathInputProps = {
   history?: string[];
   /** Called when a history entry is removed */
   onRemoveHistory?: (dir: string) => void;
-  /** Called whenever the validated path info changes (null while unknown). */
+  /**
+   * Called whenever the validated path info changes (null while unknown).
+   * Memoize with `useCallback` — the prop is in the path-validation effect's
+   * dependency array, so a fresh function on every parent render would
+   * re-fire validation and kick off duplicate API calls.
+   */
   onPathInfoChange?: (info: PathInfo | null) => void;
   /** Label text above the input */
   label?: string;
@@ -83,6 +88,10 @@ export function PathInput({
       return;
     }
     if (!showValidation) return;
+    // Treat the path as unknown until the new validation lands so callers
+    // don't act on stale info from the previous value during the debounce.
+    setPathValidation(null);
+    onPathInfoChange?.(null);
     setValidating(true);
     const timer = setTimeout(() => {
       api<PathInfo & { resolvedPath: string }>(

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai/utils";
 
 function atomWithLocalStorage<T>(key: string, initialValue: T) {
   const baseAtom = atom<T>(
@@ -44,4 +45,10 @@ export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">(
 export const soundCuesEnabledAtom = atomWithLocalStorage(
   "dispatch:soundCuesEnabled",
   true
+);
+
+// Per-cwd preferences for the Create Agent dialog. Each cwd gets its own
+// atom backed by localStorage; the family caches them by trimmed cwd.
+export const createNewBranchPrefAtom = atomFamily((cwd: string) =>
+  atomWithLocalStorage<boolean>(`dispatch:createNewBranch:${cwd}`, true)
 );

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -69,6 +69,14 @@ test.describe("Agent CRUD", () => {
     await page.getByTestId("create-agent-name").fill(agentName);
     await page.getByTestId("create-agent-cwd").fill("/tmp");
 
+    // Wait for path validation to settle before submitting. /tmp is not a git
+    // repo, so the form should detect that and skip worktree creation; if we
+    // submit before validation lands, the request races useWorktree=true
+    // against a non-git cwd and the backend (correctly) rejects it.
+    await expect(form.getByText("Valid directory")).toBeVisible({
+      timeout: 5_000,
+    });
+
     // Submit
     await page.getByTestId("create-agent-submit").click();
 

--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -87,38 +87,63 @@ test.describe("Worktree", () => {
   test("create dialog shows worktree checkbox defaulting to checked", async ({
     page,
   }) => {
-    await loadApp(page);
+    // The worktree section is gated on the cwd being a git repository (CRU-139),
+    // so point the dialog at one before checking the default state.
+    const repoPath = createTestRepo(`default-${Date.now()}`);
+    try {
+      await loadApp(page);
 
-    await page.getByTestId("create-agent-button").click();
-    const form = page.getByTestId("create-agent-form");
-    await expect(form).toBeVisible();
+      await page.getByTestId("create-agent-button").click();
+      const form = page.getByTestId("create-agent-form");
+      await expect(form).toBeVisible();
 
-    // Worktree checkbox should exist and be checked by default
-    const worktreeCheckbox = page.getByTestId("create-agent-worktree");
-    await expect(worktreeCheckbox).toBeVisible();
-    await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
+      const cwdInput = page.getByTestId("create-agent-cwd");
+      await cwdInput.fill(repoPath);
+      // Wait for path validation to register the cwd as a git repo.
+      await expect(form.getByText("Git repository")).toBeVisible({
+        timeout: 5000,
+      });
 
-    // "Create git worktree" label text should be visible
-    await expect(form.getByText("Create git worktree")).toBeVisible();
+      // Worktree checkbox should exist and be checked by default
+      const worktreeCheckbox = page.getByTestId("create-agent-worktree");
+      await expect(worktreeCheckbox).toBeVisible();
+      await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
+
+      // "Create managed git worktree" label text should be visible
+      await expect(form.getByText("Create managed git worktree")).toBeVisible();
+    } finally {
+      cleanupTestRepo(repoPath);
+    }
   });
 
   test("worktree checkbox can be toggled off and on", async ({ page }) => {
-    await loadApp(page);
+    const repoPath = createTestRepo(`toggle-${Date.now()}`);
+    try {
+      await loadApp(page);
 
-    await page.getByTestId("create-agent-button").click();
-    const form = page.getByTestId("create-agent-form");
-    await expect(form).toBeVisible();
+      await page.getByTestId("create-agent-button").click();
+      const form = page.getByTestId("create-agent-form");
+      await expect(form).toBeVisible();
 
-    const worktreeCheckbox = page.getByTestId("create-agent-worktree");
-    await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
+      const cwdInput = page.getByTestId("create-agent-cwd");
+      await cwdInput.fill(repoPath);
+      await expect(form.getByText("Git repository")).toBeVisible({
+        timeout: 5000,
+      });
 
-    // Toggle it off by clicking the label text (avoids double-toggle from label+button)
-    await form.getByText("Create git worktree").click();
-    await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "false");
+      const worktreeCheckbox = page.getByTestId("create-agent-worktree");
+      await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
 
-    // Toggle it back on
-    await form.getByText("Create git worktree").click();
-    await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
+      // Toggle it off by clicking the label text (avoids double-toggle from label+button)
+      await form.getByText("Create managed git worktree").click();
+      await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "false");
+
+      // Toggle it back on
+      await form.getByText("Create managed git worktree").click();
+      await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");
+    } finally {
+      cleanupTestRepo(repoPath);
+    }
   });
 
   test("POST /api/v1/agents accepts useWorktree=false", async ({ request }) => {


### PR DESCRIPTION
Closes [CRU-139](https://linear.app/crumbstream/issue/CRU-139/decouple-managed-worktree-creation-from-automatic-branch-creation-in).

## Summary
- Splits the Create Agent form's git section so a managed worktree no longer implies a new authoring branch.
- New nested checkbox `Create a new branch in this worktree` controls whether Dispatch forks a working branch from the chosen `Starting branch` (renamed from `Base branch`).
- When unchecked, Dispatch creates the managed worktree on the existing starting branch directly — useful for review/investigation flows.
- The worktree card stays rendered on non-git cwds in a disabled state (rather than vanishing) to avoid layout pop while typing a path; the inner controls slide open/closed via a CSS grid-template-rows transition.
- The new-branch choice is persisted per cwd via localStorage (`dispatch:createNewBranch:<cwd>`), with a wrapped setter to avoid a write-back race against the cwd-change load effect.

## Behavior
- `useWorktree=true` + `createNewBranch=true` (default): unchanged from today — fork a new branch from `baseBranch`.
- `useWorktree=true` + `createNewBranch=false`: `git worktree add <path> <baseBranch>` (no `-b`); the worktree is checked out on the user's existing branch.
- Archive cleanup: when the agent's stored `worktreeBranch` equals its `baseBranch`, the branch is preserved on archive (it belongs to the user, not Dispatch).
- Non-git cwd: worktree section is rendered but disabled with a "Working directory isn't a git repository, so a managed worktree isn't available here." note.

## Files changed
- `apps/web/src/components/app/create-agent-dialog.tsx` — UX rework + per-cwd persistence
- `apps/web/src/components/app/branch-select.tsx` — `baseBranchLabel`, `baseBranchHelper`, `showNewBranchInput` props
- `apps/web/src/components/app/path-input.tsx` — `onPathInfoChange` callback so the dialog knows whether cwd is a git repo
- `apps/server/src/shared/git/worktree.ts` — `createNewBranch` option that runs `git worktree add` without `-b` when false
- `apps/server/src/agents/manager.ts` — pass-through, set up correct `worktree_branch`, preserve user branches on cleanup
- `apps/server/src/server.ts` — POST /api/v1/agents validates and forwards `createNewBranch`

## Test plan
- [x] `pnpm run check` (server + web)
- [x] `pnpm run finalize:web`
- [x] `pnpm --filter @dispatch/server test`
- [x] `pnpm run test:e2e`
- [x] Playwright: default UX (git repo, with new branch), nested checkbox unchecked (no new branch), disabled card on non-git cwd, animated transitions
- [x] Backend smoke: `POST /api/v1/agents` with `createNewBranch:true` and `:false` → both produce correct worktrees on disk; cleanup preserves user branch in the no-new-branch case
- [x] Per-cwd persistence: localStorage stays consistent across open/close and toggling