### PR TITLE
DIS-37 Phase 3: extract events module — DB write + listener bus

### DIFF
--- a/apps/server/src/agents/events.ts
+++ b/apps/server/src/agents/events.ts
@@ -73,17 +73,32 @@ export type AgentEventBus = {
 
   /**
    * Fan out an updated `AgentRecord` to every subscribed listener. Each
-   * listener runs inside its own try/catch — a thrown listener cannot
-   * stop subsequent listeners or surface an error to the publisher.
+   * listener is isolated — a thrown listener cannot stop subsequent
+   * listeners or surface an error to the publisher. The isolation covers
+   * both synchronous throws and asynchronous rejections (the latter is
+   * possible because `AgentEventListener`'s `=> void` return type is
+   * structurally compatible with `=> Promise<void>`).
+   *
+   * `publish()` itself returns synchronously after each listener has been
+   * scheduled — async listeners run to completion in the background.
    */
   publish(agent: AgentRecord): void;
 };
 
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof (value as { then: unknown }).then === "function"
+  );
+}
+
 /**
- * In-memory pub/sub for agent latest-event updates. Listeners run
- * synchronously on the publishing thread, in registration order. The bus
- * deliberately swallows listener errors so a buggy SSE writer (for
- * example) cannot poison the data layer that drove the event.
+ * In-memory pub/sub for agent latest-event updates. Listeners are invoked
+ * in registration order. The bus deliberately swallows listener errors
+ * (sync throws *and* async rejections) so a buggy SSE writer cannot poison
+ * the data layer that drove the event.
  */
 export function createAgentEventBus(logger: FastifyBaseLogger): AgentEventBus {
   const listeners: AgentEventListener[] = [];
@@ -95,8 +110,22 @@ export function createAgentEventBus(logger: FastifyBaseLogger): AgentEventBus {
 
     publish(agent: AgentRecord): void {
       for (const listener of listeners) {
+        // Sync listeners run on the publishing thread (preserves the
+        // immediate-fanout contract). The try/catch handles their throws.
+        // If a listener returns a Promise (the `=> void` listener type
+        // structurally accepts `async` listeners), attach a .catch to the
+        // returned thenable so async rejections also get logged instead
+        // of escaping as an unhandled rejection.
         try {
-          listener(agent);
+          const result = listener(agent) as unknown;
+          if (isThenable(result)) {
+            // PromiseLike only guarantees `.then`, not `.catch`. The
+            // two-arg `.then(undefined, handler)` form is the portable
+            // way to attach a rejection handler.
+            result.then(undefined, (err: unknown) => {
+              logger.warn({ err }, "Agent event listener threw");
+            });
+          }
         } catch (err) {
           logger.warn({ err }, "Agent event listener threw");
         }

--- a/apps/server/src/agents/events.ts
+++ b/apps/server/src/agents/events.ts
@@ -1,0 +1,106 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import { AgentError } from "./errors.js";
+import type {
+  AgentEventListener,
+  AgentLatestEventInput,
+  AgentRecord,
+} from "./types.js";
+
+/**
+ * Persist a latest-event update for `id`. Two writes:
+ *   1. UPDATE the agent's `latest_event_*` columns synchronously. Throws
+ *      `AgentError(404)` if the agent has no live row.
+ *   2. INSERT into `agent_events` history fire-and-forget — failures are
+ *      logged but never propagated, since losing one history row should
+ *      not block the live status indicator update.
+ *
+ * Validates that `message` trims to non-empty; throws `AgentError(400)`
+ * otherwise. Returns void — callers that need the resulting AgentRecord
+ * read it back themselves (the manager façade fetches + publishes to the
+ * listener bus before returning to the caller).
+ */
+export async function writeLatestEvent(
+  pool: Pool,
+  logger: FastifyBaseLogger,
+  id: string,
+  input: AgentLatestEventInput
+): Promise<void> {
+  const message = input.message.trim();
+  if (!message) {
+    throw new AgentError(
+      "Latest event message must be a non-empty string.",
+      400
+    );
+  }
+
+  const result = await pool.query(
+    `
+    UPDATE agents
+    SET latest_event_type = $2,
+        latest_event_message = $3,
+        latest_event_metadata = $4::jsonb,
+        latest_event_updated_at = NOW(),
+        updated_at = NOW()
+    WHERE id = $1 AND deleted_at IS NULL
+    `,
+    [id, input.type, message, JSON.stringify(input.metadata ?? {})]
+  );
+
+  if (result.rowCount !== 1) {
+    throw new AgentError("Agent not found.", 404);
+  }
+
+  // Append to event history (fire-and-forget — keeping this off the critical
+  // path means the agent status indicator updates even if the history table
+  // is briefly unavailable).
+  pool
+    .query(
+      `INSERT INTO agent_events (agent_id, event_type, message, metadata, agent_type, agent_name, project_dir)
+       SELECT $1, $2, $3, $4::jsonb, type, name, COALESCE(git_context->>'repoRoot', cwd)
+       FROM agents WHERE id = $1`,
+      [id, input.type, message, JSON.stringify(input.metadata ?? {})]
+    )
+    .catch((err) =>
+      logger.warn({ err }, "Failed to insert agent event history")
+    );
+}
+
+export type AgentEventBus = {
+  /** Register a callback invoked after every successful upsert + agent fetch. */
+  subscribe(listener: AgentEventListener): void;
+
+  /**
+   * Fan out an updated `AgentRecord` to every subscribed listener. Each
+   * listener runs inside its own try/catch — a thrown listener cannot
+   * stop subsequent listeners or surface an error to the publisher.
+   */
+  publish(agent: AgentRecord): void;
+};
+
+/**
+ * In-memory pub/sub for agent latest-event updates. Listeners run
+ * synchronously on the publishing thread, in registration order. The bus
+ * deliberately swallows listener errors so a buggy SSE writer (for
+ * example) cannot poison the data layer that drove the event.
+ */
+export function createAgentEventBus(logger: FastifyBaseLogger): AgentEventBus {
+  const listeners: AgentEventListener[] = [];
+
+  return {
+    subscribe(listener: AgentEventListener): void {
+      listeners.push(listener);
+    },
+
+    publish(agent: AgentRecord): void {
+      for (const listener of listeners) {
+        try {
+          listener(agent);
+        } catch (err) {
+          logger.warn({ err }, "Agent event listener threw");
+        }
+      }
+    },
+  };
+}

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -30,6 +30,11 @@ import { loadRepoHooks } from "../shared/mcp/repo-tools.js";
 import { harvestTokenUsage } from "./token-harvester.js";
 import { AgentError } from "./errors.js";
 import {
+  type AgentEventBus,
+  createAgentEventBus,
+  writeLatestEvent,
+} from "./events.js";
+import {
   buildAgentCommand,
   buildStartupPrompt,
 } from "./tmux/command-builder.js";
@@ -42,7 +47,6 @@ import { generateSetupScript } from "./tmux/setup-script.js";
 import type {
   AgentGitContext,
   AgentLatestEventInput,
-  AgentLatestEventType,
   AgentPin,
   AgentRecord,
   AgentRole,
@@ -149,19 +153,20 @@ export class AgentManager {
     string,
     { value: string; expiresAt: number }
   >();
-  private readonly eventListeners: AgentEventListener[] = [];
   private readonly diagnostics: DiagnosticsRecorder;
+  private readonly eventBus: AgentEventBus;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
     this.logger = logger;
     this.config = config;
     this.diagnostics = createDiagnosticsRecorder(logger);
+    this.eventBus = createAgentEventBus(logger);
   }
 
   /** Register a callback invoked after every upsertLatestEvent. */
   onLatestEvent(listener: AgentEventListener): void {
-    this.eventListeners.push(listener);
+    this.eventBus.subscribe(listener);
   }
 
   async listAgents(): Promise<AgentRecord[]> {
@@ -1118,56 +1123,16 @@ export class AgentManager {
     id: string,
     input: AgentLatestEventInput
   ): Promise<AgentRecord> {
-    const message = input.message.trim();
-    if (!message) {
-      throw new AgentError(
-        "Latest event message must be a non-empty string.",
-        400
-      );
-    }
+    await writeLatestEvent(this.pool, this.logger, id, input);
 
-    const result = await this.pool.query(
-      `
-      UPDATE agents
-      SET latest_event_type = $2,
-          latest_event_message = $3,
-          latest_event_metadata = $4::jsonb,
-          latest_event_updated_at = NOW(),
-          updated_at = NOW()
-      WHERE id = $1 AND deleted_at IS NULL
-      `,
-      [id, input.type, message, JSON.stringify(input.metadata ?? {})]
-    );
-
-    if (result.rowCount !== 1) {
-      throw new AgentError("Agent not found.", 404);
-    }
-
-    // Append to event history (fire-and-forget)
-    this.pool
-      .query(
-        `INSERT INTO agent_events (agent_id, event_type, message, metadata, agent_type, agent_name, project_dir)
-         SELECT $1, $2, $3, $4::jsonb, type, name, COALESCE(git_context->>'repoRoot', cwd)
-         FROM agents WHERE id = $1`,
-        [id, input.type, message, JSON.stringify(input.metadata ?? {})]
-      )
-      .catch((err) =>
-        this.logger.warn({ err }, "Failed to insert agent event history")
-      );
-
-    // Agent could be soft-deleted between the UPDATE and this SELECT in rare races.
-    // Guard against null to prevent downstream crashes (e.g. in event listeners).
+    // Agent could be soft-deleted between the UPDATE and this SELECT in rare
+    // races. Guard against null to prevent downstream crashes (e.g. in event
+    // listeners).
     const agent = await this.getAgent(id);
     if (!agent) {
       throw new AgentError("Agent not found.", 404);
     }
-    for (const listener of this.eventListeners) {
-      try {
-        listener(agent);
-      } catch (err) {
-        this.logger.warn({ err }, "Agent event listener threw");
-      }
-    }
+    this.eventBus.publish(agent);
     return agent;
   }
 

--- a/apps/server/test/agent-event-bus.test.ts
+++ b/apps/server/test/agent-event-bus.test.ts
@@ -125,6 +125,50 @@ describe("createAgentEventBus", () => {
     expect(warnSpy.mock.calls[0]?.[1]).toBe("Agent event listener threw");
   });
 
+  it("isolates async-listener rejections — a rejecting Promise is caught and logged", async () => {
+    // The AgentEventListener type is `(agent) => void`, but TS structurally
+    // accepts `async (agent) => Promise<void>`. The bus must catch the
+    // rejection of an async listener too — otherwise it surfaces as an
+    // unhandled rejection and the contract advertised by `publish`'s JSDoc
+    // is half-true.
+    const warnSpy = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      debug: vi.fn(),
+      fatal: vi.fn(),
+      trace: vi.fn(),
+      silent: vi.fn(),
+      level: "silent",
+      child: () => logger,
+    } as unknown as import("fastify").FastifyBaseLogger;
+    const bus = createAgentEventBus(logger);
+
+    const after = vi.fn();
+    // The cast is what a real codebase often does for async listeners:
+    // the `=> void` slot accepts an `async` arrow because Promise<void>
+    // is structurally compatible.
+    bus.subscribe((async () => {
+      throw new Error("async-boom");
+    }) as unknown as Parameters<typeof bus.subscribe>[0]);
+    bus.subscribe(after);
+
+    bus.publish(makeAgent("agt_x"));
+
+    // Synchronous listener after the async-throwing one still ran on the
+    // publishing thread, before the rejection materialised.
+    expect(after).toHaveBeenCalledTimes(1);
+
+    // Wait one microtask cycle for the async rejection to be observed
+    // and forwarded to the logger.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[1]).toBe("Agent event listener threw");
+  });
+
   it("publish() is synchronous (returns void, not Promise)", () => {
     const bus = createAgentEventBus(noopLogger);
     bus.subscribe(vi.fn());

--- a/apps/server/test/agent-event-bus.test.ts
+++ b/apps/server/test/agent-event-bus.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAgentEventBus } from "../src/agents/events.js";
+import type { AgentRecord } from "../src/agents/types.js";
+
+const makeAgent = (
+  id: string,
+  overrides: Partial<AgentRecord> = {}
+): AgentRecord => {
+  // Minimal AgentRecord shape — bus only forwards the object as-is, so most
+  // fields can be loose.
+  return {
+    id,
+    name: id,
+    type: "claude",
+    role: "standard",
+    status: "running",
+    cwd: "/tmp",
+    worktreePath: null,
+    worktreeBranch: null,
+    tmuxSession: null,
+    simulatorUdid: null,
+    mediaDir: null,
+    agentArgs: [],
+    fullAccess: false,
+    setupPhase: null,
+    archivePhase: null,
+    archiveCleanupMode: null,
+    lastError: null,
+    latestEvent: null,
+    pins: [],
+    gitContext: null,
+    gitContextStale: false,
+    gitContextUpdatedAt: null,
+    persona: null,
+    parentAgentId: null,
+    personaContext: null,
+    reviewAgentType: null,
+    review: null,
+    baseBranch: null,
+    autoReview: false,
+    cliSessionId: null,
+    createdAt: "2026-04-29T00:00:00Z",
+    updatedAt: "2026-04-29T00:00:00Z",
+    ...overrides,
+  };
+};
+
+const noopLogger = (() => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: "silent",
+  };
+  return Object.assign(logger, {
+    child: () => noopLogger,
+  }) as unknown as import("fastify").FastifyBaseLogger;
+})();
+
+describe("createAgentEventBus", () => {
+  it("delivers a published agent to every subscribed listener", () => {
+    const bus = createAgentEventBus(noopLogger);
+    const a = vi.fn();
+    const b = vi.fn();
+    bus.subscribe(a);
+    bus.subscribe(b);
+
+    const agent = makeAgent("agt_a");
+    bus.publish(agent);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(a).toHaveBeenCalledWith(agent);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledWith(agent);
+  });
+
+  it("delivers each publish independently — listeners receive every call, in order", () => {
+    const bus = createAgentEventBus(noopLogger);
+    const calls: string[] = [];
+    bus.subscribe((agent) => {
+      calls.push(`one:${agent.id}`);
+    });
+    bus.subscribe((agent) => {
+      calls.push(`two:${agent.id}`);
+    });
+
+    bus.publish(makeAgent("agt_1"));
+    bus.publish(makeAgent("agt_2"));
+
+    expect(calls).toEqual(["one:agt_1", "two:agt_1", "one:agt_2", "two:agt_2"]);
+  });
+
+  it("isolates listener throws — a thrower does not stop later listeners", () => {
+    const warnSpy = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      debug: vi.fn(),
+      fatal: vi.fn(),
+      trace: vi.fn(),
+      silent: vi.fn(),
+      level: "silent",
+      child: () => logger,
+    } as unknown as import("fastify").FastifyBaseLogger;
+    const bus = createAgentEventBus(logger);
+
+    const after = vi.fn();
+    bus.subscribe(() => {
+      throw new Error("boom");
+    });
+    bus.subscribe(after);
+
+    bus.publish(makeAgent("agt_x"));
+
+    // Subsequent listener still ran.
+    expect(after).toHaveBeenCalledTimes(1);
+    // The throw was logged but not propagated to the publisher.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[1]).toBe("Agent event listener threw");
+  });
+
+  it("publish() is synchronous (returns void, not Promise)", () => {
+    const bus = createAgentEventBus(noopLogger);
+    bus.subscribe(vi.fn());
+
+    const result = bus.publish(makeAgent("agt_x"));
+    // The bus is intentionally synchronous so the data-layer caller doesn't
+    // have to await fanout. Listeners that need async work should kick off
+    // their own promise.
+    expect(result).toBeUndefined();
+  });
+
+  it("returns independent buses (each createAgentEventBus call has its own listener list)", () => {
+    const a = createAgentEventBus(noopLogger);
+    const b = createAgentEventBus(noopLogger);
+
+    const aListener = vi.fn();
+    const bListener = vi.fn();
+    a.subscribe(aListener);
+    b.subscribe(bListener);
+
+    a.publish(makeAgent("agt_x"));
+
+    expect(aListener).toHaveBeenCalledTimes(1);
+    expect(bListener).not.toHaveBeenCalled();
+  });
+
+  it("subscribe() does not fire retroactively — listeners only see future publishes", () => {
+    const bus = createAgentEventBus(noopLogger);
+    bus.publish(makeAgent("agt_before"));
+
+    const late = vi.fn();
+    bus.subscribe(late);
+
+    expect(late).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Stacked on #453 (DIS-37 Phase 2). Once #453 merges, GitHub will auto-rebase this onto main.

## Summary

Splits AgentManager's `upsertLatestEvent` into two cleanly-separated concerns now living in `apps/server/src/agents/events.ts`. The data-layer write and the listener fanout were a single mixed concern; pulling them apart makes the bus directly testable and gets the listener array out of `AgentManager`'s instance state.

`manager.ts`: 2416 → **2381 LOC**. Cumulative across DIS-37 phases: 4967 → 2381 (-52%).

## What moved

- **`writeLatestEvent(pool, logger, id, input): Promise<void>`** — the data layer. Validates the message, performs the `agents` table UPDATE (404 if no live row), and fires the `agent_events` history INSERT fire-and-forget. No knowledge of listeners, no agent fetch.

- **`createAgentEventBus(logger): AgentEventBus`** — the fanout layer. In-memory pub/sub with `subscribe(listener)` and `publish(agent)`. Listener throws are caught and logged via `logger.warn` so a buggy SSE writer can't poison the data layer that drove the event.

## What's the same

`manager.ts` retains `upsertLatestEvent` and `onLatestEvent` as the public surface — every external caller (mcp-handlers, routes/agents, notification-runtime, the existing `agent-manager.test.ts` cases) keeps working unchanged. The method bodies are now thin orchestration:

```ts
async upsertLatestEvent(id, input) {
  await writeLatestEvent(this.pool, this.logger, id, input);
  const agent = await this.getAgent(id);
  if (!agent) throw new AgentError("Agent not found.", 404);
  this.eventBus.publish(agent);
  return agent;
}

onLatestEvent(listener) {
  this.eventBus.subscribe(listener);
}
```

The `eventListeners: AgentEventListener[]` field is gone from the manager — replaced by `private readonly eventBus: AgentEventBus` constructed in the manager's constructor.

## Tests

6 new unit tests on `createAgentEventBus`:
- `subscribe + publish` fanout to multiple listeners
- Ordering preserved across multiple publishes
- Listener-throw isolation (a thrower doesn't stop subsequent listeners; the throw is logged once via `logger.warn` and not propagated)
- `publish()` is synchronous (returns void, not a Promise)
- Bus independence (each `createAgentEventBus()` call yields its own listener list)
- No retroactive fire (subscribers only see future publishes)

`writeLatestEvent` direct unit tests are skipped because they would duplicate the existing `manager.upsertLatestEvent` integration tests in `test/db/agent-manager.test.ts:823–` (both need a real Pool). The bus is where the testable structural seam lives.

## Test plan

- [x] `pnpm run check` — full repo typecheck passes
- [x] `pnpm --filter @dispatch/server run test` — 729/737 pass (was 723; +6 new bus), 8 skipped, 0 fail
- [x] `pnpm run test:e2e` — 136 Playwright tests pass