### PR TITLE
Use keychain profile for notarization submit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,19 @@ jobs:
             -k "$CERT_PASSWORD" \
             build.keychain
 
+      - name: Store notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool store-credentials dispatch-release-notary \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_NOTARY_PASSWORD" \
+            --keychain build.keychain
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -247,9 +260,8 @@ jobs:
           DISPATCH_CODESIGN_IDENTITY: "Developer ID Application: Brad Harris (ML8BQ6D727)"
           DISPATCH_MACOS_BUNDLE_ID: dev.bradharris.dispatch
           DISPATCH_NOTARIZE_MACOS_BINARIES: "1"
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          DISPATCH_NOTARY_KEYCHAIN: build.keychain
+          DISPATCH_NOTARY_KEYCHAIN_PROFILE: dispatch-release-notary
 
       - name: Pack release artifact
         run: bin/pack-release --output dispatch-release.tar.gz

--- a/scripts/build-bun-binaries.mjs
+++ b/scripts/build-bun-binaries.mjs
@@ -40,6 +40,8 @@ const entitlementsPath = path.join(
 );
 const shouldNotarizeMacos =
   process.env.DISPATCH_NOTARIZE_MACOS_BINARIES === "1";
+const notaryKeychainProfile = process.env.DISPATCH_NOTARY_KEYCHAIN_PROFILE;
+const notaryKeychainPath = process.env.DISPATCH_NOTARY_KEYCHAIN;
 
 if (shouldNotarizeMacos && !process.env.DISPATCH_CODESIGN_IDENTITY) {
   console.error(
@@ -66,13 +68,30 @@ function parseTargets(rawTargets) {
   return targets;
 }
 
-function validateNotaryEnv() {
+function getNotarySubmitArgs() {
+  if (notaryKeychainProfile) {
+    const args = ["--keychain-profile", notaryKeychainProfile];
+    if (notaryKeychainPath) {
+      args.push("--keychain", notaryKeychainPath);
+    }
+    return args;
+  }
+
   const requiredVars = ["APPLE_ID", "APPLE_NOTARY_PASSWORD", "APPLE_TEAM_ID"];
   const missingVars = requiredVars.filter((name) => !process.env[name]);
   if (missingVars.length > 0) {
     console.error(`Missing notarization env vars: ${missingVars.join(", ")}`);
     process.exit(1);
   }
+
+  return [
+    "--apple-id",
+    process.env.APPLE_ID,
+    "--team-id",
+    process.env.APPLE_TEAM_ID,
+    "--password",
+    process.env.APPLE_NOTARY_PASSWORD,
+  ];
 }
 
 function signAndMaybeNotarizeMacosBinary(outfile) {
@@ -100,23 +119,12 @@ function signAndMaybeNotarizeMacosBinary(outfile) {
 
   if (!shouldNotarizeMacos) return;
 
-  validateNotaryEnv();
+  const notarySubmitArgs = getNotarySubmitArgs();
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "dispatch-notary-"));
   const zipPath = path.join(tempDir, `${path.basename(outfile)}.zip`);
   try {
     run("ditto", ["-c", "-k", "--keepParent", outfile, zipPath]);
-    run("xcrun", [
-      "notarytool",
-      "submit",
-      zipPath,
-      "--apple-id",
-      process.env.APPLE_ID,
-      "--team-id",
-      process.env.APPLE_TEAM_ID,
-      "--password",
-      process.env.APPLE_NOTARY_PASSWORD,
-      "--wait",
-    ]);
+    run("xcrun", ["notarytool", "submit", zipPath, ...notarySubmitArgs, "--wait"]);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/scripts/build-bun-binaries.mjs
+++ b/scripts/build-bun-binaries.mjs
@@ -124,7 +124,13 @@ function signAndMaybeNotarizeMacosBinary(outfile) {
   const zipPath = path.join(tempDir, `${path.basename(outfile)}.zip`);
   try {
     run("ditto", ["-c", "-k", "--keepParent", outfile, zipPath]);
-    run("xcrun", ["notarytool", "submit", zipPath, ...notarySubmitArgs, "--wait"]);
+    run("xcrun", [
+      "notarytool",
+      "submit",
+      zipPath,
+      ...notarySubmitArgs,
+      "--wait",
+    ]);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- store Apple notarization credentials in the temporary `build.keychain` during the macOS release job
- pass a keychain profile into `scripts/build-bun-binaries.mjs` so the long-running `notarytool submit --wait` no longer receives the password on its command line
- keep the script backward-compatible by falling back to the existing Apple ID + password env vars when no keychain profile is provided

## Validation
- `pnpm run check`
- `pnpm run test:e2e`

## Notes
- The first `pnpm run test:e2e` attempt hit one transient `ECONNREFUSED` failure in `e2e/media-sidebar.spec.ts` while the suite was already in progress.
- Re-running the full isolated suite passed: `137 passed, 6 skipped`.