### PR TITLE
Add opt-in enhanced terminal mode

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -781,7 +781,6 @@ export class AgentManager {
             allowedExitCodes: [0, 1],
           }
         );
-
         if (!(await this.hasAgentSession(tmuxSession))) {
           const detail = await this.readSetupLogTail(id);
           throw new Error(
@@ -2215,7 +2214,6 @@ export class AgentManager {
         allowedExitCodes: [0, 1],
       }
     );
-
     // Detect fast-fail launches (for example, missing codex executable) so status
     // is not left as "running" with no backing tmux session.
     if (!(await this.hasAgentSession(sessionName))) {

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -12,6 +12,7 @@ import {
 import { getSetting } from "../db/settings.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { spawn as spawnPty } from "../shared/terminal/bun-pty.js";
+import { TmuxTerminal } from "../terminal/tmux-terminal.js";
 import {
   type CreateAgentBody,
   type StartupFileUpload,
@@ -31,6 +32,10 @@ const AGENT_LATEST_EVENT_TYPES = [
 ] as const;
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
+const TERMINAL_HISTORY_MAX_LINES = 2_000;
+const ENHANCED_TERMINAL_KEY = "enhanced_terminal";
+const ENHANCED_TERMINAL_OVERRIDE = "xterm-256color:smcup@:rmcup@";
+type TerminalSessionMode = "legacy" | "enhanced";
 
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
 
@@ -122,6 +127,109 @@ export async function registerAgentRoutes(
   app: FastifyInstance,
   deps: AgentRouteDeps
 ): Promise<void> {
+  const terminalSessionModeCache = new Map<string, TerminalSessionMode>();
+
+  const isEnhancedTerminalEnabled = async (): Promise<boolean> =>
+    (await getSetting(deps.pool, ENHANCED_TERMINAL_KEY)) === "true";
+
+  const readTmuxOptionValues = async (
+    sessionName: string,
+    option: string
+  ): Promise<string[]> => {
+    const result = await runCommand(
+      "tmux",
+      ["show-options", "-t", sessionName, "-v", option],
+      { allowedExitCodes: [0, 1] }
+    );
+    return result.stdout
+      .split(/\r?\n/g)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  };
+
+  const detectConfiguredTerminalMode = async (
+    sessionName: string
+  ): Promise<TerminalSessionMode | null> => {
+    const [mouseValues, overrideValues] = await Promise.all([
+      readTmuxOptionValues(sessionName, "mouse"),
+      readTmuxOptionValues(sessionName, "terminal-overrides"),
+    ]);
+    const mouse = mouseValues.at(-1) ?? null;
+    const hasEnhancedOverride = overrideValues.includes(
+      ENHANCED_TERMINAL_OVERRIDE
+    );
+
+    if (mouse === "off" && hasEnhancedOverride) {
+      return "enhanced";
+    }
+    if (mouse === "on" && !hasEnhancedOverride) {
+      return "legacy";
+    }
+    return null;
+  };
+
+  const configureTerminalSessionMode = async (
+    sessionName: string,
+    mode: TerminalSessionMode
+  ): Promise<TerminalSessionMode> => {
+    if (mode === "enhanced") {
+      const overrideValues = await readTmuxOptionValues(
+        sessionName,
+        "terminal-overrides"
+      );
+      if (!overrideValues.includes(ENHANCED_TERMINAL_OVERRIDE)) {
+        await runCommand(
+          "tmux",
+          [
+            "set-option",
+            "-t",
+            sessionName,
+            "-as",
+            "terminal-overrides",
+            ENHANCED_TERMINAL_OVERRIDE,
+          ],
+          {
+            allowedExitCodes: [0, 1],
+          }
+        );
+      }
+      await runCommand(
+        "tmux",
+        ["set-option", "-t", sessionName, "mouse", "off"],
+        {
+          allowedExitCodes: [0, 1],
+        }
+      );
+    } else {
+      await runCommand(
+        "tmux",
+        ["set-option", "-t", sessionName, "mouse", "on"],
+        {
+          allowedExitCodes: [0, 1],
+        }
+      );
+    }
+
+    terminalSessionModeCache.set(sessionName, mode);
+    return mode;
+  };
+
+  const resolveTerminalSessionMode = async (
+    sessionName: string,
+    preferredMode: TerminalSessionMode
+  ): Promise<TerminalSessionMode> => {
+    const cachedMode = terminalSessionModeCache.get(sessionName);
+    if (cachedMode) return cachedMode;
+
+    const detectedMode = await detectConfiguredTerminalMode(sessionName);
+    if (detectedMode) {
+      terminalSessionModeCache.set(sessionName, detectedMode);
+      return detectedMode;
+    }
+
+    return configureTerminalSessionMode(sessionName, preferredMode);
+  };
+
   app.get("/api/v1/agents", async () => {
     const agents = await deps.agentManager.listAgents();
     return { agents: agents.map(deps.withStreamFlag) };
@@ -847,6 +955,56 @@ export async function registerAgentRoutes(
     }
   });
 
+  app.get("/api/v1/agents/:id/terminal/history", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const query = request.query as {
+      lines?: string;
+      skipBottomLines?: string;
+    };
+    const id = params.id ?? "";
+
+    try {
+      const preferredMode = (await isEnhancedTerminalEnabled())
+        ? "enhanced"
+        : "legacy";
+
+      const access = await deps.agentManager.getTerminalAccess(id);
+      if (access.mode !== "tmux") {
+        return reply.code(409).send({ error: access.message });
+      }
+
+      const sessionMode = await resolveTerminalSessionMode(
+        access.sessionName,
+        preferredMode
+      );
+      if (sessionMode !== "enhanced") {
+        return reply
+          .code(409)
+          .send({ error: "Enhanced terminal mode is disabled." });
+      }
+
+      const lines = Math.min(
+        TERMINAL_HISTORY_MAX_LINES,
+        Math.max(1, Number.parseInt(query.lines ?? "1000", 10) || 1000)
+      );
+      const skipBottomLines = Math.max(
+        0,
+        Number.parseInt(query.skipBottomLines ?? "0", 10) || 0
+      );
+
+      const terminal = new TmuxTerminal(access.sessionName);
+      const data = await terminal.captureHistoryChunk(lines, skipBottomLines);
+      return {
+        mode: "tmux" as const,
+        data,
+        lines,
+        skipBottomLines,
+      };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+
   app.get(
     "/api/v1/agents/:id/terminal/ws",
     { websocket: true },
@@ -878,13 +1036,10 @@ export async function registerAgentRoutes(
           throw new Error(access.message);
         }
         tmuxSession = access.sessionName;
-        await runCommand(
-          "tmux",
-          ["set-option", "-t", tmuxSession, "mouse", "on"],
-          {
-            allowedExitCodes: [0],
-          }
-        );
+        const preferredMode = (await isEnhancedTerminalEnabled())
+          ? "enhanced"
+          : "legacy";
+        await resolveTerminalSessionMode(tmuxSession, preferredMode);
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Terminal attach failed.";

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -23,6 +23,7 @@ import { shouldSkipAutomaticMacPathProbe } from "../shared/mac-path-privacy.js";
 
 const WORKTREE_LOCATION_KEY = "worktree_location";
 const INSTANCE_NAME_KEY = "instance_name";
+const ENHANCED_TERMINAL_KEY = "enhanced_terminal";
 const VALID_WORKTREE_LOCATIONS = ["sibling", "nested"] as const;
 
 function resolveTildePath(raw: string): string {
@@ -316,10 +317,13 @@ export async function registerSystemRoutes(
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
+    const enhancedTerminal =
+      (await getSetting(deps.pool, ENHANCED_TERMINAL_KEY)) === "true";
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),
       instanceName,
+      enhancedTerminal,
     };
   });
 
@@ -328,6 +332,7 @@ export async function registerSystemRoutes(
       worktreeLocation?: unknown;
       iconColor?: unknown;
       instanceName?: unknown;
+      enhancedTerminal?: unknown;
     };
 
     if (body.worktreeLocation !== undefined) {
@@ -371,16 +376,32 @@ export async function registerSystemRoutes(
       }
     }
 
+    if (body.enhancedTerminal !== undefined) {
+      if (typeof body.enhancedTerminal !== "boolean") {
+        return reply
+          .code(400)
+          .send({ error: "enhancedTerminal must be a boolean." });
+      }
+      await setSetting(
+        deps.pool,
+        ENHANCED_TERMINAL_KEY,
+        body.enhancedTerminal ? "true" : "false"
+      );
+    }
+
     const raw = await getSetting(deps.pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation =
       raw && (VALID_WORKTREE_LOCATIONS as readonly string[]).includes(raw)
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
+    const enhancedTerminal =
+      (await getSetting(deps.pool, ENHANCED_TERMINAL_KEY)) === "true";
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),
       instanceName,
+      enhancedTerminal,
     };
   });
 

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -41,6 +41,25 @@ export class TmuxTerminal {
     return result.stdout;
   }
 
+  async captureHistoryChunk(lines = 200, skipBottomLines = 0): Promise<string> {
+    const safeLines = Math.max(1, Math.trunc(lines));
+    const safeSkipBottomLines = Math.max(0, Math.trunc(skipBottomLines));
+    const startOffset = safeLines + safeSkipBottomLines;
+    const endOffset = safeSkipBottomLines === 0 ? 1 : safeSkipBottomLines + 1;
+    const result = await runCommand("tmux", [
+      "capture-pane",
+      "-p",
+      "-t",
+      this.sessionName,
+      "-S",
+      `-${startOffset}`,
+      "-E",
+      `-${endOffset}`,
+    ]);
+
+    return result.stdout;
+  }
+
   private findLastPasteMarker(paneText: string): string | null {
     const lines = paneText
       .split("\n")

--- a/apps/server/test/api-validation.test.ts
+++ b/apps/server/test/api-validation.test.ts
@@ -225,6 +225,15 @@ describe("POST /api/v1/agents/settings", () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  it("rejects non-boolean enhancedTerminal", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/settings",
+      payload: { enhancedTerminal: "yes" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
 });
 
 describe("POST /api/v1/notifications/settings", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import { useSSE } from "@/hooks/use-sse";
 import { useAgentSoundCues } from "@/hooks/use-agent-sound-cues";
 import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
+import { useEnhancedTerminal } from "@/hooks/use-enhanced-terminal";
 import { useTheme } from "@/hooks/use-theme";
 import { useTemporaryState } from "@/hooks/use-temporary-state";
 import {
@@ -93,6 +94,7 @@ export function DashboardLayout(): JSX.Element {
     clearError: clearIconColorError,
   } = useIconColor();
   const { instanceName } = useInstanceName();
+  const { enhancedTerminal } = useEnhancedTerminal();
   const { handleLogout } = useAuthContext();
   const {
     isMobile,
@@ -127,6 +129,18 @@ export function DashboardLayout(): JSX.Element {
   useEffect(() => {
     document.title = instanceName ? `${instanceName} — Dispatch` : "Dispatch";
   }, [instanceName]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (enhancedTerminal) {
+      root.setAttribute("data-terminal-mode", "enhanced");
+    } else {
+      root.setAttribute("data-terminal-mode", "legacy");
+    }
+    return () => {
+      root.removeAttribute("data-terminal-mode");
+    };
+  }, [enhancedTerminal]);
 
   useEffect(() => initEnergyMetrics(), []);
 

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -41,6 +41,7 @@ import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
+import { useEnhancedTerminal } from "@/hooks/use-enhanced-terminal";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
@@ -120,6 +121,7 @@ export function AgentsView({
   const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<
     string | null
   >(null);
+  const { enhancedTerminal } = useEnhancedTerminal();
   const [sharedConnState, setSharedConnState] =
     useState<ConnState>("disconnected");
 
@@ -193,6 +195,7 @@ export function AgentsView({
     leftOpen,
     mediaOpen,
     feedbackOpen: !!feedbackDetail,
+    enhancedTerminal,
   });
 
   useEffect(() => {
@@ -627,6 +630,7 @@ export function AgentsView({
                 terminalMode={terminalMode}
                 terminalPlaceholderMessage={terminalPlaceholderMessage}
                 terminalHostRef={terminalHostRef}
+                enhancedTerminal={enhancedTerminal}
                 archivePhase={
                   selectedAgent?.status === "archiving"
                     ? selectedAgent.archivePhase

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -22,6 +22,7 @@ import { type ServiceState } from "@/components/app/types";
 import { Checkbox } from "@/components/ui/checkbox";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
+import { useEnhancedTerminal } from "@/hooks/use-enhanced-terminal";
 import { useReleaseStream } from "@/hooks/use-release-stream";
 import { useRewriteLocalhostPins } from "@/hooks/use-rewrite-localhost-pins";
 import { type ThemeId, THEMES } from "@/hooks/use-theme";
@@ -198,6 +199,51 @@ function RewriteLocalhostPinsSettings(): JSX.Element {
           Rewrite localhost in pins
         </div>
       </label>
+    </div>
+  );
+}
+
+function EnhancedTerminalSettings(): JSX.Element {
+  const { enhancedTerminal, setEnhancedTerminal, isSaving, saveError } =
+    useEnhancedTerminal();
+
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Terminal
+      </div>
+      <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
+        Opt in to the enhanced terminal path for local xterm scrollback,
+        attach-time history backfill, and mobile touch scrolling. Takes effect
+        the next time a terminal attaches or reconnects.
+      </p>
+      <label
+        className={cn(
+          "flex max-w-lg items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors",
+          "cursor-pointer hover:bg-muted/50",
+          isSaving && "pointer-events-none opacity-60"
+        )}
+      >
+        <Checkbox
+          checked={enhancedTerminal}
+          onCheckedChange={(v) => setEnhancedTerminal(v === true)}
+          data-testid="enhanced-terminal-toggle"
+        />
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            Use enhanced terminal mode
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Isolates the current scrollback and touch updates behind an opt-in
+            while we soak-test them.
+          </div>
+        </div>
+      </label>
+      {saveError ? (
+        <p className="mt-1.5 text-xs text-destructive">
+          Failed to save. Please try again.
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -656,6 +702,9 @@ export function SettingsContent({
           <div className="flex flex-col">
             <div className="p-4 md:p-6">
               <InstanceNameSettings />
+            </div>
+            <div className="border-t border-border p-4 md:p-6">
+              <EnhancedTerminalSettings />
             </div>
             <div className="border-t border-border">
               <AppearanceSettings

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -13,6 +13,7 @@ type TerminalPaneProps = {
   terminalPlaceholderMessage: string | null;
   terminalHostRef: RefCallback<HTMLDivElement>;
   archivePhase: Agent["archivePhase"];
+  enhancedTerminal: boolean;
 };
 
 export const TerminalPane = memo(function TerminalPane({
@@ -23,6 +24,7 @@ export const TerminalPane = memo(function TerminalPane({
   terminalPlaceholderMessage,
   terminalHostRef,
   archivePhase,
+  enhancedTerminal,
 }: TerminalPaneProps): JSX.Element {
   const [showReconnectOverlay, setShowReconnectOverlay] = useState(false);
 
@@ -45,7 +47,10 @@ export const TerminalPane = memo(function TerminalPane({
   return (
     <div
       data-testid="terminal-pane"
-      className="relative h-full min-h-0 overflow-hidden bg-background"
+      className={cn(
+        "relative h-full min-h-0 overflow-hidden bg-background",
+        enhancedTerminal && "terminal-touch-island"
+      )}
     >
       {isAttached && connState === "connected" ? (
         <div data-testid="terminal-connected-state" className="sr-only">

--- a/apps/web/src/hooks/use-enhanced-terminal.ts
+++ b/apps/web/src/hooks/use-enhanced-terminal.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+type AgentSettingsResponse = {
+  enhancedTerminal: boolean;
+};
+
+export function useEnhancedTerminal(): {
+  enhancedTerminal: boolean;
+  setEnhancedTerminal: (enabled: boolean) => void;
+  isSaving: boolean;
+  saveError: boolean;
+} {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<AgentSettingsResponse>({
+    queryKey: ["agents-settings"],
+    queryFn: async () => {
+      const res = await fetch("/api/v1/agents/settings");
+      if (!res.ok) throw new Error("Failed to fetch settings");
+      return res.json();
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (enabled: boolean) => {
+      const res = await fetch("/api/v1/agents/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enhancedTerminal: enabled }),
+      });
+      if (!res.ok) throw new Error("Failed to save enhanced terminal setting");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
+    },
+  });
+
+  const setEnhancedTerminal = useCallback(
+    (enabled: boolean) => {
+      mutation.mutate(enabled);
+    },
+    [mutation]
+  );
+
+  return useMemo(
+    () => ({
+      enhancedTerminal: data?.enhancedTerminal ?? false,
+      setEnhancedTerminal,
+      isSaving: mutation.isPending,
+      saveError: mutation.isError,
+    }),
+    [
+      data?.enhancedTerminal,
+      mutation.isError,
+      mutation.isPending,
+      setEnhancedTerminal,
+    ]
+  );
+}

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -25,12 +25,20 @@ const TERMINAL_FRESHNESS_MS =
   TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
 const RESUME_RECONNECT_DEDUPE_MS = 150;
 const SOCKET_PROBE_TIMEOUT_MS = 1_500;
+const TERMINAL_BACKFILL_LINES = 1_200;
 
 type TerminalSocketMessage =
   | { type: "heartbeat"; ts: number }
   | { type: "output"; data: string }
   | { type: "error"; message: string }
   | { type: "exit"; exitCode?: number };
+
+type TerminalHistoryResponse = {
+  mode: "tmux";
+  data: string;
+  lines: number;
+  skipBottomLines: number;
+};
 
 function isTerminalSessionGone(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -61,6 +69,10 @@ function cleanCopiedText(text: string): string {
   return text;
 }
 
+function normalizeBackfill(text: string): string {
+  return text.replace(/\r?\n/g, "\r\n");
+}
+
 export function useTerminal(args: {
   authState: AuthState;
   agents: Agent[];
@@ -70,6 +82,7 @@ export function useTerminal(args: {
   leftOpen: boolean;
   mediaOpen: boolean;
   feedbackOpen: boolean;
+  enhancedTerminal: boolean;
 }): {
   connState: ConnState;
   connectedAgentId: string | null;
@@ -96,6 +109,7 @@ export function useTerminal(args: {
     leftOpen,
     mediaOpen,
     feedbackOpen,
+    enhancedTerminal,
   } = args;
 
   const [connState, setConnState] = useState<ConnState>("disconnected");
@@ -110,6 +124,8 @@ export function useTerminal(args: {
 
   const connectedAgentIdRef = useRef<string | null>(null);
   connectedAgentIdRef.current = connectedAgentId;
+  const enhancedTerminalRef = useRef(enhancedTerminal);
+  enhancedTerminalRef.current = enhancedTerminal;
 
   const terminalHostRef = useRef<HTMLDivElement | null>(null);
   const [terminalHostElement, setTerminalHostElement] =
@@ -410,6 +426,7 @@ export function useTerminal(args: {
 
         clearReconnectTimer();
         closeSocket(false);
+        resetTerminalSurface();
 
         if (clearScreen) {
           terminalRef.current?.clear();
@@ -442,6 +459,17 @@ export function useTerminal(args: {
           const term = terminalRef.current;
           const cols = term?.cols ?? 140;
           const rows = term?.rows ?? 42;
+          if (term && enhancedTerminalRef.current) {
+            const history = await api<TerminalHistoryResponse>(
+              `/api/v1/agents/${agent.id}/terminal/history?lines=${TERMINAL_BACKFILL_LINES}&skipBottomLines=${rows}`
+            );
+            if (!isCurrentAttempt()) {
+              return;
+            }
+            if (history.data.trim().length > 0) {
+              term.write(normalizeBackfill(history.data));
+            }
+          }
           setTerminalMode("tmux");
           setTerminalPlaceholderMessage(null);
           const ws = new WebSocket(
@@ -610,7 +638,6 @@ export function useTerminal(args: {
     if (!host) return;
 
     const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
-
     const palette = getTerminalPalette(themeRef.current);
     const term = new XTerm({
       convertEol: false,
@@ -619,7 +646,7 @@ export function useTerminal(args: {
       fontSize: 13,
       scrollback: 1000,
       macOptionClickForcesSelection: true,
-      screenReaderMode: isTouchDevice,
+      screenReaderMode: isTouchDevice && !enhancedTerminal,
       minimumContrastRatio: palette.minimumContrastRatio ?? 1,
       theme: palette,
     });
@@ -688,37 +715,56 @@ export function useTerminal(args: {
     host.addEventListener("paste", handlePaste, true);
 
     const screenEl = host.querySelector(".xterm-screen") as HTMLElement | null;
+    const scrollableEl = host.querySelector(
+      ".xterm-scrollable-element"
+    ) as HTMLElement | null;
     let touchY = 0;
     let touchAccum = 0;
-    const SCROLL_SENSITIVITY = 30;
+    const TOUCH_LINE_PX = 24;
+    const LEGACY_SCROLL_SENSITIVITY_PX = 30;
     const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length === 1) {
-        touchY = e.touches[0].clientY;
-        touchAccum = 0;
-      }
+      if (!isTouchDevice || e.touches.length !== 1) return;
+      touchY = e.touches[0].clientY;
+      touchAccum = 0;
     };
     const onTouchMove = (e: TouchEvent) => {
-      if (e.touches.length !== 1 || !screenEl) return;
+      if (!isTouchDevice || e.touches.length !== 1) return;
+      if (!enhancedTerminalRef.current) {
+        if (!screenEl) return;
+        const currentY = e.touches[0].clientY;
+        const delta = touchY - currentY;
+        touchY = currentY;
+        touchAccum += delta;
+        while (Math.abs(touchAccum) >= LEGACY_SCROLL_SENSITIVITY_PX) {
+          const direction = touchAccum > 0 ? 1 : -1;
+          touchAccum -= direction * LEGACY_SCROLL_SENSITIVITY_PX;
+          screenEl.dispatchEvent(
+            new WheelEvent("wheel", {
+              deltaY: direction * 100,
+              deltaMode: 0,
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+        }
+        return;
+      }
+      const active = term.buffer.active;
+      if (active.type !== "normal" || active.baseY <= 0) return;
+      e.preventDefault();
+      e.stopPropagation();
       const currentY = e.touches[0].clientY;
       const delta = touchY - currentY;
       touchY = currentY;
       touchAccum += delta;
-      while (Math.abs(touchAccum) >= SCROLL_SENSITIVITY) {
-        const direction = touchAccum > 0 ? 1 : -1;
-        touchAccum -= direction * SCROLL_SENSITIVITY;
-        screenEl.dispatchEvent(
-          new WheelEvent("wheel", {
-            deltaY: direction * 100,
-            deltaMode: 0,
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-      }
+      const wholeLines =
+        touchAccum > 0
+          ? Math.floor(touchAccum / TOUCH_LINE_PX)
+          : Math.ceil(touchAccum / TOUCH_LINE_PX);
+      if (wholeLines === 0) return;
+      touchAccum -= wholeLines * TOUCH_LINE_PX;
+      term.scrollLines(wholeLines);
     };
-    host.addEventListener("touchstart", onTouchStart, { passive: true });
-    host.addEventListener("touchmove", onTouchMove, { passive: true });
-
     let dispatchingMouseDown = false;
     const onMouseDown = (e: MouseEvent) => {
       if (dispatchingMouseDown) return;
@@ -746,8 +792,23 @@ export function useTerminal(args: {
       );
       dispatchingMouseDown = false;
     };
-    if (screenEl) {
-      screenEl.addEventListener("mousedown", onMouseDown, true);
+
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    if (enhancedTerminal) {
+      host.addEventListener("touchmove", onTouchMove, { passive: false });
+      screenEl?.addEventListener("touchstart", onTouchStart, { passive: true });
+      screenEl?.addEventListener("touchmove", onTouchMove, { passive: false });
+      scrollableEl?.addEventListener("touchstart", onTouchStart, {
+        passive: true,
+      });
+      scrollableEl?.addEventListener("touchmove", onTouchMove, {
+        passive: false,
+      });
+    } else {
+      host.addEventListener("touchmove", onTouchMove, { passive: true });
+      if (screenEl) {
+        screenEl.addEventListener("mousedown", onMouseDown, true);
+      }
     }
 
     const disposable = term.onData((data) => {
@@ -790,8 +851,13 @@ export function useTerminal(args: {
       host.removeEventListener("paste", handlePaste, true);
       host.removeEventListener("touchstart", onTouchStart);
       host.removeEventListener("touchmove", onTouchMove);
-      if (screenEl)
+      screenEl?.removeEventListener("touchstart", onTouchStart);
+      screenEl?.removeEventListener("touchmove", onTouchMove);
+      scrollableEl?.removeEventListener("touchstart", onTouchStart);
+      scrollableEl?.removeEventListener("touchmove", onTouchMove);
+      if (screenEl) {
         screenEl.removeEventListener("mousedown", onMouseDown, true);
+      }
       window.removeEventListener("resize", onResize);
       try {
         wsRef.current?.close();
@@ -801,7 +867,13 @@ export function useTerminal(args: {
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [authState, invalidateAttachAttempt, sendResize, terminalHostElement]);
+  }, [
+    authState,
+    enhancedTerminal,
+    invalidateAttachAttempt,
+    sendResize,
+    terminalHostElement,
+  ]);
 
   // Reconnect on visibility/focus.
   useEffect(() => {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -543,13 +543,35 @@ html.ipad-pwa #root {
   touch-action: none;
 }
 
-html.ipad-pwa [style*="overflow"]:not([style*="hidden"]),
-html.ipad-pwa .overflow-y-auto,
-html.ipad-pwa .overflow-auto,
-html.ipad-pwa .overflow-y-scroll,
-html.ipad-pwa .overflow-scroll {
+html.ipad-pwa[data-terminal-mode="enhanced"]
+  [style*="overflow"]:not([style*="hidden"]),
+html.ipad-pwa[data-terminal-mode="enhanced"] .overflow-y-auto,
+html.ipad-pwa[data-terminal-mode="enhanced"] .overflow-auto,
+html.ipad-pwa[data-terminal-mode="enhanced"] .overflow-y-scroll,
+html.ipad-pwa[data-terminal-mode="enhanced"] .overflow-scroll,
+html.ipad-pwa[data-terminal-mode="enhanced"] .xterm-viewport {
   touch-action: pan-y;
   overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+html.ipad-pwa[data-terminal-mode="enhanced"] .terminal-touch-island,
+html.ipad-pwa[data-terminal-mode="enhanced"] .terminal-touch-island * {
+  overscroll-behavior: contain;
+}
+
+html.ipad-pwa[data-terminal-mode="enhanced"] .terminal-touch-island {
+  touch-action: pan-y;
+}
+
+@media (pointer: coarse) {
+  html[data-terminal-mode="legacy"] .xterm .xterm-accessibility {
+    pointer-events: auto !important;
+  }
+
+  html[data-terminal-mode="enhanced"] .terminal-touch-island .xterm-screen {
+    touch-action: none;
+  }
 }
 
 .terminal-font {
@@ -574,18 +596,6 @@ html[data-theme="matrix"] [data-radix-popper-content-wrapper] > * {
 html[data-theme="matrix"] button,
 html[data-theme="matrix"] [role="button"] {
   text-shadow: 0 0 10px hsl(var(--primary) / 0.12);
-}
-
-/* Mobile: enable native long-press text selection via the xterm
-   accessibility tree, which contains invisible positioned text over
-   the canvas.  pointer-events:auto lets long-press reach that text;
-   user-select is already "text" in xterm's own CSS.  The accessibility
-   layer sits above the canvas so it receives the touch, while our
-   custom touchstart/touchmove handlers still drive scrolling. */
-@media (pointer: coarse) {
-  .xterm .xterm-accessibility {
-    pointer-events: auto !important;
-  }
 }
 
 @keyframes media-in-slow {


### PR DESCRIPTION
## Summary
- add an instance-wide `enhancedTerminal` opt-in setting in Settings > General
- gate enhanced terminal history/backfill/touch behavior behind that setting while preserving the legacy terminal path when the setting is off
- fix tmux session mode handling so attach-time behavior is chosen once per tmux session instead of mutating shared session options on every connect

## Details
- add `/api/v1/agents/:id/terminal/history` for enhanced-mode tmux backfill
- restore the legacy phone touch-to-tmux scroll path, legacy coarse-pointer accessibility behavior, and legacy synthetic mouse handling when the setting is off
- keep the enhanced xterm local scrollback path isolated behind the opt-in

## Validation
- `pnpm run finalize:web`
- `pnpm run test`
- `pnpm run test:e2e`

## Review
- backend security persona reviewed the change with recheck enabled and approved the final diff