### PR TITLE
Guard macOS path probes

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -67,6 +67,7 @@ import { createPool } from "./db/client.js";
 import { runMigrations } from "./db/migrate.js";
 import { deleteSetting, getSetting, setSetting } from "./db/settings.js";
 import { runCommand } from "./shared/lib/run-command.js";
+import { shouldSkipAutomaticMacPathProbe } from "./shared/mac-path-privacy.js";
 import { resolveHeadSha } from "./shared/git/worktree.js";
 import { handleMcpRequest } from "./shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
@@ -2969,6 +2970,16 @@ async function registerRoutes() {
         exists: false,
         isDirectory: false,
         isGitRepo: false,
+        privacyRestricted: false,
+        resolvedPath: resolved,
+      };
+    }
+    if (await shouldSkipAutomaticMacPathProbe(resolved, os.homedir())) {
+      return {
+        exists: false,
+        isDirectory: false,
+        isGitRepo: false,
+        privacyRestricted: true,
         resolvedPath: resolved,
       };
     }
@@ -2988,12 +2999,19 @@ async function registerRoutes() {
         );
         isGitRepo = result.exitCode === 0 && result.stdout.trim() === "true";
       }
-      return { exists, isDirectory, isGitRepo, resolvedPath: resolved };
+      return {
+        exists,
+        isDirectory,
+        isGitRepo,
+        privacyRestricted: false,
+        resolvedPath: resolved,
+      };
     } catch {
       return {
         exists: false,
         isDirectory: false,
         isGitRepo: false,
+        privacyRestricted: false,
         resolvedPath: resolved,
       };
     }
@@ -3020,6 +3038,10 @@ async function registerRoutes() {
       const searchDir = isExactDir ? resolved : parentDir;
       const searchPartial = isExactDir ? "" : partial;
 
+      if (await shouldSkipAutomaticMacPathProbe(searchDir, os.homedir())) {
+        return { completions: [], privacyRestricted: true };
+      }
+
       const entries = await readdir(searchDir, { withFileTypes: true });
       const dirs = entries
         .filter((entry) => {
@@ -3041,9 +3063,9 @@ async function registerRoutes() {
           : dir
       );
 
-      return { completions };
+      return { completions, privacyRestricted: false };
     } catch {
-      return { completions: [] };
+      return { completions: [], privacyRestricted: false };
     }
   });
 

