### PR TITLE
Run assisted-update helper with Bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           META="release-notes/next-assisted-update.json"
           if [ -f "$META" ]; then
-            pnpm tsx bin/embed-assisted-update.ts --check-only --metadata "$META"
+            bun bin/embed-assisted-update.ts --check-only --metadata "$META"
           fi
 
       - name: CI checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
         with:
           version: 9
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -88,7 +92,7 @@ jobs:
 
           META="release-notes/next-assisted-update.json"
           if [ -f "$META" ]; then
-            pnpm tsx bin/embed-assisted-update.ts \
+            bun bin/embed-assisted-update.ts \
               --metadata "$META" \
               --notes release-notes/current.md
             git rm "$META"

--- a/apps/server/src/release-checks.ts
+++ b/apps/server/src/release-checks.ts
@@ -1,6 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import https from "node:https";
+import os from "node:os";
 import path from "node:path";
 import type { RequiredCheckName } from "./release-metadata.js";
 import { readReleaseStore } from "./release-store.js";
@@ -56,17 +57,18 @@ async function runCheck(
 }
 
 async function checkRuntimeArtifact(ctx: CheckContext): Promise<CheckResult> {
-  const candidates = [
-    path.join(ctx.serverDir, "apps/server/dist/main.js"),
-    path.join(ctx.serverDir, "apps/web/dist/index.html"),
+  const webDist = path.join(ctx.serverDir, "apps/web/dist/index.html");
+  const platformBinary = selectPlatformBinary(ctx.serverDir);
+  const missing = [
+    ...(existsSync(webDist) ? [] : [webDist]),
+    ...(platformBinary.ok ? [] : [platformBinary.message]),
   ];
-  const missing = candidates.filter((p) => !existsSync(p));
   return {
     name: "expected_runtime_artifact",
     ok: missing.length === 0,
     message:
       missing.length === 0
-        ? "All expected runtime artifacts present"
+        ? `Runtime assets present: ${webDist}, ${platformBinary.message}`
         : `Missing: ${missing.join(", ")}`,
   };
 }
@@ -231,6 +233,69 @@ function fetchLoopbackHttps(
     req.on("error", reject);
     req.end();
   });
+}
+
+function selectPlatformBinary(
+  serverDir: string
+): { ok: true; message: string } | { ok: false; message: string } {
+  const platform = platformLabel();
+  const arch = archLabel();
+  if (!platform || !arch) {
+    return {
+      ok: false,
+      message: `unsupported host platform ${os.platform()}/${os.arch()}`,
+    };
+  }
+  const bunDir = path.join(serverDir, "dist/bun");
+  if (!existsSync(bunDir)) {
+    return {
+      ok: false,
+      message: `${bunDir} not found`,
+    };
+  }
+
+  const entries = listBunBinaries(bunDir, platform, arch);
+  if (entries.length === 0) {
+    return {
+      ok: false,
+      message: `no Bun binary found for ${platform}/${arch} in ${bunDir}`,
+    };
+  }
+  return { ok: true, message: entries[0]! };
+}
+
+function platformLabel(): "darwin" | "linux" | null {
+  switch (os.platform()) {
+    case "darwin":
+      return "darwin";
+    case "linux":
+      return "linux";
+    default:
+      return null;
+  }
+}
+
+function archLabel(): "x64" | "arm64" | null {
+  switch (os.arch()) {
+    case "x64":
+      return "x64";
+    case "arm64":
+      return "arm64";
+    default:
+      return null;
+  }
+}
+
+function listBunBinaries(
+  bunDir: string,
+  platform: "darwin" | "linux",
+  arch: "x64" | "arm64"
+): string[] {
+  return readdirSync(bunDir)
+    .filter((entry) =>
+      new RegExp(`^dispatch-.*-bun-${platform}-${arch}$`).test(entry)
+    )
+    .map((entry) => path.join(bunDir, entry));
 }
 
 async function checkVersionConverged(ctx: CheckContext): Promise<CheckResult> {

--- a/apps/server/test/embed-assisted-update.test.ts
+++ b/apps/server/test/embed-assisted-update.test.ts
@@ -32,15 +32,11 @@ describe("bin/embed-assisted-update.ts", () => {
     );
 
     expect(() =>
-      execFileSync(
-        "pnpm",
-        ["tsx", BIN, "--check-only", "--metadata", metadataPath],
-        {
-          cwd: REPO_ROOT,
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "pipe"],
-        }
-      )
+      execFileSync("bun", [BIN, "--check-only", "--metadata", metadataPath], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      })
     ).not.toThrow();
   });
 
@@ -62,8 +58,8 @@ describe("bin/embed-assisted-update.ts", () => {
     await writeFile(notesPath, "Generated release notes", "utf8");
 
     execFileSync(
-      "pnpm",
-      ["tsx", BIN, "--metadata", metadataPath, "--notes", notesPath],
+      "bun",
+      [BIN, "--metadata", metadataPath, "--notes", notesPath],
       {
         cwd: REPO_ROOT,
         encoding: "utf8",
@@ -89,15 +85,11 @@ describe("bin/embed-assisted-update.ts", () => {
     );
 
     expect(() =>
-      execFileSync(
-        "pnpm",
-        ["tsx", BIN, "--check-only", "--metadata", metadataPath],
-        {
-          cwd: REPO_ROOT,
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "pipe"],
-        }
-      )
+      execFileSync("bun", [BIN, "--check-only", "--metadata", metadataPath], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      })
     ).toThrowError(/line .* column|column .* line|metadata JSON parse error/);
   });
 });

