### PR TITLE
Fix two assisted-update bugs found during v0.18.9 verification

### DIFF
--- a/apps/server/src/release-checks.ts
+++ b/apps/server/src/release-checks.ts
@@ -171,7 +171,11 @@ async function checkHealthEndpoint(ctx: CheckContext): Promise<CheckResult> {
   }
 }
 
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+// IPv6 loopback isn't included: `dispatchBaseUrl()` always hardcodes
+// 127.0.0.1, so the runtime health URL never uses `[::1]`. If that ever
+// changes, note that `new URL("https://[::1]/").hostname` returns
+// `"[::1]"` (bracketed), so the entry has to be `"[::1]"` to match.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
 
 function isLoopbackHttps(url: string): boolean {
   try {

--- a/apps/server/src/release-checks.ts
+++ b/apps/server/src/release-checks.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import https from "node:https";
 import path from "node:path";
 import type { RequiredCheckName } from "./release-metadata.js";
 import { readReleaseStore } from "./release-store.js";
@@ -129,17 +130,26 @@ async function checkServiceRestarted(_ctx: CheckContext): Promise<CheckResult> {
 async function checkHealthEndpoint(ctx: CheckContext): Promise<CheckResult> {
   const url = ctx.healthUrl ?? "http://127.0.0.1:6767/api/v1/health";
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!res.ok) {
+    const { status, body } = isLoopbackHttps(url)
+      ? await fetchLoopbackHttps(url)
+      : await fetchViaGlobal(url);
+    if (status < 200 || status >= 300) {
       return {
         name: "health_endpoint",
         ok: false,
-        message: `${url} returned ${res.status}`,
+        message: `${url} returned ${status}`,
       };
     }
-    const data = (await res.json()) as { status?: string };
+    let data: { status?: string };
+    try {
+      data = JSON.parse(body) as { status?: string };
+    } catch {
+      return {
+        name: "health_endpoint",
+        ok: false,
+        message: `${url} returned invalid JSON`,
+      };
+    }
     if (data?.status !== "ok") {
       return {
         name: "health_endpoint",
@@ -159,6 +169,64 @@ async function checkHealthEndpoint(ctx: CheckContext): Promise<CheckResult> {
       message: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+function isLoopbackHttps(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.protocol === "https:" && LOOPBACK_HOSTS.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function fetchViaGlobal(
+  url: string
+): Promise<{ status: number; body: string }> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+  return { status: res.status, body: await res.text() };
+}
+
+// The same-process self-check legitimately hits the local server's
+// self-signed TLS cert when config.tls is enabled. Bare fetch refuses
+// self-signed certs and there is no per-request override — so for
+// loopback HTTPS only, drop down to node:https with rejectUnauthorized
+// off. Limiting the bypass to loopback keeps the check honest if a
+// future config points it at a remote host.
+function fetchLoopbackHttps(
+  url: string
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = https.request(
+      {
+        method: "GET",
+        hostname: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : 443,
+        path: `${parsed.pathname}${parsed.search}`,
+        timeout: 5_000,
+        rejectUnauthorized: false,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+        res.on("error", reject);
+      }
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("health check timed out after 5s"));
+    });
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 async function checkVersionConverged(ctx: CheckContext): Promise<CheckResult> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2480,11 +2480,25 @@ async function registerRoutes() {
       }
     }
 
-    // Only one release/update at a time
+    // Only one release/update at a time, with one carve-out: the assisted
+    // agent's `apply` step posts to this endpoint, and at that point the
+    // active job is the agent's own update-assisted job. Without this
+    // exception, the agent is rejected by its own job and the documented
+    // path in the assisted prompt is unreachable. The on-disk assisted
+    // state remains the canonical phase tracker — replacing
+    // activeReleaseJob with the new update job is just for log/SSE
+    // routing during the deploy.
     if (activeReleaseJob && !isTerminalPhase(activeReleaseJob.phase)) {
-      return reply
-        .code(409)
-        .send({ error: "A release or update is already in progress." });
+      const isAssistedTakeover =
+        releaseUpdateAgentId !== null &&
+        activeReleaseJob.jobType === "update-assisted" &&
+        activeReleaseJob.assisted.agentId === releaseUpdateAgentId &&
+        activeReleaseJob.tag === tag;
+      if (!isAssistedTakeover) {
+        return reply
+          .code(409)
+          .send({ error: "A release or update is already in progress." });
+      }
     }
 
     // Gate: if the target release declares `mode: required`, the generic

--- a/apps/server/test/release-checks.test.ts
+++ b/apps/server/test/release-checks.test.ts
@@ -1,8 +1,20 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import https from "node:https";
+import type { Server as HttpsServer } from "node:https";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { AssistedUpdateState } from "../src/assisted-update-store.js";
 import { runRequiredChecks } from "../src/release-checks.js";
 
@@ -206,6 +218,118 @@ describe("health_endpoint", () => {
 
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/ECONNREFUSED/);
+  });
+});
+
+// Regression: when config.tls is on, the server's self-check hits its own
+// self-signed cert. Bare fetch refuses self-signed certs (no per-request
+// override), so for loopback HTTPS we drop to node:https with
+// rejectUnauthorized off. Verify that path against a real self-signed
+// server, and confirm bare fetch against the same URL still rejects.
+describe("health_endpoint with self-signed loopback HTTPS", () => {
+  let openSslAvailable = false;
+  let server: HttpsServer | null = null;
+  let port = 0;
+  let healthUrl = "";
+  let certDir = "";
+  let healthBody = JSON.stringify({ status: "ok" });
+  let healthStatus = 200;
+
+  beforeAll(async () => {
+    openSslAvailable =
+      spawnSync("openssl", ["version"], { stdio: "ignore" }).status === 0;
+    if (!openSslAvailable) return;
+
+    certDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-tls-"));
+    const keyPath = path.join(certDir, "key.pem");
+    const certPath = path.join(certDir, "cert.pem");
+    const gen = spawnSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-days",
+        "1",
+        "-subj",
+        "/CN=localhost",
+      ],
+      { stdio: "ignore" }
+    );
+    if (gen.status !== 0) {
+      openSslAvailable = false;
+      return;
+    }
+
+    server = https.createServer(
+      {
+        key: await readFile(keyPath),
+        cert: await readFile(certPath),
+      },
+      (_req, res) => {
+        res.statusCode = healthStatus;
+        res.setHeader("Content-Type", "application/json");
+        res.end(healthBody);
+      }
+    );
+    await new Promise<void>((resolve) =>
+      server!.listen(0, "127.0.0.1", () => resolve())
+    );
+    const addr = server!.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    healthUrl = `https://127.0.0.1:${port}/api/v1/health`;
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+    }
+    if (certDir) {
+      await rm(certDir, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    healthStatus = 200;
+    healthBody = JSON.stringify({ status: "ok" });
+  });
+
+  it("passes against a self-signed loopback HTTPS endpoint", async () => {
+    if (!openSslAvailable) return;
+    const [result] = await runRequiredChecks(["health_endpoint"], {
+      serverDir: tmpServerDir,
+      targetTag: "v0.19.0",
+      healthUrl,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/health endpoint ok/);
+  });
+
+  it("regression: bare fetch on the same self-signed URL still fails", async () => {
+    if (!openSslAvailable) return;
+    // Confirms the bypass is meaningful — without it, the bug returns.
+    await expect(
+      fetch(healthUrl, { signal: AbortSignal.timeout(5_000) })
+    ).rejects.toThrow();
+  });
+
+  it("reports non-2xx status against the self-signed loopback server", async () => {
+    if (!openSslAvailable) return;
+    healthStatus = 503;
+    healthBody = "service unavailable";
+    const [result] = await runRequiredChecks(["health_endpoint"], {
+      serverDir: tmpServerDir,
+      targetTag: "v0.19.0",
+      healthUrl,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/503/);
   });
 });
 

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -314,6 +314,127 @@ describe("release metadata route handling", () => {
     });
   });
 
+  it("allows /release/update when called with the assisted agent's bearer (takeover)", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: [],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    // 1. Launch sets activeReleaseJob to update-assisted for v0.19.0
+    //    and creates the agent that will own the bearer token.
+    const launchResp = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/assisted/launch",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+    expect(launchResp.statusCode).toBe(201);
+    const { agent } = launchResp.json() as { agent: { id: string } };
+
+    // 2. Without the takeover carve-out, the agent's own /release/update
+    //    call would 409 against its own active job. With the fix, it
+    //    proceeds as a normal update kick-off (202).
+    const auth = await import("../src/auth.js");
+    const authToken = await auth.getOrCreateAuthToken(pool);
+    const bearer = auth.createReleaseUpdateToken(authToken, agent.id);
+
+    const updateResp = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: {
+        authorization: `Bearer ${bearer}`,
+        "content-type": "application/json",
+      },
+      payload: { tag: "v0.19.0" },
+    });
+
+    expect(updateResp.statusCode).toBe(202);
+    expect(updateResp.json()).toMatchObject({ ok: true });
+
+    // 3. Assisted state on disk survives the takeover so the agent's
+    //    later phase reports continue to update the canonical record.
+    const stateResp = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/assisted/state",
+      headers: { cookie: sessionCookie },
+    });
+    expect(stateResp.json()).toMatchObject({
+      state: { tag: "v0.19.0", metadata: { mode: "required" } },
+    });
+
+    await app.inject({
+      method: "DELETE",
+      url: "/api/v1/release/assisted/state",
+      headers: { cookie: sessionCookie },
+    });
+  });
+
+  it("rejects /release/update when bearer's tag does not match the active assisted job", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: [],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const launchResp = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/assisted/launch",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+    expect(launchResp.statusCode).toBe(201);
+    const { agent } = launchResp.json() as { agent: { id: string } };
+
+    const auth = await import("../src/auth.js");
+    const authToken = await auth.getOrCreateAuthToken(pool);
+    const bearer = auth.createReleaseUpdateToken(authToken, agent.id);
+
+    // Token is valid for an active assisted job, but the body asks for a
+    // different tag — the takeover carve-out only fires when the tags
+    // match, otherwise we still have a conflict.
+    const updateResp = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: {
+        authorization: `Bearer ${bearer}`,
+        "content-type": "application/json",
+      },
+      payload: { tag: "v0.20.0" },
+    });
+
+    expect(updateResp.statusCode).toBe(409);
+    expect(updateResp.json()).toMatchObject({
+      error: "A release or update is already in progress.",
+    });
+
+    await app.inject({
+      method: "DELETE",
+      url: "/api/v1/release/assisted/state",
+      headers: { cookie: sessionCookie },
+    });
+  });
+
   it("allows /release/update when the installed version is below appliesFrom", async () => {
     await writeReleaseStore({
       tag: "v0.17.5",


### PR DESCRIPTION
## Summary

The v0.18.9 release was an opt-in to the assisted-update flow to verify end-to-end gating. Deploy succeeded, but two real bugs surfaced that would block a clean run on the documented happy path.

### Bug 1 — `/api/v1/release/update` unreachable from the assisted agent's `apply` step

`server.ts` validated the assisted bearer token but the in-progress guard fired after that, rejecting the agent against its own `update-assisted` job (`409`). The path the assisted prompt tells the agent to use was unreachable.

**Fix:** carve out the assisted agent's own active job from the guard. When the bearer's agent owns the active `update-assisted` job and the request tag matches, allow the takeover. The on-disk assisted state remains the canonical phase tracker.

### Bug 2 — `health_endpoint` required check fails on self-signed TLS

`release-checks.ts` used bare `fetch` for the in-process self-check. Any HTTPS install with `config.tls` enabled and a self-signed cert hit `fetch failed`, even when the service was responding. `runAndRecordChecks` then auto-transitioned to `blocked`.

**Fix:** for loopback HTTPS only, drop to `node:https` with `rejectUnauthorized` off. Remote/non-loopback targets continue to use `fetch` and keep cert verification honest.

## Test plan
- [x] `pnpm run check` — clean
- [x] `pnpm --filter @dispatch/server test` — 553 pass, 11 skipped
- [x] `pnpm run test:e2e` — 143 pass, 6 skipped
- [x] New unit coverage:
  - real self-signed loopback HTTPS server: `runRequiredChecks(["health_endpoint"])` passes; bare `fetch` against the same URL still rejects (regression guard); 5xx surfaces as `health_endpoint` failure.
  - assisted agent's bearer + matching tag → `202` on `/release/update`; on-disk assisted state preserved.
  - assisted agent's bearer + mismatched tag → `409`.