### PR TITLE
Fix path-info hang: drop realpath in mac-path-privacy

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3138,7 +3138,7 @@ async function registerRoutes() {
         resolvedPath: resolved,
       };
     }
-    if (await shouldSkipAutomaticMacPathProbe(resolved, os.homedir())) {
+    if (shouldSkipAutomaticMacPathProbe(resolved, os.homedir())) {
       return {
         exists: false,
         isDirectory: false,
@@ -3202,7 +3202,7 @@ async function registerRoutes() {
       const searchDir = isExactDir ? resolved : parentDir;
       const searchPartial = isExactDir ? "" : partial;
 
-      if (await shouldSkipAutomaticMacPathProbe(searchDir, os.homedir())) {
+      if (shouldSkipAutomaticMacPathProbe(searchDir, os.homedir())) {
         return { completions: [], privacyRestricted: true };
       }
 

--- a/apps/server/src/shared/mac-path-privacy.ts
+++ b/apps/server/src/shared/mac-path-privacy.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { realpath } from "node:fs/promises";
 
 const PROTECTED_HOME_RELATIVE_DIRS = [
   "Desktop",
@@ -12,53 +11,59 @@ const PROTECTED_HOME_RELATIVE_DIRS = [
   path.join("Library", "Mobile Documents"),
 ] as const;
 
-function normalizeForComparison(
-  value: string,
-  platform: NodeJS.Platform
-): string {
+/**
+ * Pure string-prefix check against macOS TCC-protected user folders.
+ * Intentionally does NOT call `realpath()` or any other filesystem syscall.
+ *
+ * Why no realpath: TCC routes accesses to `~/Library/Mobile Documents`
+ * (iCloud Drive) and `~/Library/CloudStorage` (third-party cloud sync)
+ * through the indirect FileProvider TCC code path. For a launchd-spawned
+ * daemon with an ad-hoc-signed binary (which Bun's `--compile` produces),
+ * an unanswered indirect TCC request hangs indefinitely instead of failing
+ * with EPERM. Calling `realpath()` on those paths to canonicalize them —
+ * what an earlier version of this file did — is enough on its own to wedge
+ * every path-info request on the dispatch server until the TCC prompt is
+ * answered (which never happens for a daemon with no foreground UI).
+ *
+ * The trade-off: we no longer follow symlinks. If a user types a path that
+ * symlinks INTO a protected dir, this check returns false. That's
+ * acceptable — the caller's downstream `stat()` will still hit TCC against
+ * the underlying protected dir, get EPERM in bounded time (this is the
+ * direct TCC path, not the indirect FileProvider one), and the request
+ * completes with `exists=false` rather than wedging.
+ */
+
+function normalize(value: string, platform: NodeJS.Platform): string {
   const resolved = path.resolve(value);
   return platform === "darwin" ? resolved.toLocaleLowerCase("en-US") : resolved;
-}
-
-async function canonicalizePath(
-  candidatePath: string,
-  platform: NodeJS.Platform
-): Promise<string> {
-  const resolved = path.resolve(candidatePath);
-  const canonical = await realpath(resolved).catch(() => resolved);
-  return normalizeForComparison(canonical, platform);
 }
 
 function isSameOrChildPath(candidate: string, parent: string): boolean {
   return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
 }
 
-export async function isMacProtectedPath(
+export function isMacProtectedPath(
   candidatePath: string,
   homeDir: string,
   platform: NodeJS.Platform = process.platform
-): Promise<boolean> {
-  const [canonicalCandidate, protectedRoots] = await Promise.all([
-    canonicalizePath(candidatePath, platform),
-    Promise.all(
-      PROTECTED_HOME_RELATIVE_DIRS.map(async (segment) =>
-        canonicalizePath(path.join(homeDir, segment), platform)
-      )
-    ),
-  ]);
-
-  return protectedRoots.some((protectedRoot) =>
-    isSameOrChildPath(canonicalCandidate, protectedRoot)
-  );
+): boolean {
+  const normalizedCandidate = normalize(candidatePath, platform);
+  for (const segment of PROTECTED_HOME_RELATIVE_DIRS) {
+    const protectedRoot = normalize(path.join(homeDir, segment), platform);
+    if (isSameOrChildPath(normalizedCandidate, protectedRoot)) {
+      return true;
+    }
+  }
+  return false;
 }
 
-export async function shouldSkipAutomaticMacPathProbe(
+export function shouldSkipAutomaticMacPathProbe(
   candidatePath: string,
   homeDir: string,
   platform: NodeJS.Platform = process.platform
-): Promise<boolean> {
+): boolean {
   return (
     platform === "darwin" &&
-    (await isMacProtectedPath(candidatePath, homeDir, platform))
+    isMacProtectedPath(candidatePath, homeDir, platform)
   );
 }

--- a/apps/server/test/mac-path-privacy.test.ts
+++ b/apps/server/test/mac-path-privacy.test.ts
@@ -1,8 +1,6 @@
 import path from "node:path";
-import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
-import os from "node:os";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   isMacProtectedPath,
@@ -13,19 +11,19 @@ describe("isMacProtectedPath", () => {
   const homeDir = "/Users/tester";
   const platform = "darwin";
 
-  it("matches protected macOS home folders", async () => {
-    await expect(
-      isMacProtectedPath(path.join(homeDir, "Documents"), homeDir, platform)
-    ).resolves.toBe(true);
+  it("matches protected macOS home folders", () => {
     expect(
-      await isMacProtectedPath(
+      isMacProtectedPath(path.join(homeDir, "Documents"), homeDir, platform)
+    ).toBe(true);
+    expect(
+      isMacProtectedPath(
         path.join(homeDir, "Desktop", "repo"),
         homeDir,
         platform
       )
     ).toBe(true);
     expect(
-      await isMacProtectedPath(
+      isMacProtectedPath(
         path.join(
           homeDir,
           "Library",
@@ -36,70 +34,84 @@ describe("isMacProtectedPath", () => {
         platform
       )
     ).toBe(true);
+    expect(
+      isMacProtectedPath(
+        path.join(homeDir, "Library", "CloudStorage", "Dropbox", "stuff"),
+        homeDir,
+        platform
+      )
+    ).toBe(true);
   });
 
-  it("matches protected paths case-insensitively on darwin", async () => {
-    await expect(
+  it("matches protected paths case-insensitively on darwin", () => {
+    expect(
       isMacProtectedPath(
         path.join(homeDir, "documents", "repo"),
         homeDir,
         platform
       )
-    ).resolves.toBe(true);
+    ).toBe(true);
   });
 
-  it("does not match unprotected paths", async () => {
-    await expect(
+  it("does not match unprotected paths", () => {
+    expect(
       isMacProtectedPath(path.join(homeDir, "code"), homeDir, platform)
-    ).resolves.toBe(false);
-    await expect(
+    ).toBe(false);
+    expect(
       isMacProtectedPath(path.join(homeDir, ".dispatch"), homeDir, platform)
-    ).resolves.toBe(false);
+    ).toBe(false);
+    // Sibling-of-protected doesn't match: ~/Library is not protected even
+    // though ~/Library/Mobile Documents is.
+    expect(
+      isMacProtectedPath(path.join(homeDir, "Library"), homeDir, platform)
+    ).toBe(false);
   });
 });
 
 describe("shouldSkipAutomaticMacPathProbe", () => {
   const homeDir = "/Users/tester";
 
-  it("only skips protected paths on darwin", async () => {
-    await expect(
+  it("only skips protected paths on darwin", () => {
+    expect(
       shouldSkipAutomaticMacPathProbe(
         path.join(homeDir, "Downloads"),
         homeDir,
         "darwin"
       )
-    ).resolves.toBe(true);
-    await expect(
+    ).toBe(true);
+    expect(
       shouldSkipAutomaticMacPathProbe(
         path.join(homeDir, "Downloads"),
         homeDir,
         "linux"
       )
-    ).resolves.toBe(false);
+    ).toBe(false);
   });
-});
 
-describe("symlink handling", () => {
-  const tempDirs: string[] = [];
+  it("does not invoke any filesystem syscall", () => {
+    // Pass a path that does NOT exist on disk anywhere. The function must
+    // return purely based on string comparison — if it ever calls
+    // realpath/stat/etc. this would either throw, return false, or hit
+    // TCC machinery on macOS. The async-free signature is the structural
+    // guarantee, but exercising it here pins the contract: synchronous,
+    // pure, no FS access. This is the property that prevents the daemon
+    // hang documented in the module header.
+    const fakePath = "/Users/this-user-does-not-exist/Documents/whatever";
+    expect(
+      isMacProtectedPath(fakePath, "/Users/this-user-does-not-exist", "darwin")
+    ).toBe(true);
+  });
 
-  afterEach(async () => {
-    await Promise.all(
-      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+  it("does NOT follow symlinks (intentional trade-off)", () => {
+    // We deliberately don't call realpath() — see module header. A path
+    // that symlinks INTO a protected dir is reported as not-protected
+    // here. Downstream stat() will hit TCC against the underlying dir
+    // and return EPERM in bounded time, so the request still completes
+    // safely with `exists=false` rather than wedging.
+    const homeDir = "/Users/tester";
+    const aliased = path.join(homeDir, "work");
+    expect(shouldSkipAutomaticMacPathProbe(aliased, homeDir, "darwin")).toBe(
+      false
     );
-  });
-
-  it("treats symlinks into protected folders as protected", async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), "dispatch-mac-privacy-"));
-    tempDirs.push(root);
-    const homeDir = path.join(root, "home");
-    const protectedTarget = path.join(homeDir, "Documents", "project");
-    const symlinkPath = path.join(homeDir, "work");
-
-    await mkdir(protectedTarget, { recursive: true });
-    await symlink(protectedTarget, symlinkPath, "dir");
-
-    await expect(
-      shouldSkipAutomaticMacPathProbe(symlinkPath, homeDir, "darwin")
-    ).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the production hang where `/api/v1/system/path-info` and `/api/v1/system/path-completions` requests never complete on the Bun-compiled daemon, leaving the agent-create dialog spinning forever and (over time) leaking ~16 unix-socket FDs/min.

## What was happening

`shouldSkipAutomaticMacPathProbe` (added in #438) proactively canonicalizes 8 protected user-folder paths via `realpath()` on every call to determine whether the user's input is in a TCC-protected dir. Two of those paths — `~/Library/Mobile Documents` (iCloud Drive) and `~/Library/CloudStorage` (third-party cloud sync) — are FileProvider domains.

macOS routes accesses to FileProvider domains through TCC's **indirect-FileProvider** code path (`TCCAccessRequestIndirectWithOptions`, visible in `tccd` logs). For a launchd-spawned daemon with an ad-hoc-signed binary — exactly what Bun's `--compile` produces — an unanswered indirect TCC request hangs indefinitely instead of failing with EPERM. The realpath syscall blocks waiting for a prompt resolution that never surfaces.

Compounding factors:

- TCC keys grants by `(executable path, code identity)`. Each release ships a fresh Bun-compiled binary with a new path AND new cdhash, so TCC re-evaluates from scratch every time. Even granting Full Disk Access wouldn't survive the next release.
- Every hung path-info request stalls 8 realpath syscalls at once, leaking unix-socket FDs that never get freed. Over ~12h this accumulated to 552 orphaned sockets and started wedging other endpoints too (the symptom that originally surfaced as "can't create agent" — see DIS-3, which we now know was a downstream effect of this bug).

The pre-#438 behavior didn't hit this because dispatch never proactively touched those paths; it only stat'd what the user explicitly typed, and direct TCC requests on Documents/Desktop/etc. fail fast with EPERM rather than hanging.

## The fix

Drop all `realpath()` calls. `mac-path-privacy.ts` is now a pure synchronous string-prefix match against the expected absolute paths (`$HOME/Documents`, `$HOME/Library/Mobile Documents`, etc.) with case-insensitive normalization on darwin. No filesystem syscalls. Cannot trigger TCC.

## Trade-off

We no longer follow symlinks. A user-typed path that symlinks INTO a protected dir is reported as not-protected here. The downstream `stat()` in the path-info handler will still hit TCC against the underlying dir, get EPERM in bounded time (this is the direct TCC path, not the indirect FileProvider one), and the request completes with `exists=false` rather than wedging. Acceptable failure mode — symlink-aliased protected paths are an edge case, and even when they hit, the worst outcome is a "looks empty" result instead of a hang.

## Other notes

- The function signatures change from async to sync. Two `await` callsites in `server.ts` (path-info, path-completions handlers) updated.
- Module header documents the rationale and the symlink trade-off.
- Test pin: a fake non-existent path still classifies correctly, proving no FS access happens.

## Future-proofing

Even after this lands, **anything else dispatch ever does that touches `~/Library/Mobile Documents` or `~/Library/CloudStorage` from the daemon will hang the same way.** The rule going forward: detect those prefixes via string match and refuse to probe. Don't call any fs syscall on FileProvider-rooted paths from the Bun-compiled binary.

The longer-term fix (separate work) is signing the binary with a stable Developer ID team identity so TCC entries persist across releases. That removes the per-release re-evaluation problem but doesn't fix the indirect-FileProvider hang on its own — this string-prefix approach is the right fix regardless.

## Test plan

- [x] `pnpm --filter @dispatch/server check` clean
- [x] `pnpm --filter @dispatch/server test mac-path-privacy` — 6/6 passing
- [ ] Deploy to production, verify path-info responds in <50ms, agent creation works without restart-cycling, FD count holds steady over hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)