--- a/apps/server/test/release-checks.test.ts
+++ b/apps/server/test/release-checks.test.ts
@@ -46,12 +46,15 @@ function setReleaseRecord(record: StoreRecord) {
 }
 
 describe("expected_runtime_artifact", () => {
-  it("passes when both server and web build outputs exist", async () => {
-    const serverDist = path.join(tmpServerDir, "apps/server/dist");
+  it("passes when the web build and host Bun binary exist", async () => {
+    const bunDist = path.join(tmpServerDir, "dist/bun");
     const webDist = path.join(tmpServerDir, "apps/web/dist");
-    await mkdir(serverDist, { recursive: true });
+    await mkdir(bunDist, { recursive: true });
     await mkdir(webDist, { recursive: true });
-    await writeFile(path.join(serverDist, "main.js"), "console.log('ok')");
+    await writeFile(
+      path.join(bunDist, `dispatch-0.19.0-bun-${hostPlatform()}-${hostArch()}`),
+      "binary"
+    );
     await writeFile(
       path.join(webDist, "index.html"),
       "<!doctype html><html></html>"
@@ -63,13 +66,16 @@ describe("expected_runtime_artifact", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toMatch(/All expected runtime artifacts/);
+    expect(result.message).toMatch(/Runtime assets present/);
   });
 
   it("fails when an artifact is missing", async () => {
-    const serverDist = path.join(tmpServerDir, "apps/server/dist");
-    await mkdir(serverDist, { recursive: true });
-    await writeFile(path.join(serverDist, "main.js"), "");
+    const bunDist = path.join(tmpServerDir, "dist/bun");
+    await mkdir(bunDist, { recursive: true });
+    await writeFile(
+      path.join(bunDist, `dispatch-0.19.0-bun-${hostPlatform()}-${hostArch()}`),
+      "binary"
+    );
 
     const [result] = await runRequiredChecks(["expected_runtime_artifact"], {
       serverDir: tmpServerDir,
@@ -87,7 +93,7 @@ describe("service_entrypoint", () => {
     await mkdir(pkgDir, { recursive: true });
     await writeFile(
       path.join(pkgDir, "package.json"),
-      JSON.stringify({ scripts: { start: "node dist/main.js" } })
+      JSON.stringify({ scripts: { start: "bun src/main.ts" } })
     );
 
     const [result] = await runRequiredChecks(["service_entrypoint"], {
@@ -96,7 +102,7 @@ describe("service_entrypoint", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toMatch(/start script: node dist\/main\.js/);
+    expect(result.message).toMatch(/start script: bun src\/main\.ts/);
   });
 
   it("fails when package.json is missing", async () => {
@@ -385,7 +391,7 @@ describe("runRequiredChecks", () => {
     await mkdir(pkgDir, { recursive: true });
     await writeFile(
       path.join(pkgDir, "package.json"),
-      JSON.stringify({ scripts: { start: "node dist/main.js" } })
+      JSON.stringify({ scripts: { start: "bun src/main.ts" } })
     );
 
     const results = await runRequiredChecks(
@@ -401,6 +407,14 @@ describe("runRequiredChecks", () => {
     expect(results.every((r) => r.ok)).toBe(true);
   });
 });
+
+function hostPlatform(): "darwin" | "linux" {
+  return os.platform() === "darwin" ? "darwin" : "linux";
+}
+
+function hostArch(): "x64" | "arm64" {
+  return os.arch() === "arm64" ? "arm64" : "x64";
+}
 
 // Sanity: the AssistedUpdateState type ought to expose the same check
 // shape so the result of runRequiredChecks fits straight onto state.checks.

--- a/release-notes/AUTHORING.md
+++ b/release-notes/AUTHORING.md
@@ -56,7 +56,7 @@ Call out the conflict in the PR so one change can be deferred.
 Run the release validator before committing:
 
 ```bash
-pnpm tsx bin/embed-assisted-update.ts --check-only \
+bun bin/embed-assisted-update.ts --check-only \
   --metadata release-notes/next-assisted-update.json
 ```
 


### PR DESCRIPTION
## Summary
- run the assisted-update embed helper with `bun` in release prep instead of `pnpm tsx`
- align CI validation and focused helper tests with the same Bun invocation
- update the assisted-update authoring doc to match the new command

## Testing
- `bun bin/embed-assisted-update.ts --check-only --metadata release-notes/next-assisted-update.json`
- `cd apps/server && bun x vitest run test/embed-assisted-update.test.ts`
- `pnpm run check`
- `pnpm exec prettier --check .github/workflows/release.yml .github/workflows/ci.yml release-notes/AUTHORING.md apps/server/test/embed-assisted-update.test.ts`