### PR TITLE
DIS-37 Phase 1: extract pure tmux builders into agents/tmux/

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -20,11 +20,6 @@ import type { Pool } from "pg";
 
 import type { AppConfig } from "../config.js";
 import {
-  createAgentMcpToken,
-  createJobMcpToken,
-  createReleaseUpdateToken,
-} from "../auth.js";
-import {
   assertSafeRefName,
   cleanupGitWorktree,
   createGitWorktree,
@@ -35,6 +30,16 @@ import { runCommand } from "../shared/lib/run-command.js";
 import { loadRepoHooks } from "../shared/mcp/repo-tools.js";
 import { harvestTokenUsage } from "./token-harvester.js";
 import { AgentError } from "./errors.js";
+import {
+  buildAgentCommand,
+  buildStartupPrompt,
+} from "./tmux/command-builder.js";
+import {
+  agentIdFromSessionName,
+  shouldSuggestSessionRename,
+  toSessionName,
+} from "./tmux/session-name.js";
+import { generateSetupScript } from "./tmux/setup-script.js";
 import type {
   AgentGitContext,
   AgentLatestEventInput,
@@ -93,19 +98,8 @@ export type {
 export { resolveProgressPingStatus } from "./persona-reviews.js";
 export type { FeedbackInput, FeedbackRecord } from "./feedback.js";
 
-const CLI_BY_AGENT_TYPE: Record<
-  Exclude<AgentType, "terminal">,
-  keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">
-> = {
-  codex: "codexBin",
-  claude: "claudeBin",
-  opencode: "opencodeBin",
-};
-
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
-const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
-const DISPATCH_RELEASE_UPDATE_TOKEN_ENV = "DISPATCH_RELEASE_UPDATE_TOKEN";
 
 type WorktreeLocation = "sibling" | "nested";
 
@@ -237,7 +231,7 @@ export class AgentManager {
         ? Array.from(new Set([...(input.agentArgs ?? []), fullAccessArg]))
         : (input.agentArgs ?? []);
     const name = input.name?.trim() || `agent-${id.slice(-6)}`;
-    const tmuxSession = this.toSessionName(id, name);
+    const tmuxSession = toSessionName(this.config.sessionPrefix, id, name);
     const mediaDir = path.join(this.config.mediaRoot, id);
     await mkdir(mediaDir, { recursive: true });
     const initialPins = input.initialPins ?? [];
@@ -361,7 +355,7 @@ export class AgentManager {
         throw error;
       }
     }
-    const startupPrompt = this.buildStartupPrompt(
+    const startupPrompt = buildStartupPrompt(
       input.initialPrompt,
       initialPins,
       initialMedia
@@ -430,7 +424,8 @@ export class AgentManager {
         await this.ensureNoExistingSession(tmuxSession);
 
         // Build the agent command that the setup script will exec into
-        const agentCommand = this.buildAgentCommand(
+        const agentCommand = buildAgentCommand(
+          this.config,
           type,
           role,
           agentArgs,
@@ -440,7 +435,7 @@ export class AgentManager {
           cliSessionId ?? undefined,
           false,
           input.jobRunId,
-          this.shouldSuggestSessionRename(name, id, {
+          shouldSuggestSessionRename(name, id, {
             persona: input.persona,
             jobRunId: input.jobRunId,
           }),
@@ -451,7 +446,7 @@ export class AgentManager {
 
         // Generate a setup script that handles worktree creation, env copy,
         // dep install, and then exec's into the agent CLI — all visible in the terminal.
-        const setupScript = this.generateSetupScript({
+        const setupScript = generateSetupScript(this.config, {
           agentId: id,
           agentType: type,
           originalCwd,
@@ -604,7 +599,8 @@ export class AgentManager {
   async startAgent(id: string): Promise<AgentRecord> {
     const agent = await this.getRequiredAgent(id);
     const tmuxSession =
-      agent.tmuxSession ?? this.toSessionName(agent.id, agent.name);
+      agent.tmuxSession ??
+      toSessionName(this.config.sessionPrefix, agent.id, agent.name);
     const hasSession = await this.hasAgentSession(tmuxSession);
 
     if (hasSession) {
@@ -1386,7 +1382,7 @@ export class AgentManager {
     if (sessions.length === 0) return;
 
     // Extract agent IDs from session names
-    const agentIds = sessions.map((s) => this.agentIdFromSessionName(s.name));
+    const agentIds = sessions.map((s) => agentIdFromSessionName(s.name));
 
     // Query DB for these agent IDs
     const placeholders = agentIds.map((_, i) => `$${i + 1}`).join(", ");
@@ -1404,7 +1400,7 @@ export class AgentManager {
     const toKill: string[] = [];
 
     for (const session of sessions) {
-      const agentId = this.agentIdFromSessionName(session.name);
+      const agentId = agentIdFromSessionName(session.name);
       const status = dbAgents.get(agentId);
 
       // Agent in terminal state — session is definitely orphaned
@@ -1883,7 +1879,8 @@ export class AgentManager {
     }
 
     await mkdir(mediaDir, { recursive: true });
-    const agentCommand = this.buildAgentCommand(
+    const agentCommand = buildAgentCommand(
+      this.config,
       type,
       role,
       agentArgs,
@@ -1893,7 +1890,7 @@ export class AgentManager {
       cliSessionId,
       resume,
       undefined,
-      this.shouldSuggestSessionRename(agentName, agentId, { persona }),
+      shouldSuggestSessionRename(agentName, agentId, { persona }),
       !persona && (autoReview ?? false)
     );
     const exitFile = `/tmp/dispatch_${sessionName}.exit`;
@@ -2024,318 +2021,6 @@ export class AgentManager {
     }
   }
 
-  private buildAgentCommand(
-    type: AgentType,
-    role: AgentRole,
-    args: string[],
-    mediaDir: string,
-    sessionName: string,
-    fullAccess: boolean,
-    cliSessionId?: string,
-    resume?: boolean,
-    jobRunId?: string,
-    suggestSessionRename?: boolean,
-    autoReview?: boolean,
-    initialPrompt?: string
-  ): string {
-    const agentId = this.agentIdFromSessionName(sessionName);
-    // Lean startup guidance shared by both agent types. Full behavioral specs live in
-    // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
-    // Rules are built as an array and numbered on output so the agent sees a scannable
-    // list rather than a run-on paragraph.
-    const rules: string[] = [];
-
-    if (jobRunId) {
-      rules.push(
-        `You are running a Dispatch job run (${jobRunId}). Job agents have a dedicated MCP route — use repo tools when relevant.`
-      );
-      if (suggestSessionRename) {
-        rules.push(
-          "Name the session. Once the topic of work is clear, call dispatch_rename_session with a short name for that topic, task, or feature. The name is a stable label describing what the run is about, not a live status update."
-        );
-      }
-      rules.push("Report status with dispatch_event to keep the UI current.");
-      rules.push("Log task-level progress with job_log.");
-      rules.push(
-        "Call a job terminal tool when the run is complete, failed, or needs input."
-      );
-    } else {
-      rules.push(
-        "No task, no work. If the user hasn't explicitly asked for a change, fix, review, or investigation, ask what they want — don't infer a task from branch/worktree context alone."
-      );
-      if (suggestSessionRename) {
-        rules.push(
-          "Name the session. Once the topic of work is clear, call dispatch_rename_session with a short name for that topic, task, or feature — the reason for the session. The name is a stable label describing what the session is about, not a live status update. Rename again if the work shifts substantially to a new topic."
-        );
-      }
-      rules.push(
-        "Report status with dispatch_event. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). Emit working at turn start and when shifting phases (e.g. research → coding → testing). Emit a terminal event before your final response. Use blocked only when truly stuck — not for errors you're actively fixing."
-      );
-      rules.push(
-        "Pin key info with dispatch_pin so it surfaces in the sidebar — especially values users may need to copy/paste: URLs, commands, branch names, IDs, tokens, simulator UDIDs. Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). Update or delete stale pins. For longer artifacts, write a file via dispatch_share and pin a reference."
-      );
-      rules.push(
-        "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done."
-      );
-      rules.push(
-        "For pull requests, use the create_pr MCP tool — not built-in PR skills or gh CLI."
-      );
-      if (autoReview) {
-        rules.push(
-          "Autonomous Review is enabled. Before emitting done: commit and push your branch, open a draft PR via create_pr (don't override baseBranch — it defaults correctly), call list_personas, then launch 1 relevant reviewer via dispatch_launch_persona. After launch, keep the turn alive and wait for server-injected review prompts instead of polling dispatch_get_feedback. For single-pass reviews you'll receive one completion prompt; for recheck reviews you'll receive a round-1 prompt and, after dispatch_submit_resolution, a round-2 prompt. Only call dispatch_get_feedback after a completion prompt says findings are ready. Address critical/high feedback before resolving; medium and below can be resolved with a comment. Call dispatch_resolve_feedback for each item. Don't emit done until all reviews are resolved."
-        );
-      }
-    }
-
-    const numbered = rules.map((rule, i) => `${i + 1}. ${rule}`).join("\n");
-    const header = jobRunId
-      ? "Dispatch job startup rules:"
-      : "Dispatch startup rules:";
-    const launchGuidance = `[dispatch:${agentId}] ${header}\n${numbered}`;
-
-    const userLocalBin = process.env.HOME
-      ? path.join(process.env.HOME, ".local/bin")
-      : null;
-    const launchPathEntries = [this.config.dispatchBinDir, userLocalBin].filter(
-      (entry): entry is string => typeof entry === "string" && entry.length > 0
-    );
-    const launchPathPrefix = Array.from(new Set(launchPathEntries)).join(":");
-
-    const envPrefixParts = [
-      `DISPATCH_AGENT_ID=${this.shellEscape(agentId)}`,
-      `DISPATCH_MEDIA_DIR=${this.shellEscape(mediaDir)}`,
-      `DISPATCH_PORT=${this.shellEscape(String(this.config.port))}`,
-      `DISPATCH_SCHEME=${this.config.tls ? "https" : "http"}`,
-      `PATH=${this.shellEscape(launchPathPrefix)}:$PATH`,
-      // Pin the Bash tool's cwd to the project root (worktree) after every command.
-      // Prevents cwd drift back to the original repo root during long conversations.
-      `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`,
-    ];
-
-    if (role === "assisted_update") {
-      envPrefixParts.push(
-        `${DISPATCH_API_URL_ENV}=${this.shellEscape(
-          `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}`
-        )}`,
-        `${DISPATCH_RELEASE_UPDATE_TOKEN_ENV}=${this.shellEscape(
-          createReleaseUpdateToken(this.config.authToken, agentId)
-        )}`
-      );
-    }
-
-    // Forward the clipboard display to agent sessions so CLI tools can read
-    // images pasted via the browser clipboard (xclip needs a DISPLAY).
-    if (process.platform === "linux" && process.env.DISPATCH_COPY_DISPLAY) {
-      envPrefixParts.push(
-        `DISPATCH_COPY_DISPLAY=${this.shellEscape(process.env.DISPATCH_COPY_DISPLAY)}`
-      );
-    }
-
-    // When TLS is enabled with a CA cert, tell agent CLI tools to trust it
-    // so loopback MCP connections don't fail certificate verification.
-    // TLS_CA should point at the CA that signed the server cert (e.g. mkcert's rootCA.pem).
-    const tlsCaPath = process.env.TLS_CA;
-    if (this.config.tls && tlsCaPath) {
-      envPrefixParts.push(`NODE_EXTRA_CA_CERTS=${this.shellEscape(tlsCaPath)}`);
-    }
-
-    if (type === "opencode" && fullAccess) {
-      envPrefixParts.push(
-        `OPENCODE_PERMISSION=${this.shellEscape(
-          JSON.stringify({
-            bash: { "*": "allow" },
-            edit: { "*": "allow" },
-            read: { "*": "allow" },
-            list: { "*": "allow" },
-            glob: { "*": "allow" },
-            grep: { "*": "allow" },
-            task: { "*": "allow" },
-            todowrite: { "*": "allow" },
-            todoread: { "*": "allow" },
-            webfetch: { "*": "allow" },
-            websearch: { "*": "allow" },
-            codesearch: { "*": "allow" },
-            lsp: { "*": "allow" },
-            skill: { "*": "allow" },
-            external_directory: { "*": "allow" },
-          })
-        )}`
-      );
-    }
-
-    const envPrefix = envPrefixParts.join(" ");
-
-    // Terminal agents have no CLI to launch — drop the user into an
-    // interactive login shell in the chosen cwd/worktree. `-l` alone starts a
-    // non-interactive login shell that exits immediately under `bash -c`,
-    // which tears down the tmux session before the browser can attach.
-    if (type === "terminal") {
-      return `${envPrefix} "\${SHELL:-/bin/bash}" -il`;
-    }
-
-    const cliBin = this.config[CLI_BY_AGENT_TYPE[type]];
-    const dispatchMcpUrl = this.dispatchMcpUrl(agentId, jobRunId);
-    const dispatchMcpToken = jobRunId
-      ? createJobMcpToken(this.config.authToken, jobRunId, agentId)
-      : createAgentMcpToken(this.config.authToken, agentId);
-    const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
-    const { passthroughArgs, appendedSystemPrompt } =
-      this.normalizeAgentArgsForType(type, args);
-
-    if (type === "claude") {
-      const mcpConfig = this.shellEscape(
-        JSON.stringify({
-          mcpServers: {
-            dispatch: {
-              type: "http",
-              url: dispatchMcpUrl,
-              headers: {
-                Authorization: `Bearer ${dispatchMcpToken}`,
-              },
-            },
-          },
-        })
-      );
-      const mcpFlag = `--mcp-config ${mcpConfig}`;
-      // Elevate guidance to system prompt so it persists through long conversations
-      // and isn't buried as an early user message. CLAUDE.md is also auto-loaded by
-      // Claude Code and provides the full behavioral spec.
-      const systemFlag = `--append-system-prompt ${this.shellEscape(launchGuidance)}`;
-      // Session tracking: --resume continues an existing session, --session-id starts
-      // a new one with a known ID for token attribution and future resume.
-      const sessionFlag = cliSessionId
-        ? resume
-          ? `--resume ${this.shellEscape(cliSessionId)}`
-          : `--session-id ${this.shellEscape(cliSessionId)}`
-        : "";
-      const flags = [mcpFlag, systemFlag, sessionFlag]
-        .filter(Boolean)
-        .join(" ");
-      // initialPrompt becomes the first user message (positional arg to Claude Code CLI)
-      const allArgs = initialPrompt ? [...args, initialPrompt] : args;
-      if (allArgs.length === 0) {
-        return `${envPrefix} ${this.shellEscape(cliBin)} ${flags}`;
-      }
-      const escaped = allArgs.map((arg) => this.shellEscape(arg)).join(" ");
-      return `${envPrefix} ${this.shellEscape(cliBin)} ${flags} ${escaped}`;
-    }
-
-    if (type === "opencode") {
-      const promptParts = [
-        launchGuidance,
-        appendedSystemPrompt,
-        initialPrompt,
-      ].filter(Boolean);
-      const startupPrompt = promptParts.join("\n\n");
-      const promptFlag = `--prompt ${this.shellEscape(startupPrompt)}`;
-      const sessionFlag =
-        resume && cliSessionId
-          ? `--session ${this.shellEscape(cliSessionId)}`
-          : "";
-      const flagParts = [promptFlag, sessionFlag].filter(Boolean).join(" ");
-      if (passthroughArgs.length === 0) {
-        return `${envPrefix} ${this.shellEscape(cliBin)} ${flagParts}`;
-      }
-      const escaped = passthroughArgs
-        .map((arg) => this.shellEscape(arg))
-        .join(" ");
-      return `${envPrefix} ${this.shellEscape(cliBin)} ${escaped} ${flagParts}`;
-    }
-
-    // Codex: positional arg — AGENTS.md is auto-loaded by Codex CLI and provides authority.
-    const codexMcpFlags = [
-      "-c",
-      this.shellEscape(
-        `mcp_servers.dispatch.url=${JSON.stringify(dispatchMcpUrl)}`
-      ),
-      "-c",
-      this.shellEscape(
-        `mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`
-      ),
-    ].join(" ");
-    const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${this.shellEscape(dispatchMcpToken)}`;
-    // Codex resume: `codex resume <sessionId>` with MCP flags
-    if (resume && cliSessionId) {
-      return `${codexEnvPrefix} ${this.shellEscape(cliBin)} resume ${this.shellEscape(cliSessionId)} ${codexMcpFlags}`;
-    }
-    const codexPromptParts = [
-      launchGuidance,
-      appendedSystemPrompt,
-      initialPrompt,
-    ].filter(Boolean);
-    const startupPrompt = codexPromptParts.join("\n\n");
-    if (passthroughArgs.length === 0) {
-      return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${this.shellEscape(startupPrompt)}`;
-    }
-    const escaped = passthroughArgs
-      .map((arg) => this.shellEscape(arg))
-      .join(" ");
-    return `${codexEnvPrefix} ${this.shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${this.shellEscape(startupPrompt)}`;
-  }
-
-  private buildStartupPrompt(
-    initialPrompt: string | undefined,
-    initialPins: AgentPin[],
-    initialMedia: Array<{
-      fileName: string;
-      displayName: string;
-      source: string;
-      description: string | null;
-    }>
-  ): string | undefined {
-    const trimmedPrompt = initialPrompt?.trim() || "";
-    if (initialPins.length === 0 && initialMedia.length === 0) {
-      return trimmedPrompt || undefined;
-    }
-
-    const sections = [
-      "Startup context is attached to this session.",
-      "Inspect the provided pins and shared media before acting. Use Dispatch shared-media tools to access attached files; do not try to locate them by searching the filesystem by name.",
-    ];
-
-    if (trimmedPrompt) {
-      sections.push(`Instructions:\n${trimmedPrompt}`);
-    }
-
-    if (initialPins.length > 0) {
-      sections.push(
-        [
-          "Links:",
-          ...initialPins.map((pin) => {
-            try {
-              const hostname =
-                new URL(pin.value).hostname.replace(/^www\./, "") || "Link";
-              const numberedHostPattern = new RegExp(
-                `^${hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}( \\d+)?$`,
-                "i"
-              );
-              return numberedHostPattern.test(pin.label)
-                ? `- ${pin.value}`
-                : `- ${pin.label}: ${pin.value}`;
-            } catch {
-              return `- ${pin.value}`;
-            }
-          }),
-        ].join("\n")
-      );
-    }
-
-    if (initialMedia.length > 0) {
-      sections.push(
-        [
-          "Attached files:",
-          ...initialMedia.map((file) => {
-            const detail = file.description?.trim();
-            const suffix = detail ? ` — ${detail}` : "";
-            return `- ${file.displayName}${suffix} (available via dispatch shared media)`;
-          }),
-        ].join("\n")
-      );
-    }
-
-    return sections.join("\n\n");
-  }
-
   private async seedInitialMedia(
     agentId: string,
     mediaDir: string,
@@ -2404,44 +2089,6 @@ export class AgentManager {
     const ext = path.extname(fileName);
     const base = path.basename(fileName, ext);
     return `${base}-${timestamp}-${index + 1}${ext}`;
-  }
-
-  private dispatchMcpUrl(agentId: string, jobRunId?: string): string {
-    const path = jobRunId
-      ? `/api/mcp/jobs/${jobRunId}/${agentId}`
-      : `/api/mcp/${agentId}`;
-    return `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}${path}`;
-  }
-
-  private shellEscape(value: string): string {
-    return `'${value.replaceAll("'", `'\\''`)}'`;
-  }
-
-  private normalizeAgentArgsForType(
-    type: AgentType,
-    args: string[]
-  ): { passthroughArgs: string[]; appendedSystemPrompt: string | null } {
-    if (type === "claude") {
-      return { passthroughArgs: args, appendedSystemPrompt: null };
-    }
-
-    const passthroughArgs: string[] = [];
-    let appendedSystemPrompt: string | null = null;
-
-    for (let index = 0; index < args.length; index += 1) {
-      const arg = args[index];
-      if (
-        arg === "--append-system-prompt" &&
-        typeof args[index + 1] === "string"
-      ) {
-        appendedSystemPrompt = args[index + 1] ?? null;
-        index += 1;
-        continue;
-      }
-      passthroughArgs.push(arg);
-    }
-
-    return { passthroughArgs, appendedSystemPrompt };
   }
 
   private async validateWorkingDirectory(rawCwd: string): Promise<string> {
@@ -2799,50 +2446,6 @@ export class AgentManager {
     return `agt_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
   }
 
-  /** Extract agent ID from a session name like "dispatch_agt_abc123_my-task" or "dispatch_dev_agt_abc123_my-task". */
-  private agentIdFromSessionName(sessionName: string): string {
-    const match = sessionName.match(/(agt_[a-f0-9]{12})/);
-    return match?.[1] ?? sessionName.replace(/^[^_]*_/, "");
-  }
-
-  private toSessionName(agentId: string, agentName?: string): string {
-    const prefix = this.config.sessionPrefix;
-    if (!agentName) {
-      return `${prefix}_${agentId}`;
-    }
-    // Sanitize: tmux disallows colons and periods in session names.
-    // Collapse whitespace/special chars to hyphens, truncate to keep it readable.
-    const slug = agentName
-      .toLowerCase()
-      .replace(/[^a-z0-9-]+/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "")
-      .slice(0, 30);
-    return `${prefix}_${agentId}_${slug}`;
-  }
-
-  private shouldSuggestSessionRename(
-    agentName: string | null | undefined,
-    agentId: string,
-    opts: { persona?: string | null; jobRunId?: string }
-  ): boolean {
-    if (opts.persona) {
-      return false;
-    }
-
-    const trimmed = agentName?.trim();
-    if (opts.jobRunId) {
-      const jobNameSuffix = `-${opts.jobRunId.slice(0, 8)}`;
-      return (
-        !!trimmed &&
-        trimmed.startsWith("job-") &&
-        trimmed.endsWith(jobNameSuffix)
-      );
-    }
-
-    return trimmed === `agent-${agentId.slice(-6)}`;
-  }
-
   private defaultMediaDir(agentId: string): string {
     return path.join(this.config.mediaRoot, agentId);
   }
@@ -2898,278 +2501,6 @@ export class AgentManager {
       `UPDATE agents SET archive_phase = $2, updated_at = NOW() WHERE id = $1`,
       [id, phase]
     );
-  }
-
-  private generateSetupScript(params: {
-    agentId: string;
-    agentType: AgentType;
-    originalCwd: string;
-    useWorktree: boolean;
-    createNewBranch: boolean;
-    worktreeBranchName?: string;
-    baseBranch?: string;
-    worktreePathOverride?: string;
-    agentName: string;
-    agentCommand: string;
-    exitFile: string;
-    jobRunId?: string;
-  }): string {
-    const {
-      agentId,
-      agentType,
-      originalCwd,
-      useWorktree,
-      createNewBranch,
-      worktreeBranchName,
-      worktreePathOverride,
-      agentName,
-      agentCommand,
-      exitFile,
-    } = params;
-
-    const serverUrl = `${this.config.tls ? "https" : "http"}://127.0.0.1:${this.config.port}`;
-    const authToken = this.config.authToken;
-
-    // Helper function to call back to the server to update setup phase
-    const curlPhase = (phase: string) =>
-      `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/phase" ` +
-      `-H "Content-Type: application/json" ` +
-      `-H "Authorization: Bearer ${authToken}" ` +
-      `-d '{"phase":"${phase}"}' > /dev/null 2>&1 || true`;
-
-    // Helper to report an unrecoverable setup failure. The bash variable
-    // SETUP_ERROR_MSG is interpolated as a JSON string body so the message
-    // surfaces in the agent's last_error.
-    const curlSetupError = (msgBashVar: string) =>
-      `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/error" ` +
-      `-H "Content-Type: application/json" ` +
-      `-H "Authorization: Bearer ${authToken}" ` +
-      `-d "{\\"message\\":\\"\${${msgBashVar}}\\"}" > /dev/null 2>&1 || true`;
-
-    // Helper function for the completion callback
-    const curlComplete = (
-      cwdVar: string,
-      worktreePathVar: string,
-      worktreeBranchVar: string
-    ) =>
-      `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/complete" ` +
-      `-H "Content-Type: application/json" ` +
-      `-H "Authorization: Bearer ${authToken}" ` +
-      `-d "{\\"effectiveCwd\\":\\"${cwdVar}\\",\\"worktreePath\\":${worktreePathVar},\\"worktreeBranch\\":${worktreeBranchVar}}" > /dev/null 2>&1`;
-
-    const lines: string[] = [
-      `#!/usr/bin/env bash`,
-      `set -euo pipefail`,
-      ``,
-      `# Dispatch agent setup script for ${agentName}`,
-      `# This script runs in tmux so the user can see setup progress in real time.`,
-      ``,
-      `# Tee stderr to a log file so the server can surface errors when the session`,
-      `# exits immediately (e.g. a broken profile script).`,
-      `exec 2> >(tee "/tmp/dispatch_setup_${agentId}.log" >&2)`,
-      ``,
-      `# Source user-defined overrides for agent sessions`,
-      `[[ -f ~/.dispatch/env ]] && { set +e; source ~/.dispatch/env; set -euo pipefail; }`,
-      ``,
-      `BOLD="\\033[1m"`,
-      `DIM="\\033[2m"`,
-      `GREEN="\\033[32m"`,
-      `YELLOW="\\033[33m"`,
-      `RED="\\033[31m"`,
-      `RESET="\\033[0m"`,
-      ``,
-      `phase() { printf "\\n\${BOLD}\${GREEN}▸ %s\${RESET}\\n" "$1"; }`,
-      `info()  { printf "  \${DIM}%s\${RESET}\\n" "$1"; }`,
-      `warn()  { printf "  \${YELLOW}⚠ %s\${RESET}\\n" "$1"; }`,
-      `fail()  { printf "  \${RED}✗ %s\${RESET}\\n" "$1"; }`,
-      `ok()    { printf "  \${GREEN}✓ %s\${RESET}\\n" "$1"; }`,
-      ``,
-      `EFFECTIVE_CWD="${this.shellQuote(originalCwd)}"`,
-      `WORKTREE_PATH="null"`,
-      `WORKTREE_BRANCH="null"`,
-      ``,
-    ];
-
-    if (useWorktree && worktreeBranchName) {
-      // Defense in depth: refs flowing through this function are interpolated
-      // into a bash script that runs in tmux, so re-validate them here even
-      // though createAgent already normalized them. A failure here is a bug,
-      // not user error.
-      assertSafeRefName(worktreeBranchName, "worktreeBranchName");
-      const effectiveBaseBranch = assertSafeRefName(
-        params.baseBranch || "main",
-        "baseBranch"
-      );
-
-      const phaseLabel = createNewBranch
-        ? "Creating git worktree"
-        : "Creating managed git worktree";
-      const branchLine = createNewBranch
-        ? `info "Branch: ${worktreeBranchName}"`
-        : `info "Checking out: ${worktreeBranchName}"`;
-      lines.push(
-        `# --- Worktree creation ---`,
-        `phase "${phaseLabel}"`,
-        branchLine,
-        ``
-      );
-
-      // Determine worktree path arg
-      const wtPathArg = worktreePathOverride ? `"${worktreePathOverride}"` : "";
-      lines.push(
-        `REPO_ROOT=$(git -C "${originalCwd}" rev-parse --show-toplevel 2>/dev/null) || {`,
-        `  warn "Not a git repository — skipping worktree"`,
-        `  ${curlPhase("session")}`,
-        `  exec_agent=true`,
-        `}`,
-        ``,
-        `if [ "\${exec_agent:-}" != "true" ]; then`,
-        `  info "Fetching origin/${effectiveBaseBranch}..."`,
-        `  git -C "$REPO_ROOT" fetch origin "${effectiveBaseBranch}" --quiet 2>/dev/null || true`,
-        ``,
-        `  BASE_REF="origin/${effectiveBaseBranch}"`,
-        `  git -C "$REPO_ROOT" rev-parse --verify "$BASE_REF" > /dev/null 2>&1 || {`,
-        `    BASE_REF="${effectiveBaseBranch}"`,
-        `  }`,
-        ``
-      );
-
-      if (worktreePathOverride) {
-        lines.push(`  WT_PATH="${worktreePathOverride}"`);
-      } else {
-        // Default sibling path: <repoRoot>/../<basename>-<slug>. Use the
-        // shared slug helper so the bash path matches what worktree.ts
-        // computes on the inert path (and includes a hash discriminator
-        // when createNewBranch=false to avoid slug collisions).
-        const slugSource = createNewBranch
-          ? worktreeBranchName
-          : effectiveBaseBranch;
-        const sluggedBranch = worktreePathSlug(slugSource, { createNewBranch });
-        lines.push(
-          `  REPO_BASENAME=$(basename "$REPO_ROOT")`,
-          `  WT_PATH="$(dirname "$REPO_ROOT")/\${REPO_BASENAME}-${sluggedBranch}"`
-        );
-      }
-
-      const addCmd = createNewBranch
-        ? `git -C "$REPO_ROOT" worktree add -b "${worktreeBranchName}" "$WT_PATH" "$BASE_REF"`
-        : `git -C "$REPO_ROOT" worktree add "$WT_PATH" "${effectiveBaseBranch}"`;
-      const upstreamLine = createNewBranch
-        ? `    git -C "$WT_PATH" branch --set-upstream-to "$BASE_REF" "${worktreeBranchName}" 2>/dev/null || true`
-        : null;
-
-      lines.push(
-        ``,
-        `  WORKTREE_ADD_OUTPUT=$(${addCmd} 2>&1)`,
-        `  if [ $? -eq 0 ]; then`,
-        `    ok "Worktree created at $WT_PATH"`,
-        ...(upstreamLine ? [upstreamLine] : []),
-        `    EFFECTIVE_CWD="$WT_PATH"`,
-        `    WORKTREE_PATH="\\"$WT_PATH\\""`,
-        `    WORKTREE_BRANCH="\\"${worktreeBranchName}\\""`,
-        ``,
-        `    # --- Copy .env ---`,
-        `    ${curlPhase("env")}`,
-        `    phase "Copying environment files"`,
-        `    if [ -f "${originalCwd}/.env" ]; then`,
-        `      cp "${originalCwd}/.env" "$WT_PATH/.env" && ok "Copied .env" || warn "Failed to copy .env"`,
-        `    else`,
-        `      info "No .env file found — skipping"`,
-        `    fi`,
-        ``
-      );
-
-      if (agentType !== "terminal") {
-        lines.push(
-          `    # --- Install dependencies ---`,
-          `    ${curlPhase("deps")}`,
-          `    phase "Installing dependencies"`,
-          `    cd "$WT_PATH"`,
-          `    if [ -f "pnpm-lock.yaml" ]; then`,
-          `      info "Detected pnpm-lock.yaml"`,
-          `      pnpm install 2>&1 || warn "pnpm install failed (continuing anyway)"`,
-          `      ok "Dependencies installed"`,
-          `    elif [ -f "yarn.lock" ]; then`,
-          `      info "Detected yarn.lock"`,
-          `      yarn install 2>&1 || warn "yarn install failed (continuing anyway)"`,
-          `      ok "Dependencies installed"`,
-          `    elif [ -f "package-lock.json" ]; then`,
-          `      info "Detected package-lock.json"`,
-          `      npm install 2>&1 || warn "npm install failed (continuing anyway)"`,
-          `      ok "Dependencies installed"`,
-          `    elif [ -f "bun.lockb" ]; then`,
-          `      info "Detected bun.lockb"`,
-          `      bun install 2>&1 || warn "bun install failed (continuing anyway)"`,
-          `      ok "Dependencies installed"`,
-          `    else`,
-          `      info "No lockfile found — skipping dependency install"`,
-          `    fi`,
-          ``
-        );
-      }
-
-      lines.push(
-        `  else`,
-        // The user explicitly asked for an isolated worktree. Don't fall back
-        // to running in the primary checkout — surface the failure to the
-        // server (so last_error shows up in the UI) and exit. The tmux
-        // session-died monitor will reconcile status to stopped.
-        `    fail "Worktree creation failed"`,
-        `    fail "$WORKTREE_ADD_OUTPUT"`,
-        `    SETUP_ERROR_MSG=$(printf "%s" "$WORKTREE_ADD_OUTPUT" | head -c 800 | tr -d "\\n\\r" | sed 's/[\\\\\\"]/\\\\&/g')`,
-        `    if [ -z "$SETUP_ERROR_MSG" ]; then SETUP_ERROR_MSG="git worktree add failed"; fi`,
-        `    ${curlSetupError("SETUP_ERROR_MSG")}`,
-        `    exit 1`,
-        `  fi`,
-        `fi`,
-        ``
-      );
-    }
-
-    lines.push(
-      `# --- Start agent session ---`,
-      `${curlPhase("session")}`,
-      `phase "Starting agent session"`,
-      `info "Type: ${params.agentName}"`,
-      ``,
-      `# Notify server that setup is complete`,
-      `cd "$EFFECTIVE_CWD"`,
-      `${curlComplete("$EFFECTIVE_CWD", "$WORKTREE_PATH", "$WORKTREE_BRANCH")}`,
-      ``
-    );
-
-    // Opencode: write opencode.json with the Dispatch MCP server config.
-    if (agentType === "opencode") {
-      const dispatchMcpUrl = this.dispatchMcpUrl(agentId, params.jobRunId);
-      const dispatchMcpToken = params.jobRunId
-        ? createJobMcpToken(authToken, params.jobRunId, agentId)
-        : createAgentMcpToken(authToken, agentId);
-      const mcpEntry = JSON.stringify({
-        type: "remote",
-        url: dispatchMcpUrl,
-        headers: { Authorization: `Bearer ${dispatchMcpToken}` },
-      });
-      lines.push(
-        `# --- Configure opencode MCP ---`,
-        `OPENCODE_CFG="$EFFECTIVE_CWD/opencode.json"`,
-        `MCP_ENTRY=${this.shellEscape(mcpEntry)}`,
-        `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcp = { ...(cfg.mcp ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$OPENCODE_CFG" "$MCP_ENTRY"`,
-        `ok "Configured dispatch MCP in opencode.json"`,
-        ``
-      );
-    }
-
-    lines.push(
-      `# exec replaces this shell with the agent CLI — seamless transition`,
-      `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`
-    );
-
-    return lines.join("\n") + "\n";
-  }
-
-  /** Quote a value for safe embedding in a bash script (single-quote wrapping). */
-  private shellQuote(value: string): string {
-    return value.replaceAll("'", "'\\''");
   }
 
   private async setSystemLatestEvent(

--- a/apps/server/src/agents/tmux/command-builder.ts
+++ b/apps/server/src/agents/tmux/command-builder.ts
@@ -1,0 +1,390 @@
+import path from "node:path";
+
+import {
+  createAgentMcpToken,
+  createJobMcpToken,
+  createReleaseUpdateToken,
+} from "../../auth.js";
+import type { AppConfig } from "../../config.js";
+import type { AgentPin, AgentRole, AgentType } from "../types.js";
+import { shellEscape } from "./quoting.js";
+import { agentIdFromSessionName } from "./session-name.js";
+
+const CLI_BY_AGENT_TYPE: Record<
+  Exclude<AgentType, "terminal">,
+  keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">
+> = {
+  codex: "codexBin",
+  claude: "claudeBin",
+  opencode: "opencodeBin",
+};
+
+const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
+const DISPATCH_RELEASE_UPDATE_TOKEN_ENV = "DISPATCH_RELEASE_UPDATE_TOKEN";
+
+/** Build the URL the agent CLI uses to reach Dispatch's MCP endpoint. */
+export function dispatchMcpUrl(
+  config: AppConfig,
+  agentId: string,
+  jobRunId?: string
+): string {
+  const route = jobRunId
+    ? `/api/mcp/jobs/${jobRunId}/${agentId}`
+    : `/api/mcp/${agentId}`;
+  return `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}${route}`;
+}
+
+/**
+ * Pull a `--append-system-prompt <value>` pair out of an arg list (codex /
+ * opencode put system prompts in their own flag). Claude doesn't need this
+ * normalization because its CLI accepts the flag directly.
+ */
+export function normalizeAgentArgsForType(
+  type: AgentType,
+  args: string[]
+): { passthroughArgs: string[]; appendedSystemPrompt: string | null } {
+  if (type === "claude") {
+    return { passthroughArgs: args, appendedSystemPrompt: null };
+  }
+
+  const passthroughArgs: string[] = [];
+  let appendedSystemPrompt: string | null = null;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (
+      arg === "--append-system-prompt" &&
+      typeof args[index + 1] === "string"
+    ) {
+      appendedSystemPrompt = args[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    passthroughArgs.push(arg);
+  }
+
+  return { passthroughArgs, appendedSystemPrompt };
+}
+
+/**
+ * Compose the first user-message-style prompt handed to the agent on
+ * launch — formats `initialPrompt`, `initialPins`, and `initialMedia` into
+ * a single string the CLI passes through as the opening turn.
+ *
+ * Returns `undefined` when there's nothing to attach (the caller can then
+ * skip the prompt entirely).
+ */
+export function buildStartupPrompt(
+  initialPrompt: string | undefined,
+  initialPins: AgentPin[],
+  initialMedia: Array<{
+    fileName: string;
+    displayName: string;
+    source: string;
+    description: string | null;
+  }>
+): string | undefined {
+  const trimmedPrompt = initialPrompt?.trim() || "";
+  if (initialPins.length === 0 && initialMedia.length === 0) {
+    return trimmedPrompt || undefined;
+  }
+
+  const sections = [
+    "Startup context is attached to this session.",
+    "Inspect the provided pins and shared media before acting. Use Dispatch shared-media tools to access attached files; do not try to locate them by searching the filesystem by name.",
+  ];
+
+  if (trimmedPrompt) {
+    sections.push(`Instructions:\n${trimmedPrompt}`);
+  }
+
+  if (initialPins.length > 0) {
+    sections.push(
+      [
+        "Links:",
+        ...initialPins.map((pin) => {
+          try {
+            const hostname =
+              new URL(pin.value).hostname.replace(/^www\./, "") || "Link";
+            const numberedHostPattern = new RegExp(
+              `^${hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}( \\d+)?$`,
+              "i"
+            );
+            return numberedHostPattern.test(pin.label)
+              ? `- ${pin.value}`
+              : `- ${pin.label}: ${pin.value}`;
+          } catch {
+            return `- ${pin.value}`;
+          }
+        }),
+      ].join("\n")
+    );
+  }
+
+  if (initialMedia.length > 0) {
+    sections.push(
+      [
+        "Attached files:",
+        ...initialMedia.map((file) => {
+          const detail = file.description?.trim();
+          const suffix = detail ? ` — ${detail}` : "";
+          return `- ${file.displayName}${suffix} (available via dispatch shared media)`;
+        }),
+      ].join("\n")
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Build the bash invocation that launches the agent CLI inside its tmux
+ * session. Pure — takes config + inputs, returns a shell-ready string.
+ *
+ * Encodes the per-CLI launch quirks (claude/opencode/codex MCP wiring,
+ * resume vs. new session flags, terminal-only fallback to `bash -il`).
+ *
+ * Security note: every interpolated value flows through `shellEscape`,
+ * since this string lands directly in `tmux new-session … bash -c …`.
+ */
+export function buildAgentCommand(
+  config: AppConfig,
+  type: AgentType,
+  role: AgentRole,
+  args: string[],
+  mediaDir: string,
+  sessionName: string,
+  fullAccess: boolean,
+  cliSessionId?: string,
+  resume?: boolean,
+  jobRunId?: string,
+  suggestSessionRename?: boolean,
+  autoReview?: boolean,
+  initialPrompt?: string
+): string {
+  const agentId = agentIdFromSessionName(sessionName);
+  // Lean startup guidance shared by both agent types. Full behavioral specs live in
+  // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
+  // Rules are built as an array and numbered on output so the agent sees a scannable
+  // list rather than a run-on paragraph.
+  const rules: string[] = [];
+
+  if (jobRunId) {
+    rules.push(
+      `You are running a Dispatch job run (${jobRunId}). Job agents have a dedicated MCP route — use repo tools when relevant.`
+    );
+    if (suggestSessionRename) {
+      rules.push(
+        "Name the session. Once the topic of work is clear, call dispatch_rename_session with a short name for that topic, task, or feature. The name is a stable label describing what the run is about, not a live status update."
+      );
+    }
+    rules.push("Report status with dispatch_event to keep the UI current.");
+    rules.push("Log task-level progress with job_log.");
+    rules.push(
+      "Call a job terminal tool when the run is complete, failed, or needs input."
+    );
+  } else {
+    rules.push(
+      "No task, no work. If the user hasn't explicitly asked for a change, fix, review, or investigation, ask what they want — don't infer a task from branch/worktree context alone."
+    );
+    if (suggestSessionRename) {
+      rules.push(
+        "Name the session. Once the topic of work is clear, call dispatch_rename_session with a short name for that topic, task, or feature — the reason for the session. The name is a stable label describing what the session is about, not a live status update. Rename again if the work shifts substantially to a new topic."
+      );
+    }
+    rules.push(
+      "Report status with dispatch_event. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). Emit working at turn start and when shifting phases (e.g. research → coding → testing). Emit a terminal event before your final response. Use blocked only when truly stuck — not for errors you're actively fixing."
+    );
+    rules.push(
+      "Pin key info with dispatch_pin so it surfaces in the sidebar — especially values users may need to copy/paste: URLs, commands, branch names, IDs, tokens, simulator UDIDs. Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). Update or delete stale pins. For longer artifacts, write a file via dispatch_share and pin a reference."
+    );
+    rules.push(
+      "Playwright: default headless. Capture at least one screenshot per UI flow via dispatch_share. Call browser_close when done."
+    );
+    rules.push(
+      "For pull requests, use the create_pr MCP tool — not built-in PR skills or gh CLI."
+    );
+    if (autoReview) {
+      rules.push(
+        "Autonomous Review is enabled. Before emitting done: commit and push your branch, open a draft PR via create_pr (don't override baseBranch — it defaults correctly), call list_personas, then launch 1 relevant reviewer via dispatch_launch_persona. After launch, keep the turn alive and wait for server-injected review prompts instead of polling dispatch_get_feedback. For single-pass reviews you'll receive one completion prompt; for recheck reviews you'll receive a round-1 prompt and, after dispatch_submit_resolution, a round-2 prompt. Only call dispatch_get_feedback after a completion prompt says findings are ready. Address critical/high feedback before resolving; medium and below can be resolved with a comment. Call dispatch_resolve_feedback for each item. Don't emit done until all reviews are resolved."
+      );
+    }
+  }
+
+  const numbered = rules.map((rule, i) => `${i + 1}. ${rule}`).join("\n");
+  const header = jobRunId
+    ? "Dispatch job startup rules:"
+    : "Dispatch startup rules:";
+  const launchGuidance = `[dispatch:${agentId}] ${header}\n${numbered}`;
+
+  const userLocalBin = process.env.HOME
+    ? path.join(process.env.HOME, ".local/bin")
+    : null;
+  const launchPathEntries = [config.dispatchBinDir, userLocalBin].filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0
+  );
+  const launchPathPrefix = Array.from(new Set(launchPathEntries)).join(":");
+
+  const envPrefixParts = [
+    `DISPATCH_AGENT_ID=${shellEscape(agentId)}`,
+    `DISPATCH_MEDIA_DIR=${shellEscape(mediaDir)}`,
+    `DISPATCH_PORT=${shellEscape(String(config.port))}`,
+    `DISPATCH_SCHEME=${config.tls ? "https" : "http"}`,
+    `PATH=${shellEscape(launchPathPrefix)}:$PATH`,
+    // Pin the Bash tool's cwd to the project root (worktree) after every command.
+    // Prevents cwd drift back to the original repo root during long conversations.
+    `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`,
+  ];
+
+  if (role === "assisted_update") {
+    envPrefixParts.push(
+      `${DISPATCH_API_URL_ENV}=${shellEscape(
+        `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}`
+      )}`,
+      `${DISPATCH_RELEASE_UPDATE_TOKEN_ENV}=${shellEscape(
+        createReleaseUpdateToken(config.authToken, agentId)
+      )}`
+    );
+  }
+
+  // Forward the clipboard display to agent sessions so CLI tools can read
+  // images pasted via the browser clipboard (xclip needs a DISPLAY).
+  if (process.platform === "linux" && process.env.DISPATCH_COPY_DISPLAY) {
+    envPrefixParts.push(
+      `DISPATCH_COPY_DISPLAY=${shellEscape(process.env.DISPATCH_COPY_DISPLAY)}`
+    );
+  }
+
+  // When TLS is enabled with a CA cert, tell agent CLI tools to trust it
+  // so loopback MCP connections don't fail certificate verification.
+  // TLS_CA should point at the CA that signed the server cert (e.g. mkcert's rootCA.pem).
+  const tlsCaPath = process.env.TLS_CA;
+  if (config.tls && tlsCaPath) {
+    envPrefixParts.push(`NODE_EXTRA_CA_CERTS=${shellEscape(tlsCaPath)}`);
+  }
+
+  if (type === "opencode" && fullAccess) {
+    envPrefixParts.push(
+      `OPENCODE_PERMISSION=${shellEscape(
+        JSON.stringify({
+          bash: { "*": "allow" },
+          edit: { "*": "allow" },
+          read: { "*": "allow" },
+          list: { "*": "allow" },
+          glob: { "*": "allow" },
+          grep: { "*": "allow" },
+          task: { "*": "allow" },
+          todowrite: { "*": "allow" },
+          todoread: { "*": "allow" },
+          webfetch: { "*": "allow" },
+          websearch: { "*": "allow" },
+          codesearch: { "*": "allow" },
+          lsp: { "*": "allow" },
+          skill: { "*": "allow" },
+          external_directory: { "*": "allow" },
+        })
+      )}`
+    );
+  }
+
+  const envPrefix = envPrefixParts.join(" ");
+
+  // Terminal agents have no CLI to launch — drop the user into an
+  // interactive login shell in the chosen cwd/worktree. `-l` alone starts a
+  // non-interactive login shell that exits immediately under `bash -c`,
+  // which tears down the tmux session before the browser can attach.
+  if (type === "terminal") {
+    return `${envPrefix} "\${SHELL:-/bin/bash}" -il`;
+  }
+
+  const cliBin = config[CLI_BY_AGENT_TYPE[type]];
+  const mcpUrl = dispatchMcpUrl(config, agentId, jobRunId);
+  const dispatchMcpToken = jobRunId
+    ? createJobMcpToken(config.authToken, jobRunId, agentId)
+    : createAgentMcpToken(config.authToken, agentId);
+  const codexDispatchAuthEnv = "DISPATCH_AUTH_TOKEN";
+  const { passthroughArgs, appendedSystemPrompt } = normalizeAgentArgsForType(
+    type,
+    args
+  );
+
+  if (type === "claude") {
+    const mcpConfig = shellEscape(
+      JSON.stringify({
+        mcpServers: {
+          dispatch: {
+            type: "http",
+            url: mcpUrl,
+            headers: {
+              Authorization: `Bearer ${dispatchMcpToken}`,
+            },
+          },
+        },
+      })
+    );
+    const mcpFlag = `--mcp-config ${mcpConfig}`;
+    // Elevate guidance to system prompt so it persists through long conversations
+    // and isn't buried as an early user message. CLAUDE.md is also auto-loaded by
+    // Claude Code and provides the full behavioral spec.
+    const systemFlag = `--append-system-prompt ${shellEscape(launchGuidance)}`;
+    // Session tracking: --resume continues an existing session, --session-id starts
+    // a new one with a known ID for token attribution and future resume.
+    const sessionFlag = cliSessionId
+      ? resume
+        ? `--resume ${shellEscape(cliSessionId)}`
+        : `--session-id ${shellEscape(cliSessionId)}`
+      : "";
+    const flags = [mcpFlag, systemFlag, sessionFlag].filter(Boolean).join(" ");
+    // initialPrompt becomes the first user message (positional arg to Claude Code CLI)
+    const allArgs = initialPrompt ? [...args, initialPrompt] : args;
+    if (allArgs.length === 0) {
+      return `${envPrefix} ${shellEscape(cliBin)} ${flags}`;
+    }
+    const escaped = allArgs.map((arg) => shellEscape(arg)).join(" ");
+    return `${envPrefix} ${shellEscape(cliBin)} ${flags} ${escaped}`;
+  }
+
+  if (type === "opencode") {
+    const promptParts = [
+      launchGuidance,
+      appendedSystemPrompt,
+      initialPrompt,
+    ].filter(Boolean);
+    const startupPrompt = promptParts.join("\n\n");
+    const promptFlag = `--prompt ${shellEscape(startupPrompt)}`;
+    const sessionFlag =
+      resume && cliSessionId ? `--session ${shellEscape(cliSessionId)}` : "";
+    const flagParts = [promptFlag, sessionFlag].filter(Boolean).join(" ");
+    if (passthroughArgs.length === 0) {
+      return `${envPrefix} ${shellEscape(cliBin)} ${flagParts}`;
+    }
+    const escaped = passthroughArgs.map((arg) => shellEscape(arg)).join(" ");
+    return `${envPrefix} ${shellEscape(cliBin)} ${escaped} ${flagParts}`;
+  }
+
+  // Codex: positional arg — AGENTS.md is auto-loaded by Codex CLI and provides authority.
+  const codexMcpFlags = [
+    "-c",
+    shellEscape(`mcp_servers.dispatch.url=${JSON.stringify(mcpUrl)}`),
+    "-c",
+    shellEscape(
+      `mcp_servers.dispatch.bearer_token_env_var=${JSON.stringify(codexDispatchAuthEnv)}`
+    ),
+  ].join(" ");
+  const codexEnvPrefix = `${envPrefix} ${codexDispatchAuthEnv}=${shellEscape(dispatchMcpToken)}`;
+  // Codex resume: `codex resume <sessionId>` with MCP flags
+  if (resume && cliSessionId) {
+    return `${codexEnvPrefix} ${shellEscape(cliBin)} resume ${shellEscape(cliSessionId)} ${codexMcpFlags}`;
+  }
+  const codexPromptParts = [
+    launchGuidance,
+    appendedSystemPrompt,
+    initialPrompt,
+  ].filter(Boolean);
+  const startupPrompt = codexPromptParts.join("\n\n");
+  if (passthroughArgs.length === 0) {
+    return `${codexEnvPrefix} ${shellEscape(cliBin)} ${codexMcpFlags} ${shellEscape(startupPrompt)}`;
+  }
+  const escaped = passthroughArgs.map((arg) => shellEscape(arg)).join(" ");
+  return `${codexEnvPrefix} ${shellEscape(cliBin)} ${codexMcpFlags} ${escaped} ${shellEscape(startupPrompt)}`;
+}

--- a/apps/server/src/agents/tmux/command-builder.ts
+++ b/apps/server/src/agents/tmux/command-builder.ts
@@ -7,6 +7,7 @@ import {
 } from "../../auth.js";
 import type { AppConfig } from "../../config.js";
 import type { AgentPin, AgentRole, AgentType } from "../types.js";
+import { dispatchMcpUrl } from "./mcp-url.js";
 import { shellEscape } from "./quoting.js";
 import { agentIdFromSessionName } from "./session-name.js";
 
@@ -21,18 +22,6 @@ const CLI_BY_AGENT_TYPE: Record<
 
 const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
 const DISPATCH_RELEASE_UPDATE_TOKEN_ENV = "DISPATCH_RELEASE_UPDATE_TOKEN";
-
-/** Build the URL the agent CLI uses to reach Dispatch's MCP endpoint. */
-export function dispatchMcpUrl(
-  config: AppConfig,
-  agentId: string,
-  jobRunId?: string
-): string {
-  const route = jobRunId
-    ? `/api/mcp/jobs/${jobRunId}/${agentId}`
-    : `/api/mcp/${agentId}`;
-  return `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}${route}`;
-}
 
 /**
  * Pull a `--append-system-prompt <value>` pair out of an arg list (codex /
@@ -139,10 +128,20 @@ export function buildStartupPrompt(
 
 /**
  * Build the bash invocation that launches the agent CLI inside its tmux
- * session. Pure — takes config + inputs, returns a shell-ready string.
+ * session. Returns a shell-ready string.
  *
  * Encodes the per-CLI launch quirks (claude/opencode/codex MCP wiring,
  * resume vs. new session flags, terminal-only fallback to `bash -il`).
+ *
+ * Reads from the host environment (not threaded through `AppConfig`):
+ * - `process.env.HOME` — appended to PATH so the agent can find tools in
+ *   `~/.local/bin`. Falls back gracefully when unset.
+ * - `process.platform` + `process.env.DISPATCH_COPY_DISPLAY` — Linux only;
+ *   forwards the X display so xclip can paste browser-clipboard images.
+ * - `process.env.TLS_CA` — when TLS is enabled, sets `NODE_EXTRA_CA_CERTS`
+ *   so the agent's MCP loopback connection trusts the server cert.
+ *
+ * These are stubbable via `vi.stubEnv` for testing.
  *
  * Security note: every interpolated value flows through `shellEscape`,
  * since this string lands directly in `tmux new-session … bash -c …`.

--- a/apps/server/src/agents/tmux/mcp-url.ts
+++ b/apps/server/src/agents/tmux/mcp-url.ts
@@ -1,0 +1,17 @@
+import type { AppConfig } from "../../config.js";
+
+/**
+ * Build the URL the agent CLI uses to reach Dispatch's MCP endpoint.
+ * Standard agents go through `/api/mcp/<agentId>`; job runs use the
+ * dedicated `/api/mcp/jobs/<jobRunId>/<agentId>` route.
+ */
+export function dispatchMcpUrl(
+  config: AppConfig,
+  agentId: string,
+  jobRunId?: string
+): string {
+  const route = jobRunId
+    ? `/api/mcp/jobs/${jobRunId}/${agentId}`
+    : `/api/mcp/${agentId}`;
+  return `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}${route}`;
+}

--- a/apps/server/src/agents/tmux/quoting.ts
+++ b/apps/server/src/agents/tmux/quoting.ts
@@ -1,0 +1,17 @@
+/**
+ * Wrap a value in single quotes for use as a Bash argument, escaping any
+ * embedded single quotes via the `'\''` idiom. Use this when the value will
+ * be passed to a tmux/bash command as a standalone argument.
+ */
+export function shellEscape(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Escape embedded single quotes only — no outer quotes. Use this when the
+ * value will be interpolated *inside* an existing single-quoted Bash string
+ * (where `shellEscape` would over-quote and break the surrounding string).
+ */
+export function shellQuote(value: string): string {
+  return value.replaceAll("'", "'\\''");
+}

--- a/apps/server/src/agents/tmux/session-name.ts
+++ b/apps/server/src/agents/tmux/session-name.ts
@@ -1,0 +1,76 @@
+/**
+ * Helpers for converting between agent IDs and tmux session names.
+ *
+ * Session names follow the shape `<prefix>_<agentId>[_<slug>]`, e.g.
+ * `dispatch_agt_abc123def456_my-task` or `dispatch_dev_agt_abc123def456`.
+ * The `<slug>` is a sanitized form of the agent's display name, included
+ * for human readability in `tmux ls` output.
+ */
+
+const AGENT_ID_PATTERN = /(agt_[a-f0-9]{12})/;
+
+/**
+ * Extract the agent ID embedded in a session name. Falls back to stripping
+ * the leading `<prefix>_` segment if no canonical `agt_…` ID is present
+ * (legacy sessions).
+ */
+export function agentIdFromSessionName(sessionName: string): string {
+  const match = sessionName.match(AGENT_ID_PATTERN);
+  return match?.[1] ?? sessionName.replace(/^[^_]*_/, "");
+}
+
+/**
+ * Build a tmux session name from `(prefix, agentId, agentName?)`. The
+ * optional `agentName` is slug-sanitized: lowercased, non-alphanumerics
+ * collapsed to hyphens, edge hyphens trimmed, truncated to 30 chars.
+ *
+ * tmux disallows colons and periods in session names, so the slug rules
+ * are conservative — alphanumerics + hyphens only.
+ */
+export function toSessionName(
+  prefix: string,
+  agentId: string,
+  agentName?: string
+): string {
+  if (!agentName) {
+    return `${prefix}_${agentId}`;
+  }
+  const slug = agentName
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 30);
+  return `${prefix}_${agentId}_${slug}`;
+}
+
+/**
+ * Decide whether the launch guidance should ask the agent to rename its
+ * session. Returns `true` only when the existing name is a default
+ * placeholder — never when the user (or a persona) chose a meaningful name.
+ *
+ * - Persona agents: never suggest (the persona name is the meaningful one).
+ * - Job runs: suggest only when the name still matches the auto-generated
+ *   `job-…-<jobRunIdPrefix>` shape.
+ * - Standard agents: suggest only when the name still matches the
+ *   `agent-<last6>` placeholder generated when no name is supplied.
+ */
+export function shouldSuggestSessionRename(
+  agentName: string | null | undefined,
+  agentId: string,
+  opts: { persona?: string | null; jobRunId?: string }
+): boolean {
+  if (opts.persona) {
+    return false;
+  }
+
+  const trimmed = agentName?.trim();
+  if (opts.jobRunId) {
+    const jobNameSuffix = `-${opts.jobRunId.slice(0, 8)}`;
+    return (
+      !!trimmed && trimmed.startsWith("job-") && trimmed.endsWith(jobNameSuffix)
+    );
+  }
+
+  return trimmed === `agent-${agentId.slice(-6)}`;
+}

--- a/apps/server/src/agents/tmux/session-name.ts
+++ b/apps/server/src/agents/tmux/session-name.ts
@@ -41,6 +41,11 @@ export function toSessionName(
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 30);
+  // If sanitization stripped everything, fall through to the no-name shape
+  // rather than emitting a trailing underscore that no other branch produces.
+  if (!slug) {
+    return `${prefix}_${agentId}`;
+  }
   return `${prefix}_${agentId}_${slug}`;
 }
 

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -1,0 +1,299 @@
+import { createAgentMcpToken, createJobMcpToken } from "../../auth.js";
+import type { AppConfig } from "../../config.js";
+import {
+  assertSafeRefName,
+  worktreePathSlug,
+} from "../../shared/git/worktree.js";
+import type { AgentType } from "../types.js";
+import { dispatchMcpUrl } from "./command-builder.js";
+import { shellEscape, shellQuote } from "./quoting.js";
+
+export type SetupScriptParams = {
+  agentId: string;
+  agentType: AgentType;
+  originalCwd: string;
+  useWorktree: boolean;
+  createNewBranch: boolean;
+  worktreeBranchName?: string;
+  baseBranch?: string;
+  worktreePathOverride?: string;
+  agentName: string;
+  agentCommand: string;
+  exitFile: string;
+  jobRunId?: string;
+};
+
+/**
+ * Generate the bash setup script that runs in the agent's tmux pane on
+ * launch. Pure — takes config + inputs, returns the full script as a
+ * single string (the caller writes it to `/tmp/dispatch_setup_<id>.sh`
+ * and execs it via tmux).
+ *
+ * The script:
+ *   1. Optionally creates a git worktree from `baseBranch` and copies
+ *      `.env` + installs deps inside it.
+ *   2. Phones the server back via curl at each phase boundary
+ *      (`worktree`/`env`/`deps`/`session`).
+ *   3. For opencode agents, writes `opencode.json` with the dispatch
+ *      MCP entry before launch.
+ *   4. `exec`s into `agentCommand` so the tmux pane becomes the agent.
+ *
+ * Security note: ref names flowing into the bash script are re-validated
+ * via `assertSafeRefName` even though `createAgent` already normalizes
+ * them — defense in depth, since a failure here is a bug rather than
+ * user error.
+ */
+export function generateSetupScript(
+  config: AppConfig,
+  params: SetupScriptParams
+): string {
+  const {
+    agentId,
+    agentType,
+    originalCwd,
+    useWorktree,
+    createNewBranch,
+    worktreeBranchName,
+    worktreePathOverride,
+    agentName,
+    agentCommand,
+    exitFile,
+  } = params;
+
+  const serverUrl = `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}`;
+  const authToken = config.authToken;
+
+  // Helper function to call back to the server to update setup phase
+  const curlPhase = (phase: string) =>
+    `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/phase" ` +
+    `-H "Content-Type: application/json" ` +
+    `-H "Authorization: Bearer ${authToken}" ` +
+    `-d '{"phase":"${phase}"}' > /dev/null 2>&1 || true`;
+
+  // Helper to report an unrecoverable setup failure. The bash variable
+  // SETUP_ERROR_MSG is interpolated as a JSON string body so the message
+  // surfaces in the agent's last_error.
+  const curlSetupError = (msgBashVar: string) =>
+    `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/error" ` +
+    `-H "Content-Type: application/json" ` +
+    `-H "Authorization: Bearer ${authToken}" ` +
+    `-d "{\\"message\\":\\"\${${msgBashVar}}\\"}" > /dev/null 2>&1 || true`;
+
+  // Helper function for the completion callback
+  const curlComplete = (
+    cwdVar: string,
+    worktreePathVar: string,
+    worktreeBranchVar: string
+  ) =>
+    `curl -sf -X POST "${serverUrl}/api/v1/agents/${agentId}/setup/complete" ` +
+    `-H "Content-Type: application/json" ` +
+    `-H "Authorization: Bearer ${authToken}" ` +
+    `-d "{\\"effectiveCwd\\":\\"${cwdVar}\\",\\"worktreePath\\":${worktreePathVar},\\"worktreeBranch\\":${worktreeBranchVar}}" > /dev/null 2>&1`;
+
+  const lines: string[] = [
+    `#!/usr/bin/env bash`,
+    `set -euo pipefail`,
+    ``,
+    `# Dispatch agent setup script for ${agentName}`,
+    `# This script runs in tmux so the user can see setup progress in real time.`,
+    ``,
+    `# Tee stderr to a log file so the server can surface errors when the session`,
+    `# exits immediately (e.g. a broken profile script).`,
+    `exec 2> >(tee "/tmp/dispatch_setup_${agentId}.log" >&2)`,
+    ``,
+    `# Source user-defined overrides for agent sessions`,
+    `[[ -f ~/.dispatch/env ]] && { set +e; source ~/.dispatch/env; set -euo pipefail; }`,
+    ``,
+    `BOLD="\\033[1m"`,
+    `DIM="\\033[2m"`,
+    `GREEN="\\033[32m"`,
+    `YELLOW="\\033[33m"`,
+    `RED="\\033[31m"`,
+    `RESET="\\033[0m"`,
+    ``,
+    `phase() { printf "\\n\${BOLD}\${GREEN}▸ %s\${RESET}\\n" "$1"; }`,
+    `info()  { printf "  \${DIM}%s\${RESET}\\n" "$1"; }`,
+    `warn()  { printf "  \${YELLOW}⚠ %s\${RESET}\\n" "$1"; }`,
+    `fail()  { printf "  \${RED}✗ %s\${RESET}\\n" "$1"; }`,
+    `ok()    { printf "  \${GREEN}✓ %s\${RESET}\\n" "$1"; }`,
+    ``,
+    `EFFECTIVE_CWD="${shellQuote(originalCwd)}"`,
+    `WORKTREE_PATH="null"`,
+    `WORKTREE_BRANCH="null"`,
+    ``,
+  ];
+
+  if (useWorktree && worktreeBranchName) {
+    // Defense in depth: refs flowing through this function are interpolated
+    // into a bash script that runs in tmux, so re-validate them here even
+    // though createAgent already normalized them. A failure here is a bug,
+    // not user error.
+    assertSafeRefName(worktreeBranchName, "worktreeBranchName");
+    const effectiveBaseBranch = assertSafeRefName(
+      params.baseBranch || "main",
+      "baseBranch"
+    );
+
+    const phaseLabel = createNewBranch
+      ? "Creating git worktree"
+      : "Creating managed git worktree";
+    const branchLine = createNewBranch
+      ? `info "Branch: ${worktreeBranchName}"`
+      : `info "Checking out: ${worktreeBranchName}"`;
+    lines.push(
+      `# --- Worktree creation ---`,
+      `phase "${phaseLabel}"`,
+      branchLine,
+      ``
+    );
+
+    lines.push(
+      `REPO_ROOT=$(git -C "${originalCwd}" rev-parse --show-toplevel 2>/dev/null) || {`,
+      `  warn "Not a git repository — skipping worktree"`,
+      `  ${curlPhase("session")}`,
+      `  exec_agent=true`,
+      `}`,
+      ``,
+      `if [ "\${exec_agent:-}" != "true" ]; then`,
+      `  info "Fetching origin/${effectiveBaseBranch}..."`,
+      `  git -C "$REPO_ROOT" fetch origin "${effectiveBaseBranch}" --quiet 2>/dev/null || true`,
+      ``,
+      `  BASE_REF="origin/${effectiveBaseBranch}"`,
+      `  git -C "$REPO_ROOT" rev-parse --verify "$BASE_REF" > /dev/null 2>&1 || {`,
+      `    BASE_REF="${effectiveBaseBranch}"`,
+      `  }`,
+      ``
+    );
+
+    if (worktreePathOverride) {
+      lines.push(`  WT_PATH="${worktreePathOverride}"`);
+    } else {
+      // Default sibling path: <repoRoot>/../<basename>-<slug>. Use the
+      // shared slug helper so the bash path matches what worktree.ts
+      // computes on the inert path (and includes a hash discriminator
+      // when createNewBranch=false to avoid slug collisions).
+      const slugSource = createNewBranch
+        ? worktreeBranchName
+        : effectiveBaseBranch;
+      const sluggedBranch = worktreePathSlug(slugSource, { createNewBranch });
+      lines.push(
+        `  REPO_BASENAME=$(basename "$REPO_ROOT")`,
+        `  WT_PATH="$(dirname "$REPO_ROOT")/\${REPO_BASENAME}-${sluggedBranch}"`
+      );
+    }
+
+    const addCmd = createNewBranch
+      ? `git -C "$REPO_ROOT" worktree add -b "${worktreeBranchName}" "$WT_PATH" "$BASE_REF"`
+      : `git -C "$REPO_ROOT" worktree add "$WT_PATH" "${effectiveBaseBranch}"`;
+    const upstreamLine = createNewBranch
+      ? `    git -C "$WT_PATH" branch --set-upstream-to "$BASE_REF" "${worktreeBranchName}" 2>/dev/null || true`
+      : null;
+
+    lines.push(
+      ``,
+      `  WORKTREE_ADD_OUTPUT=$(${addCmd} 2>&1)`,
+      `  if [ $? -eq 0 ]; then`,
+      `    ok "Worktree created at $WT_PATH"`,
+      ...(upstreamLine ? [upstreamLine] : []),
+      `    EFFECTIVE_CWD="$WT_PATH"`,
+      `    WORKTREE_PATH="\\"$WT_PATH\\""`,
+      `    WORKTREE_BRANCH="\\"${worktreeBranchName}\\""`,
+      ``,
+      `    # --- Copy .env ---`,
+      `    ${curlPhase("env")}`,
+      `    phase "Copying environment files"`,
+      `    if [ -f "${originalCwd}/.env" ]; then`,
+      `      cp "${originalCwd}/.env" "$WT_PATH/.env" && ok "Copied .env" || warn "Failed to copy .env"`,
+      `    else`,
+      `      info "No .env file found — skipping"`,
+      `    fi`,
+      ``
+    );
+
+    if (agentType !== "terminal") {
+      lines.push(
+        `    # --- Install dependencies ---`,
+        `    ${curlPhase("deps")}`,
+        `    phase "Installing dependencies"`,
+        `    cd "$WT_PATH"`,
+        `    if [ -f "pnpm-lock.yaml" ]; then`,
+        `      info "Detected pnpm-lock.yaml"`,
+        `      pnpm install 2>&1 || warn "pnpm install failed (continuing anyway)"`,
+        `      ok "Dependencies installed"`,
+        `    elif [ -f "yarn.lock" ]; then`,
+        `      info "Detected yarn.lock"`,
+        `      yarn install 2>&1 || warn "yarn install failed (continuing anyway)"`,
+        `      ok "Dependencies installed"`,
+        `    elif [ -f "package-lock.json" ]; then`,
+        `      info "Detected package-lock.json"`,
+        `      npm install 2>&1 || warn "npm install failed (continuing anyway)"`,
+        `      ok "Dependencies installed"`,
+        `    elif [ -f "bun.lockb" ]; then`,
+        `      info "Detected bun.lockb"`,
+        `      bun install 2>&1 || warn "bun install failed (continuing anyway)"`,
+        `      ok "Dependencies installed"`,
+        `    else`,
+        `      info "No lockfile found — skipping dependency install"`,
+        `    fi`,
+        ``
+      );
+    }
+
+    lines.push(
+      `  else`,
+      // The user explicitly asked for an isolated worktree. Don't fall back
+      // to running in the primary checkout — surface the failure to the
+      // server (so last_error shows up in the UI) and exit. The tmux
+      // session-died monitor will reconcile status to stopped.
+      `    fail "Worktree creation failed"`,
+      `    fail "$WORKTREE_ADD_OUTPUT"`,
+      `    SETUP_ERROR_MSG=$(printf "%s" "$WORKTREE_ADD_OUTPUT" | head -c 800 | tr -d "\\n\\r" | sed 's/[\\\\\\"]/\\\\&/g')`,
+      `    if [ -z "$SETUP_ERROR_MSG" ]; then SETUP_ERROR_MSG="git worktree add failed"; fi`,
+      `    ${curlSetupError("SETUP_ERROR_MSG")}`,
+      `    exit 1`,
+      `  fi`,
+      `fi`,
+      ``
+    );
+  }
+
+  lines.push(
+    `# --- Start agent session ---`,
+    `${curlPhase("session")}`,
+    `phase "Starting agent session"`,
+    `info "Type: ${params.agentName}"`,
+    ``,
+    `# Notify server that setup is complete`,
+    `cd "$EFFECTIVE_CWD"`,
+    `${curlComplete("$EFFECTIVE_CWD", "$WORKTREE_PATH", "$WORKTREE_BRANCH")}`,
+    ``
+  );
+
+  // Opencode: write opencode.json with the Dispatch MCP server config.
+  if (agentType === "opencode") {
+    const mcpUrl = dispatchMcpUrl(config, agentId, params.jobRunId);
+    const dispatchMcpToken = params.jobRunId
+      ? createJobMcpToken(authToken, params.jobRunId, agentId)
+      : createAgentMcpToken(authToken, agentId);
+    const mcpEntry = JSON.stringify({
+      type: "remote",
+      url: mcpUrl,
+      headers: { Authorization: `Bearer ${dispatchMcpToken}` },
+    });
+    lines.push(
+      `# --- Configure opencode MCP ---`,
+      `OPENCODE_CFG="$EFFECTIVE_CWD/opencode.json"`,
+      `MCP_ENTRY=${shellEscape(mcpEntry)}`,
+      `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcp = { ...(cfg.mcp ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$OPENCODE_CFG" "$MCP_ENTRY"`,
+      `ok "Configured dispatch MCP in opencode.json"`,
+      ``
+    );
+  }
+
+  lines.push(
+    `# exec replaces this shell with the agent CLI — seamless transition`,
+    `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`
+  );
+
+  return lines.join("\n") + "\n";
+}

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -5,7 +5,7 @@ import {
   worktreePathSlug,
 } from "../../shared/git/worktree.js";
 import type { AgentType } from "../types.js";
-import { dispatchMcpUrl } from "./command-builder.js";
+import { dispatchMcpUrl } from "./mcp-url.js";
 import { shellEscape, shellQuote } from "./quoting.js";
 
 export type SetupScriptParams = {

--- a/apps/server/test/tmux-command-builder.test.ts
+++ b/apps/server/test/tmux-command-builder.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import type { AppConfig } from "../src/config.js";
 import {
   buildAgentCommand,
   buildStartupPrompt,
-  dispatchMcpUrl,
   normalizeAgentArgsForType,
 } from "../src/agents/tmux/command-builder.js";
+import { dispatchMcpUrl } from "../src/agents/tmux/mcp-url.js";
 
 const baseConfig: AppConfig = {
   host: "127.0.0.1",
@@ -401,5 +401,143 @@ describe("buildAgentCommand", () => {
       "begin work"
     );
     expect(cmd).toContain("'begin work'");
+  });
+});
+
+describe("buildAgentCommand — host-env reads (process.env / process.platform)", () => {
+  // The function reads a handful of values from the host environment
+  // rather than from AppConfig. The JSDoc lists them; these tests pin
+  // down the conditional branches so a future refactor (threading them
+  // into config) can't silently change behaviour.
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("PATH prefix: includes ~/.local/bin when HOME is set", () => {
+    vi.stubEnv("HOME", "/home/agentuser");
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    // Expected: dispatchBinDir + ~/.local/bin joined by ':' — the order
+    // is dispatchBinDir first because that's where the wrapper scripts live.
+    expect(cmd).toContain(
+      `PATH='/usr/local/bin/dispatch:/home/agentuser/.local/bin':$PATH`
+    );
+  });
+
+  it("PATH prefix: omits ~/.local/bin when HOME is unset", () => {
+    vi.stubEnv("HOME", "");
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain(`PATH='/usr/local/bin/dispatch':$PATH`);
+    expect(cmd).not.toContain("/.local/bin");
+  });
+
+  it("DISPATCH_COPY_DISPLAY: forwards on linux when set", () => {
+    vi.stubEnv("DISPATCH_COPY_DISPLAY", ":99");
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+    try {
+      const cmd = buildAgentCommand(
+        baseConfig,
+        "claude",
+        "standard",
+        [],
+        "/tmp/media",
+        SESSION,
+        false
+      );
+      expect(cmd).toContain(`DISPATCH_COPY_DISPLAY=':99'`);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: process.platform === "linux" ? "linux" : "darwin",
+        configurable: true,
+      });
+    }
+  });
+
+  it("DISPATCH_COPY_DISPLAY: never forwarded on non-linux platforms", () => {
+    vi.stubEnv("DISPATCH_COPY_DISPLAY", ":99");
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).not.toContain("DISPATCH_COPY_DISPLAY=");
+  });
+
+  it("TLS_CA: sets NODE_EXTRA_CA_CERTS when TLS is configured AND TLS_CA is set", () => {
+    vi.stubEnv("TLS_CA", "/etc/dispatch/rootCA.pem");
+    const tlsConfig: AppConfig = {
+      ...baseConfig,
+      tls: { cert: Buffer.from(""), key: Buffer.from("") },
+    };
+    const cmd = buildAgentCommand(
+      tlsConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain(`NODE_EXTRA_CA_CERTS='/etc/dispatch/rootCA.pem'`);
+  });
+
+  it("TLS_CA: NOT set when TLS_CA is configured but TLS is not enabled", () => {
+    vi.stubEnv("TLS_CA", "/etc/dispatch/rootCA.pem");
+    // baseConfig has tls: null
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).not.toContain("NODE_EXTRA_CA_CERTS");
+  });
+
+  it("TLS_CA: NOT set when TLS is enabled but TLS_CA is not configured", () => {
+    vi.stubEnv("TLS_CA", "");
+    const tlsConfig: AppConfig = {
+      ...baseConfig,
+      tls: { cert: Buffer.from(""), key: Buffer.from("") },
+    };
+    const cmd = buildAgentCommand(
+      tlsConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).not.toContain("NODE_EXTRA_CA_CERTS");
   });
 });

--- a/apps/server/test/tmux-command-builder.test.ts
+++ b/apps/server/test/tmux-command-builder.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from "vitest";
+
+import type { AppConfig } from "../src/config.js";
+import {
+  buildAgentCommand,
+  buildStartupPrompt,
+  dispatchMcpUrl,
+  normalizeAgentArgsForType,
+} from "../src/agents/tmux/command-builder.js";
+
+const baseConfig: AppConfig = {
+  host: "127.0.0.1",
+  port: 6767,
+  databaseUrl: "",
+  authToken: "test-token",
+  mediaRoot: "/tmp/dispatch-test-media",
+  dispatchBinDir: "/usr/local/bin/dispatch",
+  codexBin: "/opt/codex",
+  claudeBin: "/opt/claude",
+  opencodeBin: "/opt/opencode",
+  agentRuntime: "inert",
+  sessionPrefix: "dispatch",
+  tls: null,
+};
+
+const SESSION = "dispatch_agt_abc123def456_my-task";
+const AGENT_ID = "agt_abc123def456";
+
+describe("dispatchMcpUrl", () => {
+  it("uses /api/mcp/<agentId> for standard agents", () => {
+    expect(dispatchMcpUrl(baseConfig, AGENT_ID)).toBe(
+      `http://127.0.0.1:6767/api/mcp/${AGENT_ID}`
+    );
+  });
+
+  it("uses /api/mcp/jobs/<jobRunId>/<agentId> when jobRunId is supplied", () => {
+    expect(dispatchMcpUrl(baseConfig, AGENT_ID, "run_jobid")).toBe(
+      `http://127.0.0.1:6767/api/mcp/jobs/run_jobid/${AGENT_ID}`
+    );
+  });
+
+  it("emits https:// when tls is configured", () => {
+    const tlsConfig: AppConfig = {
+      ...baseConfig,
+      tls: { cert: Buffer.from(""), key: Buffer.from("") },
+    };
+    expect(dispatchMcpUrl(tlsConfig, AGENT_ID)).toMatch(/^https:\/\//);
+  });
+});
+
+describe("normalizeAgentArgsForType", () => {
+  it("passes Claude args through untouched (Claude CLI accepts the flag directly)", () => {
+    const args = ["--append-system-prompt", "be helpful", "--verbose"];
+    const result = normalizeAgentArgsForType("claude", args);
+    expect(result.passthroughArgs).toEqual(args);
+    expect(result.appendedSystemPrompt).toBeNull();
+  });
+
+  it("for codex, lifts --append-system-prompt out of the args", () => {
+    const result = normalizeAgentArgsForType("codex", [
+      "--verbose",
+      "--append-system-prompt",
+      "be helpful",
+      "--debug",
+    ]);
+    expect(result.passthroughArgs).toEqual(["--verbose", "--debug"]);
+    expect(result.appendedSystemPrompt).toBe("be helpful");
+  });
+
+  it("for opencode, lifts --append-system-prompt out of the args", () => {
+    const result = normalizeAgentArgsForType("opencode", [
+      "--append-system-prompt",
+      "do this",
+    ]);
+    expect(result.passthroughArgs).toEqual([]);
+    expect(result.appendedSystemPrompt).toBe("do this");
+  });
+
+  it("ignores --append-system-prompt with no following value (last-arg edge case)", () => {
+    // Without a string value after the flag, the arg becomes uninterpretable;
+    // the function leaves it in passthrough rather than silently swallowing it.
+    const result = normalizeAgentArgsForType("codex", [
+      "--verbose",
+      "--append-system-prompt",
+    ]);
+    expect(result.passthroughArgs).toEqual([
+      "--verbose",
+      "--append-system-prompt",
+    ]);
+    expect(result.appendedSystemPrompt).toBeNull();
+  });
+});
+
+describe("buildStartupPrompt", () => {
+  it("returns just the prompt when there are no pins or media", () => {
+    expect(buildStartupPrompt("do the thing", [], [])).toBe("do the thing");
+  });
+
+  it("returns undefined for empty input (caller skips prompt entirely)", () => {
+    expect(buildStartupPrompt(undefined, [], [])).toBeUndefined();
+    expect(buildStartupPrompt("", [], [])).toBeUndefined();
+  });
+
+  it("includes a Links section when pins are present", () => {
+    const result = buildStartupPrompt(
+      "ship it",
+      [
+        {
+          label: "PR",
+          value: "https://github.com/x/y/pull/1",
+          type: "pr",
+        },
+      ],
+      []
+    );
+    expect(result).toContain("Links:");
+    expect(result).toContain("- PR: https://github.com/x/y/pull/1");
+    expect(result).toContain("Instructions:\nship it");
+  });
+
+  it("drops the redundant label when label matches the URL hostname", () => {
+    const result = buildStartupPrompt(
+      undefined,
+      [
+        {
+          label: "github.com",
+          value: "https://github.com/x/y/pull/1",
+          type: "url",
+        },
+      ],
+      []
+    );
+    // When the label adds no information, the line is just `- <url>`.
+    expect(result).toContain("- https://github.com/x/y/pull/1");
+    expect(result).not.toContain("github.com:");
+  });
+
+  it("falls back to bare value when the pin value is not a URL", () => {
+    const result = buildStartupPrompt(
+      undefined,
+      [{ label: "Token", value: "not a url", type: "code" }],
+      []
+    );
+    expect(result).toContain("- not a url");
+  });
+
+  it("includes an Attached files section when media is present", () => {
+    const result = buildStartupPrompt(
+      undefined,
+      [],
+      [
+        {
+          fileName: "screenshot-2026.png",
+          displayName: "screenshot.png",
+          source: "user",
+          description: "the bug",
+        },
+      ]
+    );
+    expect(result).toContain("Attached files:");
+    expect(result).toContain("- screenshot.png — the bug");
+  });
+});
+
+describe("buildAgentCommand", () => {
+  it("for terminal type, drops the user into an interactive login shell (no CLI args)", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "terminal",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain('"${SHELL:-/bin/bash}" -il');
+    // Terminal sessions never need MCP tokens or system prompts.
+    expect(cmd).not.toContain("--mcp-config");
+    expect(cmd).not.toContain("--append-system-prompt");
+  });
+
+  it("for claude type, includes --mcp-config, --append-system-prompt, and the cli binary", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain("'/opt/claude'");
+    expect(cmd).toContain("--mcp-config");
+    expect(cmd).toContain("--append-system-prompt");
+    // The launch guidance carries the agent's ID so the in-CLI banner can
+    // reference it. This lock-in keeps the tmux-side rename suggestion working.
+    expect(cmd).toContain(AGENT_ID);
+  });
+
+  it("for claude with cliSessionId + resume, emits --resume; without resume, emits --session-id", () => {
+    const resumed = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      "session-uuid",
+      true
+    );
+    expect(resumed).toContain("--resume 'session-uuid'");
+    expect(resumed).not.toContain("--session-id");
+
+    const fresh = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      "session-uuid",
+      false
+    );
+    expect(fresh).toContain("--session-id 'session-uuid'");
+    expect(fresh).not.toContain("--resume");
+  });
+
+  it("for codex type, the CLI flags include the dispatch MCP url + bearer token env var", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "codex",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain("'/opt/codex'");
+    expect(cmd).toContain("mcp_servers.dispatch.url=");
+    expect(cmd).toContain("mcp_servers.dispatch.bearer_token_env_var=");
+    expect(cmd).toContain("DISPATCH_AUTH_TOKEN=");
+  });
+
+  it("for codex resume, emits 'codex resume <sessionId>'", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "codex",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      "codex-session",
+      true
+    );
+    expect(cmd).toContain("'/opt/codex' resume 'codex-session'");
+  });
+
+  it("for opencode with fullAccess=true, sets OPENCODE_PERMISSION env", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "opencode",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      true
+    );
+    expect(cmd).toContain("OPENCODE_PERMISSION=");
+    expect(cmd).toContain("bash");
+  });
+
+  it("for opencode without fullAccess, does NOT set OPENCODE_PERMISSION", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "opencode",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).not.toContain("OPENCODE_PERMISSION=");
+  });
+
+  it("for assisted_update role, sets DISPATCH_API_URL and DISPATCH_RELEASE_UPDATE_TOKEN env", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "assisted_update",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain("DISPATCH_API_URL=");
+    expect(cmd).toContain("DISPATCH_RELEASE_UPDATE_TOKEN=");
+  });
+
+  it("includes Autonomous Review guidance when autoReview is true", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      undefined,
+      false,
+      undefined,
+      false,
+      true
+    );
+    expect(cmd).toContain("Autonomous Review is enabled");
+  });
+
+  it("omits Autonomous Review guidance when autoReview is false", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    expect(cmd).not.toContain("Autonomous Review is enabled");
+  });
+
+  it("uses jobRun-flavoured guidance when jobRunId is supplied", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      undefined,
+      false,
+      "run_jobid"
+    );
+    expect(cmd).toContain("Dispatch job startup rules:");
+    expect(cmd).toContain("job_log");
+    // Job agents use the dedicated /api/mcp/jobs/<runId>/<agentId> route.
+    expect(cmd).toContain("/api/mcp/jobs/run_jobid/");
+  });
+
+  it("escapes user-controllable inputs that land in env vars (mediaDir)", () => {
+    // mediaDir is interpolated into DISPATCH_MEDIA_DIR=…; an attacker-controlled
+    // value with a single quote must not break out of the surrounding bash
+    // string. shellEscape uses the canonical '\'' idiom.
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/it's-bad",
+      SESSION,
+      false
+    );
+    expect(cmd).toContain(`DISPATCH_MEDIA_DIR='/tmp/it'\\''s-bad'`);
+  });
+
+  it("appends extra args after the cli flags for claude", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      ["--verbose"],
+      "/tmp/media",
+      SESSION,
+      false
+    );
+    // The launch guidance contains newlines, so `.*` doesn't span the whole
+    // command — use the dotall form via `[\s\S]*`.
+    expect(cmd).toMatch(/'\/opt\/claude' [\s\S]* '--verbose'/);
+    // The --verbose arg appears after the cli binary (not before).
+    const claudeIdx = cmd.indexOf("'/opt/claude'");
+    const verboseIdx = cmd.indexOf("'--verbose'");
+    expect(verboseIdx).toBeGreaterThan(claudeIdx);
+  });
+
+  it("for claude with initialPrompt, appends the prompt as a positional arg", () => {
+    const cmd = buildAgentCommand(
+      baseConfig,
+      "claude",
+      "standard",
+      [],
+      "/tmp/media",
+      SESSION,
+      false,
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      "begin work"
+    );
+    expect(cmd).toContain("'begin work'");
+  });
+});

