### PR TITLE
Surface migration eval errors and never block standard update

### DIFF
--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -118,7 +118,7 @@ export async function registerReleaseRoutes(
     return { tag: record?.tag ?? null, deployedAt: record?.deployedAt ?? null };
   });
 
-  app.get("/api/v1/release/info", async (_, reply) => {
+  app.get("/api/v1/release/info", async (request, reply) => {
     try {
       await runCommand("git", [
         "-C",
@@ -226,6 +226,10 @@ export async function registerReleaseRoutes(
         } catch (err) {
           migrationsError =
             err instanceof Error ? err.message : "migration evaluation failed";
+          request.log.error(
+            { err, tag: latestTag },
+            "release/info: migration evaluation failed; UI will surface error and offer standard update fallback"
+          );
         }
       }
       const assistedRequired =
@@ -427,7 +431,7 @@ export async function registerReleaseRoutes(
   });
 
   app.post("/api/v1/release/update", async (request, reply) => {
-    const body = request.body as { tag?: unknown } | undefined;
+    const body = request.body as { tag?: unknown; force?: unknown } | undefined;
     const bearerToken = deps.getBearerToken(request);
     if (
       !body?.tag ||
@@ -439,6 +443,7 @@ export async function registerReleaseRoutes(
       });
     }
     const tag = body.tag;
+    const force = body.force === true;
     const releaseUpdateAgentId = bearerToken
       ? getReleaseUpdateAgentId(deps.config.authToken, bearerToken)
       : null;
@@ -491,19 +496,23 @@ export async function registerReleaseRoutes(
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.warn(
-          `[release/update] migration evaluation failed for ${tag}: ${message}`
+        request.log.warn(
+          { err, tag, force },
+          "release/update: migration evaluation failed"
         );
-        return reply.code(503).send({
-          error: "MIGRATION_EVALUATION_UNAVAILABLE",
-          message: `Could not evaluate update migrations for ${tag}: ${message}. Retry once the underlying issue clears.`,
-        });
+        if (!force) {
+          return reply.code(503).send({
+            error: "MIGRATION_EVALUATION_UNAVAILABLE",
+            message: `Could not evaluate update migrations for ${tag}: ${message}. Retry once the underlying issue clears, or pass force=true to skip the check.`,
+          });
+        }
+        pendingMigrationsForGate = [];
       }
-      if (pendingMigrationsForGate.length > 0) {
+      if (pendingMigrationsForGate.length > 0 && !force) {
         return reply.code(409).send({
           error: "ASSISTED_UPDATE_REQUIRED",
           message:
-            "This release has unapplied migrations. POST to /api/v1/release/assisted/launch instead.",
+            "This release has unapplied migrations. POST to /api/v1/release/assisted/launch instead, or pass force=true to override.",
           pendingMigrations: pendingMigrationsForGate,
         });
       }
@@ -518,13 +527,30 @@ export async function registerReleaseRoutes(
       }
       const targetAssisted =
         inspected.state === "valid" ? inspected.metadata : null;
-      if (isAssistedUpdateRequired(targetAssisted, installed?.tag ?? null)) {
+      if (
+        isAssistedUpdateRequired(targetAssisted, installed?.tag ?? null) &&
+        !force
+      ) {
         return reply.code(409).send({
           error: "ASSISTED_UPDATE_REQUIRED",
           message:
-            "This release requires the assisted update flow. POST to /api/v1/release/assisted/launch instead.",
+            "This release requires the assisted update flow. POST to /api/v1/release/assisted/launch instead, or pass force=true to override.",
           assisted: targetAssisted,
         });
+      }
+      if (
+        force &&
+        (pendingMigrationsForGate.length > 0 ||
+          isAssistedUpdateRequired(targetAssisted, installed?.tag ?? null))
+      ) {
+        request.log.warn(
+          {
+            tag,
+            pendingMigrationCount: pendingMigrationsForGate.length,
+            assistedMode: targetAssisted?.mode ?? null,
+          },
+          "release/update: force=true bypassing assisted-update gate"
+        );
       }
     }
 

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -581,6 +581,125 @@ describe("release metadata route handling", () => {
     expect(response.statusCode).toBe(202);
     expect(response.json()).toMatchObject({ ok: true });
   });
+
+  it("allows /release/update with force=true to bypass mode=required gate", async () => {
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "required",
+              title: "Bun runtime migration",
+              summary: "Switch runtime from Node to Bun.",
+              requiredChecks: [],
+              appliesFrom: "v0.18.0",
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0", force: true },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({ ok: true });
+  });
+
+  it("allows /release/update with force=true to bypass pending-migrations gate", async () => {
+    evaluateMock.mockResolvedValueOnce({
+      pending: [
+        {
+          filename: "0001-bun-cutover.yaml",
+          order: 1,
+          manifest: {
+            id: "bun-cutover",
+            title: "Bun runtime cutover",
+            summary: "Switch runtime from Node to Bun.",
+            alreadySatisfied: { description: "x" },
+            instructions: ["x"],
+            validation: { requiredChecks: [] },
+            rollback: [],
+          },
+        },
+      ],
+      all: [],
+      appliedIds: new Set(),
+      errors: [],
+    });
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({ body: "no fenced metadata" }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0", force: true },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({ ok: true });
+  });
+
+  it("allows /release/update with force=true to bypass migration evaluator failure", async () => {
+    evaluateMock.mockRejectedValueOnce(
+      new Error("simulated network failure fetching tarball")
+    );
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody(
+            JSON.stringify({
+              mode: "normal",
+              title: "x",
+              summary: "x",
+              requiredChecks: [],
+            })
+          ),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0", force: true },
+    });
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({ ok: true });
+  });
+
+  it("rejects /release/update with force=true when target metadata is malformed", async () => {
+    // force=true should not bypass the malformed-metadata error — that's a
+    // real correctness signal, not a "we couldn't check" signal.
+    mockReleaseCommands({
+      releaseViews: {
+        "v0.19.0": validReleaseView({
+          body: releaseBody("{ not valid json }"),
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/release/update",
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { tag: "v0.19.0", force: true },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: "ASSISTED_UPDATE_METADATA_INVALID",
+    });
+  });
 });
 
 async function writeReleaseStore(record: {

--- a/apps/web/src/components/app/assisted-update-card.tsx
+++ b/apps/web/src/components/app/assisted-update-card.tsx
@@ -41,31 +41,21 @@ type AssistedUpdateGateProps = {
   metadata: AssistedUpdateMetadata;
   /** True when the release is mode=required for the current install. */
   required: boolean;
-  onStart: () => Promise<void>;
-  starting: boolean;
-  startError: string | null;
 };
 
 type PendingMigrationsGateProps = {
   tag: string;
   pendingMigrations: PendingMigration[];
-  onStart: () => Promise<void>;
-  starting: boolean;
-  startError: string | null;
 };
 
 /**
  * Pre-launch card shown when the target release has unapplied install-update
- * migration manifests (CRU-146). Replaces the legacy single-block gate when
- * any migrations are pending; the one-click update is hidden so the only
- * forward path is the assisted flow.
+ * migration manifests (CRU-146). Informational only — the action lives in the
+ * unified split button rendered by UpdatesSection below.
  */
 export function PendingMigrationsGate({
   tag,
   pendingMigrations,
-  onStart,
-  starting,
-  startError,
 }: PendingMigrationsGateProps): JSX.Element {
   return (
     <div
@@ -73,6 +63,7 @@ export function PendingMigrationsGate({
         "flex flex-col gap-4 rounded-lg border p-4",
         "border-amber-500/40 bg-amber-500/[0.06]"
       )}
+      data-testid="pending-migrations-gate"
     >
       <div className="flex items-start gap-2">
         <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
@@ -110,40 +101,20 @@ export function PendingMigrationsGate({
           </li>
         ))}
       </ul>
-
-      {startError && (
-        <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {startError}
-        </div>
-      )}
-
-      <Button
-        size="sm"
-        variant="primary"
-        disabled={starting}
-        onClick={() => void onStart()}
-        className="self-start"
-        data-testid="pending-migrations-start"
-      >
-        {starting ? "Launching agent..." : `Start assisted update to ${tag}`}
-      </Button>
     </div>
   );
 }
 
 /**
- * The pre-launch card shown in place of the one-click update button when a
- * release declares assisted-update metadata. For required releases the
- * generic update path is unavailable — the operator launches the assisted
- * agent from this card.
+ * Informational card describing the release's declared assisted-update
+ * metadata (instructions, required checks, rollback guidance). Shown when the
+ * release is `mode=required` or `mode=recommended`. The action sits in the
+ * unified split button rendered by UpdatesSection — this card is context.
  */
 export function AssistedUpdateGate({
   tag,
   metadata,
   required,
-  onStart,
-  starting,
-  startError,
 }: AssistedUpdateGateProps): JSX.Element {
   const [instructionsOpen, setInstructionsOpen] = useState(true);
   const [rollbackOpen, setRollbackOpen] = useState(false);
@@ -239,22 +210,6 @@ export function AssistedUpdateGate({
           )}
         </div>
       )}
-
-      {startError && (
-        <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {startError}
-        </div>
-      )}
-
-      <Button
-        size="sm"
-        variant="primary"
-        disabled={starting}
-        onClick={() => void onStart()}
-        className="self-start"
-      >
-        {starting ? "Launching agent..." : `Start assisted update to ${tag}`}
-      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/app/assisted-update-card.tsx
+++ b/apps/web/src/components/app/assisted-update-card.tsx
@@ -69,10 +69,10 @@ export function PendingMigrationsGate({
         <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         <div className="flex flex-col gap-1">
           <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
-            Assisted update required
+            Agent-assisted update required
           </div>
           <div className="text-sm font-semibold text-foreground">
-            {pendingMigrations.length} pending migration
+            {pendingMigrations.length} complex update step
             {pendingMigrations.length === 1 ? "" : "s"}
           </div>
           <div className="font-mono text-xs text-muted-foreground">{tag}</div>
@@ -80,9 +80,8 @@ export function PendingMigrationsGate({
       </div>
 
       <p className="text-sm text-muted-foreground">
-        This release ships install-update migrations that haven&rsquo;t been
-        applied on this Dispatch yet. The assisted-update agent walks them in
-        order and validates each before marking it applied.
+        This release has update steps that haven&rsquo;t run on this install
+        yet. The agent walks them in order and validates each.
       </p>
 
       <ul className="flex flex-col gap-2 text-sm">
@@ -138,8 +137,8 @@ export function AssistedUpdateGate({
         <div className="flex flex-col gap-1">
           <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
             {required
-              ? "Assisted update required"
-              : "Assisted update recommended"}
+              ? "Agent-assisted update required"
+              : "Agent-assisted update recommended"}
           </div>
           <div className="text-sm font-semibold text-foreground">
             {metadata.title}

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import {
   AlertTriangle,
   ArrowDownToLine,
+  Bot,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
@@ -16,7 +17,6 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -74,28 +74,23 @@ function cleanError(raw: string): string {
 
 function describeForceTriggers(info: ReleaseInfo): string {
   const migrationCount = info.pendingMigrations?.length ?? 0;
-  const isRequired = info.assistedRequired === true && migrationCount === 0;
-  const reasons: string[] = [];
+  // Migrations are the concrete signal — when present the user already
+  // sees them spelled out in the gate card, so the dialog references the
+  // count directly. mode=required is meta (release author flagged it);
+  // when migrations are also present, the migration count is the more
+  // useful framing, so we don't double-mention.
   if (migrationCount > 0) {
-    reasons.push(
-      `ships ${migrationCount} install-update migration${
-        migrationCount === 1 ? "" : "s"
-      } that haven't been applied here yet`
-    );
+    return `has ${migrationCount} complex update step${
+      migrationCount === 1 ? "" : "s"
+    }; safer with the agent`;
   }
-  if (info.assistedRequired === true) {
-    // Distinct phrasing depending on whether migrations are also pending —
-    // when both apply, the operator should know they're overriding both
-    // signals, not just one.
-    reasons.push(
-      isRequired
-        ? "is marked assisted-update required"
-        : "is also marked assisted-update required"
-    );
+  if (info.assisted?.mode === "required") {
+    return "needs the agent for a safe update";
   }
-  if (reasons.length === 0) return "is gated by the assisted-update flow";
-  if (reasons.length === 1) return reasons[0]!;
-  return `${reasons[0]} and ${reasons[1]}`;
+  if (info.migrationsError) {
+    return "couldn't be checked for complex update steps";
+  }
+  return "is gated by the assisted-update flow";
 }
 
 type UpdatesSectionProps = {
@@ -511,29 +506,36 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                   />
                 )}
 
-                <UpdateActions
-                  tag={info.latestTag}
-                  assistedPreferred={
+                {(() => {
+                  const assistedPreferred =
                     info.assistedRequired === true ||
                     (info.pendingMigrations?.length ?? 0) > 0 ||
-                    info.assisted?.mode === "recommended"
-                  }
-                  forceRequired={
-                    info.assistedRequired === true ||
-                    (info.pendingMigrations?.length ?? 0) > 0
-                  }
-                  assistedLaunching={assistedUpdateLaunching}
-                  onStandardUpdate={() => void handleUpdate(info.latestTag!)}
-                  onAssistedUpdate={() =>
-                    void handleAssistedUpdate(info.latestTag!)
-                  }
-                  onForceStandardUpdate={() => setForceConfirmOpen(true)}
-                />
-                <p className="max-w-xl text-xs text-muted-foreground">
-                  Assisted update launches a full-access agent on the production
-                  checkout, redirects you into its terminal, and tells it to
-                  recover service first if the restart goes sideways.
-                </p>
+                    info.assisted?.mode === "recommended";
+                  return (
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 self-start">
+                      <UpdateActions
+                        tag={info.latestTag}
+                        assistedPreferred={assistedPreferred}
+                        forceRequired={
+                          info.assistedRequired === true ||
+                          (info.pendingMigrations?.length ?? 0) > 0
+                        }
+                        assistedLaunching={assistedUpdateLaunching}
+                        onStandardUpdate={() =>
+                          void handleUpdate(info.latestTag!)
+                        }
+                        onAssistedUpdate={() =>
+                          void handleAssistedUpdate(info.latestTag!)
+                        }
+                        onForceStandardUpdate={() => setForceConfirmOpen(true)}
+                      />
+                      <span className="text-xs text-muted-foreground">
+                        or {assistedPreferred ? "standard" : "agent-assisted"}{" "}
+                        update
+                      </span>
+                    </div>
+                  );
+                })()}
               </div>
             ) : (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -592,18 +594,21 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
         <Dialog open={forceConfirmOpen} onOpenChange={setForceConfirmOpen}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Skip the assisted-update flow?</DialogTitle>
-              <DialogDescription>
-                This release <span className="font-mono">{info.latestTag}</span>{" "}
-                {describeForceTriggers(info)}. The standard update skips the
-                agent-driven steps — it just fetches the new artifact and
-                restarts the service. Use it as a recovery path when the
-                assisted flow can&rsquo;t run (for example if the AI provider is
-                unreachable). Your install may end up in an unsupported state if
-                the migration steps were actually needed.
-              </DialogDescription>
+              <DialogTitle>Skip the agent-assisted update?</DialogTitle>
             </DialogHeader>
-            <div className="mt-2 flex flex-wrap gap-2">
+
+            <div className="flex items-start gap-2 rounded border border-amber-500/30 bg-amber-500/[0.08] px-3 py-2 text-sm text-amber-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+              <span>
+                <span className="font-mono text-amber-100">
+                  {info.latestTag}
+                </span>{" "}
+                {describeForceTriggers(info)}. This may leave your install in a
+                non-working state.
+              </span>
+            </div>
+
+            <div className="mt-1 flex flex-wrap gap-2">
               <Button
                 variant="primary"
                 onClick={() => {
@@ -657,7 +662,8 @@ function UpdateActions({
   const standardLabel = `Update to ${tag}`;
   const assistedLabel = assistedLaunching
     ? "Launching agent..."
-    : "Assisted update";
+    : "Agent-assisted update";
+  const assistedDescription = "Agent runs and validates each step";
 
   // Trailing ellipsis follows the platform convention "selecting this opens
   // a dialog before committing." Used in the forceRequired branch where the
@@ -692,9 +698,10 @@ function UpdateActions({
               onClick={() =>
                 forceRequired ? onForceStandardUpdate() : onStandardUpdate()
               }
+              className="flex items-center gap-2.5 text-foreground"
               data-testid="standard-update-menu-item"
             >
-              <ArrowDownToLine className="mr-2 h-3.5 w-3.5" />
+              <ArrowDownToLine className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               {standardMenuLabel}
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -729,9 +736,16 @@ function UpdateActions({
           <DropdownMenuItem
             disabled={assistedLaunching}
             onClick={onAssistedUpdate}
+            className="flex items-start gap-2.5 text-foreground"
             data-testid="assisted-update-menu-item"
           >
-            {assistedLabel}
+            <Bot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <div className="flex flex-col">
+              <span>{assistedLabel}</span>
+              <span className="text-xs text-muted-foreground">
+                {assistedDescription}
+              </span>
+            </div>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+  AlertTriangle,
   ArrowDownToLine,
   CheckCircle2,
   ChevronDown,
@@ -12,6 +13,13 @@ import {
 } from "lucide-react";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
 import {
   DropdownMenu,
@@ -64,6 +72,32 @@ function cleanError(raw: string): string {
   return raw;
 }
 
+function describeForceTriggers(info: ReleaseInfo): string {
+  const migrationCount = info.pendingMigrations?.length ?? 0;
+  const isRequired = info.assistedRequired === true && migrationCount === 0;
+  const reasons: string[] = [];
+  if (migrationCount > 0) {
+    reasons.push(
+      `ships ${migrationCount} install-update migration${
+        migrationCount === 1 ? "" : "s"
+      } that haven't been applied here yet`
+    );
+  }
+  if (info.assistedRequired === true) {
+    // Distinct phrasing depending on whether migrations are also pending —
+    // when both apply, the operator should know they're overriding both
+    // signals, not just one.
+    reasons.push(
+      isRequired
+        ? "is marked assisted-update required"
+        : "is also marked assisted-update required"
+    );
+  }
+  if (reasons.length === 0) return "is gated by the assisted-update flow";
+  if (reasons.length === 1) return reasons[0]!;
+  return `${reasons[0]} and ${reasons[1]}`;
+}
+
 type UpdatesSectionProps = {
   stream: UseReleaseStreamResult;
 };
@@ -81,6 +115,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const [infoError, setInfoError] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [assistedUpdateLaunching, setAssistedUpdateLaunching] = useState(false);
+  const [forceConfirmOpen, setForceConfirmOpen] = useState(false);
   const reloadingRef = useRef(false);
 
   // Fetch version info + channel on mount
@@ -142,25 +177,15 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
     }
   };
 
-  const handleUpdate = async (tag: string) => {
+  const handleUpdate = async (tag: string, options?: { force?: boolean }) => {
     setUpdateError(null);
     const res = await fetch("/api/v1/release/update", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tag }),
+      body: JSON.stringify({ tag, force: options?.force === true }),
     });
     if (!res.ok) {
       const err = (await res.json()) as { error?: string };
-      // The backend returns 409 with code "ASSISTED_UPDATE_REQUIRED" when
-      // the target release gates the generic flow. Re-fetch info so the
-      // assisted gate card renders in place of the standard button.
-      if (err.error === "ASSISTED_UPDATE_REQUIRED") {
-        setUpdateError(
-          "This release requires the assisted update flow. Use the assisted-update card below."
-        );
-        await handleCheckForUpdates();
-        return;
-      }
       setUpdateError(cleanError(err.error ?? "Failed to start update"));
       return;
     }
@@ -444,76 +469,71 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                   </div>
                 )}
 
-                {/*
-                  Gate visibility:
-                  - migrations:  the new persistent-migration model (CRU-146).
-                                 When the target release ships unapplied
-                                 migration manifests, the standard buttons
-                                 are hidden and the operator must launch the
-                                 assisted flow from the migrations gate card.
-                  - legacy required: same UX as migrations, but driven by the
-                                 release-scoped `dispatch-update` block. We
-                                 still hide the standard buttons when
-                                 `info.assistedRequired` is true — the server
-                                 will 409 on the one-click path.
-                  - recommended: legacy gate AND standard buttons (operator
-                                 may opt into the assisted flow but isn't
-                                 forced).
-                  - normal/none: standard buttons only.
-                */}
-                {info.pendingMigrations && info.pendingMigrations.length > 0 ? (
-                  <PendingMigrationsGate
-                    tag={info.latestTag}
-                    pendingMigrations={info.pendingMigrations}
-                    onStart={() => handleAssistedUpdate(info.latestTag!)}
-                    starting={assistedUpdateLaunching}
-                    startError={null}
-                  />
-                ) : (
-                  info.assisted &&
-                  info.assisted.mode !== "normal" && (
-                    <AssistedUpdateGate
-                      tag={info.latestTag}
-                      metadata={info.assisted}
-                      required={info.assistedRequired === true}
-                      onStart={() => handleAssistedUpdate(info.latestTag!)}
-                      starting={assistedUpdateLaunching}
-                      startError={null}
-                    />
-                  )
-                )}
-                {!(info.assistedRequired === true) && (
-                  <>
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        onClick={() => void handleUpdate(info.latestTag!)}
-                        className="self-start rounded border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-400 transition-all hover:border-blue-500/60 hover:bg-blue-500/20"
-                      >
-                        Update to {info.latestTag}
-                      </button>
-                      <Button
-                        size="sm"
-                        variant="default"
-                        data-testid="assisted-update-button"
-                        disabled={assistedUpdateLaunching}
-                        onClick={() =>
-                          void handleAssistedUpdate(info.latestTag!)
-                        }
-                        className="text-muted-foreground hover:text-foreground"
-                      >
-                        {assistedUpdateLaunching
-                          ? "Launching agent..."
-                          : "Assisted update"}
-                      </Button>
+                {info.migrationsError && (
+                  <div
+                    className="flex items-start gap-2 rounded border border-amber-500/30 bg-amber-500/[0.08] px-3 py-2 text-sm text-amber-200"
+                    data-testid="migration-eval-warning"
+                  >
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="font-medium text-amber-100">
+                        Could not evaluate update migrations
+                      </span>
+                      <span className="max-h-24 overflow-y-auto break-all text-xs text-amber-200/80">
+                        {info.migrationsError}
+                      </span>
+                      <span className="text-xs text-amber-200/60">
+                        Standard update is still available — the assisted flow
+                        is the safer choice if you&rsquo;re unsure.
+                      </span>
                     </div>
-                    <p className="max-w-xl text-xs text-muted-foreground">
-                      Assisted update launches a full-access agent on the
-                      production checkout, redirects you into its terminal, and
-                      tells it to recover service first if the restart goes
-                      sideways.
-                    </p>
-                  </>
+                  </div>
                 )}
+
+                {/*
+                  Informational gate cards — the action lives in the split
+                  button below. Migration list shows when the release ships
+                  unapplied install-update migrations; assisted-metadata card
+                  shows when the release declares mode=required/recommended.
+                */}
+                {info.pendingMigrations &&
+                  info.pendingMigrations.length > 0 && (
+                    <PendingMigrationsGate
+                      tag={info.latestTag}
+                      pendingMigrations={info.pendingMigrations}
+                    />
+                  )}
+                {info.assisted && info.assisted.mode !== "normal" && (
+                  <AssistedUpdateGate
+                    tag={info.latestTag}
+                    metadata={info.assisted}
+                    required={info.assistedRequired === true}
+                  />
+                )}
+
+                <UpdateActions
+                  tag={info.latestTag}
+                  assistedPreferred={
+                    info.assistedRequired === true ||
+                    (info.pendingMigrations?.length ?? 0) > 0 ||
+                    info.assisted?.mode === "recommended"
+                  }
+                  forceRequired={
+                    info.assistedRequired === true ||
+                    (info.pendingMigrations?.length ?? 0) > 0
+                  }
+                  assistedLaunching={assistedUpdateLaunching}
+                  onStandardUpdate={() => void handleUpdate(info.latestTag!)}
+                  onAssistedUpdate={() =>
+                    void handleAssistedUpdate(info.latestTag!)
+                  }
+                  onForceStandardUpdate={() => setForceConfirmOpen(true)}
+                />
+                <p className="max-w-xl text-xs text-muted-foreground">
+                  Assisted update launches a full-access agent on the production
+                  checkout, redirects you into its terminal, and tells it to
+                  recover service first if the restart goes sideways.
+                </p>
               </div>
             ) : (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -567,6 +587,154 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
           </DropdownMenu>
         </div>
       </div>
+
+      {info?.updateAvailable && info.latestTag && (
+        <Dialog open={forceConfirmOpen} onOpenChange={setForceConfirmOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Skip the assisted-update flow?</DialogTitle>
+              <DialogDescription>
+                This release <span className="font-mono">{info.latestTag}</span>{" "}
+                {describeForceTriggers(info)}. The standard update skips the
+                agent-driven steps — it just fetches the new artifact and
+                restarts the service. Use it as a recovery path when the
+                assisted flow can&rsquo;t run (for example if the AI provider is
+                unreachable). Your install may end up in an unsupported state if
+                the migration steps were actually needed.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Button
+                variant="primary"
+                onClick={() => {
+                  setForceConfirmOpen(false);
+                  void handleUpdate(info.latestTag!, { force: true });
+                }}
+                data-testid="force-standard-update-confirm"
+              >
+                Run standard update anyway
+              </Button>
+              <Button
+                variant="default"
+                onClick={() => setForceConfirmOpen(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}
+
+type UpdateActionsProps = {
+  tag: string;
+  /** True when the assisted flow should be the primary action — release ships
+   *  pending migrations, declares mode=required, or declares mode=recommended. */
+  assistedPreferred: boolean;
+  /** True when the standard path requires a force-override confirmation —
+   *  pending migrations or mode=required. mode=recommended does not require
+   *  confirmation; the operator can still run standard one-click. */
+  forceRequired: boolean;
+  assistedLaunching: boolean;
+  onStandardUpdate: () => void;
+  onAssistedUpdate: () => void;
+  /** Invoked when the user picks "Standard update" from the menu in a state
+   *  that requires force-override confirmation. */
+  onForceStandardUpdate: () => void;
+};
+
+function UpdateActions({
+  tag,
+  assistedPreferred,
+  forceRequired,
+  assistedLaunching,
+  onStandardUpdate,
+  onAssistedUpdate,
+  onForceStandardUpdate,
+}: UpdateActionsProps): JSX.Element {
+  const standardLabel = `Update to ${tag}`;
+  const assistedLabel = assistedLaunching
+    ? "Launching agent..."
+    : "Assisted update";
+
+  // Trailing ellipsis follows the platform convention "selecting this opens
+  // a dialog before committing." Used in the forceRequired branch where the
+  // menu item triggers a confirmation, not the update itself.
+  const standardMenuLabel = forceRequired ? `${standardLabel}…` : standardLabel;
+
+  if (assistedPreferred) {
+    return (
+      <div className="inline-flex items-center self-start">
+        <Button
+          variant="primary"
+          disabled={assistedLaunching}
+          onClick={onAssistedUpdate}
+          className="rounded-r-none border-r-0"
+          data-testid="assisted-update-button"
+        >
+          {assistedLabel}
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="primary"
+              disabled={assistedLaunching}
+              className="rounded-l-none border-l border-white/[0.18] px-1"
+              aria-label="More update options"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={() =>
+                forceRequired ? onForceStandardUpdate() : onStandardUpdate()
+              }
+              data-testid="standard-update-menu-item"
+            >
+              <ArrowDownToLine className="mr-2 h-3.5 w-3.5" />
+              {standardMenuLabel}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center self-start">
+      <Button
+        variant="primary"
+        disabled={assistedLaunching}
+        onClick={onStandardUpdate}
+        className="rounded-r-none border-r-0"
+        data-testid="standard-update-button"
+      >
+        {standardLabel}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="primary"
+            disabled={assistedLaunching}
+            className="rounded-l-none border-l border-white/[0.18] px-1"
+            aria-label="More update options"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            disabled={assistedLaunching}
+            onClick={onAssistedUpdate}
+            data-testid="assisted-update-menu-item"
+          >
+            {assistedLabel}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The Updates page was silently dead-ending users when the install-update migration check failed: server set `assistedRequired: true` from a swallowed `migrationsError`, the UI hid every action button because of that flag, and the error itself was never displayed. Operator saw an announcement and a Reload section with no path forward.

This branch surfaces the failure server-side, gives the operator an explicit force-override escape hatch, and rebuilds the action surface around a single split button so there's only ever one primary action with the alternative one keystroke away.

### Server (`apps/server/src/routes/release.ts`, `release-routes.test.ts`)

- `/api/v1/release/info` now logs migration eval failures with `request.log.error` so future repeats of "30 minutes of silent eval failure" leave a server-side trail.
- `/api/v1/release/update` accepts `body.force === true` to bypass:
  - `MIGRATION_EVALUATION_UNAVAILABLE` (the eval threw)
  - `ASSISTED_UPDATE_REQUIRED` from pending migrations
  - `ASSISTED_UPDATE_REQUIRED` from `mode=required` releases
- `ASSISTED_UPDATE_METADATA_INVALID` still fails closed regardless of `force` — that's a real correctness signal, not "we couldn't check."
- Force bypasses are logged with a warn line.
- 4 new test cases cover each force-bypass path + verify `force=true` does *not* bypass malformed metadata.

### UI (`apps/web/src/components/app/release-manager.tsx`, `assisted-update-card.tsx`)

- New yellow warning banner above the action button surfaces `info.migrationsError` when set (with `break-all` + `max-h-24 overflow-y-auto` so long URL/stack-trace strings don't push the column wider).
- Replaced the parallel `Update to vX` + `Assisted update` button row with a `<UpdateActions>` split button:
  - Primary action is `Agent-assisted update` when the release ships migrations, declares `mode=required`, or `mode=recommended`. Otherwise the primary is `Update to vX`.
  - The other action lives in the dropdown menu with a `Bot` icon (muted) and is gated by `disabled={assistedLaunching}` on every half so an in-flight launch can't fire a concurrent operation.
- Standard update is always reachable. In the force-required state the menu item shows the platform ellipsis convention (`Update to vX…`) and clicking opens a confirmation `<Dialog>` that posts `force: true` after explicit acknowledgement.
- Confirmation dialog stripped to title + amber callout (reason + risk in two short sentences) + buttons. No more wall of text.
- Plain-language pass replaces "install-update migrations" jargon throughout: dialog says `has X complex update steps; safer with the agent`, gate card eyebrow is `AGENT-ASSISTED UPDATE REQUIRED`, gate card title is `X complex update steps`, body explains in normal words.
- `describeForceTriggers` now checks `info.assisted?.mode === "required"` for the "marked required" clause (was checking the derived `assistedRequired` flag, which fires in three cases — only one of which is "the release author flagged this"). Adds a dedicated branch for the eval-failure case.
- `PendingMigrationsGate` and `AssistedUpdateGate` are now informational only; the unified split button below is the action surface. Inline adaptive hint (`or agent-assisted update` / `or standard update`) replaces the old paragraph under the buttons.
- Override on the project's default destructive-red `DropdownMenuItem` styling — both menu items use `flex items-center gap-2.5 text-foreground` so "Agent-assisted update" no longer reads as a delete action.

### Round-trip review

`/ultrareview` `frontend-ux-review` round-1 surfaced 6 findings; round-2 approved after 5 fixes (severity alignment, error-banner overflow handling, in-flight gating on every split-button half, ellipsis convention for the dialog-opening menu item, composed dialog clauses for migrations + `mode=required` together). One reviewer claim about a "regression" in the Reload split button was incorrect — verified via git that the pre-diff Reload had no spinner/disabled-halves behavior; that's a pre-existing UX gap from PR #446 (DIS-2), correctly scoped out of this branch.

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run test` (635 server + 31 web tests, including 4 new force-override cases) passes
- [x] `pnpm run finalize:web` produces a clean production build
- [x] Playwright smoke verified all five UI states (normal, recommended, pending migrations, mode=required, migrationsError) plus the force-confirm dialog with composed clauses
- [ ] Manual sanity check on a fresh dev stack (run with `dispatch-dev up`, navigate to Settings → Updates, verify the split button + dropdown render correctly and the confirmation dialog opens for the migrations / required cases)
- [ ] Confirm production install can still take the standard one-click update against a `mode=normal` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)