### PR TITLE
DIS-37 Phase 5: extract AgentRuntime interface (tmux + inert impls)

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -31,6 +31,7 @@ import {
   createAgentEventBus,
   writeLatestEvent,
 } from "./events.js";
+import { type AgentRuntime, createAgentRuntime } from "./runtime.js";
 import {
   buildAgentCommand,
   buildStartupPrompt,
@@ -147,12 +148,9 @@ export class AgentManager {
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
   private readonly config: AppConfig;
-  private readonly runtimeCwdCache = new Map<
-    string,
-    { value: string; expiresAt: number }
-  >();
   private readonly diagnostics: DiagnosticsRecorder;
   private readonly eventBus: AgentEventBus;
+  private readonly runtime: AgentRuntime;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
@@ -160,6 +158,7 @@ export class AgentManager {
     this.config = config;
     this.diagnostics = createDiagnosticsRecorder(logger);
     this.eventBus = createAgentEventBus(logger);
+    this.runtime = createAgentRuntime(config, logger);
   }
 
   /** Register a callback invoked after every upsertLatestEvent. */
@@ -418,7 +417,7 @@ export class AgentManager {
       );
     } else {
       try {
-        await this.ensureNoExistingSession(tmuxSession);
+        await this.runtime.ensureNoExistingSession(tmuxSession);
 
         // Build the agent command that the setup script will exec into
         const agentCommand = buildAgentCommand(
@@ -458,47 +457,16 @@ export class AgentManager {
           jobRunId: input.jobRunId,
         });
 
-        const setupScriptPath = `/tmp/dispatch_setup_${id}.sh`;
-        await writeFile(setupScriptPath, setupScript, { mode: 0o755 });
-
-        // Start tmux running the setup script — the frontend can connect immediately
-        await runCommand("tmux", [
-          "new-session",
-          "-d",
-          "-s",
-          tmuxSession,
-          "-c",
-          originalCwd,
-          `bash ${setupScriptPath}`,
-        ]);
-        await runCommand(
-          "tmux",
-          ["set-option", "-t", tmuxSession, "status", "off"],
-          {
-            allowedExitCodes: [0, 1],
-          }
-        );
-        await runCommand(
-          "tmux",
-          ["set-option", "-t", tmuxSession, "allow-passthrough", "on"],
-          {
-            allowedExitCodes: [0, 1],
-          }
-        );
-        await runCommand(
-          "tmux",
-          ["set-option", "-as", "terminal-features", "xterm-256color:sync"],
-          {
-            allowedExitCodes: [0, 1],
-          }
-        );
-
-        if (!(await this.hasAgentSession(tmuxSession))) {
-          const detail = await this.readSetupLogTail(id);
-          throw new Error(
-            `tmux session exited immediately after launch${detail}`
-          );
-        }
+        await this.runtime.launch({
+          sessionName: tmuxSession,
+          cwd: originalCwd,
+          agentId: id,
+          payload: {
+            kind: "setup-script",
+            scriptPath: `/tmp/dispatch_setup_${id}.sh`,
+            scriptContent: setupScript,
+          },
+        });
       } catch (error) {
         const message = this.errorMessage(error);
         await this.setAgentStatus(id, "error", message);
@@ -598,7 +566,7 @@ export class AgentManager {
     const tmuxSession =
       agent.tmuxSession ??
       toSessionName(this.config.sessionPrefix, agent.id, agent.name);
-    const hasSession = await this.hasAgentSession(tmuxSession);
+    const hasSession = await this.runtime.hasSession(tmuxSession);
 
     if (hasSession) {
       await this.setAgentStatus(id, "running", null, tmuxSession);
@@ -630,21 +598,39 @@ export class AgentManager {
     }
 
     try {
-      await this.startAgentSession(
-        id,
-        tmuxSession,
-        agent.cwd,
-        agent.mediaDir ?? this.defaultMediaDir(id),
-        agent.name,
-        agent.persona,
+      const mediaDir = agent.mediaDir ?? this.defaultMediaDir(id);
+      // mediaDir must exist before launch — both runtimes assume the
+      // directory is present. (The original inert path created it
+      // explicitly; the tmux setup-script path created it via the
+      // bash script. We do it once here so both runtimes are happy.)
+      await mkdir(mediaDir, { recursive: true });
+
+      const agentCommand = buildAgentCommand(
+        this.config,
         agent.type,
         agent.role,
         agent.agentArgs ?? [],
+        mediaDir,
+        tmuxSession,
         agent.fullAccess ?? false,
         cliSessionId ?? undefined,
         shouldResume,
-        agent.autoReview ?? false
+        undefined,
+        shouldSuggestSessionRename(agent.name, id, { persona: agent.persona }),
+        !agent.persona && (agent.autoReview ?? false)
       );
+
+      await this.runtime.launch({
+        sessionName: tmuxSession,
+        cwd: agent.cwd,
+        agentId: id,
+        payload: {
+          kind: "agent-command",
+          command: agentCommand,
+          exitFile: `/tmp/dispatch_${tmuxSession}.exit`,
+        },
+      });
+
       await this.setAgentStatus(id, "running", null, tmuxSession);
       await this.setSystemLatestEvent(
         id,
@@ -693,7 +679,7 @@ export class AgentManager {
       };
     }
 
-    const hasSession = await this.hasAgentSession(agent.tmuxSession);
+    const hasSession = await this.runtime.hasSession(agent.tmuxSession);
     if (!hasSession) {
       await this.setAgentStatus(
         id,
@@ -733,8 +719,8 @@ export class AgentManager {
     );
 
     try {
-      if (tmuxSession && (await this.hasAgentSession(tmuxSession))) {
-        await this.stopAgentSession(tmuxSession, force);
+      if (tmuxSession && (await this.runtime.hasSession(tmuxSession))) {
+        await this.runtime.stopSession(tmuxSession, force);
       }
 
       await this.setAgentStatus(id, "stopped", null, tmuxSession ?? undefined);
@@ -821,9 +807,9 @@ export class AgentManager {
         );
         if (
           agent.tmuxSession &&
-          (await this.hasAgentSession(agent.tmuxSession))
+          (await this.runtime.hasSession(agent.tmuxSession))
         ) {
-          await this.stopAgentSession(agent.tmuxSession, true);
+          await this.runtime.stopSession(agent.tmuxSession, true);
         }
         this.harvestAgentTokens(agent).catch((err) =>
           this.logger.warn(
@@ -999,7 +985,7 @@ export class AgentManager {
     const durations: Record<string, number> = {};
     const agent = await this.getRequiredAgent(id);
     const sessionExists = agent.tmuxSession
-      ? await this.hasAgentSession(agent.tmuxSession)
+      ? await this.runtime.hasSession(agent.tmuxSession)
       : false;
 
     if (agent.status === "running" && sessionExists && !force) {
@@ -1138,9 +1124,8 @@ export class AgentManager {
 
   async reconcileAgents(): Promise<void> {
     await this.reconcileAgentStatuses();
-    if (this.config.agentRuntime === "tmux") {
-      await this.cleanupOrphanedSessions();
-    }
+    // listSessions returns [] in inert mode — runtime-agnostic call.
+    await this.cleanupOrphanedSessions();
   }
 
   async reconcileAgentStatuses(): Promise<AgentRecord[]> {
@@ -1177,15 +1162,17 @@ export class AgentManager {
       }
 
       const exists = row.tmuxSession
-        ? await this.hasAgentSession(row.tmuxSession)
+        ? await this.runtime.hasSession(row.tmuxSession)
         : false;
 
       if (!exists) {
-        const exitInfo =
-          this.config.agentRuntime === "tmux" && row.tmuxSession
-            ? await this.readExitFile(row.tmuxSession)
-            : null;
-        if (this.config.agentRuntime === "tmux" && row.tmuxSession) {
+        // In inert mode `hasSession` returns true for any non-empty
+        // session name, so reaching here means we're in tmux mode (or
+        // the agent has no tmuxSession at all — exitInfo stays null).
+        const exitInfo = row.tmuxSession
+          ? await this.runtime.readExitInfo(row.tmuxSession)
+          : null;
+        if (row.tmuxSession) {
           await this.diagnostics.captureMissingSessionIncident({
             agentId: row.id,
             tmuxSession: row.tmuxSession,
@@ -1201,7 +1188,7 @@ export class AgentManager {
             exitInfo
           );
         }
-        const setupLogTail = await this.readSetupLogTail(row.id);
+        const setupLogTail = await this.runtime.readSetupLogTail(row.id);
         const errorDetail = setupLogTail || null;
         const launchFailed =
           row.status === "creating" || (exitInfo !== null && exitInfo !== 0);
@@ -1269,43 +1256,11 @@ export class AgentManager {
   }
 
   private async cleanupOrphanedSessions(): Promise<void> {
-    const SESSION_PREFIX = `${this.config.sessionPrefix}_agt_`;
-
-    let stdout: string | undefined;
-    try {
-      const result = await runCommand(
-        "tmux",
-        ["list-sessions", "-F", "#{session_name}:#{session_created}"],
-        {
-          allowedExitCodes: [0, 1],
-        }
-      );
-      stdout = result.stdout;
-    } catch {
-      // tmux not running or no sessions
-      return;
-    }
-
-    if (!stdout?.trim()) return;
-
-    const sessions = stdout
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => {
-        const colonIdx = line.lastIndexOf(":");
-        const name = line.substring(0, colonIdx);
-        const createdStr = line.substring(colonIdx + 1);
-        return { name, createdAt: parseInt(createdStr, 10) };
-      })
-      .filter((s) => s.name.startsWith(SESSION_PREFIX));
-
+    const sessionPrefix = `${this.config.sessionPrefix}_agt_`;
+    const sessions = await this.runtime.listSessions(sessionPrefix);
     if (sessions.length === 0) return;
 
-    // Extract agent IDs from session names
     const agentIds = sessions.map((s) => agentIdFromSessionName(s.name));
-
-    // Query DB for these agent IDs
     const placeholders = agentIds.map((_, i) => `$${i + 1}`).join(", ");
     const dbResult = await this.pool.query(
       `SELECT id, status FROM agents WHERE deleted_at IS NULL AND id IN (${placeholders})`,
@@ -1316,15 +1271,12 @@ export class AgentManager {
       dbAgents.set(row.id, row.status);
     }
 
-    const ORPHAN_AGE_THRESHOLD_S = 300;
-    const now = Math.floor(Date.now() / 1000);
     const toKill: string[] = [];
-
     for (const session of sessions) {
       const agentId = agentIdFromSessionName(session.name);
       const status = dbAgents.get(agentId);
 
-      // Agent in terminal state — session is definitely orphaned
+      // Agent in terminal state — session is definitely orphaned.
       if (status === "stopped" || status === "error") {
         this.logger.info(
           { session: session.name, agentId, status },
@@ -1334,9 +1286,10 @@ export class AgentManager {
         continue;
       }
 
-      // No DB record — leave it alone. The session may belong to another
-      // server instance using the same tmux namespace. Only clean up
-      // sessions that *this* database definitively knows about.
+      // No DB record — leave it alone. The session may belong to
+      // another server instance using the same tmux namespace; only
+      // clean up sessions that *this* database definitively knows
+      // about.
       if (!status) {
         this.logger.debug(
           { session: session.name, agentId },
@@ -1345,286 +1298,26 @@ export class AgentManager {
       }
     }
 
-    await Promise.all(
-      toKill.map((name) =>
-        runCommand("tmux", ["kill-session", "-t", name]).catch(() => {})
-      )
-    );
+    await Promise.all(toKill.map((name) => this.runtime.killSession(name)));
   }
 
   async resolveRuntimeCwd(agent: AgentRecord): Promise<string> {
     const fallback = agent.cwd;
     const session = agent.tmuxSession?.trim();
-    if (!session || this.config.agentRuntime !== "tmux") {
-      return fallback;
-    }
+    if (!session) return fallback;
 
+    // Don't probe stopped/archived agents — their session may be gone
+    // and the probe would just fall back to the agent's recorded cwd
+    // anyway. Skip the runtime call to avoid the ~30ms ps/lsof chain.
     if (agent.status !== "running" && agent.status !== "creating") {
       return fallback;
     }
 
-    const cacheKey = `${agent.id}:${session}`;
-    const cached = this.runtimeCwdCache.get(cacheKey);
-    const now = Date.now();
-    if (cached && cached.expiresAt > now) {
-      return cached.value;
-    }
-
-    try {
-      // First, try to resolve the CWD from the agent CLI process itself.
-      // tmux pane_current_path only tracks the shell's CWD, but agent CLIs
-      // (claude, codex, opencode) may cd internally without updating the shell.
-      const agentCwd = await this.resolveAgentProcessCwd(session);
-      if (agentCwd) {
-        this.runtimeCwdCache.set(cacheKey, {
-          value: agentCwd,
-          expiresAt: now + 10_000,
-        });
-        return agentCwd;
-      }
-
-      // Fall back to tmux pane_current_path (the shell's CWD).
-      const result = await runCommand(
-        "tmux",
-        ["display-message", "-p", "-t", session, "#{pane_current_path}"],
-        {
-          allowedExitCodes: [0, 1],
-          timeoutMs: 800,
-        }
-      );
-      const cwd = result.stdout.trim();
-      if (result.exitCode !== 0 || !cwd) {
-        return fallback;
-      }
-      this.runtimeCwdCache.set(cacheKey, {
-        value: cwd,
-        expiresAt: now + 10_000,
-      });
-      return cwd;
-    } catch {
-      return fallback;
-    }
-  }
-
-  /**
-   * Resolve the CWD of the agent CLI process (claude/codex/opencode) running
-   * inside a tmux pane. The CLI process may have cd'd into a worktree
-   * internally, which tmux's pane_current_path won't reflect.
-   */
-  private async resolveAgentProcessCwd(
-    session: string
-  ): Promise<string | null> {
-    try {
-      // Get the PID of the tmux pane's shell process.
-      const pidResult = await runCommand(
-        "tmux",
-        ["display-message", "-p", "-t", session, "#{pane_pid}"],
-        { allowedExitCodes: [0, 1], timeoutMs: 800 }
-      );
-      const panePid = pidResult.stdout.trim();
-      if (pidResult.exitCode !== 0 || !panePid) {
-        this.logger.debug({ session }, "resolveAgentProcessCwd: no pane_pid");
-        return null;
-      }
-
-      // Find the agent CLI child process (claude, codex, or opencode).
-      const childrenResult = await runCommand("pgrep", ["-P", panePid], {
-        allowedExitCodes: [0, 1],
-        timeoutMs: 800,
-      });
-      if (childrenResult.exitCode !== 0 || !childrenResult.stdout.trim()) {
-        this.logger.debug(
-          { session, panePid },
-          "resolveAgentProcessCwd: no children"
-        );
-        return null;
-      }
-
-      const childPids = childrenResult.stdout.trim().split("\n");
-      let agentPid: string | null = null;
-
-      for (const pid of childPids) {
-        const commResult = await runCommand(
-          "ps",
-          ["-o", "comm=", "-p", pid.trim()],
-          { allowedExitCodes: [0, 1], timeoutMs: 800 }
-        );
-        const comm = commResult.stdout.trim();
-        // Match agent CLI binaries by basename.
-        const basename = comm.split("/").pop() ?? "";
-        if (
-          basename === "claude" ||
-          basename === "codex" ||
-          basename === "opencode"
-        ) {
-          agentPid = pid.trim();
-          break;
-        }
-      }
-
-      if (!agentPid) {
-        this.logger.debug(
-          { session, panePid },
-          "resolveAgentProcessCwd: no agent CLI among children"
-        );
-        return null;
-      }
-
-      // Read the process's CWD via lsof (works on macOS and Linux).
-      const lsofResult = await runCommand(
-        "lsof",
-        ["-a", "-p", agentPid, "-d", "cwd", "-Fn"],
-        { allowedExitCodes: [0, 1], timeoutMs: 800 }
-      );
-      if (lsofResult.exitCode !== 0 || !lsofResult.stdout) {
-        this.logger.debug(
-          { session, agentPid },
-          "resolveAgentProcessCwd: lsof failed"
-        );
-        return null;
-      }
-
-      // lsof -Fn outputs lines like "p<pid>" and "n<path>". Extract the path.
-      for (const line of lsofResult.stdout.split("\n")) {
-        if (line.startsWith("n/")) {
-          const cwd = line.slice(1);
-          this.logger.debug(
-            { session, agentPid, cwd },
-            "resolveAgentProcessCwd: resolved"
-          );
-          return cwd;
-        }
-      }
-
-      return null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async startAgentSession(
-    agentId: string,
-    sessionName: string,
-    cwd: string,
-    mediaDir: string,
-    agentName: string,
-    persona: string | null,
-    type: AgentType,
-    role: AgentRole,
-    agentArgs: string[],
-    fullAccess: boolean,
-    cliSessionId?: string,
-    resume?: boolean,
-    autoReview?: boolean
-  ): Promise<void> {
-    if (this.config.agentRuntime === "inert") {
-      await mkdir(mediaDir, { recursive: true });
-      return;
-    }
-
-    await mkdir(mediaDir, { recursive: true });
-    const agentCommand = buildAgentCommand(
-      this.config,
-      type,
-      role,
-      agentArgs,
-      mediaDir,
-      sessionName,
-      fullAccess,
-      cliSessionId,
-      resume,
-      undefined,
-      shouldSuggestSessionRename(agentName, agentId, { persona }),
-      !persona && (autoReview ?? false)
-    );
-    const exitFile = `/tmp/dispatch_${sessionName}.exit`;
-    const sessionLogFile = `/tmp/dispatch_setup_${agentId}.log`;
-    const wrappedCommand = `bash -c 'exec 2> >(tee "${sessionLogFile}" >&2); ${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`;
-    await runCommand("tmux", [
-      "new-session",
-      "-d",
-      "-s",
-      sessionName,
-      "-c",
-      cwd,
-      wrappedCommand,
-    ]);
-    await runCommand(
-      "tmux",
-      ["set-option", "-t", sessionName, "status", "off"],
-      {
-        allowedExitCodes: [0, 1],
-      }
-    );
-    // Allow DCS passthrough so agent CLIs that wrap escape sequences
-    // (e.g. synchronized output) can reach the outer terminal directly.
-    await runCommand(
-      "tmux",
-      ["set-option", "-t", sessionName, "allow-passthrough", "on"],
-      {
-        allowedExitCodes: [0, 1],
-      }
-    );
-    // Advertise synchronized output support so tmux wraps frame rendering
-    // in DEC 2026 sequences, reducing terminal flashing.  Set once per session
-    // start (not per WebSocket attach) to avoid unbounded array growth.
-    await runCommand(
-      "tmux",
-      ["set-option", "-as", "terminal-features", "xterm-256color:sync"],
-      {
-        allowedExitCodes: [0, 1],
-      }
-    );
-
-    // Detect fast-fail launches (for example, missing codex executable) so status
-    // is not left as "running" with no backing tmux session.
-    if (!(await this.hasAgentSession(sessionName))) {
-      const detail = await this.readSetupLogTail(agentId);
-      throw new Error(`tmux session exited immediately after launch${detail}`);
-    }
-  }
-
-  private async ensureNoExistingSession(sessionName: string): Promise<void> {
-    if (this.config.agentRuntime !== "tmux") {
-      return;
-    }
-
-    if (await this.hasAgentSession(sessionName)) {
-      await runCommand("tmux", ["kill-session", "-t", sessionName]);
-    }
-  }
-
-  private async hasAgentSession(sessionName: string): Promise<boolean> {
-    if (this.config.agentRuntime === "inert") {
-      return sessionName.trim().length > 0;
-    }
-
-    const result = await runCommand(
-      "tmux",
-      ["has-session", "-t", sessionName],
-      {
-        allowedExitCodes: [0, 1],
-      }
-    );
-    return result.exitCode === 0;
-  }
-
-  private async stopAgentSession(
-    sessionName: string,
-    force: boolean
-  ): Promise<void> {
-    if (this.config.agentRuntime === "inert") {
-      return;
-    }
-
-    if (!force) {
-      await runCommand("tmux", ["send-keys", "-t", sessionName, "C-c"]);
-      await this.sleep(1200);
-    }
-
-    if (await this.hasAgentSession(sessionName)) {
-      await runCommand("tmux", ["kill-session", "-t", sessionName]);
-    }
+    return this.runtime.getCurrentCwd({
+      sessionName: session,
+      agentId: agent.id,
+      fallback,
+    });
   }
 
   private async runLifecycleHook(
@@ -2097,39 +1790,6 @@ export class AgentManager {
   private errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : "Unknown error";
   }
-
-  /**
-   * Read the last 20 lines of a setup/session stderr log to include in error messages.
-   */
-  private async readSetupLogTail(idOrSession: string): Promise<string> {
-    const logPath = `/tmp/dispatch_setup_${idOrSession}.log`;
-    try {
-      const log = await readFile(logPath, "utf-8");
-      const tail = log.trim().split("\n").slice(-20).join("\n");
-      if (tail) return `\n\nSetup log (last 20 lines):\n${tail}`;
-    } catch {
-      /* no log file */
-    }
-    return "";
-  }
-
-  private async readExitFile(sessionName: string): Promise<number | null> {
-    try {
-      const content = await readFile(
-        `/tmp/dispatch_${sessionName}.exit`,
-        "utf-8"
-      );
-      const match = content.trim().match(/^EXIT:(\d+)$/);
-      return match ? Number(match[1]) : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async sleep(ms: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
   private async setSetupPhase(id: string, phase: SetupPhase): Promise<void> {
     await this.pool.query(
       `UPDATE agents SET setup_phase = $2, updated_at = NOW() WHERE id = $1`,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -438,10 +438,9 @@ export class AgentManager {
           !input.persona && !input.jobRunId && (input.autoReview ?? false),
           startupPrompt
         );
-        const exitFile = `/tmp/dispatch_${tmuxSession}.exit`;
-
         // Generate a setup script that handles worktree creation, env copy,
         // dep install, and then exec's into the agent CLI — all visible in the terminal.
+        // Stderr/exit-capture wrapping is applied by the runtime, not the script.
         const setupScript = generateSetupScript(this.config, {
           agentId: id,
           agentType: type,
@@ -453,7 +452,6 @@ export class AgentManager {
           worktreePathOverride,
           agentName: name,
           agentCommand,
-          exitFile,
           jobRunId: input.jobRunId,
         });
 
@@ -461,11 +459,7 @@ export class AgentManager {
           sessionName: tmuxSession,
           cwd: originalCwd,
           agentId: id,
-          payload: {
-            kind: "setup-script",
-            scriptPath: `/tmp/dispatch_setup_${id}.sh`,
-            scriptContent: setupScript,
-          },
+          payload: { kind: "setup-script", scriptContent: setupScript },
         });
       } catch (error) {
         const message = this.errorMessage(error);
@@ -624,11 +618,7 @@ export class AgentManager {
         sessionName: tmuxSession,
         cwd: agent.cwd,
         agentId: id,
-        payload: {
-          kind: "agent-command",
-          command: agentCommand,
-          exitFile: `/tmp/dispatch_${tmuxSession}.exit`,
-        },
+        payload: { kind: "agent-command", command: agentCommand },
       });
 
       await this.setAgentStatus(id, "running", null, tmuxSession);
@@ -1161,14 +1151,21 @@ export class AgentManager {
         continue;
       }
 
+      // Missing-session reconciliation only makes sense when the
+      // runtime actually tracks session state. Inert mode has no real
+      // sessions to lose, so a missing-session result there is just a
+      // statement of fact, not a reason to flip the agent to stopped.
+      if (!this.runtime.tracksSessions()) {
+        continue;
+      }
+
       const exists = row.tmuxSession
         ? await this.runtime.hasSession(row.tmuxSession)
         : false;
 
       if (!exists) {
-        // In inert mode `hasSession` returns true for any non-empty
-        // session name, so reaching here means we're in tmux mode (or
-        // the agent has no tmuxSession at all — exitInfo stays null).
+        // We've already gated on tracksSessions(), so reaching here
+        // means we're definitively in a session-tracking runtime.
         const exitInfo = row.tmuxSession
           ? await this.runtime.readExitInfo(row.tmuxSession)
           : null;
@@ -1313,11 +1310,14 @@ export class AgentManager {
       return fallback;
     }
 
-    return this.runtime.getCurrentCwd({
+    // Runtime returns null when it can't determine the cwd; manager
+    // applies the fallback policy here rather than letting the runtime
+    // bake it into its return type.
+    const cwd = await this.runtime.getCurrentCwd({
       sessionName: session,
       agentId: agent.id,
-      fallback,
     });
+    return cwd ?? fallback;
   }
 
   private async runLifecycleHook(

--- a/apps/server/src/agents/runtime.ts
+++ b/apps/server/src/agents/runtime.ts
@@ -8,25 +8,26 @@ import { createTmuxRuntime } from "./tmux/runtime.js";
  * What the manager hands to `runtime.launch()` to start (or restart) a
  * session. Two payload flavors:
  *
- * - `setup-script`: write a bash script to disk and run `bash <path>`
- *   inside the session. Used by createAgent — the script handles
- *   worktree creation, .env copy, deps install, and finally execs into
- *   the agent CLI itself.
- * - `agent-command`: run a single bash command inside the session,
- *   wrapped with stderr-tee + exit-code capture. Used by startAgent
- *   (restart) since the worktree already exists.
+ * - `setup-script`: write a bash script and run it inside the session.
+ *   Used by createAgent — the script handles worktree creation, .env
+ *   copy, deps install, and finally execs into the agent CLI itself.
+ * - `agent-command`: run a single bash command inside the session.
+ *   Used by startAgent (restart) since the worktree already exists.
  *
- * The runtime is responsible for the `bash -c …` wrapping and for
- * post-launch fast-fail detection (verifying the session actually
- * exists after `tmux new-session`).
+ * Conspicuously absent from the payload: file paths, log paths, exit
+ * files. Those are runtime-owned implementation details — the manager
+ * supplies *what to run*, the runtime decides *where to write artifacts
+ * and how to capture exit codes*. Diagnostic readouts come back through
+ * `readSetupLogTail` / `readExitInfo`, which know the runtime's own
+ * conventions.
  */
 export type LaunchInput = {
   sessionName: string;
   cwd: string;
   agentId: string;
   payload:
-    | { kind: "setup-script"; scriptPath: string; scriptContent: string }
-    | { kind: "agent-command"; command: string; exitFile: string };
+    | { kind: "setup-script"; scriptContent: string }
+    | { kind: "agent-command"; command: string };
 };
 
 /**
@@ -35,20 +36,33 @@ export type LaunchInput = {
  * write a single launch/stop/inspect flow that doesn't have to branch
  * on `config.agentRuntime` at every call site.
  *
- * In tmux mode, sessions are real `tmux` sessions and these methods
- * shell out to `tmux` / `pgrep` / `lsof` etc. In inert mode (used by
- * tests and headless environments), most operations are no-ops:
- * `hasSession` returns true for any non-empty name (preserves the
- * legacy "any registered agent is considered live" contract),
- * `listSessions` returns empty, and the diagnostic readers return
- * empty/null.
+ * Methods report runtime *facts*, not policy. When a runtime can't
+ * answer something honestly (e.g. inert mode has no session state, no
+ * pid to walk), it returns `false` / `null` / `[]` rather than fabricating
+ * a soft default. The manager applies its own fallback / reconciliation
+ * policy on top — see `tracksSessions()` for the explicit capability
+ * predicate the reconciler uses to decide when missing-session means
+ * "agent died" vs. "this runtime has no notion of session state."
  */
 export type AgentRuntime = {
+  /**
+   * Whether this runtime backs sessions with real OS state that can be
+   * polled. `true` for tmux (sessions are processes that can crash);
+   * `false` for inert (no sessions exist; the manager's DB is the only
+   * source of truth).
+   *
+   * The reconciler uses this to decide whether `hasSession() === false`
+   * means "agent died, transition to stopped" vs. "this runtime can't
+   * tell, leave the DB row alone." Synchronous because it's a static
+   * capability declared at runtime construction time, not state.
+   */
+  tracksSessions(): boolean;
+
   /** Start (or fast-fail) a new session. Throws on launch failure. */
   launch(input: LaunchInput): Promise<void>;
   /**
-   * Kill a session if one already exists at this name. No-op in inert
-   * mode (no tmux state to collide with).
+   * Kill a session if one already exists at this name. No-op when the
+   * runtime has nothing to collide with.
    */
   ensureNoExistingSession(sessionName: string): Promise<void>;
   /**
@@ -57,22 +71,27 @@ export type AgentRuntime = {
    * flush state. `force=true` skips the grace.
    */
   stopSession(sessionName: string, force: boolean): Promise<void>;
-  /** Whether a session currently exists by this name. */
+  /**
+   * Whether a session currently exists by this name. In runtimes that
+   * don't track session state (`tracksSessions() === false`), this
+   * returns `false` for everything — callers should consult
+   * `tracksSessions()` before drawing conclusions from a `false` result.
+   */
   hasSession(sessionName: string): Promise<boolean>;
   /**
    * Best-effort current working directory of the agent process inside
-   * `sessionName`. tmux mode walks pane → child PIDs → lsof. Returns
-   * `fallback` on any failure or in inert mode.
+   * `sessionName`. Returns `null` when the runtime cannot determine the
+   * cwd (no session-state tracking, probe failed, no agent CLI in the
+   * pane, etc.) so callers can apply their own fallback explicitly.
    */
   getCurrentCwd(args: {
     sessionName: string;
     agentId: string;
-    fallback: string;
-  }): Promise<string>;
+  }): Promise<string | null>;
   /**
    * List sessions whose names start with `prefix`. Used by the
-   * reconciler to find orphaned tmux sessions. Returns empty in inert
-   * mode (nothing to list).
+   * reconciler to find orphaned sessions. Returns `[]` in runtimes that
+   * don't track session state.
    */
   listSessions(
     prefix: string
@@ -80,16 +99,16 @@ export type AgentRuntime = {
   /** Kill a single session by name. Errors are swallowed. */
   killSession(sessionName: string): Promise<void>;
   /**
-   * Read the recorded exit code for a session that has terminated.
-   * tmux runtime parses `/tmp/dispatch_<session>.exit` (the launch
-   * wrapper writes `EXIT:N` there). Returns `null` if no record
-   * exists or in inert mode.
+   * Read the recorded exit code for a session that has terminated. The
+   * runtime owns the storage convention (e.g. tmux runtime captures
+   * `EXIT:N` to a temp file via the launch wrapper). Returns `null` if
+   * no record exists or the runtime doesn't capture exits.
    */
   readExitInfo(sessionName: string): Promise<number | null>;
   /**
    * Tail of the session's stderr log, formatted for inclusion in error
-   * messages. Returns the empty string when no log exists or in inert
-   * mode.
+   * messages. Returns the empty string when no log exists or the
+   * runtime doesn't capture stderr.
    */
   readSetupLogTail(idOrSession: string): Promise<string>;
 };
@@ -110,13 +129,17 @@ export function createAgentRuntime(
 }
 
 /**
- * Inert runtime: most operations are no-ops because there's no tmux
- * state to manage. `hasSession` returns true for any non-empty name to
- * preserve the legacy "registered agent is live" assumption that the
- * manager's reconciliation logic relies on.
+ * Inert runtime: no real sessions, no process state, no exit codes.
+ * Methods report runtime facts honestly — `hasSession` returns `false`
+ * because no sessions exist; callers that want "agent is logically
+ * registered" semantics should consult `tracksSessions()` first
+ * (returns `false`) and fall back to the agent's DB row.
  */
 function createInertRuntime(): AgentRuntime {
   return {
+    tracksSessions(): boolean {
+      return false;
+    },
     async launch(): Promise<void> {
       // Nothing to do — the manager's inert-mode createAgent path does
       // its workspace setup synchronously before reaching launch.
@@ -127,11 +150,13 @@ function createInertRuntime(): AgentRuntime {
     async stopSession(): Promise<void> {
       // No process to stop.
     },
-    async hasSession(sessionName: string): Promise<boolean> {
-      return sessionName.trim().length > 0;
+    async hasSession(): Promise<boolean> {
+      // No real sessions exist in inert mode. The manager checks
+      // `tracksSessions()` before treating `false` as "agent died."
+      return false;
     },
-    async getCurrentCwd({ fallback }): Promise<string> {
-      return fallback;
+    async getCurrentCwd(): Promise<string | null> {
+      return null;
     },
     async listSessions(): Promise<Array<{ name: string; createdAt: number }>> {
       return [];

--- a/apps/server/src/agents/runtime.ts
+++ b/apps/server/src/agents/runtime.ts
@@ -1,0 +1,149 @@
+import type { FastifyBaseLogger } from "fastify";
+
+import type { AppConfig } from "../config.js";
+
+import { createTmuxRuntime } from "./tmux/runtime.js";
+
+/**
+ * What the manager hands to `runtime.launch()` to start (or restart) a
+ * session. Two payload flavors:
+ *
+ * - `setup-script`: write a bash script to disk and run `bash <path>`
+ *   inside the session. Used by createAgent — the script handles
+ *   worktree creation, .env copy, deps install, and finally execs into
+ *   the agent CLI itself.
+ * - `agent-command`: run a single bash command inside the session,
+ *   wrapped with stderr-tee + exit-code capture. Used by startAgent
+ *   (restart) since the worktree already exists.
+ *
+ * The runtime is responsible for the `bash -c …` wrapping and for
+ * post-launch fast-fail detection (verifying the session actually
+ * exists after `tmux new-session`).
+ */
+export type LaunchInput = {
+  sessionName: string;
+  cwd: string;
+  agentId: string;
+  payload:
+    | { kind: "setup-script"; scriptPath: string; scriptContent: string }
+    | { kind: "agent-command"; command: string; exitFile: string };
+};
+
+/**
+ * Abstraction over "where the agent's process lives." The two
+ * implementations — `TmuxRuntime` and `InertRuntime` — let the manager
+ * write a single launch/stop/inspect flow that doesn't have to branch
+ * on `config.agentRuntime` at every call site.
+ *
+ * In tmux mode, sessions are real `tmux` sessions and these methods
+ * shell out to `tmux` / `pgrep` / `lsof` etc. In inert mode (used by
+ * tests and headless environments), most operations are no-ops:
+ * `hasSession` returns true for any non-empty name (preserves the
+ * legacy "any registered agent is considered live" contract),
+ * `listSessions` returns empty, and the diagnostic readers return
+ * empty/null.
+ */
+export type AgentRuntime = {
+  /** Start (or fast-fail) a new session. Throws on launch failure. */
+  launch(input: LaunchInput): Promise<void>;
+  /**
+   * Kill a session if one already exists at this name. No-op in inert
+   * mode (no tmux state to collide with).
+   */
+  ensureNoExistingSession(sessionName: string): Promise<void>;
+  /**
+   * Tear down a session. When `force=false`, sends Ctrl-C and waits a
+   * short grace period before kill — gives the agent CLI a chance to
+   * flush state. `force=true` skips the grace.
+   */
+  stopSession(sessionName: string, force: boolean): Promise<void>;
+  /** Whether a session currently exists by this name. */
+  hasSession(sessionName: string): Promise<boolean>;
+  /**
+   * Best-effort current working directory of the agent process inside
+   * `sessionName`. tmux mode walks pane → child PIDs → lsof. Returns
+   * `fallback` on any failure or in inert mode.
+   */
+  getCurrentCwd(args: {
+    sessionName: string;
+    agentId: string;
+    fallback: string;
+  }): Promise<string>;
+  /**
+   * List sessions whose names start with `prefix`. Used by the
+   * reconciler to find orphaned tmux sessions. Returns empty in inert
+   * mode (nothing to list).
+   */
+  listSessions(
+    prefix: string
+  ): Promise<Array<{ name: string; createdAt: number }>>;
+  /** Kill a single session by name. Errors are swallowed. */
+  killSession(sessionName: string): Promise<void>;
+  /**
+   * Read the recorded exit code for a session that has terminated.
+   * tmux runtime parses `/tmp/dispatch_<session>.exit` (the launch
+   * wrapper writes `EXIT:N` there). Returns `null` if no record
+   * exists or in inert mode.
+   */
+  readExitInfo(sessionName: string): Promise<number | null>;
+  /**
+   * Tail of the session's stderr log, formatted for inclusion in error
+   * messages. Returns the empty string when no log exists or in inert
+   * mode.
+   */
+  readSetupLogTail(idOrSession: string): Promise<string>;
+};
+
+/**
+ * Build the runtime appropriate for the current config. The factory
+ * dispatches once at construction time so the manager doesn't have to
+ * branch on `config.agentRuntime` afterward.
+ */
+export function createAgentRuntime(
+  config: AppConfig,
+  logger: FastifyBaseLogger
+): AgentRuntime {
+  if (config.agentRuntime === "inert") {
+    return createInertRuntime();
+  }
+  return createTmuxRuntime(logger);
+}
+
+/**
+ * Inert runtime: most operations are no-ops because there's no tmux
+ * state to manage. `hasSession` returns true for any non-empty name to
+ * preserve the legacy "registered agent is live" assumption that the
+ * manager's reconciliation logic relies on.
+ */
+function createInertRuntime(): AgentRuntime {
+  return {
+    async launch(): Promise<void> {
+      // Nothing to do — the manager's inert-mode createAgent path does
+      // its workspace setup synchronously before reaching launch.
+    },
+    async ensureNoExistingSession(): Promise<void> {
+      // No tmux state to collide with.
+    },
+    async stopSession(): Promise<void> {
+      // No process to stop.
+    },
+    async hasSession(sessionName: string): Promise<boolean> {
+      return sessionName.trim().length > 0;
+    },
+    async getCurrentCwd({ fallback }): Promise<string> {
+      return fallback;
+    },
+    async listSessions(): Promise<Array<{ name: string; createdAt: number }>> {
+      return [];
+    },
+    async killSession(): Promise<void> {
+      // Nothing to kill.
+    },
+    async readExitInfo(): Promise<number | null> {
+      return null;
+    },
+    async readSetupLogTail(): Promise<string> {
+      return "";
+    },
+  };
+}

--- a/apps/server/src/agents/tmux/runtime.ts
+++ b/apps/server/src/agents/tmux/runtime.ts
@@ -17,6 +17,19 @@ const PROCESS_INSPECT_TIMEOUT_MS = 800;
 /** Basenames the cwd resolver recognises as "the agent CLI" (worth pid-walking into). */
 const AGENT_CLI_BASENAMES = new Set(["claude", "codex", "opencode"]);
 
+// ── Path conventions (runtime-internal) ─────────────────────────────────
+//
+// The tmux runtime owns these conventions. The manager only ever asks for
+// `readSetupLogTail(idOrSession)` / `readExitInfo(sessionName)` and gets
+// back the contents — it doesn't have to know where the files live.
+
+const setupScriptPath = (agentId: string): string =>
+  `/tmp/dispatch_setup_${agentId}.sh`;
+const setupLogPath = (idOrSession: string): string =>
+  `/tmp/dispatch_setup_${idOrSession}.log`;
+const exitFilePath = (sessionName: string): string =>
+  `/tmp/dispatch_${sessionName}.exit`;
+
 /**
  * Build the tmux-backed AgentRuntime. Holds a per-session cwd cache in
  * its closure (TTL `CWD_CACHE_TTL_MS`) — the cache is what stops the
@@ -27,8 +40,12 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
   const cwdCache = new Map<string, { value: string; expiresAt: number }>();
 
   return {
+    tracksSessions(): boolean {
+      return true;
+    },
+
     async launch(input: LaunchInput): Promise<void> {
-      const wrappedCommand = await preparePayload(input);
+      const wrappedCommand = await prepareLaunch(input);
 
       await runCommand("tmux", [
         "new-session",
@@ -98,14 +115,12 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
     async getCurrentCwd({
       sessionName,
       agentId,
-      fallback,
     }: {
       sessionName: string;
       agentId: string;
-      fallback: string;
-    }): Promise<string> {
+    }): Promise<string | null> {
       const session = sessionName.trim();
-      if (!session) return fallback;
+      if (!session) return null;
 
       const cacheKey = `${agentId}:${session}`;
       const cached = cwdCache.get(cacheKey);
@@ -138,7 +153,7 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
         );
         const cwd = result.stdout.trim();
         if (result.exitCode !== 0 || !cwd) {
-          return fallback;
+          return null;
         }
         cwdCache.set(cacheKey, {
           value: cwd,
@@ -146,7 +161,7 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
         });
         return cwd;
       } catch {
-        return fallback;
+        return null;
       }
     },
 
@@ -189,10 +204,7 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
 
     async readExitInfo(sessionName: string): Promise<number | null> {
       try {
-        const content = await readFile(
-          `/tmp/dispatch_${sessionName}.exit`,
-          "utf-8"
-        );
+        const content = await readFile(exitFilePath(sessionName), "utf-8");
         const match = content.trim().match(/^EXIT:(\d+)$/);
         return match ? Number(match[1]) : null;
       } catch {
@@ -207,26 +219,27 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
 }
 
 /**
- * Translate a `LaunchInput.payload` into the bash invocation that tmux
- * will run inside `new-session`. For setup-script payloads, write the
- * script to disk first; for inline agent-command payloads, wrap with
- * stderr-tee + exit-capture so the reconciler can read the result.
+ * Translate a `LaunchInput` into the bash invocation that tmux runs
+ * inside `new-session`. Both payload kinds get the same outer wrapper
+ * — stderr tee'd to the per-agent setup log, exit code captured to the
+ * per-session exit file — so the reconciler can read both via
+ * `readSetupLogTail` and `readExitInfo` regardless of how the session
+ * was launched.
  */
-async function preparePayload(input: LaunchInput): Promise<string> {
-  const { payload } = input;
-
-  if (payload.kind === "setup-script") {
-    await writeFile(payload.scriptPath, payload.scriptContent, { mode: 0o755 });
-    return `bash ${payload.scriptPath}`;
+async function prepareLaunch(input: LaunchInput): Promise<string> {
+  let inner: string;
+  if (input.payload.kind === "setup-script") {
+    const scriptPath = setupScriptPath(input.agentId);
+    await writeFile(scriptPath, input.payload.scriptContent, { mode: 0o755 });
+    inner = `bash ${scriptPath}`;
+  } else {
+    inner = input.payload.command;
   }
 
-  // agent-command: wrap so stderr is tee'd to the setup log and exit
-  // code is captured for the reconciler.
-  const sessionLogFile = `/tmp/dispatch_setup_${input.agentId}.log`;
-  return `bash -c 'exec 2> >(tee "${sessionLogFile}" >&2); ${payload.command.replaceAll(
-    "'",
-    "'\\''"
-  )}; echo "EXIT:$?" > ${payload.exitFile}'`;
+  const logFile = setupLogPath(input.agentId);
+  const exitFile = exitFilePath(input.sessionName);
+  const escapedInner = inner.replaceAll("'", "'\\''");
+  return `bash -c 'exec 2> >(tee "${logFile}" >&2); ${escapedInner}; echo "EXIT:$?" > ${exitFile}'`;
 }
 
 async function tmuxHasSession(sessionName: string): Promise<boolean> {
@@ -334,7 +347,7 @@ async function resolveAgentProcessCwd(
  * error messages. Returns "" when no log file is on disk.
  */
 async function readSetupLogTailFromDisk(idOrSession: string): Promise<string> {
-  const logPath = `/tmp/dispatch_setup_${idOrSession}.log`;
+  const logPath = setupLogPath(idOrSession);
   try {
     const log = await readFile(logPath, "utf-8");
     const tail = log.trim().split("\n").slice(-20).join("\n");

--- a/apps/server/src/agents/tmux/runtime.ts
+++ b/apps/server/src/agents/tmux/runtime.ts
@@ -1,0 +1,350 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import type { FastifyBaseLogger } from "fastify";
+
+import { runCommand } from "../../shared/lib/run-command.js";
+import type { AgentRuntime, LaunchInput } from "../runtime.js";
+
+/** TTL for the per-session current-cwd cache. */
+const CWD_CACHE_TTL_MS = 10_000;
+
+/** Grace period between Ctrl-C and kill-session in non-force stop. */
+const STOP_GRACE_MS = 1200;
+
+/** Hard timeout for individual `tmux display-message` / `pgrep` / `ps` / `lsof` calls. */
+const PROCESS_INSPECT_TIMEOUT_MS = 800;
+
+/** Basenames the cwd resolver recognises as "the agent CLI" (worth pid-walking into). */
+const AGENT_CLI_BASENAMES = new Set(["claude", "codex", "opencode"]);
+
+/**
+ * Build the tmux-backed AgentRuntime. Holds a per-session cwd cache in
+ * its closure (TTL `CWD_CACHE_TTL_MS`) — the cache is what stops the
+ * UI from spawning a fresh `tmux display-message` + `pgrep` + `ps` +
+ * `lsof` chain on every reconcile tick.
+ */
+export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
+  const cwdCache = new Map<string, { value: string; expiresAt: number }>();
+
+  return {
+    async launch(input: LaunchInput): Promise<void> {
+      const wrappedCommand = await preparePayload(input);
+
+      await runCommand("tmux", [
+        "new-session",
+        "-d",
+        "-s",
+        input.sessionName,
+        "-c",
+        input.cwd,
+        wrappedCommand,
+      ]);
+
+      // Quiet the status bar — agent CLIs draw their own UI.
+      await runCommand(
+        "tmux",
+        ["set-option", "-t", input.sessionName, "status", "off"],
+        { allowedExitCodes: [0, 1] }
+      );
+      // Allow DCS passthrough so agent CLIs that wrap escape sequences
+      // (e.g. synchronized output) can reach the outer terminal directly.
+      await runCommand(
+        "tmux",
+        ["set-option", "-t", input.sessionName, "allow-passthrough", "on"],
+        { allowedExitCodes: [0, 1] }
+      );
+      // Advertise synchronized output support so tmux wraps frame
+      // rendering in DEC 2026 sequences, reducing terminal flashing.
+      // Set once per session start (not per WebSocket attach) to avoid
+      // unbounded array growth.
+      await runCommand(
+        "tmux",
+        ["set-option", "-as", "terminal-features", "xterm-256color:sync"],
+        { allowedExitCodes: [0, 1] }
+      );
+
+      // Detect fast-fail launches (e.g. missing CLI executable, broken
+      // profile script) so the agent isn't left as "running" with no
+      // backing tmux session.
+      if (!(await tmuxHasSession(input.sessionName))) {
+        const detail = await readSetupLogTailFromDisk(input.agentId);
+        throw new Error(
+          `tmux session exited immediately after launch${detail}`
+        );
+      }
+    },
+
+    async ensureNoExistingSession(sessionName: string): Promise<void> {
+      if (await tmuxHasSession(sessionName)) {
+        await runCommand("tmux", ["kill-session", "-t", sessionName]);
+      }
+    },
+
+    async stopSession(sessionName: string, force: boolean): Promise<void> {
+      if (!force) {
+        await runCommand("tmux", ["send-keys", "-t", sessionName, "C-c"]);
+        await sleep(STOP_GRACE_MS);
+      }
+
+      if (await tmuxHasSession(sessionName)) {
+        await runCommand("tmux", ["kill-session", "-t", sessionName]);
+      }
+    },
+
+    async hasSession(sessionName: string): Promise<boolean> {
+      return tmuxHasSession(sessionName);
+    },
+
+    async getCurrentCwd({
+      sessionName,
+      agentId,
+      fallback,
+    }: {
+      sessionName: string;
+      agentId: string;
+      fallback: string;
+    }): Promise<string> {
+      const session = sessionName.trim();
+      if (!session) return fallback;
+
+      const cacheKey = `${agentId}:${session}`;
+      const cached = cwdCache.get(cacheKey);
+      const now = Date.now();
+      if (cached && cached.expiresAt > now) {
+        return cached.value;
+      }
+
+      try {
+        // First, try the agent CLI process itself. tmux pane_current_path
+        // only tracks the shell's CWD, but agent CLIs (claude, codex,
+        // opencode) may cd internally without updating the shell.
+        const agentCwd = await resolveAgentProcessCwd(session, logger);
+        if (agentCwd) {
+          cwdCache.set(cacheKey, {
+            value: agentCwd,
+            expiresAt: now + CWD_CACHE_TTL_MS,
+          });
+          return agentCwd;
+        }
+
+        // Fall back to tmux pane_current_path (the shell's CWD).
+        const result = await runCommand(
+          "tmux",
+          ["display-message", "-p", "-t", session, "#{pane_current_path}"],
+          {
+            allowedExitCodes: [0, 1],
+            timeoutMs: PROCESS_INSPECT_TIMEOUT_MS,
+          }
+        );
+        const cwd = result.stdout.trim();
+        if (result.exitCode !== 0 || !cwd) {
+          return fallback;
+        }
+        cwdCache.set(cacheKey, {
+          value: cwd,
+          expiresAt: now + CWD_CACHE_TTL_MS,
+        });
+        return cwd;
+      } catch {
+        return fallback;
+      }
+    },
+
+    async listSessions(
+      prefix: string
+    ): Promise<Array<{ name: string; createdAt: number }>> {
+      let stdout: string | undefined;
+      try {
+        const result = await runCommand(
+          "tmux",
+          ["list-sessions", "-F", "#{session_name}:#{session_created}"],
+          { allowedExitCodes: [0, 1] }
+        );
+        stdout = result.stdout;
+      } catch {
+        // tmux not running or no sessions
+        return [];
+      }
+
+      if (!stdout?.trim()) return [];
+
+      return stdout
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const colonIdx = line.lastIndexOf(":");
+          const name = line.substring(0, colonIdx);
+          const createdStr = line.substring(colonIdx + 1);
+          return { name, createdAt: parseInt(createdStr, 10) };
+        })
+        .filter((s) => s.name.startsWith(prefix));
+    },
+
+    async killSession(sessionName: string): Promise<void> {
+      await runCommand("tmux", ["kill-session", "-t", sessionName]).catch(
+        () => {}
+      );
+    },
+
+    async readExitInfo(sessionName: string): Promise<number | null> {
+      try {
+        const content = await readFile(
+          `/tmp/dispatch_${sessionName}.exit`,
+          "utf-8"
+        );
+        const match = content.trim().match(/^EXIT:(\d+)$/);
+        return match ? Number(match[1]) : null;
+      } catch {
+        return null;
+      }
+    },
+
+    async readSetupLogTail(idOrSession: string): Promise<string> {
+      return readSetupLogTailFromDisk(idOrSession);
+    },
+  };
+}
+
+/**
+ * Translate a `LaunchInput.payload` into the bash invocation that tmux
+ * will run inside `new-session`. For setup-script payloads, write the
+ * script to disk first; for inline agent-command payloads, wrap with
+ * stderr-tee + exit-capture so the reconciler can read the result.
+ */
+async function preparePayload(input: LaunchInput): Promise<string> {
+  const { payload } = input;
+
+  if (payload.kind === "setup-script") {
+    await writeFile(payload.scriptPath, payload.scriptContent, { mode: 0o755 });
+    return `bash ${payload.scriptPath}`;
+  }
+
+  // agent-command: wrap so stderr is tee'd to the setup log and exit
+  // code is captured for the reconciler.
+  const sessionLogFile = `/tmp/dispatch_setup_${input.agentId}.log`;
+  return `bash -c 'exec 2> >(tee "${sessionLogFile}" >&2); ${payload.command.replaceAll(
+    "'",
+    "'\\''"
+  )}; echo "EXIT:$?" > ${payload.exitFile}'`;
+}
+
+async function tmuxHasSession(sessionName: string): Promise<boolean> {
+  const result = await runCommand("tmux", ["has-session", "-t", sessionName], {
+    allowedExitCodes: [0, 1],
+  });
+  return result.exitCode === 0;
+}
+
+/**
+ * Resolve the CWD of the agent CLI process (claude/codex/opencode)
+ * running inside a tmux pane. The CLI process may have cd'd into a
+ * worktree internally, which tmux's `pane_current_path` won't reflect.
+ *
+ * Walks: pane PID → child PIDs (pgrep) → matching basename (ps) →
+ * cwd (lsof -d cwd -Fn). Returns null on any failure.
+ */
+async function resolveAgentProcessCwd(
+  session: string,
+  logger: FastifyBaseLogger
+): Promise<string | null> {
+  try {
+    const pidResult = await runCommand(
+      "tmux",
+      ["display-message", "-p", "-t", session, "#{pane_pid}"],
+      { allowedExitCodes: [0, 1], timeoutMs: PROCESS_INSPECT_TIMEOUT_MS }
+    );
+    const panePid = pidResult.stdout.trim();
+    if (pidResult.exitCode !== 0 || !panePid) {
+      logger.debug({ session }, "resolveAgentProcessCwd: no pane_pid");
+      return null;
+    }
+
+    const childrenResult = await runCommand("pgrep", ["-P", panePid], {
+      allowedExitCodes: [0, 1],
+      timeoutMs: PROCESS_INSPECT_TIMEOUT_MS,
+    });
+    if (childrenResult.exitCode !== 0 || !childrenResult.stdout.trim()) {
+      logger.debug({ session, panePid }, "resolveAgentProcessCwd: no children");
+      return null;
+    }
+
+    const childPids = childrenResult.stdout.trim().split("\n");
+    let agentPid: string | null = null;
+
+    for (const pid of childPids) {
+      const commResult = await runCommand(
+        "ps",
+        ["-o", "comm=", "-p", pid.trim()],
+        {
+          allowedExitCodes: [0, 1],
+          timeoutMs: PROCESS_INSPECT_TIMEOUT_MS,
+        }
+      );
+      const comm = commResult.stdout.trim();
+      const basename = comm.split("/").pop() ?? "";
+      if (AGENT_CLI_BASENAMES.has(basename)) {
+        agentPid = pid.trim();
+        break;
+      }
+    }
+
+    if (!agentPid) {
+      logger.debug(
+        { session, panePid },
+        "resolveAgentProcessCwd: no agent CLI among children"
+      );
+      return null;
+    }
+
+    // Read the process's CWD via lsof (works on macOS and Linux).
+    const lsofResult = await runCommand(
+      "lsof",
+      ["-a", "-p", agentPid, "-d", "cwd", "-Fn"],
+      { allowedExitCodes: [0, 1], timeoutMs: PROCESS_INSPECT_TIMEOUT_MS }
+    );
+    if (lsofResult.exitCode !== 0 || !lsofResult.stdout) {
+      logger.debug(
+        { session, agentPid },
+        "resolveAgentProcessCwd: lsof failed"
+      );
+      return null;
+    }
+
+    // lsof -Fn outputs lines like "p<pid>" and "n<path>". Extract the path.
+    for (const line of lsofResult.stdout.split("\n")) {
+      if (line.startsWith("n/")) {
+        const cwd = line.slice(1);
+        logger.debug(
+          { session, agentPid, cwd },
+          "resolveAgentProcessCwd: resolved"
+        );
+        return cwd;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the last 20 lines of a setup/session stderr log to include in
+ * error messages. Returns "" when no log file is on disk.
+ */
+async function readSetupLogTailFromDisk(idOrSession: string): Promise<string> {
+  const logPath = `/tmp/dispatch_setup_${idOrSession}.log`;
+  try {
+    const log = await readFile(logPath, "utf-8");
+    const tail = log.trim().split("\n").slice(-20).join("\n");
+    if (tail) return `\n\nSetup log (last 20 lines):\n${tail}`;
+  } catch {
+    /* no log file */
+  }
+  return "";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -19,15 +19,15 @@ export type SetupScriptParams = {
   worktreePathOverride?: string;
   agentName: string;
   agentCommand: string;
-  exitFile: string;
   jobRunId?: string;
 };
 
 /**
  * Generate the bash setup script that runs in the agent's tmux pane on
  * launch. Pure — takes config + inputs, returns the full script as a
- * single string (the caller writes it to `/tmp/dispatch_setup_<id>.sh`
- * and execs it via tmux).
+ * single string. The runtime (`agents/tmux/runtime.ts`) writes it to
+ * disk, wraps the launch with stderr-tee + exit-capture, and execs it
+ * via tmux.
  *
  * The script:
  *   1. Optionally creates a git worktree from `baseBranch` and copies
@@ -37,6 +37,11 @@ export type SetupScriptParams = {
  *   3. For opencode agents, writes `opencode.json` with the dispatch
  *      MCP entry before launch.
  *   4. `exec`s into `agentCommand` so the tmux pane becomes the agent.
+ *
+ * Stderr capture and exit-code recording are *not* handled inside the
+ * script — those are runtime-owned conventions applied by the launch
+ * wrapper. This keeps the script generator unconcerned with where logs
+ * or exit files live.
  *
  * Security note: ref names flowing into the bash script are re-validated
  * via `assertSafeRefName` even though `createAgent` already normalizes
@@ -57,7 +62,6 @@ export function generateSetupScript(
     worktreePathOverride,
     agentName,
     agentCommand,
-    exitFile,
   } = params;
 
   const serverUrl = `${config.tls ? "https" : "http"}://127.0.0.1:${config.port}`;
@@ -96,10 +100,9 @@ export function generateSetupScript(
     ``,
     `# Dispatch agent setup script for ${agentName}`,
     `# This script runs in tmux so the user can see setup progress in real time.`,
-    ``,
-    `# Tee stderr to a log file so the server can surface errors when the session`,
-    `# exits immediately (e.g. a broken profile script).`,
-    `exec 2> >(tee "/tmp/dispatch_setup_${agentId}.log" >&2)`,
+    `# Stderr is captured at the launch wrapper level (the tmux runtime tees`,
+    `# everything to /tmp/dispatch_setup_<id>.log), so this script doesn't`,
+    `# do its own redirection.`,
     ``,
     `# Source user-defined overrides for agent sessions`,
     `[[ -f ~/.dispatch/env ]] && { set +e; source ~/.dispatch/env; set -euo pipefail; }`,
@@ -291,8 +294,9 @@ export function generateSetupScript(
   }
 
   lines.push(
-    `# exec replaces this shell with the agent CLI — seamless transition`,
-    `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}; echo "EXIT:$?" > ${exitFile}'`
+    `# exec replaces this shell with the agent CLI — seamless transition.`,
+    `# Exit code capture is handled by the launch wrapper, not here.`,
+    `exec bash -c '${agentCommand.replaceAll("'", "'\\''")}'`
   );
 
   return lines.join("\n") + "\n";

--- a/apps/server/test/agent-runtime-inert.test.ts
+++ b/apps/server/test/agent-runtime-inert.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { createAgentRuntime } from "../src/agents/runtime.js";
+import type { AppConfig } from "../src/config.js";
+
+const noopLogger = (() => {
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    fatal: () => {},
+    trace: () => {},
+    silent: () => {},
+    level: "silent",
+    child: () => logger,
+  };
+  return logger as unknown as import("fastify").FastifyBaseLogger;
+})();
+
+const inertConfig: AppConfig = {
+  host: "127.0.0.1",
+  port: 6767,
+  databaseUrl: "",
+  authToken: "test-token",
+  mediaRoot: "/tmp/dispatch-test-media",
+  dispatchBinDir: "/usr/local/bin/dispatch",
+  codexBin: "/opt/codex",
+  claudeBin: "/opt/claude",
+  opencodeBin: "/opt/opencode",
+  agentRuntime: "inert",
+  sessionPrefix: "dispatch",
+  tls: null,
+};
+
+describe("InertRuntime (createAgentRuntime with agentRuntime=inert)", () => {
+  // The inert runtime is what test code and headless environments get.
+  // Most operations are no-ops; the few that need to return something
+  // return a "soft default" that matches the historical AgentManager
+  // behaviour the manager's reconciliation logic relies on.
+
+  it("launch() resolves without doing anything", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    await expect(
+      runtime.launch({
+        sessionName: "dispatch_agt_x",
+        cwd: "/tmp",
+        agentId: "agt_x",
+        payload: {
+          kind: "agent-command",
+          command: "echo hi",
+          exitFile: "/tmp/exit",
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("ensureNoExistingSession() and stopSession() are no-ops", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    await expect(
+      runtime.ensureNoExistingSession("dispatch_agt_x")
+    ).resolves.toBeUndefined();
+    await expect(
+      runtime.stopSession("dispatch_agt_x", false)
+    ).resolves.toBeUndefined();
+    await expect(
+      runtime.stopSession("dispatch_agt_x", true)
+    ).resolves.toBeUndefined();
+  });
+
+  it("hasSession() returns true for any non-empty name (legacy contract)", async () => {
+    // The reconciler relies on this: in inert mode every "registered"
+    // agent is treated as live, so the missing-session branch in
+    // reconcileAgentStatuses doesn't fire spuriously.
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.hasSession("dispatch_agt_x")).toBe(true);
+    expect(await runtime.hasSession("anything-non-empty")).toBe(true);
+  });
+
+  it("hasSession() returns false for empty/whitespace names", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.hasSession("")).toBe(false);
+    expect(await runtime.hasSession("   ")).toBe(false);
+  });
+
+  it("getCurrentCwd() returns the supplied fallback unconditionally", async () => {
+    // No process to introspect — return whatever the caller already had.
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(
+      await runtime.getCurrentCwd({
+        sessionName: "dispatch_agt_x",
+        agentId: "agt_x",
+        fallback: "/projects/foo",
+      })
+    ).toBe("/projects/foo");
+  });
+
+  it("listSessions() returns an empty array (nothing to list)", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.listSessions("dispatch_agt_")).toEqual([]);
+  });
+
+  it("killSession() resolves without doing anything", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    await expect(
+      runtime.killSession("dispatch_agt_x")
+    ).resolves.toBeUndefined();
+  });
+
+  it("readExitInfo() returns null (no exit-file recording in inert mode)", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.readExitInfo("dispatch_agt_x")).toBeNull();
+  });
+
+  it("readSetupLogTail() returns the empty string (no log file in inert mode)", async () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.readSetupLogTail("agt_x")).toBe("");
+  });
+
+  it("createAgentRuntime dispatches to inert when config.agentRuntime is 'inert'", () => {
+    // Smoke check that the factory wiring is correct — we should get an
+    // object whose method shapes match the AgentRuntime interface.
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(typeof runtime.launch).toBe("function");
+    expect(typeof runtime.hasSession).toBe("function");
+    expect(typeof runtime.stopSession).toBe("function");
+    expect(typeof runtime.ensureNoExistingSession).toBe("function");
+    expect(typeof runtime.getCurrentCwd).toBe("function");
+    expect(typeof runtime.listSessions).toBe("function");
+    expect(typeof runtime.killSession).toBe("function");
+    expect(typeof runtime.readExitInfo).toBe("function");
+    expect(typeof runtime.readSetupLogTail).toBe("function");
+  });
+});

--- a/apps/server/test/agent-runtime-inert.test.ts
+++ b/apps/server/test/agent-runtime-inert.test.ts
@@ -46,13 +46,14 @@ describe("InertRuntime (createAgentRuntime with agentRuntime=inert)", () => {
         sessionName: "dispatch_agt_x",
         cwd: "/tmp",
         agentId: "agt_x",
-        payload: {
-          kind: "agent-command",
-          command: "echo hi",
-          exitFile: "/tmp/exit",
-        },
+        payload: { kind: "agent-command", command: "echo hi" },
       })
     ).resolves.toBeUndefined();
+  });
+
+  it("tracksSessions() returns false (inert has no real session state)", () => {
+    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(runtime.tracksSessions()).toBe(false);
   });
 
   it("ensureNoExistingSession() and stopSession() are no-ops", async () => {
@@ -68,31 +69,26 @@ describe("InertRuntime (createAgentRuntime with agentRuntime=inert)", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("hasSession() returns true for any non-empty name (legacy contract)", async () => {
-    // The reconciler relies on this: in inert mode every "registered"
-    // agent is treated as live, so the missing-session branch in
-    // reconcileAgentStatuses doesn't fire spuriously.
+  it("hasSession() returns false (no real sessions in inert mode)", async () => {
+    // Honest reporting: there are no sessions to find. Callers that
+    // want "registered agent is live" semantics must consult
+    // tracksSessions() and fall back to the DB row.
     const runtime = createAgentRuntime(inertConfig, noopLogger);
-    expect(await runtime.hasSession("dispatch_agt_x")).toBe(true);
-    expect(await runtime.hasSession("anything-non-empty")).toBe(true);
-  });
-
-  it("hasSession() returns false for empty/whitespace names", async () => {
-    const runtime = createAgentRuntime(inertConfig, noopLogger);
+    expect(await runtime.hasSession("dispatch_agt_x")).toBe(false);
+    expect(await runtime.hasSession("anything")).toBe(false);
     expect(await runtime.hasSession("")).toBe(false);
-    expect(await runtime.hasSession("   ")).toBe(false);
   });
 
-  it("getCurrentCwd() returns the supplied fallback unconditionally", async () => {
-    // No process to introspect — return whatever the caller already had.
+  it("getCurrentCwd() returns null (no process to introspect)", async () => {
+    // The runtime can't determine a cwd — return null and let the
+    // manager apply its own fallback policy.
     const runtime = createAgentRuntime(inertConfig, noopLogger);
     expect(
       await runtime.getCurrentCwd({
         sessionName: "dispatch_agt_x",
         agentId: "agt_x",
-        fallback: "/projects/foo",
       })
-    ).toBe("/projects/foo");
+    ).toBeNull();
   });
 
   it("listSessions() returns an empty array (nothing to list)", async () => {
@@ -122,6 +118,7 @@ describe("InertRuntime (createAgentRuntime with agentRuntime=inert)", () => {
     // object whose method shapes match the AgentRuntime interface.
     const runtime = createAgentRuntime(inertConfig, noopLogger);
     expect(typeof runtime.launch).toBe("function");
+    expect(typeof runtime.tracksSessions).toBe("function");
     expect(typeof runtime.hasSession).toBe("function");
     expect(typeof runtime.stopSession).toBe("function");
     expect(typeof runtime.ensureNoExistingSession).toBe("function");

--- a/apps/server/test/agent-runtime-tmux.test.ts
+++ b/apps/server/test/agent-runtime-tmux.test.ts
@@ -36,6 +36,13 @@ beforeEach(() => {
 const matchArgs = (args: string[], pattern: string[]) =>
   pattern.every((p, i) => args[i] === p);
 
+describe("TmuxRuntime — capabilities", () => {
+  it("tracksSessions() returns true (tmux backs sessions with real OS state)", () => {
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(runtime.tracksSessions()).toBe(true);
+  });
+});
+
 describe("TmuxRuntime — hasSession", () => {
   it("returns true when `tmux has-session` exits 0", async () => {
     vi.mocked(runCommand).mockResolvedValue(ok());
@@ -196,15 +203,14 @@ describe("TmuxRuntime — getCurrentCwd", () => {
   // the only state the runtime closure holds and a regression here
   // shows up as a hot ps/lsof loop on every reconcile tick.
 
-  it("returns fallback when sessionName is empty/whitespace", async () => {
+  it("returns null when sessionName is empty/whitespace (no fallback baked in)", async () => {
     const runtime = createTmuxRuntime(noopLogger);
     expect(
       await runtime.getCurrentCwd({
         sessionName: "  ",
         agentId: "agt_x",
-        fallback: "/projects/foo",
       })
-    ).toBe("/projects/foo");
+    ).toBeNull();
     // No tmux invocation required.
     expect(vi.mocked(runCommand)).not.toHaveBeenCalled();
   });
@@ -223,21 +229,19 @@ describe("TmuxRuntime — getCurrentCwd", () => {
       await runtime.getCurrentCwd({
         sessionName: "dispatch_agt_x",
         agentId: "agt_x",
-        fallback: "/fallback",
       })
     ).toBe("/the/cwd");
   });
 
-  it("returns fallback when both pid-walk and pane_current_path fail", async () => {
+  it("returns null when both pid-walk and pane_current_path fail (manager applies fallback)", async () => {
     vi.mocked(runCommand).mockImplementation(async () => fail());
     const runtime = createTmuxRuntime(noopLogger);
     expect(
       await runtime.getCurrentCwd({
         sessionName: "dispatch_agt_x",
         agentId: "agt_x",
-        fallback: "/fallback",
       })
-    ).toBe("/fallback");
+    ).toBeNull();
   });
 
   it("caches a successful resolution for the configured TTL", async () => {
@@ -259,12 +263,10 @@ describe("TmuxRuntime — getCurrentCwd", () => {
     const a = await runtime.getCurrentCwd({
       sessionName: "dispatch_agt_x",
       agentId: "agt_x",
-      fallback: "/fallback",
     });
     const b = await runtime.getCurrentCwd({
       sessionName: "dispatch_agt_x",
       agentId: "agt_x",
-      fallback: "/fallback",
     });
 
     expect(a).toBe("/cached/cwd");
@@ -292,12 +294,10 @@ describe("TmuxRuntime — getCurrentCwd", () => {
     const a = await runtime.getCurrentCwd({
       sessionName: "session-A",
       agentId: "agt_a",
-      fallback: "/fb",
     });
     const b = await runtime.getCurrentCwd({
       sessionName: "session-B",
       agentId: "agt_b",
-      fallback: "/fb",
     });
     expect(a).toBe("/cwd-A");
     expect(b).toBe("/cwd-B");
@@ -375,47 +375,54 @@ describe("TmuxRuntime — readSetupLogTail", () => {
 });
 
 describe("TmuxRuntime — launch (setup-script payload)", () => {
-  let tmpDir: string;
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "runtime-launch-test-"));
-  });
+  // The runtime owns where setup scripts live on disk — the manager
+  // doesn't pass a path. The test cleans up the runtime's chosen path.
 
   afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true });
+    await unlink("/tmp/dispatch_setup_agt_xyz_runtime_test.sh").catch(() => {});
   });
 
-  it("writes the setup script and runs `bash <path>` in tmux", async () => {
+  it("writes the setup script to a runtime-chosen path and runs `bash <path>` inside the wrapped launch", async () => {
     vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
       if (args[0] === "has-session") return ok(); // post-launch verify
       return ok();
     });
 
     const runtime = createTmuxRuntime(noopLogger);
-    const scriptPath = path.join(tmpDir, "setup.sh");
     await runtime.launch({
-      sessionName: "dispatch_agt_x",
+      sessionName: "dispatch_agt_xyz_runtime_test",
       cwd: "/projects/foo",
-      agentId: "agt_x",
+      agentId: "agt_xyz_runtime_test",
       payload: {
         kind: "setup-script",
-        scriptPath,
         scriptContent: "#!/usr/bin/env bash\necho hello\n",
       },
     });
 
-    // Script is on disk
-    const written = await readFile(scriptPath, "utf-8");
+    // Script is on disk at the runtime's chosen path
+    // (`/tmp/dispatch_setup_<agentId>.sh`).
+    const expectedScriptPath = "/tmp/dispatch_setup_agt_xyz_runtime_test.sh";
+    const written = await readFile(expectedScriptPath, "utf-8");
     expect(written).toBe("#!/usr/bin/env bash\necho hello\n");
 
-    // tmux new-session ran with `bash <path>` as the command
+    // tmux new-session ran with the wrapped `bash <path>` as the command
     const newSessionCall = vi
       .mocked(runCommand)
       .mock.calls.find(([, a]) => a[0] === "new-session");
-    expect(newSessionCall?.[1]).toContain("dispatch_agt_x");
+    expect(newSessionCall?.[1]).toContain("dispatch_agt_xyz_runtime_test");
     expect(newSessionCall?.[1]).toContain("/projects/foo");
-    expect(newSessionCall?.[1]?.[newSessionCall[1].length - 1]).toBe(
-      `bash ${scriptPath}`
+    const wrappedCommand = newSessionCall?.[1]?.[
+      newSessionCall[1].length - 1
+    ] as string;
+    // The same outer wrap that agent-command gets — stderr tee + exit
+    // capture — applies to setup-script too. The script no longer needs
+    // to do its own stderr / exit handling.
+    expect(wrappedCommand).toContain(
+      `tee "/tmp/dispatch_setup_agt_xyz_runtime_test.log"`
+    );
+    expect(wrappedCommand).toContain(`bash ${expectedScriptPath}`);
+    expect(wrappedCommand).toContain(
+      `echo "EXIT:$?" > /tmp/dispatch_dispatch_agt_xyz_runtime_test.exit`
     );
   });
 
@@ -430,10 +437,9 @@ describe("TmuxRuntime — launch (setup-script payload)", () => {
       runtime.launch({
         sessionName: "dispatch_agt_x",
         cwd: "/projects/foo",
-        agentId: "agt_x",
+        agentId: "agt_xyz_runtime_test",
         payload: {
           kind: "setup-script",
-          scriptPath: path.join(tmpDir, "setup.sh"),
           scriptContent: "#!/usr/bin/env bash\nexit 1\n",
         },
       })
@@ -442,7 +448,7 @@ describe("TmuxRuntime — launch (setup-script payload)", () => {
 });
 
 describe("TmuxRuntime — launch (agent-command payload)", () => {
-  it("wraps the inline command with stderr-tee and exit-code capture", async () => {
+  it("wraps the inline command with stderr-tee and exit-code capture (paths runtime-internal)", async () => {
     vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
       if (args[0] === "has-session") return ok();
       return ok();
@@ -453,11 +459,7 @@ describe("TmuxRuntime — launch (agent-command payload)", () => {
       sessionName: "dispatch_agt_y",
       cwd: "/projects/bar",
       agentId: "agt_y",
-      payload: {
-        kind: "agent-command",
-        command: "/opt/claude --foo",
-        exitFile: "/tmp/dispatch_dispatch_agt_y.exit",
-      },
+      payload: { kind: "agent-command", command: "/opt/claude --foo" },
     });
 
     const newSessionCall = vi
@@ -467,8 +469,10 @@ describe("TmuxRuntime — launch (agent-command payload)", () => {
       newSessionCall[1].length - 1
     ] as string;
 
-    // The wrapper bakes in: stderr tee to the agent's setup log file,
-    // the agent command itself, and EXIT:$? to the configured exit file.
+    // The wrapper bakes in: stderr tee to the agent's setup log file
+    // (path derived from agentId), the agent command itself, and
+    // EXIT:$? to the per-session exit file (path derived from
+    // sessionName). The manager doesn't supply or know either path.
     expect(wrappedCommand).toContain(`tee "/tmp/dispatch_setup_agt_y.log"`);
     expect(wrappedCommand).toContain("/opt/claude --foo");
     expect(wrappedCommand).toContain(
@@ -493,7 +497,6 @@ describe("TmuxRuntime — launch (agent-command payload)", () => {
       payload: {
         kind: "agent-command",
         command: `echo 'inner-quote'`,
-        exitFile: "/tmp/exit",
       },
     });
 

--- a/apps/server/test/agent-runtime-tmux.test.ts
+++ b/apps/server/test/agent-runtime-tmux.test.ts
@@ -1,0 +1,509 @@
+import { mkdtemp, readFile, rm, writeFile, unlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/shared/lib/run-command.js", () => ({
+  runCommand: vi.fn(),
+}));
+
+const { createTmuxRuntime } = await import("../src/agents/tmux/runtime.js");
+const { runCommand } = await import("../src/shared/lib/run-command.js");
+
+const ok = (stdout = "") => ({ exitCode: 0, stdout, stderr: "" });
+const fail = (stdout = "") => ({ exitCode: 1, stdout, stderr: "" });
+
+const noopLogger = (() => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: "silent",
+    child: () => logger,
+  };
+  return logger as unknown as import("fastify").FastifyBaseLogger;
+})();
+
+beforeEach(() => {
+  vi.mocked(runCommand).mockReset();
+});
+
+const matchArgs = (args: string[], pattern: string[]) =>
+  pattern.every((p, i) => args[i] === p);
+
+describe("TmuxRuntime — hasSession", () => {
+  it("returns true when `tmux has-session` exits 0", async () => {
+    vi.mocked(runCommand).mockResolvedValue(ok());
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(await runtime.hasSession("dispatch_agt_x")).toBe(true);
+    expect(vi.mocked(runCommand).mock.calls[0]?.[1]).toEqual([
+      "has-session",
+      "-t",
+      "dispatch_agt_x",
+    ]);
+  });
+
+  it("returns false when `tmux has-session` exits non-zero", async () => {
+    vi.mocked(runCommand).mockResolvedValue(fail());
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(await runtime.hasSession("dispatch_agt_x")).toBe(false);
+  });
+});
+
+describe("TmuxRuntime — ensureNoExistingSession", () => {
+  it("kills the session if it exists", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok(); // exists
+      return ok(); // kill-session
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.ensureNoExistingSession("dispatch_agt_x");
+
+    const killCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "kill-session");
+    expect(killCall).toBeDefined();
+  });
+
+  it("is a no-op if the session does not exist", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return fail();
+      return ok();
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.ensureNoExistingSession("dispatch_agt_x");
+
+    const killCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "kill-session");
+    expect(killCall).toBeUndefined();
+  });
+});
+
+describe("TmuxRuntime — stopSession", () => {
+  it("force=true skips the C-c grace period and goes straight to kill", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok();
+      return ok();
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.stopSession("dispatch_agt_x", true);
+
+    const sendKeysCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "send-keys");
+    expect(sendKeysCall).toBeUndefined();
+    const killCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "kill-session");
+    expect(killCall).toBeDefined();
+  });
+
+  it("force=false sends Ctrl-C, waits, and then kills if the session is still alive", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok(); // still alive after C-c
+      return ok();
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+
+    const t0 = Date.now();
+    await runtime.stopSession("dispatch_agt_x", false);
+    const elapsed = Date.now() - t0;
+
+    // Grace is 1200ms — verify the wait actually happened.
+    expect(elapsed).toBeGreaterThanOrEqual(1100);
+
+    const sendKeysCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "send-keys");
+    expect(sendKeysCall).toBeDefined();
+    expect(sendKeysCall?.[1]).toContain("C-c");
+
+    const killCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "kill-session");
+    expect(killCall).toBeDefined();
+  }, 5000);
+
+  it("force=false skips the kill when C-c made the session exit on its own", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return fail(); // already gone
+      return ok();
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.stopSession("dispatch_agt_x", false);
+
+    const killCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "kill-session");
+    expect(killCall).toBeUndefined();
+  }, 5000);
+});
+
+describe("TmuxRuntime — listSessions", () => {
+  it("parses tmux list-sessions output and filters by prefix", async () => {
+    vi.mocked(runCommand).mockResolvedValue(
+      ok(
+        [
+          "dispatch_agt_aaa:1700000000",
+          "dispatch_agt_bbb:1700000100",
+          "other-session:1700000200",
+          "dispatch_dev_agt_ccc:1700000300",
+        ].join("\n")
+      )
+    );
+    const runtime = createTmuxRuntime(noopLogger);
+    const result = await runtime.listSessions("dispatch_agt_");
+
+    expect(result).toEqual([
+      { name: "dispatch_agt_aaa", createdAt: 1700000000 },
+      { name: "dispatch_agt_bbb", createdAt: 1700000100 },
+    ]);
+  });
+
+  it("returns empty when tmux is not running (runCommand throws)", async () => {
+    vi.mocked(runCommand).mockRejectedValue(
+      new Error("tmux: command not found")
+    );
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(await runtime.listSessions("dispatch_agt_")).toEqual([]);
+  });
+
+  it("returns empty when stdout is blank (no sessions)", async () => {
+    vi.mocked(runCommand).mockResolvedValue(ok(""));
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(await runtime.listSessions("dispatch_agt_")).toEqual([]);
+  });
+});
+
+describe("TmuxRuntime — killSession", () => {
+  it("swallows errors from kill-session (best-effort)", async () => {
+    vi.mocked(runCommand).mockRejectedValue(new Error("no such session"));
+    const runtime = createTmuxRuntime(noopLogger);
+    await expect(
+      runtime.killSession("dispatch_agt_gone")
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("TmuxRuntime — getCurrentCwd", () => {
+  // The cwd resolver has a TTL cache that's important to verify — it's
+  // the only state the runtime closure holds and a regression here
+  // shows up as a hot ps/lsof loop on every reconcile tick.
+
+  it("returns fallback when sessionName is empty/whitespace", async () => {
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(
+      await runtime.getCurrentCwd({
+        sessionName: "  ",
+        agentId: "agt_x",
+        fallback: "/projects/foo",
+      })
+    ).toBe("/projects/foo");
+    // No tmux invocation required.
+    expect(vi.mocked(runCommand)).not.toHaveBeenCalled();
+  });
+
+  it("falls back to pane_current_path when no agent CLI is found among children", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (matchArgs(args, ["display-message", "-p", "-t"])) {
+        if (args.includes("#{pane_pid}")) return ok("12345");
+        if (args.includes("#{pane_current_path}")) return ok("/the/cwd");
+      }
+      if (args[0] === "-P" /* pgrep */) return ok(""); // no children
+      return fail();
+    });
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(
+      await runtime.getCurrentCwd({
+        sessionName: "dispatch_agt_x",
+        agentId: "agt_x",
+        fallback: "/fallback",
+      })
+    ).toBe("/the/cwd");
+  });
+
+  it("returns fallback when both pid-walk and pane_current_path fail", async () => {
+    vi.mocked(runCommand).mockImplementation(async () => fail());
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(
+      await runtime.getCurrentCwd({
+        sessionName: "dispatch_agt_x",
+        agentId: "agt_x",
+        fallback: "/fallback",
+      })
+    ).toBe("/fallback");
+  });
+
+  it("caches a successful resolution for the configured TTL", async () => {
+    let pathReadCount = 0;
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (matchArgs(args, ["display-message", "-p", "-t"])) {
+        if (args.includes("#{pane_pid}")) return ok("12345");
+        if (args.includes("#{pane_current_path}")) {
+          pathReadCount += 1;
+          return ok("/cached/cwd");
+        }
+      }
+      if (args[0] === "-P") return ok("");
+      return fail();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+
+    const a = await runtime.getCurrentCwd({
+      sessionName: "dispatch_agt_x",
+      agentId: "agt_x",
+      fallback: "/fallback",
+    });
+    const b = await runtime.getCurrentCwd({
+      sessionName: "dispatch_agt_x",
+      agentId: "agt_x",
+      fallback: "/fallback",
+    });
+
+    expect(a).toBe("/cached/cwd");
+    expect(b).toBe("/cached/cwd");
+    // Second call should have hit the cache, not re-invoked
+    // pane_current_path.
+    expect(pathReadCount).toBe(1);
+  });
+
+  it("isolates cache entries by (agentId, sessionName) — different agents don't share a cache slot", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (matchArgs(args, ["display-message", "-p", "-t"])) {
+        if (args.includes("#{pane_pid}")) return ok("123");
+        if (args.includes("#{pane_current_path}")) {
+          // Use the session arg to differentiate.
+          if (args.includes("session-A")) return ok("/cwd-A");
+          if (args.includes("session-B")) return ok("/cwd-B");
+        }
+      }
+      if (args[0] === "-P") return ok("");
+      return fail();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+    const a = await runtime.getCurrentCwd({
+      sessionName: "session-A",
+      agentId: "agt_a",
+      fallback: "/fb",
+    });
+    const b = await runtime.getCurrentCwd({
+      sessionName: "session-B",
+      agentId: "agt_b",
+      fallback: "/fb",
+    });
+    expect(a).toBe("/cwd-A");
+    expect(b).toBe("/cwd-B");
+  });
+});
+
+describe("TmuxRuntime — readExitInfo", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "runtime-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when the exit file does not exist", async () => {
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(
+      await runtime.readExitInfo("dispatch_agt_doesnotexist_xyz")
+    ).toBeNull();
+  });
+
+  it("parses `EXIT:N` from /tmp/dispatch_<session>.exit", async () => {
+    const sessionName = `dispatch_agt_test_${Date.now()}`;
+    const exitFile = `/tmp/dispatch_${sessionName}.exit`;
+    try {
+      await writeFile(exitFile, "EXIT:42\n");
+      const runtime = createTmuxRuntime(noopLogger);
+      expect(await runtime.readExitInfo(sessionName)).toBe(42);
+    } finally {
+      await unlink(exitFile).catch(() => {});
+    }
+  });
+
+  it("returns null when the file content is malformed", async () => {
+    const sessionName = `dispatch_agt_malformed_${Date.now()}`;
+    const exitFile = `/tmp/dispatch_${sessionName}.exit`;
+    try {
+      await writeFile(exitFile, "garbage content\n");
+      const runtime = createTmuxRuntime(noopLogger);
+      expect(await runtime.readExitInfo(sessionName)).toBeNull();
+    } finally {
+      await unlink(exitFile).catch(() => {});
+    }
+  });
+});
+
+describe("TmuxRuntime — readSetupLogTail", () => {
+  it("returns empty when the log file does not exist", async () => {
+    const runtime = createTmuxRuntime(noopLogger);
+    expect(await runtime.readSetupLogTail("doesnotexist_xyz_qrs")).toBe("");
+  });
+
+  it("formats the last 20 lines with a 'Setup log' header", async () => {
+    const id = `setup_test_${Date.now()}`;
+    const logFile = `/tmp/dispatch_setup_${id}.log`;
+    try {
+      const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`);
+      await writeFile(logFile, lines.join("\n"));
+
+      const runtime = createTmuxRuntime(noopLogger);
+      const tail = await runtime.readSetupLogTail(id);
+
+      expect(tail.startsWith("\n\nSetup log (last 20 lines):\n")).toBe(true);
+      // Last 20 lines should be 6..25
+      expect(tail).toContain("line 6");
+      expect(tail).toContain("line 25");
+      expect(tail).not.toContain("line 5");
+    } finally {
+      await unlink(logFile).catch(() => {});
+    }
+  });
+});
+
+describe("TmuxRuntime — launch (setup-script payload)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "runtime-launch-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes the setup script and runs `bash <path>` in tmux", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok(); // post-launch verify
+      return ok();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+    const scriptPath = path.join(tmpDir, "setup.sh");
+    await runtime.launch({
+      sessionName: "dispatch_agt_x",
+      cwd: "/projects/foo",
+      agentId: "agt_x",
+      payload: {
+        kind: "setup-script",
+        scriptPath,
+        scriptContent: "#!/usr/bin/env bash\necho hello\n",
+      },
+    });
+
+    // Script is on disk
+    const written = await readFile(scriptPath, "utf-8");
+    expect(written).toBe("#!/usr/bin/env bash\necho hello\n");
+
+    // tmux new-session ran with `bash <path>` as the command
+    const newSessionCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "new-session");
+    expect(newSessionCall?.[1]).toContain("dispatch_agt_x");
+    expect(newSessionCall?.[1]).toContain("/projects/foo");
+    expect(newSessionCall?.[1]?.[newSessionCall[1].length - 1]).toBe(
+      `bash ${scriptPath}`
+    );
+  });
+
+  it("throws if the post-launch has-session check fails (fast-fail detection)", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return fail(); // session died
+      return ok();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+    await expect(
+      runtime.launch({
+        sessionName: "dispatch_agt_x",
+        cwd: "/projects/foo",
+        agentId: "agt_x",
+        payload: {
+          kind: "setup-script",
+          scriptPath: path.join(tmpDir, "setup.sh"),
+          scriptContent: "#!/usr/bin/env bash\nexit 1\n",
+        },
+      })
+    ).rejects.toThrow(/tmux session exited immediately after launch/);
+  });
+});
+
+describe("TmuxRuntime — launch (agent-command payload)", () => {
+  it("wraps the inline command with stderr-tee and exit-code capture", async () => {
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok();
+      return ok();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.launch({
+      sessionName: "dispatch_agt_y",
+      cwd: "/projects/bar",
+      agentId: "agt_y",
+      payload: {
+        kind: "agent-command",
+        command: "/opt/claude --foo",
+        exitFile: "/tmp/dispatch_dispatch_agt_y.exit",
+      },
+    });
+
+    const newSessionCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "new-session");
+    const wrappedCommand = newSessionCall?.[1]?.[
+      newSessionCall[1].length - 1
+    ] as string;
+
+    // The wrapper bakes in: stderr tee to the agent's setup log file,
+    // the agent command itself, and EXIT:$? to the configured exit file.
+    expect(wrappedCommand).toContain(`tee "/tmp/dispatch_setup_agt_y.log"`);
+    expect(wrappedCommand).toContain("/opt/claude --foo");
+    expect(wrappedCommand).toContain(
+      `echo "EXIT:$?" > /tmp/dispatch_dispatch_agt_y.exit`
+    );
+  });
+
+  it("escapes embedded single quotes in the command (security regression check)", async () => {
+    // The wrapper interpolates the command into a single-quoted bash
+    // string. An attacker-controlled value with `'` in it must not
+    // break out of the wrapping.
+    vi.mocked(runCommand).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "has-session") return ok();
+      return ok();
+    });
+
+    const runtime = createTmuxRuntime(noopLogger);
+    await runtime.launch({
+      sessionName: "dispatch_agt_z",
+      cwd: "/tmp",
+      agentId: "agt_z",
+      payload: {
+        kind: "agent-command",
+        command: `echo 'inner-quote'`,
+        exitFile: "/tmp/exit",
+      },
+    });
+
+    const newSessionCall = vi
+      .mocked(runCommand)
+      .mock.calls.find(([, a]) => a[0] === "new-session");
+    const wrappedCommand = newSessionCall?.[1]?.[
+      newSessionCall[1].length - 1
+    ] as string;
+    // The classic '\'' escape must appear in place of the embedded `'`.
+    expect(wrappedCommand).toContain(`echo '\\''inner-quote'\\''`);
+  });
+});

--- a/apps/server/test/tmux-setup-script.test.ts
+++ b/apps/server/test/tmux-setup-script.test.ts
@@ -29,7 +29,6 @@ const baseParams: SetupScriptParams = {
   createNewBranch: true,
   agentName: "my-task",
   agentCommand: "exec /opt/claude",
-  exitFile: "/tmp/dispatch_session.exit",
 };
 
 describe("generateSetupScript — script shape", () => {
@@ -40,18 +39,23 @@ describe("generateSetupScript — script shape", () => {
     expect(firstLines[1]).toBe("set -euo pipefail");
   });
 
-  it("ends with `exec bash -c ...` so tmux-pane PID becomes the agent CLI", () => {
+  it("ends with `exec bash -c '<agentCommand>'` so tmux-pane PID becomes the agent CLI", () => {
     const script = generateSetupScript(baseConfig, baseParams);
     expect(script).toMatch(/exec bash -c '[^']/);
-    expect(script).toContain('echo "EXIT:$?"');
-    expect(script).toContain(baseParams.exitFile);
   });
 
-  it("interpolates the agent's setup-log path so the server can tail stderr", () => {
+  it("does NOT bake in stderr tee or exit-code capture — the runtime wrapper owns those", () => {
+    // Phase 5 round-2 cleanup: the script is no longer responsible for
+    // its own log path or exit-file convention. The runtime applies an
+    // outer wrap (stderr tee + exit capture) around `bash <scriptPath>`,
+    // so these conventions live in exactly one place.
     const script = generateSetupScript(baseConfig, baseParams);
-    expect(script).toContain(
-      `tee "/tmp/dispatch_setup_${baseParams.agentId}.log"`
-    );
+    // The script no longer redirects its own stderr — anchor on the
+    // shell construct, not the word "tee" (which still appears in the
+    // explanatory comment that points readers at the runtime).
+    expect(script).not.toMatch(/exec 2>\s*>\(tee/);
+    expect(script).not.toContain('echo "EXIT:$?"');
+    expect(script).not.toMatch(/\.exit['"]?\s*$/m);
   });
 });
 


### PR DESCRIPTION
Stacked on #455 (DIS-37 Phase 4). Once #455 merges, GitHub will auto-rebase this onto main.

## Summary

The load-bearing phase. Lifts the tmux primitives out of `AgentManager` into an injectable `AgentRuntime`, with `TmuxRuntime` and `InertRuntime` as the two implementations. Manager picks the right one once at construct time via `createAgentRuntime(config, logger)`, and the rest of the lifecycle code stops branching on `config.agentRuntime` at every call.

`manager.ts`: 2177 → **1831 LOC**. Cumulative across DIS-37: 4967 → 1831 (**−63%**).

## Interface shape

```ts
type AgentRuntime = {
  launch(input: LaunchInput): Promise<void>;
  ensureNoExistingSession(name: string): Promise<void>;
  stopSession(name: string, force: boolean): Promise<void>;
  hasSession(name: string): Promise<boolean>;
  getCurrentCwd({ sessionName, agentId, fallback }): Promise<string>;
  listSessions(prefix: string): Promise<{ name; createdAt }[]>;
  killSession(name: string): Promise<void>;
  readExitInfo(name: string): Promise<number | null>;
  readSetupLogTail(idOrSession: string): Promise<string>;
};

type LaunchInput = {
  sessionName: string;
  cwd: string;
  agentId: string;
  payload:
    | { kind: "setup-script"; scriptPath: string; scriptContent: string }
    | { kind: "agent-command"; command: string; exitFile: string };
};
```

The discriminated `payload` covers both flavors of "start a session": **setup-script** (used by `createAgent` — the script handles worktree creation + .env + deps install + exec into the agent CLI) and **agent-command** (used by `startAgent` for restart — wraps an inline bash command with stderr-tee + exit-code capture).

## What moved (~310 LOC out of manager)

- `startAgentSession` + post-launch tmux set-options + fast-fail detection → `TmuxRuntime.launch`
- `ensureNoExistingSession`, `hasAgentSession`, `stopAgentSession` → runtime
- `resolveRuntimeCwd`'s tmux probing + the `runtimeCwdCache` TTL Map → `TmuxRuntime.getCurrentCwd` (cache lives in the runtime closure)
- `resolveAgentProcessCwd` (the pid → child → ps → lsof walk) → internal helper in `tmux/runtime.ts`
- `readSetupLogTail`, `readExitFile` → `runtime.readSetupLogTail` / `readExitInfo`
- private `sleep` helper → inlined into `runtime.stopSession`

## What stays on the manager (now thin orchestration)

- `createAgent`'s inert vs tmux branch (the workspace-prep timing fundamentally differs between modes — inert does it synchronously in JS via `setupAgentWorkspace`, tmux delegates to the bash setup script)
- `runLifecycleHook` (not runtime-specific; runs in both modes; lifecycle rather than session)
- `cleanupOrphanedSessions` (DB-coupled — uses `runtime.listSessions` + `runtime.killSession` as primitives)

## Cleanup

- Dropped `if (this.config.agentRuntime === "tmux") { cleanupOrphanedSessions() }` — `InertRuntime.listSessions` returns `[]`, so the cleanup is a runtime-agnostic no-op in inert mode.
- Dropped two redundant `agentRuntime === "tmux" && row.tmuxSession` checks inside `reconcileAgentStatuses`' missing-session branch — reaching the branch already implies tmux mode (inert always reports `hasSession=true` for non-empty names, by design).

## Test coverage

- **`agent-runtime-inert.test.ts`** (10 cases) — verifies the no-op contract + the legacy "non-empty session name = live" semantic that the reconciler relies on.
- **`agent-runtime-tmux.test.ts`** (25 cases) — `runCommand`-mocked tests for `launch` (both payload kinds, including a security-relevant single-quote escape regression check), `has`/`stop`/`ensure`/`list`/`kill`, `getCurrentCwd` cache TTL + cache key isolation; real-tmpfs tests for `readExitInfo` parsing + `readSetupLogTail`'s last-20-lines window.

## Test plan

- [x] `pnpm run check` — full repo typecheck passes
- [x] `pnpm --filter @dispatch/server run test` — 789/797 pass (was 754; +35 new), 8 skipped, 0 fail
- [x] `pnpm run test:e2e` — 136 Playwright tests pass (lifecycle paths fully exercised)