--- a/apps/server/test/tmux-quoting.test.ts
+++ b/apps/server/test/tmux-quoting.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+
+import { shellEscape, shellQuote } from "../src/agents/tmux/quoting.js";
+
+describe("shellEscape", () => {
+  it("wraps a plain value in single quotes", () => {
+    expect(shellEscape("hello")).toBe("'hello'");
+  });
+
+  it("preserves whitespace and shell metacharacters inside the quotes", () => {
+    expect(shellEscape("a b $c `d` *e*")).toBe("'a b $c `d` *e*'");
+  });
+
+  it("escapes embedded single quotes via the '\\'' idiom", () => {
+    expect(shellEscape("it's fine")).toBe(`'it'\\''s fine'`);
+  });
+
+  it("escapes every embedded single quote, not just the first", () => {
+    expect(shellEscape("a'b'c")).toBe(`'a'\\''b'\\''c'`);
+  });
+
+  it("handles an empty string", () => {
+    expect(shellEscape("")).toBe("''");
+  });
+
+  it("produces output that round-trips through bash unchanged", () => {
+    // Sanity: when bash receives `'a'\''b'`, the parser concatenates
+    // 'a' + \' + 'b' and the resulting argv[1] is `a'b`. We can't run bash
+    // here, but the construction must follow the canonical idiom.
+    expect(shellEscape("a'b")).toBe(`'a'\\''b'`);
+  });
+});
+
+describe("shellQuote", () => {
+  it("returns a value unchanged when there are no single quotes", () => {
+    expect(shellQuote("hello world")).toBe("hello world");
+  });
+
+  it("escapes embedded single quotes for embedding inside an existing single-quoted string", () => {
+    expect(shellQuote("it's fine")).toBe(`it'\\''s fine`);
+  });
+
+  it("escapes every embedded single quote", () => {
+    expect(shellQuote("a'b'c")).toBe(`a'\\''b'\\''c`);
+  });
+
+  it("preserves shell metacharacters that are safe inside single quotes", () => {
+    expect(shellQuote("$x `y` *.txt")).toBe("$x `y` *.txt");
+  });
+
+  it("does NOT add outer quotes (that's what shellEscape is for)", () => {
+    // The two helpers solve different problems:
+    //   shellEscape: I'm building a new bash arg → wrap in single quotes
+    //   shellQuote:  I'm injecting into an existing single-quoted string
+    // Mixing them would either over-quote or fail to escape.
+    expect(shellQuote("hello").startsWith("'")).toBe(false);
+    expect(shellQuote("hello").endsWith("'")).toBe(false);
+  });
+});

