### PR TITLE
Persist media sidebar state per agent

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,7 @@ import {
 import { type IdeType, sanitizeEnabledIdes } from "@/lib/ide-types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { agentRoute } from "@/lib/agent-routes";
+import { reconcileMediaSidebarStateStorage } from "@/lib/store";
 import { UpdateAvailableToast } from "@/components/app/update-available-toast";
 
 type RouteHandle = {
@@ -45,17 +46,13 @@ export type DashboardContextValue = {
   handleLogout: () => void;
   isMobile: boolean;
   leftOpen: boolean;
-  mediaOpen: boolean;
   leftPanelOpen: boolean;
-  mediaPanelOpen: boolean;
   mobileLeftOpen: boolean;
   mobileMediaOpen: boolean;
   setLeftOpen: (open: boolean) => void;
-  setMediaOpen: (open: boolean) => void;
   setMobileLeftOpen: (open: boolean) => void;
   setMobileMediaOpen: (open: boolean) => void;
   handleSetLeftPanelOpen: (open: boolean) => void;
-  handleSetMediaPanelOpen: (open: boolean) => void;
   apiState: ServiceState;
   dbState: ServiceState;
   pulsingNavItem: string | null;
@@ -99,17 +96,13 @@ export function DashboardLayout(): JSX.Element {
   const {
     isMobile,
     leftOpen,
-    mediaOpen,
     leftPanelOpen,
-    mediaPanelOpen,
     mobileLeftOpen,
     mobileMediaOpen,
     setLeftOpen,
-    setMediaOpen,
     setMobileLeftOpen,
     setMobileMediaOpen,
     handleSetLeftPanelOpen,
-    handleSetMediaPanelOpen,
   } = useLayout();
   const { apiState, dbState } = useHealth(true);
 
@@ -125,6 +118,10 @@ export function DashboardLayout(): JSX.Element {
     },
     select: (data) => sortAgentsByCreatedAtDesc(data),
   });
+
+  useEffect(() => {
+    reconcileMediaSidebarStateStorage(agents.map((agent) => agent.id));
+  }, [agents]);
 
   useEffect(() => {
     document.title = instanceName ? `${instanceName} — Dispatch` : "Dispatch";
@@ -237,17 +234,13 @@ export function DashboardLayout(): JSX.Element {
     handleLogout,
     isMobile,
     leftOpen,
-    mediaOpen,
     leftPanelOpen,
-    mediaPanelOpen,
     mobileLeftOpen,
     mobileMediaOpen,
     setLeftOpen,
-    setMediaOpen,
     setMobileLeftOpen,
     setMobileMediaOpen,
     handleSetLeftPanelOpen,
-    handleSetMediaPanelOpen,
     apiState,
     dbState,
     pulsingNavItem,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,7 +30,6 @@ import {
 import { type IdeType, sanitizeEnabledIdes } from "@/lib/ide-types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { agentRoute } from "@/lib/agent-routes";
-import { reconcileMediaSidebarStateStorage } from "@/lib/store";
 import { UpdateAvailableToast } from "@/components/app/update-available-toast";
 
 type RouteHandle = {
@@ -110,7 +109,7 @@ export function DashboardLayout(): JSX.Element {
     ...AGENT_TYPES,
   ]);
   const [enabledIdes, setEnabledIdes] = useState<IdeType[]>([]);
-  const { data: agents = [], isSuccess: agentsLoaded } = useQuery<Agent[]>({
+  const { data: agents = [] } = useQuery<Agent[]>({
     queryKey: ["agents"],
     queryFn: async () => {
       const payload = await api<{ agents: Agent[] }>("/api/v1/agents");
@@ -118,11 +117,6 @@ export function DashboardLayout(): JSX.Element {
     },
     select: (data) => sortAgentsByCreatedAtDesc(data),
   });
-
-  useEffect(() => {
-    if (!agentsLoaded) return;
-    reconcileMediaSidebarStateStorage(agents.map((agent) => agent.id));
-  }, [agents, agentsLoaded]);
 
   useEffect(() => {
     document.title = instanceName ? `${instanceName} — Dispatch` : "Dispatch";

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -110,7 +110,7 @@ export function DashboardLayout(): JSX.Element {
     ...AGENT_TYPES,
   ]);
   const [enabledIdes, setEnabledIdes] = useState<IdeType[]>([]);
-  const { data: agents = [] } = useQuery<Agent[]>({
+  const { data: agents = [], isSuccess: agentsLoaded } = useQuery<Agent[]>({
     queryKey: ["agents"],
     queryFn: async () => {
       const payload = await api<{ agents: Agent[] }>("/api/v1/agents");
@@ -120,8 +120,9 @@ export function DashboardLayout(): JSX.Element {
   });
 
   useEffect(() => {
+    if (!agentsLoaded) return;
     reconcileMediaSidebarStateStorage(agents.map((agent) => agent.id));
-  }, [agents]);
+  }, [agents, agentsLoaded]);
 
   useEffect(() => {
     document.title = instanceName ? `${instanceName} — Dispatch` : "Dispatch";

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
+import { useAtom } from "jotai";
 
 import { AgentListContent } from "@/components/app/agent-sidebar";
 import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
@@ -42,6 +43,11 @@ import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { useEnhancedTerminal } from "@/hooks/use-enhanced-terminal";
+import {
+  inactiveMediaSidebarStateAtom,
+  mediaSidebarStateAtomFamily,
+  type MediaSidebarTab,
+} from "@/lib/store";
 
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
@@ -79,17 +85,13 @@ type AgentsViewProps = {
   enabledIdes: IdeType[];
   isMobile: boolean;
   leftOpen: boolean;
-  mediaOpen: boolean;
   leftPanelOpen: boolean;
-  mediaPanelOpen: boolean;
   mobileLeftOpen: boolean;
   mobileMediaOpen: boolean;
   setLeftOpen: (open: boolean) => void;
-  setMediaOpen: (open: boolean) => void;
   setMobileLeftOpen: (open: boolean) => void;
   setMobileMediaOpen: (open: boolean) => void;
   handleSetLeftPanelOpen: (open: boolean) => void;
-  handleSetMediaPanelOpen: (open: boolean) => void;
   pulsingNavItem: string | null;
   triggerNavAnimation: (navItem: string) => void;
   onNavigateSection: (section: NavSection) => void;
@@ -100,17 +102,13 @@ export function AgentsView({
   enabledIdes,
   isMobile,
   leftOpen,
-  mediaOpen,
   leftPanelOpen,
-  mediaPanelOpen,
   mobileLeftOpen,
   mobileMediaOpen,
   setLeftOpen,
-  setMediaOpen,
   setMobileLeftOpen,
   setMobileMediaOpen,
   handleSetLeftPanelOpen,
-  handleSetMediaPanelOpen,
   pulsingNavItem,
   triggerNavAnimation,
   onNavigateSection,
@@ -173,6 +171,57 @@ export function AgentsView({
   const feedbackDetailRendered =
     feedbackDetail ?? feedbackDetailStaleRef.current;
   const pendingAutoAttachAgentIdRef = useRef<string | null>(null);
+  const sidebarAgentId = sharedConnectedAgentId ?? validatedSelectedAgentId;
+  const desktopMediaSidebarAtom = useMemo(
+    () =>
+      sidebarAgentId
+        ? mediaSidebarStateAtomFamily(sidebarAgentId)
+        : inactiveMediaSidebarStateAtom,
+    [sidebarAgentId]
+  );
+  const [desktopMediaSidebarState, setDesktopMediaSidebarState] = useAtom(
+    desktopMediaSidebarAtom
+  );
+  const mediaOpen = isMobile
+    ? mobileMediaOpen
+    : desktopMediaSidebarState.isOpen;
+  const mediaPanelOpen = mediaOpen;
+  const mediaActiveTab = desktopMediaSidebarState.activeTab;
+
+  const setMediaActiveTab = useCallback(
+    (activeTab: MediaSidebarTab) => {
+      setDesktopMediaSidebarState((prev) => ({ ...prev, activeTab }));
+    },
+    [setDesktopMediaSidebarState]
+  );
+
+  const setMediaOpen = useCallback(
+    (open: boolean) => {
+      if (isMobile) {
+        if (open) setMobileLeftOpen(false);
+        setMobileMediaOpen(open);
+        return;
+      }
+
+      setDesktopMediaSidebarState((prev) =>
+        prev.isOpen === open ? prev : { ...prev, isOpen: open }
+      );
+    },
+    [
+      isMobile,
+      setDesktopMediaSidebarState,
+      setMobileLeftOpen,
+      setMobileMediaOpen,
+    ]
+  );
+
+  const openMediaPanel = useCallback(
+    (activeTab: MediaSidebarTab) => {
+      setMediaActiveTab(activeTab);
+      setMediaOpen(true);
+    },
+    [setMediaActiveTab, setMediaOpen]
+  );
 
   const {
     connState,
@@ -605,7 +654,7 @@ export function AgentsView({
                     size="icon"
                     variant="ghost"
                     className="pointer-events-auto relative"
-                    onClick={() => handleSetMediaPanelOpen(true)}
+                    onClick={() => openMediaPanel("media")}
                     title="Open media sidebar"
                     data-testid="toggle-media-sidebar"
                   >
@@ -710,6 +759,8 @@ export function AgentsView({
             unseenMediaCount={unseenMediaCount}
             mediaViewportRef={mediaViewportRef}
             setMediaOpen={setMediaOpen}
+            activeTab={mediaActiveTab}
+            setActiveTab={setMediaActiveTab}
             hasStream={focusedAgentHasStream}
             streamUrl={focusedAgentStreamUrl}
             openLightbox={openLightbox}
@@ -768,6 +819,8 @@ export function AgentsView({
             animatingMediaKeys={animatingMediaKeys}
             unseenMediaCount={unseenMediaCount}
             mediaViewportRef={mediaViewportRef}
+            activeTab={mediaActiveTab}
+            setActiveTab={setMediaActiveTab}
             hasStream={focusedAgentHasStream}
             streamUrl={focusedAgentStreamUrl}
             openLightbox={openLightbox}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -317,6 +317,15 @@ export function AgentsView({
   const focusedAgentStreamUrl = focusedAgentId
     ? `/api/v1/agents/${focusedAgentId}/stream`
     : null;
+  const prevFocusedAgentHasStreamRef = useRef(focusedAgentHasStream);
+
+  useEffect(() => {
+    const streamStarted =
+      !prevFocusedAgentHasStreamRef.current && focusedAgentHasStream;
+    prevFocusedAgentHasStreamRef.current = focusedAgentHasStream;
+    if (!streamStarted) return;
+    setMediaOpen(true);
+  }, [focusedAgentHasStream, setMediaOpen]);
 
   useAgentFocus(focusedAgentId, "authenticated");
 

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -17,6 +17,7 @@ import { MediaLightbox } from "@/components/app/media-lightbox";
 import {
   MediaSidebar,
   MediaSidebarContent,
+  MEDIA_SIDEBAR_SETTLE_FALLBACK_MS,
 } from "@/components/app/media-sidebar";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
 import { SidebarShell, type NavSection } from "@/components/app/sidebar-shell";
@@ -46,6 +47,7 @@ import { useEnhancedTerminal } from "@/hooks/use-enhanced-terminal";
 import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
+  reconcileMediaSidebarStateStorage,
   type MediaSidebarTab,
 } from "@/lib/store";
 
@@ -53,8 +55,6 @@ const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
 const EXPANDED_AGENT_ID_KEY = "dispatch:expandedAgentId";
-const MEDIA_SIDEBAR_RESIZE_SETTLE_MS = 340;
-
 function agentProjectRoot(agent: Agent | undefined | null): string | undefined {
   return agent?.gitContext?.repoRoot?.trim() || agent?.cwd?.trim() || undefined;
 }
@@ -230,6 +230,11 @@ export function AgentsView({
 
   const prevDesktopMediaOpenRef = useRef(mediaOpen);
   useEffect(() => {
+    if (!agentsLoaded) return;
+    reconcileMediaSidebarStateStorage(agents.map((agent) => agent.id));
+  }, [agents, agentsLoaded]);
+
+  useEffect(() => {
     if (isMobile) {
       prevDesktopMediaOpenRef.current = mediaOpen;
       return;
@@ -242,7 +247,7 @@ export function AgentsView({
     }
     mediaResizeTimerRef.current = window.setTimeout(
       finishMediaResizeSettle,
-      MEDIA_SIDEBAR_RESIZE_SETTLE_MS
+      MEDIA_SIDEBAR_SETTLE_FALLBACK_MS
     );
   }, [finishMediaResizeSettle, isMobile, mediaOpen]);
 
@@ -274,7 +279,6 @@ export function AgentsView({
     theme: "dark" as never,
     isMobile,
     leftOpen,
-    mediaOpen,
     deferMediaResize,
     mediaResizeSettleKey,
     feedbackOpen: !!feedbackDetail,

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -53,6 +53,7 @@ const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
 const EXPANDED_AGENT_ID_KEY = "dispatch:expandedAgentId";
+const MEDIA_SIDEBAR_RESIZE_SETTLE_MS = 340;
 
 function agentProjectRoot(agent: Agent | undefined | null): string | undefined {
   return agent?.gitContext?.repoRoot?.trim() || agent?.cwd?.trim() || undefined;
@@ -182,11 +183,14 @@ export function AgentsView({
   const [desktopMediaSidebarState, setDesktopMediaSidebarState] = useAtom(
     desktopMediaSidebarAtom
   );
+  const [deferMediaResize, setDeferMediaResize] = useState(false);
+  const [mediaResizeSettleKey, setMediaResizeSettleKey] = useState(0);
   const mediaOpen = isMobile
     ? mobileMediaOpen
     : desktopMediaSidebarState.isOpen;
   const mediaPanelOpen = mediaOpen;
   const mediaActiveTab = desktopMediaSidebarState.activeTab;
+  const mediaResizeTimerRef = useRef<number | null>(null);
 
   const setMediaActiveTab = useCallback(
     (activeTab: MediaSidebarTab) => {
@@ -215,6 +219,42 @@ export function AgentsView({
     ]
   );
 
+  const finishMediaResizeSettle = useCallback(() => {
+    if (mediaResizeTimerRef.current) {
+      window.clearTimeout(mediaResizeTimerRef.current);
+      mediaResizeTimerRef.current = null;
+    }
+    setDeferMediaResize(false);
+    setMediaResizeSettleKey((current) => current + 1);
+  }, []);
+
+  const prevDesktopMediaOpenRef = useRef(mediaOpen);
+  useEffect(() => {
+    if (isMobile) {
+      prevDesktopMediaOpenRef.current = mediaOpen;
+      return;
+    }
+    if (prevDesktopMediaOpenRef.current === mediaOpen) return;
+    prevDesktopMediaOpenRef.current = mediaOpen;
+    setDeferMediaResize(true);
+    if (mediaResizeTimerRef.current) {
+      window.clearTimeout(mediaResizeTimerRef.current);
+    }
+    mediaResizeTimerRef.current = window.setTimeout(
+      finishMediaResizeSettle,
+      MEDIA_SIDEBAR_RESIZE_SETTLE_MS
+    );
+  }, [finishMediaResizeSettle, isMobile, mediaOpen]);
+
+  useEffect(
+    () => () => {
+      if (mediaResizeTimerRef.current) {
+        window.clearTimeout(mediaResizeTimerRef.current);
+      }
+    },
+    []
+  );
+
   const {
     connState,
     connectedAgentId,
@@ -235,6 +275,8 @@ export function AgentsView({
     isMobile,
     leftOpen,
     mediaOpen,
+    deferMediaResize,
+    mediaResizeSettleKey,
     feedbackOpen: !!feedbackDetail,
     enhancedTerminal,
   });
@@ -753,6 +795,7 @@ export function AgentsView({
             setMediaOpen={setMediaOpen}
             activeTab={mediaActiveTab}
             setActiveTab={setMediaActiveTab}
+            onWidthTransitionEnd={finishMediaResizeSettle}
             hasStream={focusedAgentHasStream}
             streamUrl={focusedAgentStreamUrl}
             openLightbox={openLightbox}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -215,14 +215,6 @@ export function AgentsView({
     ]
   );
 
-  const openMediaPanel = useCallback(
-    (activeTab: MediaSidebarTab) => {
-      setMediaActiveTab(activeTab);
-      setMediaOpen(true);
-    },
-    [setMediaActiveTab, setMediaOpen]
-  );
-
   const {
     connState,
     connectedAgentId,
@@ -654,7 +646,7 @@ export function AgentsView({
                     size="icon"
                     variant="ghost"
                     className="pointer-events-auto relative"
-                    onClick={() => openMediaPanel("media")}
+                    onClick={() => setMediaOpen(true)}
                     title="Open media sidebar"
                     data-testid="toggle-media-sidebar"
                   >

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -28,6 +28,10 @@ import { cn } from "@/lib/utils";
 
 const ACCEPTED_EXTENSIONS =
   ".png,.jpg,.jpeg,.gif,.webp,.mp4,.pdf,.txt,.md,.json,.yaml,.yml,.toml,.csv,.log,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.sh,.sql,.diff,.patch,.env,.ini,.cfg,.conf,.swift,.kt,.java,.c,.cpp,.h,.hpp,.rb,.php,.lua,.zig,.nim,.r,.m,.ex,.exs,.erl,.hs";
+export const MEDIA_SIDEBAR_WIDTH_PX = 360;
+export const MEDIA_SIDEBAR_TRANSITION_MS = 300;
+export const MEDIA_SIDEBAR_SETTLE_FALLBACK_MS =
+  MEDIA_SIDEBAR_TRANSITION_MS + 40;
 
 function fileExtension(name: string): string {
   const dot = name.lastIndexOf(".");
@@ -500,20 +504,25 @@ export function MediaSidebar({
 }: MediaSidebarProps): JSX.Element {
   return (
     <div
-      className="h-full min-w-0 flex-none overflow-hidden transition-[width] duration-300 ease-out"
-      style={{ width: mediaOpen ? 360 : 0 }}
+      className="h-full min-w-0 flex-none overflow-hidden transition-[width] ease-out"
+      style={{
+        width: mediaOpen ? MEDIA_SIDEBAR_WIDTH_PX : 0,
+        transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
+      }}
       onTransitionEnd={(event) => {
         if (event.propertyName === "width") {
           onWidthTransitionEnd?.();
         }
       }}
     >
-      <MediaSidebarContent
-        {...props}
-        onRequestClose={() => setMediaOpen(false)}
-        closeButtonIcon="chevron"
-        className={cn("w-[360px] rounded-l-lg border-l", glassPanel)}
-      />
+      <div className="h-full min-h-0" style={{ width: MEDIA_SIDEBAR_WIDTH_PX }}>
+        <MediaSidebarContent
+          {...props}
+          onRequestClose={() => setMediaOpen(false)}
+          closeButtonIcon="chevron"
+          className={cn("rounded-l-lg border-l", glassPanel)}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -1,10 +1,4 @@
-import {
-  type RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type RefObject, useCallback, useRef, useState } from "react";
 import {
   Check,
   ChevronRight,
@@ -18,10 +12,9 @@ import {
   Upload,
   User,
 } from "lucide-react";
-import { useAtom } from "jotai";
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
-import { mediaSidebarTabAtom } from "@/lib/store";
+import { type MediaSidebarTab } from "@/lib/store";
 import {
   MediaActions,
   isTextFile,
@@ -59,9 +52,13 @@ type MediaSidebarSharedProps = {
 type MediaSidebarProps = MediaSidebarSharedProps & {
   mediaOpen: boolean;
   setMediaOpen: (open: boolean) => void;
+  activeTab: MediaSidebarTab;
+  setActiveTab: (tab: MediaSidebarTab) => void;
 };
 
 type MediaSidebarContentProps = MediaSidebarSharedProps & {
+  activeTab: MediaSidebarTab;
+  setActiveTab: (tab: MediaSidebarTab) => void;
   onRequestClose?: () => void;
   closeButtonIcon?: "chevron" | "x";
   className?: string;
@@ -383,23 +380,14 @@ export function MediaSidebarContent({
   openLightbox,
   hasStream,
   streamUrl,
+  activeTab,
+  setActiveTab,
   onRequestClose,
   closeButtonIcon = "x",
   className,
   unseenMediaCount,
   onUploadFile,
 }: MediaSidebarContentProps & { unseenMediaCount: number }): JSX.Element {
-  const [activeTab, setActiveTab] = useAtom(mediaSidebarTabAtom);
-  const prevAgentIdRef = useRef(selectedAgentId);
-
-  // Reset to pins tab when agent changes
-  if (prevAgentIdRef.current !== selectedAgentId) {
-    prevAgentIdRef.current = selectedAgentId;
-    if (activeTab !== "pins") {
-      setActiveTab("pins");
-    }
-  }
-
   return (
     <aside
       data-testid="media-sidebar"
@@ -506,16 +494,8 @@ export function MediaSidebarContent({
 export function MediaSidebar({
   mediaOpen,
   setMediaOpen,
-  hasStream,
   ...props
 }: MediaSidebarProps): JSX.Element {
-  // Auto-open the sidebar when a stream starts so the user doesn't miss it
-  useEffect(() => {
-    if (hasStream) {
-      setMediaOpen(true);
-    }
-  }, [hasStream, setMediaOpen]);
-
   return (
     <div
       className="h-full min-w-0 flex-none overflow-hidden transition-[width] duration-300 ease-out"
@@ -523,7 +503,6 @@ export function MediaSidebar({
     >
       <MediaSidebarContent
         {...props}
-        hasStream={hasStream}
         onRequestClose={() => setMediaOpen(false)}
         closeButtonIcon="chevron"
         className={cn("w-[360px] rounded-l-lg border-l", glassPanel)}

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -54,6 +54,7 @@ type MediaSidebarProps = MediaSidebarSharedProps & {
   setMediaOpen: (open: boolean) => void;
   activeTab: MediaSidebarTab;
   setActiveTab: (tab: MediaSidebarTab) => void;
+  onWidthTransitionEnd?: () => void;
 };
 
 type MediaSidebarContentProps = MediaSidebarSharedProps & {
@@ -494,12 +495,18 @@ export function MediaSidebarContent({
 export function MediaSidebar({
   mediaOpen,
   setMediaOpen,
+  onWidthTransitionEnd,
   ...props
 }: MediaSidebarProps): JSX.Element {
   return (
     <div
       className="h-full min-w-0 flex-none overflow-hidden transition-[width] duration-300 ease-out"
       style={{ width: mediaOpen ? 360 : 0 }}
+      onTransitionEnd={(event) => {
+        if (event.propertyName === "width") {
+          onWidthTransitionEnd?.();
+        }
+      }}
     >
       <MediaSidebarContent
         {...props}

--- a/apps/web/src/hooks/use-layout.ts
+++ b/apps/web/src/hooks/use-layout.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAtom } from "jotai";
-import { leftSidebarOpenAtom, mediaSidebarOpenAtom } from "@/lib/store";
+import { leftSidebarOpenAtom } from "@/lib/store";
 
 const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px)";
 
 export function useLayout() {
   const [leftOpen, setLeftOpen] = useAtom(leftSidebarOpenAtom);
-  const [mediaOpen, setMediaOpen] = useAtom(mediaSidebarOpenAtom);
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== "undefined"
       ? window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches
@@ -16,7 +15,6 @@ export function useLayout() {
   const [mobileMediaOpen, setMobileMediaOpen] = useState(false);
 
   const leftPanelOpen = isMobile ? mobileLeftOpen : leftOpen;
-  const mediaPanelOpen = isMobile ? mobileMediaOpen : mediaOpen;
 
   // Media query listener for mobile breakpoint.
   useEffect(() => {
@@ -47,46 +45,26 @@ export function useLayout() {
     [isMobile, setLeftOpen]
   );
 
-  const handleSetMediaPanelOpen = useCallback(
-    (open: boolean) => {
-      if (isMobile) {
-        if (open) setMobileLeftOpen(false);
-        setMobileMediaOpen(open);
-        return;
-      }
-      setMediaOpen(open);
-    },
-    [isMobile, setMediaOpen]
-  );
-
   return useMemo(
     () => ({
       isMobile,
       leftOpen,
-      mediaOpen,
       leftPanelOpen,
-      mediaPanelOpen,
       mobileLeftOpen,
       mobileMediaOpen,
       setLeftOpen,
-      setMediaOpen,
       setMobileLeftOpen,
       setMobileMediaOpen,
       handleSetLeftPanelOpen,
-      handleSetMediaPanelOpen,
     }),
     [
       isMobile,
       leftOpen,
-      mediaOpen,
       leftPanelOpen,
-      mediaPanelOpen,
       mobileLeftOpen,
       mobileMediaOpen,
       setLeftOpen,
-      setMediaOpen,
       handleSetLeftPanelOpen,
-      handleSetMediaPanelOpen,
     ]
   );
 }

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -81,6 +81,8 @@ export function useTerminal(args: {
   isMobile: boolean;
   leftOpen: boolean;
   mediaOpen: boolean;
+  deferMediaResize: boolean;
+  mediaResizeSettleKey: number;
   feedbackOpen: boolean;
   enhancedTerminal: boolean;
 }): {
@@ -108,6 +110,8 @@ export function useTerminal(args: {
     isMobile,
     leftOpen,
     mediaOpen,
+    deferMediaResize,
+    mediaResizeSettleKey,
     feedbackOpen,
     enhancedTerminal,
   } = args;
@@ -836,6 +840,7 @@ export function useTerminal(args: {
     });
 
     const onResize = () => {
+      if (deferMediaResize) return;
       fit.fit();
       sendResize();
     };
@@ -873,6 +878,7 @@ export function useTerminal(args: {
     };
   }, [
     authState,
+    deferMediaResize,
     enhancedTerminal,
     invalidateAttachAttempt,
     sendResize,
@@ -933,7 +939,16 @@ export function useTerminal(args: {
     fitNow();
     const timer = window.setTimeout(fitNow, 340);
     return () => window.clearTimeout(timer);
-  }, [isMobile, leftOpen, mediaOpen, feedbackOpen, sendResize]);
+  }, [isMobile, leftOpen, feedbackOpen, sendResize]);
+
+  // Media sidebar width animates; wait until it settles before resizing the
+  // terminal so content doesn't reflow continuously during the slide.
+  useEffect(() => {
+    if (isMobile) return;
+    if (deferMediaResize) return;
+    fitAddonRef.current?.fit();
+    sendResize();
+  }, [deferMediaResize, isMobile, mediaOpen, mediaResizeSettleKey, sendResize]);
 
   // Update terminal palette and reconnect when theme changes.
   const prevThemeRef = useRef(theme);

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -80,7 +80,6 @@ export function useTerminal(args: {
   theme: ThemeId;
   isMobile: boolean;
   leftOpen: boolean;
-  mediaOpen: boolean;
   deferMediaResize: boolean;
   mediaResizeSettleKey: number;
   feedbackOpen: boolean;
@@ -109,7 +108,6 @@ export function useTerminal(args: {
     theme,
     isMobile,
     leftOpen,
-    mediaOpen,
     deferMediaResize,
     mediaResizeSettleKey,
     feedbackOpen,
@@ -949,7 +947,7 @@ export function useTerminal(args: {
     if (deferMediaResize) return;
     fitAddonRef.current?.fit();
     sendResize();
-  }, [deferMediaResize, isMobile, mediaOpen, mediaResizeSettleKey, sendResize]);
+  }, [deferMediaResize, isMobile, mediaResizeSettleKey, sendResize]);
 
   // Update terminal palette and reconnect when theme changes.
   const prevThemeRef = useRef(theme);

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -166,6 +166,8 @@ export function useTerminal(args: {
   // effect and cause spurious reconnect attempts that abort in-flight connects).
   const agentsRef = useRef(agents);
   agentsRef.current = agents;
+  const deferMediaResizeRef = useRef(deferMediaResize);
+  deferMediaResizeRef.current = deferMediaResize;
 
   const sendResize = useCallback(() => {
     const ws = wsRef.current;
@@ -840,7 +842,7 @@ export function useTerminal(args: {
     });
 
     const onResize = () => {
-      if (deferMediaResize) return;
+      if (deferMediaResizeRef.current) return;
       fit.fit();
       sendResize();
     };
@@ -878,7 +880,6 @@ export function useTerminal(args: {
     };
   }, [
     authState,
-    deferMediaResize,
     enhancedTerminal,
     invalidateAttachAttempt,
     sendResize,

--- a/apps/web/src/layouts/dashboard-sections.tsx
+++ b/apps/web/src/layouts/dashboard-sections.tsx
@@ -123,17 +123,13 @@ export function AgentsRoute(): JSX.Element {
       enabledIdes={context.enabledIdes}
       isMobile={context.isMobile}
       leftOpen={context.leftOpen}
-      mediaOpen={context.mediaOpen}
       leftPanelOpen={context.leftPanelOpen}
-      mediaPanelOpen={context.mediaPanelOpen}
       mobileLeftOpen={context.mobileLeftOpen}
       mobileMediaOpen={context.mobileMediaOpen}
       setLeftOpen={context.setLeftOpen}
-      setMediaOpen={context.setMediaOpen}
       setMobileLeftOpen={context.setMobileLeftOpen}
       setMobileMediaOpen={context.setMobileMediaOpen}
       handleSetLeftPanelOpen={context.handleSetLeftPanelOpen}
-      handleSetMediaPanelOpen={context.handleSetMediaPanelOpen}
       pulsingNavItem={context.pulsingNavItem}
       triggerNavAnimation={context.triggerNavAnimation}
       onNavigateSection={context.handleSidebarNavigate}

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -36,14 +36,6 @@ export const leftSidebarOpenAtom = atomWithLocalStorage(
   "dispatch:leftSidebarOpen",
   true
 );
-export const mediaSidebarOpenAtom = atomWithLocalStorage(
-  "dispatch:mediaSidebarOpen",
-  false
-);
-export const mediaSidebarTabAtom = atomWithLocalStorage<"pins" | "media">(
-  "dispatch:mediaSidebarTab",
-  "pins"
-);
 export const soundCuesEnabledAtom = atomWithLocalStorage(
   "dispatch:soundCuesEnabled",
   true
@@ -59,3 +51,48 @@ export const preferredIdeAtom = atomWithLocalStorage<IdeType>(
 export const createNewBranchPrefAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage<boolean>(`dispatch:createNewBranch:${cwd}`, true)
 );
+
+export type MediaSidebarTab = "pins" | "media";
+
+export type MediaSidebarState = {
+  isOpen: boolean;
+  activeTab: MediaSidebarTab;
+};
+
+export const defaultMediaSidebarState: MediaSidebarState = {
+  isOpen: false,
+  activeTab: "pins",
+};
+
+export const inactiveMediaSidebarStateAtom = atom<MediaSidebarState>(
+  defaultMediaSidebarState
+);
+
+export const MEDIA_SIDEBAR_STATE_STORAGE_PREFIX = "dispatch:mediaSidebarState:";
+
+export const mediaSidebarStateAtomFamily = atomFamily((agentId: string) =>
+  atomWithLocalStorage<MediaSidebarState>(
+    `${MEDIA_SIDEBAR_STATE_STORAGE_PREFIX}${agentId}`,
+    defaultMediaSidebarState
+  )
+);
+
+export function reconcileMediaSidebarStateStorage(
+  agentIds: Iterable<string>
+): void {
+  if (typeof window === "undefined") return;
+
+  const liveAgentIds = new Set(agentIds);
+  const keysToDelete: string[] = [];
+
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    if (!key?.startsWith(MEDIA_SIDEBAR_STATE_STORAGE_PREFIX)) continue;
+
+    const agentId = key.slice(MEDIA_SIDEBAR_STATE_STORAGE_PREFIX.length).trim();
+    if (!agentId || liveAgentIds.has(agentId)) continue;
+    keysToDelete.push(key);
+  }
+
+  keysToDelete.forEach((key) => window.localStorage.removeItem(key));
+}

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -12,13 +12,10 @@ async function openMediaSidebarForAgent(
   page: Page,
   agent: { id: string; name: string }
 ) {
-  await page.getByText(agent.name, { exact: true }).click();
-  await expect(page.getByTestId(`agent-card-${agent.id}`)).toHaveClass(
-    /bg-muted\/60/
-  );
+  await page.getByTestId(`agent-row-${agent.id}`).click();
   const toggle = page.getByTestId("toggle-media-sidebar");
   await expect(toggle).toBeVisible();
-  await toggle.evaluate((el) => (el as HTMLButtonElement).click());
+  await toggle.click();
 }
 
 test.describe("Media sidebar", () => {
@@ -50,27 +47,66 @@ test.describe("Media sidebar", () => {
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
-
-    // Switch to Media tab (sidebar defaults to Pins tab)
-    await mediaSidebar.getByRole("button", { name: "Media" }).click();
     await expect(mediaSidebar.getByText("First image")).toBeVisible();
 
-    await page.getByText(secondAgent.name, { exact: true }).click();
-    // Agent switch resets to Pins tab — switch back to Media
-    await mediaSidebar.getByRole("button", { name: "Media" }).click();
+    await page.getByTestId(`agent-row-${secondAgent.id}`).click();
     await uploadMediaViaAPI(
       request,
       firstAgent.id,
       "Second image",
       "second-image.png"
     );
-    await page.getByText(firstAgent.name, { exact: true }).click();
-    // Agent switch resets to Pins tab again
-    await mediaSidebar.getByRole("button", { name: "Media" }).click();
+    await page.getByTestId(`agent-row-${firstAgent.id}`).click();
 
     await expect(mediaSidebar.getByText("Second image")).toBeVisible({
       timeout: 10_000,
     });
+  });
+
+  test("remembers sidebar open state and active tab per agent", async ({
+    page,
+    request,
+  }) => {
+    const firstAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-sidebar-state-a-${Date.now()}`,
+      cwd: process.cwd(),
+    });
+    const secondAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-sidebar-state-b-${Date.now()}`,
+      cwd: process.cwd(),
+    });
+
+    await setAgentPinsViaDB(firstAgent.id, [
+      { label: "First pin", type: "string", value: "Pinned for agent A" },
+    ]);
+    await setAgentPinsViaDB(secondAgent.id, [
+      { label: "Second pin", type: "string", value: "Pinned for agent B" },
+    ]);
+    await uploadMediaViaAPI(
+      request,
+      firstAgent.id,
+      "Remembered image",
+      "remembered-image.png"
+    );
+
+    await loadApp(page);
+
+    await openMediaSidebarForAgent(page, firstAgent);
+    const mediaSidebar = page.getByTestId("media-sidebar");
+    await expect(mediaSidebar.getByText("Remembered image")).toBeVisible();
+
+    await page.getByTestId(`agent-row-${secondAgent.id}`).click();
+    await page.getByTestId("toggle-media-sidebar").click();
+    await mediaSidebar.getByRole("button", { name: "Pins" }).click();
+    await expect(mediaSidebar.getByText("Pinned for agent B")).toBeVisible();
+
+    await page.getByTestId(`agent-row-${firstAgent.id}`).click();
+    await expect(page.getByTestId("toggle-media-sidebar")).toBeHidden();
+    await expect(mediaSidebar.getByText("Remembered image")).toBeVisible();
+
+    await page.getByTestId(`agent-row-${secondAgent.id}`).click();
+    await expect(page.getByTestId("toggle-media-sidebar")).toBeHidden();
+    await expect(mediaSidebar.getByText("Pinned for agent B")).toBeVisible();
   });
 
   test("navigates between fullscreen media items", async ({

--- a/e2e/media-sidebar.spec.ts
+++ b/e2e/media-sidebar.spec.ts
@@ -47,6 +47,7 @@ test.describe("Media sidebar", () => {
 
     const mediaSidebar = page.getByTestId("media-sidebar");
     await expect(mediaSidebar).toBeVisible();
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
     await expect(mediaSidebar.getByText("First image")).toBeVisible();
 
     await page.getByTestId(`agent-row-${secondAgent.id}`).click();
@@ -93,6 +94,7 @@ test.describe("Media sidebar", () => {
 
     await openMediaSidebarForAgent(page, firstAgent);
     const mediaSidebar = page.getByTestId("media-sidebar");
+    await mediaSidebar.getByRole("button", { name: "Media" }).click();
     await expect(mediaSidebar.getByText("Remembered image")).toBeVisible();
 
     await page.getByTestId(`agent-row-${secondAgent.id}`).click();

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -141,6 +141,9 @@ test.describe("Overflow layout", () => {
     const agentSidebarScroll = page.getByTestId("agent-sidebar-scroll");
     const pinsPanelScroll = page.getByTestId("pins-panel-scroll");
     const terminalPane = page.getByTestId("terminal-pane");
+    const mediaSidebar = page.getByTestId("media-sidebar");
+
+    await mediaSidebar.getByRole("button", { name: "Pins" }).click();
 
     await expect(agentSidebarScroll).toBeVisible();
     await expect(pinsPanelScroll).toBeVisible();
@@ -173,7 +176,6 @@ test.describe("Overflow layout", () => {
       )
     ).toBeLessThan(2);
 
-    const mediaSidebar = page.getByTestId("media-sidebar");
     await mediaSidebar.getByRole("button", { name: "Media" }).click();
 
     const mediaPanelScroll = page.getByTestId("media-panel-scroll");


### PR DESCRIPTION
## Summary
- persist desktop media sidebar open state and active tab per agent using a jotai atom family
- clean up orphaned per-agent sidebar state after the agents query resolves
- update media sidebar e2e coverage for per-agent restored state and the new default-closed behavior

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- Playwright validation on local dev stack (`http://127.0.0.1:59426`)