### PR TITLE
Expand create agent startup context

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   readdir,
   rename,
+  rm,
   stat,
   unlink,
   writeFile,
@@ -185,6 +186,7 @@ type CreateAgentInput = {
   initialPins?: AgentPin[];
   initialFiles?: Array<{
     fileName: string;
+    originalName?: string;
     buffer: Buffer;
     source: "text" | "user";
     description?: string | null;
@@ -650,10 +652,27 @@ export class AgentManager {
       ]
     );
 
-    const initialMedia =
-      input.initialFiles && input.initialFiles.length > 0
-        ? await this.seedInitialMedia(id, mediaDir, input.initialFiles)
-        : [];
+    let initialMedia: Array<{
+      fileName: string;
+      displayName: string;
+      source: string;
+      description: string | null;
+    }> = [];
+    if (input.initialFiles && input.initialFiles.length > 0) {
+      try {
+        initialMedia = await this.seedInitialMedia(
+          id,
+          mediaDir,
+          input.initialFiles
+        );
+      } catch (error) {
+        await this.pool
+          .query("DELETE FROM agents WHERE id = $1", [id])
+          .catch(() => {});
+        await rm(mediaDir, { recursive: true, force: true }).catch(() => {});
+        throw error;
+      }
+    }
     const startupPrompt = this.buildStartupPrompt(
       input.initialPrompt,
       initialPins,
@@ -2571,6 +2590,7 @@ export class AgentManager {
     initialPins: AgentPin[],
     initialMedia: Array<{
       fileName: string;
+      displayName: string;
       source: string;
       description: string | null;
     }>
@@ -2582,7 +2602,7 @@ export class AgentManager {
 
     const sections = [
       "Startup context is attached to this session.",
-      "Inspect the provided pins and shared media before acting, acknowledge what you were able to access, incorporate that context into the task, and continue unless the instructions explicitly ask you to pause or wait for confirmation.",
+      "Inspect the provided pins and shared media before acting. Use Dispatch shared-media tools to access attached files; do not try to locate them by searching the filesystem by name.",
     ];
 
     if (trimmedPrompt) {
@@ -2593,7 +2613,21 @@ export class AgentManager {
       sections.push(
         [
           "Links:",
-          ...initialPins.map((pin) => `- ${pin.label}: ${pin.value}`),
+          ...initialPins.map((pin) => {
+            try {
+              const hostname =
+                new URL(pin.value).hostname.replace(/^www\./, "") || "Link";
+              const numberedHostPattern = new RegExp(
+                `^${hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}( \\d+)?$`,
+                "i"
+              );
+              return numberedHostPattern.test(pin.label)
+                ? `- ${pin.value}`
+                : `- ${pin.label}: ${pin.value}`;
+            } catch {
+              return `- ${pin.value}`;
+            }
+          }),
         ].join("\n")
       );
     }
@@ -2601,11 +2635,11 @@ export class AgentManager {
     if (initialMedia.length > 0) {
       sections.push(
         [
-          "Files shared into Dispatch media:",
+          "Attached files:",
           ...initialMedia.map((file) => {
             const detail = file.description?.trim();
             const suffix = detail ? ` — ${detail}` : "";
-            return `- ${file.fileName} (${file.source})${suffix}`;
+            return `- ${file.displayName}${suffix} (available via dispatch shared media)`;
           }),
         ].join("\n")
       );
@@ -2619,16 +2653,23 @@ export class AgentManager {
     mediaDir: string,
     files: Array<{
       fileName: string;
+      originalName?: string;
       buffer: Buffer;
       source: "text" | "user";
       description?: string | null;
     }>
   ): Promise<
-    Array<{ fileName: string; source: string; description: string | null }>
+    Array<{
+      fileName: string;
+      displayName: string;
+      source: string;
+      description: string | null;
+    }>
   > {
     const createdAt = new Date();
     const results: Array<{
       fileName: string;
+      displayName: string;
       source: string;
       description: string | null;
     }> = [];
@@ -2653,6 +2694,7 @@ export class AgentManager {
       );
       results.push({
         fileName: timestampedFileName,
+        displayName: file.originalName?.trim() || file.fileName,
         source: file.source,
         description: file.description ?? null,
       });

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -182,6 +182,13 @@ type CreateAgentInput = {
   cliSessionId?: string;
   jobRunId?: string;
   initialPrompt?: string;
+  initialPins?: AgentPin[];
+  initialFiles?: Array<{
+    fileName: string;
+    buffer: Buffer;
+    source: "text" | "user";
+    description?: string | null;
+  }>;
 };
 
 type WorktreeCleanupMode = "auto" | "keep" | "force";
@@ -543,6 +550,7 @@ export class AgentManager {
     const tmuxSession = this.toSessionName(id, name);
     const mediaDir = path.join(this.config.mediaRoot, id);
     await mkdir(mediaDir, { recursive: true });
+    const initialPins = input.initialPins ?? [];
 
     const useWorktree = input.useWorktree !== false;
     const createNewBranch = input.createNewBranch ?? true;
@@ -617,8 +625,8 @@ export class AgentManager {
     const initialSetupPhase: SetupPhase = useWorktree ? "worktree" : "session";
     await this.pool.query(
       `
-      INSERT INTO agents (id, name, type, role, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, review_agent_type, cli_session_id, auto_review, base_branch, updated_at)
-      VALUES ($1, $2, $3, $4, 'creating', $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
+      INSERT INTO agents (id, name, type, role, status, cwd, tmux_session, media_dir, codex_args, full_access, setup_phase, persona, parent_agent_id, persona_context, review_agent_type, cli_session_id, auto_review, base_branch, pins, updated_at)
+      VALUES ($1, $2, $3, $4, 'creating', $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::jsonb, NOW())
       `,
       [
         id,
@@ -638,7 +646,18 @@ export class AgentManager {
         cliSessionId,
         input.autoReview ?? false,
         normalizedBaseBranch ?? null,
+        JSON.stringify(initialPins),
       ]
+    );
+
+    const initialMedia =
+      input.initialFiles && input.initialFiles.length > 0
+        ? await this.seedInitialMedia(id, mediaDir, input.initialFiles)
+        : [];
+    const startupPrompt = this.buildStartupPrompt(
+      input.initialPrompt,
+      initialPins,
+      initialMedia
     );
 
     if (this.config.agentRuntime === "inert") {
@@ -719,7 +738,7 @@ export class AgentManager {
             jobRunId: input.jobRunId,
           }),
           !input.persona && !input.jobRunId && (input.autoReview ?? false),
-          input.initialPrompt
+          startupPrompt
         );
         const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
 
@@ -2545,6 +2564,116 @@ export class AgentManager {
       .map((arg) => this.shellEscape(arg))
       .join(" ");
     return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(startupPrompt)}`;
+  }
+
+  private buildStartupPrompt(
+    initialPrompt: string | undefined,
+    initialPins: AgentPin[],
+    initialMedia: Array<{
+      fileName: string;
+      source: string;
+      description: string | null;
+    }>
+  ): string | undefined {
+    const trimmedPrompt = initialPrompt?.trim() || "";
+    if (initialPins.length === 0 && initialMedia.length === 0) {
+      return trimmedPrompt || undefined;
+    }
+
+    const sections = [
+      "Startup context is attached to this session.",
+      "Inspect the provided pins and shared media before acting, acknowledge what you were able to access, incorporate that context into the task, and continue unless the instructions explicitly ask you to pause or wait for confirmation.",
+    ];
+
+    if (trimmedPrompt) {
+      sections.push(`Instructions:\n${trimmedPrompt}`);
+    }
+
+    if (initialPins.length > 0) {
+      sections.push(
+        [
+          "Links:",
+          ...initialPins.map((pin) => `- ${pin.label}: ${pin.value}`),
+        ].join("\n")
+      );
+    }
+
+    if (initialMedia.length > 0) {
+      sections.push(
+        [
+          "Files shared into Dispatch media:",
+          ...initialMedia.map((file) => {
+            const detail = file.description?.trim();
+            const suffix = detail ? ` — ${detail}` : "";
+            return `- ${file.fileName} (${file.source})${suffix}`;
+          }),
+        ].join("\n")
+      );
+    }
+
+    return sections.join("\n\n");
+  }
+
+  private async seedInitialMedia(
+    agentId: string,
+    mediaDir: string,
+    files: Array<{
+      fileName: string;
+      buffer: Buffer;
+      source: "text" | "user";
+      description?: string | null;
+    }>
+  ): Promise<
+    Array<{ fileName: string; source: string; description: string | null }>
+  > {
+    const createdAt = new Date();
+    const results: Array<{
+      fileName: string;
+      source: string;
+      description: string | null;
+    }> = [];
+
+    for (const [index, file] of files.entries()) {
+      const timestampedFileName = this.timestampMediaFileName(
+        file.fileName,
+        createdAt,
+        index
+      );
+      await writeFile(path.join(mediaDir, timestampedFileName), file.buffer);
+      await this.pool.query(
+        `INSERT INTO media (agent_id, file_name, source, size_bytes, description)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          agentId,
+          timestampedFileName,
+          file.source,
+          file.buffer.length,
+          file.description ?? null,
+        ]
+      );
+      results.push({
+        fileName: timestampedFileName,
+        source: file.source,
+        description: file.description ?? null,
+      });
+    }
+
+    return results;
+  }
+
+  private timestampMediaFileName(
+    fileName: string,
+    createdAt: Date,
+    index: number
+  ): string {
+    const timestamp = createdAt
+      .toISOString()
+      .replace(/[:.]/g, "-")
+      .replace("T", "-")
+      .replace("Z", "");
+    const ext = path.extname(fileName);
+    const base = path.basename(fileName, ext);
+    return `${base}-${timestamp}-${index + 1}${ext}`;
   }
 
   private dispatchMcpUrl(agentId: string, jobRunId?: string): string {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -242,6 +242,19 @@ function createStartupPins(urls: string[]): Array<{
   });
 }
 
+function sanitizeUploadedFileName(name: string): string {
+  const ext = path.extname(name).toLowerCase();
+  const baseName = path.basename(name, ext).normalize("NFKD");
+  const collapsed = baseName
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9._() -]+/g, "-")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+  return `${collapsed || "file"}${ext}`;
+}
+
 async function parseCreateAgentRequest(request: {
   body?: unknown;
   isMultipart: () => boolean;
@@ -275,8 +288,10 @@ async function parseCreateAgentRequest(request: {
       if (part.fieldname !== "startupFiles") {
         throw new Error("Unexpected file field.");
       }
-      const fileName = path.basename(part.filename || "");
-      if (!/^[A-Za-z0-9._-]+$/.test(fileName)) {
+      const fileName = sanitizeUploadedFileName(
+        path.basename(part.filename || "")
+      );
+      if (!fileName) {
         throw new Error("Invalid file name.");
       }
       if (!isMediaFile(fileName)) {
@@ -3761,8 +3776,8 @@ async function registerRoutes() {
       return reply.code(400).send({ error: "A file field is required." });
     }
 
-    const fileName = path.basename(data.filename);
-    if (!/^[A-Za-z0-9._-]+$/.test(fileName)) {
+    const fileName = sanitizeUploadedFileName(path.basename(data.filename));
+    if (!fileName) {
       return reply.code(400).send({ error: "Invalid file name." });
     }
     if (!isMediaFile(fileName)) {
@@ -4030,12 +4045,9 @@ async function registerRoutes() {
         parsedRequest.isMultipart
       );
     } catch (error) {
-      return reply
-        .code(400)
-        .send({
-          error:
-            error instanceof Error ? error.message : "Invalid request body.",
-        });
+      return reply.code(400).send({
+        error: error instanceof Error ? error.message : "Invalid request body.",
+      });
     }
 
     if (
@@ -4114,9 +4126,16 @@ async function registerRoutes() {
       !isTerminalAgent && fullAccess === true && fullAccessArg
         ? Array.from(new Set([...(parsedAgentArgs ?? []), fullAccessArg]))
         : parsedAgentArgs;
+    let startupPins: ReturnType<typeof createStartupPins>;
+    try {
+      startupPins = createStartupPins(startupLinks ?? []);
+    } catch (error) {
+      return reply.code(400).send({
+        error: error instanceof Error ? error.message : "Invalid startupLinks.",
+      });
+    }
 
     try {
-      const startupPins = createStartupPins(startupLinks ?? []);
       const worktreeLocationRaw = await getSetting(pool, WORKTREE_LOCATION_KEY);
       const worktreeLocation: WorktreeLocation =
         worktreeLocationRaw &&

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -182,10 +182,14 @@ type CreateAgentBody = {
 
 type StartupFileUpload = {
   fileName: string;
+  originalName: string;
   buffer: Buffer;
   source: "text" | "user";
   description: string | null;
 };
+
+const MAX_STARTUP_FILE_COUNT = 10;
+const MAX_STARTUP_FILE_NAME_LENGTH = 128;
 
 function parseOptionalBooleanField(
   value: unknown,
@@ -255,6 +259,20 @@ function sanitizeUploadedFileName(name: string): string {
   return `${collapsed || "file"}${ext}`;
 }
 
+function sanitizeStartupDisplayName(
+  name: string | undefined,
+  fallback: string
+): string {
+  const normalized = path
+    .basename(name || "")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim();
+  if (!normalized) {
+    return fallback;
+  }
+  return normalized.slice(0, MAX_STARTUP_FILE_NAME_LENGTH);
+}
+
 async function parseCreateAgentRequest(request: {
   body?: unknown;
   isMultipart: () => boolean;
@@ -288,6 +306,11 @@ async function parseCreateAgentRequest(request: {
       if (part.fieldname !== "startupFiles") {
         throw new Error("Unexpected file field.");
       }
+      if (startupFiles.length >= MAX_STARTUP_FILE_COUNT) {
+        throw new Error(
+          `A maximum of ${MAX_STARTUP_FILE_COUNT} startup files is allowed.`
+        );
+      }
       const fileName = sanitizeUploadedFileName(
         path.basename(part.filename || "")
       );
@@ -304,6 +327,7 @@ async function parseCreateAgentRequest(request: {
       }
       startupFiles.push({
         fileName,
+        originalName: sanitizeStartupDisplayName(part.filename, fileName),
         buffer: await part.toBuffer(),
         source: isTextFile(fileName) ? "text" : "user",
         description: null,
@@ -1457,7 +1481,12 @@ async function registerRoutes() {
   const cookieSecret = await getOrCreateCookieSecret(pool);
   await app.register(fastifyCookie, { secret: cookieSecret });
   await app.register(fastifyMultipart, {
-    limits: { fileSize: 20 * 1024 * 1024 },
+    limits: {
+      fileSize: 20 * 1024 * 1024,
+      files: MAX_STARTUP_FILE_COUNT,
+      fields: 24,
+      parts: 32,
+    },
   });
   await app.register(fastifyWebsocket);
   await app.register(fastifyRateLimit, { global: false });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -161,6 +161,147 @@ jobService.onRunStateChange((run) => {
 const WEB_NOTIFY_ACK_TIMEOUT_MS = 3_000;
 const pendingWebNotifications = new Map<string, NodeJS.Timeout>();
 
+type CreateAgentBody = {
+  name?: unknown;
+  type?: unknown;
+  cwd?: unknown;
+  agentArgs?: unknown;
+  codexArgs?: unknown;
+  fullAccess?: unknown;
+  useWorktree?: unknown;
+  createNewBranch?: unknown;
+  worktreeBranch?: unknown;
+  baseBranch?: unknown;
+  persona?: unknown;
+  parentAgentId?: unknown;
+  personaContext?: unknown;
+  autoReview?: unknown;
+  initialPrompt?: unknown;
+  startupLinks?: unknown;
+};
+
+type StartupFileUpload = {
+  fileName: string;
+  buffer: Buffer;
+  source: "text" | "user";
+  description: string | null;
+};
+
+function parseOptionalBooleanField(
+  value: unknown,
+  fieldName: string,
+  allowStringCoercion: boolean
+): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (allowStringCoercion && value === "true") return true;
+  if (allowStringCoercion && value === "false") return false;
+  throw new Error(`${fieldName} must be a boolean when provided.`);
+}
+
+function parseOptionalStringArrayField(
+  value: unknown,
+  fieldName: string,
+  allowStringCoercion: boolean
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+  if (!allowStringCoercion || typeof value !== "string") {
+    throw new Error(`${fieldName} must be an array of strings.`);
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === "string")
+    ) {
+      return parsed;
+    }
+  } catch {}
+  throw new Error(`${fieldName} must be an array of strings.`);
+}
+
+function createStartupPins(urls: string[]): Array<{
+  label: string;
+  value: string;
+  type: "url";
+}> {
+  const counts = new Map<string, number>();
+  return urls.map((rawUrl) => {
+    validatePinValue("url", rawUrl);
+    const hostname = new URL(rawUrl).hostname.replace(/^www\./, "") || "Link";
+    const seen = counts.get(hostname) ?? 0;
+    counts.set(hostname, seen + 1);
+    return {
+      label: seen === 0 ? hostname : `${hostname} ${seen + 1}`,
+      value: rawUrl,
+      type: "url",
+    };
+  });
+}
+
+async function parseCreateAgentRequest(request: {
+  body?: unknown;
+  isMultipart: () => boolean;
+  parts: () => AsyncIterable<unknown>;
+}): Promise<{
+  body: CreateAgentBody;
+  startupFiles: StartupFileUpload[];
+  isMultipart: boolean;
+}> {
+  const multipart = request.isMultipart();
+  if (!multipart) {
+    return {
+      body: (request.body as CreateAgentBody | undefined) ?? {},
+      startupFiles: [],
+      isMultipart: false,
+    };
+  }
+
+  const body: CreateAgentBody = {};
+  const startupFiles: StartupFileUpload[] = [];
+
+  for await (const rawPart of request.parts()) {
+    const part = rawPart as {
+      type: "file" | "field";
+      fieldname: string;
+      filename?: string;
+      value?: unknown;
+      toBuffer?: () => Promise<Buffer>;
+    };
+    if (part.type === "file") {
+      if (part.fieldname !== "startupFiles") {
+        throw new Error("Unexpected file field.");
+      }
+      const fileName = path.basename(part.filename || "");
+      if (!/^[A-Za-z0-9._-]+$/.test(fileName)) {
+        throw new Error("Invalid file name.");
+      }
+      if (!isMediaFile(fileName)) {
+        throw new Error(
+          "Unsupported file type. Use images (png/jpg/gif/webp), video (mp4), documents (pdf), or text files (txt/md/json/yaml/ts/py/etc)."
+        );
+      }
+      if (!part.toBuffer) {
+        throw new Error("Invalid file upload.");
+      }
+      startupFiles.push({
+        fileName,
+        buffer: await part.toBuffer(),
+        source: isTextFile(fileName) ? "text" : "user",
+        description: null,
+      });
+      continue;
+    }
+
+    body[part.fieldname as keyof CreateAgentBody] = part.value;
+  }
+
+  return { body, startupFiles, isMultipart: true };
+}
+
 /** Called by the ack endpoint when a client confirms delivery. */
 function ackWebNotification(notificationId: string): boolean {
   const timer = pendingWebNotifications.get(notificationId);
@@ -3830,23 +3971,19 @@ async function registerRoutes() {
   });
 
   app.post("/api/v1/agents", async (request, reply) => {
-    const body = request.body as {
-      name?: unknown;
-      type?: unknown;
-      cwd?: unknown;
-      agentArgs?: unknown;
-      codexArgs?: unknown;
-      fullAccess?: unknown;
-      useWorktree?: unknown;
-      createNewBranch?: unknown;
-      worktreeBranch?: unknown;
-      baseBranch?: unknown;
-      persona?: unknown;
-      parentAgentId?: unknown;
-      personaContext?: unknown;
-      autoReview?: unknown;
-      initialPrompt?: unknown;
+    let parsedRequest: {
+      body: CreateAgentBody;
+      startupFiles: StartupFileUpload[];
+      isMultipart: boolean;
     };
+    try {
+      parsedRequest = await parseCreateAgentRequest(request);
+    } catch (error) {
+      return reply.code(400).send({
+        error: error instanceof Error ? error.message : "Invalid request body.",
+      });
+    }
+    const { body, startupFiles } = parsedRequest;
 
     if (typeof body?.cwd !== "string") {
       return reply
@@ -3854,16 +3991,51 @@ async function registerRoutes() {
         .send({ error: "Body must include cwd as a string." });
     }
 
-    const providedAgentArgs = body.agentArgs ?? body.codexArgs;
-    const agentArgsValid =
-      providedAgentArgs === undefined ||
-      (Array.isArray(providedAgentArgs) &&
-        providedAgentArgs.every((item) => typeof item === "string"));
+    let parsedAgentArgs: string[] | undefined;
+    let startupLinks: string[] | undefined;
+    let fullAccess: boolean | undefined;
+    let useWorktree: boolean | undefined;
+    let createNewBranch: boolean | undefined;
+    let autoReview: boolean | undefined;
 
-    if (!agentArgsValid) {
+    try {
+      parsedAgentArgs = parseOptionalStringArrayField(
+        body.agentArgs ?? body.codexArgs,
+        "agentArgs",
+        parsedRequest.isMultipart
+      );
+      startupLinks = parseOptionalStringArrayField(
+        body.startupLinks,
+        "startupLinks",
+        parsedRequest.isMultipart
+      );
+      fullAccess = parseOptionalBooleanField(
+        body.fullAccess,
+        "fullAccess",
+        parsedRequest.isMultipart
+      );
+      useWorktree = parseOptionalBooleanField(
+        body.useWorktree,
+        "useWorktree",
+        parsedRequest.isMultipart
+      );
+      createNewBranch = parseOptionalBooleanField(
+        body.createNewBranch,
+        "createNewBranch",
+        parsedRequest.isMultipart
+      );
+      autoReview = parseOptionalBooleanField(
+        body.autoReview,
+        "autoReview",
+        parsedRequest.isMultipart
+      );
+    } catch (error) {
       return reply
         .code(400)
-        .send({ error: "agentArgs must be an array of strings." });
+        .send({
+          error:
+            error instanceof Error ? error.message : "Invalid request body.",
+        });
     }
 
     if (
@@ -3877,36 +4049,6 @@ async function registerRoutes() {
         error:
           "type must be codex, claude, opencode, or terminal when provided.",
       });
-    }
-
-    if (body.fullAccess !== undefined && typeof body.fullAccess !== "boolean") {
-      return reply
-        .code(400)
-        .send({ error: "fullAccess must be a boolean when provided." });
-    }
-
-    if (
-      body.useWorktree !== undefined &&
-      typeof body.useWorktree !== "boolean"
-    ) {
-      return reply
-        .code(400)
-        .send({ error: "useWorktree must be a boolean when provided." });
-    }
-
-    if (
-      body.createNewBranch !== undefined &&
-      typeof body.createNewBranch !== "boolean"
-    ) {
-      return reply
-        .code(400)
-        .send({ error: "createNewBranch must be a boolean when provided." });
-    }
-
-    if (body.autoReview !== undefined && typeof body.autoReview !== "boolean") {
-      return reply
-        .code(400)
-        .send({ error: "autoReview must be a boolean when provided." });
     }
 
     if (
@@ -3942,7 +4084,6 @@ async function registerRoutes() {
       });
     }
 
-    const agentArgs = providedAgentArgs as string[] | undefined;
     const agentType =
       body.type === "claude"
         ? "claude"
@@ -3970,11 +4111,12 @@ async function registerRoutes() {
           ? CODEX_FULL_ACCESS_ARG
           : null;
     const resolvedAgentArgs =
-      !isTerminalAgent && body.fullAccess === true && fullAccessArg
-        ? Array.from(new Set([...(agentArgs ?? []), fullAccessArg]))
-        : agentArgs;
+      !isTerminalAgent && fullAccess === true && fullAccessArg
+        ? Array.from(new Set([...(parsedAgentArgs ?? []), fullAccessArg]))
+        : parsedAgentArgs;
 
     try {
+      const startupPins = createStartupPins(startupLinks ?? []);
       const worktreeLocationRaw = await getSetting(pool, WORKTREE_LOCATION_KEY);
       const worktreeLocation: WorktreeLocation =
         worktreeLocationRaw &&
@@ -3987,13 +4129,9 @@ async function registerRoutes() {
         type: agentType,
         cwd: body.cwd,
         agentArgs: resolvedAgentArgs,
-        fullAccess: !isTerminalAgent && body.fullAccess === true,
-        useWorktree:
-          typeof body.useWorktree === "boolean" ? body.useWorktree : undefined,
-        createNewBranch:
-          typeof body.createNewBranch === "boolean"
-            ? body.createNewBranch
-            : undefined,
+        fullAccess: !isTerminalAgent && fullAccess === true,
+        useWorktree,
+        createNewBranch,
         worktreeBranch:
           typeof body.worktreeBranch === "string"
             ? body.worktreeBranch
@@ -4010,11 +4148,13 @@ async function registerRoutes() {
           typeof body.personaContext === "string"
             ? body.personaContext
             : undefined,
-        autoReview: !isTerminalAgent && body.autoReview === true,
+        autoReview: !isTerminalAgent && autoReview === true,
         initialPrompt:
           !isTerminalAgent && typeof body.initialPrompt === "string"
             ? body.initialPrompt.trim() || undefined
             : undefined,
+        initialPins: !isTerminalAgent ? startupPins : [],
+        initialFiles: !isTerminalAgent ? startupFiles : [],
       });
       queueGitContextRefresh([agent.id]);
       uiEventBroker.publish({

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -1,4 +1,6 @@
 import {
+  type ChangeEvent,
+  type ClipboardEvent,
   type FormEvent,
   useCallback,
   useEffect,
@@ -7,7 +9,16 @@ import {
   useState,
 } from "react";
 import { useAtom } from "jotai";
-import { Check, ChevronDown, GitBranch, ChevronLeft } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  GitBranch,
+  ChevronLeft,
+  Link2,
+  Paperclip,
+  Plus,
+  X,
+} from "lucide-react";
 
 import { BranchSelect } from "@/components/app/branch-select";
 import { PathInput } from "@/components/app/path-input";
@@ -47,6 +58,12 @@ const CWD_HISTORY_MAX = 20;
 const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
 const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
 const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
+const STARTUP_FILE_ACCEPT =
+  ".png,.jpg,.jpeg,.gif,.webp,.mp4,.pdf,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
+
+function startupFileKey(file: File): string {
+  return `${file.name}:${file.size}:${file.lastModified}`;
+}
 
 function readStoredString(key: string): string {
   if (typeof window === "undefined") return "";
@@ -211,8 +228,9 @@ function CreateAgentDialogContent({
   resolveDefaultCwd,
   onCreated,
 }: Omit<CreateAgentDialogProps, "open">): JSX.Element {
-  const [step, setStep] = useState<"config" | "prompt">("config");
+  const [step, setStep] = useState<"config" | "context">("config");
   const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const startupFileInputRef = useRef<HTMLInputElement>(null);
   const [createName, setCreateName] = useState("");
   const [createType, setCreateType] = useState<AgentType>(() => {
     const preferred = initialAgentType ?? readLastUsedAgentType();
@@ -231,6 +249,9 @@ function CreateAgentDialogContent({
   const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
   const [cwdIsGitRepo, setCwdIsGitRepo] = useState<boolean | null>(null);
   const [initialPrompt, setInitialPrompt] = useState("");
+  const [startupFiles, setStartupFiles] = useState<File[]>([]);
+  const [startupLinks, setStartupLinks] = useState<string[]>([]);
+  const [linkDraft, setLinkDraft] = useState("");
   const [creating, setCreating] = useState(false);
   const [cwdHistory, setCwdHistory] = useState<string[]>(() =>
     readCwdHistory()
@@ -279,7 +300,7 @@ function CreateAgentDialogContent({
   }, [createType, enabledAgentTypes]);
 
   useEffect(() => {
-    if (step === "prompt") {
+    if (step === "context") {
       requestAnimationFrame(() => promptTextareaRef.current?.focus());
     }
   }, [step]);
@@ -301,6 +322,66 @@ function CreateAgentDialogContent({
     []
   );
 
+  const appendStartupFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+    setStartupFiles((current) => {
+      const next = [...current];
+      const seen = new Set(current.map(startupFileKey));
+      for (const file of files) {
+        const key = startupFileKey(file);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        next.push(file);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleStartupPaste = useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      const pastedFiles = Array.from(event.clipboardData.items)
+        .filter((item) => item.kind === "file")
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file !== null);
+      if (pastedFiles.length === 0) return;
+      event.preventDefault();
+      appendStartupFiles(pastedFiles);
+    },
+    [appendStartupFiles]
+  );
+
+  const handleStartupFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(event.target.files ?? []);
+      appendStartupFiles(selected);
+      event.target.value = "";
+    },
+    [appendStartupFiles]
+  );
+
+  const handleRemoveStartupFile = useCallback((fileToRemove: File) => {
+    setStartupFiles((current) =>
+      current.filter(
+        (file) => startupFileKey(file) !== startupFileKey(fileToRemove)
+      )
+    );
+  }, []);
+
+  const addStartupLink = useCallback(() => {
+    const trimmed = linkDraft.trim();
+    if (!trimmed) return;
+    setStartupLinks((current) =>
+      current.includes(trimmed) ? current : [...current, trimmed]
+    );
+    setLinkDraft("");
+  }, [linkDraft]);
+
+  const handleRemoveStartupLink = useCallback((linkToRemove: string) => {
+    setStartupLinks((current) =>
+      current.filter((link) => link !== linkToRemove)
+    );
+  }, []);
+
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -314,27 +395,56 @@ function CreateAgentDialogContent({
         // try to run git in a non-repo directory.
         const submitUseWorktree =
           cwdIsGitRepo === false ? false : createUseWorktree;
-        const payload = await api<{ agent: Agent }>("/api/v1/agents", {
-          method: "POST",
-          body: JSON.stringify({
-            name: createName.trim(),
-            cwd,
-            type: createType,
-            fullAccess: createFullAccess,
-            autoReview: createAutoReview,
-            useWorktree: submitUseWorktree,
-            createNewBranch: submitUseWorktree ? createNewBranch : undefined,
-            worktreeBranch:
-              submitUseWorktree && createNewBranch
-                ? createWorktreeBranch.trim() || undefined
-                : undefined,
-            baseBranch:
-              submitUseWorktree && createBaseBranch !== "main"
-                ? createBaseBranch
-                : undefined,
-            initialPrompt: initialPrompt.trim() || undefined,
-          }),
-        });
+        const payloadBase = {
+          name: createName.trim(),
+          cwd,
+          type: createType,
+          fullAccess: createFullAccess,
+          autoReview: createAutoReview,
+          useWorktree: submitUseWorktree,
+          createNewBranch: submitUseWorktree ? createNewBranch : undefined,
+          worktreeBranch:
+            submitUseWorktree && createNewBranch
+              ? createWorktreeBranch.trim() || undefined
+              : undefined,
+          baseBranch:
+            submitUseWorktree && createBaseBranch !== "main"
+              ? createBaseBranch
+              : undefined,
+          initialPrompt: initialPrompt.trim() || undefined,
+        };
+        const resolvedStartupLinks =
+          step === "context" && linkDraft.trim()
+            ? Array.from(new Set([...startupLinks, linkDraft.trim()]))
+            : startupLinks;
+        const useStartupContext =
+          step === "context" &&
+          (payloadBase.initialPrompt ||
+            startupFiles.length > 0 ||
+            resolvedStartupLinks.length > 0);
+        const payload = useStartupContext
+          ? await (async () => {
+              const formData = new FormData();
+              for (const [key, value] of Object.entries(payloadBase)) {
+                if (value === undefined || value === "") continue;
+                formData.append(key, String(value));
+              }
+              formData.append(
+                "startupLinks",
+                JSON.stringify(resolvedStartupLinks)
+              );
+              for (const file of startupFiles) {
+                formData.append("startupFiles", file);
+              }
+              return api<{ agent: Agent }>("/api/v1/agents", {
+                method: "POST",
+                body: formData,
+              });
+            })()
+          : await api<{ agent: Agent }>("/api/v1/agents", {
+              method: "POST",
+              body: JSON.stringify(payloadBase),
+            });
 
         if (typeof window !== "undefined") {
           window.localStorage.setItem(LAST_USED_CWD_KEY, cwd);
@@ -359,6 +469,10 @@ function CreateAgentDialogContent({
       cwdIsGitRepo,
       initialPrompt,
       onCreated,
+      linkDraft,
+      startupFiles,
+      startupLinks,
+      step,
     ]
   );
 
@@ -373,7 +487,7 @@ function CreateAgentDialogContent({
         if (typeDropdownOpen) {
           e.preventDefault();
         }
-        if (step === "prompt") {
+        if (step === "context") {
           e.preventDefault();
           setStep("config");
         }
@@ -688,10 +802,10 @@ function CreateAgentDialogContent({
                   variant="default"
                   tabIndex={0}
                   disabled={creating || !createCwd.trim()}
-                  data-testid="create-agent-with-prompt"
-                  onClick={() => setStep("prompt")}
+                  data-testid="create-agent-with-context"
+                  onClick={() => setStep("context")}
                 >
-                  Create with prompt
+                  Create with context
                 </Button>
               ) : null}
               <Button
@@ -712,29 +826,152 @@ function CreateAgentDialogContent({
       ) : (
         <>
           <DialogHeader>
-            <DialogTitle>Initial Prompt</DialogTitle>
+            <DialogTitle>Create with context</DialogTitle>
             <DialogDescription>
-              This prompt will be sent as the agent&apos;s first message.
+              Add startup instructions, files, and links for the agent to use
+              when the session starts.
             </DialogDescription>
           </DialogHeader>
 
           <form
-            data-testid="create-agent-prompt-form"
+            data-testid="create-agent-context-form"
             className="space-y-3"
             onSubmit={(event) => void handleSubmit(event)}
+            onPaste={handleStartupPaste}
           >
-            <textarea
-              ref={promptTextareaRef}
-              value={initialPrompt}
-              onChange={(event) => setInitialPrompt(event.target.value)}
-              placeholder="Enter instructions for the agent..."
-              data-testid="create-agent-initial-prompt"
-              className={cn(
-                "flex min-h-[200px] w-full resize-y rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
-                "ring-offset-background placeholder:text-muted-foreground",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            <div className="space-y-1">
+              <label className="text-sm text-muted-foreground">
+                Instructions
+              </label>
+              <textarea
+                ref={promptTextareaRef}
+                value={initialPrompt}
+                onChange={(event) => setInitialPrompt(event.target.value)}
+                placeholder="Enter instructions for the agent..."
+                data-testid="create-agent-initial-prompt"
+                className={cn(
+                  "flex min-h-[180px] w-full resize-y rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+                  "ring-offset-background placeholder:text-muted-foreground",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                )}
+              />
+            </div>
+
+            <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-foreground">
+                    Files
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Attach files or paste images/documents from the clipboard.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="default"
+                  size="sm"
+                  onClick={() => startupFileInputRef.current?.click()}
+                  data-testid="create-agent-context-files-button"
+                >
+                  <Paperclip className="mr-1.5 h-3.5 w-3.5" />
+                  Add files
+                </Button>
+              </div>
+              <input
+                ref={startupFileInputRef}
+                type="file"
+                multiple
+                accept={STARTUP_FILE_ACCEPT}
+                className="hidden"
+                onChange={handleStartupFileChange}
+                data-testid="create-agent-context-files-input"
+              />
+              {startupFiles.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {startupFiles.map((file) => (
+                    <div
+                      key={startupFileKey(file)}
+                      className="flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1 text-xs text-foreground"
+                    >
+                      <Paperclip className="h-3 w-3 text-muted-foreground" />
+                      <span className="max-w-[260px] truncate">
+                        {file.name}
+                      </span>
+                      <button
+                        type="button"
+                        className="text-muted-foreground hover:text-foreground"
+                        onClick={() => handleRemoveStartupFile(file)}
+                        aria-label={`Remove ${file.name}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  No files added yet.
+                </p>
               )}
-            />
+            </div>
+
+            <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+              <div>
+                <div className="text-sm font-medium text-foreground">Links</div>
+                <p className="text-xs text-muted-foreground">
+                  Add one or more URLs to pin into the new session.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  value={linkDraft}
+                  onChange={(event) => setLinkDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      addStartupLink();
+                    }
+                  }}
+                  placeholder="https://..."
+                  data-testid="create-agent-context-link-input"
+                />
+                <Button
+                  type="button"
+                  variant="default"
+                  onClick={addStartupLink}
+                  data-testid="create-agent-context-link-add"
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Add
+                </Button>
+              </div>
+              {startupLinks.length > 0 ? (
+                <div className="space-y-2">
+                  {startupLinks.map((link) => (
+                    <div
+                      key={link}
+                      className="flex items-center gap-2 rounded-md border border-border/70 bg-background/70 px-3 py-2 text-xs text-foreground"
+                    >
+                      <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1 truncate">{link}</span>
+                      <button
+                        type="button"
+                        className="text-muted-foreground hover:text-foreground"
+                        onClick={() => handleRemoveStartupLink(link)}
+                        aria-label={`Remove ${link}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  No links added yet.
+                </p>
+              )}
+            </div>
 
             <div className="flex justify-between pt-1">
               <Button
@@ -742,7 +979,7 @@ function CreateAgentDialogContent({
                 variant="ghost"
                 tabIndex={0}
                 onClick={() => setStep("config")}
-                data-testid="create-agent-prompt-back"
+                data-testid="create-agent-context-back"
               >
                 <ChevronLeft className="mr-1 h-4 w-4" />
                 Back
@@ -761,7 +998,7 @@ function CreateAgentDialogContent({
                   variant="primary"
                   tabIndex={0}
                   disabled={creating}
-                  data-testid="create-agent-prompt-submit"
+                  data-testid="create-agent-context-submit"
                 >
                   {creating ? (
                     <ActivityBars size={16} className="mr-1.5" />

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -121,10 +121,10 @@ const SECTIONS: SectionDef[] = [
           </ul>
           <P>
             Click <strong>Create</strong> to start the agent immediately. For
-            CLI types, <strong>Create with prompt</strong> opens a second step
-            where you can enter an initial prompt that is sent as the agent's
-            first message; terminal agents skip this since there is no CLI to
-            send a message to.
+            CLI types, <strong>Create with context</strong> opens a second step
+            where you can add startup instructions, attach files, and pin links
+            for the new session before launch; terminal agents skip this since
+            there is no CLI to send a message to.
           </P>
         </Section>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,10 +25,12 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   recordHTTPRequest();
 
   const hasBody = init?.body !== undefined && init?.body !== null;
+  const isFormData =
+    typeof FormData !== "undefined" && init?.body instanceof FormData;
   const res = await fetch(path, {
     credentials: "include",
     headers: {
-      ...(hasBody ? { "content-type": "application/json" } : {}),
+      ...(hasBody && !isFormData ? { "content-type": "application/json" } : {}),
       ...(init?.headers ?? {}),
     },
     ...init,

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -198,6 +198,58 @@ test.describe("Agent CRUD", () => {
     });
   });
 
+  test("POST /api/v1/agents accepts multipart startup context", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/v1/agents", {
+      headers: AUTH_HEADER,
+      multipart: {
+        name: `e2e-agent-${Date.now()}`,
+        cwd: "/tmp",
+        useWorktree: "false",
+        initialPrompt: "inspect startup context and continue",
+        startupLinks: JSON.stringify(["https://example.com/task"]),
+        startupFiles: {
+          name: "Screenshot 2026-04-25 at 09.41.02.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("hello startup context"),
+        },
+      },
+    });
+    expect(res.status()).toBe(201);
+    const { agent } = (await res.json()) as {
+      agent: {
+        id: string;
+        pins: Array<{ label: string; value: string; type: string }>;
+      };
+    };
+    expect(agent.pins).toEqual([
+      {
+        label: "example.com",
+        value: "https://example.com/task",
+        type: "url",
+      },
+    ]);
+  });
+
+  test("POST /api/v1/agents rejects invalid multipart startup links", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/v1/agents", {
+      headers: AUTH_HEADER,
+      multipart: {
+        name: `e2e-agent-${Date.now()}`,
+        cwd: "/tmp",
+        useWorktree: "false",
+        startupLinks: JSON.stringify(["github.com/selfcontained/dispatch"]),
+      },
+    });
+    expect(res.status()).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "URL pins must be valid http or https URLs.",
+    });
+  });
+
   test("cancel create dialog does not create an agent", async ({ page }) => {
     await loadApp(page);
 

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -124,11 +124,11 @@ test.describe("Terminal agent type", () => {
     const form = page.getByTestId("create-agent-form");
     await expect(form).toBeVisible();
 
-    // Full access + auto review + "Create with prompt" are all visible for
+    // Full access + auto review + "Create with context" are all visible for
     // the default CLI type.
     await expect(form.getByText("Start in full access mode")).toBeVisible();
     await expect(form.getByText("Autonomous Review")).toBeVisible();
-    await expect(page.getByTestId("create-agent-with-prompt")).toBeVisible();
+    await expect(page.getByTestId("create-agent-with-context")).toBeVisible();
 
     // Switch to terminal.
     const typeTrigger = form.getByRole("combobox").first();
@@ -140,8 +140,26 @@ test.describe("Terminal agent type", () => {
     await expect(form.getByText("Start in full access mode")).not.toBeVisible();
     await expect(form.getByText("Autonomous Review")).not.toBeVisible();
     await expect(
-      page.getByTestId("create-agent-with-prompt")
+      page.getByTestId("create-agent-with-context")
     ).not.toBeVisible();
     await expect(page.getByTestId("create-agent-worktree")).toBeVisible();
+  });
+
+  test("create with context shows instructions, files, and links", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    await page.getByTestId("create-agent-with-context").click();
+
+    await expect(page.getByText("Create with context")).toBeVisible();
+    await expect(page.getByTestId("create-agent-initial-prompt")).toBeVisible();
+    await expect(
+      page.getByTestId("create-agent-context-files-button")
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("create-agent-context-link-input")
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- rename the second-step create-agent flow to "Create with context"
- let users provide startup instructions, links, and attached files in that step
- seed startup pins/media before launch and include them in the agent's startup guidance

## Testing
- pnpm run check
- pnpm run finalize:web
- pnpm run test
- pnpm run test:e2e