--- a/apps/server/src/shared/mac-path-privacy.ts
+++ b/apps/server/src/shared/mac-path-privacy.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { realpath } from "node:fs/promises";
+
+const PROTECTED_HOME_RELATIVE_DIRS = [
+  "Desktop",
+  "Documents",
+  "Downloads",
+  "Movies",
+  "Music",
+  "Pictures",
+  path.join("Library", "CloudStorage"),
+  path.join("Library", "Mobile Documents"),
+] as const;
+
+function normalizeForComparison(
+  value: string,
+  platform: NodeJS.Platform
+): string {
+  const resolved = path.resolve(value);
+  return platform === "darwin" ? resolved.toLocaleLowerCase("en-US") : resolved;
+}
+
+async function canonicalizePath(
+  candidatePath: string,
+  platform: NodeJS.Platform
+): Promise<string> {
+  const resolved = path.resolve(candidatePath);
+  const canonical = await realpath(resolved).catch(() => resolved);
+  return normalizeForComparison(canonical, platform);
+}
+
+function isSameOrChildPath(candidate: string, parent: string): boolean {
+  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+export async function isMacProtectedPath(
+  candidatePath: string,
+  homeDir: string,
+  platform: NodeJS.Platform = process.platform
+): Promise<boolean> {
+  const [canonicalCandidate, protectedRoots] = await Promise.all([
+    canonicalizePath(candidatePath, platform),
+    Promise.all(
+      PROTECTED_HOME_RELATIVE_DIRS.map(async (segment) =>
+        canonicalizePath(path.join(homeDir, segment), platform)
+      )
+    ),
+  ]);
+
+  return protectedRoots.some((protectedRoot) =>
+    isSameOrChildPath(canonicalCandidate, protectedRoot)
+  );
+}
+
+export async function shouldSkipAutomaticMacPathProbe(
+  candidatePath: string,
+  homeDir: string,
+  platform: NodeJS.Platform = process.platform
+): Promise<boolean> {
+  return (
+    platform === "darwin" &&
+    (await isMacProtectedPath(candidatePath, homeDir, platform))
+  );
+}

--- a/apps/server/test/mac-path-privacy.test.ts
+++ b/apps/server/test/mac-path-privacy.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  isMacProtectedPath,
+  shouldSkipAutomaticMacPathProbe,
+} from "../src/shared/mac-path-privacy.js";
+
+describe("isMacProtectedPath", () => {
+  const homeDir = "/Users/tester";
+  const platform = "darwin";
+
+  it("matches protected macOS home folders", async () => {
+    await expect(
+      isMacProtectedPath(path.join(homeDir, "Documents"), homeDir, platform)
+    ).resolves.toBe(true);
+    expect(
+      await isMacProtectedPath(
+        path.join(homeDir, "Desktop", "repo"),
+        homeDir,
+        platform
+      )
+    ).toBe(true);
+    expect(
+      await isMacProtectedPath(
+        path.join(
+          homeDir,
+          "Library",
+          "Mobile Documents",
+          "com~apple~CloudDocs"
+        ),
+        homeDir,
+        platform
+      )
+    ).toBe(true);
+  });
+
+  it("matches protected paths case-insensitively on darwin", async () => {
+    await expect(
+      isMacProtectedPath(
+        path.join(homeDir, "documents", "repo"),
+        homeDir,
+        platform
+      )
+    ).resolves.toBe(true);
+  });
+
+  it("does not match unprotected paths", async () => {
+    await expect(
+      isMacProtectedPath(path.join(homeDir, "code"), homeDir, platform)
+    ).resolves.toBe(false);
+    await expect(
+      isMacProtectedPath(path.join(homeDir, ".dispatch"), homeDir, platform)
+    ).resolves.toBe(false);
+  });
+});
+
+describe("shouldSkipAutomaticMacPathProbe", () => {
+  const homeDir = "/Users/tester";
+
+  it("only skips protected paths on darwin", async () => {
+    await expect(
+      shouldSkipAutomaticMacPathProbe(
+        path.join(homeDir, "Downloads"),
+        homeDir,
+        "darwin"
+      )
+    ).resolves.toBe(true);
+    await expect(
+      shouldSkipAutomaticMacPathProbe(
+        path.join(homeDir, "Downloads"),
+        homeDir,
+        "linux"
+      )
+    ).resolves.toBe(false);
+  });
+});
+
+describe("symlink handling", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+  });
+
+  it("treats symlinks into protected folders as protected", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "dispatch-mac-privacy-"));
+    tempDirs.push(root);
+    const homeDir = path.join(root, "home");
+    const protectedTarget = path.join(homeDir, "Documents", "project");
+    const symlinkPath = path.join(homeDir, "work");
+
+    await mkdir(protectedTarget, { recursive: true });
+    await symlink(protectedTarget, symlinkPath, "dir");
+
+    await expect(
+      shouldSkipAutomaticMacPathProbe(symlinkPath, homeDir, "darwin")
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -18,7 +18,12 @@ import { useClickOutside } from "@/hooks/use-click-outside";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type PathInfo = { exists: boolean; isDirectory: boolean; isGitRepo: boolean };
+type PathInfo = {
+  exists: boolean;
+  isDirectory: boolean;
+  isGitRepo: boolean;
+  privacyRestricted?: boolean;
+};
 
 type PathInputProps = {
   value: string;
@@ -98,6 +103,11 @@ export function PathInput({
         `/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`
       )
         .then((result) => {
+          if (result.privacyRestricted) {
+            setPathValidation(null);
+            onPathInfoChange?.(null);
+            return;
+          }
           const info: PathInfo = {
             exists: result.exists,
             isDirectory: result.isDirectory,
@@ -126,10 +136,14 @@ export function PathInput({
       return;
     }
     const timer = setTimeout(() => {
-      api<{ completions: string[] }>(
+      api<{ completions: string[]; privacyRestricted?: boolean }>(
         `/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`
       )
         .then((result) => {
+          if (result.privacyRestricted) {
+            setGhostSuffix("");
+            return;
+          }
           if (result.completions.length > 0) {
             const best = result.completions[0];
             if (best.startsWith(trimmed.replace(/\/$/, ""))) {


### PR DESCRIPTION
## Summary
- guard automatic macOS path probes for protected folders
- keep the Create Agent UI neutral for privacy-restricted paths
- handle case variants and symlink aliases into protected locations