--- a/apps/server/test/tmux-session-name.test.ts
+++ b/apps/server/test/tmux-session-name.test.ts
@@ -85,12 +85,11 @@ describe("toSessionName", () => {
     );
   });
 
-  it("handles a name that sanitizes to an empty string", () => {
-    // All non-alphanumeric input collapses to empty after trimming. Current
-    // behaviour is to still emit the trailing underscore — we lock that in
-    // with a test rather than a code comment so any future change is
-    // intentional.
-    expect(toSessionName("dispatch", "agt_x", "!!!")).toBe("dispatch_agt_x_");
+  it("falls through to the no-name shape when sanitization strips everything", () => {
+    // `!!!` sanitizes to "", so the function collapses to `<prefix>_<id>`
+    // rather than emitting a trailing-underscore shape that no other
+    // branch produces.
+    expect(toSessionName("dispatch", "agt_x", "!!!")).toBe("dispatch_agt_x");
   });
 });
 

--- a/apps/server/test/tmux-session-name.test.ts
+++ b/apps/server/test/tmux-session-name.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  agentIdFromSessionName,
+  shouldSuggestSessionRename,
+  toSessionName,
+} from "../src/agents/tmux/session-name.js";
+
+describe("agentIdFromSessionName", () => {
+  it("extracts the agent ID from the canonical 12-hex pattern", () => {
+    expect(agentIdFromSessionName("dispatch_agt_abc123def456_my-task")).toBe(
+      "agt_abc123def456"
+    );
+  });
+
+  it("works with the dev prefix variant", () => {
+    expect(
+      agentIdFromSessionName("dispatch_dev_agt_abc123def456_my-task")
+    ).toBe("agt_abc123def456");
+  });
+
+  it("works when there is no slug suffix", () => {
+    expect(agentIdFromSessionName("dispatch_agt_abc123def456")).toBe(
+      "agt_abc123def456"
+    );
+  });
+
+  it("falls back to stripping the leading <prefix>_ when no canonical ID is present (legacy sessions)", () => {
+    // Legacy session names didn't include the `agt_` discriminator. The
+    // fallback strips just the prefix segment so the rest is treated as
+    // the agent ID.
+    expect(agentIdFromSessionName("dispatch_legacyagent")).toBe("legacyagent");
+  });
+
+  it("handles uppercase or non-hex IDs by falling through to the legacy path", () => {
+    // The pattern requires lowercase hex specifically; everything else
+    // takes the legacy fallback.
+    expect(agentIdFromSessionName("dispatch_agt_ABCDEF123456")).toBe(
+      "agt_ABCDEF123456"
+    );
+  });
+});
+
+describe("toSessionName", () => {
+  it("returns <prefix>_<id> when no name is supplied", () => {
+    expect(toSessionName("dispatch", "agt_abc123def456")).toBe(
+      "dispatch_agt_abc123def456"
+    );
+  });
+
+  it("appends a sanitized slug when a name is supplied", () => {
+    expect(toSessionName("dispatch", "agt_abc123def456", "My Cool Task")).toBe(
+      "dispatch_agt_abc123def456_my-cool-task"
+    );
+  });
+
+  it("collapses runs of non-alphanumeric chars into a single hyphen", () => {
+    expect(toSessionName("dispatch", "agt_x", "foo!!!bar @@ baz")).toBe(
+      "dispatch_agt_x_foo-bar-baz"
+    );
+  });
+
+  it("strips leading and trailing hyphens from the slug", () => {
+    expect(toSessionName("dispatch", "agt_x", "---name---")).toBe(
+      "dispatch_agt_x_name"
+    );
+  });
+
+  it("truncates the slug to 30 chars (tmux name length is bounded)", () => {
+    const longName = "a".repeat(50);
+    const prefix = "dispatch";
+    const id = "agt_abc123def456";
+    const result = toSessionName(prefix, id, longName);
+    // Strip the known `<prefix>_<id>_` head; what remains is the slug.
+    const slug = result.slice(`${prefix}_${id}_`.length);
+    expect(slug.length).toBeLessThanOrEqual(30);
+    // The leading 30 'a's match — confirms truncation, not over-eager
+    // sanitization removing valid chars.
+    expect(slug).toBe("a".repeat(30));
+  });
+
+  it("respects the prefix argument (used to vary in dev mode)", () => {
+    expect(toSessionName("dispatch_dev", "agt_x", "task")).toBe(
+      "dispatch_dev_agt_x_task"
+    );
+  });
+
+  it("handles a name that sanitizes to an empty string", () => {
+    // All non-alphanumeric input collapses to empty after trimming. Current
+    // behaviour is to still emit the trailing underscore — we lock that in
+    // with a test rather than a code comment so any future change is
+    // intentional.
+    expect(toSessionName("dispatch", "agt_x", "!!!")).toBe("dispatch_agt_x_");
+  });
+});
+
+describe("shouldSuggestSessionRename", () => {
+  const id = "agt_abc123def456";
+  const placeholder = `agent-${id.slice(-6)}`;
+
+  it("never suggests rename for persona agents", () => {
+    expect(
+      shouldSuggestSessionRename(placeholder, id, { persona: "code-review" })
+    ).toBe(false);
+  });
+
+  it("suggests rename for a standard agent still on the placeholder name", () => {
+    expect(shouldSuggestSessionRename(placeholder, id, {})).toBe(true);
+  });
+
+  it("does not suggest rename when the user has chosen a meaningful name", () => {
+    expect(shouldSuggestSessionRename("my-feature", id, {})).toBe(false);
+  });
+
+  it("trims surrounding whitespace before checking the placeholder", () => {
+    expect(shouldSuggestSessionRename(`  ${placeholder}  `, id, {})).toBe(true);
+  });
+
+  it("returns false for null/undefined names", () => {
+    expect(shouldSuggestSessionRename(null, id, {})).toBe(false);
+    expect(shouldSuggestSessionRename(undefined, id, {})).toBe(false);
+  });
+
+  it("for job runs, suggests rename only when name still matches job-...-<jobIdPrefix>", () => {
+    const jobRunId = "run_jobid12345678";
+    const placeholderJobName = `job-thing-${jobRunId.slice(0, 8)}`;
+    expect(
+      shouldSuggestSessionRename(placeholderJobName, id, { jobRunId })
+    ).toBe(true);
+  });
+
+  it("for job runs, does not suggest rename for a renamed job", () => {
+    const jobRunId = "run_jobid12345678";
+    expect(shouldSuggestSessionRename("renamed-job", id, { jobRunId })).toBe(
+      false
+    );
+  });
+});

