### PR TITLE
Default media sidebar to drawer mode with optional pin

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -591,7 +591,7 @@ export function AgentsView({
 
   return (
     <div className="h-full min-h-0 overflow-hidden text-foreground">
-      <div className="flex h-full min-h-0 min-w-0 overflow-hidden py-2">
+      <div className="relative flex h-full min-h-0 min-w-0 overflow-hidden py-2">
         <GlassSidebar
           open={isMobile ? mobileLeftOpen : leftOpen}
           onOpenChange={(open) => {

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -188,6 +188,10 @@ export function AgentsView({
     : desktopMediaSidebarState.isOpen;
   const mediaPanelOpen = mediaOpen;
   const mediaActiveTab = desktopMediaSidebarState.activeTab;
+  const mediaPinned = desktopMediaSidebarState.isPinned ?? false;
+  // Layout only shifts (and the terminal needs a refit) when the sidebar is
+  // open AND pinned. Drawer (unpinned) mode floats over the terminal.
+  const mediaShiftsLayout = !isMobile && mediaOpen && mediaPinned;
   const mediaResizeTimerRef = useRef<number | null>(null);
 
   const setMediaActiveTab = useCallback(
@@ -217,6 +221,13 @@ export function AgentsView({
     ]
   );
 
+  const toggleMediaPinned = useCallback(() => {
+    setDesktopMediaSidebarState((prev) => ({
+      ...prev,
+      isPinned: !(prev.isPinned ?? false),
+    }));
+  }, [setDesktopMediaSidebarState]);
+
   const finishMediaResizeSettle = useCallback(() => {
     if (mediaResizeTimerRef.current) {
       window.clearTimeout(mediaResizeTimerRef.current);
@@ -226,7 +237,7 @@ export function AgentsView({
     setMediaResizeSettleKey((current) => current + 1);
   }, []);
 
-  const prevDesktopMediaOpenRef = useRef(mediaOpen);
+  const prevMediaShiftsLayoutRef = useRef(mediaShiftsLayout);
   useEffect(() => {
     if (!agentsLoaded) return;
     reconcileMediaSidebarStateStorage(agents.map((agent) => agent.id));
@@ -234,11 +245,11 @@ export function AgentsView({
 
   useEffect(() => {
     if (isMobile) {
-      prevDesktopMediaOpenRef.current = mediaOpen;
+      prevMediaShiftsLayoutRef.current = mediaShiftsLayout;
       return;
     }
-    if (prevDesktopMediaOpenRef.current === mediaOpen) return;
-    prevDesktopMediaOpenRef.current = mediaOpen;
+    if (prevMediaShiftsLayoutRef.current === mediaShiftsLayout) return;
+    prevMediaShiftsLayoutRef.current = mediaShiftsLayout;
     setDeferMediaResize(true);
     if (mediaResizeTimerRef.current) {
       window.clearTimeout(mediaResizeTimerRef.current);
@@ -247,7 +258,7 @@ export function AgentsView({
       finishMediaResizeSettle,
       MEDIA_SIDEBAR_SETTLE_FALLBACK_MS
     );
-  }, [finishMediaResizeSettle, isMobile, mediaOpen]);
+  }, [finishMediaResizeSettle, isMobile, mediaShiftsLayout]);
 
   useEffect(
     () => () => {
@@ -807,6 +818,8 @@ export function AgentsView({
             setMediaOpen={setMediaOpen}
             activeTab={mediaActiveTab}
             setActiveTab={setMediaActiveTab}
+            pinned={mediaPinned}
+            onTogglePin={toggleMediaPinned}
             onWidthTransitionEnd={finishMediaResizeSettle}
             hasStream={focusedAgentHasStream}
             streamUrl={focusedAgentStreamUrl}

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -5,6 +5,8 @@ import {
   ExternalLink,
   FileText,
   MonitorPlay,
+  Pin,
+  PinOff,
   X,
   Image,
   File as FileIcon,
@@ -58,6 +60,8 @@ type MediaSidebarProps = MediaSidebarSharedProps & {
   setMediaOpen: (open: boolean) => void;
   activeTab: MediaSidebarTab;
   setActiveTab: (tab: MediaSidebarTab) => void;
+  pinned: boolean;
+  onTogglePin: () => void;
   onWidthTransitionEnd?: () => void;
 };
 
@@ -66,6 +70,8 @@ type MediaSidebarContentProps = MediaSidebarSharedProps & {
   setActiveTab: (tab: MediaSidebarTab) => void;
   onRequestClose?: () => void;
   closeButtonIcon?: "chevron" | "x";
+  pinned?: boolean;
+  onTogglePin?: () => void;
   className?: string;
 };
 
@@ -389,6 +395,8 @@ export function MediaSidebarContent({
   setActiveTab,
   onRequestClose,
   closeButtonIcon = "x",
+  pinned,
+  onTogglePin,
   className,
   unseenMediaCount,
   onUploadFile,
@@ -443,8 +451,25 @@ export function MediaSidebarContent({
             )}
           </button>
         </div>
-        {onRequestClose ? (
-          <div className="px-2">
+        <div className="flex items-center gap-1 px-2">
+          {onTogglePin ? (
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={onTogglePin}
+              title={pinned ? "Unpin sidebar" : "Pin sidebar"}
+              data-testid="toggle-media-sidebar-pin"
+              data-pinned={pinned ? "true" : "false"}
+              className="h-7 w-7"
+            >
+              {pinned ? (
+                <PinOff className="h-4 w-4" />
+              ) : (
+                <Pin className="h-4 w-4" />
+              )}
+            </Button>
+          ) : null}
+          {onRequestClose ? (
             <Button
               size="icon"
               variant="ghost"
@@ -458,8 +483,8 @@ export function MediaSidebarContent({
                 <X className="h-4 w-4" />
               )}
             </Button>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
 
       {/* Tab content — both panels stay mounted so refs (e.g. IntersectionObserver) remain attached */}
@@ -499,28 +524,75 @@ export function MediaSidebarContent({
 export function MediaSidebar({
   mediaOpen,
   setMediaOpen,
+  pinned,
+  onTogglePin,
   onWidthTransitionEnd,
   ...props
 }: MediaSidebarProps): JSX.Element {
+  if (pinned) {
+    // Inline mode: takes layout space and shrinks the terminal.
+    return (
+      <div
+        data-testid="media-sidebar-wrapper"
+        data-pinned="true"
+        className="h-full min-w-0 flex-none overflow-hidden transition-[width] ease-out"
+        style={{
+          width: mediaOpen ? MEDIA_SIDEBAR_WIDTH_PX : 0,
+          transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
+        }}
+        onTransitionEnd={(event) => {
+          if (event.propertyName === "width") {
+            onWidthTransitionEnd?.();
+          }
+        }}
+      >
+        <div
+          className="h-full min-h-0"
+          style={{ width: MEDIA_SIDEBAR_WIDTH_PX }}
+        >
+          <MediaSidebarContent
+            {...props}
+            onRequestClose={() => setMediaOpen(false)}
+            closeButtonIcon="chevron"
+            pinned={pinned}
+            onTogglePin={onTogglePin}
+            className={cn("rounded-l-lg border-l", glassPanel)}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Drawer mode: floats over the terminal, slides in/out without shifting
+  // layout. The wrapper is 0-width so the flex layout is unchanged; the inner
+  // panel is absolutely positioned at the wrapper's right edge and extends
+  // left over the terminal area.
   return (
     <div
-      className="h-full min-w-0 flex-none overflow-hidden transition-[width] ease-out"
-      style={{
-        width: mediaOpen ? MEDIA_SIDEBAR_WIDTH_PX : 0,
-        transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
-      }}
-      onTransitionEnd={(event) => {
-        if (event.propertyName === "width") {
-          onWidthTransitionEnd?.();
-        }
-      }}
+      data-testid="media-sidebar-wrapper"
+      data-pinned="false"
+      className="relative h-full w-0 flex-none"
     >
-      <div className="h-full min-h-0" style={{ width: MEDIA_SIDEBAR_WIDTH_PX }}>
+      <div
+        className={cn(
+          "absolute bottom-0 right-0 top-0 z-30 transition-transform ease-out",
+          !mediaOpen && "pointer-events-none"
+        )}
+        style={{
+          width: MEDIA_SIDEBAR_WIDTH_PX,
+          transform: mediaOpen
+            ? "translateX(0)"
+            : `translateX(${MEDIA_SIDEBAR_WIDTH_PX}px)`,
+          transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
+        }}
+      >
         <MediaSidebarContent
           {...props}
           onRequestClose={() => setMediaOpen(false)}
           closeButtonIcon="chevron"
-          className={cn("rounded-l-lg border-l", glassPanel)}
+          pinned={pinned}
+          onTogglePin={onTogglePin}
+          className={cn("rounded-l-lg border-l shadow-2xl", glassPanel)}
         />
       </div>
     </div>

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -458,6 +458,8 @@ export function MediaSidebarContent({
               variant="ghost"
               onClick={onTogglePin}
               title={pinned ? "Unpin sidebar" : "Pin sidebar"}
+              aria-label={pinned ? "Unpin sidebar" : "Pin sidebar"}
+              aria-pressed={pinned ?? false}
               data-testid="toggle-media-sidebar-pin"
               data-pinned={pinned ? "true" : "false"}
               className="h-7 w-7"
@@ -564,37 +566,33 @@ export function MediaSidebar({
   }
 
   // Drawer mode: floats over the terminal, slides in/out without shifting
-  // layout. The wrapper is 0-width so the flex layout is unchanged; the inner
-  // panel is absolutely positioned at the wrapper's right edge and extends
-  // left over the terminal area.
+  // layout. The panel is positioned absolutely against the agents-view flex
+  // container (which sets `position: relative`), so it has a real hit-testable
+  // box at the right edge instead of being anchored inside a 0-width wrapper.
   return (
     <div
       data-testid="media-sidebar-wrapper"
       data-pinned="false"
-      className="relative h-full w-0 flex-none"
+      className={cn(
+        "absolute bottom-0 right-0 top-0 z-30 transition-transform ease-out",
+        !mediaOpen && "pointer-events-none"
+      )}
+      style={{
+        width: MEDIA_SIDEBAR_WIDTH_PX,
+        transform: mediaOpen
+          ? "translateX(0)"
+          : `translateX(${MEDIA_SIDEBAR_WIDTH_PX}px)`,
+        transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
+      }}
     >
-      <div
-        className={cn(
-          "absolute bottom-0 right-0 top-0 z-30 transition-transform ease-out",
-          !mediaOpen && "pointer-events-none"
-        )}
-        style={{
-          width: MEDIA_SIDEBAR_WIDTH_PX,
-          transform: mediaOpen
-            ? "translateX(0)"
-            : `translateX(${MEDIA_SIDEBAR_WIDTH_PX}px)`,
-          transitionDuration: `${MEDIA_SIDEBAR_TRANSITION_MS}ms`,
-        }}
-      >
-        <MediaSidebarContent
-          {...props}
-          onRequestClose={() => setMediaOpen(false)}
-          closeButtonIcon="chevron"
-          pinned={pinned}
-          onTogglePin={onTogglePin}
-          className={cn("rounded-l-lg border-l shadow-2xl", glassPanel)}
-        />
-      </div>
+      <MediaSidebarContent
+        {...props}
+        onRequestClose={() => setMediaOpen(false)}
+        closeButtonIcon="chevron"
+        pinned={pinned}
+        onTogglePin={onTogglePin}
+        className={cn("rounded-l-lg border-l shadow-2xl", glassPanel)}
+      />
     </div>
   );
 }

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -57,11 +57,16 @@ export type MediaSidebarTab = "pins" | "media";
 export type MediaSidebarState = {
   isOpen: boolean;
   activeTab: MediaSidebarTab;
+  // When true (desktop only), the sidebar takes layout space and shrinks the
+  // terminal. When false, the sidebar floats over the terminal as a drawer
+  // that slides in/out without shifting layout. Default is false.
+  isPinned: boolean;
 };
 
 export const defaultMediaSidebarState: MediaSidebarState = {
   isOpen: false,
   activeTab: "pins",
+  isPinned: false,
 };
 
 export const inactiveMediaSidebarStateAtom = atom<MediaSidebarState>(


### PR DESCRIPTION
## Summary

The desktop media sidebar now opens as a drawer that floats over the terminal by default, so opening it for a quick peek doesn't shift the terminal width. A new pin/unpin toggle in the sidebar header switches it to the prior inline behavior, where it takes layout space and shrinks the terminal — best of both worlds.

- Per-agent `MediaSidebarState` gets a new `isPinned` field (default `false`); the preference persists alongside `isOpen` and `activeTab`.
- `MediaSidebar` renders two distinct layouts: pinned = inline width-animated wrapper (existing behavior), unpinned = absolutely-positioned panel that slides in/out via `translateX` over the terminal area.
- The terminal-resize defer/settle gate is now driven by `(mediaOpen && pinned)` instead of `mediaOpen` alone, since drawer mode never shifts layout and doesn't need a terminal refit.
- New `Pin` / `PinOff` lucide icon button in the sidebar header (`data-testid="toggle-media-sidebar-pin"`).

## Test plan

- [x] `pnpm run check` (server + web typecheck)
- [x] `pnpm run finalize:web` (production build)
- [x] `pnpm run test:e2e` — 137 passed, 6 skipped, no regressions in existing media-sidebar tests
- [x] Playwright manual validation:
  - Default drawer mode: terminal width unchanged (1080px), drawer floats at right (1040–1400)
  - Click pin: terminal shrinks to 720px, sidebar takes layout space
  - Click unpin: terminal expands back to 1080px, sidebar returns to floating
  - Close drawer: slides out via `translateX(360px)`, becomes pointer-events-none, open-toggle reappears
  - Reload page with pinned state: state restored from per-agent localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)