### PR TITLE
Persistent update migrations + drop gh release download (CRU-146)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,18 +14,19 @@
     "db:migrate": "bun run prepare:runtime-assets && bun src/db/migrate.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
     "@fastify/cookie": "^11.0.2",
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^8.3.0",
     "@fastify/websocket": "^11.2.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "bcryptjs": "^3.0.3",
     "croner": "^10.0.1",
     "dotenv": "^17.3.1",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.20.0",
+    "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/server/src/applied-migrations-store.ts
+++ b/apps/server/src/applied-migrations-store.ts
@@ -1,0 +1,107 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+
+/**
+ * Local source of truth for which install-update migrations (CRU-146) have
+ * been applied on this install. Lives outside the repo checkout so reinstalls
+ * and tarball deploys don't clobber it. One entry per migration id, recorded
+ * after validation passes for the run that applied it.
+ */
+
+// Resolved per call so tests can rebind the env var between runs without
+// reloading the module. Production hosts only set the env var at boot, so
+// the lookup cost is negligible.
+function appliedStorePath(): string {
+  return (
+    process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH ??
+    path.join(os.homedir(), ".dispatch", "applied-migrations.json")
+  );
+}
+
+export type AppliedMigrationRecord = {
+  appliedAt: string;
+  /** The release tag the migration was applied during. */
+  targetTag: string;
+};
+
+export type AppliedMigrationsState = {
+  appliedMigrations: Record<string, AppliedMigrationRecord>;
+};
+
+const EMPTY_STATE: AppliedMigrationsState = { appliedMigrations: {} };
+
+export async function readAppliedMigrationsState(): Promise<AppliedMigrationsState> {
+  try {
+    const raw = await readFile(appliedStorePath(), "utf-8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return EMPTY_STATE;
+    }
+    if (!isAppliedState(parsed)) return EMPTY_STATE;
+    return parsed;
+  } catch {
+    return EMPTY_STATE;
+  }
+}
+
+export async function writeAppliedMigrationsState(
+  state: AppliedMigrationsState
+): Promise<void> {
+  const filePath = appliedStorePath();
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  await writeFile(tmp, JSON.stringify(state, null, 2) + "\n", "utf-8");
+  await rename(tmp, filePath);
+}
+
+/**
+ * Record that one or more migration IDs were applied during the deploy of
+ * `targetTag`. No-op for IDs that are already recorded — the operation is
+ * idempotent so a re-run of validation after a partial failure can safely
+ * mark the rest. Atomic via tmp-file + rename in writeAppliedMigrationsState.
+ */
+export async function markMigrationsApplied(
+  ids: ReadonlyArray<string>,
+  targetTag: string,
+  now: () => Date = () => new Date()
+): Promise<AppliedMigrationsState> {
+  if (ids.length === 0) return readAppliedMigrationsState();
+  const state = await readAppliedMigrationsState();
+  const next: AppliedMigrationsState = {
+    appliedMigrations: { ...state.appliedMigrations },
+  };
+  const stamp = now().toISOString();
+  for (const id of ids) {
+    if (!next.appliedMigrations[id]) {
+      next.appliedMigrations[id] = { appliedAt: stamp, targetTag };
+    }
+  }
+  await writeAppliedMigrationsState(next);
+  return next;
+}
+
+export function appliedIdSet(state: AppliedMigrationsState): Set<string> {
+  return new Set(Object.keys(state.appliedMigrations));
+}
+
+function isAppliedState(value: unknown): value is AppliedMigrationsState {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  if (!obj.appliedMigrations || typeof obj.appliedMigrations !== "object") {
+    return false;
+  }
+  for (const [, rec] of Object.entries(
+    obj.appliedMigrations as Record<string, unknown>
+  )) {
+    if (!rec || typeof rec !== "object") return false;
+    const r = rec as Record<string, unknown>;
+    if (typeof r.appliedAt !== "string") return false;
+    if (typeof r.targetTag !== "string") return false;
+  }
+  return true;
+}
+
+export { appliedStorePath as APPLIED_MIGRATIONS_STORE_PATH_FN };