--- a/apps/server/test/tmux-setup-script.test.ts
+++ b/apps/server/test/tmux-setup-script.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+
+import type { AppConfig } from "../src/config.js";
+import {
+  generateSetupScript,
+  type SetupScriptParams,
+} from "../src/agents/tmux/setup-script.js";
+
+const baseConfig: AppConfig = {
+  host: "127.0.0.1",
+  port: 6767,
+  databaseUrl: "",
+  authToken: "test-token",
+  mediaRoot: "/tmp/dispatch-test-media",
+  dispatchBinDir: "/usr/local/bin/dispatch",
+  codexBin: "/opt/codex",
+  claudeBin: "/opt/claude",
+  opencodeBin: "/opt/opencode",
+  agentRuntime: "inert",
+  sessionPrefix: "dispatch",
+  tls: null,
+};
+
+const baseParams: SetupScriptParams = {
+  agentId: "agt_abc123def456",
+  agentType: "claude",
+  originalCwd: "/Users/me/proj",
+  useWorktree: false,
+  createNewBranch: true,
+  agentName: "my-task",
+  agentCommand: "exec /opt/claude",
+  exitFile: "/tmp/dispatch_session.exit",
+};
+
+describe("generateSetupScript — script shape", () => {
+  it("starts with a bash shebang and 'set -euo pipefail'", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    const firstLines = script.split("\n").slice(0, 2);
+    expect(firstLines[0]).toBe("#!/usr/bin/env bash");
+    expect(firstLines[1]).toBe("set -euo pipefail");
+  });
+
+  it("ends with `exec bash -c ...` so tmux-pane PID becomes the agent CLI", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).toMatch(/exec bash -c '[^']/);
+    expect(script).toContain('echo "EXIT:$?"');
+    expect(script).toContain(baseParams.exitFile);
+  });
+
+  it("interpolates the agent's setup-log path so the server can tail stderr", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).toContain(
+      `tee "/tmp/dispatch_setup_${baseParams.agentId}.log"`
+    );
+  });
+});
+
+describe("generateSetupScript — worktree creation branch", () => {
+  it("emits NO worktree commands when useWorktree=false", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).not.toContain("git worktree add");
+    expect(script).not.toContain("Creating git worktree");
+  });
+
+  it("emits `worktree add -b <branch>` when createNewBranch=true", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+    });
+    expect(script).toContain('worktree add -b "my-branch"');
+    expect(script).toContain("Creating git worktree");
+    expect(script).toContain("Branch: my-branch");
+  });
+
+  it("emits `worktree add` (no -b) when createNewBranch=false", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      useWorktree: true,
+      createNewBranch: false,
+      worktreeBranchName: "main",
+      baseBranch: "main",
+    });
+    expect(script).toContain('worktree add "$WT_PATH" "main"');
+    expect(script).toContain("Creating managed git worktree");
+    expect(script).toContain("Checking out: main");
+    // No `-b` flag
+    expect(script).not.toContain("worktree add -b");
+  });
+
+  it("uses the provided worktreePathOverride literally", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+      worktreePathOverride: "/tmp/explicit-path",
+    });
+    expect(script).toContain('WT_PATH="/tmp/explicit-path"');
+    // The default sibling-path computation should not appear when an
+    // override is supplied.
+    expect(script).not.toContain("REPO_BASENAME=");
+  });
+
+  it("computes a sibling worktree path when no override is given", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+    });
+    expect(script).toContain("REPO_BASENAME=");
+    expect(script).toContain('WT_PATH="$(dirname "$REPO_ROOT")/');
+  });
+
+  it("rejects unsafe ref names (defense in depth even though createAgent already validated)", () => {
+    expect(() =>
+      generateSetupScript(baseConfig, {
+        ...baseParams,
+        useWorktree: true,
+        createNewBranch: true,
+        // Embedded shell metacharacter; assertSafeRefName must reject this.
+        worktreeBranchName: "evil; rm -rf /",
+      })
+    ).toThrow();
+  });
+});
+
+describe("generateSetupScript — type-specific blocks", () => {
+  it("for opencode, emits the opencode.json MCP-config block", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      agentType: "opencode",
+    });
+    expect(script).toContain("Configure opencode MCP");
+    expect(script).toContain("opencode.json");
+    expect(script).toContain("MCP_ENTRY=");
+  });
+
+  it("for non-opencode agents, does NOT emit the opencode MCP block", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).not.toContain("Configure opencode MCP");
+    expect(script).not.toContain("opencode.json");
+  });
+
+  it("for terminal agents in a worktree, skips the deps install block", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      agentType: "terminal",
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+    });
+    expect(script).not.toContain("Installing dependencies");
+    // Worktree creation + .env copy should still happen.
+    expect(script).toContain("Copying environment files");
+  });
+
+  it("for non-terminal agents in a worktree, emits the deps install block", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      agentType: "claude",
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+    });
+    expect(script).toContain("Installing dependencies");
+    expect(script).toContain("pnpm-lock.yaml");
+    expect(script).toContain("yarn.lock");
+    expect(script).toContain("package-lock.json");
+    expect(script).toContain("bun.lockb");
+  });
+});
+
+describe("generateSetupScript — server callbacks", () => {
+  it("phones home with the agent's auth token in the Authorization header", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).toContain("Authorization: Bearer test-token");
+  });
+
+  it("pushes phase transitions to /api/v1/agents/<id>/setup/phase", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).toContain(
+      `/api/v1/agents/${baseParams.agentId}/setup/phase`
+    );
+    expect(script).toContain('"phase":"session"');
+  });
+
+  it("pushes the completion callback to /api/v1/agents/<id>/setup/complete", () => {
+    const script = generateSetupScript(baseConfig, baseParams);
+    expect(script).toContain(
+      `/api/v1/agents/${baseParams.agentId}/setup/complete`
+    );
+  });
+
+  it("on worktree-add failure, pushes the error message to /setup/error and exits", () => {
+    const script = generateSetupScript(baseConfig, {
+      ...baseParams,
+      useWorktree: true,
+      createNewBranch: true,
+      worktreeBranchName: "my-branch",
+    });
+    expect(script).toContain(
+      `/api/v1/agents/${baseParams.agentId}/setup/error`
+    );
+    expect(script).toContain("SETUP_ERROR_MSG=");
+    expect(script).toContain("exit 1");
+  });
+});


