### PR TITLE
Make file/line optional in persona feedback guidance

### DIFF
--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -131,7 +131,7 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 ## Feedback Guidelines (from Dispatch)
 
 ### How to submit feedback
-- Call \`dispatch_feedback\` for each finding with: severity, file path, line number, description, and a concrete suggestion.
+- Call \`dispatch_feedback\` for each finding with: severity, description, and a concrete suggestion. Include file path and line number when applicable.
 - Only flag issues that are within the scope of the changes (the diff below). Do not flag pre-existing issues unless directly caused or worsened by the new changes.
 
 ### Review lifecycle


### PR DESCRIPTION
## Summary
- Reframe the standard `dispatch_feedback` instructions injected into persona prompts so file path and line number are described as optional rather than always required.
- Aligns the prompt wording with the actual MCP schema (`filePath`/`lineNumber` are optional) and reduces false pressure on persona reviewers handling non-code artifacts (PRDs, PDFs, screenshots).

## Change
Single-line wording change in `apps/server/src/personas/loader.ts` (`STANDARD_FEEDBACK_GUIDANCE`):

- Before: `Call dispatch_feedback for each finding with: severity, file path, line number, description, and a concrete suggestion.`
- After: `Call dispatch_feedback for each finding with: severity, description, and a concrete suggestion. Include file path and line number when applicable.`

The rest of the guidance (severity ladder, info-feedback limits, review lifecycle) is unchanged.

## Why this is safe
- The web docs at `apps/web/src/components/app/docs-pane.tsx:716` already framed file/line as optional, so this brings the prompt in line with the docs (no contradictions).
- No tests assert the exact phrasing; the existing `apps/server/test/persona-loader.test.ts` only checks for the section header, severity labels, and recheck block presence — all still pass (27/27).
- No schema, lifecycle, or UI changes.

## Test plan
- [x] `pnpm run check` (server + web tsc)
- [x] `pnpm --filter @dispatch/server exec vitest run test/persona-loader.test.ts` — 27/27 pass
- [ ] Spot-check a future persona launch to confirm reviewers still anchor code findings with file/line where appropriate