### PR TITLE
Add assisted-update release metadata embedding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
 
+      - name: Validate assisted-update metadata
+        run: |
+          META="release-notes/next-assisted-update.json"
+          if [ -f "$META" ]; then
+            pnpm tsx bin/embed-assisted-update.ts --check-only --metadata "$META"
+          fi
+
       - name: CI checks
         run: pnpm run ci
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,14 +106,29 @@ jobs:
           git commit -m "Release ${NEW_VERSION}"
           # Pull in any commits that landed on main during the CI run
           git pull --rebase origin main
-          git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
-          # Push branch first, then tag separately — if the branch push
-          # fails we don't leave an orphan tag on the remote.
-          git push origin main
-          git push origin "${NEW_VERSION}"
           echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Embed assisted-update metadata if present
+        run: |
+          META="release-notes/next-assisted-update.json"
+          if [ -f "$META" ]; then
+            pnpm tsx bin/embed-assisted-update.ts \
+              --metadata "$META" \
+              --notes release-notes/current.md
+            git rm "$META"
+            git add release-notes/current.md
+            git commit --amend --no-edit
+          fi
+
+      - name: Push release commit and tag
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          # Push branch first, then tag separately — if the branch push
+          # fails we don't leave an orphan tag on the remote.
+          git push origin main
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Pack release artifact
         run: bin/pack-release --output dispatch-release.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,12 @@ Before marking any task as done, run the following checks and fix any failures:
 - Production uses the `dispatch` database. Never connect to it from dev servers.
 - `repo_dev_up` creates an isolated Postgres container with its own port — no manual `DATABASE_URL` setup needed.
 - Migrations run automatically on API server start.
+
+## Assisted Update Release Notes
+
+- When the user indicates that a release should require or recommend assisted update handling, create or update `release-notes/next-assisted-update.json`.
+- Follow `release-notes/AUTHORING.md` for the schema, merge rules, and authoring guidance. Do not invent a parallel format.
+- If `release-notes/next-assisted-update.json` already exists, merge your change into that file instead of creating a second metadata file.
+- Validate the file before finishing with:
+
+  `pnpm tsx bin/embed-assisted-update.ts --check-only --metadata release-notes/next-assisted-update.json`

--- a/apps/server/src/release-metadata.ts
+++ b/apps/server/src/release-metadata.ts
@@ -48,6 +48,7 @@ export type AssistedUpdateMetadata = z.infer<
 };
 
 const FENCE_RE = /```dispatch-update[ \t]*\r?\n([\s\S]*?)\r?\n```/i;
