### PR TITLE
Show image thumbnails in create-agent file chips

### DIFF
--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -17,6 +17,7 @@ import {
   GitBranch,
   Link2,
   Plus,
+  Upload,
   X,
 } from "lucide-react";
 
@@ -39,6 +40,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { type Agent } from "@/components/app/types";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import {
@@ -73,6 +79,94 @@ function startupFileExt(name: string): string {
         .slice(dot + 1)
         .toUpperCase()
         .slice(0, 4);
+}
+
+function startupLinkLabel(url: string): { host: string; rest: string } {
+  try {
+    const u = new URL(url);
+    const rest =
+      (u.pathname === "/" ? "" : u.pathname) +
+      (u.search || "") +
+      (u.hash || "");
+    return { host: u.hostname.replace(/^www\./, ""), rest };
+  } catch {
+    return { host: url, rest: "" };
+  }
+}
+
+function AddContextMenu({
+  onAddFile,
+  onAddLink,
+}: {
+  onAddFile: () => void;
+  onAddLink: () => void;
+}) {
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={onAddFile}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-foreground hover:bg-muted/60"
+      >
+        <Upload className="h-3.5 w-3.5 text-muted-foreground" />
+        Add file
+      </button>
+      <button
+        type="button"
+        onClick={onAddLink}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-foreground hover:bg-muted/60"
+      >
+        <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+        Add link
+      </button>
+    </div>
+  );
+}
+
+function AddContextLinkForm({
+  value,
+  onChange,
+  onSubmit,
+  onBack,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="space-y-1.5 p-1">
+      <Input
+        autoFocus
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+        placeholder="https://..."
+        data-testid="create-agent-context-link-input"
+      />
+      <div className="flex justify-between gap-2">
+        <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+          <ChevronLeft className="mr-1 h-3 w-3" />
+          Back
+        </Button>
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          onClick={onSubmit}
+          disabled={value.trim().length === 0}
+          data-testid="create-agent-context-link-add"
+        >
+          Add link
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function readStoredString(key: string): string {
@@ -403,20 +497,90 @@ function CreateAgentDialogContent({
     };
   }, []);
 
-  const addStartupLink = useCallback(() => {
+  const handleRemoveStartupLink = useCallback((linkToRemove: string) => {
+    setStartupLinks((current) =>
+      current.filter((link) => link !== linkToRemove)
+    );
+  }, []);
+
+  // Add-context popover: clicking the Add CTA opens a small menu with
+  // "Add file" / "Add link"; "Add link" swaps the popover content for an
+  // inline URL form rather than navigating away.
+  const [addOpen, setAddOpen] = useState(false);
+  const [addMode, setAddMode] = useState<"menu" | "link">("menu");
+  const [dragOver, setDragOver] = useState(false);
+  const dragDepthRef = useRef(0);
+
+  const handleAddOpenChange = useCallback((next: boolean) => {
+    setAddOpen(next);
+    if (!next) setAddMode("menu");
+  }, []);
+
+  const handleAddFileFromMenu = useCallback(() => {
+    setAddOpen(false);
+    setAddMode("menu");
+    // Defer the file picker click so the popover unmounts cleanly first.
+    requestAnimationFrame(() => startupFileInputRef.current?.click());
+  }, []);
+
+  const handleAddLinkFromMenu = useCallback(() => {
+    setAddMode("link");
+  }, []);
+
+  const handleAddLinkSubmit = useCallback(() => {
     const trimmed = linkDraft.trim();
     if (!trimmed) return;
     setStartupLinks((current) =>
       current.includes(trimmed) ? current : [...current, trimmed]
     );
     setLinkDraft("");
+    setAddMode("menu");
+    setAddOpen(false);
   }, [linkDraft]);
 
-  const handleRemoveStartupLink = useCallback((linkToRemove: string) => {
-    setStartupLinks((current) =>
-      current.filter((link) => link !== linkToRemove)
-    );
+  // Radix Popover defaults to z-50 inline, but DialogContent is z-70.
+  // Bump the popper wrapper while this dialog content is mounted.
+  useEffect(() => {
+    const style = document.createElement("style");
+    style.textContent =
+      "[data-radix-popper-content-wrapper]{z-index:80!important}";
+    document.head.appendChild(style);
+    return () => {
+      style.remove();
+    };
   }, []);
+
+  const handleContextDragEnter = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+      dragDepthRef.current += 1;
+      setDragOver(true);
+    },
+    []
+  );
+  const handleContextDragLeave = useCallback(() => {
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setDragOver(false);
+  }, []);
+  const handleContextDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (Array.from(event.dataTransfer.types).includes("Files")) {
+        event.preventDefault();
+      }
+    },
+    []
+  );
+  const handleContextDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const dropped = Array.from(event.dataTransfer.files);
+      if (dropped.length === 0) return;
+      event.preventDefault();
+      dragDepthRef.current = 0;
+      setDragOver(false);
+      appendStartupFiles(dropped);
+    },
+    [appendStartupFiles]
+  );
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -893,11 +1057,22 @@ function CreateAgentDialogContent({
               />
             </div>
 
-            <div className="space-y-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+            <div
+              className={cn(
+                "space-y-3 rounded-md border bg-muted/20 px-3 py-3 transition-colors",
+                dragOver ? "border-primary/60 bg-primary/5" : "border-border/70"
+              )}
+              onDragEnter={handleContextDragEnter}
+              onDragLeave={handleContextDragLeave}
+              onDragOver={handleContextDragOver}
+              onDrop={handleContextDrop}
+            >
               <div>
-                <div className="text-sm font-medium text-foreground">Files</div>
+                <div className="text-sm font-medium text-foreground">
+                  Context
+                </div>
                 <p className="text-xs text-muted-foreground">
-                  Attach images or documents.
+                  Attach files or links to give the agent context.
                 </p>
               </div>
               <input
@@ -909,27 +1084,62 @@ function CreateAgentDialogContent({
                 onChange={handleStartupFileChange}
                 data-testid="create-agent-context-files-input"
               />
-              {startupFiles.length === 0 ? (
-                <button
-                  type="button"
-                  onClick={() => startupFileInputRef.current?.click()}
-                  data-testid="create-agent-context-files-button"
-                  className="flex w-full flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-4 py-6 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
-                >
-                  <Plus className="h-5 w-5" />
-                  <span>Add images or documents</span>
-                </button>
+              {startupFiles.length === 0 && startupLinks.length === 0 ? (
+                <Popover open={addOpen} onOpenChange={handleAddOpenChange}>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      data-testid="create-agent-context-files-button"
+                      className={cn(
+                        "flex w-full flex-col items-center justify-center gap-1.5 rounded-md border border-dashed px-4 py-6 text-sm transition-colors",
+                        dragOver
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border/70 bg-background/40 text-muted-foreground hover:border-border hover:bg-background/70 hover:text-foreground"
+                      )}
+                    >
+                      {dragOver ? (
+                        <>
+                          <Upload className="h-5 w-5" />
+                          <span>Drop file to add</span>
+                        </>
+                      ) : (
+                        <>
+                          <Plus className="h-5 w-5" />
+                          <span>Add files or links</span>
+                          <span className="text-[11px] text-muted-foreground/80">
+                            Click to choose, or drop a file here
+                          </span>
+                        </>
+                      )}
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent align="start" className="w-56 p-1">
+                    {addMode === "menu" ? (
+                      <AddContextMenu
+                        onAddFile={handleAddFileFromMenu}
+                        onAddLink={handleAddLinkFromMenu}
+                      />
+                    ) : (
+                      <AddContextLinkForm
+                        value={linkDraft}
+                        onChange={setLinkDraft}
+                        onSubmit={handleAddLinkSubmit}
+                        onBack={() => setAddMode("menu")}
+                      />
+                    )}
+                  </PopoverContent>
+                </Popover>
               ) : (
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-wrap items-start gap-3">
                   {startupFiles.map((file) => {
                     const key = startupFileKey(file);
                     const preview = startupFilePreviewsRef.current.get(key);
                     return (
                       <div
                         key={key}
-                        className="group flex w-24 flex-col gap-1.5"
+                        className="group flex w-12 flex-col gap-0.5"
                       >
-                        <div className="relative h-24 w-24 overflow-hidden rounded-md border border-border/70 bg-muted/40">
+                        <div className="relative h-12 w-12 overflow-hidden rounded-md border border-border/70 bg-muted/40">
                           {preview ? (
                             <img
                               src={preview}
@@ -937,24 +1147,24 @@ function CreateAgentDialogContent({
                               className="h-full w-full object-cover"
                             />
                           ) : (
-                            <div className="flex h-full w-full flex-col items-center justify-center gap-1 text-muted-foreground">
-                              <FileText className="h-6 w-6" />
-                              <span className="text-[10px] font-medium tracking-wide">
+                            <div className="flex h-full w-full flex-col items-center justify-center text-muted-foreground">
+                              <FileText className="h-3.5 w-3.5" />
+                              <span className="text-[8px] font-medium tracking-wide">
                                 {startupFileExt(file.name)}
                               </span>
                             </div>
                           )}
                           <button
                             type="button"
-                            className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-background/80 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+                            className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-border/70 bg-background text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
                             onClick={() => handleRemoveStartupFile(file)}
                             aria-label={`Remove ${file.name}`}
                           >
-                            <X className="h-3 w-3" />
+                            <X className="h-2.5 w-2.5" />
                           </button>
                         </div>
                         <span
-                          className="w-full truncate text-[10px] text-muted-foreground"
+                          className="w-full truncate text-[8px] leading-tight text-muted-foreground"
                           title={file.name}
                         >
                           {file.name}
@@ -962,74 +1172,71 @@ function CreateAgentDialogContent({
                       </div>
                     );
                   })}
-                  <button
-                    type="button"
-                    onClick={() => startupFileInputRef.current?.click()}
-                    data-testid="create-agent-context-files-button"
-                    aria-label="Add more files"
-                    className="flex h-24 w-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border/70 bg-background/40 text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
-                  >
-                    <Plus className="h-5 w-5" />
-                    <span>Add</span>
-                  </button>
-                </div>
-              )}
-            </div>
-
-            <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-              <div>
-                <div className="text-sm font-medium text-foreground">Links</div>
-                <p className="text-xs text-muted-foreground">
-                  Add one or more URLs to pin into the new session.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <Input
-                  value={linkDraft}
-                  onChange={(event) => setLinkDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      addStartupLink();
-                    }
-                  }}
-                  placeholder="https://..."
-                  data-testid="create-agent-context-link-input"
-                />
-                <Button
-                  type="button"
-                  variant="default"
-                  onClick={addStartupLink}
-                  data-testid="create-agent-context-link-add"
-                >
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Add
-                </Button>
-              </div>
-              {startupLinks.length > 0 ? (
-                <div className="space-y-2">
-                  {startupLinks.map((link) => (
-                    <div
-                      key={link}
-                      className="flex items-center gap-2 rounded-md border border-border/70 bg-background/70 px-3 py-2 text-xs text-foreground"
-                    >
-                      <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1 truncate">{link}</span>
+                  {startupLinks.map((link) => {
+                    const { host, rest } = startupLinkLabel(link);
+                    return (
+                      <div
+                        key={link}
+                        className="group relative flex h-12 max-w-[180px] flex-col justify-center gap-0.5 rounded-md border border-border/70 bg-muted/40 px-2 pr-5 leading-tight"
+                        title={link}
+                      >
+                        <div className="flex items-center gap-1 text-[10px] text-foreground">
+                          <Link2 className="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
+                          <span className="truncate font-medium">{host}</span>
+                        </div>
+                        {rest ? (
+                          <span className="truncate text-[9px] text-muted-foreground">
+                            {rest}
+                          </span>
+                        ) : null}
+                        <button
+                          type="button"
+                          className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-border/70 bg-background text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+                          onClick={() => handleRemoveStartupLink(link)}
+                          aria-label={`Remove ${link}`}
+                        >
+                          <X className="h-2.5 w-2.5" />
+                        </button>
+                      </div>
+                    );
+                  })}
+                  <Popover open={addOpen} onOpenChange={handleAddOpenChange}>
+                    <PopoverTrigger asChild>
                       <button
                         type="button"
-                        className="text-muted-foreground hover:text-foreground"
-                        onClick={() => handleRemoveStartupLink(link)}
-                        aria-label={`Remove ${link}`}
+                        data-testid="create-agent-context-files-button"
+                        aria-label="Add context"
+                        className={cn(
+                          "flex h-12 w-12 items-center justify-center rounded-md border border-dashed transition-colors",
+                          dragOver
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border/70 bg-background/40 text-muted-foreground hover:border-border hover:bg-background/70 hover:text-foreground"
+                        )}
                       >
-                        <X className="h-3 w-3" />
+                        {dragOver ? (
+                          <Upload className="h-4 w-4" />
+                        ) : (
+                          <Plus className="h-4 w-4" />
+                        )}
                       </button>
-                    </div>
-                  ))}
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-56 p-1">
+                      {addMode === "menu" ? (
+                        <AddContextMenu
+                          onAddFile={handleAddFileFromMenu}
+                          onAddLink={handleAddLinkFromMenu}
+                        />
+                      ) : (
+                        <AddContextLinkForm
+                          value={linkDraft}
+                          onChange={setLinkDraft}
+                          onSubmit={handleAddLinkSubmit}
+                          onBack={() => setAddMode("menu")}
+                        />
+                      )}
+                    </PopoverContent>
+                  </Popover>
                 </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  No links added yet.
-                </p>
               )}
             </div>
 

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -12,10 +12,10 @@ import { useAtom } from "jotai";
 import {
   Check,
   ChevronDown,
-  GitBranch,
   ChevronLeft,
+  FileText,
+  GitBranch,
   Link2,
-  Paperclip,
   Plus,
   X,
 } from "lucide-react";
@@ -63,6 +63,16 @@ const STARTUP_FILE_ACCEPT =
 
 function startupFileKey(file: File): string {
   return `${file.name}:${file.size}:${file.lastModified}`;
+}
+
+function startupFileExt(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot === -1
+    ? "FILE"
+    : name
+        .slice(dot + 1)
+        .toUpperCase()
+        .slice(0, 4);
 }
 
 function readStoredString(key: string): string {
@@ -322,6 +332,12 @@ function CreateAgentDialogContent({
     []
   );
 
+  // Object URLs for image previews are tracked in a ref so they're created
+  // and revoked synchronously alongside the file list, not derived from an
+  // effect — that avoids both a one-frame paperclip→thumbnail flicker on add
+  // and unnecessary URL churn for unchanged chips on every mutation.
+  const startupFilePreviewsRef = useRef<Map<string, string>>(new Map());
+
   const appendStartupFiles = useCallback((files: File[]) => {
     if (files.length === 0) return;
     setStartupFiles((current) => {
@@ -332,6 +348,12 @@ function CreateAgentDialogContent({
         if (seen.has(key)) continue;
         seen.add(key);
         next.push(file);
+        if (
+          file.type.startsWith("image/") &&
+          !startupFilePreviewsRef.current.has(key)
+        ) {
+          startupFilePreviewsRef.current.set(key, URL.createObjectURL(file));
+        }
       }
       return next;
     });
@@ -360,31 +382,26 @@ function CreateAgentDialogContent({
   );
 
   const handleRemoveStartupFile = useCallback((fileToRemove: File) => {
+    const key = startupFileKey(fileToRemove);
+    const url = startupFilePreviewsRef.current.get(key);
+    if (url) {
+      URL.revokeObjectURL(url);
+      startupFilePreviewsRef.current.delete(key);
+    }
     setStartupFiles((current) =>
-      current.filter(
-        (file) => startupFileKey(file) !== startupFileKey(fileToRemove)
-      )
+      current.filter((file) => startupFileKey(file) !== key)
     );
   }, []);
 
-  const [startupFilePreviews, setStartupFilePreviews] = useState<
-    Record<string, string>
-  >({});
-
   useEffect(() => {
-    const next: Record<string, string> = {};
-    for (const file of startupFiles) {
-      if (file.type.startsWith("image/")) {
-        next[startupFileKey(file)] = URL.createObjectURL(file);
-      }
-    }
-    setStartupFilePreviews(next);
+    const previews = startupFilePreviewsRef.current;
     return () => {
-      for (const url of Object.values(next)) {
+      for (const url of previews.values()) {
         URL.revokeObjectURL(url);
       }
+      previews.clear();
     };
-  }, [startupFiles]);
+  }, []);
 
   const addStartupLink = useCallback(() => {
     const trimmed = linkDraft.trim();
@@ -876,26 +893,12 @@ function CreateAgentDialogContent({
               />
             </div>
 
-            <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-sm font-medium text-foreground">
-                    Files
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    Attach images or documents.
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="default"
-                  size="sm"
-                  onClick={() => startupFileInputRef.current?.click()}
-                  data-testid="create-agent-context-files-button"
-                >
-                  <Paperclip className="mr-1.5 h-3.5 w-3.5" />
-                  Add files
-                </Button>
+            <div className="space-y-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+              <div>
+                <div className="text-sm font-medium text-foreground">Files</div>
+                <p className="text-xs text-muted-foreground">
+                  Attach images or documents.
+                </p>
               </div>
               <input
                 ref={startupFileInputRef}
@@ -906,46 +909,70 @@ function CreateAgentDialogContent({
                 onChange={handleStartupFileChange}
                 data-testid="create-agent-context-files-input"
               />
-              {startupFiles.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
+              {startupFiles.length === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => startupFileInputRef.current?.click()}
+                  data-testid="create-agent-context-files-button"
+                  className="flex w-full flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-4 py-6 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
+                >
+                  <Plus className="h-5 w-5" />
+                  <span>Add images or documents</span>
+                </button>
+              ) : (
+                <div className="flex flex-wrap gap-3">
                   {startupFiles.map((file) => {
                     const key = startupFileKey(file);
-                    const preview = startupFilePreviews[key];
+                    const preview = startupFilePreviewsRef.current.get(key);
                     return (
                       <div
                         key={key}
-                        className="flex items-center gap-2 rounded-full border border-border/70 bg-background/70 py-1 pr-3 pl-1 text-xs text-foreground"
+                        className="group flex w-[88px] flex-col gap-1.5"
                       >
-                        {preview ? (
-                          <img
-                            src={preview}
-                            alt=""
-                            className="h-7 w-7 shrink-0 rounded-full object-cover"
-                          />
-                        ) : (
-                          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted/60">
-                            <Paperclip className="h-3.5 w-3.5 text-muted-foreground" />
-                          </span>
-                        )}
-                        <span className="max-w-[260px] truncate">
+                        <div className="relative h-[72px] w-[72px] overflow-hidden rounded-md border border-border/70 bg-muted/40">
+                          {preview ? (
+                            <img
+                              src={preview}
+                              alt=""
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full flex-col items-center justify-center gap-1 text-muted-foreground">
+                              <FileText className="h-6 w-6" />
+                              <span className="text-[10px] font-medium tracking-wide">
+                                {startupFileExt(file.name)}
+                              </span>
+                            </div>
+                          )}
+                          <button
+                            type="button"
+                            className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-background/80 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+                            onClick={() => handleRemoveStartupFile(file)}
+                            aria-label={`Remove ${file.name}`}
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </div>
+                        <span
+                          className="w-[72px] truncate text-[11px] text-muted-foreground"
+                          title={file.name}
+                        >
                           {file.name}
                         </span>
-                        <button
-                          type="button"
-                          className="text-muted-foreground hover:text-foreground"
-                          onClick={() => handleRemoveStartupFile(file)}
-                          aria-label={`Remove ${file.name}`}
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
                       </div>
                     );
                   })}
+                  <button
+                    type="button"
+                    onClick={() => startupFileInputRef.current?.click()}
+                    data-testid="create-agent-context-files-button"
+                    aria-label="Add more files"
+                    className="flex h-[72px] w-[72px] flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border/70 bg-background/40 text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
+                  >
+                    <Plus className="h-5 w-5" />
+                    <span>Add</span>
+                  </button>
                 </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  No files added yet.
-                </p>
               )}
             </div>
 

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -367,6 +367,25 @@ function CreateAgentDialogContent({
     );
   }, []);
 
+  const [startupFilePreviews, setStartupFilePreviews] = useState<
+    Record<string, string>
+  >({});
+
+  useEffect(() => {
+    const next: Record<string, string> = {};
+    for (const file of startupFiles) {
+      if (file.type.startsWith("image/")) {
+        next[startupFileKey(file)] = URL.createObjectURL(file);
+      }
+    }
+    setStartupFilePreviews(next);
+    return () => {
+      for (const url of Object.values(next)) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [startupFiles]);
+
   const addStartupLink = useCallback(() => {
     const trimmed = linkDraft.trim();
     if (!trimmed) return;
@@ -864,7 +883,7 @@ function CreateAgentDialogContent({
                     Files
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Attach files or paste images/documents from the clipboard.
+                    Attach images or documents.
                   </p>
                 </div>
                 <Button
@@ -889,25 +908,39 @@ function CreateAgentDialogContent({
               />
               {startupFiles.length > 0 ? (
                 <div className="flex flex-wrap gap-2">
-                  {startupFiles.map((file) => (
-                    <div
-                      key={startupFileKey(file)}
-                      className="flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1 text-xs text-foreground"
-                    >
-                      <Paperclip className="h-3 w-3 text-muted-foreground" />
-                      <span className="max-w-[260px] truncate">
-                        {file.name}
-                      </span>
-                      <button
-                        type="button"
-                        className="text-muted-foreground hover:text-foreground"
-                        onClick={() => handleRemoveStartupFile(file)}
-                        aria-label={`Remove ${file.name}`}
+                  {startupFiles.map((file) => {
+                    const key = startupFileKey(file);
+                    const preview = startupFilePreviews[key];
+                    return (
+                      <div
+                        key={key}
+                        className="flex items-center gap-2 rounded-full border border-border/70 bg-background/70 py-1 pr-3 pl-1 text-xs text-foreground"
                       >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </div>
-                  ))}
+                        {preview ? (
+                          <img
+                            src={preview}
+                            alt=""
+                            className="h-7 w-7 shrink-0 rounded-full object-cover"
+                          />
+                        ) : (
+                          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted/60">
+                            <Paperclip className="h-3.5 w-3.5 text-muted-foreground" />
+                          </span>
+                        )}
+                        <span className="max-w-[260px] truncate">
+                          {file.name}
+                        </span>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground"
+                          onClick={() => handleRemoveStartupFile(file)}
+                          aria-label={`Remove ${file.name}`}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 <p className="text-xs text-muted-foreground">

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -927,9 +927,9 @@ function CreateAgentDialogContent({
                     return (
                       <div
                         key={key}
-                        className="group flex w-[88px] flex-col gap-1.5"
+                        className="group flex w-24 flex-col gap-1.5"
                       >
-                        <div className="relative h-[72px] w-[72px] overflow-hidden rounded-md border border-border/70 bg-muted/40">
+                        <div className="relative h-24 w-24 overflow-hidden rounded-md border border-border/70 bg-muted/40">
                           {preview ? (
                             <img
                               src={preview}
@@ -954,7 +954,7 @@ function CreateAgentDialogContent({
                           </button>
                         </div>
                         <span
-                          className="w-[72px] truncate text-[11px] text-muted-foreground"
+                          className="w-full truncate text-[10px] text-muted-foreground"
                           title={file.name}
                         >
                           {file.name}
@@ -967,7 +967,7 @@ function CreateAgentDialogContent({
                     onClick={() => startupFileInputRef.current?.click()}
                     data-testid="create-agent-context-files-button"
                     aria-label="Add more files"
-                    className="flex h-[72px] w-[72px] flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border/70 bg-background/40 text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
+                    className="flex h-24 w-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border/70 bg-background/40 text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-background/70 hover:text-foreground"
                   >
                     <Plus className="h-5 w-5" />
                     <span>Add</span>

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -158,6 +158,10 @@ test.describe("Terminal agent type", () => {
     await expect(
       page.getByTestId("create-agent-context-files-button")
     ).toBeVisible();
+
+    // The link input lives in the Add Context popover behind "Add link".
+    await page.getByTestId("create-agent-context-files-button").click();
+    await page.getByRole("button", { name: "Add link" }).click();
     await expect(
       page.getByTestId("create-agent-context-link-input")
     ).toBeVisible();


### PR DESCRIPTION
## Summary
Reworks the second step of the Create Agent dialog from two separate Files + Links sections into a single **Context** area.

- Single dashed CTA card opens an Add menu (**Add file** / **Add link**); the link option swaps the popover content for an inline URL form rather than navigating somewhere else.
- The whole section is a drop target for files; CTA shows "Drop file to add" with a primary tint on drag-over.
- Files render as 48×48 tiles (image preview or extension card); links render as 48px-tall variable-width tiles up to 180px so they don't look hollow next to the squares.
- Object URLs for image previews live in a ref-held Map updated synchronously in the add/remove handlers — no per-mutation churn or paperclip→thumbnail flicker.

## Test plan
- [x] `pnpm run check` (backend + web typecheck)
- [x] `pnpm run finalize:web` (production build)
- [x] `pnpm run test:e2e` (149 passed, 6 skipped — including the updated `terminal-agent-type` "create with context" check that walks the new popover flow)
- [x] Manual: dialog renders empty CTA → click → popover with Add file / Add link → both flows produce tiles (image, .md, .json, github.com link) — see attached screenshot.