### PR TITLE
Add macOS binary signing workflow

### DIFF
--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -1,121 +1,20 @@
-name: Release
+name: Release Signing Smoke
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version bump type"
+      ref:
+        description: "Git ref to test (branch, tag, or SHA)"
         required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+        default: "main"
+        type: string
 
 concurrency:
-  group: dispatch-release
+  group: dispatch-release-signing-smoke-${{ inputs.ref }}
   cancel-in-progress: false
 
 jobs:
-  prepare-release:
-    runs-on:
-      - self-hosted
-      - Linux
-
-    permissions:
-      contents: write
-
-    outputs:
-      tag: ${{ steps.prepare.outputs.tag }}
-      release_commit: ${{ steps.prepare.outputs.release_commit }}
-      artifact_name: ${{ steps.prepare.outputs.artifact_name }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.13"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Prepare release commit
-        id: prepare
-        run: |
-          set -euo pipefail
-
-          git fetch origin main --tags --prune
-          git checkout main
-          git reset --hard origin/main
-
-          mkdir -p release-notes
-          PREV_TAG=$(git tag --sort=-version:refname | head -n 1)
-          NEW_VERSION=$(npm version ${{ inputs.version }} --no-git-tag-version)
-          pnpm -r exec npm version ${{ inputs.version }} --no-git-tag-version
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_VERSION}" >/dev/null 2>&1; then
-            echo "error: remote tag ${NEW_VERSION} already exists" >&2
-            exit 1
-          fi
-
-          if [ -n "$PREV_TAG" ]; then
-            gh api "repos/${{ github.repository }}/releases/generate-notes" \
-              -X POST \
-              -f tag_name="$NEW_VERSION" \
-              -f target_commitish="main" \
-              -f previous_tag_name="$PREV_TAG" \
-              --jq '.body' > release-notes/current.md
-          else
-            gh api "repos/${{ github.repository }}/releases/generate-notes" \
-              -X POST \
-              -f tag_name="$NEW_VERSION" \
-              -f target_commitish="main" \
-              --jq '.body' > release-notes/current.md
-          fi
-
-          git add package.json apps/*/package.json pnpm-lock.yaml release-notes/current.md
-          git commit -m "Release ${NEW_VERSION}"
-
-          META="release-notes/next-assisted-update.json"
-          if [ -f "$META" ]; then
-            bun bin/embed-assisted-update.ts \
-              --metadata "$META" \
-              --notes release-notes/current.md
-            git rm "$META"
-            git add release-notes/current.md
-            git commit --amend --no-edit
-          fi
-
-          git pull --rebase origin main
-          git push origin HEAD:main
-
-          RELEASE_COMMIT=$(git rev-parse HEAD)
-          ARTIFACT_NAME="release-bundle-${NEW_VERSION}"
-
-          {
-            echo "tag=${NEW_VERSION}"
-            echo "release_commit=${RELEASE_COMMIT}"
-            echo "artifact_name=${ARTIFACT_NAME}"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  verify-release:
-    needs: prepare-release
+  verify-ref:
     runs-on:
       - self-hosted
       - Linux
@@ -126,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-release.outputs.release_commit }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 1
 
       - uses: pnpm/action-setup@v4
@@ -144,7 +43,7 @@ jobs:
       - name: Start Postgres
         id: postgres
         run: |
-          CONTAINER="dispatch-release-verify-pg-$GITHUB_RUN_ID"
+          CONTAINER="dispatch-signing-smoke-verify-pg-$GITHUB_RUN_ID"
           echo "container=$CONTAINER" >> "$GITHUB_OUTPUT"
           PORT=$((RANDOM % 10000 + 10000))
           echo "port=$PORT" >> "$GITHUB_OUTPUT"
@@ -178,10 +77,8 @@ jobs:
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true
 
-  build-binaries:
-    needs:
-      - prepare-release
-      - verify-release
+  build-signed-binaries:
+    needs: verify-ref
     runs-on:
       - self-hosted
       - macOS
@@ -189,11 +86,20 @@ jobs:
     permissions:
       contents: read
 
+    outputs:
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-release.outputs.release_commit }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 1
+
+      - name: Derive artifact name
+        id: meta
+        run: |
+          REF_SLUG=$(printf '%s' '${{ inputs.ref }}' | tr '/:' '--')
+          echo "artifact_name=release-signing-smoke-${REF_SLUG}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v4
         with:
@@ -241,7 +147,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Bun binaries
+      - name: Build signed Bun binaries
         run: pnpm run build:bun
         env:
           DISPATCH_CODESIGN_IDENTITY: "Developer ID Application: Brad Harris (ML8BQ6D727)"
@@ -251,13 +157,13 @@ jobs:
           APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      - name: Pack release artifact
+      - name: Pack smoke artifact
         run: bin/pack-release --output dispatch-release.tar.gz
 
-      - name: Upload release bundle
+      - name: Upload smoke bundle
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.prepare-release.outputs.artifact_name }}
+          name: ${{ steps.meta.outputs.artifact_name }}
           if-no-files-found: error
           path: |
             dist/bun/
@@ -270,9 +176,7 @@ jobs:
         run: security delete-keychain build.keychain || true
 
   smoke-linux:
-    needs:
-      - prepare-release
-      - build-binaries
+    needs: build-signed-binaries
     runs-on:
       - self-hosted
       - Linux
@@ -283,7 +187,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-release.outputs.release_commit }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 1
 
       - uses: pnpm/action-setup@v4
@@ -301,10 +205,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download release bundle
+      - name: Download smoke bundle
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.prepare-release.outputs.artifact_name }}
+          name: ${{ needs.build-signed-binaries.outputs.artifact_name }}
 
       - name: Restore binary execute bits
         run: chmod +x dist/bun/dispatch-*
@@ -312,7 +216,7 @@ jobs:
       - name: Start Postgres
         id: postgres
         run: |
-          CONTAINER="dispatch-release-linux-pg-$GITHUB_RUN_ID"
+          CONTAINER="dispatch-signing-smoke-linux-pg-$GITHUB_RUN_ID"
           echo "container=$CONTAINER" >> "$GITHUB_OUTPUT"
           PORT=$((RANDOM % 10000 + 10000))
           echo "port=$PORT" >> "$GITHUB_OUTPUT"
@@ -349,9 +253,7 @@ jobs:
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true
 
   smoke-macos:
-    needs:
-      - prepare-release
-      - build-binaries
+    needs: build-signed-binaries
     runs-on:
       - self-hosted
       - macOS
@@ -362,7 +264,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-release.outputs.release_commit }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 1
 
       - uses: pnpm/action-setup@v4
@@ -380,10 +282,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download release bundle
+      - name: Download smoke bundle
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.prepare-release.outputs.artifact_name }}
+          name: ${{ needs.build-signed-binaries.outputs.artifact_name }}
 
       - name: Restore binary execute bits
         run: chmod +x dist/bun/dispatch-*
@@ -391,7 +293,7 @@ jobs:
       - name: Start Postgres
         id: postgres
         run: |
-          CONTAINER="dispatch-release-macos-pg-$GITHUB_RUN_ID"
+          CONTAINER="dispatch-signing-smoke-macos-pg-$GITHUB_RUN_ID"
           echo "container=$CONTAINER" >> "$GITHUB_OUTPUT"
           PORT=$((RANDOM % 10000 + 10000))
           echo "port=$PORT" >> "$GITHUB_OUTPUT"
@@ -428,58 +330,3 @@ jobs:
       - name: Stop Postgres
         if: always()
         run: docker stop ${{ steps.postgres.outputs.container }} 2>/dev/null || true
-
-  publish-release:
-    needs:
-      - prepare-release
-      - build-binaries
-      - smoke-linux
-      - smoke-macos
-    runs-on:
-      - self-hosted
-      - Linux
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Download release bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.prepare-release.outputs.artifact_name }}
-
-      - name: Verify release still publishable
-        run: |
-          set -euo pipefail
-
-          TAG="${{ needs.prepare-release.outputs.tag }}"
-          RELEASE_COMMIT="${{ needs.prepare-release.outputs.release_commit }}"
-
-          git fetch origin main --tags --prune
-
-          REMOTE_MAIN=$(git rev-parse origin/main)
-          if [[ "$REMOTE_MAIN" != "$RELEASE_COMMIT" ]]; then
-            echo "error: origin/main advanced to $REMOTE_MAIN after smoke tests; expected $RELEASE_COMMIT" >&2
-            exit 1
-          fi
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "error: remote tag ${TAG} already exists" >&2
-            exit 1
-          fi
-
-      - name: Create GitHub release from tested artifact
-        run: |
-          gh release create "${{ needs.prepare-release.outputs.tag }}" \
-            --target "${{ needs.prepare-release.outputs.release_commit }}" \
-            --title "${{ needs.prepare-release.outputs.tag }}" \
-            --notes-file release-notes/current.md \
-            --prerelease \
-            dispatch-release.tar.gz
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build-bun-binaries.mjs
+++ b/scripts/build-bun-binaries.mjs
@@ -2,12 +2,16 @@
 
 import { createHash } from "node:crypto";
 import {
+  existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   rmSync,
+  readdirSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -21,12 +25,125 @@ const version = JSON.parse(
   readFileSync(path.join(repoRoot, "package.json"), "utf8")
 ).version;
 
-const targets = [
+const defaultTargets = [
   "bun-darwin-x64",
   "bun-darwin-arm64",
   "bun-linux-x64",
   "bun-linux-arm64",
 ];
+const bundleIdentifier =
+  process.env.DISPATCH_MACOS_BUNDLE_ID ?? "dev.bradharris.dispatch";
+const entitlementsPath = path.join(
+  repoRoot,
+  "scripts",
+  "dispatch-bun.entitlements.plist"
+);
+const shouldNotarizeMacos =
+  process.env.DISPATCH_NOTARIZE_MACOS_BINARIES === "1";
+
+if (shouldNotarizeMacos && !process.env.DISPATCH_CODESIGN_IDENTITY) {
+  console.error(
+    "DISPATCH_NOTARIZE_MACOS_BINARIES=1 requires DISPATCH_CODESIGN_IDENTITY"
+  );
+  process.exit(1);
+}
+
+function parseTargets(rawTargets) {
+  if (!rawTargets?.trim()) return defaultTargets;
+  const targets = rawTargets
+    .split(/[,\s]+/)
+    .map((target) => target.trim())
+    .filter(Boolean);
+  const invalidTargets = targets.filter(
+    (target) => !defaultTargets.includes(target)
+  );
+  if (invalidTargets.length > 0) {
+    console.error(
+      `Unsupported Bun build targets: ${invalidTargets.join(", ")}`
+    );
+    process.exit(1);
+  }
+  return targets;
+}
+
+function validateNotaryEnv() {
+  const requiredVars = ["APPLE_ID", "APPLE_NOTARY_PASSWORD", "APPLE_TEAM_ID"];
+  const missingVars = requiredVars.filter((name) => !process.env[name]);
+  if (missingVars.length > 0) {
+    console.error(
+      `Missing notarization env vars: ${missingVars.join(", ")}`
+    );
+    process.exit(1);
+  }
+}
+
+function signAndMaybeNotarizeMacosBinary(outfile) {
+  const signingIdentity = process.env.DISPATCH_CODESIGN_IDENTITY;
+  if (!signingIdentity) return;
+
+  if (!existsSync(entitlementsPath)) {
+    console.error(`Missing macOS entitlements file: ${entitlementsPath}`);
+    process.exit(1);
+  }
+
+  run("codesign", [
+    "--force",
+    "--sign",
+    signingIdentity,
+    "--options",
+    "runtime",
+    "--timestamp",
+    "--identifier",
+    bundleIdentifier,
+    "--entitlements",
+    entitlementsPath,
+    outfile,
+  ]);
+
+  if (!shouldNotarizeMacos) return;
+
+  validateNotaryEnv();
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "dispatch-notary-"));
+  const zipPath = path.join(tempDir, `${path.basename(outfile)}.zip`);
+  try {
+    run("ditto", ["-c", "-k", "--keepParent", outfile, zipPath]);
+    run("xcrun", [
+      "notarytool",
+      "submit",
+      zipPath,
+      "--apple-id",
+      process.env.APPLE_ID,
+      "--team-id",
+      process.env.APPLE_TEAM_ID,
+      "--password",
+      process.env.APPLE_NOTARY_PASSWORD,
+      "--wait",
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function writeChecksums() {
+  const checksumLines = readdirSync(outDir)
+    .filter((entry) => entry.startsWith("dispatch-"))
+    .sort()
+    .map((entry) => {
+      const filePath = path.join(outDir, entry);
+      const binary = readFileSync(filePath);
+      const sha256 = createHash("sha256").update(binary).digest("hex");
+      const sizeBytes = statSync(filePath).size;
+      return `${sha256}  ${entry}  ${sizeBytes}`;
+    });
+
+  writeFileSync(
+    path.join(outDir, "SHA256SUMS.txt"),
+    `${checksumLines.join("\n")}\n`,
+    "utf8"
+  );
+}
+
+const targets = parseTargets(process.env.DISPATCH_BUN_TARGETS);
 
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -45,7 +162,6 @@ mkdirSync(outDir, { recursive: true });
 run("pnpm", ["run", "build:web"]);
 run("bun", ["scripts/generate-server-runtime-assets.mjs"]);
 
-const checksumLines = [];
 for (const target of targets) {
   const outfile = path.join(outDir, `dispatch-${version}-${target}`);
   run("bun", [
@@ -56,17 +172,11 @@ for (const target of targets) {
     "--outfile",
     outfile,
   ]);
-
-  const binary = readFileSync(outfile);
-  const sha256 = createHash("sha256").update(binary).digest("hex");
-  const sizeBytes = statSync(outfile).size;
-  checksumLines.push(`${sha256}  ${path.basename(outfile)}  ${sizeBytes}`);
+  if (target.startsWith("bun-darwin-")) {
+    signAndMaybeNotarizeMacosBinary(outfile);
+  }
 }
 
-writeFileSync(
-  path.join(outDir, "SHA256SUMS.txt"),
-  `${checksumLines.join("\n")}\n`,
-  "utf8"
-);
+writeChecksums();
 
 console.log(`Built Bun binaries in ${path.relative(repoRoot, outDir)}`);

--- a/scripts/build-bun-binaries.mjs
+++ b/scripts/build-bun-binaries.mjs
@@ -70,9 +70,7 @@ function validateNotaryEnv() {
   const requiredVars = ["APPLE_ID", "APPLE_NOTARY_PASSWORD", "APPLE_TEAM_ID"];
   const missingVars = requiredVars.filter((name) => !process.env[name]);
   if (missingVars.length > 0) {
-    console.error(
-      `Missing notarization env vars: ${missingVars.join(", ")}`
-    );
+    console.error(`Missing notarization env vars: ${missingVars.join(", ")}`);
     process.exit(1);
   }
 }

--- a/scripts/dispatch-bun.entitlements.plist
+++ b/scripts/dispatch-bun.entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/write-bun-checksums.mjs
+++ b/scripts/write-bun-checksums.mjs
@@ -8,7 +8,9 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const outDir = path.resolve(process.argv[2] ?? path.join(repoRoot, "dist", "bun"));
+const outDir = path.resolve(
+  process.argv[2] ?? path.join(repoRoot, "dist", "bun")
+);
 
 const checksumLines = readdirSync(outDir)
   .filter((entry) => entry.startsWith("dispatch-"))
@@ -21,4 +23,8 @@ const checksumLines = readdirSync(outDir)
     return `${sha256}  ${entry}  ${sizeBytes}`;
   });
 
-writeFileSync(path.join(outDir, "SHA256SUMS.txt"), `${checksumLines.join("\n")}\n`, "utf8");
+writeFileSync(
+  path.join(outDir, "SHA256SUMS.txt"),
+  `${checksumLines.join("\n")}\n`,
+  "utf8"
+);

--- a/scripts/write-bun-checksums.mjs
+++ b/scripts/write-bun-checksums.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const outDir = path.resolve(process.argv[2] ?? path.join(repoRoot, "dist", "bun"));
+
+const checksumLines = readdirSync(outDir)
+  .filter((entry) => entry.startsWith("dispatch-"))
+  .sort()
+  .map((entry) => {
+    const filePath = path.join(outDir, entry);
+    const binary = readFileSync(filePath);
+    const sha256 = createHash("sha256").update(binary).digest("hex");
+    const sizeBytes = statSync(filePath).size;
+    return `${sha256}  ${entry}  ${sizeBytes}`;
+  });
+
+writeFileSync(path.join(outDir, "SHA256SUMS.txt"), `${checksumLines.join("\n")}\n`, "utf8");


### PR DESCRIPTION
## Summary
- sign macOS Bun binaries with the Developer ID Application identity during release builds
- notarize the macOS binaries in the release pipeline and verify them in smoke tests
- add a branch-safe Release Signing Smoke workflow for validating signing/notarization without bumping versions or publishing a release

## Validation
- pnpm run check
- pnpm run test:e2e
- local Developer ID codesign sanity check