### PR TITLE
Fallback to plain terminal attach when history backfill fails

### DIFF
--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -460,14 +460,18 @@ export function useTerminal(args: {
           const cols = term?.cols ?? 140;
           const rows = term?.rows ?? 42;
           if (term && enhancedTerminalRef.current) {
-            const history = await api<TerminalHistoryResponse>(
-              `/api/v1/agents/${agent.id}/terminal/history?lines=${TERMINAL_BACKFILL_LINES}&skipBottomLines=${rows}`
-            );
-            if (!isCurrentAttempt()) {
-              return;
-            }
-            if (history.data.trim().length > 0) {
-              term.write(normalizeBackfill(history.data));
+            try {
+              const history = await api<TerminalHistoryResponse>(
+                `/api/v1/agents/${agent.id}/terminal/history?lines=${TERMINAL_BACKFILL_LINES}&skipBottomLines=${rows}`
+              );
+              if (!isCurrentAttempt()) {
+                return;
+              }
+              if (history.data.trim().length > 0) {
+                term.write(normalizeBackfill(history.data));
+              }
+            } catch (error) {
+              console.warn("Terminal history backfill failed:", error);
             }
           }
           setTerminalMode("tmux");


### PR DESCRIPTION
## Summary
- catch enhanced terminal history backfill failures in `use-terminal`
- continue with WebSocket attach instead of aborting the whole session connect flow
- log the degraded backfill path so rollout issues stay observable

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- live tmux validation in Playwright covering:
  - session started with toggle off, reconnect with toggle off
  - session started with toggle off, reconnect with toggle on
  - session started with toggle on, reconnect with toggle on
  - session started with toggle on, reconnect with toggle off

## Notes
- This intentionally preserves the old plain attach path as an escape hatch while enhanced terminal mode is still soaking.
- An unrelated local edit remains in `apps/server/src/agents/manager.ts` and is not part of this PR.