### PR TITLE
Mark next release as assisted-update required

### DIFF
--- a/release-notes/next-assisted-update.json
+++ b/release-notes/next-assisted-update.json
@@ -1,0 +1,14 @@
+{
+  "mode": "required",
+  "title": "Verify assisted-update gating flow",
+  "summary": "This release intentionally opts into the assisted-update flow to verify end-to-end gating: metadata embedding, runtime parsing, and the agent-assisted update path. There are no runtime changes that require manual intervention beyond running the standard assisted update steps.",
+  "instructions": "1. Stop the dispatch service.\n2. Pull the new release artifact.\n3. Restart the service and confirm /api/v1/health returns ok.\n4. Confirm the running version reports the new tag.",
+  "requiredChecks": [
+    "expected_runtime_artifact",
+    "service_entrypoint",
+    "service_restarted",
+    "health_endpoint",
+    "version_converged"
+  ],
+  "rollbackGuidance": "If the assisted update flow fails to converge, restore the prior release artifact and restart the service. No data or schema changes ship with this release."
+}


### PR DESCRIPTION
## Summary

- Adds `release-notes/next-assisted-update.json` with `mode: "required"` so the next release opts into the assisted-update gating flow.
- No runtime code changes — this PR exists to exercise end-to-end gating: metadata embedding by the release workflow, runtime parsing, and the agent-assisted update path.
- Validator passes: `pnpm tsx bin/embed-assisted-update.ts --check-only --metadata release-notes/next-assisted-update.json`.

## Test plan

- [ ] Cut a release after merge and confirm the workflow embeds a canonical `dispatch-update` block in the GitHub release body.
- [ ] Confirm `release-notes/next-assisted-update.json` is removed in the release commit.
- [ ] Confirm a running install at v0.18.8 (or earlier) sees the assisted update flow gate the one-click path.
- [ ] Confirm `isAssistedUpdateRequired` returns true for the new release vs current tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)