--- a/apps/server/src/applied-migrations-store.ts
+++ b/apps/server/src/applied-migrations-store.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
@@ -52,34 +53,55 @@ export async function writeAppliedMigrationsState(
 ): Promise<void> {
   const filePath = appliedStorePath();
   await mkdir(path.dirname(filePath), { recursive: true });
-  const tmp = `${filePath}.tmp`;
+  // Per-call unique temp filename so two writers can't blow each other's
+  // tmp file away. rename() is atomic, so the last writer wins on the
+  // final path — that's fine for the apply-state semantics, since the
+  // markMigrationsApplied serialization below ensures any two writes
+  // agree on the union of ids.
+  const tmp = `${filePath}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
   await writeFile(tmp, JSON.stringify(state, null, 2) + "\n", "utf-8");
   await rename(tmp, filePath);
 }
+
+// Per-process serialization of read-modify-write cycles in
+// `markMigrationsApplied`. Without this, two overlapping callers can each
+// read the pre-write state, build their own next state, and the loser's
+// rename clobbers the winner's ids. Chaining each call through a single
+// promise makes the cycle effectively transactional within this process.
+// Cross-process serialization isn't a concern: the dispatch service runs
+// as a single process per install.
+let markChain: Promise<AppliedMigrationsState> = Promise.resolve(EMPTY_STATE);
 
 /**
  * Record that one or more migration IDs were applied during the deploy of
  * `targetTag`. No-op for IDs that are already recorded — the operation is
  * idempotent so a re-run of validation after a partial failure can safely
- * mark the rest. Atomic via tmp-file + rename in writeAppliedMigrationsState.
+ * mark the rest. Concurrent calls are serialized so two read/modify/write
+ * cycles cannot drop each other's IDs.
  */
 export async function markMigrationsApplied(
   ids: ReadonlyArray<string>,
   targetTag: string,
   now: () => Date = () => new Date()
 ): Promise<AppliedMigrationsState> {
-  if (ids.length === 0) return readAppliedMigrationsState();
-  const state = await readAppliedMigrationsState();
-  const next: AppliedMigrationsState = {
-    appliedMigrations: { ...state.appliedMigrations },
-  };
-  const stamp = now().toISOString();
-  for (const id of ids) {
-    if (!next.appliedMigrations[id]) {
-      next.appliedMigrations[id] = { appliedAt: stamp, targetTag };
+  const next = markChain.then(async () => {
+    if (ids.length === 0) return readAppliedMigrationsState();
+    const state = await readAppliedMigrationsState();
+    const merged: AppliedMigrationsState = {
+      appliedMigrations: { ...state.appliedMigrations },
+    };
+    const stamp = now().toISOString();
+    for (const id of ids) {
+      if (!merged.appliedMigrations[id]) {
+        merged.appliedMigrations[id] = { appliedAt: stamp, targetTag };
+      }
     }
-  }
-  await writeAppliedMigrationsState(next);
+    await writeAppliedMigrationsState(merged);
+    return merged;
+  });
+  // Swallow errors so a failed write doesn't poison the chain for every
+  // future caller. The current call still rejects with the original error.
+  markChain = next.catch(() => readAppliedMigrationsState());
   return next;
 }
 

--- a/apps/server/src/assisted-update-store.ts
+++ b/apps/server/src/assisted-update-store.ts
@@ -6,6 +6,7 @@ import type {
   RequiredCheckName,
 } from "./release-metadata.js";
 import type { CheckResult } from "./release-checks.js";
+import type { UpdateMigrationManifest } from "./update-migrations.js";
 
 export const ASSISTED_PHASES = [
   "inspect",
@@ -39,7 +40,19 @@ const TERMINAL: AssistedPhase[] = ["done", "rollback", "blocked", "failed"];
 export type AssistedUpdateState = {
   tag: string;
   fromTag: string | null;
-  metadata: AssistedUpdateMetadata;
+  /**
+   * Legacy release-scoped assisted-update metadata. Set on runs gated by
+   * the `dispatch-update` block in the release body. Mutually exclusive
+   * with `migrations` — exactly one of the two drives a given run.
+   */
+  metadata: AssistedUpdateMetadata | null;
+  /**
+   * Ordered pending migration manifests snapshotted at launch time. New
+   * preferred path (CRU-146). When set, drives prompt rendering and the
+   * apply-on-success bookkeeping. When null, the run falls back to
+   * `metadata` for the legacy single-block flow.
+   */
+  migrations: UpdateMigrationManifest[] | null;
   requiredChecks: RequiredCheckName[];
   phase: AssistedPhase;
   /** Random nonce; the launched agent uses this to authenticate phase POSTs. */

--- a/apps/server/src/assisted-update-store.ts
+++ b/apps/server/src/assisted-update-store.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
@@ -67,15 +68,23 @@ export type AssistedUpdateState = {
   notes: Partial<Record<AssistedPhase, string>>;
 };
 
-export const ASSISTED_UPDATE_STORE_PATH = path.join(
-  os.homedir(),
-  ".dispatch",
-  "assisted-update.json"
-);
+// Resolved per call so tests can rebind the env var between runs without
+// reloading the module. Production hosts only set the env var at boot, so
+// the lookup cost is negligible.
+function assistedStorePath(): string {
+  return (
+    process.env.DISPATCH_ASSISTED_UPDATE_STORE_PATH ??
+    path.join(os.homedir(), ".dispatch", "assisted-update.json")
+  );
+}
+
+// Backwards-compatible alias for callers that imported the constant. The
+// runtime value is now resolved per call via `assistedStorePath()`.
+export const ASSISTED_UPDATE_STORE_PATH = assistedStorePath();
 
 export async function readAssistedUpdateState(): Promise<AssistedUpdateState | null> {
   try {
-    const raw = await readFile(ASSISTED_UPDATE_STORE_PATH, "utf-8");
+    const raw = await readFile(assistedStorePath(), "utf-8");
     const parsed = JSON.parse(raw) as AssistedUpdateState;
     // Light sanity check; missing fields means the file is from an older
     // version and should be ignored rather than crashing the boot.
@@ -95,16 +104,22 @@ export async function readAssistedUpdateState(): Promise<AssistedUpdateState | n
 export async function writeAssistedUpdateState(
   state: AssistedUpdateState
 ): Promise<void> {
-  await mkdir(path.dirname(ASSISTED_UPDATE_STORE_PATH), { recursive: true });
-  const tmp = `${ASSISTED_UPDATE_STORE_PATH}.tmp`;
+  const filePath = assistedStorePath();
+  await mkdir(path.dirname(filePath), { recursive: true });
+  // Per-call unique temp filename. A fixed `.tmp` would race with itself
+  // when overlapping phase POSTs both write at the same time: one
+  // `rename()` could move the shared tmp out from under the other,
+  // surfacing as ENOENT or last-writer-wins state loss. The unique
+  // suffix makes each writer own its own tmp, and rename is atomic.
+  const tmp = `${filePath}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
   await writeFile(tmp, JSON.stringify(state, null, 2) + "\n", "utf-8");
-  await rename(tmp, ASSISTED_UPDATE_STORE_PATH);
+  await rename(tmp, filePath);
 }
 
 export async function clearAssistedUpdateState(): Promise<void> {
   try {
     const { unlink } = await import("node:fs/promises");
-    await unlink(ASSISTED_UPDATE_STORE_PATH);
+    await unlink(assistedStorePath());
   } catch {
     // best effort
   }

--- a/apps/server/src/assisted-update.ts
+++ b/apps/server/src/assisted-update.ts
@@ -93,7 +93,13 @@ export async function buildAssistedUpdateContext(
     checks: [],
     notes: {},
   };
-  await writeAssistedUpdateState(state);
+
+  // Intentionally NOT persisted here. If `agentManager.createAgent` later
+  // fails in `release/assisted/launch`, a state file with `agentId: null`
+  // would be left behind and `rehydrateActiveAssistedJob` would resurrect
+  // it on next boot/reconnect as a phantom in-flight run with no owner.
+  // The launch endpoint persists state via `attachAssistedAgent` once the
+  // agent is created — that's the first durable write.
 
   const prompt = renderAssistedPrompt(
     state,
@@ -163,12 +169,19 @@ export async function applyAssistedPhase(input: {
   return { ok: true, state };
 }
 
+/**
+ * First durable persistence of the assisted-update state. Called by the
+ * launch endpoint AFTER `agentManager.createAgent` succeeds, so a failed
+ * createAgent can never leave a phantom record on disk that
+ * `rehydrateActiveAssistedJob` would resurrect at boot.
+ *
+ * This is the single point where state.agentId transitions from null to a
+ * real agent id; subsequent updates flow through `applyAssistedPhase`.
+ */
 export async function attachAssistedAgent(
-  token: string,
+  state: AssistedUpdateState,
   agentId: string
-): Promise<AssistedUpdateState | null> {
-  const state = await readAssistedUpdateState();
-  if (!state || !tokensEqual(state.token, token)) return null;
+): Promise<AssistedUpdateState> {
   state.agentId = agentId;
   state.updatedAt = new Date().toISOString();
   await writeAssistedUpdateState(state);

--- a/apps/server/src/assisted-update.ts
+++ b/apps/server/src/assisted-update.ts
@@ -16,11 +16,20 @@ import {
   type AssistedUpdateState,
 } from "./assisted-update-store.js";
 import { runRequiredChecks, type CheckContext } from "./release-checks.js";
+import type { RequiredCheckName } from "./release-metadata.js";
+import type { UpdateMigrationManifest } from "./update-migrations.js";
+import { markMigrationsApplied } from "./applied-migrations-store.js";
+import { clearEvaluatorCache } from "./update-migrations-evaluator.js";
 
 export type StartAssistedUpdateInput = {
   tag: string;
   fromTag: string | null;
-  metadata: AssistedUpdateMetadata;
+  /**
+   * Either `metadata` (legacy single-block release-scoped run) or
+   * `migrations` (preferred manifest-driven run, CRU-146) is required.
+   */
+  metadata?: AssistedUpdateMetadata;
+  migrations?: UpdateMigrationManifest[];
   /**
    * The directory the launched agent will run in. Owned by the caller
    * (server.ts) so this module stays a pure orchestrator with no
@@ -57,11 +66,23 @@ export async function buildAssistedUpdateContext(
   input: StartAssistedUpdateInput,
   baseUrl: string
 ): Promise<AssistedAgentContext> {
+  const migrations = input.migrations ?? null;
+  const metadata = input.metadata ?? null;
+  if (!migrations && !metadata) {
+    throw new Error(
+      "buildAssistedUpdateContext requires either migrations or metadata"
+    );
+  }
+  const requiredChecks: RequiredCheckName[] = migrations
+    ? unionMigrationChecks(migrations)
+    : normalizeRequiredChecks(metadata!);
+
   const state: AssistedUpdateState = {
     tag: input.tag,
     fromTag: input.fromTag,
-    metadata: input.metadata,
-    requiredChecks: normalizeRequiredChecks(input.metadata),
+    metadata,
+    migrations,
+    requiredChecks,
     phase: "inspect",
     token: randomBytes(24).toString("base64url"),
     agentId: null,
@@ -81,6 +102,21 @@ export async function buildAssistedUpdateContext(
     input.recovery
   );
   return { state, prompt };
+}
+
+function unionMigrationChecks(
+  migrations: UpdateMigrationManifest[]
+): RequiredCheckName[] {
+  const seen = new Set<RequiredCheckName>();
+  const ordered: RequiredCheckName[] = [];
+  for (const m of migrations) {
+    for (const c of m.validation.requiredChecks) {
+      if (seen.has(c)) continue;
+      seen.add(c);
+      ordered.push(c);
+    }
+  }
+  return ordered;
 }
 
 /**
@@ -140,9 +176,12 @@ export async function attachAssistedAgent(
 }
 
 /**
- * Run the metadata's `requiredChecks` set and return their results. The
- * orchestrator persists results onto state so operators can see exactly what
- * passed before the framework marked the job successful.
+ * Run the run's `requiredChecks` set and return their results. The
+ * orchestrator persists results onto state so operators can see exactly
+ * what passed before the framework marked the job successful. When the run
+ * is migrations-driven (CRU-146) and every check passes, mark each pending
+ * migration ID applied locally so the next `release/info` poll picks the
+ * change up.
  */
 export async function runAndRecordChecks(
   state: AssistedUpdateState,
@@ -153,18 +192,40 @@ export async function runAndRecordChecks(
   state.updatedAt = new Date().toISOString();
   await writeAssistedUpdateState(state);
   const allPassed = results.every((r) => r.ok);
-  if (allPassed) return state;
+  if (!allPassed) {
+    // Route the failed-checks → blocked transition through the canonical
+    // helper so it goes through `isLegalTransition` (no-op when state is
+    // already terminal at rollback/blocked/failed) and the same
+    // persist + completedAt stamping every other phase change uses.
+    const transition = await applyAssistedPhase({
+      token: state.token,
+      phase: "blocked",
+      error: "one or more required checks failed",
+    });
+    return transition.ok ? transition.state : state;
+  }
 
-  // Route the failed-checks → blocked transition through the canonical
-  // helper so it goes through `isLegalTransition` (no-op when state is
-  // already terminal at rollback/blocked/failed) and the same
-  // persist + completedAt stamping every other phase change uses.
-  const transition = await applyAssistedPhase({
-    token: state.token,
-    phase: "blocked",
-    error: "one or more required checks failed",
-  });
-  return transition.ok ? transition.state : state;
+  // Migrations-driven success path: record every pending migration ID as
+  // applied, atomically, before reporting success upstream. The whole
+  // pending set is marked together — v1 is all-or-nothing per the issue.
+  if (state.migrations && state.migrations.length > 0) {
+    const ids = state.migrations.map((m) => m.id);
+    try {
+      await markMigrationsApplied(ids, state.tag);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const transition = await applyAssistedPhase({
+        token: state.token,
+        phase: "blocked",
+        error: `failed to record migration apply state: ${message}`,
+      });
+      return transition.ok ? transition.state : state;
+    }
+    // Force the next `release/info` poll to re-evaluate so applied IDs
+    // disappear from `pendingMigrations`.
+    clearEvaluatorCache();
+  }
+  return state;
 }
 
 export { isAssistedUpdateRequired };
@@ -175,13 +236,21 @@ function renderAssistedPrompt(
   serverDir: string,
   recovery: AssistedRecoveryContext
 ): string {
-  const { metadata, tag, fromTag, requiredChecks, token } = state;
+  const { tag, fromTag, requiredChecks, token, migrations, metadata } = state;
   const checksList =
     requiredChecks.length > 0
       ? requiredChecks.map((c) => `  - ${c}`).join("\n")
       : "  (none)";
   const platform = `${process.platform}/${process.arch}`;
   const phaseUrl = `${baseUrl.replace(/\/$/, "")}/api/v1/release/assisted/phase`;
+  const modeLabel = migrations
+    ? `migration-driven (${migrations.length} pending)`
+    : (metadata?.mode ?? "unknown");
+
+  const migrationSections =
+    migrations && migrations.length > 0
+      ? renderMigrationSections(migrations)
+      : renderLegacyMetadataSections(metadata);
 
   return [
     `# Assisted release update`,
@@ -201,7 +270,7 @@ function renderAssistedPrompt(
     `- installed: ${fromTag ?? "(unknown)"}`,
     `- platform: ${platform}`,
     `- service dir: ${serverDir}`,
-    `- mode: ${metadata.mode}`,
+    `- mode: ${modeLabel}`,
     `- health endpoint: ${recovery.healthEndpoint}`,
     `- service restart command: ${recovery.serviceCommand}`,
     `- main service log: ${recovery.serviceLogPath}`,
@@ -217,24 +286,11 @@ function renderAssistedPrompt(
     `- Do not assume release.json points to a healthy rollback target after a failed deploy; confirm the last healthy tag from git/service history before rolling back.`,
     `- Restore service availability before deeper diagnosis.`,
     ``,
-    `## Title`,
-    ``,
-    metadata.title,
-    ``,
-    `## Summary`,
-    ``,
-    metadata.summary,
-    ``,
-    metadata.instructions
-      ? `## Instructions\n\n${metadata.instructions}\n`
-      : "",
+    migrationSections,
     `## Required checks (must all pass before reporting "validate" → "done")`,
     ``,
     checksList,
     ``,
-    metadata.rollbackGuidance
-      ? `## Rollback guidance\n\n${metadata.rollbackGuidance}\n`
-      : "",
     `## Phase reporting`,
     ``,
     `Move through these phases in order, reporting each one BEFORE you start it:`,
@@ -269,4 +325,82 @@ function renderAssistedPrompt(
   ]
     .filter((line) => line !== undefined)
     .join("\n");
+}
+
+function renderMigrationSections(
+  migrations: UpdateMigrationManifest[]
+): string {
+  const sections: string[] = [
+    `## Pending migrations`,
+    ``,
+    `This run includes ${migrations.length} pending migration${
+      migrations.length === 1 ? "" : "s"
+    }. Treat them as one ordered plan: walk each in order, evaluate the`,
+    `\`alreadySatisfied\` condition first, perform the migration only if it`,
+    `is not already satisfied, then continue to the next. The framework`,
+    `runs the union of every \`validation.requiredChecks\` after you report`,
+    `\`validate\`, and only marks all migrations applied when every check`,
+    `passes. If validation fails, none of this run's migrations are marked`,
+    `applied — the operator can re-run the assisted flow.`,
+    ``,
+  ];
+
+  migrations.forEach((m, idx) => {
+    const heading = `### Migration ${idx + 1}/${migrations.length}: ${m.title} (id: \`${m.id}\`)`;
+    sections.push(heading, ``);
+    sections.push(`**Summary**`, ``, m.summary.trim(), ``);
+    sections.push(
+      `**Already satisfied?**`,
+      ``,
+      m.alreadySatisfied.description.trim(),
+      ``
+    );
+    sections.push(
+      `**Instructions**`,
+      ``,
+      ...m.instructions.map((step) => `- ${step}`),
+      ``
+    );
+    if (m.validation.requiredChecks.length > 0) {
+      sections.push(
+        `**Validation checks for this migration**`,
+        ``,
+        ...m.validation.requiredChecks.map((c) => `- ${c}`),
+        ``
+      );
+    }
+    if (m.rollback.length > 0) {
+      sections.push(
+        `**Rollback**`,
+        ``,
+        ...m.rollback.map((step) => `- ${step}`),
+        ``
+      );
+    }
+  });
+
+  return sections.join("\n");
+}
+
+function renderLegacyMetadataSections(
+  metadata: AssistedUpdateMetadata | null
+): string {
+  if (!metadata) return "";
+  const sections: string[] = [
+    `## Title`,
+    ``,
+    metadata.title,
+    ``,
+    `## Summary`,
+    ``,
+    metadata.summary,
+    ``,
+  ];
+  if (metadata.instructions) {
+    sections.push(`## Instructions`, ``, metadata.instructions, ``);
+  }
+  if (metadata.rollbackGuidance) {
+    sections.push(`## Rollback guidance`, ``, metadata.rollbackGuidance, ``);
+  }
+  return sections.join("\n");
 }

--- a/apps/server/src/release-tarball-cache.ts
+++ b/apps/server/src/release-tarball-cache.ts
@@ -26,9 +26,15 @@ import { runCommand } from "./shared/lib/run-command.js";
 
 export const RELEASE_ARTIFACT_NAME = "dispatch-release.tar.gz";
 
-const CACHE_DIR =
-  process.env.DISPATCH_RELEASE_CACHE_DIR ??
-  path.join(os.homedir(), ".dispatch", "cache");
+// Resolved per call so tests can rebind the env var between runs without
+// reloading the module. Production hosts only set the env var at boot, so
+// the lookup cost is negligible.
+function cacheDir(): string {
+  return (
+    process.env.DISPATCH_RELEASE_CACHE_DIR ??
+    path.join(os.homedir(), ".dispatch", "cache")
+  );
+}
 
 export type DownloadProgress = (info: {
   message: string;
@@ -47,7 +53,7 @@ export type CachedReleaseTarball = {
  * deploy step can probe the cache before falling back to a download.
  */
 export function cachedTarballPath(tag: string): string {
-  return path.join(CACHE_DIR, `release-${sanitizeTag(tag)}.tar.gz`);
+  return path.join(cacheDir(), `release-${sanitizeTag(tag)}.tar.gz`);
 }
 
 /**
@@ -84,7 +90,7 @@ export async function ensureCachedTarball(input: {
     return existing;
   }
 
-  await mkdir(CACHE_DIR, { recursive: true });
+  await mkdir(cacheDir(), { recursive: true });
   const finalPath = cachedTarballPath(tag);
   const partialPath = `${finalPath}.partial`;
   // If a previous attempt left a partial behind, remove it so we don't
@@ -246,7 +252,7 @@ export async function pruneCacheExcept(
 ): Promise<void> {
   let entries: string[];
   try {
-    entries = await readdir(CACHE_DIR);
+    entries = await readdir(cacheDir());
   } catch {
     return;
   }
@@ -256,7 +262,7 @@ export async function pruneCacheExcept(
   for (const entry of entries) {
     if (!entry.startsWith("release-") || !entry.endsWith(".tar.gz")) continue;
     if (keep.has(entry)) continue;
-    await unlink(path.join(CACHE_DIR, entry)).catch(() => {});
+    await unlink(path.join(cacheDir(), entry)).catch(() => {});
   }
 }
 
@@ -323,7 +329,11 @@ const ALLOWED_REDIRECT_HOSTS: ReadonlyArray<string | RegExp> = [
 
 const DOWNLOAD_REQUEST_TIMEOUT_MS = 60_000;
 
-function isAllowedRedirectHost(host: string): boolean {
+/**
+ * Exported for testability. Production callers go through `openHttpsStream`,
+ * which calls this on every redirect hop.
+ */
+export function isAllowedRedirectHost(host: string): boolean {
   return ALLOWED_REDIRECT_HOSTS.some((pat) =>
     typeof pat === "string" ? host === pat : pat.test(host)
   );
@@ -421,7 +431,6 @@ function sanitizeTag(tag: string): string {
   // Tags from the release flow look like `v0.18.13`, but be defensive: a
   // future release tag could include characters that would escape the cache
   // dir (e.g. "../../etc/passwd"). Replace anything outside [A-Za-z0-9._-]
-  // with "_" so the cache filename is always a child of CACHE_DIR.
   return tag.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 

--- a/apps/server/src/release-tarball-cache.ts
+++ b/apps/server/src/release-tarball-cache.ts
@@ -1,0 +1,319 @@
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rename, rm, stat } from "node:fs/promises";
+import { readdir, unlink } from "node:fs/promises";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { runCommand } from "./shared/lib/run-command.js";
+
+/**
+ * Local cache for the prebuilt release tarball. Replaces the previous
+ * `gh release download` path so the runtime can fetch a target release
+ * artifact over plain HTTPS without requiring the GitHub CLI to be
+ * authenticated. The cache lives in `~/.dispatch/cache/` and is keyed by
+ * tag, which is immutable on GitHub — once a tarball is downloaded for a
+ * tag it stays valid forever, and pruning is just "delete every cached
+ * tarball that isn't ahead of the current install."
+ *
+ * The same cached file is used twice in the assisted-update flow (CRU-146):
+ *   1. On "Check for Updates" the runtime extracts only `update-migrations/`
+ *      from it to determine whether assisted update is required.
+ *   2. On the actual deploy the same tarball is extracted into the install
+ *      directory — no second download.
+ */
+
+export const RELEASE_ARTIFACT_NAME = "dispatch-release.tar.gz";
+
+const CACHE_DIR =
+  process.env.DISPATCH_RELEASE_CACHE_DIR ??
+  path.join(os.homedir(), ".dispatch", "cache");
+
+export type DownloadProgress = (info: {
+  message: string;
+  bytesReceived?: number;
+  totalBytes?: number | null;
+}) => void;
+
+export type CachedReleaseTarball = {
+  tag: string;
+  path: string;
+  bytes: number;
+};
+
+/**
+ * Resolve the cache path for a given tag. The path is deterministic so the
+ * deploy step can probe the cache before falling back to a download.
+ */
+export function cachedTarballPath(tag: string): string {
+  return path.join(CACHE_DIR, `release-${sanitizeTag(tag)}.tar.gz`);
+}
+
+/**
+ * Returns the cached tarball if one is present for `tag`, or null when the
+ * cache is empty / corrupt. Never throws.
+ */
+export async function readCachedTarball(
+  tag: string
+): Promise<CachedReleaseTarball | null> {
+  const filePath = cachedTarballPath(tag);
+  try {
+    const info = await stat(filePath);
+    if (!info.isFile() || info.size === 0) return null;
+    return { tag, path: filePath, bytes: info.size };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure a release tarball for `tag` is on disk in the cache. Downloads it
+ * if missing. Idempotent — returns the cached entry without re-downloading
+ * when the file is already present.
+ */
+export async function ensureCachedTarball(input: {
+  tag: string;
+  repo: string;
+  onProgress?: DownloadProgress;
+}): Promise<CachedReleaseTarball> {
+  const { tag, repo, onProgress } = input;
+  const existing = await readCachedTarball(tag);
+  if (existing) {
+    onProgress?.({ message: `cached ${RELEASE_ARTIFACT_NAME} for ${tag}` });
+    return existing;
+  }
+
+  await mkdir(CACHE_DIR, { recursive: true });
+  const finalPath = cachedTarballPath(tag);
+  const partialPath = `${finalPath}.partial`;
+  // If a previous attempt left a partial behind, remove it so we don't
+  // resume into a half-downloaded file with the wrong size.
+  await rm(partialPath, { force: true }).catch(() => {});
+
+  const url = releaseDownloadUrl(repo, tag);
+  onProgress?.({ message: `==> downloading ${url}` });
+
+  const { totalBytes } = await downloadToFile({
+    url,
+    destination: partialPath,
+    onProgress: (bytes) => {
+      onProgress?.({
+        message: `downloaded ${formatBytes(bytes)}`,
+        bytesReceived: bytes,
+        totalBytes,
+      });
+    },
+  });
+
+  // Atomic-publish the cache entry: a partial file must never be observable
+  // as the canonical cache. rename() on the same filesystem is atomic.
+  await rename(partialPath, finalPath);
+
+  const info = await stat(finalPath);
+  return { tag, path: finalPath, bytes: info.size };
+}
+
+/**
+ * Extract `update-migrations/` from a cached tarball into a fresh temp
+ * directory. The bulk of the tarball (Bun binaries, web dist) stays inside
+ * the cache file — only the migration manifests hit the temp dir. Caller is
+ * responsible for cleanup.
+ */
+export async function extractUpdateMigrationsTo(
+  tarballPath: string
+): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-migrations-"));
+  // Best-effort path-traversal guard mirroring deployFromArtifact: list
+  // first, refuse anything with `..` or absolute paths under the
+  // update-migrations/ prefix.
+  const listing = await runCommand("tar", ["tzf", tarballPath]);
+  const unsafeEntries = listing.stdout
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => entry.startsWith("/") || entry.includes("../"));
+  if (unsafeEntries.length > 0) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    throw new Error(
+      `Release tarball contains unsafe paths: ${unsafeEntries.slice(0, 5).join(", ")}`
+    );
+  }
+  const hasMigrations = listing.stdout
+    .split("\n")
+    .some((entry) => entry.startsWith("update-migrations/"));
+  if (!hasMigrations) {
+    return {
+      dir: path.join(tmpDir, "update-migrations"),
+      cleanup: async () => {
+        await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      },
+    };
+  }
+
+  await runCommand("tar", [
+    "xzf",
+    tarballPath,
+    "--no-same-owner",
+    "-C",
+    tmpDir,
+    "update-migrations",
+  ]);
+
+  return {
+    dir: path.join(tmpDir, "update-migrations"),
+    cleanup: async () => {
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}
+
+/**
+ * Read every file under `update-migrations/` inside a tarball into memory.
+ * Useful for cheap inspection passes that don't need a temp dir on disk —
+ * but we still go through tar so the streaming/path-safety story matches
+ * `extractUpdateMigrationsTo`.
+ */
+export async function readMigrationsFromTarball(
+  tarballPath: string
+): Promise<Array<{ filename: string; contents: string }>> {
+  const { dir, cleanup } = await extractUpdateMigrationsTo(tarballPath);
+  try {
+    const entries = await readdir(dir).catch(() => [] as string[]);
+    const files: Array<{ filename: string; contents: string }> = [];
+    for (const entry of entries) {
+      const filePath = path.join(dir, entry);
+      const stats = await stat(filePath).catch(() => null);
+      if (!stats || !stats.isFile()) continue;
+      const contents = await readFile(filePath, "utf-8");
+      files.push({ filename: entry, contents });
+    }
+    return files;
+  } finally {
+    await cleanup();
+  }
+}
+
+/**
+ * Drop cached tarballs for tags the install no longer needs. Keeps the
+ * cache for `tagsToKeep` (typically the current tag and any "ahead"
+ * targets). Best-effort — disk errors are swallowed so a deploy never fails
+ * because cleanup did.
+ */
+export async function pruneCacheExcept(
+  tagsToKeep: ReadonlyArray<string>
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(CACHE_DIR);
+  } catch {
+    return;
+  }
+  const keep = new Set(
+    tagsToKeep.map((tag) => `release-${sanitizeTag(tag)}.tar.gz`)
+  );
+  for (const entry of entries) {
+    if (!entry.startsWith("release-") || !entry.endsWith(".tar.gz")) continue;
+    if (keep.has(entry)) continue;
+    await unlink(path.join(CACHE_DIR, entry)).catch(() => {});
+  }
+}
+
+export function releaseDownloadUrl(repo: string, tag: string): string {
+  // GitHub serves a deterministic public URL for release assets; this
+  // path is what `gh release download` resolves to under the hood. Public
+  // repos return the file directly; private repos 302 to a signed S3 URL
+  // that requires authentication, which the runtime doesn't have today.
+  // That's acceptable for v1 — Dispatch is currently distributed from a
+  // public release. When private deploys come online we can layer a
+  // GH_TOKEN-bearing fetch on top.
+  return `https://github.com/${repo}/releases/download/${encodeURIComponent(
+    tag
+  )}/${RELEASE_ARTIFACT_NAME}`;
+}
+
+async function downloadToFile(input: {
+  url: string;
+  destination: string;
+  onProgress?: (bytesReceived: number) => void;
+}): Promise<{ totalBytes: number | null }> {
+  const { url, destination, onProgress } = input;
+  const { stream, totalBytes } = await openHttpsStream(url);
+  let received = 0;
+  let lastReportedAt = 0;
+  stream.on("data", (chunk: Buffer) => {
+    received += chunk.length;
+    const now = Date.now();
+    if (now - lastReportedAt > 250) {
+      lastReportedAt = now;
+      onProgress?.(received);
+    }
+  });
+  await pipeline(stream, createWriteStream(destination));
+  onProgress?.(received);
+  return { totalBytes };
+}
+
+async function openHttpsStream(
+  url: string,
+  redirectsRemaining = 5
+): Promise<{ stream: Readable; totalBytes: number | null }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: "GET",
+        headers: {
+          "User-Agent": "dispatch-update-client",
+          Accept: "application/octet-stream",
+        },
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        if (status >= 300 && status < 400 && res.headers.location) {
+          // GitHub redirects the public release-asset URL to a signed S3
+          // URL. Follow the redirect with a fresh request — node:https
+          // doesn't auto-follow.
+          if (redirectsRemaining <= 0) {
+            res.resume();
+            reject(new Error(`Too many redirects fetching ${url}`));
+            return;
+          }
+          res.resume();
+          openHttpsStream(res.headers.location, redirectsRemaining - 1).then(
+            resolve,
+            reject
+          );
+          return;
+        }
+        if (status < 200 || status >= 300) {
+          res.resume();
+          reject(new Error(`Failed to download ${url}: HTTP ${status}`));
+          return;
+        }
+        const lengthHeader = res.headers["content-length"];
+        const totalBytes =
+          typeof lengthHeader === "string"
+            ? Number(lengthHeader) || null
+            : null;
+        resolve({ stream: res, totalBytes });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function sanitizeTag(tag: string): string {
+  // Tags from the release flow look like `v0.18.13`, but be defensive: a
+  // future release tag could include characters that would escape the cache
+  // dir (e.g. "../../etc/passwd"). Replace anything outside [A-Za-z0-9._-]
+  // with "_" so the cache filename is always a child of CACHE_DIR.
+  return tag.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}M`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)}K`;
+  return `${bytes}B`;
+}

--- a/apps/server/src/release-tarball-cache.ts
+++ b/apps/server/src/release-tarball-cache.ts
@@ -118,6 +118,11 @@ export async function ensureCachedTarball(input: {
 
   const downloadPromise = (async () => {
     await mkdir(cacheDir(), { recursive: true });
+    // Best-effort sweep: if a previous server process exited between
+    // createWriteStream and rename, an orphan `.partial.<pid>.<rand>`
+    // is sitting in the cache dir. The new pid won't reuse the name,
+    // but the file would still leak forever otherwise.
+    await sweepOrphanPartials();
     const finalPath = cachedTarballPath(tag);
     // Per-caller partial filename so two writers can never trip over the
     // same path. The atomic-rename below adopts the first one to finish;
@@ -280,10 +285,20 @@ export async function readMigrationsFromTarball(
 }
 
 /**
+ * Pattern for orphan partial-download files. ensureCachedTarball mints
+ * one per call as `<final>.partial.<pid>.<rand>` and unlinks it on the
+ * local error path, but a hard process exit between createWriteStream and
+ * rename leaves the file behind. Sweep them on prune so the cache
+ * directory doesn't grow unbounded across crashed deploys.
+ */
+const PARTIAL_FILE_RE = /^release-.+\.tar\.gz\.partial\..+$/;
+
+/**
  * Drop cached tarballs for tags the install no longer needs. Keeps the
  * cache for `tagsToKeep` (typically the current tag and any "ahead"
- * targets). Best-effort — disk errors are swallowed so a deploy never fails
- * because cleanup did.
+ * targets). Also sweeps any orphan `.partial.*` files left behind by
+ * crashed downloads. Best-effort — disk errors are swallowed so a deploy
+ * never fails because cleanup did.
  */
 export async function pruneCacheExcept(
   tagsToKeep: ReadonlyArray<string>
@@ -298,8 +313,30 @@ export async function pruneCacheExcept(
     tagsToKeep.map((tag) => `release-${sanitizeTag(tag)}.tar.gz`)
   );
   for (const entry of entries) {
-    if (!entry.startsWith("release-") || !entry.endsWith(".tar.gz")) continue;
-    if (keep.has(entry)) continue;
+    const isCanonical =
+      entry.startsWith("release-") && entry.endsWith(".tar.gz");
+    const isOrphanPartial = PARTIAL_FILE_RE.test(entry);
+    if (!isCanonical && !isOrphanPartial) continue;
+    if (isCanonical && keep.has(entry)) continue;
+    await unlink(path.join(cacheDir(), entry)).catch(() => {});
+  }
+}
+
+/**
+ * Sweep orphan `.partial.*` files that don't belong to an in-flight
+ * download in this process. Runs at the start of `ensureCachedTarball`
+ * so a long-running server gradually reclaims disk after crashed
+ * downloads even if `pruneCacheExcept` isn't called.
+ */
+async function sweepOrphanPartials(): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(cacheDir());
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!PARTIAL_FILE_RE.test(entry)) continue;
     await unlink(path.join(cacheDir(), entry)).catch(() => {});
   }
 }

--- a/apps/server/src/release-tarball-cache.ts
+++ b/apps/server/src/release-tarball-cache.ts
@@ -94,17 +94,26 @@ export async function ensureCachedTarball(input: {
   const url = releaseDownloadUrl(repo, tag);
   onProgress?.({ message: `==> downloading ${url}` });
 
-  const { totalBytes } = await downloadToFile({
-    url,
-    destination: partialPath,
-    onProgress: (bytes) => {
-      onProgress?.({
-        message: `downloaded ${formatBytes(bytes)}`,
-        bytesReceived: bytes,
-        totalBytes,
-      });
-    },
-  });
+  try {
+    await downloadToFile({
+      url,
+      destination: partialPath,
+      onProgress: (bytes, totalBytes) => {
+        onProgress?.({
+          message: `downloaded ${formatBytes(bytes)}`,
+          bytesReceived: bytes,
+          totalBytes,
+        });
+      },
+    });
+  } catch (err) {
+    // Make sure we don't leave an orphaned `.partial` for the next call to
+    // resume from — that would conflict with the rm-then-write contract
+    // above, and a future "size > 0" cache check could mistake it for a
+    // canonical cache entry on a filesystem that lost the rename atomicity.
+    await rm(partialPath, { force: true }).catch(() => {});
+    throw err;
+  }
 
   // Atomic-publish the cache entry: a partial file must never be observable
   // as the canonical cache. rename() on the same filesystem is atomic.
@@ -115,10 +124,25 @@ export async function ensureCachedTarball(input: {
 }
 
 /**
+ * Drop the cached tarball for a given tag. Used when a cached file fails
+ * subsequent integrity checks (e.g. `tar tzf` rejects it as corrupt) so
+ * the next call re-downloads instead of looping on the bad artifact.
+ */
+export async function unlinkCachedTarball(tag: string): Promise<void> {
+  await unlink(cachedTarballPath(tag)).catch(() => {});
+}
+
+/**
  * Extract `update-migrations/` from a cached tarball into a fresh temp
  * directory. The bulk of the tarball (Bun binaries, web dist) stays inside
  * the cache file — only the migration manifests hit the temp dir. Caller is
  * responsible for cleanup.
+ *
+ * If `tar tzf` rejects the file as corrupt the cache entry is unlinked
+ * before re-throwing — otherwise the next call would re-use the bad
+ * tarball, fail the same way, and the only path forward would be a manual
+ * `rm ~/.dispatch/cache/release-*.tar.gz`. Re-downloading on the next
+ * attempt is the right recovery for a corrupt artifact.
  */
 export async function extractUpdateMigrationsTo(
   tarballPath: string
@@ -127,7 +151,18 @@ export async function extractUpdateMigrationsTo(
   // Best-effort path-traversal guard mirroring deployFromArtifact: list
   // first, refuse anything with `..` or absolute paths under the
   // update-migrations/ prefix.
-  const listing = await runCommand("tar", ["tzf", tarballPath]);
+  let listing: Awaited<ReturnType<typeof runCommand>>;
+  try {
+    listing = await runCommand("tar", ["tzf", tarballPath]);
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    await unlink(tarballPath).catch(() => {});
+    throw err instanceof Error
+      ? new Error(
+          `Failed to read tarball at ${tarballPath} (cache entry removed): ${err.message}`
+        )
+      : err;
+  }
   const unsafeEntries = listing.stdout
     .split("\n")
     .map((entry) => entry.trim())
@@ -151,14 +186,20 @@ export async function extractUpdateMigrationsTo(
     };
   }
 
-  await runCommand("tar", [
-    "xzf",
-    tarballPath,
-    "--no-same-owner",
-    "-C",
-    tmpDir,
-    "update-migrations",
-  ]);
+  try {
+    await runCommand("tar", [
+      "xzf",
+      tarballPath,
+      "--no-same-owner",
+      "-C",
+      tmpDir,
+      "update-migrations",
+    ]);
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    await unlink(tarballPath).catch(() => {});
+    throw err;
+  }
 
   return {
     dir: path.join(tmpDir, "update-migrations"),
@@ -235,7 +276,7 @@ export function releaseDownloadUrl(repo: string, tag: string): string {
 async function downloadToFile(input: {
   url: string;
   destination: string;
-  onProgress?: (bytesReceived: number) => void;
+  onProgress?: (bytesReceived: number, totalBytes: number | null) => void;
 }): Promise<{ totalBytes: number | null }> {
   const { url, destination, onProgress } = input;
   const { stream, totalBytes } = await openHttpsStream(url);
@@ -246,12 +287,46 @@ async function downloadToFile(input: {
     const now = Date.now();
     if (now - lastReportedAt > 250) {
       lastReportedAt = now;
-      onProgress?.(received);
+      onProgress?.(received, totalBytes);
     }
   });
   await pipeline(stream, createWriteStream(destination));
-  onProgress?.(received);
+  onProgress?.(received, totalBytes);
+
+  // pipeline() resolves on a clean upstream FIN — but a hung-up-mid-body
+  // response is also "clean" from Node's stream perspective when the body
+  // is chunked or when the connection drops without the writable seeing
+  // an error. If the server told us how many bytes to expect, refuse to
+  // accept anything else: a truncated cache file would be reused forever
+  // (cache reuse is "size > 0", and we don't checksum the artifact).
+  if (totalBytes !== null && received !== totalBytes) {
+    throw new Error(
+      `Truncated download from ${url}: received ${received} bytes, expected ${totalBytes}`
+    );
+  }
   return { totalBytes };
+}
+
+/**
+ * Hosts we'll follow a redirect to. The release-asset URL starts at
+ * `github.com` and 302s to `objects.githubusercontent.com` (signed S3
+ * frontend). Anything outside this allowlist is treated as a hostile
+ * redirect and rejected — without a checksum on the tarball, an attacker
+ * who could redirect us to an arbitrary HTTPS host could feed us their
+ * artifact. Defense-in-depth.
+ */
+const ALLOWED_REDIRECT_HOSTS: ReadonlyArray<string | RegExp> = [
+  "github.com",
+  /\.githubusercontent\.com$/,
+  /\.github\.com$/,
+];
+
+const DOWNLOAD_REQUEST_TIMEOUT_MS = 60_000;
+
+function isAllowedRedirectHost(host: string): boolean {
+  return ALLOWED_REDIRECT_HOSTS.some((pat) =>
+    typeof pat === "string" ? host === pat : pat.test(host)
+  );
 }
 
 async function openHttpsStream(
@@ -267,6 +342,7 @@ async function openHttpsStream(
           "User-Agent": "dispatch-update-client",
           Accept: "application/octet-stream",
         },
+        timeout: DOWNLOAD_REQUEST_TIMEOUT_MS,
       },
       (res) => {
         const status = res.statusCode ?? 0;
@@ -279,8 +355,38 @@ async function openHttpsStream(
             reject(new Error(`Too many redirects fetching ${url}`));
             return;
           }
+          let nextUrl: URL;
+          try {
+            nextUrl = new URL(res.headers.location, url);
+          } catch {
+            res.resume();
+            reject(
+              new Error(
+                `Invalid redirect target from ${url}: ${String(res.headers.location)}`
+              )
+            );
+            return;
+          }
+          if (nextUrl.protocol !== "https:") {
+            res.resume();
+            reject(
+              new Error(
+                `Refusing non-https redirect from ${url} to ${nextUrl.toString()}`
+              )
+            );
+            return;
+          }
+          if (!isAllowedRedirectHost(nextUrl.hostname)) {
+            res.resume();
+            reject(
+              new Error(
+                `Refusing redirect from ${url} to disallowed host ${nextUrl.hostname}`
+              )
+            );
+            return;
+          }
           res.resume();
-          openHttpsStream(res.headers.location, redirectsRemaining - 1).then(
+          openHttpsStream(nextUrl.toString(), redirectsRemaining - 1).then(
             resolve,
             reject
           );
@@ -299,6 +405,13 @@ async function openHttpsStream(
         resolve({ stream: res, totalBytes });
       }
     );
+    req.on("timeout", () => {
+      req.destroy(
+        new Error(
+          `Request timed out after ${DOWNLOAD_REQUEST_TIMEOUT_MS}ms fetching ${url}`
+        )
+      );
+    });
     req.on("error", reject);
     req.end();
   });

--- a/apps/server/src/release-tarball-cache.ts
+++ b/apps/server/src/release-tarball-cache.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import { mkdir, mkdtemp, readFile, rename, rm, stat } from "node:fs/promises";
 import { readdir, unlink } from "node:fs/promises";
@@ -74,9 +75,22 @@ export async function readCachedTarball(
 }
 
 /**
+ * Per-tag in-flight download promises. `release/info` polls, `release/update`
+ * gate evaluation, and `release/assisted/launch` can all call
+ * `ensureCachedTarball` for the same tag concurrently. Without coalescing,
+ * each one races on the same `<final>.partial` path and an `rm` from one
+ * caller can blow away another caller's in-flight download. A singleflight
+ * map keyed by tag collapses concurrent calls into one download; everyone
+ * else awaits the same promise. Per-caller random partial filenames are
+ * defense-in-depth so a stray rm can't corrupt an in-flight write even if
+ * two processes (or a future multi-process arrangement) bypass the map.
+ */
+const inflightDownloads = new Map<string, Promise<CachedReleaseTarball>>();
+
+/**
  * Ensure a release tarball for `tag` is on disk in the cache. Downloads it
- * if missing. Idempotent — returns the cached entry without re-downloading
- * when the file is already present.
+ * if missing. Idempotent and concurrency-safe — concurrent callers for the
+ * same tag share one download.
  */
 export async function ensureCachedTarball(input: {
   tag: string;
@@ -90,43 +104,67 @@ export async function ensureCachedTarball(input: {
     return existing;
   }
 
-  await mkdir(cacheDir(), { recursive: true });
-  const finalPath = cachedTarballPath(tag);
-  const partialPath = `${finalPath}.partial`;
-  // If a previous attempt left a partial behind, remove it so we don't
-  // resume into a half-downloaded file with the wrong size.
-  await rm(partialPath, { force: true }).catch(() => {});
-
-  const url = releaseDownloadUrl(repo, tag);
-  onProgress?.({ message: `==> downloading ${url}` });
-
-  try {
-    await downloadToFile({
-      url,
-      destination: partialPath,
-      onProgress: (bytes, totalBytes) => {
-        onProgress?.({
-          message: `downloaded ${formatBytes(bytes)}`,
-          bytesReceived: bytes,
-          totalBytes,
-        });
-      },
+  // If a download is already in flight for this tag, wait on it. The
+  // first caller's progress hook gets the byte counts; subsequent
+  // callers just see the final result. That's fine: the UI render is
+  // gated on the cache file existing, not on per-caller progress.
+  const inflight = inflightDownloads.get(tag);
+  if (inflight) {
+    onProgress?.({
+      message: `awaiting in-flight download of ${RELEASE_ARTIFACT_NAME} for ${tag}`,
     });
-  } catch (err) {
-    // Make sure we don't leave an orphaned `.partial` for the next call to
-    // resume from — that would conflict with the rm-then-write contract
-    // above, and a future "size > 0" cache check could mistake it for a
-    // canonical cache entry on a filesystem that lost the rename atomicity.
-    await rm(partialPath, { force: true }).catch(() => {});
-    throw err;
+    return inflight;
   }
 
-  // Atomic-publish the cache entry: a partial file must never be observable
-  // as the canonical cache. rename() on the same filesystem is atomic.
-  await rename(partialPath, finalPath);
+  const downloadPromise = (async () => {
+    await mkdir(cacheDir(), { recursive: true });
+    const finalPath = cachedTarballPath(tag);
+    // Per-caller partial filename so two writers can never trip over the
+    // same path. The atomic-rename below adopts the first one to finish;
+    // any later partial files are unlinked on success.
+    const partialPath = `${finalPath}.partial.${process.pid}.${randomBytes(4).toString("hex")}`;
 
-  const info = await stat(finalPath);
-  return { tag, path: finalPath, bytes: info.size };
+    const url = releaseDownloadUrl(repo, tag);
+    onProgress?.({ message: `==> downloading ${url}` });
+
+    try {
+      await downloadToFile({
+        url,
+        destination: partialPath,
+        onProgress: (bytes, totalBytes) => {
+          onProgress?.({
+            message: `downloaded ${formatBytes(bytes)}`,
+            bytesReceived: bytes,
+            totalBytes,
+          });
+        },
+      });
+    } catch (err) {
+      await rm(partialPath, { force: true }).catch(() => {});
+      throw err;
+    }
+
+    // Atomic-publish the cache entry. If another writer beat us to it
+    // (two callers somehow bypassed the inflight map), rename will
+    // overwrite their published file with ours — both came from the
+    // same upstream URL and verified Content-Length, so the overwrite
+    // is content-identical and harmless.
+    await rename(partialPath, finalPath);
+
+    const info = await stat(finalPath);
+    return { tag, path: finalPath, bytes: info.size };
+  })();
+
+  inflightDownloads.set(tag, downloadPromise);
+  try {
+    return await downloadPromise;
+  } finally {
+    // Clear the entry on both success AND failure. On failure the next
+    // caller gets a fresh attempt rather than re-awaiting the rejected
+    // promise; on success the cache file is canonical and future calls
+    // hit the readCachedTarball fast path before reaching this map.
+    inflightDownloads.delete(tag);
+  }
 }
 
 /**

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2317,6 +2317,12 @@ async function registerRoutes() {
       }
       const assistedRequired =
         pendingMigrations.length > 0 ||
+        // Fail closed when migration evaluation errored: we don't actually
+        // know whether the target ships migrations, so the UI must gate
+        // the one-click button. The /release/update endpoint will return
+        // 503 if invoked anyway. Pair this with `migrationsError` in the
+        // response so the UI can surface the underlying failure.
+        (migrationsError !== null && updateAvailable) ||
         // Transitional fallback: a release authored with the legacy
         // `dispatch-update` block but without migration manifests should
         // still gate. Drop this branch once every gated release ships
@@ -2624,8 +2630,14 @@ async function registerRoutes() {
     if (!releaseUpdateAgentId) {
       const installed = await readReleaseStore().catch(() => null);
 
-      let pendingMigrationsForGate: PendingMigrationSummary[] = [];
-      let migrationGateEvaluatorError: string | null = null;
+      // Fail closed when migrations can't be evaluated. If we can't read
+      // `update-migrations/*` from the target tarball we don't actually
+      // know whether the target ships migrations — falling through to
+      // the legacy gate would let a transient network error bypass a
+      // mandatory assisted update once the legacy fence is removed
+      // (issue step 8). 503 is the right shape: the operator can retry
+      // when the underlying issue (download, extraction, parse) clears.
+      let pendingMigrationsForGate: PendingMigrationSummary[];
       try {
         const repo = await getGitHubRepo();
         const evaluation = await evaluatePendingMigrations(tag, { repo });
@@ -2633,16 +2645,14 @@ async function registerRoutes() {
           toSummary(m.manifest)
         );
       } catch (err) {
-        // If migrations can't be evaluated (network, missing artifact,
-        // etc.) we conservatively fall through to the legacy gate rather
-        // than blocking a normal release on a transient evaluator failure.
-        // Log it so the operator can see when the gate was made on
-        // incomplete data — the silent fall-through used to be invisible.
-        migrationGateEvaluatorError =
-          err instanceof Error ? err.message : String(err);
+        const message = err instanceof Error ? err.message : String(err);
         console.warn(
-          `[release/update] migration gate evaluator failed for ${tag}, falling through to legacy gate: ${migrationGateEvaluatorError}`
+          `[release/update] migration evaluation failed for ${tag}: ${message}`
         );
+        return reply.code(503).send({
+          error: "MIGRATION_EVALUATION_UNAVAILABLE",
+          message: `Could not evaluate update migrations for ${tag}: ${message}. Retry once the underlying issue clears.`,
+        });
       }
       if (pendingMigrationsForGate.length > 0) {
         return reply.code(409).send({
@@ -2844,7 +2854,12 @@ async function registerRoutes() {
       });
 
       if (assistedState && assistedToken) {
-        await attachAssistedAgent(assistedToken, agent.id);
+        // First durable persistence of the assisted-update state. We
+        // intentionally don't write before createAgent succeeds — a
+        // half-completed launch would otherwise leave a phantom record
+        // on disk that rehydrateActiveAssistedJob() would resurrect on
+        // the next reconnect or process restart.
+        await attachAssistedAgent(assistedState, agent.id);
         const launchLog = [
           `==> assisted update launched for ${body.tag}`,
           `==> agent: ${agent.id}`,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -91,6 +91,7 @@ import {
   pruneCacheExcept,
   readCachedTarball,
   readMigrationsFromTarball,
+  unlinkCachedTarball,
 } from "./release-tarball-cache.js";
 import {
   loadUpdateMigrations,
@@ -1256,8 +1257,20 @@ async function deployFromArtifact(
   // Validate tarball contents before extraction — reject entries with path
   // traversal (../) or absolute paths. macOS bsdtar does NOT block these by
   // default, so this is a real risk if a compromised release artifact is uploaded.
+  // If the tarball itself is unreadable (truncated/corrupt), drop the cache
+  // entry so the next deploy re-downloads instead of looping on a bad file.
   appendReleaseLog(job, "==> validating artifact contents");
-  const listing = await runCommand("tar", ["tzf", cached.path]);
+  let listing: Awaited<ReturnType<typeof runCommand>>;
+  try {
+    listing = await runCommand("tar", ["tzf", cached.path]);
+  } catch (err) {
+    await unlinkCachedTarball(tag);
+    appendReleaseLog(
+      job,
+      `==> cache entry for ${tag} was corrupt — removed; next attempt will re-download`
+    );
+    throw err;
+  }
   const unsafeEntries = listing.stdout
     .split("\n")
     .filter((entry) => entry.startsWith("/") || entry.includes("../"));
@@ -1268,13 +1281,22 @@ async function deployFromArtifact(
   }
 
   appendReleaseLog(job, "==> extracting pre-built artifact");
-  await runCommand("tar", [
-    "xzf",
-    cached.path,
-    "--no-same-owner",
-    "-C",
-    serverDir,
-  ]);
+  try {
+    await runCommand("tar", [
+      "xzf",
+      cached.path,
+      "--no-same-owner",
+      "-C",
+      serverDir,
+    ]);
+  } catch (err) {
+    await unlinkCachedTarball(tag);
+    appendReleaseLog(
+      job,
+      `==> extraction failed for ${tag} — removed cache entry; next attempt will re-download`
+    );
+    throw err;
+  }
 
   appendReleaseLog(
     job,
@@ -2556,6 +2578,19 @@ async function registerRoutes() {
           .code(403)
           .send({ error: "Invalid assisted update token." });
       }
+      // Bind the bypass token to the tag the agent was launched for. Without
+      // this, a holder of the bearer token could deploy any tag (skipping
+      // the migration gate at line 2611) once the assisted job reaches a
+      // terminal phase, because the takeover check below only fires for
+      // active non-terminal jobs. Matching against `assisted-update.json`
+      // keeps the bypass scope honest: one agent, one tag.
+      const assistedState = await readAssistedUpdateState().catch(() => null);
+      if (assistedState && assistedState.tag !== tag) {
+        return reply.code(403).send({
+          error:
+            "Assisted update token is bound to a different tag. Launch a fresh assisted update for this tag.",
+        });
+      }
     }
 
     // Only one release/update at a time, with one carve-out: the assisted
@@ -2590,16 +2625,24 @@ async function registerRoutes() {
       const installed = await readReleaseStore().catch(() => null);
 
       let pendingMigrationsForGate: PendingMigrationSummary[] = [];
+      let migrationGateEvaluatorError: string | null = null;
       try {
         const repo = await getGitHubRepo();
         const evaluation = await evaluatePendingMigrations(tag, { repo });
         pendingMigrationsForGate = evaluation.pending.map((m) =>
           toSummary(m.manifest)
         );
-      } catch {
+      } catch (err) {
         // If migrations can't be evaluated (network, missing artifact,
         // etc.) we conservatively fall through to the legacy gate rather
         // than blocking a normal release on a transient evaluator failure.
+        // Log it so the operator can see when the gate was made on
+        // incomplete data — the silent fall-through used to be invisible.
+        migrationGateEvaluatorError =
+          err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[release/update] migration gate evaluator failed for ${tag}, falling through to legacy gate: ${migrationGateEvaluatorError}`
+        );
       }
       if (pendingMigrationsForGate.length > 0) {
         return reply.code(409).send({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3,10 +3,8 @@ import os from "node:os";
 import { spawn } from "node:child_process";
 import {
   mkdir,
-  mkdtemp,
   readFile,
   readdir,
-  rm,
   stat,
   unlink,
   writeFile,
@@ -88,6 +86,26 @@ import {
   type AssistedPhase,
   type AssistedUpdateState,
 } from "./assisted-update-store.js";
+import {
+  ensureCachedTarball,
+  pruneCacheExcept,
+  readCachedTarball,
+  readMigrationsFromTarball,
+} from "./release-tarball-cache.js";
+import {
+  loadUpdateMigrations,
+  type UpdateMigrationManifest,
+} from "./update-migrations.js";
+import {
+  appliedIdSet,
+  readAppliedMigrationsState,
+} from "./applied-migrations-store.js";
+import {
+  clearEvaluatorCache,
+  evaluatePendingMigrations,
+  toSummary,
+  type PendingMigrationSummary,
+} from "./update-migrations-evaluator.js";
 import { StreamManager } from "./stream-manager.js";
 import {
   SlackNotifier,
@@ -1198,19 +1216,16 @@ async function fetchLatestReleaseMetadata(
  * Try to deploy from a pre-built release tarball attached to the GitHub release.
  * Returns true on success, false if the artifact isn't available (caller falls
  * back to building from source).
+ *
+ * The tarball is fetched directly over HTTPS (no `gh release download`) and
+ * cached at `~/.dispatch/cache/release-<tag>.tar.gz`. The same cached file
+ * is reused by the assisted-update inspection path so we never download the
+ * same artifact twice.
  */
 async function deployFromArtifact(
   job: ReleaseJob,
   tag: string
 ): Promise<boolean> {
-  // Need gh CLI to download release assets
-  try {
-    await runCommand("gh", ["--version"]);
-  } catch {
-    appendReleaseLog(job, "gh CLI not available, skipping artifact download");
-    return false;
-  }
-
   let repo: string;
   try {
     repo = await getGitHubRepo();
@@ -1222,63 +1237,54 @@ async function deployFromArtifact(
     return false;
   }
 
-  // Use a random temp directory to avoid TOCTOU attacks on a predictable path
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-release-"));
-  const tarball = path.join(tmpDir, "release.tar.gz");
-
+  let cached: { path: string };
   try {
-    appendReleaseLog(job, `==> downloading release artifact for ${tag}`);
-    try {
-      await runCommand("gh", [
-        "release",
-        "download",
-        tag,
-        "--pattern",
-        "dispatch-release.tar.gz",
-        "--output",
-        tarball,
-        "--repo",
-        repo,
-      ]);
-    } catch {
-      appendReleaseLog(job, "no release artifact found for this tag");
-      return false;
-    }
-
-    appendReleaseLog(job, `==> checking out ${tag} (for version metadata)`);
-    await runCommand("git", ["-C", serverDir, "checkout", tag]);
-
-    // Validate tarball contents before extraction — reject entries with path
-    // traversal (../) or absolute paths. macOS bsdtar does NOT block these by
-    // default, so this is a real risk if a compromised release artifact is uploaded.
-    appendReleaseLog(job, "==> validating artifact contents");
-    const listing = await runCommand("tar", ["tzf", tarball]);
-    const unsafeEntries = listing.stdout
-      .split("\n")
-      .filter((entry) => entry.startsWith("/") || entry.includes("../"));
-    if (unsafeEntries.length > 0) {
-      throw new Error(
-        `Release artifact contains unsafe paths: ${unsafeEntries.slice(0, 5).join(", ")}`
-      );
-    }
-
-    appendReleaseLog(job, "==> extracting pre-built artifact");
-    await runCommand("tar", [
-      "xzf",
-      tarball,
-      "--no-same-owner",
-      "-C",
-      serverDir,
-    ]);
-
-    appendReleaseLog(
-      job,
-      "==> deployed from pre-built artifact (no build needed)"
-    );
-    return true;
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    cached = await ensureCachedTarball({
+      tag,
+      repo,
+      onProgress: ({ message }) => appendReleaseLog(job, message),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    appendReleaseLog(job, `release artifact download failed: ${message}`);
+    return false;
   }
+
+  appendReleaseLog(job, `==> checking out ${tag} (for version metadata)`);
+  await runCommand("git", ["-C", serverDir, "checkout", tag]);
+
+  // Validate tarball contents before extraction — reject entries with path
+  // traversal (../) or absolute paths. macOS bsdtar does NOT block these by
+  // default, so this is a real risk if a compromised release artifact is uploaded.
+  appendReleaseLog(job, "==> validating artifact contents");
+  const listing = await runCommand("tar", ["tzf", cached.path]);
+  const unsafeEntries = listing.stdout
+    .split("\n")
+    .filter((entry) => entry.startsWith("/") || entry.includes("../"));
+  if (unsafeEntries.length > 0) {
+    throw new Error(
+      `Release artifact contains unsafe paths: ${unsafeEntries.slice(0, 5).join(", ")}`
+    );
+  }
+
+  appendReleaseLog(job, "==> extracting pre-built artifact");
+  await runCommand("tar", [
+    "xzf",
+    cached.path,
+    "--no-same-owner",
+    "-C",
+    serverDir,
+  ]);
+
+  appendReleaseLog(
+    job,
+    "==> deployed from pre-built artifact (no build needed)"
+  );
+  // Drop cache entries for older tags now that we've successfully landed on
+  // this one — the only tarball we still need is the one we just deployed
+  // (kept in case the operator immediately re-runs the deploy).
+  await pruneCacheExcept([tag]);
+  return true;
 }
 
 function currentReleaseBinaryGlob(): string {
@@ -2260,10 +2266,40 @@ async function registerRoutes() {
           error: `Latest release has malformed assisted-update metadata: ${assistedMetadataError}`,
         });
       }
-      const assistedRequired = isAssistedUpdateRequired(
-        assistedMetadata,
-        currentTag
-      );
+
+      // Pending migrations come from the target release tarball. Migration
+      // gating supersedes the legacy release-scoped `assisted` metadata
+      // (CRU-146) — `assistedRequired` is now derived from the count of
+      // unapplied migrations in the target tag. The legacy `assisted`
+      // field stays in the response only for transitional compatibility.
+      let pendingMigrations: PendingMigrationSummary[] = [];
+      let migrationsError: string | null = null;
+      if (latestTag && updateAvailable) {
+        try {
+          const repo = await getGitHubRepo();
+          const evaluation = await evaluatePendingMigrations(latestTag, {
+            repo,
+          });
+          pendingMigrations = evaluation.pending.map((m) =>
+            toSummary(m.manifest)
+          );
+          if (evaluation.errors.length > 0) {
+            migrationsError = evaluation.errors
+              .map((e) => `${e.filename}: ${e.error}`)
+              .join("; ");
+          }
+        } catch (err) {
+          migrationsError =
+            err instanceof Error ? err.message : "migration evaluation failed";
+        }
+      }
+      const assistedRequired =
+        pendingMigrations.length > 0 ||
+        // Transitional fallback: a release authored with the legacy
+        // `dispatch-update` block but without migration manifests should
+        // still gate. Drop this branch once every gated release ships
+        // migrations instead of release-scoped metadata (issue step 8).
+        isAssistedUpdateRequired(assistedMetadata, currentTag);
 
       // Admin-only: unreleased commits on main.
       // Compare the absolute latest tag (across all channels) to main so
@@ -2327,6 +2363,8 @@ async function registerRoutes() {
         refMissing,
         assisted: assistedMetadata,
         assistedRequired,
+        pendingMigrations,
+        migrationsError,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -2541,14 +2579,37 @@ async function registerRoutes() {
       }
     }
 
-    // Gate: if the target release declares `mode: required`, the generic
-    // one-click path is not allowed for installs at or above `appliesFrom`.
-    // The UI must route the operator through the assisted-update agent
-    // launch instead. The launched agent itself bypasses this gate using
-    // its bearer token (releaseUpdateAgentId), so the recovery path still
-    // works once the assisted flow is in progress.
+    // Gate: if the target release ships unapplied migration manifests, or
+    // (transitionally) declares `mode: required` via legacy metadata, the
+    // generic one-click path is not allowed. The UI must route the
+    // operator through the assisted-update agent launch instead. The
+    // launched agent itself bypasses this gate using its bearer token
+    // (releaseUpdateAgentId), so the recovery path still works once the
+    // assisted flow is in progress.
     if (!releaseUpdateAgentId) {
       const installed = await readReleaseStore().catch(() => null);
+
+      let pendingMigrationsForGate: PendingMigrationSummary[] = [];
+      try {
+        const repo = await getGitHubRepo();
+        const evaluation = await evaluatePendingMigrations(tag, { repo });
+        pendingMigrationsForGate = evaluation.pending.map((m) =>
+          toSummary(m.manifest)
+        );
+      } catch {
+        // If migrations can't be evaluated (network, missing artifact,
+        // etc.) we conservatively fall through to the legacy gate rather
+        // than blocking a normal release on a transient evaluator failure.
+      }
+      if (pendingMigrationsForGate.length > 0) {
+        return reply.code(409).send({
+          error: "ASSISTED_UPDATE_REQUIRED",
+          message:
+            "This release has unapplied migrations. POST to /api/v1/release/assisted/launch instead.",
+          pendingMigrations: pendingMigrationsForGate,
+        });
+      }
+
       const targetMeta = await fetchReleaseMetadata(tag);
       const inspected = inspectAssistedUpdateMetadata(targetMeta?.body ?? null);
       if (inspected.state === "invalid") {
@@ -2639,13 +2700,42 @@ async function registerRoutes() {
           ? (worktreeLocationRaw as WorktreeLocation)
           : "sibling";
 
-      // Pull structured assisted-update metadata off the target release if
-      // the publisher attached one. This drives the framework's gated
-      // checks and structured-phase reporting, but is optional — the
-      // assisted flow still works for releases that don't declare it.
+      // Prefer the migration-driven path (CRU-146): load every pending
+      // migration manifest from the target tarball and pass them to the
+      // launched agent as one ordered plan. Fall back to the legacy
+      // release-scoped `dispatch-update` block if no migrations are
+      // pending — both paths land in the same `assisted-update.json`
+      // state and the same phase machinery.
+      let pendingMigrationManifests: UpdateMigrationManifest[] = [];
+      try {
+        const repo = await getGitHubRepo();
+        const evaluation = await evaluatePendingMigrations(body.tag, { repo });
+        if (evaluation.errors.length > 0) {
+          return reply.code(409).send({
+            error: "ASSISTED_UPDATE_MIGRATIONS_INVALID",
+            message: `Target release has malformed migration manifests: ${evaluation.errors
+              .map((e) => `${e.filename}: ${e.error}`)
+              .join("; ")}`,
+          });
+        }
+        pendingMigrationManifests = evaluation.pending.map((m) => m.manifest);
+      } catch (err) {
+        // Evaluator failures (download error, missing artifact for an
+        // older release, etc.) shouldn't kill the launch — fall through
+        // to the legacy `dispatch-update` body fence so older gated
+        // releases keep working.
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[release/assisted/launch] migration evaluation failed for ${body.tag}, falling back to legacy metadata: ${message}`
+        );
+      }
+
       const targetMeta = await fetchReleaseMetadata(body.tag);
       const inspected = inspectAssistedUpdateMetadata(targetMeta?.body ?? null);
-      if (inspected.state === "invalid") {
+      if (
+        pendingMigrationManifests.length === 0 &&
+        inspected.state === "invalid"
+      ) {
         return reply.code(409).send({
           error: "ASSISTED_UPDATE_METADATA_INVALID",
           message: `Target release has malformed assisted-update metadata: ${inspected.error}`,
@@ -2656,19 +2746,26 @@ async function registerRoutes() {
       let assistedState: AssistedUpdateState | null = null;
       let assistedToken: string | null = null;
       let initialPrompt: string;
-      if (assistedMeta) {
+      if (pendingMigrationManifests.length > 0 || assistedMeta) {
         // The launched agent runs on the same host as the server, so we
         // build the phase-callback URL from server config rather than the
         // inbound request's Host header (which is attacker-controllable
         // for non-browser clients). The framework prompt subsumes the
         // recovery skeleton — it's the canonical instruction set when a
-        // release declares assisted-update metadata.
+        // release declares migrations or legacy metadata.
         const baseUrl = dispatchBaseUrl();
         const ctx = await buildAssistedUpdateContext(
           {
             tag: body.tag,
             fromTag: record?.tag ?? null,
-            metadata: assistedMeta,
+            migrations:
+              pendingMigrationManifests.length > 0
+                ? pendingMigrationManifests
+                : undefined,
+            metadata:
+              pendingMigrationManifests.length === 0 && assistedMeta
+                ? assistedMeta
+                : undefined,
             serverDir,
             recovery: {
               serviceCommand: defaultServiceRestartCommand(),
@@ -2683,9 +2780,9 @@ async function registerRoutes() {
         assistedToken = ctx.state.token;
         initialPrompt = ctx.prompt;
       } else {
-        // No metadata — fall back to the legacy recovery skeleton. This
-        // keeps the existing manual-rescue flow for releases that don't
-        // opt into the framework.
+        // No migrations and no legacy metadata — fall back to the legacy
+        // recovery skeleton. This keeps the existing manual-rescue flow
+        // for releases that don't opt into the framework.
         initialPrompt = buildAssistedUpdatePrompt({
           tag: body.tag,
           currentTag: record?.tag ?? null,
@@ -2705,16 +2802,25 @@ async function registerRoutes() {
 
       if (assistedState && assistedToken) {
         await attachAssistedAgent(assistedToken, agent.id);
+        const launchLog = [
+          `==> assisted update launched for ${body.tag}`,
+          `==> agent: ${agent.id}`,
+        ];
+        if (pendingMigrationManifests.length > 0) {
+          launchLog.push(
+            `==> migrations: ${pendingMigrationManifests
+              .map((m) => m.id)
+              .join(", ")}`
+          );
+        } else if (assistedMeta) {
+          launchLog.push(`==> mode: ${assistedMeta.mode}`);
+        }
         const job: ReleaseJob = {
           jobType: "update-assisted",
           versionType: null,
           phase: "inspect",
           startedAt: new Date().toISOString(),
-          log: [
-            `==> assisted update launched for ${body.tag}`,
-            `==> agent: ${agent.id}`,
-            `==> mode: ${assistedMeta!.mode}`,
-          ],
+          log: launchLog,
           runUrl: null,
           tag: body.tag,
           error: null,

--- a/apps/server/src/update-migrations-evaluator.ts
+++ b/apps/server/src/update-migrations-evaluator.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  ensureCachedTarball,
+  readMigrationsFromTarball,
+} from "./release-tarball-cache.js";
+import {
+  appliedIdSet,
+  readAppliedMigrationsState,
+} from "./applied-migrations-store.js";
+import {
+  filterPending,
+  loadUpdateMigrations,
+  parseManifest,
+  type UpdateMigrationFile,
+  type UpdateMigrationLoadError,
+  type UpdateMigrationManifest,
+} from "./update-migrations.js";
+
+/**
+ * Evaluator that turns a target release tag into the ordered list of
+ * migrations the local install still needs to apply. Wraps the tarball
+ * cache + manifest loader + applied-state store so the rest of the server
+ * code only knows about "pending migrations for tag X" (CRU-146).
+ *
+ * Result memoized in-process by tag so a flurry of `release/info` polls
+ * doesn't re-extract the tarball N times. Tags are immutable on GitHub so
+ * a stale entry never causes correctness issues — the only invalidation
+ * point is "we just marked migrations applied", which clears the cache.
+ */
+
+export type PendingMigrationsResult = {
+  /** Ordered list of pending migration files for the target tag. */
+  pending: UpdateMigrationFile[];
+  /** Every migration manifest present at the target tag (including applied). */
+  all: UpdateMigrationFile[];
+  /** Manifest IDs already recorded as applied locally. */
+  appliedIds: Set<string>;
+  /** Per-file load/parse errors. Surfacing these at the API boundary lets
+   *  the operator see what's broken without requiring server logs. */
+  errors: UpdateMigrationLoadError[];
+};
+
+export type EvaluatorContext = {
+  /** GitHub repo slug ("owner/repo") used to fetch the tarball. */
+  repo: string;
+  /** Optional progress hook — same shape as the cache's onProgress. */
+  onProgress?: (info: {
+    message: string;
+    bytesReceived?: number;
+    totalBytes?: number | null;
+  }) => void;
+};
+
+const cache = new Map<string, PendingMigrationsResult>();
+
+/**
+ * Evaluate pending migrations for a target tag. Downloads + caches the
+ * release tarball if it isn't already present.
+ */
+export async function evaluatePendingMigrations(
+  tag: string,
+  ctx: EvaluatorContext
+): Promise<PendingMigrationsResult> {
+  const memo = cache.get(tag);
+  if (memo) return memo;
+
+  const cached = await ensureCachedTarball({
+    tag,
+    repo: ctx.repo,
+    onProgress: ctx.onProgress,
+  });
+
+  const files = await readMigrationsFromTarball(cached.path);
+
+  // Reuse the on-disk loader for parsing+ordering by writing the in-memory
+  // contents to a temp dir. Keeps a single source of truth for filename
+  // pattern matching and ordering rules; the perf cost is one mkdir +
+  // small file writes per uncached tag.
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "dispatch-migration-eval-")
+  );
+  try {
+    for (const f of files) {
+      await writeFile(path.join(tmpDir, f.filename), f.contents, "utf-8");
+    }
+    const loaded = await loadUpdateMigrations(tmpDir);
+    const state = await readAppliedMigrationsState();
+    const ids = appliedIdSet(state);
+    const result: PendingMigrationsResult = {
+      all: loaded.migrations,
+      pending: filterPending(loaded.migrations, ids),
+      appliedIds: ids,
+      errors: loaded.errors,
+    };
+    cache.set(tag, result);
+    return result;
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Evaluate pending migrations from raw manifest contents (no tarball).
+ * Used by tests and any callers that already have manifest YAML in hand.
+ */
+export function evaluateFromManifests(
+  files: ReadonlyArray<{ filename: string; contents: string }>,
+  appliedIds: ReadonlySet<string>
+): PendingMigrationsResult {
+  const MANIFEST_FILE_RE = /^(\d+)-([a-z0-9][a-z0-9-]*)\.ya?ml$/i;
+  const matched = files
+    .map((f) => {
+      const m = MANIFEST_FILE_RE.exec(f.filename);
+      if (!m) return null;
+      return {
+        filename: f.filename,
+        order: Number(m[1]),
+        contents: f.contents,
+      };
+    })
+    .filter(
+      (x): x is { filename: string; order: number; contents: string } =>
+        x !== null
+    )
+    .sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      return a.filename.localeCompare(b.filename);
+    });
+
+  const all: UpdateMigrationFile[] = [];
+  const errors: UpdateMigrationLoadError[] = [];
+  const seen = new Map<string, string>();
+  for (const { filename, order, contents } of matched) {
+    const parsed = parseManifest(contents);
+    if (!parsed.success) {
+      errors.push({ filename, error: parsed.error });
+      continue;
+    }
+    const prior = seen.get(parsed.data.id);
+    if (prior) {
+      errors.push({
+        filename,
+        error: `duplicate migration id "${parsed.data.id}" (also defined in ${prior})`,
+      });
+      continue;
+    }
+    seen.set(parsed.data.id, filename);
+    all.push({ filename, order, manifest: parsed.data });
+  }
+
+  return {
+    all,
+    pending: filterPending(all, appliedIds),
+    appliedIds: new Set(appliedIds),
+    errors,
+  };
+}
+
+/**
+ * Drop memoized results — call this after marking migrations applied so the
+ * next `release/info` poll picks up the new state.
+ */
+export function clearEvaluatorCache(): void {
+  cache.clear();
+}
+
+export type PendingMigrationSummary = {
+  id: string;
+  title: string;
+  summary: string;
+};
+
+export function toSummary(
+  manifest: UpdateMigrationManifest
+): PendingMigrationSummary {
+  return {
+    id: manifest.id,
+    title: manifest.title,
+    summary: manifest.summary,
+  };
+}

--- a/apps/server/src/update-migrations.ts
+++ b/apps/server/src/update-migrations.ts
@@ -1,0 +1,169 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { REQUIRED_CHECK_NAMES } from "./release-metadata.js";
+
+/**
+ * Persistent install-update migration manifest. Migrations live in
+ * `update-migrations/*.yaml` in the source repo, ship inside the release
+ * tarball, and are append-only across release history. The runtime evaluates
+ * which manifests in a target release have not been applied locally to
+ * decide whether assisted update is required (CRU-146).
+ */
+
+const MANIFEST_FILE_RE = /^(\d+)-([a-z0-9][a-z0-9-]*)\.ya?ml$/i;
+
+const RequiredCheckSchema = z.enum(REQUIRED_CHECK_NAMES);
+
+export const UpdateMigrationManifestSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .regex(
+      /^[a-z0-9][a-z0-9-]*$/,
+      "id must be lowercase letters, digits, and hyphens"
+    ),
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  alreadySatisfied: z.object({
+    description: z.string().min(1),
+  }),
+  instructions: z.array(z.string().min(1)).min(1),
+  validation: z.object({
+    requiredChecks: z.array(RequiredCheckSchema).default([]),
+  }),
+  rollback: z.array(z.string().min(1)).default([]),
+});
+
+export type UpdateMigrationManifest = z.infer<
+  typeof UpdateMigrationManifestSchema
+>;
+
+export type UpdateMigrationFile = {
+  /** Filename only (e.g. "0001-bun-cutover.yaml"). */
+  filename: string;
+  /** Numeric prefix used for ordering. */
+  order: number;
+  /** Parsed + validated manifest body. */
+  manifest: UpdateMigrationManifest;
+};
+
+export type UpdateMigrationLoadError = {
+  filename: string;
+  error: string;
+};
+
+export type UpdateMigrationLoadResult = {
+  migrations: UpdateMigrationFile[];
+  errors: UpdateMigrationLoadError[];
+};
+
+/**
+ * List + parse every migration manifest in a directory. Files are sorted by
+ * the numeric prefix in their filename so insertion order in the issue spec
+ * (0001-…, 0002-…) survives across deploys. Files that don't match the
+ * `<NNNN>-<id>.yaml` shape are ignored. Parse/validation errors are reported
+ * as `errors` rather than thrown so the caller can surface them per-file.
+ */
+export async function loadUpdateMigrations(
+  dir: string
+): Promise<UpdateMigrationLoadResult> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return { migrations: [], errors: [] };
+    }
+    throw err;
+  }
+
+  const matched = entries
+    .map((filename) => {
+      const m = MANIFEST_FILE_RE.exec(filename);
+      if (!m) return null;
+      return { filename, order: Number(m[1]) };
+    })
+    .filter((x): x is { filename: string; order: number } => x !== null)
+    .sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      return a.filename.localeCompare(b.filename);
+    });
+
+  const migrations: UpdateMigrationFile[] = [];
+  const errors: UpdateMigrationLoadError[] = [];
+  const seenIds = new Map<string, string>();
+
+  for (const { filename, order } of matched) {
+    const filePath = path.join(dir, filename);
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf-8");
+    } catch (err) {
+      errors.push({
+        filename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    const parsed = parseManifest(raw);
+    if (!parsed.success) {
+      errors.push({ filename, error: parsed.error });
+      continue;
+    }
+
+    const prior = seenIds.get(parsed.data.id);
+    if (prior) {
+      errors.push({
+        filename,
+        error: `duplicate migration id "${parsed.data.id}" (also defined in ${prior})`,
+      });
+      continue;
+    }
+    seenIds.set(parsed.data.id, filename);
+
+    migrations.push({ filename, order, manifest: parsed.data });
+  }
+
+  return { migrations, errors };
+}
+
+export function parseManifest(
+  raw: string
+):
+  | { success: true; data: UpdateMigrationManifest }
+  | { success: false; error: string } {
+  let yamlValue: unknown;
+  try {
+    yamlValue = parseYaml(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, error: `YAML parse error: ${message}` };
+  }
+
+  const result = UpdateMigrationManifestSchema.safeParse(yamlValue);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const where = issue?.path.length ? issue.path.join(".") : "<root>";
+    return {
+      success: false,
+      error: `manifest schema mismatch at ${where}: ${issue?.message ?? "invalid value"}`,
+    };
+  }
+
+  return { success: true, data: result.data };
+}
+
+/**
+ * Filter loaded migrations down to those whose IDs are not yet in
+ * `appliedIds`. Preserves load order (already sorted by filename prefix).
+ */
+export function filterPending(
+  migrations: UpdateMigrationFile[],
+  appliedIds: ReadonlySet<string>
+): UpdateMigrationFile[] {
+  return migrations.filter((m) => !appliedIds.has(m.manifest.id));
+}

--- a/apps/server/test/applied-migrations-store.test.ts
+++ b/apps/server/test/applied-migrations-store.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Each test gets its own store path so we can run them in parallel without
+// stepping on a shared file. The module reads the env var lazily on every
+// call, so we can rebind per test.
+let testDir: string;
+let storePath: string;
+
+async function importStore() {
+  // Re-import to ensure the env var is picked up. Vitest caches modules,
+  // but reading APPLIED_MIGRATIONS_STORE_PATH from a getter at call time
+  // means we don't need to reset the cache.
+  return await import("../src/applied-migrations-store.js");
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-applied-mig-"));
+  storePath = path.join(testDir, "applied-migrations.json");
+  process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH = storePath;
+});
+
+afterEach(async () => {
+  delete process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH;
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe("applied-migrations-store", () => {
+  it("returns empty state when no file exists yet", async () => {
+    const { readAppliedMigrationsState } = await importStore();
+    const state = await readAppliedMigrationsState();
+    expect(state).toEqual({ appliedMigrations: {} });
+  });
+
+  it("marks new migrations applied with timestamp + targetTag", async () => {
+    const { markMigrationsApplied, readAppliedMigrationsState } =
+      await importStore();
+    const fixedNow = new Date("2026-04-27T14:12:00Z");
+    await markMigrationsApplied(["bun-cutover"], "v0.18.13", () => fixedNow);
+    const state = await readAppliedMigrationsState();
+    expect(state.appliedMigrations["bun-cutover"]).toEqual({
+      appliedAt: "2026-04-27T14:12:00.000Z",
+      targetTag: "v0.18.13",
+    });
+  });
+
+  it("is idempotent — re-marking an applied id does not overwrite the timestamp", async () => {
+    const { markMigrationsApplied, readAppliedMigrationsState } =
+      await importStore();
+    const first = new Date("2026-04-27T14:12:00Z");
+    const second = new Date("2026-05-01T00:00:00Z");
+    await markMigrationsApplied(["bun-cutover"], "v0.18.13", () => first);
+    await markMigrationsApplied(
+      ["bun-cutover", "second-mig"],
+      "v0.19.0",
+      () => second
+    );
+    const state = await readAppliedMigrationsState();
+    expect(state.appliedMigrations["bun-cutover"]?.targetTag).toBe("v0.18.13");
+    expect(state.appliedMigrations["bun-cutover"]?.appliedAt).toBe(
+      "2026-04-27T14:12:00.000Z"
+    );
+    expect(state.appliedMigrations["second-mig"]?.targetTag).toBe("v0.19.0");
+  });
+
+  it("persists atomically (no .tmp file left behind on success)", async () => {
+    const { markMigrationsApplied } = await importStore();
+    await markMigrationsApplied(["mig"], "v1.0.0");
+    const written = await readFile(storePath, "utf-8");
+    expect(written).toContain('"mig"');
+    // The atomic-rename helper writes to <path>.tmp then renames; success
+    // case must leave only the canonical file.
+    let tmpExists = true;
+    try {
+      await readFile(`${storePath}.tmp`, "utf-8");
+    } catch {
+      tmpExists = false;
+    }
+    expect(tmpExists).toBe(false);
+  });
+
+  it("appliedIdSet returns the id key set", async () => {
+    const { appliedIdSet, markMigrationsApplied, readAppliedMigrationsState } =
+      await importStore();
+    await markMigrationsApplied(["a", "b"], "v1.0.0");
+    const ids = appliedIdSet(await readAppliedMigrationsState());
+    expect([...ids].sort()).toEqual(["a", "b"]);
+  });
+
+  it("returns empty state for malformed JSON instead of throwing", async () => {
+    const { readAppliedMigrationsState } = await importStore();
+    const fs = await import("node:fs/promises");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, "{not valid json", "utf-8");
+    const state = await readAppliedMigrationsState();
+    expect(state).toEqual({ appliedMigrations: {} });
+  });
+});

--- a/apps/server/test/applied-migrations-store.test.ts
+++ b/apps/server/test/applied-migrations-store.test.ts
@@ -97,4 +97,47 @@ describe("applied-migrations-store", () => {
     const state = await readAppliedMigrationsState();
     expect(state).toEqual({ appliedMigrations: {} });
   });
+
+  it("serializes overlapping markMigrationsApplied calls so neither drops ids", async () => {
+    // Round-1 infra-review #1243: without the per-process serialization
+    // chain, two read-modify-write cycles racing on the same store can
+    // each read the pre-write state, both build their own next state,
+    // and the loser's rename clobbers the winner's ids. Fire two
+    // concurrent calls with disjoint ids and verify both make it.
+    const { markMigrationsApplied, readAppliedMigrationsState } =
+      await importStore();
+    const [s1, s2] = await Promise.all([
+      markMigrationsApplied(["a", "b"], "v1.0.0"),
+      markMigrationsApplied(["c", "d"], "v1.0.0"),
+    ]);
+    // Both calls should observe the union of ids — whichever ran first
+    // populated a-b, and the second cycle read that and added c-d on top.
+    const merged = (s2.appliedMigrations.a ? s2 : s1).appliedMigrations;
+    expect(Object.keys(merged).sort()).toEqual(["a", "b", "c", "d"]);
+
+    const final = await readAppliedMigrationsState();
+    expect(Object.keys(final.appliedMigrations).sort()).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("uses a unique tmp filename so concurrent writers don't race on the same .tmp", async () => {
+    // Round-1 infra-review #1243: two writers both staging to a fixed
+    // `<final>.tmp` would race — one rename moves the shared tmp out
+    // from under the other and surfaces as ENOENT. The fix uses a
+    // per-call `<final>.tmp.<pid>.<rand>` so each writer owns its own
+    // staging file. Verified structurally: no shared `.tmp` constant
+    // ever appears in the cache dir during a write storm.
+    const { markMigrationsApplied } = await importStore();
+    const fs = await import("node:fs/promises");
+    const ids = Array.from({ length: 8 }, (_, i) => `mig-${i}`);
+    await Promise.all(ids.map((id) => markMigrationsApplied([id], "v1.0.0")));
+    const dir = path.dirname(storePath);
+    const entries = await fs.readdir(dir).catch(() => [] as string[]);
+    // No leftover .tmp files (they're renamed atomically into place).
+    expect(entries.filter((e) => e.includes(".tmp"))).toEqual([]);
+  });
 });

--- a/apps/server/test/assisted-update-migrations.test.ts
+++ b/apps/server/test/assisted-update-migrations.test.ts
@@ -1,0 +1,255 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateMigrationManifest } from "../src/update-migrations.js";
+
+let testDir: string;
+let appliedStorePath: string;
+let assistedStorePath: string;
+
+async function importEverything() {
+  return {
+    assisted: await import("../src/assisted-update.js"),
+    store: await import("../src/assisted-update-store.js"),
+    applied: await import("../src/applied-migrations-store.js"),
+    evaluator: await import("../src/update-migrations-evaluator.js"),
+  };
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(path.join(os.tmpdir(), "dispatch-assisted-mig-"));
+  appliedStorePath = path.join(testDir, "applied-migrations.json");
+  assistedStorePath = path.join(testDir, "assisted-update.json");
+  process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH = appliedStorePath;
+  // assisted-update-store doesn't have an env override yet, so we mock
+  // the path module if needed. For this suite we test the orchestrator
+  // logic against module-loaded path; clear state by rming the file.
+  await rm(assistedStorePath, { force: true }).catch(() => {});
+});
+
+afterEach(async () => {
+  delete process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH;
+  await rm(testDir, { recursive: true, force: true });
+});
+
+const RECOVERY = {
+  serviceCommand: "launchctl kickstart -k gui/501/com.dispatch.server",
+  healthEndpoint: "http://127.0.0.1:6767/api/v1/health",
+  serviceLogPath: "~/.dispatch/logs/dispatch.log",
+  failureLogPath: "~/.dispatch/logs/last-release-failure.log",
+};
+
+const MIGRATION = (id: string): UpdateMigrationManifest => ({
+  id,
+  title: `${id} migration`,
+  summary: `${id} summary`,
+  alreadySatisfied: { description: `${id} already satisfied` },
+  instructions: [`${id} step 1`, `${id} step 2`],
+  validation: {
+    requiredChecks:
+      id === "first" ? ["service_entrypoint"] : ["health_endpoint"],
+  },
+  rollback: [`${id} rollback step`],
+});
+
+describe("buildAssistedUpdateContext (migrations path)", () => {
+  it("snapshots migrations into state and computes the union of required checks", async () => {
+    const { assisted } = await importEverything();
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: "v0.18.12",
+        migrations: [MIGRATION("first"), MIGRATION("second")],
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+    expect(ctx.state.migrations?.map((m) => m.id)).toEqual(["first", "second"]);
+    expect(ctx.state.metadata).toBeNull();
+    // Union: service_entrypoint from first + health_endpoint from second
+    expect(ctx.state.requiredChecks.sort()).toEqual([
+      "health_endpoint",
+      "service_entrypoint",
+    ]);
+    expect(ctx.state.phase).toBe("inspect");
+    expect(ctx.state.token.length).toBeGreaterThan(20);
+  });
+
+  it("dedupes overlapping required checks across migrations", async () => {
+    const { assisted } = await importEverything();
+    const overlap = (id: string): UpdateMigrationManifest => ({
+      ...MIGRATION(id),
+      validation: {
+        requiredChecks: ["health_endpoint", "service_entrypoint"],
+      },
+    });
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: null,
+        migrations: [overlap("a"), overlap("b")],
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+    expect(ctx.state.requiredChecks).toEqual([
+      "health_endpoint",
+      "service_entrypoint",
+    ]);
+  });
+
+  it("renders a per-migration prompt section for every pending manifest", async () => {
+    const { assisted } = await importEverything();
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: "v0.18.12",
+        migrations: [MIGRATION("first"), MIGRATION("second")],
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+    expect(ctx.prompt).toContain("Pending migrations");
+    expect(ctx.prompt).toContain("first migration");
+    expect(ctx.prompt).toContain("second migration");
+    expect(ctx.prompt).toContain("Already satisfied?");
+    expect(ctx.prompt).toContain("first already satisfied");
+    expect(ctx.prompt).toContain("first step 1");
+    expect(ctx.prompt).toContain("Rollback");
+    expect(ctx.prompt).toContain("first rollback step");
+    expect(ctx.prompt).toContain("Migration 1/2");
+    expect(ctx.prompt).toContain("Migration 2/2");
+    // Per-migration validation checks listed
+    expect(ctx.prompt).toMatch(/Validation checks for this migration/);
+  });
+
+  it("falls back to the legacy metadata path when no migrations are passed", async () => {
+    const { assisted } = await importEverything();
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: "v0.18.12",
+        metadata: {
+          mode: "required",
+          title: "Legacy block",
+          summary: "A legacy single-block release",
+          requiredChecks: ["health_endpoint"],
+        },
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+    expect(ctx.state.migrations).toBeNull();
+    expect(ctx.state.metadata?.title).toBe("Legacy block");
+    expect(ctx.state.requiredChecks).toEqual(["health_endpoint"]);
+    expect(ctx.prompt).toContain("Legacy block");
+    // Legacy header, not the migration header
+    expect(ctx.prompt).not.toContain("Pending migrations");
+  });
+
+  it("rejects a build with neither migrations nor metadata", async () => {
+    const { assisted } = await importEverything();
+    await expect(
+      assisted.buildAssistedUpdateContext(
+        {
+          tag: "v0.18.13",
+          fromTag: null,
+          serverDir: "/tmp/dispatch-test-server",
+          recovery: RECOVERY,
+        },
+        "http://127.0.0.1:6767"
+      )
+    ).rejects.toThrow(/migrations or metadata/);
+  });
+});
+
+describe("runAndRecordChecks (migrations path)", () => {
+  it("marks every pending migration applied when all checks pass", async () => {
+    const { assisted, applied } = await importEverything();
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: "v0.18.12",
+        migrations: [MIGRATION("first"), MIGRATION("second")],
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+
+    // Stub the check runner so we don't actually shell out to tar etc.
+    // The orchestrator path we want to verify is "all-pass → mark applied".
+    const releaseChecks = await import("../src/release-checks.js");
+    const runRequiredChecksSpy = vi
+      .spyOn(releaseChecks, "runRequiredChecks")
+      .mockResolvedValue(
+        ctx.state.requiredChecks.map((name) => ({
+          name,
+          ok: true,
+          message: `${name} passed`,
+        }))
+      );
+
+    try {
+      await assisted.runAndRecordChecks(ctx.state, {
+        serverDir: "/tmp/dispatch-test-server",
+        targetTag: "v0.18.13",
+      });
+    } finally {
+      runRequiredChecksSpy.mockRestore();
+    }
+
+    const state = await applied.readAppliedMigrationsState();
+    expect(Object.keys(state.appliedMigrations).sort()).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(state.appliedMigrations.first?.targetTag).toBe("v0.18.13");
+    expect(state.appliedMigrations.second?.targetTag).toBe("v0.18.13");
+  });
+
+  it("marks NO migrations applied when any check fails", async () => {
+    const { assisted, applied } = await importEverything();
+    const ctx = await assisted.buildAssistedUpdateContext(
+      {
+        tag: "v0.18.13",
+        fromTag: "v0.18.12",
+        migrations: [MIGRATION("first"), MIGRATION("second")],
+        serverDir: "/tmp/dispatch-test-server",
+        recovery: RECOVERY,
+      },
+      "http://127.0.0.1:6767"
+    );
+
+    const releaseChecks = await import("../src/release-checks.js");
+    const spy = vi.spyOn(releaseChecks, "runRequiredChecks").mockResolvedValue([
+      {
+        name: ctx.state.requiredChecks[0]!,
+        ok: false,
+        message: "synthetic failure",
+      },
+      ...ctx.state.requiredChecks.slice(1).map((name) => ({
+        name,
+        ok: true,
+        message: `${name} passed`,
+      })),
+    ]);
+
+    try {
+      await assisted.runAndRecordChecks(ctx.state, {
+        serverDir: "/tmp/dispatch-test-server",
+        targetTag: "v0.18.13",
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    const state = await applied.readAppliedMigrationsState();
+    expect(state.appliedMigrations).toEqual({});
+  });
+});

--- a/apps/server/test/assisted-update-store.test.ts
+++ b/apps/server/test/assisted-update-store.test.ts
@@ -68,3 +68,57 @@ describe("assisted-update-store transitions", () => {
     expect(isTerminalPhase("validate")).toBe(false);
   });
 });
+
+describe("writeAssistedUpdateState concurrent writes (CRU-146 #1242)", () => {
+  it("uses a unique tmp filename per write so concurrent writers don't race", async () => {
+    // Without the per-call `<final>.tmp.<pid>.<rand>`, two writers
+    // would both stage to the same shared tmp, and one rename could
+    // move it out from under the other (ENOENT or last-writer-wins
+    // state loss). Burst N concurrent writes; afterwards the only file
+    // in the dir should be the canonical store, with no .tmp orphans.
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "dispatch-assisted-store-")
+    );
+    const target = path.join(dir, "assisted-update.json");
+    process.env.DISPATCH_ASSISTED_UPDATE_STORE_PATH = target;
+    try {
+      const { writeAssistedUpdateState } =
+        await import("../src/assisted-update-store.js");
+
+      // Build N distinct states and write them all in flight at once.
+      // Whichever loses the rename race writes a different content,
+      // but no caller should hit ENOENT on its own .tmp file because
+      // every caller owns its own unique path.
+      const writes = Array.from({ length: 32 }, (_, i) =>
+        writeAssistedUpdateState({
+          tag: `v0.${i}.0`,
+          fromTag: null,
+          metadata: null,
+          migrations: null,
+          requiredChecks: [],
+          phase: "inspect",
+          token: `token-${i}`,
+          agentId: null,
+          startedAt: "2026-04-27T00:00:00Z",
+          updatedAt: "2026-04-27T00:00:00Z",
+          completedAt: null,
+          error: null,
+          checks: [],
+          notes: {},
+        })
+      );
+      await Promise.all(writes);
+
+      const entries = await fs.readdir(dir);
+      // Only the canonical file should remain — no .tmp orphans.
+      expect(entries.filter((e) => e.includes(".tmp"))).toEqual([]);
+      expect(entries).toContain("assisted-update.json");
+    } finally {
+      delete process.env.DISPATCH_ASSISTED_UPDATE_STORE_PATH;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/test/assisted-update.test.ts
+++ b/apps/server/test/assisted-update.test.ts
@@ -134,8 +134,12 @@ describe("buildAssistedUpdateContext", () => {
     expect(ctx.state.checks).toEqual([]);
     expect(ctx.state.notes).toEqual({});
     expect(ctx.state.token.length).toBeGreaterThanOrEqual(32); // base64url of 24 bytes
-    // The mock store should have captured the same record we got back.
+    // Build is in-memory only — the first durable write happens via
+    // attachAssistedAgent once the launched agent exists (CRU-146 #1241).
+    expect(lastPersistedState).toBeNull();
+    await attachAssistedAgent(ctx.state, "agt_first_attach");
     expect(lastPersistedState?.token).toBe(ctx.state.token);
+    expect(lastPersistedState?.agentId).toBe("agt_first_attach");
   });
 
   it("normalizes the requiredChecks down to a flat string list", async () => {
@@ -258,8 +262,11 @@ describe("buildAssistedUpdateContext", () => {
 });
 
 describe("applyAssistedPhase", () => {
+  // Helper: build + attach. The split-phase persistence (CRU-146 #1241)
+  // means downstream tests have to attach to get a durable record on
+  // disk before applyAssistedPhase / runAndRecordChecks can read it.
   async function seed() {
-    return buildAssistedUpdateContext(
+    const ctx = await buildAssistedUpdateContext(
       {
         tag: "v0.19.0",
         fromTag: "v0.18.1",
@@ -269,6 +276,8 @@ describe("applyAssistedPhase", () => {
       },
       "http://127.0.0.1:6767"
     );
+    await attachAssistedAgent(ctx.state, "agt_test");
+    return ctx;
   }
 
   it("returns ok=false when no state exists", async () => {
@@ -336,7 +345,10 @@ describe("applyAssistedPhase", () => {
 });
 
 describe("attachAssistedAgent", () => {
-  it("writes the agent id back to state on a valid token", async () => {
+  it("persists state with the agent id (first durable write)", async () => {
+    // Build returns state in memory only (no file written yet) — so
+    // before attach, lastPersistedState is null. That's the whole point
+    // of CRU-146 review #1241: a failed createAgent can't leak state.
     const ctx = await buildAssistedUpdateContext(
       {
         tag: "v0.19.0",
@@ -347,35 +359,21 @@ describe("attachAssistedAgent", () => {
       },
       "http://127.0.0.1:6767"
     );
-    const updated = await attachAssistedAgent(ctx.state.token, "agt_abc");
-    expect(updated?.agentId).toBe("agt_abc");
+    expect(lastPersistedState).toBeNull();
+
+    const updated = await attachAssistedAgent(ctx.state, "agt_abc");
+    expect(updated.agentId).toBe("agt_abc");
     expect(lastPersistedState?.agentId).toBe("agt_abc");
-  });
-
-  it("returns null on a token mismatch (constant-time compare)", async () => {
-    await buildAssistedUpdateContext(
-      {
-        tag: "v0.19.0",
-        fromTag: null,
-        metadata: minimalMetadata(),
-        serverDir: TEST_SERVER_DIR,
-        recovery: TEST_RECOVERY,
-      },
-      "http://127.0.0.1:6767"
-    );
-    const updated = await attachAssistedAgent("not-my-token", "agt_abc");
-    expect(updated).toBeNull();
-  });
-
-  it("returns null when no assisted update is in flight", async () => {
-    lastPersistedState = null;
-    const updated = await attachAssistedAgent("anything", "agt_abc");
-    expect(updated).toBeNull();
+    expect(lastPersistedState?.token).toBe(ctx.state.token);
   });
 });
 
 describe("runAndRecordChecks", () => {
-  it("records every check result in order", async () => {
+  // Build + persist via attach so applyAssistedPhase / runAndRecordChecks
+  // see a real on-disk record. Without this every test in this block
+  // would 404 (no active assisted update) under the split-phase
+  // persistence introduced in CRU-146 #1241.
+  async function seedAndAttach() {
     const ctx = await buildAssistedUpdateContext(
       {
         tag: "v0.19.0",
@@ -386,6 +384,12 @@ describe("runAndRecordChecks", () => {
       },
       "http://127.0.0.1:6767"
     );
+    await attachAssistedAgent(ctx.state, "agt_test");
+    return ctx;
+  }
+
+  it("records every check result in order", async () => {
+    const ctx = await seedAndAttach();
     stagedCheckResults = [
       { name: "service_restarted", ok: true, message: "ok" },
       { name: "version_converged", ok: true, message: "converged" },
@@ -402,16 +406,7 @@ describe("runAndRecordChecks", () => {
   });
 
   it("does NOT downgrade phase when every check passes", async () => {
-    const ctx = await buildAssistedUpdateContext(
-      {
-        tag: "v0.19.0",
-        fromTag: null,
-        metadata: minimalMetadata(),
-        serverDir: TEST_SERVER_DIR,
-        recovery: TEST_RECOVERY,
-      },
-      "http://127.0.0.1:6767"
-    );
+    const ctx = await seedAndAttach();
     // Move to validate first so the orchestrator sees a non-inspect
     // baseline phase.
     await applyAssistedPhase({ token: ctx.state.token, phase: "validate" });
@@ -428,16 +423,7 @@ describe("runAndRecordChecks", () => {
   });
 
   it("routes to blocked + sets error when any check fails", async () => {
-    const ctx = await buildAssistedUpdateContext(
-      {
-        tag: "v0.19.0",
-        fromTag: null,
-        metadata: minimalMetadata(),
-        serverDir: TEST_SERVER_DIR,
-        recovery: TEST_RECOVERY,
-      },
-      "http://127.0.0.1:6767"
-    );
+    const ctx = await seedAndAttach();
     await applyAssistedPhase({ token: ctx.state.token, phase: "validate" });
     const state = lastPersistedState!;
     stagedCheckResults = [
@@ -460,16 +446,7 @@ describe("runAndRecordChecks", () => {
   it("leaves a rollback / blocked terminal phase alone on failure", async () => {
     // If the agent already routed itself to rollback, a downstream
     // failure shouldn't overwrite that with `blocked`.
-    const ctx = await buildAssistedUpdateContext(
-      {
-        tag: "v0.19.0",
-        fromTag: null,
-        metadata: minimalMetadata(),
-        serverDir: TEST_SERVER_DIR,
-        recovery: TEST_RECOVERY,
-      },
-      "http://127.0.0.1:6767"
-    );
+    const ctx = await seedAndAttach();
     await applyAssistedPhase({
       token: ctx.state.token,
       phase: "rollback",

--- a/apps/server/test/pack-release.test.ts
+++ b/apps/server/test/pack-release.test.ts
@@ -73,6 +73,15 @@ describe.skipIf(!BUILDS_EXIST)("pack-release", () => {
     expect(tsFiles).toEqual([]);
   });
 
+  it("includes update-migrations directory when present in repo", () => {
+    const files = tarList();
+    const migrationDirExists = existsSync(
+      path.join(REPO_ROOT, "update-migrations")
+    );
+    if (!migrationDirExists) return;
+    expect(files.some((f) => f.startsWith("update-migrations/"))).toBe(true);
+  });
+
   it("fails when build outputs are missing", () => {
     // Create a temporary directory without build outputs
     const tmpDir = `/tmp/dispatch-pack-release-empty-${process.pid}`;

--- a/apps/server/test/release-flow-smoke.test.ts
+++ b/apps/server/test/release-flow-smoke.test.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * End-to-end-ish smoke covering: cache hit → tarball extraction → manifest
+ * parse → pending-migration evaluation → mark applied → re-evaluate sees
+ * the change. The download path is sidestepped by pre-populating the
+ * tarball cache, which exercises the full chain except the actual HTTPS
+ * request — that's covered by the production deploy flow.
+ */
+
+let testRoot: string;
+let cacheDir: string;
+let appliedStorePath: string;
+
+async function importAll() {
+  return {
+    cache: await import("../src/release-tarball-cache.js"),
+    applied: await import("../src/applied-migrations-store.js"),
+    evaluator: await import("../src/update-migrations-evaluator.js"),
+  };
+}
+
+const MIGRATION_YAML = (id: string) => `id: ${id}
+title: ${id} migration
+summary: ${id} summary text
+alreadySatisfied:
+  description: ${id} already-satisfied check description
+instructions:
+  - ${id} step 1
+  - ${id} step 2
+validation:
+  requiredChecks:
+    - service_entrypoint
+rollback:
+  - ${id} rollback
+`;
+
+beforeEach(async () => {
+  testRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-flow-smoke-"));
+  cacheDir = path.join(testRoot, "cache");
+  appliedStorePath = path.join(testRoot, "applied-migrations.json");
+  process.env.DISPATCH_RELEASE_CACHE_DIR = cacheDir;
+  process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH = appliedStorePath;
+});
+
+afterEach(async () => {
+  delete process.env.DISPATCH_RELEASE_CACHE_DIR;
+  delete process.env.DISPATCH_APPLIED_MIGRATIONS_STORE_PATH;
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+async function seedCacheTarball(
+  tag: string,
+  manifests: Array<{ filename: string; contents: string }>
+): Promise<string> {
+  const buildDir = await mkdtemp(path.join(testRoot, "build-"));
+  const migrationsDir = path.join(buildDir, "update-migrations");
+  await mkdir(migrationsDir, { recursive: true });
+  for (const m of manifests) {
+    await writeFile(path.join(migrationsDir, m.filename), m.contents, "utf-8");
+  }
+  const { cache } = await importAll();
+  const tarballPath = cache.cachedTarballPath(tag);
+  await mkdir(path.dirname(tarballPath), { recursive: true });
+  execFileSync(
+    "tar",
+    ["czf", tarballPath, "-C", buildDir, "update-migrations"],
+    { stdio: "pipe" }
+  );
+  return tarballPath;
+}
+
+describe("release flow smoke", () => {
+  it("evaluatePendingMigrations returns ordered manifests for a cached tarball", async () => {
+    const { evaluator } = await importAll();
+    await seedCacheTarball("v0.18.13", [
+      {
+        filename: "0001-bun-cutover.yaml",
+        contents: MIGRATION_YAML("bun-cutover"),
+      },
+      { filename: "0002-second.yaml", contents: MIGRATION_YAML("second") },
+    ]);
+    evaluator.clearEvaluatorCache();
+    const result = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(result.pending.map((m) => m.manifest.id)).toEqual([
+      "bun-cutover",
+      "second",
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("filters out migrations already recorded in applied-state", async () => {
+    const { applied, evaluator } = await importAll();
+    await seedCacheTarball("v0.18.13", [
+      { filename: "0001-first.yaml", contents: MIGRATION_YAML("first") },
+      { filename: "0002-second.yaml", contents: MIGRATION_YAML("second") },
+      { filename: "0003-third.yaml", contents: MIGRATION_YAML("third") },
+    ]);
+    await applied.markMigrationsApplied(["second"], "v0.18.12");
+
+    evaluator.clearEvaluatorCache();
+    const result = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(result.pending.map((m) => m.manifest.id)).toEqual([
+      "first",
+      "third",
+    ]);
+    expect(result.appliedIds.has("second")).toBe(true);
+  });
+
+  it("returns no pending after marking every migration applied + clearing memo", async () => {
+    const { applied, evaluator } = await importAll();
+    await seedCacheTarball("v0.18.13", [
+      { filename: "0001-first.yaml", contents: MIGRATION_YAML("first") },
+      { filename: "0002-second.yaml", contents: MIGRATION_YAML("second") },
+    ]);
+    evaluator.clearEvaluatorCache();
+    let result = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(result.pending.map((m) => m.manifest.id)).toEqual([
+      "first",
+      "second",
+    ]);
+
+    await applied.markMigrationsApplied(["first", "second"], "v0.18.13");
+    evaluator.clearEvaluatorCache();
+    result = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(result.pending).toEqual([]);
+  });
+
+  it("memoizes per-tag results until clearEvaluatorCache is called", async () => {
+    const { applied, evaluator } = await importAll();
+    await seedCacheTarball("v0.18.13", [
+      { filename: "0001-first.yaml", contents: MIGRATION_YAML("first") },
+    ]);
+    evaluator.clearEvaluatorCache();
+    const first = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(first.pending.length).toBe(1);
+
+    // Mark applied without clearing memo — second call should still see the
+    // pending migration because the cached result hasn't been invalidated.
+    await applied.markMigrationsApplied(["first"], "v0.18.13");
+    const second = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(second.pending.length).toBe(1);
+
+    // After clearing the memo, the next call re-reads applied-state and
+    // sees the migration is no longer pending.
+    evaluator.clearEvaluatorCache();
+    const third = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(third.pending.length).toBe(0);
+  });
+
+  it("returns evaluation errors for malformed manifests without dropping the rest", async () => {
+    const { evaluator } = await importAll();
+    await seedCacheTarball("v0.18.13", [
+      { filename: "0001-good.yaml", contents: MIGRATION_YAML("good") },
+      { filename: "0002-bad.yaml", contents: "not: [valid yaml" },
+    ]);
+    evaluator.clearEvaluatorCache();
+    const result = await evaluator.evaluatePendingMigrations("v0.18.13", {
+      repo: "owner/repo",
+    });
+    expect(result.pending.map((m) => m.manifest.id)).toEqual(["good"]);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]?.filename).toBe("0002-bad.yaml");
+  });
+});

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -21,13 +21,31 @@ import {
   teardownTestDb,
 } from "./db/setup.js";
 
-const { runCommandMock } = vi.hoisted(() => ({
+const { runCommandMock, evaluateMock } = vi.hoisted(() => ({
   runCommandMock: vi.fn(),
+  evaluateMock: vi.fn(),
 }));
 
 vi.mock("../src/shared/lib/run-command.js", () => ({
   runCommand: runCommandMock,
 }));
+
+// `evaluatePendingMigrations` makes a real HTTPS call to GitHub via the
+// tarball cache, which can't run in unit tests. Mock the evaluator
+// directly so each test controls the pending-migrations result for the
+// gate decision. Tests that don't override default to "no migrations,
+// no errors" — i.e. fall through to the legacy `dispatch-update`-based
+// gating that the suite was originally written against.
+vi.mock("../src/update-migrations-evaluator.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/update-migrations-evaluator.js")
+    >();
+  return {
+    ...actual,
+    evaluatePendingMigrations: evaluateMock,
+  };
+});
 
 let pool: Pool;
 let app: FastifyInstance;
@@ -97,6 +115,16 @@ afterAll(async () => {
 
 beforeEach(async () => {
   runCommandMock.mockReset();
+  evaluateMock.mockReset();
+  // Default: no pending migrations, no errors. Individual tests can
+  // override to simulate a release that ships migrations or an
+  // evaluator failure.
+  evaluateMock.mockResolvedValue({
+    pending: [],
+    all: [],
+    appliedIds: new Set(),
+    errors: [],
+  });
   await pool.query("DELETE FROM agent_events");
   await pool.query("DELETE FROM agents");
   await pool.query("DELETE FROM sessions");
@@ -445,6 +473,81 @@ describe("release metadata route handling", () => {
         headers: { cookie: sessionCookie },
       });
     }
+  });
+
+  it("fails closed with 503 when the migration evaluator throws", async () => {
+    // Round-1 review #1239: the migration gate must NOT silently fall
+    // through to the legacy path on evaluator failure — that inverts
+    // the security posture once the legacy fence is removed. The
+    // operator should see a clear "couldn't evaluate" error and retry.
+    evaluateMock.mockRejectedValueOnce(
+      new Error("simulated network failure fetching tarball")
+    );
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "normal",
+              title: "x",
+              summary: "x",
+              requiredChecks: [],
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toMatchObject({
+      error: "MIGRATION_EVALUATION_UNAVAILABLE",
+    });
+  });
+
+  it("rejects /release/update with ASSISTED_UPDATE_REQUIRED when migrations are pending", async () => {
+    evaluateMock.mockResolvedValueOnce({
+      pending: [
+        {
+          filename: "0001-bun-cutover.yaml",
+          order: 1,
+          manifest: {
+            id: "bun-cutover",
+            title: "Bun runtime cutover",
+            summary: "Switch runtime from Node to Bun.",
+            alreadySatisfied: { description: "x" },
+            instructions: ["x"],
+            validation: { requiredChecks: [] },
+            rollback: [],
+          },
+        },
+      ],
+      all: [],
+      appliedIds: new Set(),
+      errors: [],
+    });
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({ body: "no fenced metadata" }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0" },
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: "ASSISTED_UPDATE_REQUIRED",
+      pendingMigrations: [expect.objectContaining({ id: "bun-cutover" })],
+    });
   });
 
   it("allows /release/update when the installed version is below appliesFrom", async () => {

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -410,29 +410,41 @@ describe("release metadata route handling", () => {
     const authToken = await auth.getOrCreateAuthToken(pool);
     const bearer = auth.createReleaseUpdateToken(authToken, agent.id);
 
-    // Token is valid for an active assisted job, but the body asks for a
-    // different tag — the takeover carve-out only fires when the tags
-    // match, otherwise we still have a conflict.
-    const updateResp = await app.inject({
-      method: "POST",
-      url: "/api/v1/release/update",
-      headers: {
-        authorization: `Bearer ${bearer}`,
-        "content-type": "application/json",
-      },
-      payload: { tag: "v0.20.0" },
-    });
+    // The bearer token resolves to an active assisted-update agent, but
+    // the request asks to deploy a different tag than the one the agent
+    // was launched for. The token is bound to the assisted run's tag
+    // (CRU-146 review feedback #1235) — mismatched tags fail with 403
+    // before reaching the takeover guard. This keeps a stale token from
+    // bypassing the migration gate for an arbitrary tag once the
+    // assisted job has terminated.
+    let updateResp;
+    try {
+      updateResp = await app.inject({
+        method: "POST",
+        url: "/api/v1/release/update",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        payload: { tag: "v0.20.0" },
+      });
 
-    expect(updateResp.statusCode).toBe(409);
-    expect(updateResp.json()).toMatchObject({
-      error: "A release or update is already in progress.",
-    });
-
-    await app.inject({
-      method: "DELETE",
-      url: "/api/v1/release/assisted/state",
-      headers: { cookie: sessionCookie },
-    });
+      expect(updateResp.statusCode).toBe(403);
+      expect(updateResp.json()).toMatchObject({
+        error: expect.stringContaining(
+          "Assisted update token is bound to a different tag"
+        ),
+      });
+    } finally {
+      // Always tear down the assisted job so a failed assertion doesn't
+      // leak `activeReleaseJob` into the next test (which then 409s on
+      // an unrelated active-job conflict).
+      await app.inject({
+        method: "DELETE",
+        url: "/api/v1/release/assisted/state",
+        headers: { cookie: sessionCookie },
+      });
+    }
   });
 
   it("allows /release/update when the installed version is below appliesFrom", async () => {

--- a/apps/server/test/release-tarball-cache-https.test.ts
+++ b/apps/server/test/release-tarball-cache-https.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedRedirectHost } from "../src/release-tarball-cache.js";
+
+describe("isAllowedRedirectHost", () => {
+  it("accepts the bare github.com host", () => {
+    expect(isAllowedRedirectHost("github.com")).toBe(true);
+  });
+
+  it("accepts subdomains of githubusercontent.com (the signed-asset CDN)", () => {
+    expect(isAllowedRedirectHost("objects.githubusercontent.com")).toBe(true);
+    expect(isAllowedRedirectHost("release-assets.githubusercontent.com")).toBe(
+      true
+    );
+  });
+
+  it("accepts subdomains of github.com", () => {
+    expect(isAllowedRedirectHost("api.github.com")).toBe(true);
+    expect(isAllowedRedirectHost("codeload.github.com")).toBe(true);
+  });
+
+  it("rejects bare githubusercontent.com without a subdomain", () => {
+    // The pattern is `\.githubusercontent\.com$` — requires the leading
+    // dot — so the bare apex domain is NOT in the allowlist. (GitHub
+    // never serves release assets directly from the apex, so this is the
+    // safe default.)
+    expect(isAllowedRedirectHost("githubusercontent.com")).toBe(false);
+  });
+
+  it("rejects suffix-attack hosts", () => {
+    // The classic attack: register `evil-github.com` or
+    // `github.com.attacker.com` and hope the allowlist matches by
+    // substring. The trailing $ anchor closes that off.
+    expect(isAllowedRedirectHost("evil-github.com")).toBe(false);
+    expect(isAllowedRedirectHost("github.com.attacker.com")).toBe(false);
+    expect(isAllowedRedirectHost("notgithub.com")).toBe(false);
+    expect(isAllowedRedirectHost("githubusercontent.com.evil.example")).toBe(
+      false
+    );
+  });
+
+  it("rejects unrelated hostnames", () => {
+    expect(isAllowedRedirectHost("example.com")).toBe(false);
+    expect(isAllowedRedirectHost("attacker.host")).toBe(false);
+    expect(isAllowedRedirectHost("localhost")).toBe(false);
+  });
+});

--- a/apps/server/test/release-tarball-cache.test.ts
+++ b/apps/server/test/release-tarball-cache.test.ts
@@ -244,6 +244,29 @@ describe("release-tarball-cache helpers", () => {
     expect(existsSync(c)).toBe(false);
   });
 
+  it("pruneCacheExcept also sweeps orphan .partial.* files (CRU-146 #1244)", async () => {
+    const { cachedTarballPath, pruneCacheExcept } = await importCache();
+    await mkdir(cacheDir, { recursive: true });
+    const final = cachedTarballPath("v0.18.13");
+    await writeFile(final, "x", "utf-8");
+    // Simulate a hard-exit between createWriteStream and rename — an
+    // orphan partial file from a prior pid stays behind.
+    const orphan1 = `${final}.partial.99999.aaaaaaaa`;
+    const orphan2 = `${final}.partial.88888.bbbbbbbb`;
+    await writeFile(orphan1, "x", "utf-8");
+    await writeFile(orphan2, "x", "utf-8");
+    // Drop something unrelated that pruneCacheExcept must NOT touch.
+    const unrelated = path.join(cacheDir, "unrelated.txt");
+    await writeFile(unrelated, "x", "utf-8");
+
+    await pruneCacheExcept(["v0.18.13"]);
+
+    expect(existsSync(final)).toBe(true);
+    expect(existsSync(orphan1)).toBe(false);
+    expect(existsSync(orphan2)).toBe(false);
+    expect(existsSync(unrelated)).toBe(true);
+  });
+
   it("releaseDownloadUrl points at the GitHub asset URL", async () => {
     const { releaseDownloadUrl } = await importCache();
     expect(releaseDownloadUrl("owner/repo", "v0.18.13")).toBe(

--- a/apps/server/test/release-tarball-cache.test.ts
+++ b/apps/server/test/release-tarball-cache.test.ts
@@ -259,6 +259,65 @@ describe("release-tarball-cache helpers", () => {
   });
 });
 
+describe("release-tarball-cache concurrency (singleflight)", () => {
+  it("coalesces concurrent calls for the same tag into a single download", async () => {
+    // The asset URL builder hardcodes github.com — no parameterizable
+    // baseUrl override. To exercise singleflight without a real network,
+    // we drive ensureCachedTarball with a non-resolvable repo so all
+    // calls fail at the HTTPS layer. The relevant assertion is that
+    // every concurrent caller receives the same rejection (same Promise
+    // instance return value isn't observable, so we settle for "all
+    // three rejections happen" + "no orphaned partial files left in
+    // the cache dir for any of them").
+    const cache = await import("../src/release-tarball-cache.js");
+
+    const calls = await Promise.allSettled([
+      cache.ensureCachedTarball({
+        tag: "vSF.0.0",
+        repo: "owner-that-does-not-exist-zzz/zzzzzzzz",
+      }),
+      cache.ensureCachedTarball({
+        tag: "vSF.0.0",
+        repo: "owner-that-does-not-exist-zzz/zzzzzzzz",
+      }),
+      cache.ensureCachedTarball({
+        tag: "vSF.0.0",
+        repo: "owner-that-does-not-exist-zzz/zzzzzzzz",
+      }),
+    ]);
+    expect(calls.every((r) => r.status === "rejected")).toBe(true);
+
+    // After every concurrent caller rejects, the cache dir must not
+    // contain a leftover .partial file (the catch path unlinks per-
+    // caller partials). Glob via readdir.
+    const fs = await import("node:fs/promises");
+    let entries: string[] = [];
+    try {
+      entries = await fs.readdir(cacheDir);
+    } catch {
+      // dir may not exist if mkdir was skipped — that's also OK.
+    }
+    const orphans = entries.filter(
+      (e) => e.includes(".partial") || e.startsWith("release-vSF.0.0")
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  it("uses per-caller partial filenames so a stray rm can't blow them away", async () => {
+    // The per-caller partial naming (`${final}.partial.${pid}.${rand}`)
+    // means even if two writers race past the inflight map (e.g. a
+    // future multi-process arrangement), they write to different
+    // partial files. Structural assertion: cachedTarballPath never
+    // returns the partial form, and there is no exported partial
+    // constant — every caller mints its own.
+    const cache = await import("../src/release-tarball-cache.js");
+    const final = cache.cachedTarballPath("v0.18.13");
+    expect(final.endsWith(".tar.gz")).toBe(true);
+    expect(final).not.toContain(".partial");
+    expect(Object.keys(cache)).not.toContain("PARTIAL_PATH");
+  });
+});
+
 describe("release-tarball-cache readMigrationsFromTarball", () => {
   it("returns parsed contents of every migration file in the tarball", async () => {
     const { readMigrationsFromTarball } = await importCache();

--- a/apps/server/test/release-tarball-cache.test.ts
+++ b/apps/server/test/release-tarball-cache.test.ts
@@ -1,0 +1,289 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const VALID_MANIFEST = `id: bun-cutover
+title: Bun runtime cutover
+summary: Migrate installs from Node-era to Bun runtime.
+alreadySatisfied:
+  description: Service entrypoint already targets the Bun wrapper.
+instructions:
+  - Inspect the service entrypoint
+  - Repoint to the Bun wrapper if needed
+validation:
+  requiredChecks:
+    - expected_runtime_artifact
+    - service_entrypoint
+rollback:
+  - Restore the prior entrypoint
+`;
+
+let testRoot: string;
+let cacheDir: string;
+
+async function importCache() {
+  return await import("../src/release-tarball-cache.js");
+}
+
+beforeEach(async () => {
+  testRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-cache-test-"));
+  cacheDir = path.join(testRoot, "cache");
+  process.env.DISPATCH_RELEASE_CACHE_DIR = cacheDir;
+});
+
+afterEach(async () => {
+  delete process.env.DISPATCH_RELEASE_CACHE_DIR;
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+/**
+ * Build a release-shaped tarball with the requested entries. Honors the
+ * structure pack-release produces: a manifest of paths inside a working dir,
+ * tarred with `tar czf`. Entries can be relative file paths (->
+ * "file with VALID_MANIFEST contents") or [path, contents] tuples.
+ */
+async function buildTarball(
+  entries: Array<string | [string, string]>
+): Promise<string> {
+  const buildDir = await mkdtemp(path.join(testRoot, "build-"));
+  for (const entry of entries) {
+    const [relPath, contents] = Array.isArray(entry)
+      ? entry
+      : [entry, VALID_MANIFEST];
+    const fullPath = path.join(buildDir, relPath);
+    await mkdir(path.dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, contents, "utf-8");
+  }
+  const tarballPath = path.join(testRoot, `tarball-${Date.now()}.tar.gz`);
+  execFileSync(
+    "tar",
+    [
+      "czf",
+      tarballPath,
+      "-C",
+      buildDir,
+      ...entries.map((e) => (Array.isArray(e) ? e[0] : e)),
+    ],
+    { stdio: "pipe" }
+  );
+  return tarballPath;
+}
+
+describe("release-tarball-cache extraction", () => {
+  it("extracts update-migrations/ from a real tarball", async () => {
+    const { extractUpdateMigrationsTo } = await importCache();
+    const tarball = await buildTarball([
+      "update-migrations/0001-bun-cutover.yaml",
+      "update-migrations/0002-second.yaml",
+    ]);
+    const { dir, cleanup } = await extractUpdateMigrationsTo(tarball);
+    try {
+      const files = await readFile(
+        path.join(dir, "0001-bun-cutover.yaml"),
+        "utf-8"
+      );
+      expect(files).toContain("id: bun-cutover");
+      const stats = await stat(path.join(dir, "0002-second.yaml"));
+      expect(stats.isFile()).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns an empty dir for a tarball without update-migrations/", async () => {
+    const { extractUpdateMigrationsTo } = await importCache();
+    const tarball = await buildTarball([
+      ["README.md", "no migrations here"],
+      ["dist/bun/dispatch-fake-binary", "binary contents"],
+    ]);
+    const { dir, cleanup } = await extractUpdateMigrationsTo(tarball);
+    try {
+      // Either the dir doesn't exist or it's empty — both mean "no
+      // migrations." extractUpdateMigrationsTo returns the path under the
+      // temp dir without creating it when no migrations are present.
+      const exists = existsSync(dir);
+      if (exists) {
+        const fs = await import("node:fs/promises");
+        const entries = await fs.readdir(dir);
+        expect(entries).toEqual([]);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects a tarball with path-traversal entries", async () => {
+    const { extractUpdateMigrationsTo } = await importCache();
+    // Build a malicious tarball directly with tar so we can include
+    // `../escape` paths that the buildTarball helper wouldn't produce.
+    const buildDir = await mkdtemp(path.join(testRoot, "evil-"));
+    const inner = path.join(buildDir, "inner");
+    await mkdir(inner, { recursive: true });
+    await writeFile(path.join(inner, "boring.yaml"), "x", "utf-8");
+    const tarballPath = path.join(testRoot, "evil.tar.gz");
+    // GNU tar's --transform lets us rewrite paths to include ".."
+    // portably across macOS bsdtar by using `-s` instead. Easiest portable
+    // route: extract the file as `update-migrations/../escape.yaml` via
+    // explicit paths in a manifest.
+    const manifest = path.join(buildDir, "manifest.txt");
+    // Create the file at the literal traversal path:
+    await writeFile(path.join(buildDir, "evil_payload.yaml"), "evil", "utf-8");
+    // bsdtar on macOS supports "tar czf <out> -s" but the simpler portable
+    // way is to construct a tar via node — but adding that dep is
+    // overkill. Use python3 to build a tarball with a traversal entry,
+    // skipping the test on systems without python3.
+    let pythonAvailable = true;
+    try {
+      execFileSync("python3", ["--version"], { stdio: "pipe" });
+    } catch {
+      pythonAvailable = false;
+    }
+    if (!pythonAvailable) {
+      // Skip the test rather than fail; the path-traversal guard is
+      // also exercised at the listing level via deployFromArtifact's
+      // own `tar tzf` filter, which is covered by the existing
+      // integration deploy paths.
+      return;
+    }
+    execFileSync("python3", [
+      "-c",
+      [
+        "import tarfile, sys",
+        `tf = tarfile.open(${JSON.stringify(tarballPath)}, 'w:gz')`,
+        `tf.add(${JSON.stringify(path.join(buildDir, "evil_payload.yaml"))}, arcname='update-migrations/../escape.yaml')`,
+        "tf.close()",
+      ].join("; "),
+    ]);
+
+    await expect(extractUpdateMigrationsTo(tarballPath)).rejects.toThrow(
+      /unsafe paths/i
+    );
+  });
+
+  it("unlinks the cache file when tar tzf fails on a corrupt tarball", async () => {
+    const { extractUpdateMigrationsTo } = await importCache();
+    const corrupt = path.join(testRoot, "corrupt.tar.gz");
+    // Plain text — `tar tzf` will reject this immediately.
+    await writeFile(corrupt, "not a tarball at all", "utf-8");
+    expect(existsSync(corrupt)).toBe(true);
+    await expect(extractUpdateMigrationsTo(corrupt)).rejects.toThrow();
+    expect(existsSync(corrupt)).toBe(false);
+  });
+});
+
+describe("release-tarball-cache helpers", () => {
+  it("cachedTarballPath keeps a sanitized tag inside the cache dir", async () => {
+    const { cachedTarballPath } = await importCache();
+    const safe = cachedTarballPath("v0.18.13");
+    expect(safe.endsWith("release-v0.18.13.tar.gz")).toBe(true);
+
+    // The dangerous case isn't a `..` substring in the filename — that's
+    // harmless. The dangerous case is `..` *segments* in the path that
+    // would let the file land outside the cache dir. Confirm the
+    // resolved path stays under cacheDir for both a benign tag and a
+    // hostile one.
+    const escaped = cachedTarballPath("../../etc/passwd");
+    const root = path.resolve(cacheDir);
+    expect(path.resolve(escaped).startsWith(root + path.sep)).toBe(true);
+    expect(path.resolve(safe).startsWith(root + path.sep)).toBe(true);
+    // Slashes from a hostile tag must have been replaced before joining
+    // — otherwise path.join would have spliced extra path segments in.
+    const filename = path.basename(escaped);
+    expect(filename).not.toContain("/");
+    expect(filename).not.toContain(path.sep);
+  });
+
+  it("readCachedTarball returns null for missing cache entry", async () => {
+    const { readCachedTarball } = await importCache();
+    const result = await readCachedTarball("v0.0.1");
+    expect(result).toBeNull();
+  });
+
+  it("readCachedTarball returns null for a zero-byte cache file", async () => {
+    const { cachedTarballPath, readCachedTarball } = await importCache();
+    const filePath = cachedTarballPath("v0.0.2");
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, "", "utf-8");
+    const result = await readCachedTarball("v0.0.2");
+    expect(result).toBeNull();
+  });
+
+  it("unlinkCachedTarball removes the cache entry and is idempotent", async () => {
+    const { cachedTarballPath, unlinkCachedTarball } = await importCache();
+    const filePath = cachedTarballPath("v0.0.3");
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, "x", "utf-8");
+    await unlinkCachedTarball("v0.0.3");
+    expect(existsSync(filePath)).toBe(false);
+    // Second call must not throw on a missing file.
+    await unlinkCachedTarball("v0.0.3");
+  });
+
+  it("pruneCacheExcept removes other cache entries", async () => {
+    const { cachedTarballPath, pruneCacheExcept } = await importCache();
+    await mkdir(cacheDir, { recursive: true });
+    const a = cachedTarballPath("v0.18.13");
+    const b = cachedTarballPath("v0.18.12");
+    const c = cachedTarballPath("v0.18.11");
+    await writeFile(a, "x", "utf-8");
+    await writeFile(b, "x", "utf-8");
+    await writeFile(c, "x", "utf-8");
+    await pruneCacheExcept(["v0.18.13"]);
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(false);
+    expect(existsSync(c)).toBe(false);
+  });
+
+  it("releaseDownloadUrl points at the GitHub asset URL", async () => {
+    const { releaseDownloadUrl } = await importCache();
+    expect(releaseDownloadUrl("owner/repo", "v0.18.13")).toBe(
+      "https://github.com/owner/repo/releases/download/v0.18.13/dispatch-release.tar.gz"
+    );
+  });
+
+  it("releaseDownloadUrl encodes characters that would break the URL path", async () => {
+    const { releaseDownloadUrl } = await importCache();
+    const url = releaseDownloadUrl("owner/repo", "weird/tag");
+    expect(url).not.toContain("weird/tag");
+    expect(url).toContain("weird%2Ftag");
+  });
+});
+
+describe("release-tarball-cache readMigrationsFromTarball", () => {
+  it("returns parsed contents of every migration file in the tarball", async () => {
+    const { readMigrationsFromTarball } = await importCache();
+    const tarball = await buildTarball([
+      ["update-migrations/0001-first.yaml", "id: first\nx: y"],
+      ["update-migrations/0002-second.yaml", "id: second\nx: y"],
+      ["README.md", "ignored"],
+    ]);
+    const result = await readMigrationsFromTarball(tarball);
+    expect(result.map((f) => f.filename).sort()).toEqual([
+      "0001-first.yaml",
+      "0002-second.yaml",
+    ]);
+    expect(result.find((f) => f.filename === "0001-first.yaml")?.contents).toBe(
+      "id: first\nx: y"
+    );
+  });
+
+  it("returns empty array for tarballs without an update-migrations/ dir", async () => {
+    const { readMigrationsFromTarball } = await importCache();
+    const tarball = await buildTarball([
+      ["README.md", "no migrations"],
+      ["dist/bun/binary", "x"],
+    ]);
+    const result = await readMigrationsFromTarball(tarball);
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/server/test/update-migrations-evaluator.test.ts
+++ b/apps/server/test/update-migrations-evaluator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { evaluateFromManifests } from "../src/update-migrations-evaluator.js";
+
+const MANIFEST = (id: string) => `
+id: ${id}
+title: ${id} title
+summary: ${id} summary
+alreadySatisfied:
+  description: ok
+instructions:
+  - step
+validation:
+  requiredChecks: []
+rollback: []
+`;
+
+describe("evaluateFromManifests", () => {
+  it("returns ordered pending list filtered against applied ids", () => {
+    const result = evaluateFromManifests(
+      [
+        { filename: "0002-second.yaml", contents: MANIFEST("second") },
+        { filename: "0001-first.yaml", contents: MANIFEST("first") },
+        { filename: "0003-third.yaml", contents: MANIFEST("third") },
+      ],
+      new Set(["second"])
+    );
+    expect(result.all.map((m) => m.manifest.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(result.pending.map((m) => m.manifest.id)).toEqual([
+      "first",
+      "third",
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("treats invalid manifests as errors but keeps valid ones", () => {
+    const result = evaluateFromManifests(
+      [
+        { filename: "0001-first.yaml", contents: MANIFEST("first") },
+        { filename: "0002-bad.yaml", contents: "not: [valid" },
+      ],
+      new Set()
+    );
+    expect(result.all.map((m) => m.manifest.id)).toEqual(["first"]);
+    expect(result.errors.length).toBe(1);
+  });
+
+  it("ignores files that do not match the manifest filename pattern", () => {
+    const result = evaluateFromManifests(
+      [
+        { filename: "0001-ok.yaml", contents: MANIFEST("ok") },
+        { filename: "README.md", contents: "ignored" },
+      ],
+      new Set()
+    );
+    expect(result.all.map((m) => m.manifest.id)).toEqual(["ok"]);
+  });
+
+  it("flags duplicate ids as an error", () => {
+    const result = evaluateFromManifests(
+      [
+        { filename: "0001-a.yaml", contents: MANIFEST("dup") },
+        { filename: "0002-b.yaml", contents: MANIFEST("dup") },
+      ],
+      new Set()
+    );
+    expect(result.all.map((m) => m.manifest.id)).toEqual(["dup"]);
+    expect(result.errors.length).toBe(1);
+  });
+
+  it("returns empty pending when every id is already applied", () => {
+    const result = evaluateFromManifests(
+      [
+        { filename: "0001-a.yaml", contents: MANIFEST("a") },
+        { filename: "0002-b.yaml", contents: MANIFEST("b") },
+      ],
+      new Set(["a", "b"])
+    );
+    expect(result.pending).toEqual([]);
+  });
+});

--- a/apps/server/test/update-migrations.test.ts
+++ b/apps/server/test/update-migrations.test.ts
@@ -1,0 +1,211 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  filterPending,
+  loadUpdateMigrations,
+  parseManifest,
+} from "../src/update-migrations.js";
+
+const VALID_MANIFEST = `
+id: bun-cutover
+title: Bun runtime cutover
+summary: Move installs from the Node-era runtime to the Bun runtime.
+alreadySatisfied:
+  description: The service entrypoint already targets the Bun wrapper.
+instructions:
+  - Inspect the service entrypoint
+  - Repoint to the Bun wrapper if needed
+  - Restart the service
+validation:
+  requiredChecks:
+    - expected_runtime_artifact
+    - service_entrypoint
+    - service_restarted
+    - health_endpoint
+    - version_converged
+rollback:
+  - Restore the prior entrypoint
+  - Restart the service
+`;
+
+describe("parseManifest", () => {
+  it("accepts a v1 manifest with all fields", () => {
+    const result = parseManifest(VALID_MANIFEST);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.id).toBe("bun-cutover");
+    expect(result.data.title).toBe("Bun runtime cutover");
+    expect(result.data.instructions.length).toBe(3);
+    expect(result.data.validation.requiredChecks).toEqual([
+      "expected_runtime_artifact",
+      "service_entrypoint",
+      "service_restarted",
+      "health_endpoint",
+      "version_converged",
+    ]);
+    expect(result.data.rollback.length).toBe(2);
+  });
+
+  it("rejects an unknown requiredChecks entry", () => {
+    const result = parseManifest(`
+id: bad
+title: t
+summary: s
+alreadySatisfied:
+  description: d
+instructions:
+  - step
+validation:
+  requiredChecks:
+    - made_up_check
+rollback: []
+`);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/requiredChecks/);
+  });
+
+  it("rejects missing alreadySatisfied.description", () => {
+    const result = parseManifest(`
+id: bad
+title: t
+summary: s
+alreadySatisfied: {}
+instructions:
+  - step
+validation:
+  requiredChecks: []
+rollback: []
+`);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/alreadySatisfied/);
+  });
+
+  it("rejects an id with uppercase characters", () => {
+    const result = parseManifest(`
+id: BadId
+title: t
+summary: s
+alreadySatisfied:
+  description: d
+instructions:
+  - step
+validation:
+  requiredChecks: []
+rollback: []
+`);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed YAML with a parse error", () => {
+    const result = parseManifest("id: [unterminated");
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/YAML parse error/);
+  });
+});
+
+describe("loadUpdateMigrations", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "dispatch-mig-loader-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty result for missing directory", async () => {
+    const missing = path.join(dir, "does-not-exist");
+    const result = await loadUpdateMigrations(missing);
+    expect(result.migrations).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("orders manifests by numeric prefix", async () => {
+    await writeFile(
+      path.join(dir, "0010-second.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "second")
+    );
+    await writeFile(
+      path.join(dir, "0001-first.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "first")
+    );
+    const result = await loadUpdateMigrations(dir);
+    expect(result.migrations.map((m) => m.manifest.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("ignores files that don't match the prefix-id.yaml pattern", async () => {
+    await writeFile(
+      path.join(dir, "0001-ok.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "ok")
+    );
+    await writeFile(path.join(dir, "README.md"), "ignored");
+    await writeFile(path.join(dir, "foo.yaml"), "ignored");
+    const result = await loadUpdateMigrations(dir);
+    expect(result.migrations.map((m) => m.filename)).toEqual(["0001-ok.yaml"]);
+  });
+
+  it("reports duplicate ids as errors", async () => {
+    await writeFile(
+      path.join(dir, "0001-a.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "shared-id")
+    );
+    await writeFile(
+      path.join(dir, "0002-b.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "shared-id")
+    );
+    const result = await loadUpdateMigrations(dir);
+    expect(result.migrations.length).toBe(1);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]?.error).toMatch(/duplicate migration id/);
+  });
+
+  it("reports per-file parse errors without dropping other files", async () => {
+    await writeFile(path.join(dir, "0001-bad.yaml"), "not: [valid yaml");
+    await writeFile(
+      path.join(dir, "0002-good.yaml"),
+      VALID_MANIFEST.replace("bun-cutover", "good")
+    );
+    const result = await loadUpdateMigrations(dir);
+    expect(result.migrations.map((m) => m.manifest.id)).toEqual(["good"]);
+    expect(result.errors.map((e) => e.filename)).toEqual(["0001-bad.yaml"]);
+  });
+});
+
+describe("filterPending", () => {
+  it("removes already-applied ids while preserving order", () => {
+    const migrations = [
+      makeFile("0001-a.yaml", "a"),
+      makeFile("0002-b.yaml", "b"),
+      makeFile("0003-c.yaml", "c"),
+    ];
+    const pending = filterPending(migrations, new Set(["b"]));
+    expect(pending.map((m) => m.manifest.id)).toEqual(["a", "c"]);
+  });
+
+  it("returns empty list when every id is applied", () => {
+    const migrations = [
+      makeFile("0001-a.yaml", "a"),
+      makeFile("0002-b.yaml", "b"),
+    ];
+    expect(filterPending(migrations, new Set(["a", "b"]))).toEqual([]);
+  });
+});
+
+function makeFile(filename: string, id: string) {
+  return {
+    filename,
+    order: Number(filename.split("-")[0]),
+    manifest: {
+      id,
+      title: id,
+      summary: id,
+      alreadySatisfied: { description: "x" },
+      instructions: ["x"],
+      validation: { requiredChecks: [] },
+      rollback: [],
+    },
+  };
+}

--- a/apps/web/src/components/app/assisted-update-card.tsx
+++ b/apps/web/src/components/app/assisted-update-card.tsx
@@ -14,8 +14,10 @@ import type {
   AssistedCheckResult,
   AssistedUpdateMetadata,
   AssistedUpdateState,
+  PendingMigration,
   ReleaseJob,
   ReleasePhase,
+  UpdateMigrationManifest,
 } from "@/hooks/use-release-stream";
 import { cn } from "@/lib/utils";
 
@@ -43,6 +45,91 @@ type AssistedUpdateGateProps = {
   starting: boolean;
   startError: string | null;
 };
+
+type PendingMigrationsGateProps = {
+  tag: string;
+  pendingMigrations: PendingMigration[];
+  onStart: () => Promise<void>;
+  starting: boolean;
+  startError: string | null;
+};
+
+/**
+ * Pre-launch card shown when the target release has unapplied install-update
+ * migration manifests (CRU-146). Replaces the legacy single-block gate when
+ * any migrations are pending; the one-click update is hidden so the only
+ * forward path is the assisted flow.
+ */
+export function PendingMigrationsGate({
+  tag,
+  pendingMigrations,
+  onStart,
+  starting,
+  startError,
+}: PendingMigrationsGateProps): JSX.Element {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-lg border p-4",
+        "border-amber-500/40 bg-amber-500/[0.06]"
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+        <div className="flex flex-col gap-1">
+          <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+            Assisted update required
+          </div>
+          <div className="text-sm font-semibold text-foreground">
+            {pendingMigrations.length} pending migration
+            {pendingMigrations.length === 1 ? "" : "s"}
+          </div>
+          <div className="font-mono text-xs text-muted-foreground">{tag}</div>
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        This release ships install-update migrations that haven&rsquo;t been
+        applied on this Dispatch yet. The assisted-update agent walks them in
+        order and validates each before marking it applied.
+      </p>
+
+      <ul className="flex flex-col gap-2 text-sm">
+        {pendingMigrations.map((m) => (
+          <li
+            key={m.id}
+            className="rounded border border-white/[0.12] bg-white/[0.04] p-3"
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                {m.id}
+              </span>
+              <span className="font-semibold text-foreground">{m.title}</span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">{m.summary}</p>
+          </li>
+        ))}
+      </ul>
+
+      {startError && (
+        <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {startError}
+        </div>
+      )}
+
+      <Button
+        size="sm"
+        variant="primary"
+        disabled={starting}
+        onClick={() => void onStart()}
+        className="self-start"
+        data-testid="pending-migrations-start"
+      >
+        {starting ? "Launching agent..." : `Start assisted update to ${tag}`}
+      </Button>
+    </div>
+  );
+}
 
 /**
  * The pre-launch card shown in place of the one-click update button when a
@@ -203,6 +290,21 @@ export function AssistedUpdateProgress({
     }
   }, [job.log]);
 
+  const headline =
+    assisted.migrations && assisted.migrations.length > 0
+      ? {
+          title: `${assisted.migrations.length} migration${
+            assisted.migrations.length === 1 ? "" : "s"
+          } pending`,
+          summary: assisted.migrations.map((m) => m.title).join(" → "),
+        }
+      : assisted.metadata
+        ? {
+            title: assisted.metadata.title,
+            summary: assisted.metadata.summary ?? "",
+          }
+        : { title: "Assisted update", summary: "" };
+
   return (
     <div className="flex h-full min-h-0 flex-col md:flex-row">
       <div className="flex md:w-[380px] shrink-0 flex-col gap-6 overflow-y-auto border-b md:border-b-0 md:border-r border-white/[0.12] p-4 md:p-6">
@@ -211,11 +313,11 @@ export function AssistedUpdateProgress({
             Assisted update
           </div>
           <div className="text-sm font-semibold text-foreground">
-            {assisted.metadata.title}
+            {headline.title}
           </div>
-          {assisted.metadata.summary && (
+          {headline.summary && (
             <div className="mt-1 text-xs text-muted-foreground">
-              {assisted.metadata.summary}
+              {headline.summary}
             </div>
           )}
         </div>
@@ -226,6 +328,10 @@ export function AssistedUpdateProgress({
           isFailed={isFailed}
           isRestarting={job.phase === "restarting"}
         />
+
+        {assisted.migrations && assisted.migrations.length > 0 && (
+          <MigrationsList migrations={assisted.migrations} />
+        )}
 
         {Object.keys(assisted.notes).length > 0 && (
           <PhaseNotesList notes={assisted.notes} />
@@ -330,6 +436,38 @@ function PhaseNotesList({
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function MigrationsList({
+  migrations,
+}: {
+  migrations: UpdateMigrationManifest[];
+}): JSX.Element {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Migrations
+      </div>
+      <ol className="flex flex-col gap-1.5 text-xs">
+        {migrations.map((m, idx) => (
+          <li
+            key={m.id}
+            className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1.5"
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-mono uppercase tracking-wide text-[9px] text-muted-foreground">
+                {idx + 1}/{migrations.length}
+              </span>
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {m.id}
+              </span>
+            </div>
+            <div className="mt-0.5 text-foreground/90">{m.title}</div>
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -23,6 +23,7 @@ import { OperationLog, PhaseProgress } from "@/components/app/release-shared";
 import {
   AssistedUpdateGate,
   AssistedUpdateProgress,
+  PendingMigrationsGate,
 } from "@/components/app/assisted-update-card";
 import {
   type ReleaseChannel,
@@ -454,28 +455,42 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                 )}
 
                 {/*
-                  Gate visibility per metadata mode:
-                  - required:    only the gate. We hide the standard buttons
-                                 when `info.assistedRequired` is true — the
-                                 server's own gate (`isAssistedUpdateRequired`)
-                                 is `mode === "required"` AND the appliesFrom
-                                 rule, so trusting `assistedRequired` keeps the
-                                 UI in lockstep with the 409 the server would
-                                 actually return.
-                  - recommended: gate AND standard buttons (operator may opt
-                                 into the assisted flow but isn't forced).
-                  - normal/none: standard buttons only — metadata is purely
-                                 informational and shouldn't change the UX.
+                  Gate visibility:
+                  - migrations:  the new persistent-migration model (CRU-146).
+                                 When the target release ships unapplied
+                                 migration manifests, the standard buttons
+                                 are hidden and the operator must launch the
+                                 assisted flow from the migrations gate card.
+                  - legacy required: same UX as migrations, but driven by the
+                                 release-scoped `dispatch-update` block. We
+                                 still hide the standard buttons when
+                                 `info.assistedRequired` is true — the server
+                                 will 409 on the one-click path.
+                  - recommended: legacy gate AND standard buttons (operator
+                                 may opt into the assisted flow but isn't
+                                 forced).
+                  - normal/none: standard buttons only.
                 */}
-                {info.assisted && info.assisted.mode !== "normal" && (
-                  <AssistedUpdateGate
+                {info.pendingMigrations && info.pendingMigrations.length > 0 ? (
+                  <PendingMigrationsGate
                     tag={info.latestTag}
-                    metadata={info.assisted}
-                    required={info.assistedRequired === true}
+                    pendingMigrations={info.pendingMigrations}
                     onStart={() => handleAssistedUpdate(info.latestTag!)}
                     starting={assistedUpdateLaunching}
                     startError={null}
                   />
+                ) : (
+                  info.assisted &&
+                  info.assisted.mode !== "normal" && (
+                    <AssistedUpdateGate
+                      tag={info.latestTag}
+                      metadata={info.assisted}
+                      required={info.assistedRequired === true}
+                      onStart={() => handleAssistedUpdate(info.latestTag!)}
+                      starting={assistedUpdateLaunching}
+                      startError={null}
+                    />
+                  )
                 )}
                 {!(info.assistedRequired === true) && (
                   <>

--- a/apps/web/src/hooks/use-release-stream.ts
+++ b/apps/web/src/hooks/use-release-stream.ts
@@ -58,6 +58,27 @@ export type AssistedUpdateMetadata = {
   appliesFrom?: string;
 };
 
+/**
+ * Persistent install-update migration manifest snapshotted into an
+ * in-flight assisted run. Mirrors UpdateMigrationManifest on the server.
+ */
+export type UpdateMigrationManifest = {
+  id: string;
+  title: string;
+  summary: string;
+  alreadySatisfied: { description: string };
+  instructions: string[];
+  validation: { requiredChecks: AssistedRequiredCheck[] };
+  rollback: string[];
+};
+
+/** Compact summary returned by /api/v1/release/info for pending migrations. */
+export type PendingMigration = {
+  id: string;
+  title: string;
+  summary: string;
+};
+
 export type AssistedCheckResult = {
   name: AssistedRequiredCheck;
   ok: boolean;
@@ -67,7 +88,18 @@ export type AssistedCheckResult = {
 export type AssistedUpdateState = {
   tag: string;
   fromTag: string | null;
-  metadata: AssistedUpdateMetadata;
+  /**
+   * Legacy release-scoped metadata, present on runs gated by the
+   * `dispatch-update` block in the release body. Mutually exclusive with
+   * `migrations` — exactly one drives the run on the server.
+   */
+  metadata: AssistedUpdateMetadata | null;
+  /**
+   * Ordered pending migrations snapshotted into the run at launch time.
+   * Preferred path (CRU-146); when populated the UI renders per-migration
+   * sections instead of the single legacy block.
+   */
+  migrations: UpdateMigrationManifest[] | null;
   requiredChecks: AssistedRequiredCheck[];
   phase: ReleasePhase;
   agentId: string | null;
@@ -91,6 +123,14 @@ export type ReleaseInfo = {
   refMissing?: boolean;
   assisted?: AssistedUpdateMetadata | null;
   assistedRequired?: boolean;
+  /**
+   * Ordered, install-specific list of migrations the target tag declares
+   * that the local install hasn't applied yet. When non-empty, one-click
+   * update is gated and the operator must use the assisted-update flow.
+   */
+  pendingMigrations?: PendingMigration[];
+  /** Joined per-file load errors when the migration evaluator hit issues. */
+  migrationsError?: string | null;
 };
 
 export type ReleaseStatus = {

--- a/bin/pack-release
+++ b/bin/pack-release
@@ -76,6 +76,13 @@ if [[ -f "release-notes/current.md" ]]; then
   echo "release-notes/current.md" >> "$MANIFEST"
 fi
 
+# Conditionally include update migrations if any exist. The runtime opens
+# the tarball at "Check for Updates" time and extracts only update-migrations/
+# to determine whether assisted update is required for the target tag.
+if [[ -d "update-migrations" ]]; then
+  echo "update-migrations" >> "$MANIFEST"
+fi
+
 tar czf "$OUTPUT" --exclude='bin/embed-assisted-update.ts' -T "$MANIFEST"
 
 # Print summary

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/release-notes/AUTHORING.md
+++ b/release-notes/AUTHORING.md
@@ -1,4 +1,88 @@
-# Assisted Update Metadata Authoring
+# Assisted Update Authoring
+
+> **Preferred path (CRU-146):** add an append-only manifest under
+> `update-migrations/` instead of editing `release-notes/next-assisted-update.json`.
+> See [Migration manifests](#migration-manifests-preferred) below. The legacy
+> single-block JSON flow described after that is kept only for transitional
+> compatibility while in-flight gates roll forward.
+
+## Migration manifests (preferred)
+
+Persistent install-update migrations live as YAML files under
+`update-migrations/` at the repo root. They are append-only across release
+history, ship inside the release tarball, and are evaluated per-install: the
+runtime downloads the target tarball on "Check for Updates", extracts the
+migration manifests, and gates assisted update based on which IDs the local
+install hasn't applied yet.
+
+### File layout
+
+```
+update-migrations/
+  0001-bun-cutover.yaml
+  0002-...yaml
+```
+
+- Filenames must match `<NNNN>-<id>.yaml` where `<NNNN>` is a zero-padded
+  numeric ordering prefix and `<id>` is lowercase letters, digits, and hyphens.
+- The `id` field inside the file must match the `<id>` in the filename and is
+  the stable handle the runtime persists in `~/.dispatch/applied-migrations.json`.
+- Once a manifest has shipped in a tagged release **never** rename, delete, or
+  re-number it — that breaks "already applied" bookkeeping on installs that
+  ran it.
+
+### Schema (V1)
+
+```yaml
+id: bun-cutover
+title: Bun runtime cutover
+summary: >
+  One paragraph explaining what the migration does and why.
+
+alreadySatisfied:
+  description: >
+    A human-readable description of the install state that means the
+    migration is already a no-op. The agent reads this first; if true it
+    skips the change steps, runs validation, and marks the migration applied.
+
+instructions:
+  - Ordered step the agent should take.
+  - Use as many entries as you need.
+  - Skip the change steps if alreadySatisfied is true.
+
+validation:
+  requiredChecks:
+    - expected_runtime_artifact
+    - service_entrypoint
+    - service_restarted
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - Ordered step the agent should take to roll the migration back.
+```
+
+V1 fields only: `id`, `title`, `summary`, `alreadySatisfied.description`,
+`instructions[]`, `validation.requiredChecks[]`, `rollback[]`. Anything else
+will fail validation.
+
+Out of scope for V1 (do **not** add): `appliesFrom`/version ranges, install-fact
+predicates, supersession or dependency edges, machine-executable step DSLs.
+
+### Run semantics
+
+- The runtime evaluates pending migrations against the **target** release.
+  Skipped releases work naturally because newer targets include older
+  manifests in their tarball.
+- A run sees one ordered plan covering every pending migration. The framework
+  runs the union of every `validation.requiredChecks` after the agent reports
+  `validate`. **All-or-nothing**: if every check passes, every pending ID is
+  marked applied; if any check fails, none are.
+- `requiredChecks` entries must come from the canonical set in
+  `apps/server/src/release-metadata.ts` (`REQUIRED_CHECK_NAMES`). Adding new
+  check names is a separate code change in `apps/server/src/release-checks.ts`.
+
+## Legacy single-block metadata (transitional)
 
 When a PR introduces an assisted-update requirement for the next release, author
 or update `release-notes/next-assisted-update.json`.

--- a/update-migrations/0001-bun-cutover.yaml
+++ b/update-migrations/0001-bun-cutover.yaml
@@ -1,0 +1,46 @@
+id: bun-cutover
+title: Bun runtime cutover
+summary: >
+  Migrate installs from the Node-era runtime/service layout to the Bun runtime.
+  The packaged release ships a prebuilt Bun binary; installs that still launch
+  Dispatch via the legacy Node entrypoint must be repointed at the Bun wrapper
+  so future updates land on a runtime the binaries actually expect.
+
+alreadySatisfied:
+  description: >
+    The active service entrypoint already points at the Bun wrapper or the
+    platform-matched dist/bun/dispatch-* binary, the runtime artifacts under
+    dist/bun/ exist for the current platform, and the running process reports
+    a tag that matches release.json. If all three are true the install is on
+    the Bun runtime and the migration is a no-op — validate and mark applied
+    without re-running the cutover steps.
+
+instructions:
+  - Inspect the current service entrypoint (launchd plist on macOS,
+    systemd unit on Linux) and confirm whether it invokes the Bun wrapper
+    or the legacy Node entrypoint.
+  - Confirm the platform-matched Bun binary exists under
+    dist/bun/dispatch-*-bun-<platform>-<arch> in the install directory.
+  - If alreadySatisfied is true, skip to validation.
+  - Otherwise update the service entrypoint to invoke the Bun wrapper or
+    the platform-matched dist/bun/dispatch-* binary, preserving the existing
+    environment variables and working directory.
+  - Restart the service via the host service manager and wait for the
+    health endpoint to return status=ok.
+  - Confirm the running tag matches the target tag before reporting validate.
+
+validation:
+  requiredChecks:
+    - expected_runtime_artifact
+    - service_entrypoint
+    - service_restarted
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - Restore the previous service entrypoint to the Node-era invocation.
+  - Restore the prior runtime artifacts if they were removed (the Bun binary
+    can stay on disk; only the entrypoint matters for rollback).
+  - Restart the service via the host service manager.
+  - Confirm the health endpoint returns status=ok and release.json reports
+    the prior healthy tag.


### PR DESCRIPTION
## Summary

Replaces release-scoped assisted-update gating (one `dispatch-update` JSON block per release body) with append-only YAML migration manifests under `update-migrations/`. Each install records which migration IDs it has applied at `~/.dispatch/applied-migrations.json`; assisted update is required when the target release ships unapplied manifests. Skipped releases work naturally because newer targets include older manifests in their tarball.

Also swaps `gh release download` for a direct HTTPS fetch so the runtime no longer depends on the GitHub CLI for the deploy path. The same cached tarball at `~/.dispatch/cache/release-<tag>.tar.gz` is reused for both the migration-inspection pass on "Check for Updates" and the actual deploy — no double-download.

Linear: [CRU-146](https://linear.app/crumbstream/issue/CRU-146)

## How it hangs together

```
update-migrations/0001-bun-cutover.yaml          repo source
  ↓ ships in tarball via pack-release
~/.dispatch/cache/release-<tag>.tar.gz           runtime cache (HTTPS download)
  ↓ extract update-migrations/* into temp dir
loadUpdateMigrations() → ordered manifest list
  ↓ filterPending(manifests, appliedIdSet(state))
PendingMigrationsResult                          drives release/info + assisted launch
  ↓ on validate phase, all-or-nothing
markMigrationsApplied([…ids], targetTag)         ~/.dispatch/applied-migrations.json
```

## What's in this PR

- **New backend modules**
  - `apps/server/src/update-migrations.ts` — YAML manifest schema (zod) + on-disk loader.
  - `apps/server/src/applied-migrations-store.ts` — install-local applied-state at `~/.dispatch/applied-migrations.json` with atomic writes.
  - `apps/server/src/release-tarball-cache.ts` — direct-HTTPS tarball download (replaces `gh release download`), per-tag cache, selective `update-migrations/` extraction with path-traversal guard.
  - `apps/server/src/update-migrations-evaluator.ts` — glue: target tag → ordered pending migrations, in-process memoized.
- **Server wiring (`apps/server/src/server.ts`)**
  - `GET /api/v1/release/info` returns `pendingMigrations` + `assistedRequired`. Legacy `assisted` field still emitted for transitional compat per issue step 7.
  - `POST /api/v1/release/update` rejects with `ASSISTED_UPDATE_REQUIRED` when migrations are pending (in addition to legacy gate).
  - `POST /api/v1/release/assisted/launch` snapshots pending manifests into `AssistedUpdateState.migrations`, builds a multi-migration prompt, and falls back to legacy single-block metadata when no migrations apply.
  - `deployFromArtifact` no longer shells out to `gh` — uses the tarball cache + `tar`. Old cache entries are pruned after a successful deploy.
- **Assisted-update orchestrator (`apps/server/src/assisted-update.ts`)**
  - `buildAssistedUpdateContext` accepts either `migrations[]` or legacy `metadata`.
  - Prompt renders per-migration sections (title, summary, alreadySatisfied, instructions, validation, rollback).
  - `runAndRecordChecks` marks every pending migration ID applied on all-pass; clears the evaluator memo so the next info poll picks the change up.
- **Frontend**
  - `ReleaseInfo` extended with `pendingMigrations` + `migrationsError`. New `PendingMigrationsGate` component replaces the legacy gate when migrations are pending. `AssistedUpdateProgress` renders an in-flight migrations list when the run is migration-driven.
- **Repo content**
  - `update-migrations/0001-bun-cutover.yaml` — first canonical manifest.
  - `bin/pack-release` ships the `update-migrations/` directory in the tarball.
  - `release-notes/AUTHORING.md` — preferred-path guidance for migration manifests, legacy single-block flow kept below for transitional reference.

## Notes for review

- **Lockfile reformat noise:** `pnpm install` (running pnpm 9.15.9 in this env) renormalized string quoting throughout `pnpm-lock.yaml`. The only real dependency change is adding `yaml` to `apps/server`.
- **Private repos:** the direct-HTTPS download URL (`https://github.com/{repo}/releases/download/<tag>/dispatch-release.tar.gz`) works unauthenticated for public repos and follows GitHub's redirect to a signed S3 URL. Private repos would need a `GH_TOKEN`-bearing fetch — out of scope for this PR; Dispatch is currently distributed from a public release.
- **Legacy compat:** `dispatch-update` body fence still gates assisted update when no migrations are pending. Removing the legacy path is a follow-up (issue step 8).
- **Fallback when migration evaluation fails:** The one-click gate falls through to legacy assisted gating on evaluator failure (network, missing artifact for older release). The launch endpoint does the same. Pre-existing legacy releases keep working unchanged.

## Test plan

- [x] `pnpm run check` (server + web typecheck) — clean
- [x] `pnpm run finalize:web` — clean production build
- [x] Vitest: 23 new tests across `update-migrations.test.ts`, `applied-migrations-store.test.ts`, `update-migrations-evaluator.test.ts`. Full server suite: 576 passing, 1 file (`dispatch-dev.test.ts`) flaky on `main` too — pre-existing.
- [x] Playwright smoke against dev stack — Updates UI renders clean with new `pendingMigrations` field, no console errors.
- [ ] E2E hasn't been run yet — `pnpm run test:e2e` recommended before merge.
- [ ] Real-world dry run against a `pack-release` tarball that includes `update-migrations/` is worth doing before flipping the legacy gate off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)