### PR DESCRIPTION
Stacked on #451 (DIS-37 Phase 0). Once #451 merges, GitHub will auto-rebase this onto main.

## Summary

Lifts ~670 LOC of pure string-assembly logic out of `AgentManager` into four sibling files under `apps/server/src/agents/tmux/`. No behaviour change — manager.ts just calls the new module functions in place of the private methods. **The win is testability**: ~520 LOC of injection-prone shell/script generation had zero unit coverage; this PR adds 74 tests.

`manager.ts`: 3368 → **2699 LOC** (-46% from the DIS-37 starting point of 4967).

## What moved

- **`tmux/quoting.ts`** — `shellEscape` (wraps in single quotes, escapes via the `'\''` idiom) and `shellQuote` (escape only, no outer quotes — for embedding inside an existing single-quoted string). The two-helper split is preexisting; the tests lock in *why* they're different so a future refactor can't accidentally collapse them.
- **`tmux/session-name.ts`** — `agentIdFromSessionName`, `toSessionName`, `shouldSuggestSessionRename`. `toSessionName` now takes the prefix as an explicit parameter (was reading `this.config.sessionPrefix`) — matches the way the function is conceptually parameterized.
- **`tmux/command-builder.ts`** — `buildAgentCommand`, `buildStartupPrompt`, `dispatchMcpUrl`, `normalizeAgentArgsForType`. Takes `AppConfig` as the first argument. Preserves the existing positional signature on `buildAgentCommand` to keep the call-site diff minimal — the boolean-arg-soup is a separate concern, best cleaned up in a later phase rather than mixed with the extraction.
- **`tmux/setup-script.ts`** — `generateSetupScript`. Same shape: pure function taking `(config, params)` and returning the bash script string. Re-validates ref names via `assertSafeRefName` (defense in depth) just like the original did.

