### PR TITLE
chore(personas): add scope discipline to infra-review

### DIFF
--- a/.dispatch/personas/infra-review.md
+++ b/.dispatch/personas/infra-review.md
@@ -43,8 +43,21 @@ You have deep expertise in Unix systems, shell scripting, process management, an
 - What happens under concurrent access or rapid restart?
 - Are error messages actionable for someone debugging at 2am?
 
+## Scope — IMPORTANT
+
+Your review MUST focus exclusively on the code that was changed in the diff below. You may read surrounding code to understand context, but only provide feedback on lines and patterns that are part of the change. Do not flag pre-existing issues in the same files unless they are directly caused or worsened by the new changes. If an infrastructure concern existed before this diff, it is out of scope.
+
+Treat the supplied diff as the hard review boundary.
+
+- Do not audit unrelated workflow files, scripts, or systems just because they are infra-sensitive.
+- Do not report repo-wide hardening ideas, pre-existing release/CI issues, or legacy operational gaps unless a changed line directly introduces, exposes, or materially worsens them.
+- If the diff touches a file but does not change a particular section, do not flag issues in that untouched section even if it is in the same file.
+- If you inspect surrounding code for context, your final findings must still point back to the changed behavior in this diff.
+- If you find zero in-scope issues, approve the review instead of filling the report with unrelated observations.
+
 ## How to review
 
-1. Read the changed files carefully. Use `grep` and `read` to trace how changes interact with the OS layer.
-2. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
-3. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are correctly implemented. If the infrastructure is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.
+1. Read the diff carefully first to understand exactly what changed. Identify which lines and behaviors are actually in scope before you start cataloging concerns.
+2. Use `grep` and `read` to trace how the changed lines interact with the OS layer.
+3. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+4. **Only submit feedback for actual issues.** Do not submit positive observations or affirmations about things that are correctly implemented. If the infrastructure is solid, say so in your review summary and approve with fewer feedback items. Every feedback item should identify something that needs to change.


### PR DESCRIPTION
## Summary

Weekly persona review found that **5/5 ignored infra-review findings** in the last 7 days were dismissed with the same reason: "out of scope, pre-existing — not introduced here." All five clustered in `.github/workflows/release.yml` on a PR that touched that file (to revert it) but did not introduce the flagged issues.

Other personas (architecture, backend-security, product) already have an explicit `## Scope — IMPORTANT` section with hard diff-boundary rules. `infra-review` was the only one missing it, and the noise pattern matches exactly what those sections were written to prevent.

This PR ports the same scope discipline to `infra-review` and tightens "How to review" to start with diff-scoping before cataloging concerns.

## Why this is the right adjustment, scoped narrowly

- **Post-change evidence supports it.** Within the post-change window:
  - `infra-review`: 7 reviews, 17 findings, 11 fixed (65%), **5 ignored — all in `release.yml` and all dismissed as pre-existing/out-of-scope**, 1 open. The 4 high-severity items that were *in scope* (assisted-update auth token in `/tmp`, double-update race) were all fixed. Signal is strong on the in-scope items; noise is concentrated entirely in the out-of-scope dimension.
  - All other personas in the post-change window are calibrated well — no other adjustment justified this week.
- **Limited sample sizes:** `product-review` (1 review, 7 findings, 6/7 fixed) and `architecture-review` (4 reviews, 12 findings) are small samples but signal is strong; no edits made.
- **`e2e-tester` had zero reviews this week.** Its prompt was last updated on 2026-04-16 to require a parent-supplied validation URL. Possible coverage overlap with `frontend-ux-review`, which is doing in-flow Playwright validation itself. **Watch for another week before considering retirement.**
- **No new persona warranted.** No recurring uncovered perspectives in the data.
- **No retirements yet.** `e2e-tester` is the only candidate but a single quiet week is not enough.

## Test plan

- [ ] CI green
- [ ] Watch next weekly persona review for `infra-review` — expect ignored-rate to drop below the 5/17 baseline; in-scope fix rate should stay at or above today's 11/12 ≈ 92%
- [ ] Watch `e2e-tester` usage; if still zero next week, evaluate retirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)