### PR TITLE
Remove auto clipboard read on create-agent context open

### DIFF
--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -493,33 +493,6 @@ function CreateAgentDialogContent({
     }
   }, [step]);
 
-  useEffect(() => {
-    if (step !== "context") return;
-
-    const clipboardSupported = clipboardReadSupported();
-    setCanReadClipboard(clipboardSupported);
-    setClipboardReadFeedback(null);
-    setClipboardSuggestion(null);
-
-    if (!clipboardSupported) {
-      setCheckingClipboard(false);
-      return;
-    }
-
-    setCheckingClipboard(true);
-    const requestId = clipboardRequestIdRef.current + 1;
-    clipboardRequestIdRef.current = requestId;
-
-    void getClipboardSuggestion().then((result) => {
-      if (clipboardRequestIdRef.current !== requestId) return;
-      setCheckingClipboard(false);
-      setCanReadClipboard(result.canRead);
-      if (result.suggestion) {
-        setClipboardSuggestion(result.suggestion);
-      }
-    });
-  }, [step]);
-
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
@@ -646,7 +619,7 @@ function CreateAgentDialogContent({
     setStep("context");
     setClipboardSuggestion(null);
     setCheckingClipboard(false);
-    setCanReadClipboard(false);
+    setCanReadClipboard(clipboardReadSupported());
     setClipboardReadFeedback(null);
   }, []);
 

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -344,9 +344,14 @@ test.describe("Terminal agent type", () => {
     await expect(
       page.getByTestId("create-agent-context-clipboard-check")
     ).toBeVisible();
-    await page
-      .getByTestId("create-agent-context-clipboard-check-action")
-      .click();
+    const readClipboard = page.getByTestId(
+      "create-agent-context-clipboard-check-action"
+    );
+    await readClipboard.click();
+    await expect(
+      page.getByTestId("create-agent-context-clipboard-feedback")
+    ).toContainText("Nothing readable found.");
+    await readClipboard.click();
 
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
     await expect(cta).toContainText("Add copied link?");

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -255,7 +255,7 @@ test.describe("Terminal agent type", () => {
     ).toBeVisible();
   });
 
-  test("create with context suggests a copied link without auto-attaching it", async ({
+  test("create with context reads a copied link only from the explicit action", async ({
     page,
   }) => {
     await stubClipboard(page, {
@@ -266,6 +266,13 @@ test.describe("Terminal agent type", () => {
 
     await page.getByTestId("create-agent-button").click();
     await page.getByTestId("create-agent-with-context").click();
+
+    await expect(
+      page.getByTestId("create-agent-context-clipboard-cta")
+    ).not.toBeVisible();
+    await page
+      .getByTestId("create-agent-context-clipboard-check-action")
+      .click();
 
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
     await expect(cta).toContainText("Add copied link?");
@@ -281,7 +288,7 @@ test.describe("Terminal agent type", () => {
     await expect(cta).not.toBeVisible();
   });
 
-  test("create with context treats rich-text links as links, not files", async ({
+  test("create with context treats rich-text clipboard links as links, not files", async ({
     page,
   }) => {
     await stubClipboard(page, {
@@ -293,13 +300,16 @@ test.describe("Terminal agent type", () => {
 
     await page.getByTestId("create-agent-button").click();
     await page.getByTestId("create-agent-with-context").click();
+    await page
+      .getByTestId("create-agent-context-clipboard-check-action")
+      .click();
 
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
     await expect(cta).toContainText("Add copied link?");
     await expect(cta).not.toContainText("Clipboard file ready");
   });
 
-  test("create with context advances before clipboard lookup resolves", async ({
+  test("create with context opens without auto-reading the clipboard", async ({
     page,
   }) => {
     await stubClipboard(page, {
@@ -313,12 +323,9 @@ test.describe("Terminal agent type", () => {
 
     await expect(page.getByTestId("create-agent-context-form")).toBeVisible();
     await expect(page.getByText("Create with context")).toBeVisible();
-
-    await page.evaluate(() => window.__dispatchResolveClipboardRead?.());
-
     await expect(
       page.getByTestId("create-agent-context-clipboard-cta")
-    ).toContainText("Add copied link?");
+    ).not.toBeVisible();
   });
 
   test("create with context can retry clipboard detection from an explicit button", async ({
@@ -480,6 +487,10 @@ test.describe("Terminal agent type", () => {
     await page.getByTestId("create-agent-with-context").click();
 
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
+    await expect(cta).not.toBeVisible();
+    await page
+      .getByTestId("create-agent-context-clipboard-check-action")
+      .click();
     await expect(cta).toBeVisible();
 
     await page.getByTestId("create-agent-context-clipboard-dismiss").click();
@@ -487,7 +498,7 @@ test.describe("Terminal agent type", () => {
     await expect(cta).not.toBeVisible();
   });
 
-  test("create with context suggests a clipboard image without auto-attaching it", async ({
+  test("create with context reads a clipboard image only from the explicit action", async ({
     page,
   }) => {
     await stubClipboard(page, {
@@ -499,6 +510,9 @@ test.describe("Terminal agent type", () => {
 
     await page.getByTestId("create-agent-button").click();
     await page.getByTestId("create-agent-with-context").click();
+    await page
+      .getByTestId("create-agent-context-clipboard-check-action")
+      .click();
 
     const cta = page.getByTestId("create-agent-context-clipboard-cta");
     await expect(cta).toContainText("Add copied image?");


### PR DESCRIPTION
## Summary
- remove automatic clipboard probing when entering the create-agent context step
- leave clipboard access only on explicit step-2 actions like `Read clipboard` and paste into `Instructions`
- update the create-agent clipboard e2e expectations to match the explicit-read flow

## Validation
- `pnpm exec prettier --write apps/web/src/components/app/create-agent-dialog.tsx e2e/terminal-agent-type.spec.ts`
- `pnpm --filter @dispatch/web exec eslint --config eslint.config.js src/components/app/create-agent-dialog.tsx`
- `pnpm run check`

Note: per request, I did not run the full local E2E suite; CI can cover that.