### PR TITLE
Fix create-agent context clipboard timing

### DIFF
--- a/apps/web/src/components/app/create-agent-dialog-clipboard.test.ts
+++ b/apps/web/src/components/app/create-agent-dialog-clipboard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clipboardReadSupported,
   createClipboardSuggestionFromFile,
   createClipboardSuggestionFromText,
   describeClipboardFileType,
@@ -118,6 +119,24 @@ describe("create-agent-dialog clipboard helpers", () => {
   });
 
   describe("getClipboardSuggestion", () => {
+    it("detects clipboard read support without reading", () => {
+      vi.stubGlobal("navigator", {
+        clipboard: {
+          readText: vi.fn(),
+        },
+      });
+
+      expect(clipboardReadSupported()).toBe(true);
+    });
+
+    it("returns false when clipboard read apis are unavailable", () => {
+      vi.stubGlobal("navigator", {
+        clipboard: {},
+      });
+
+      expect(clipboardReadSupported()).toBe(false);
+    });
+
     it("returns unsupported when clipboard api is absent", async () => {
       vi.stubGlobal("navigator", {});
 

--- a/apps/web/src/components/app/create-agent-dialog-clipboard.ts
+++ b/apps/web/src/components/app/create-agent-dialog-clipboard.ts
@@ -179,6 +179,17 @@ export function getClipboardFilesFromEvent(
     .filter((file): file is File => file !== null);
 }
 
+export function clipboardReadSupported(): boolean {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    return false;
+  }
+
+  return (
+    typeof navigator.clipboard.read === "function" ||
+    typeof navigator.clipboard.readText === "function"
+  );
+}
+
 export async function getClipboardSuggestion(): Promise<ClipboardLookupResult> {
   if (typeof navigator === "undefined" || !navigator.clipboard) {
     return {
@@ -188,9 +199,7 @@ export async function getClipboardSuggestion(): Promise<ClipboardLookupResult> {
     };
   }
 
-  const canRead =
-    typeof navigator.clipboard.read === "function" ||
-    typeof navigator.clipboard.readText === "function";
+  const canRead = clipboardReadSupported();
 
   if (typeof navigator.clipboard.read === "function") {
     try {

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -675,10 +675,6 @@ function CreateAgentDialogContent({
   const trimmedLinkDraft = linkDraft.trim();
   const linkDraftIsValid =
     trimmedLinkDraft.length === 0 || isLikelyUrl(trimmedLinkDraft);
-  const hasQueuedPrompt = initialPrompt.trim().length > 0;
-  const hasQueuedFiles = startupFiles.length > 0;
-  const hasQueuedLinks = startupLinks.length > 0;
-  const hasQueuedContext = hasQueuedPrompt || hasQueuedFiles || hasQueuedLinks;
 
   const addStartupLink = useCallback(() => {
     const trimmed = linkDraft.trim();
@@ -753,6 +749,23 @@ function CreateAgentDialogContent({
     setAddOpen(false);
   }, [addStartupLink]);
 
+  const clearStartupContext = useCallback(() => {
+    for (const url of startupFilePreviewsRef.current.values()) {
+      URL.revokeObjectURL(url);
+    }
+    startupFilePreviewsRef.current.clear();
+    setInitialPrompt("");
+    setStartupFiles([]);
+    setStartupLinks([]);
+    setLinkDraft("");
+    setClipboardSuggestion(null);
+    setClipboardReadFeedback(null);
+    setCheckingClipboard(false);
+    setDraggingFiles(false);
+    setAddMode("menu");
+    setAddOpen(false);
+  }, []);
+
   // Radix Popover defaults to z-50 inline, but DialogContent is z-70.
   // Bump the popper wrapper while this dialog content is mounted.
   useEffect(() => {
@@ -779,6 +792,8 @@ function CreateAgentDialogContent({
         // try to run git in a non-repo directory.
         const submitUseWorktree =
           cwdIsGitRepo === false ? false : createUseWorktree;
+        const contextInitialPrompt =
+          step === "context" ? initialPrompt.trim() || undefined : undefined;
         const payloadBase = {
           name: createName.trim(),
           cwd,
@@ -795,11 +810,12 @@ function CreateAgentDialogContent({
             submitUseWorktree && createBaseBranch !== "main"
               ? createBaseBranch
               : undefined,
-          initialPrompt: initialPrompt.trim() || undefined,
+          initialPrompt: contextInitialPrompt,
         };
         const resolvedStartupLinks = startupLinks;
         const useStartupContext =
-          startupFiles.length > 0 || resolvedStartupLinks.length > 0;
+          step === "context" &&
+          (startupFiles.length > 0 || resolvedStartupLinks.length > 0);
         const payload = useStartupContext
           ? await (async () => {
               const formData = new FormData();
@@ -1167,24 +1183,6 @@ function CreateAgentDialogContent({
                 ) : null}
               </div>
             </div>
-            {hasQueuedContext ? (
-              <div
-                className="rounded-md border border-border/70 bg-muted/20 px-3 py-2"
-                data-testid="create-agent-context-summary"
-              >
-                <p className="text-xs text-muted-foreground">
-                  Startup context queued:
-                  {hasQueuedPrompt ? " instructions" : ""}
-                  {hasQueuedFiles
-                    ? `${hasQueuedPrompt ? "," : ""} ${startupFiles.length} file${startupFiles.length === 1 ? "" : "s"}`
-                    : ""}
-                  {hasQueuedLinks
-                    ? `${hasQueuedPrompt || hasQueuedFiles ? "," : ""} ${startupLinks.length} link${startupLinks.length === 1 ? "" : "s"}`
-                    : ""}
-                  . This context will be included if you create from this step.
-                </p>
-              </div>
-            ) : null}
             <div className="flex justify-end gap-2 pt-3">
               <Button
                 type="button"
@@ -1579,7 +1577,10 @@ function CreateAgentDialogContent({
                 variant="ghost"
                 tabIndex={0}
                 className="min-h-11 px-3"
-                onClick={() => setStep("config")}
+                onClick={() => {
+                  clearStartupContext();
+                  setStep("config");
+                }}
                 data-testid="create-agent-context-back"
               >
                 <ChevronLeft className="mr-1 h-4 w-4" />

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -194,7 +194,9 @@ function AddContextLinkForm({
         onKeyDown={(event) => {
           if (event.key === "Enter") {
             event.preventDefault();
-            onSubmit();
+            if (value.trim().length > 0 && isValid) {
+              onSubmit();
+            }
           }
         }}
         placeholder="https://..."
@@ -673,14 +675,19 @@ function CreateAgentDialogContent({
   const trimmedLinkDraft = linkDraft.trim();
   const linkDraftIsValid =
     trimmedLinkDraft.length === 0 || isLikelyUrl(trimmedLinkDraft);
+  const hasQueuedPrompt = initialPrompt.trim().length > 0;
+  const hasQueuedFiles = startupFiles.length > 0;
+  const hasQueuedLinks = startupLinks.length > 0;
+  const hasQueuedContext = hasQueuedPrompt || hasQueuedFiles || hasQueuedLinks;
 
   const addStartupLink = useCallback(() => {
     const trimmed = linkDraft.trim();
-    if (!trimmed || !isLikelyUrl(trimmed)) return;
+    if (!trimmed || !isLikelyUrl(trimmed)) return false;
     setStartupLinks((current) =>
       current.includes(trimmed) ? current : [...current, trimmed]
     );
     setLinkDraft("");
+    return true;
   }, [linkDraft]);
 
   const handleUseClipboardSuggestion = useCallback(() => {
@@ -741,7 +748,7 @@ function CreateAgentDialogContent({
   }, []);
 
   const handleAddLinkSubmit = useCallback(() => {
-    addStartupLink();
+    if (!addStartupLink()) return;
     setAddMode("menu");
     setAddOpen(false);
   }, [addStartupLink]);
@@ -792,10 +799,7 @@ function CreateAgentDialogContent({
         };
         const resolvedStartupLinks = startupLinks;
         const useStartupContext =
-          step === "context" &&
-          (payloadBase.initialPrompt ||
-            startupFiles.length > 0 ||
-            resolvedStartupLinks.length > 0);
+          startupFiles.length > 0 || resolvedStartupLinks.length > 0;
         const payload = useStartupContext
           ? await (async () => {
               const formData = new FormData();
@@ -1163,6 +1167,24 @@ function CreateAgentDialogContent({
                 ) : null}
               </div>
             </div>
+            {hasQueuedContext ? (
+              <div
+                className="rounded-md border border-border/70 bg-muted/20 px-3 py-2"
+                data-testid="create-agent-context-summary"
+              >
+                <p className="text-xs text-muted-foreground">
+                  Startup context queued:
+                  {hasQueuedPrompt ? " instructions" : ""}
+                  {hasQueuedFiles
+                    ? `${hasQueuedPrompt ? "," : ""} ${startupFiles.length} file${startupFiles.length === 1 ? "" : "s"}`
+                    : ""}
+                  {hasQueuedLinks
+                    ? `${hasQueuedPrompt || hasQueuedFiles ? "," : ""} ${startupLinks.length} link${startupLinks.length === 1 ? "" : "s"}`
+                    : ""}
+                  . This context will be included if you create from this step.
+                </p>
+              </div>
+            ) : null}
             <div className="flex justify-end gap-2 pt-3">
               <Button
                 type="button"

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -44,6 +44,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   type ClipboardSuggestion,
+  clipboardReadSupported,
   createClipboardSuggestionFromFile,
   createClipboardSuggestionFromText,
   getClipboardFilesFromEvent,
@@ -490,6 +491,33 @@ function CreateAgentDialogContent({
     }
   }, [step]);
 
+  useEffect(() => {
+    if (step !== "context") return;
+
+    const clipboardSupported = clipboardReadSupported();
+    setCanReadClipboard(clipboardSupported);
+    setClipboardReadFeedback(null);
+    setClipboardSuggestion(null);
+
+    if (!clipboardSupported) {
+      setCheckingClipboard(false);
+      return;
+    }
+
+    setCheckingClipboard(true);
+    const requestId = clipboardRequestIdRef.current + 1;
+    clipboardRequestIdRef.current = requestId;
+
+    void getClipboardSuggestion().then((result) => {
+      if (clipboardRequestIdRef.current !== requestId) return;
+      setCheckingClipboard(false);
+      setCanReadClipboard(result.canRead);
+      if (result.suggestion) {
+        setClipboardSuggestion(result.suggestion);
+      }
+    });
+  }, [step]);
+
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
@@ -615,21 +643,9 @@ function CreateAgentDialogContent({
   const enterContextStep = useCallback(() => {
     setStep("context");
     setClipboardSuggestion(null);
-    setCheckingClipboard(true);
+    setCheckingClipboard(false);
     setCanReadClipboard(false);
     setClipboardReadFeedback(null);
-    const requestId = clipboardRequestIdRef.current + 1;
-    clipboardRequestIdRef.current = requestId;
-    void getClipboardSuggestion().then((result) => {
-      if (clipboardRequestIdRef.current !== requestId) return;
-      setCheckingClipboard(false);
-      setCanReadClipboard(result.canRead);
-      if (result.suggestion) {
-        setClipboardSuggestion(result.suggestion);
-        return;
-      }
-      setClipboardReadFeedback(null);
-    });
   }, []);
 
   const handleCheckClipboard = useCallback(() => {

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -749,23 +749,6 @@ function CreateAgentDialogContent({
     setAddOpen(false);
   }, [addStartupLink]);
 
-  const clearStartupContext = useCallback(() => {
-    for (const url of startupFilePreviewsRef.current.values()) {
-      URL.revokeObjectURL(url);
-    }
-    startupFilePreviewsRef.current.clear();
-    setInitialPrompt("");
-    setStartupFiles([]);
-    setStartupLinks([]);
-    setLinkDraft("");
-    setClipboardSuggestion(null);
-    setClipboardReadFeedback(null);
-    setCheckingClipboard(false);
-    setDraggingFiles(false);
-    setAddMode("menu");
-    setAddOpen(false);
-  }, []);
-
   // Radix Popover defaults to z-50 inline, but DialogContent is z-70.
   // Bump the popper wrapper while this dialog content is mounted.
   useEffect(() => {
@@ -1577,10 +1560,7 @@ function CreateAgentDialogContent({
                 variant="ghost"
                 tabIndex={0}
                 className="min-h-11 px-3"
-                onClick={() => {
-                  clearStartupContext();
-                  setStep("config");
-                }}
+                onClick={() => setStep("config")}
                 data-testid="create-agent-context-back"
               >
                 <ChevronLeft className="mr-1 h-4 w-4" />

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -545,6 +545,64 @@ test.describe("Terminal agent type", () => {
     ).toBeDisabled();
   });
 
+  test("create with context keeps invalid manual-link drafts open on Enter", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    await page.getByTestId("create-agent-with-context").click();
+
+    await page.getByTestId("create-agent-context-files-button").click();
+    await page.getByRole("button", { name: "Add link" }).click();
+
+    const linkInput = page.getByTestId("create-agent-context-link-input");
+    await linkInput.fill("not-a-url");
+    await linkInput.press("Enter");
+
+    await expect(linkInput).toBeVisible();
+    await expect(linkInput).toHaveValue("not-a-url");
+    await expect(
+      page.getByTestId("create-agent-context-link-error")
+    ).toBeVisible();
+  });
+
+  test("create step preserves queued context after going back", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    await page.getByTestId("create-agent-with-context").click();
+
+    await page.getByTestId("create-agent-initial-prompt").fill("Use this.");
+    await page.getByTestId("create-agent-context-files-button").click();
+    await page.getByRole("button", { name: "Add link" }).click();
+    await page
+      .getByTestId("create-agent-context-link-input")
+      .fill("https://example.com/preserved");
+    await page.getByTestId("create-agent-context-link-add").click();
+
+    await page.getByTestId("create-agent-context-back").click();
+    await expect(
+      page.getByTestId("create-agent-context-summary")
+    ).toContainText("instructions, 1 link");
+
+    const createRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().includes("/api/v1/agents") &&
+        request.postData()?.includes("https://example.com/preserved") === true
+    );
+
+    await page.getByTestId("create-agent-submit").click();
+
+    const request = await createRequest;
+    expect(request.postData()).toContain("startupLinks");
+    expect(request.postData()).toContain("https://example.com/preserved");
+    expect(request.postData()).toContain("Use this.");
+  });
+
   test("create with context clears an unconfirmed link draft when the popover closes", async ({
     page,
   }) => {

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -23,6 +23,7 @@ async function stubClipboard(
   config:
     | { kind: "text"; text: string }
     | { kind: "deferred-text"; firstText: string; nextText: string }
+    | { kind: "pending-text"; text: string }
     | { kind: "blocked" }
     | { kind: "unsupported" }
     | { kind: "rich-text-link"; text: string; html: string }
@@ -56,31 +57,40 @@ async function stubClipboard(
               ],
               readText: async () => value.text,
             }
-          : value.kind === "deferred-text"
+          : value.kind === "pending-text"
             ? {
                 read: async () => [],
-                readText: async () => {
-                  const current =
-                    window.__dispatchClipboardText ?? value.firstText;
-                  window.__dispatchClipboardText = value.nextText;
-                  return current;
-                },
+                readText: async () =>
+                  await new Promise<string>((resolve) => {
+                    window.__dispatchResolveClipboardRead = () =>
+                      resolve(value.text);
+                  }),
               }
-            : value.kind === "blocked"
+            : value.kind === "deferred-text"
               ? {
-                  read: async () => {
-                    throw new DOMException("Blocked", "NotAllowedError");
-                  },
+                  read: async () => [],
                   readText: async () => {
-                    throw new DOMException("Blocked", "NotAllowedError");
+                    const current =
+                      window.__dispatchClipboardText ?? value.firstText;
+                    window.__dispatchClipboardText = value.nextText;
+                    return current;
                   },
                 }
-              : value.kind === "unsupported"
-                ? undefined
-                : {
-                    read: async () => [],
-                    readText: async () => value.text,
-                  };
+              : value.kind === "blocked"
+                ? {
+                    read: async () => {
+                      throw new DOMException("Blocked", "NotAllowedError");
+                    },
+                    readText: async () => {
+                      throw new DOMException("Blocked", "NotAllowedError");
+                    },
+                  }
+                : value.kind === "unsupported"
+                  ? undefined
+                  : {
+                      read: async () => [],
+                      readText: async () => value.text,
+                    };
 
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -92,6 +102,7 @@ async function stubClipboard(
 declare global {
   interface Window {
     __dispatchClipboardText?: string;
+    __dispatchResolveClipboardRead?: () => void;
   }
 }
 
@@ -286,6 +297,28 @@ test.describe("Terminal agent type", () => {
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
     await expect(cta).toContainText("Add copied link?");
     await expect(cta).not.toContainText("Clipboard file ready");
+  });
+
+  test("create with context advances before clipboard lookup resolves", async ({
+    page,
+  }) => {
+    await stubClipboard(page, {
+      kind: "pending-text",
+      text: "https://example.com/mounted-step-read",
+    });
+    await loadApp(page);
+
+    await page.getByTestId("create-agent-button").click();
+    await page.getByTestId("create-agent-with-context").click();
+
+    await expect(page.getByTestId("create-agent-context-form")).toBeVisible();
+    await expect(page.getByText("Create with context")).toBeVisible();
+
+    await page.evaluate(() => window.__dispatchResolveClipboardRead?.());
+
+    await expect(
+      page.getByTestId("create-agent-context-clipboard-cta")
+    ).toContainText("Add copied link?");
   });
 
   test("create with context can retry clipboard detection from an explicit button", async ({

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -567,7 +567,7 @@ test.describe("Terminal agent type", () => {
     ).toBeVisible();
   });
 
-  test("create step preserves queued context after going back", async ({
+  test("backing out of create with context clears queued context", async ({
     page,
   }) => {
     await loadApp(page);
@@ -584,23 +584,26 @@ test.describe("Terminal agent type", () => {
     await page.getByTestId("create-agent-context-link-add").click();
 
     await page.getByTestId("create-agent-context-back").click();
+    await page.getByTestId("create-agent-with-context").click();
+    await expect(page.getByTestId("create-agent-initial-prompt")).toHaveValue(
+      ""
+    );
     await expect(
-      page.getByTestId("create-agent-context-summary")
-    ).toContainText("instructions, 1 link");
+      page.getByText("No links added yet.", { exact: true })
+    ).toBeVisible();
+    await page.getByTestId("create-agent-context-back").click();
 
     const createRequest = page.waitForRequest(
       (request) =>
-        request.method() === "POST" &&
-        request.url().includes("/api/v1/agents") &&
-        request.postData()?.includes("https://example.com/preserved") === true
+        request.method() === "POST" && request.url().includes("/api/v1/agents")
     );
 
     await page.getByTestId("create-agent-submit").click();
 
     const request = await createRequest;
-    expect(request.postData()).toContain("startupLinks");
-    expect(request.postData()).toContain("https://example.com/preserved");
-    expect(request.postData()).toContain("Use this.");
+    expect(request.postData()).not.toContain("startupLinks");
+    expect(request.postData()).not.toContain("https://example.com/preserved");
+    expect(request.postData()).not.toContain("Use this.");
   });
 
   test("create with context clears an unconfirmed link draft when the popover closes", async ({

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -567,7 +567,7 @@ test.describe("Terminal agent type", () => {
     ).toBeVisible();
   });
 
-  test("backing out of create with context clears queued context", async ({
+  test("plain create ignores queued context after backing out", async ({
     page,
   }) => {
     await loadApp(page);
@@ -586,10 +586,10 @@ test.describe("Terminal agent type", () => {
     await page.getByTestId("create-agent-context-back").click();
     await page.getByTestId("create-agent-with-context").click();
     await expect(page.getByTestId("create-agent-initial-prompt")).toHaveValue(
-      ""
+      "Use this."
     );
     await expect(
-      page.getByText("No links added yet.", { exact: true })
+      page.locator('[title="https://example.com/preserved"]')
     ).toBeVisible();
     await page.getByTestId("create-agent-context-back").click();
 


### PR DESCRIPTION
## Summary
- move automatic clipboard lookup out of the step-1 button click and into the mounted context step
- keep explicit clipboard retry and paste fallbacks intact via shared clipboard capability helpers
- add an e2e regression covering advancing into step 2 before clipboard lookup resolves

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- pnpm run test:e2e -- e2e/terminal-agent-type.spec.ts
- pnpm --filter @dispatch/web test -- create-agent-dialog-clipboard
- Playwright validation against local dev stack (`http://127.0.0.1:61688`)