### PR TITLE
Fix terminal emoji rendering

### DIFF
--- a/apps/server/src/agents/tmux/runtime.ts
+++ b/apps/server/src/agents/tmux/runtime.ts
@@ -48,6 +48,7 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
       const wrappedCommand = await prepareLaunch(input);
 
       await runCommand("tmux", [
+        "-u",
         "new-session",
         "-d",
         "-s",

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -906,7 +906,7 @@ export async function registerAgentRoutes(
       const rows = Number(query.rows ?? 42);
       const ptyProcess = spawnPty(
         "tmux",
-        ["attach-session", "-t", tmuxSession],
+        ["-u", "attach-session", "-t", tmuxSession],
         {
           name: "xterm-256color",
           cols: Number.isFinite(cols) ? cols : 140,

--- a/apps/server/test/agent-runtime-tmux.test.ts
+++ b/apps/server/test/agent-runtime-tmux.test.ts
@@ -408,7 +408,7 @@ describe("TmuxRuntime — launch (setup-script payload)", () => {
     // tmux new-session ran with the wrapped `bash <path>` as the command
     const newSessionCall = vi
       .mocked(runCommand)
-      .mock.calls.find(([, a]) => a[0] === "new-session");
+      .mock.calls.find(([, a]) => a.includes("new-session"));
     expect(newSessionCall?.[1]).toContain("dispatch_agt_xyz_runtime_test");
     expect(newSessionCall?.[1]).toContain("/projects/foo");
     const wrappedCommand = newSessionCall?.[1]?.[
@@ -464,7 +464,7 @@ describe("TmuxRuntime — launch (agent-command payload)", () => {
 
     const newSessionCall = vi
       .mocked(runCommand)
-      .mock.calls.find(([, a]) => a[0] === "new-session");
+      .mock.calls.find(([, a]) => a.includes("new-session"));
     const wrappedCommand = newSessionCall?.[1]?.[
       newSessionCall[1].length - 1
     ] as string;
@@ -502,7 +502,7 @@ describe("TmuxRuntime — launch (agent-command payload)", () => {
 
     const newSessionCall = vi
       .mocked(runCommand)
-      .mock.calls.find(([, a]) => a[0] === "new-session");
+      .mock.calls.find(([, a]) => a.includes("new-session"));
     const wrappedCommand = newSessionCall?.[1]?.[
       newSessionCall[1].length - 1
     ] as string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.91.2",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -10,6 +10,7 @@ import {
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import {
   type Agent,
   type AuthState,
@@ -25,6 +26,15 @@ const TERMINAL_FRESHNESS_MS =
   TERMINAL_HEARTBEAT_INTERVAL_MS + TERMINAL_LIVENESS_GRACE_MS;
 const RESUME_RECONNECT_DEDUPE_MS = 150;
 const SOCKET_PROBE_TIMEOUT_MS = 1_500;
+
+function getTerminalFontFamily(): string {
+  const fontFamily = getComputedStyle(document.documentElement)
+    .getPropertyValue("--font-terminal")
+    .trim();
+  return fontFamily.length > 0
+    ? fontFamily
+    : '"JetBrains Mono", Menlo, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", monospace';
+}
 
 type TerminalSocketMessage =
   | { type: "heartbeat"; ts: number }
@@ -655,9 +665,10 @@ export function useTerminal(args: {
     const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
     const palette = getTerminalPalette(themeRef.current);
     const term = new XTerm({
+      allowProposedApi: true,
       convertEol: false,
       cursorBlink: true,
-      fontFamily: "JetBrains Mono, Menlo, monospace",
+      fontFamily: getTerminalFontFamily(),
       fontSize: 13,
       scrollback: 1000,
       macOptionClickForcesSelection: true,
@@ -667,9 +678,12 @@ export function useTerminal(args: {
     });
 
     const fit = new FitAddon();
+    const unicode11 = new Unicode11Addon();
 
     terminalRef.current = term;
     fitAddonRef.current = fit;
+    term.loadAddon(unicode11);
+    term.unicode.activeVersion = "11";
     term.loadAddon(fit);
     try {
       term.loadAddon(new ClipboardAddon());

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 
 :root {
+  --font-terminal:
+    "JetBrains Mono", Menlo, "Apple Color Emoji", "Segoe UI Emoji",
+    "Noto Color Emoji", monospace;
   --background: 55 8% 6%;
   --foreground: 60 30% 96%;
   --card: 50 8% 9%;
@@ -378,7 +381,7 @@ body {
 
 body {
   @apply bg-background text-foreground antialiased;
-  font-family: "JetBrains Mono", Menlo, monospace;
+  font-family: var(--font-terminal);
 }
 
 /* Glass atmosphere — subtle radial gradients behind all content.
@@ -571,7 +574,7 @@ html[data-theme="matrix"] body::after {
 }
 
 .terminal-font {
-  font-family: "JetBrains Mono", Menlo, monospace;
+  font-family: var(--font-terminal);
 }
 
 html[data-theme="matrix"] .xterm {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       "@xterm/addon-fit":
         specifier: ^0.11.0
         version: 0.11.0
+      "@xterm/addon-unicode11":
+        specifier: ^0.9.0
+        version: 0.9.0
       "@xterm/xterm":
         specifier: ^6.0.0
         version: 6.0.0
@@ -3638,6 +3641,12 @@ packages:
     resolution:
       {
         integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==,
+      }
+
+  "@xterm/addon-unicode11@0.9.0":
+    resolution:
+      {
+        integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==,
       }
 
   "@xterm/xterm@6.0.0":
@@ -11001,6 +11010,8 @@ snapshots:
       js-base64: 3.7.8
 
   "@xterm/addon-fit@0.11.0": {}
+
+  "@xterm/addon-unicode11@0.9.0": {}
 
   "@xterm/xterm@6.0.0": {}
 


### PR DESCRIPTION
## Summary
- force tmux to launch and attach with `-u` so terminal sessions emit UTF-8 instead of replacing emoji with `_`
- keep the web terminal configured with an emoji-capable fallback font stack and xterm's Unicode 11 addon
- update tmux runtime tests to account for the new tmux argv shape

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test`
- `pnpm run test:e2e`
- validated on live dev stack:
  - web: http://127.0.0.1:61368
  - api: http://127.0.0.1:61353
- proof screenshot: http://127.0.0.1:61353/api/v1/agents/agt_ac9e1dcb503a/media/tmux-u-emoji-proof-2026-04-30-21-45-52-451.png