`manager.ts` call sites now import the helpers directly rather than going through `this.<helper>(…)`. The two private methods that *stayed* in manager.ts (`seedInitialMedia`, `timestampMediaFileName`) are I/O- or manager-state-coupled and don't fit the tmux-builders module — they'll travel with media-related work in a future phase.

## Test plan

- [x] `pnpm run check` — full repo typecheck (server + web + scripts) passes
- [x] `pnpm --filter @dispatch/server run test` — 705/713 pass (was 631 + 74 new), 8 skipped, 0 fail. New tests cover:
  - `shellEscape` / `shellQuote` round-trip and the embedded-single-quote edge case (security-relevant — these strings land in `tmux new-session … bash -c …`)
  - All `agentIdFromSessionName` paths (canonical 12-hex, dev prefix, no-slug, legacy fallback, uppercase)
  - `toSessionName` slug sanitization, truncation at 30 chars, prefix variation
  - `shouldSuggestSessionRename` for persona / job-run / standard / placeholder / renamed cases
  - `dispatchMcpUrl` standard vs job-run paths and tls=null vs tls-truthy scheme
  - `normalizeAgentArgsForType` for claude (passthrough) vs codex/opencode (lift `--append-system-prompt`) plus the last-arg edge case
  - `buildStartupPrompt` empty / prompt-only / pins-only / media-only / combined, plus the URL-hostname-dedupe shortcut
  - `buildAgentCommand` per CLI type (terminal / claude / codex / opencode), resume vs fresh, full-access env, assisted_update env, autoReview guidance, jobRun-flavoured guidance, and a quote-injection regression check
  - `generateSetupScript` worktree on/off, createNewBranch true/false, `worktreePathOverride` literal vs computed sibling path, opencode MCP block presence/absence, terminal skipping deps install, server-callback URL shape, unsafe-ref rejection
- [x] `pnpm run test:e2e` — 136 Playwright tests pass