### PR TITLE
[codex] Remove CI bun artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,13 +98,6 @@ jobs:
           path: test-results/
           retention-days: 7
 
-      - name: Upload Bun binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: bun-binaries
-          path: dist/bun/
-          retention-days: 7
-
       - name: Stop Postgres
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true


### PR DESCRIPTION
## What changed

This PR removes the `Upload Bun binaries` step from `.github/workflows/ci.yml`.

PR CI still:
- builds Bun binaries with `pnpm run build:bun`
- smoke-tests the compiled binary for the host platform

It no longer uploads `dist/bun/` as the temporary `bun-binaries` artifact on pull request runs.

## Why

The release workflow does not call or depend on `ci.yml`. It performs its own fresh verification and binary build in `release.yml`, then uploads its own release bundle.

That means the PR CI artifact upload is redundant unless someone specifically wants the temporary PR artifact for manual inspection/debugging.

## Validation

- workflow YAML parses successfully
- diff is limited to removing the `Upload Bun binaries` step

I did not run the full app test suite for this workflow-only change.