+const EMBEDDED_FENCE_RE = /```/;
 
 /**
  * Parse the structured assisted-update metadata block out of a GitHub release
@@ -77,6 +78,80 @@ export function parseAssistedUpdateMetadata(
   const result = AssistedUpdateMetadataSchema.safeParse(parsed);
   if (!result.success) return null;
   return result.data as AssistedUpdateMetadata;
+}
+
+export function validateAssistedUpdateMetadataJson(
+  raw: string
+):
+  | { success: true; data: AssistedUpdateMetadata }
+  | { success: false; error: string } {
+  let parsed: unknown;
+  try {
+    parsed = parseJsonWithLocation(raw);
+  } catch (error) {
+    return {
+      success: false,
+      error: formatJsonParseError(raw, error),
+    };
+  }
+
+  const result = AssistedUpdateMetadataSchema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue?.path.length ? issue.path.join(".") : "<root>";
+    return {
+      success: false,
+      error: `metadata schema mismatch at ${path}: ${issue?.message ?? "invalid value"}`,
+    };
+  }
+
+  const fenceBreaker = findFenceBreakerField(result.data);
+  if (fenceBreaker) {
+    return {
+      success: false,
+      error: `metadata field ${fenceBreaker} contains a literal triple-backtick fence`,
+    };
+  }
+
+  return {
+    success: true,
+    data: result.data as AssistedUpdateMetadata,
+  };
+}
+
+export function canonicalizeAssistedUpdateMetadata(
+  metadata: AssistedUpdateMetadata
+): string {
+  const canonical: Record<string, unknown> = {
+    mode: metadata.mode,
+    title: metadata.title,
+    summary: metadata.summary,
+  };
+
+  if (metadata.instructions !== undefined) {
+    canonical.instructions = metadata.instructions;
+  }
+
+  canonical.requiredChecks = [...metadata.requiredChecks];
+
+  if (metadata.rollbackGuidance !== undefined) {
+    canonical.rollbackGuidance = metadata.rollbackGuidance;
+  }
+
+  if (metadata.appliesFrom !== undefined) {
+    canonical.appliesFrom = metadata.appliesFrom;
+  }
+
+  return JSON.stringify(canonical, null, 2);
+}
+
+export function appendAssistedUpdateMetadataBlock(
+  notes: string,
+  metadata: AssistedUpdateMetadata
+): string {
+  const canonical = canonicalizeAssistedUpdateMetadata(metadata);
+  const prefix = notes.trimEnd().length > 0 ? `${notes.trimEnd()}\n\n` : "";
+  return `${prefix}\`\`\`dispatch-update\n${canonical}\n\`\`\`\n`;
 }
 
 /**
@@ -115,4 +190,172 @@ function compareSemver(a: string, b: string): number {
     if (diff !== 0) return diff;
   }
   return 0;
+}
+
+function findFenceBreakerField(
+  metadata: AssistedUpdateMetadata
+): "title" | "summary" | "instructions" | "rollbackGuidance" | null {
+  const proseFields = [
+    ["title", metadata.title],
+    ["summary", metadata.summary],
+    ["instructions", metadata.instructions],
+    ["rollbackGuidance", metadata.rollbackGuidance],
+  ] as const;
+
+  for (const [field, value] of proseFields) {
+    if (typeof value === "string" && EMBEDDED_FENCE_RE.test(value)) {
+      return field;
+    }
+  }
+
+  return null;
+}
+
+function formatJsonParseError(raw: string, error: unknown): string {
+  const base = error instanceof Error ? error.message : "invalid JSON metadata";
+  if (/line \d+ column \d+/i.test(base)) {
+    return `metadata JSON parse error: ${base}`;
+  }
+
+  const positionMatch = /position (\d+)/.exec(base);
+  if (!positionMatch) {
+    return `metadata JSON parse error: ${base}`;
+  }
+
+  const position = Number(positionMatch[1]);
+  if (!Number.isFinite(position) || position < 0) {
+    return `metadata JSON parse error: ${base}`;
+  }
+
+  const slice = raw.slice(0, position);
+  const lines = slice.split("\n");
+  const line = lines.length;
+  const column = (lines.at(-1)?.length ?? 0) + 1;
+  return `metadata JSON parse error at line ${line} column ${column}: ${base}`;
+}
+
+function parseJsonWithLocation(raw: string): unknown {
+  let i = 0;
+
+  const skipWhitespace = () => {
+    while (i < raw.length && /\s/.test(raw[i]!)) i++;
+  };
+
+  const fail = (message: string, index = i): never => {
+    const slice = raw.slice(0, index);
+    const lines = slice.split("\n");
+    const line = lines.length;
+    const column = (lines.at(-1)?.length ?? 0) + 1;
+    throw new Error(`${message} at line ${line} column ${column}`);
+  };
+
+  const parseValue = (): unknown => {
+    skipWhitespace();
+    if (i >= raw.length) fail("unexpected end of JSON input");
+    const ch = raw[i]!;
+    if (ch === "{") return parseObject();
+    if (ch === "[") return parseArray();
+    if (ch === '"') return parseString();
+    if (ch === "-" || /\d/.test(ch)) return parseNumber();
+    if (raw.startsWith("true", i)) {
+      i += 4;
+      return true;
+    }
+    if (raw.startsWith("false", i)) {
+      i += 5;
+      return false;
+    }
+    if (raw.startsWith("null", i)) {
+      i += 4;
+      return null;
+    }
+    fail(`unexpected token ${JSON.stringify(ch)}`);
+  };
+
+  const parseObject = (): Record<string, unknown> => {
+    const value: Record<string, unknown> = {};
+    i++;
+    skipWhitespace();
+    if (raw[i] === "}") {
+      i++;
+      return value;
+    }
+    while (i < raw.length) {
+      skipWhitespace();
+      if (raw[i] !== '"') fail("expected string key");
+      const key = parseString();
+      skipWhitespace();
+      if (raw[i] !== ":") fail("expected ':' after object key");
+      i++;
+      value[key] = parseValue();
+      skipWhitespace();
+      if (raw[i] === "}") {
+        i++;
+        return value;
+      }
+      if (raw[i] !== ",") fail("expected ',' or '}' after object entry");
+      i++;
+    }
+    return fail("unterminated object");
+  };
+
+  const parseArray = (): unknown[] => {
+    const value: unknown[] = [];
+    i++;
+    skipWhitespace();
+    if (raw[i] === "]") {
+      i++;
+      return value;
+    }
+    while (i < raw.length) {
+      value.push(parseValue());
+      skipWhitespace();
+      if (raw[i] === "]") {
+        i++;
+        return value;
+      }
+      if (raw[i] !== ",") fail("expected ',' or ']' after array entry");
+      i++;
+    }
+    return fail("unterminated array");
+  };
+
+  const parseString = (): string => {
+    const start = i;
+    i++;
+    while (i < raw.length) {
+      const ch = raw[i]!;
+      if (ch === '"') {
+        i++;
+        try {
+          return JSON.parse(raw.slice(start, i)) as string;
+        } catch {
+          fail("invalid string escape", start);
+        }
+      }
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === "\n" || ch === "\r") fail("unterminated string");
+      i++;
+    }
+    return fail("unterminated string", start);
+  };
+
+  const parseNumber = (): number => {
+    const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(
+      raw.slice(i)
+    );
+    if (!match) return fail("invalid number");
+    i += match[0]!.length;
+    return Number(match[0]!);
+  };
+
+  const value = parseValue();
+  skipWhitespace();
+  if (i !== raw.length) {
+    fail("unexpected trailing content");
+  }
+  return value;
 }

--- a/apps/server/src/release-metadata.ts
+++ b/apps/server/src/release-metadata.ts
@@ -47,6 +47,11 @@ export type AssistedUpdateMetadata = z.infer<
   >;
 };
 
+export type AssistedUpdateMetadataInspection =
+  | { state: "absent" }
+  | { state: "invalid"; error: string }
+  | { state: "valid"; metadata: AssistedUpdateMetadata };
+
 const FENCE_RE = /```dispatch-update[ \t]*\r?\n([\s\S]*?)\r?\n```/i;
 const EMBEDDED_FENCE_RE = /```/;
 
@@ -64,20 +69,23 @@ const EMBEDDED_FENCE_RE = /```/;
 export function parseAssistedUpdateMetadata(
   body: string | null | undefined
 ): AssistedUpdateMetadata | null {
-  if (!body) return null;
+  const inspected = inspectAssistedUpdateMetadata(body);
+  return inspected.state === "valid" ? inspected.metadata : null;
+}
+
+export function inspectAssistedUpdateMetadata(
+  body: string | null | undefined
+): AssistedUpdateMetadataInspection {
+  if (!body) return { state: "absent" };
   const match = body.match(FENCE_RE);
-  if (!match) return null;
+  if (!match) return { state: "absent" };
   const raw = match[1].trim();
-  if (!raw) return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
+  if (!raw) return { state: "invalid", error: "metadata block is empty" };
+  const validated = validateAssistedUpdateMetadataJson(raw);
+  if (!validated.success) {
+    return { state: "invalid", error: validated.error };
   }
-  const result = AssistedUpdateMetadataSchema.safeParse(parsed);
-  if (!result.success) return null;
-  return result.data as AssistedUpdateMetadata;
+  return { state: "valid", metadata: validated.data };
 }
 
 export function validateAssistedUpdateMetadataJson(
@@ -194,7 +202,13 @@ function compareSemver(a: string, b: string): number {
 
 function findFenceBreakerField(
   metadata: AssistedUpdateMetadata
-): "title" | "summary" | "instructions" | "rollbackGuidance" | null {
+):
+  | "title"
+  | "summary"
+  | "instructions"
+  | "rollbackGuidance"
+  | `requiredChecks.${number}.description`
+  | null {
   const proseFields = [
     ["title", metadata.title],
     ["summary", metadata.summary],
@@ -205,6 +219,16 @@ function findFenceBreakerField(
   for (const [field, value] of proseFields) {
     if (typeof value === "string" && EMBEDDED_FENCE_RE.test(value)) {
       return field;
+    }
+  }
+
+  for (const [index, check] of metadata.requiredChecks.entries()) {
+    if (
+      typeof check === "object" &&
+      typeof check.description === "string" &&
+      EMBEDDED_FENCE_RE.test(check.description)
+    ) {
+      return `requiredChecks.${index}.description`;
     }
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -91,7 +91,7 @@ import { resolveHeadSha } from "./shared/git/worktree.js";
 import { handleMcpRequest } from "./shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import {
-  parseAssistedUpdateMetadata,
+  inspectAssistedUpdateMetadata,
   isAssistedUpdateRequired,
   type AssistedUpdateMetadata,
 } from "./release-metadata.js";
@@ -2196,6 +2196,7 @@ async function registerRoutes() {
         url: string;
       } | null = null;
       let assistedMetadata: AssistedUpdateMetadata | null = null;
+      let assistedMetadataError: string | null = null;
       if (latestTag && updateAvailable) {
         const fullRelease = await fetchLatestReleaseMetadata(latestTag);
         latestRelease = fullRelease
@@ -2205,9 +2206,19 @@ async function registerRoutes() {
               url: fullRelease.url,
             }
           : null;
-        assistedMetadata = parseAssistedUpdateMetadata(
+        const inspected = inspectAssistedUpdateMetadata(
           fullRelease?.body ?? null
         );
+        if (inspected.state === "invalid") {
+          assistedMetadataError = inspected.error;
+        } else if (inspected.state === "valid") {
+          assistedMetadata = inspected.metadata;
+        }
+      }
+      if (assistedMetadataError) {
+        return reply.code(500).send({
+          error: `Latest release has malformed assisted-update metadata: ${assistedMetadataError}`,
+        });
       }
       const assistedRequired = isAssistedUpdateRequired(
         assistedMetadata,
@@ -2485,9 +2496,15 @@ async function registerRoutes() {
     if (!releaseUpdateAgentId) {
       const installed = await readReleaseStore().catch(() => null);
       const targetMeta = await fetchReleaseMetadata(tag);
-      const targetAssisted = parseAssistedUpdateMetadata(
-        targetMeta?.body ?? null
-      );
+      const inspected = inspectAssistedUpdateMetadata(targetMeta?.body ?? null);
+      if (inspected.state === "invalid") {
+        return reply.code(409).send({
+          error: "ASSISTED_UPDATE_METADATA_INVALID",
+          message: `Target release has malformed assisted-update metadata: ${inspected.error}`,
+        });
+      }
+      const targetAssisted =
+        inspected.state === "valid" ? inspected.metadata : null;
       if (isAssistedUpdateRequired(targetAssisted, installed?.tag ?? null)) {
         return reply.code(409).send({
           error: "ASSISTED_UPDATE_REQUIRED",
@@ -2573,9 +2590,15 @@ async function registerRoutes() {
       // checks and structured-phase reporting, but is optional — the
       // assisted flow still works for releases that don't declare it.
       const targetMeta = await fetchReleaseMetadata(body.tag);
-      const assistedMeta = parseAssistedUpdateMetadata(
-        targetMeta?.body ?? null
-      );
+      const inspected = inspectAssistedUpdateMetadata(targetMeta?.body ?? null);
+      if (inspected.state === "invalid") {
+        return reply.code(409).send({
+          error: "ASSISTED_UPDATE_METADATA_INVALID",
+          message: `Target release has malformed assisted-update metadata: ${inspected.error}`,
+        });
+      }
+      const assistedMeta =
+        inspected.state === "valid" ? inspected.metadata : null;
       let assistedState: AssistedUpdateState | null = null;
       let assistedToken: string | null = null;
       let initialPrompt: string;

--- a/apps/server/test/embed-assisted-update.test.ts
+++ b/apps/server/test/embed-assisted-update.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const BIN = path.join(REPO_ROOT, "bin", "embed-assisted-update.ts");
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe("bin/embed-assisted-update.ts", () => {
+  it("validates metadata in check-only mode", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "dispatch-assisted-"));
+    tmpDirs.push(dir);
+    const metadataPath = path.join(dir, "meta.json");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({
+        mode: "required",
+        title: "Migration",
+        summary: "Run a migration before restart.",
+      }),
+      "utf8"
+    );
+
+    expect(() =>
+      execFileSync(
+        "pnpm",
+        ["tsx", BIN, "--check-only", "--metadata", metadataPath],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }
+      )
+    ).not.toThrow();
+  });
+
+  it("embeds canonical metadata into release notes", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "dispatch-assisted-"));
+    tmpDirs.push(dir);
+    const metadataPath = path.join(dir, "meta.json");
+    const notesPath = path.join(dir, "notes.md");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({
+        mode: "required",
+        title: "Migration",
+        summary: "Run a migration before restart.",
+        requiredChecks: ["service_restarted"],
+      }),
+      "utf8"
+    );
+    await writeFile(notesPath, "Generated release notes", "utf8");
+
+    execFileSync(
+      "pnpm",
+      ["tsx", BIN, "--metadata", metadataPath, "--notes", notesPath],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }
+    );
+
+    const notes = await readFile(notesPath, "utf8");
+    expect(notes).toContain("Generated release notes\n\n```dispatch-update\n");
+    expect(notes).toContain(
+      '"requiredChecks": [\n    "service_restarted"\n  ]'
+    );
+  });
+
+  it("fails with a useful parse error for malformed json", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "dispatch-assisted-"));
+    tmpDirs.push(dir);
+    const metadataPath = path.join(dir, "meta.json");
+    await writeFile(
+      metadataPath,
+      '{\n  "mode": "required",\n  "title": "Migration",\n  "summary":\n}\n',
+      "utf8"
+    );
+
+    expect(() =>
+      execFileSync(
+        "pnpm",
+        ["tsx", BIN, "--check-only", "--metadata", metadataPath],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }
+      )
+    ).toThrowError(/line .* column|column .* line|metadata JSON parse error/);
+  });
+});

--- a/apps/server/test/release-metadata.test.ts
+++ b/apps/server/test/release-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   appendAssistedUpdateMetadataBlock,
   canonicalizeAssistedUpdateMetadata,
+  inspectAssistedUpdateMetadata,
   isAssistedUpdateRequired,
   normalizeRequiredChecks,
   parseAssistedUpdateMetadata,
@@ -32,6 +33,13 @@ describe("parseAssistedUpdateMetadata", () => {
   it("returns null when the fence body is malformed JSON", () => {
     const body = sampleBody("{ not: valid json }");
     expect(parseAssistedUpdateMetadata(body)).toBeNull();
+  });
+
+  it("reports invalid metadata distinctly when the fence is malformed", () => {
+    const body = sampleBody("{ not: valid json }");
+    expect(inspectAssistedUpdateMetadata(body)).toMatchObject({
+      state: "invalid",
+    });
   });
 
   it("returns null when required fields are missing", () => {
@@ -178,6 +186,26 @@ describe("validateAssistedUpdateMetadataJson", () => {
     );
     expect(result.success).toBe(false);
     expect(result.success ? "" : result.error).toContain("summary");
+  });
+
+  it("rejects triple backticks inside required check descriptions", () => {
+    const result = validateAssistedUpdateMetadataJson(
+      JSON.stringify({
+        mode: "required",
+        title: "x",
+        summary: "y",
+        requiredChecks: [
+          {
+            name: "service_restarted",
+            description: "contains ``` fence",
+          },
+        ],
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.success ? "" : result.error).toContain(
+      "requiredChecks.0.description"
+    );
   });
 
   it("includes a line and column hint for malformed json", () => {

--- a/apps/server/test/release-metadata.test.ts
+++ b/apps/server/test/release-metadata.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendAssistedUpdateMetadataBlock,
+  canonicalizeAssistedUpdateMetadata,
   isAssistedUpdateRequired,
   normalizeRequiredChecks,
   parseAssistedUpdateMetadata,
   type AssistedUpdateMetadata,
+  validateAssistedUpdateMetadataJson,
 } from "../src/release-metadata.js";
 
 const sampleBody = (block: string) => `Some prose at the top.
@@ -146,5 +149,79 @@ describe("isAssistedUpdateRequired", () => {
     expect(
       isAssistedUpdateRequired(required({ appliesFrom: "v0.18.0" }), "v0.17.5")
     ).toBe(false);
+  });
+});
+
+describe("validateAssistedUpdateMetadataJson", () => {
+  it("returns a schema error with a zod path", () => {
+    const result = validateAssistedUpdateMetadataJson(
+      JSON.stringify({
+        mode: "required",
+        title: "x",
+        summary: "y",
+        requiredChecks: ["not-a-real-check"],
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.success ? "" : result.error).toContain(
+      "metadata schema mismatch at requiredChecks.0"
+    );
+  });
+
+  it("rejects prose fields containing triple backticks", () => {
+    const result = validateAssistedUpdateMetadataJson(
+      JSON.stringify({
+        mode: "required",
+        title: "x",
+        summary: "contains ``` fence",
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.success ? "" : result.error).toContain("summary");
+  });
+
+  it("includes a line and column hint for malformed json", () => {
+    const result = validateAssistedUpdateMetadataJson(`{
+  "mode": "required",
+  "title": "x",
+  "summary":
+}`);
+    expect(result.success).toBe(false);
+    expect(result.success ? "" : result.error).toContain("line");
+    expect(result.success ? "" : result.error).toContain("column");
+  });
+});
+
+describe("assisted-update metadata embedding", () => {
+  const metadata: AssistedUpdateMetadata = {
+    mode: "required",
+    title: "Bun runtime migration",
+    summary: "Switches the runtime from Node to Bun.",
+    instructions: "1. Stop the service.",
+    requiredChecks: ["service_restarted", "version_converged"],
+    rollbackGuidance: "Restore the previous symlink.",
+    appliesFrom: "v0.18.0",
+  };
+
+  it("canonicalizes keys in a stable order", () => {
+    expect(canonicalizeAssistedUpdateMetadata(metadata)).toBe(`{
+  "mode": "required",
+  "title": "Bun runtime migration",
+  "summary": "Switches the runtime from Node to Bun.",
+  "instructions": "1. Stop the service.",
+  "requiredChecks": [
+    "service_restarted",
+    "version_converged"
+  ],
+  "rollbackGuidance": "Restore the previous symlink.",
+  "appliesFrom": "v0.18.0"
+}`);
+  });
+
+  it("appends a fenced block to release notes", () => {
+    const notes = appendAssistedUpdateMetadataBlock("Release prose", metadata);
+    expect(notes).toContain("Release prose\n\n```dispatch-update\n");
+    expect(notes).toContain('"mode": "required"');
+    expect(notes.endsWith("```\n")).toBe(true);
   });
 });

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 
 import {
   afterAll,
@@ -51,6 +51,9 @@ beforeAll(async () => {
 
   tempRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-release-routes-"));
   releaseStorePath = path.join(tempRoot, "release.json");
+  await mkdir(path.join(os.homedir(), ".dispatch", "server"), {
+    recursive: true,
+  });
 
   pool = await setupTestDb();
   await runTestMigrations();
@@ -228,6 +231,67 @@ describe("release metadata route handling", () => {
     });
   });
 
+  it("creates structured assisted-update state for valid metadata on /release/assisted/launch", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: ["service_restarted"],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/assisted/launch",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      agent: {
+        role: "assisted_update",
+      },
+      assisted: {
+        tag: "v0.19.0",
+        metadata: {
+          title: "Bun runtime migration",
+          mode: "required",
+        },
+        phase: "inspect",
+      },
+    });
+
+    const stateResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/assisted/state",
+      headers: { cookie: sessionCookie },
+    });
+    expect(stateResponse.statusCode).toBe(200);
+    expect(stateResponse.json()).toMatchObject({
+      state: {
+        tag: "v0.19.0",
+        metadata: {
+          title: "Bun runtime migration",
+        },
+      },
+    });
+
+    await app.inject({
+      method: "DELETE",
+      url: "/api/v1/release/assisted/state",
+      headers: { cookie: sessionCookie },
+    });
+  });
+
   it("rejects /release/assisted/launch when the target release metadata is malformed", async () => {
     mockReleaseCommands({
       releaseViews: {
@@ -248,6 +312,38 @@ describe("release metadata route handling", () => {
     expect(response.json()).toMatchObject({
       error: "ASSISTED_UPDATE_METADATA_INVALID",
     });
+  });
+
+  it("allows /release/update when the installed version is below appliesFrom", async () => {
+    await writeReleaseStore({
+      tag: "v0.17.5",
+      deployedAt: "2026-04-01T00:00:00Z",
+    });
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: [],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({ ok: true });
   });
 });
 

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -1,0 +1,373 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { FastifyInstance } from "fastify";
+import type { Pool } from "pg";
+
+import {
+  getTestDatabaseUrl,
+  runTestMigrations,
+  setupTestDb,
+  teardownTestDb,
+} from "./db/setup.js";
+
+const { runCommandMock } = vi.hoisted(() => ({
+  runCommandMock: vi.fn(),
+}));
+
+vi.mock("../src/shared/lib/run-command.js", () => ({
+  runCommand: runCommandMock,
+}));
+
+let pool: Pool;
+let app: FastifyInstance;
+let createSession: typeof import("../src/auth.js").createSession;
+let sessionCookie: string;
+let tempRoot: string;
+let releaseStorePath: string;
+
+const uncaughtExceptionFilter = (err: Error): void => {
+  if (
+    err instanceof TypeError &&
+    err.message.includes("destroySoon is not a function")
+  ) {
+    return;
+  }
+  throw err;
+};
+
+beforeAll(async () => {
+  process.prependListener("uncaughtException", uncaughtExceptionFilter);
+
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-release-routes-"));
+  releaseStorePath = path.join(tempRoot, "release.json");
+
+  pool = await setupTestDb();
+  await runTestMigrations();
+
+  process.env.DATABASE_URL = getTestDatabaseUrl();
+  process.env.DISPATCH_AGENT_RUNTIME = "inert";
+  process.env.DISPATCH_PORT = "6771";
+  process.env.DISPATCH_HOST = "127.0.0.1";
+  process.env.DISPATCH_RELEASE_STORE_PATH = releaseStorePath;
+
+  const auth = await import("../src/auth.js");
+  ({ createSession } = auth);
+
+  const serverModule = await import("../src/server.js");
+  app = await serverModule.initializeApp({
+    runMigrations: false,
+    reconcileState: false,
+  });
+
+  const setupResponse = await app.inject({
+    method: "POST",
+    url: "/api/v1/auth/setup",
+    payload: { password: "hunter2hunter2" },
+  });
+  expect(setupResponse.statusCode).toBe(200);
+});
+
+afterAll(async () => {
+  const serverModule = await import("../src/server.js");
+  await serverModule.closeApp();
+  delete process.env.DISPATCH_AGENT_RUNTIME;
+  delete process.env.DATABASE_URL;
+  delete process.env.DISPATCH_PORT;
+  delete process.env.DISPATCH_HOST;
+  delete process.env.DISPATCH_RELEASE_STORE_PATH;
+  await teardownTestDb();
+  await rm(tempRoot, { recursive: true, force: true });
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  process.off("uncaughtException", uncaughtExceptionFilter);
+});
+
+beforeEach(async () => {
+  runCommandMock.mockReset();
+  await pool.query("DELETE FROM agent_events");
+  await pool.query("DELETE FROM agents");
+  await pool.query("DELETE FROM sessions");
+  await writeReleaseStore({
+    tag: "v0.18.0",
+    deployedAt: "2026-04-01T00:00:00Z",
+  });
+
+  const session = await createSession(pool);
+  const signed = (
+    app as FastifyInstance & { signCookie: (value: string) => string }
+  ).signCookie(session);
+  sessionCookie = `dispatch_session=${signed}`;
+});
+
+describe("release metadata route handling", () => {
+  it("returns assisted metadata in /release/info when the release body is valid", async () => {
+    mockReleaseCommands({
+      releaseList: [{ tagName: "v0.19.0", isPrerelease: false }],
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: ["service_restarted"],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/info",
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      latestTag: "v0.19.0",
+      updateAvailable: true,
+      assistedRequired: true,
+      assisted: {
+        mode: "required",
+        title: "Bun runtime migration",
+        requiredChecks: ["service_restarted"],
+        appliesFrom: "v0.18.0",
+      },
+    });
+  });
+
+  it("fails closed in /release/info when release metadata is malformed", async () => {
+    mockReleaseCommands({
+      releaseList: [{ tagName: "v0.19.0", isPrerelease: false }],
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody("{ not valid json }"),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/info",
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({
+      error: expect.stringContaining(
+        "Latest release has malformed assisted-update metadata"
+      ),
+    });
+  });
+
+  it("rejects /release/update when the target release requires assisted flow", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: [],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: "ASSISTED_UPDATE_REQUIRED",
+      assisted: {
+        mode: "required",
+        title: "Bun runtime migration",
+      },
+    });
+  });
+
+  it("rejects /release/update when the target release metadata is malformed", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody("{ not valid json }"),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: "ASSISTED_UPDATE_METADATA_INVALID",
+    });
+  });
+
+  it("rejects /release/assisted/launch when the target release metadata is malformed", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody("{ not valid json }"),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/assisted/launch",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: "ASSISTED_UPDATE_METADATA_INVALID",
+    });
+  });
+});
+
+async function writeReleaseStore(record: {
+  tag: string;
+  deployedAt: string;
+}): Promise<void> {
+  await writeFile(
+    releaseStorePath,
+    JSON.stringify(record, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+function releaseBody(block: string): string {
+  return `Notes before.
+
+\`\`\`dispatch-update
+${block}
+\`\`\`
+
+Notes after.`;
+}
+
+function validReleaseView({
+  body,
+  tag = "v0.19.0",
+}: {
+  body: string | null;
+  tag?: string;
+}): string {
+  return JSON.stringify({
+    tagName: tag,
+    publishedAt: "2026-04-26T00:00:00Z",
+    url: `https://github.com/selfcontained/dispatch/releases/tag/${tag}`,
+    body,
+  });
+}
+
+function mockReleaseCommands({
+  releaseList = [],
+  releaseViews = {},
+}: {
+  releaseList?: Array<{ tagName: string; isPrerelease: boolean }>;
+  releaseViews?: Record<string, string>;
+}) {
+  runCommandMock.mockImplementation(
+    async (
+      cmd: string,
+      args: string[],
+      opts?: { allowedExitCodes?: number[] }
+    ) => {
+      if (cmd === "gh" && args[0] === "--version") {
+        return { exitCode: 0, stdout: "gh 2.0.0\n", stderr: "" };
+      }
+      if (
+        cmd === "git" &&
+        args.includes("fetch") &&
+        args.includes("origin") &&
+        args.includes("--tags")
+      ) {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (
+        cmd === "git" &&
+        args.includes("remote") &&
+        args.includes("get-url") &&
+        args.includes("origin")
+      ) {
+        return {
+          exitCode: 0,
+          stdout: "git@github.com:selfcontained/dispatch.git\n",
+          stderr: "",
+        };
+      }
+      if (
+        cmd === "gh" &&
+        args[0] === "repo" &&
+        args[1] === "view" &&
+        args.includes("--jq")
+      ) {
+        return { exitCode: 0, stdout: "ADMIN\n", stderr: "" };
+      }
+      if (cmd === "gh" && args[0] === "release" && args[1] === "list") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify(releaseList),
+          stderr: "",
+        };
+      }
+      if (cmd === "gh" && args[0] === "release" && args[1] === "view") {
+        const tag = args[2];
+        const stdout = releaseViews[tag];
+        if (!stdout) {
+          throw new Error(`no mocked release view for ${tag}`);
+        }
+        return { exitCode: 0, stdout, stderr: "" };
+      }
+      if (
+        cmd === "git" &&
+        args.includes("rev-parse") &&
+        args.includes("--verify")
+      ) {
+        return {
+          exitCode: 128,
+          stdout: "",
+          stderr: "fatal: bad revision",
+        };
+      }
+      if (
+        cmd === "git" &&
+        args.includes("tag") &&
+        args.includes("--sort=-version:refname")
+      ) {
+        return { exitCode: 0, stdout: "v0.19.0\nv0.18.0\n", stderr: "" };
+      }
+      if (opts?.allowedExitCodes?.includes(128)) {
+        return { exitCode: 128, stdout: "", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    }
+  );
+}

--- a/bin/embed-assisted-update.ts
+++ b/bin/embed-assisted-update.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+
+import {
+  appendAssistedUpdateMetadataBlock,
+  validateAssistedUpdateMetadataJson,
+} from "../apps/server/src/release-metadata.js";
+
+type CliOptions = {
+  checkOnly: boolean;
+  metadataPath: string;
+  notesPath?: string;
+};
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const rawMetadata = await readRequiredFile(
+    options.metadataPath,
+    "metadata file"
+  );
+  const validated = validateAssistedUpdateMetadataJson(rawMetadata);
+  if (!validated.success) {
+    fail(validated.error);
+  }
+
+  if (options.checkOnly) {
+    return;
+  }
+
+  if (!options.notesPath) {
+    fail("--notes is required unless --check-only is set");
+  }
+
+  const rawNotes = await readRequiredFile(options.notesPath, "release notes");
+  const nextNotes = appendAssistedUpdateMetadataBlock(rawNotes, validated.data);
+  await writeFile(options.notesPath, nextNotes, "utf8");
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let checkOnly = false;
+  let metadataPath: string | undefined;
+  let notesPath: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--check-only":
+        checkOnly = true;
+        break;
+      case "--metadata":
+        metadataPath = argv[++i];
+        break;
+      case "--notes":
+        notesPath = argv[++i];
+        break;
+      default:
+        fail(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (!metadataPath) {
+    fail("--metadata is required");
+  }
+
+  if (!checkOnly && !notesPath) {
+    fail("--notes is required unless --check-only is set");
+  }
+
+  return { checkOnly, metadataPath, notesPath };
+}
+
+async function readRequiredFile(path: string, label: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`unable to read ${label} at ${path}: ${message}`);
+  }
+}
+
+function fail(message: string): never {
+  console.error(`embed-assisted-update: ${message}`);
+  process.exit(1);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+});

--- a/bin/pack-release
+++ b/bin/pack-release
@@ -86,7 +86,7 @@ if [[ -f "release-notes/current.md" ]]; then
   echo "release-notes/current.md" >> "$MANIFEST"
 fi
 
-tar czf "$OUTPUT" -T "$MANIFEST"
+tar czf "$OUTPUT" --exclude='bin/embed-assisted-update.ts' -T "$MANIFEST"
 
 # Print summary
 SIZE=$(wc -c < "$OUTPUT" | tr -d ' ')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "pnpm --filter @dispatch/server start",
     "release": "bin/dispatch-server update",
     "db:migrate": "pnpm --filter @dispatch/server db:migrate",
-    "check": "pnpm --filter @dispatch/server check && pnpm run check:web",
+    "check": "pnpm --filter @dispatch/server check && pnpm run check:web && tsc -p tsconfig.scripts.json --noEmit",
     "ci": "pnpm run format && pnpm run check && pnpm run lint:web && pnpm run build && pnpm run test && pnpm run test:e2e",
     "test": "pnpm --filter @dispatch/server test && pnpm --filter @dispatch/web test",
     "test:watch": "pnpm --filter @dispatch/server test:watch",

--- a/release-notes/AUTHORING.md
+++ b/release-notes/AUTHORING.md
@@ -1,0 +1,86 @@
+# Assisted Update Metadata Authoring
+
+When a PR introduces an assisted-update requirement for the next release, author
+or update `release-notes/next-assisted-update.json`.
+
+## File lifecycle
+
+- The file lives at `release-notes/next-assisted-update.json`.
+- The first PR in a release cycle creates it.
+- Later PRs update that same file in place.
+- The release workflow validates it, appends a canonical
+  `dispatch-update` block to `release-notes/current.md`, then removes the JSON
+  file before pushing the release commit.
+
+## Schema
+
+The file uses the same flat `AssistedUpdateMetadata` schema the runtime parser
+already consumes:
+
+```json
+{
+  "mode": "required",
+  "title": "Bun runtime migration",
+  "summary": "Switches the runtime from Node to Bun and changes the systemd unit shape.",
+  "instructions": "1. Stop the service.\n2. Replace the runtime symlink.\n3. Restart and watch /api/v1/health.",
+  "requiredChecks": [
+    "expected_runtime_artifact",
+    "service_entrypoint",
+    "service_restarted",
+    "health_endpoint",
+    "version_converged"
+  ],
+  "rollbackGuidance": "If health does not return within 60s, restore the previous symlink and `launchctl kickstart -k`.",
+  "appliesFrom": "v0.18.0"
+}
+```
+
+## Merge rules
+
+If the file already exists, rewrite it as one cohesive block using these rules:
+
+- `mode`: never downgrade. `required > recommended > normal`.
+- `appliesFrom`: keep the earlier semver.
+- `requiredChecks`: union existing and new entries. Never remove a prior check.
+- `title`: rewrite to cover the whole release, not just your PR.
+- `summary`: rewrite as one cohesive paragraph. Do not concatenate.
+- `instructions`: restructure into ordered steps. Use markdown sub-headings when
+  the migrations are still logically separate.
+- `rollbackGuidance`: describe how to roll back the full combined change set.
+
+If the two migrations are not meaningfully reconcilable, do not force a merge.
+Call out the conflict in the PR so one change can be deferred.
+
+## Local validation
+
+Run the release validator before committing:
+
+```bash
+pnpm tsx bin/embed-assisted-update.ts --check-only \
+  --metadata release-notes/next-assisted-update.json
+```
+
+The validator rejects:
+
+- malformed JSON, with a line and column hint
+- schema mismatches against `AssistedUpdateMetadataSchema`
+- unknown `requiredChecks`
+- non-semver `appliesFrom`
+- literal triple-backtick fences in `title`, `summary`, `instructions`, or
+  `rollbackGuidance`
+
+## Release embedding
+
+At release time the workflow canonicalizes the JSON and appends:
+
+````md
+```dispatch-update
+{
+  "mode": "required",
+  ...
+}
+```
+````
+
+The runtime agent reads that single block from the GitHub release body. It does
+not merge multiple producer entries at runtime.

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["bin/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a validator/embed CLI for `release-notes/next-assisted-update.json` backed by the existing assisted-update schema
- validate assisted-update metadata in CI and embed/remove it during the release workflow before pushing the release commit and tag
- document the authoring and merge rules for producer PRs

## Testing
- pnpm run check
- pnpm run test
- pnpm run test:e2e