### PR TITLE
Highlight active review agent row

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -138,7 +138,11 @@ export function AgentCard({
   enabledAgentTypes,
 }: AgentCardProps): JSX.Element {
   const state = getVisualState(agent);
-  const isSelected = selectedAgentId === agent.id;
+  const hasActiveChild = childAgents.some(
+    (child) => child.id === connectedAgentId
+  );
+  const effectiveState: AgentVisualState = hasActiveChild ? "idle" : state;
+  const isSelected = selectedAgentId === agent.id && !hasActiveChild;
   const isStopped = state === "stopped";
   const isExpanded = expandedAgentId === agent.id;
   const fullAccessEnabled = isFullAccessEnabled(agent);
@@ -155,7 +159,7 @@ export function AgentCard({
         data-testid={`agent-card-${agent.id}`}
         className={cn(
           "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
-          borderForAgentState(state),
+          borderForAgentState(effectiveState),
           isSelected && "bg-muted/60",
           isStopped && "opacity-60"
         )}

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -512,7 +512,11 @@ export function ParentFeedbackPanel({
             return (
               <div
                 key={child.id}
-                className="rounded-xl border border-border/60 bg-background/25 px-1.5 py-1.5"
+                data-testid={`review-agent-block-${child.id}`}
+                className={cn(
+                  "rounded-xl border border-border/60 border-r-4 border-r-transparent bg-background/25 px-1.5 py-1.5 transition-colors duration-200",
+                  childState === "active" && "border-r-status-done bg-muted/20"
+                )}
               >
                 {getVisualState && detachTerminal && attachToAgent ? (
                   <div

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -321,8 +321,7 @@ export function PersonaAgentRow({
         hasFeedback && "cursor-pointer hover:bg-muted/50",
         isSelected && "bg-muted/35",
         (isSelected || isReviewing) && "rounded-lg",
-        isReviewing && "persona-reviewing-row",
-        childIsActive && "bg-muted/35"
+        isReviewing && "persona-reviewing-row"
       )}
     >
       <div className="flex shrink-0 items-center pt-0.5">
@@ -456,13 +455,6 @@ export function PersonaAgentRow({
           )
         ) : null}
       </div>
-      {childIsActive ? (
-        <span
-          aria-hidden="true"
-          data-testid={`review-agent-active-band-${child.id}`}
-          className="absolute inset-y-0 right-0 w-1 rounded-r-lg bg-status-done"
-        />
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -333,21 +333,22 @@ export function PersonaAgentRow({
         />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="flex items-start gap-1.5">
+        <div className="flex flex-wrap items-start gap-1.5">
           <span
             className="min-w-0 flex-1 truncate text-xs font-medium"
             style={{ color: `hsl(${colorVar})` }}
           >
             {child.persona ?? child.name}
           </span>
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex min-w-0 flex-wrap items-center justify-end gap-1 sm:shrink-0">
             {childIsActive ? (
               <Badge
                 variant="running"
                 className="h-5 px-1.5 text-[9px]"
                 data-testid={`review-agent-active-badge-${child.id}`}
               >
-                Active terminal
+                <span className="sm:hidden">Active</span>
+                <span className="hidden sm:inline">Active terminal</span>
               </Badge>
             ) : null}
             {roundBadge ? <RoundBadge badge={roundBadge} /> : null}

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -13,6 +13,7 @@ import {
   type ReviewVerdict,
 } from "@/components/app/agent-event-utils";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
+import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipContent,
@@ -316,11 +317,12 @@ export function PersonaAgentRow({
     <div
       data-testid={`agent-card-${child.id}`}
       className={cn(
-        "flex items-start gap-2.5 px-2.5 py-2.5 transition-colors duration-200",
+        "relative flex items-start gap-2.5 px-2.5 py-2.5 transition-colors duration-200",
         hasFeedback && "cursor-pointer hover:bg-muted/50",
         isSelected && "bg-muted/35",
         (isSelected || isReviewing) && "rounded-lg",
-        isReviewing && "persona-reviewing-row"
+        isReviewing && "persona-reviewing-row",
+        childIsActive && "bg-muted/35"
       )}
     >
       <div className="flex shrink-0 items-center pt-0.5">
@@ -339,6 +341,15 @@ export function PersonaAgentRow({
             {child.persona ?? child.name}
           </span>
           <div className="flex shrink-0 items-center gap-1">
+            {childIsActive ? (
+              <Badge
+                variant="running"
+                className="h-5 px-1.5 text-[9px]"
+                data-testid={`review-agent-active-badge-${child.id}`}
+              >
+                Active terminal
+              </Badge>
+            ) : null}
             {roundBadge ? <RoundBadge badge={roundBadge} /> : null}
             {feedbackCount != null && feedbackCount > 0 ? (
               <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-status-waiting/45 bg-status-waiting/15 px-1.5 text-[10px] font-semibold text-status-waiting">
@@ -444,6 +455,13 @@ export function PersonaAgentRow({
           )
         ) : null}
       </div>
+      {childIsActive ? (
+        <span
+          aria-hidden="true"
+          data-testid={`review-agent-active-band-${child.id}`}
+          className="absolute inset-y-0 right-0 w-1 rounded-r-lg bg-status-done"
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move the active review-agent callout into the sidebar review row
- show the active marker as a separate right-edge band plus badge
- keep the reviewing animation intact when the review row is active

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- manual Playwright validation against seeded live review agent row