### PR TITLE
test: add verify-migration-flow no-op manifest

### DIFF
--- a/update-migrations/0002-verify-migration-flow.yaml
+++ b/update-migrations/0002-verify-migration-flow.yaml
@@ -1,0 +1,36 @@
+id: verify-migration-flow
+title: Verify install-update migration flow
+summary: >
+  No-op migration that exercises the persistent-migration assisted-update
+  flow end to end. Lets us confirm gating, agent-driven validation, and
+  applied-state recording without making any actual install changes — the
+  migration framework's first real shakedown after CRU-146.
+
+alreadySatisfied:
+  description: >
+    Any healthy install at the target tag satisfies this trivially: the
+    local health endpoint returns status=ok and release.json reports
+    the target tag. Because the migration makes no install-state
+    changes, the alreadySatisfied path is the canonical one — the
+    agent should always reach validate without performing any change
+    steps.
+
+instructions:
+  - Confirm the local health endpoint at $DISPATCH_API_URL/api/v1/health
+    returns status=ok.
+  - Confirm release.json under the install directory reports the target
+    tag.
+  - Since alreadySatisfied is true on every healthy install at the target
+    tag, do not perform any change steps — proceed straight to the
+    validate phase. The framework re-runs the checks below server-side
+    and marks the migration applied.
+
+validation:
+  requiredChecks:
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - No rollback steps — this migration makes no install-state changes.
+    If validation fails for this migration, the failure is in the
+    framework or the install itself, not in anything this manifest did.


### PR DESCRIPTION
## Summary

First real shakedown of the persistent-migration assisted-update flow introduced in CRU-146 (PR #437). The new manifest at `update-migrations/0002-verify-migration-flow.yaml` is a deliberate no-op — it makes no install-state changes, only exercises gating, agent-driven validation, and applied-state recording end to end against a real GitHub release.

## Why this PR exists

Until now, the migration framework has only been exercised against synthetic in-test tarballs. Cutting a release that ships an actual manifest is the only way to verify:

- `release/info` correctly downloads the tarball and surfaces `pendingMigrations`.
- The UI gates the one-click button when migrations are pending.
- `release/assisted/launch` snapshots the manifest into `~/.dispatch/assisted-update.json`.
- The agent walks `alreadySatisfied` → `validate` → applied.
- The framework's per-migration check union (`health_endpoint` from this manifest + the canonical 5 from `bun-cutover`) runs server-side and marks both IDs applied atomically.

## What it does

```yaml
id: verify-migration-flow
title: Verify install-update migration flow
alreadySatisfied:
  description: any healthy install at the target tag — trivially true
instructions: confirm health endpoint + release.json, skip change steps
validation.requiredChecks: [health_endpoint, version_converged]
rollback: []  # no install-state change to roll back
```

## Run semantics on existing installs

- Install on v0.18.14 (post-CRU-146): on next `release/info` poll, sees `bun-cutover` + `verify-migration-flow` as pending → `assistedRequired = true` → one-click gated.
- Operator launches assisted update. Agent gets one ordered plan with both migrations.
- Walks `alreadySatisfied` for each (both trivially true), reaches `validate`.
- Framework re-runs the union of required checks server-side: `expected_runtime_artifact`, `service_entrypoint`, `service_restarted`, `health_endpoint`, `version_converged`.
- All pass → both IDs marked applied in `~/.dispatch/applied-migrations.json`.
- Subsequent updates one-click unless a future PR adds another migration.

## Test plan

- [x] `pnpm --filter @dispatch/server test -- update-migrations applied-migrations release-tarball-cache release-flow-smoke` — 59/59 passing.
- [x] `bun -e 'await import("./apps/server/src/update-migrations.ts").loadUpdateMigrations(...)' ` validates both manifests parse + dedupe IDs cleanly.
- [ ] Cut a release with this PR merged. Confirm the GitHub release artifact tarball contains `update-migrations/0002-verify-migration-flow.yaml`.
- [ ] On an install at v0.18.14, confirm `release/info` returns `pendingMigrations: [bun-cutover, verify-migration-flow]` and gates the one-click button.
- [ ] Confirm assisted launch + agent run + validate phase + applied-state recording work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)