### PR TITLE
Fix sidebar expansion reset on agent activity

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -386,6 +386,13 @@ export function AgentsView({
     pendingAutoAttachAgentIdRef.current = routeAgentId ?? null;
   }, [routeAgentId]);
 
+  const selectedExpansionTarget = useMemo(() => {
+    if (!validatedSelectedAgentId) return null;
+    const selected = agents.find((a) => a.id === validatedSelectedAgentId);
+    return selected?.parentAgentId ?? validatedSelectedAgentId;
+  }, [agents, validatedSelectedAgentId]);
+  const prevSelectedExpansionTargetRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!routeAgentId) return;
     if (!agentsLoaded) return;
@@ -394,11 +401,18 @@ export function AgentsView({
   }, [agentsLoaded, navigate, routeAgentId, validatedSelectedAgentId]);
 
   useEffect(() => {
-    if (!validatedSelectedAgentId) return;
-    const selected = agents.find((a) => a.id === validatedSelectedAgentId);
-    const target = selected?.parentAgentId ?? validatedSelectedAgentId;
-    setExpandedAgentId((current) => (current === target ? current : target));
-  }, [agents, validatedSelectedAgentId]);
+    if (!selectedExpansionTarget) {
+      prevSelectedExpansionTargetRef.current = null;
+      return;
+    }
+    if (prevSelectedExpansionTargetRef.current === selectedExpansionTarget) {
+      return;
+    }
+    prevSelectedExpansionTargetRef.current = selectedExpansionTarget;
+    setExpandedAgentId((current) =>
+      current === selectedExpansionTarget ? current : selectedExpansionTarget
+    );
+  }, [selectedExpansionTarget]);
 
   useEffect(() => {
     if (!routeAgentId) return;

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "@playwright/test";
-import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  loadApp,
+  setAgentLatestEventViaAPI,
+} from "./helpers";
 
 const AUTH_HEADER = {
   Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
@@ -271,6 +276,45 @@ test.describe("Agent CRUD", () => {
     await page.getByTestId(`agent-expand-toggle-${peekAgent.id}`).click();
 
     await expect(attachedCard.getByText("/tmp")).toBeVisible();
+    await expect(peekCard.getByText("/tmp")).toBeVisible();
+  });
+
+  test("manual expansion survives attached agent activity updates", async ({
+    page,
+    request,
+  }) => {
+    const attachedAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-attached-${Date.now()}`,
+    });
+    const peekAgent = await createAgentViaAPI(request, {
+      name: `e2e-agent-peek-${Date.now()}`,
+    });
+
+    await request.post(`/api/v1/agents/${attachedAgent.id}/start`, {
+      headers: AUTH_HEADER,
+    });
+
+    await loadApp(page);
+
+    const attachedCard = page.getByTestId(`agent-card-${attachedAgent.id}`);
+    const peekCard = page.getByTestId(`agent-card-${peekAgent.id}`);
+
+    await page.getByTestId(`agent-row-${attachedAgent.id}`).click();
+    await expect(attachedCard.getByText("/tmp")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId(`agent-expand-toggle-${peekAgent.id}`).click();
+    await expect(peekCard.getByText("/tmp")).toBeVisible();
+
+    await setAgentLatestEventViaAPI(request, attachedAgent.id, {
+      type: "working",
+      message: "refreshing sidebar state",
+    });
+
+    await expect(
+      attachedCard.getByText("refreshing sidebar state")
+    ).toBeVisible({ timeout: 5_000 });
     await expect(peekCard.getByText("/tmp")).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- stop sidebar expansion state from being reset on unrelated agent list refreshes
- only auto-sync the expanded card when the selected expansion target actually changes
- add an e2e regression for attached-agent activity while another card is manually expanded

## Testing
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- Playwright manual validation on isolated dev stack

## Review
- frontend-ux-review approved in both rounds with no findings