### PR TITLE
Expose parent media filePath and sizeBytes to persona agents (DIS-135)

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -3701,8 +3701,10 @@ export class AgentManager {
   async listMedia(agentId: string): Promise<
     Array<{
       fileName: string;
+      filePath: string;
       description: string | null;
       source: string;
+      sizeBytes: number;
       createdAt: string;
     }>
   > {
@@ -3710,13 +3712,30 @@ export class AgentManager {
       fileName: string;
       description: string | null;
       source: string;
-      createdAt: string;
+      sizeBytes: number;
+      createdAt: Date;
+      mediaDir: string | null;
     }>(
-      `SELECT file_name AS "fileName", description, source, created_at AS "createdAt"
-       FROM media WHERE agent_id = $1 ORDER BY created_at`,
+      `SELECT m.file_name AS "fileName", m.description, m.source,
+              m.size_bytes AS "sizeBytes", m.created_at AS "createdAt",
+              a.media_dir AS "mediaDir"
+       FROM media m
+       JOIN agents a ON a.id = m.agent_id
+       WHERE m.agent_id = $1
+       ORDER BY m.created_at`,
       [agentId]
     );
-    return result.rows;
+    return result.rows.map((row) => ({
+      fileName: row.fileName,
+      filePath: path.join(
+        row.mediaDir ?? this.defaultMediaDir(agentId),
+        row.fileName
+      ),
+      description: row.description,
+      source: row.source,
+      sizeBytes: row.sizeBytes,
+      createdAt: row.createdAt.toISOString(),
+    }));
   }
 
   // --- Feedback ---

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -395,8 +395,10 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         pins,
         media: media.map((m) => ({
           fileName: m.fileName,
+          filePath: m.filePath,
           description: m.description,
           source: m.source,
+          sizeBytes: m.sizeBytes,
           createdAt: m.createdAt,
         })),
       };

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -225,8 +225,10 @@ export type ParentContextResult = {
   pins: Array<{ label: string; value: string; type: string }>;
   media: Array<{
     fileName: string;
+    filePath: string;
     description: string | null;
     source: string;
+    sizeBytes: number;
     createdAt: string;
   }>;
 };
@@ -571,7 +573,8 @@ async function createDispatchMcpServer(
       {
         description:
           "Retrieve the parent agent's pins and shared media. Use this to discover dev server URLs, " +
-          "key files, screenshots, and other context the parent agent has surfaced.",
+          "key files, screenshots, and other context the parent agent has surfaced. Each shared media " +
+          "item includes an absolute filePath and sizeBytes so you can open or inspect the artifact directly.",
         inputSchema: {},
       },
       async () => {
@@ -590,7 +593,7 @@ async function createDispatchMcpServer(
             parts.push("\nShared media:");
             for (const m of result.media) {
               parts.push(
-                `  ${m.fileName}: ${m.description ?? "(no description)"}`
+                `  ${m.fileName} (${m.sizeBytes} bytes) at ${m.filePath}: ${m.description ?? "(no description)"}`
               );
             }
           }

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -2952,4 +2952,59 @@ describe("AgentManager", () => {
       await rm(reviewerDir, { recursive: true, force: true });
     });
   });
+
+  describe("listMedia", () => {
+    it("should include filePath and sizeBytes for each media item", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+
+      await pool.query(
+        `INSERT INTO media (agent_id, file_name, source, size_bytes, description)
+         VALUES ($1, 'doc.pdf', 'upload', 4096, 'Product brief')`,
+        [agent.id]
+      );
+
+      const media = await manager.listMedia(agent.id);
+      expect(media).toHaveLength(1);
+      const item = media[0]!;
+      expect(item.fileName).toBe("doc.pdf");
+      expect(item.description).toBe("Product brief");
+      expect(item.source).toBe("upload");
+      expect(item.sizeBytes).toBe(4096);
+      expect(typeof item.createdAt).toBe("string");
+      expect(item.filePath.endsWith(`${agent.id}/doc.pdf`)).toBe(true);
+      expect(path.isAbsolute(item.filePath)).toBe(true);
+    });
+
+    it("should resolve filePath using the agent's media_dir override", async () => {
+      const customDir = await mkdtemp(
+        path.join(os.tmpdir(), "dispatch-media-")
+      );
+      try {
+        const agent = await manager.createAgent({
+          cwd: "/tmp",
+          useWorktree: false,
+        });
+        await pool.query(`UPDATE agents SET media_dir = $2 WHERE id = $1`, [
+          agent.id,
+          customDir,
+        ]);
+
+        await pool.query(
+          `INSERT INTO media (agent_id, file_name, source, size_bytes)
+           VALUES ($1, 'screen.png', 'screenshot', 256)`,
+          [agent.id]
+        );
+
+        const media = await manager.listMedia(agent.id);
+        expect(media).toHaveLength(1);
+        expect(media[0]!.filePath).toBe(path.join(customDir, "screen.png"));
+        expect(media[0]!.sizeBytes).toBe(256);
+      } finally {
+        await rm(customDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -674,6 +674,9 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             <Code>dispatch_share</Code> for surfacing files or screenshots, and{" "}
             <Code>get_parent_context</Code> to retrieve the parent agent's pins
             and shared media (for example, a dev server URL to test against).
+            Each media item also includes an absolute <Code>filePath</Code> and{" "}
+            <Code>sizeBytes</Code> so reviewers can open or inspect the artifact
+            directly — useful for doc-centric review flows.
           </P>
         </Section>
 


### PR DESCRIPTION
## Summary

Persona agents that call `get_parent_context` can now see, for each parent-shared media item:

- `filePath` — absolute local path to the artifact
- `sizeBytes` — file size in bytes

Previously the response only included `fileName`, `description`, `source`, and `createdAt`, which forced reviewers in doc-centric flows (e.g. PM-style PRD review) to guess at how to open the underlying file. Linear: [DIS-135](https://linear.app/dispatch/issue/DIS-135).

## Changes

- `AgentManager.listMedia` now joins `agents.media_dir` and returns `filePath` (resolved against the agent's `media_dir` or the default `mediaRoot`) plus `sizeBytes`.
- `ParentContextResult` (in `apps/server/src/shared/mcp/server.ts`) and the `get_parent_context` MCP tool description / text output advertise the new fields.
- `mcp-handlers.getParentContext` passes the new fields through.
- `docs-pane.tsx` updates the persona docs to mention the new fields.
- New `listMedia` tests cover the default media dir and a custom `media_dir` override.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm --filter @dispatch/server test` (631 passed)
- [x] `pnpm run finalize:web`
- [x] `pnpm run test:e2e` (136 passed)

## Notes

- `filePath` is an absolute path inside the agent's media directory. Visibility is unchanged otherwise — only the parent → child persona path exposes it, matching the existing trust model for `get_parent_context`.
- Backward compatible: existing fields are preserved; this is an additive change to the response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)