### PR TITLE
Restore terminal focus after copy mode exit

### DIFF
--- a/apps/server/src/copy-mode-assist-settings.ts
+++ b/apps/server/src/copy-mode-assist-settings.ts
@@ -1,0 +1,21 @@
+import type { Pool } from "pg";
+
+import { getSetting } from "./db/settings.js";
+
+export const COPY_MODE_ASSIST_ENABLED_KEY = "copy_mode_assist_enabled";
+
+export function parseBooleanSetting(
+  value: string | null,
+  defaultValue: boolean
+): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return defaultValue;
+}
+
+export async function getCopyModeAssistEnabled(pool: Pool): Promise<boolean> {
+  return parseBooleanSetting(
+    await getSetting(pool, COPY_MODE_ASSIST_ENABLED_KEY),
+    false
+  );
+}

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -88,7 +88,7 @@ function decodeClientMessage(
 ):
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number }
-  | { type: "interaction"; interaction: "scroll" | "exit_copy_mode" }
+  | { type: "interaction"; interaction: "scroll" }
   | null {
   try {
     const asString = typeof buffer === "string" ? buffer : buffer.toString();
@@ -113,11 +113,7 @@ function decodeClientMessage(
         rows: parsed.rows,
       };
     }
-    if (
-      parsed.type === "interaction" &&
-      (parsed.interaction === "scroll" ||
-        parsed.interaction === "exit_copy_mode")
-    ) {
+    if (parsed.type === "interaction" && parsed.interaction === "scroll") {
       return { type: "interaction", interaction: parsed.interaction };
     }
     return null;
@@ -932,13 +928,8 @@ export async function registerAgentRoutes(
       const body = request.body as { interaction?: unknown };
       const id = params.id ?? "";
 
-      if (
-        body?.interaction !== "scroll" &&
-        body?.interaction !== "exit_copy_mode"
-      ) {
-        return reply
-          .code(400)
-          .send({ error: "interaction must be 'scroll' or 'exit_copy_mode'." });
+      if (body?.interaction !== "scroll") {
+        return reply.code(400).send({ error: "interaction must be 'scroll'." });
       }
 
       try {

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1013,13 +1013,8 @@ export async function registerAgentRoutes(
       const cols = Number(query.cols ?? 140);
       const rows = Number(query.rows ?? 42);
       const ptyProcess = spawnPty(
-        "sh",
-        [
-          "-lc",
-          `exec tmux attach-session -t "$1"`,
-          "dispatch-terminal",
-          tmuxSession,
-        ],
+        "tmux",
+        ["attach-session", "-t", tmuxSession],
         {
           name: "xterm-256color",
           cols: Number.isFinite(cols) ? cols : 140,

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -12,6 +12,7 @@ import {
 import { getSetting } from "../db/settings.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { spawn as spawnPty } from "../shared/terminal/bun-pty.js";
+import { TmuxTerminal } from "../terminal/tmux-terminal.js";
 import {
   type CreateAgentBody,
   type StartupFileUpload,
@@ -136,6 +137,8 @@ export async function registerAgentRoutes(
       // ignore — tmux may have raced with shutdown
     }
   };
+
+  const TMUX_CLIENT_TTY_MARKER = "__DISPATCH_TMUX_CLIENT_TTY__";
 
   app.get("/api/v1/agents", async () => {
     const agents = await deps.agentManager.listAgents();
@@ -862,6 +865,27 @@ export async function registerAgentRoutes(
     }
   });
 
+  app.post(
+    "/api/v1/agents/:id/terminal/copy-mode/exit",
+    async (request, reply) => {
+      const params = request.params as { id?: string };
+      const id = params.id ?? "";
+
+      try {
+        const access = await deps.agentManager.getTerminalAccess(id);
+        if (access.mode !== "tmux") {
+          return reply.code(409).send({ error: access.message });
+        }
+
+        const terminal = new TmuxTerminal(access.sessionName);
+        await terminal.exitCopyMode();
+        return reply.code(204).send();
+      } catch (error) {
+        return deps.handleAgentError(reply, error);
+      }
+    }
+  );
+
   app.get(
     "/api/v1/agents/:id/terminal/ws",
     { websocket: true },
@@ -902,11 +926,17 @@ export async function registerAgentRoutes(
         return;
       }
 
+      const tmuxTerminal = new TmuxTerminal(tmuxSession);
       const cols = Number(query.cols ?? 140);
       const rows = Number(query.rows ?? 42);
       const ptyProcess = spawnPty(
-        "tmux",
-        ["attach-session", "-t", tmuxSession],
+        "sh",
+        [
+          "-lc",
+          `printf '${TMUX_CLIENT_TTY_MARKER}%s\n' "$(tty)"; exec tmux attach-session -t "$1"`,
+          "dispatch-terminal",
+          tmuxSession,
+        ],
         {
           name: "xterm-256color",
           cols: Number.isFinite(cols) ? cols : 140,
@@ -920,8 +950,43 @@ export async function registerAgentRoutes(
         }
       };
 
+      let tmuxClientTarget: string | null = null;
+      let ttyProbeResolved = false;
+      let ttyProbeBuffer = "";
       ptyProcess.onData((data) => {
-        sendJson({ type: "output", data });
+        if (ttyProbeResolved) {
+          sendJson({ type: "output", data });
+          return;
+        }
+
+        ttyProbeBuffer += data;
+        const markerLineEnd = ttyProbeBuffer.indexOf("\n");
+        if (markerLineEnd === -1) {
+          return;
+        }
+
+        const firstLine = ttyProbeBuffer
+          .slice(0, markerLineEnd)
+          .replace(/\r$/, "");
+        const remainder = ttyProbeBuffer.slice(markerLineEnd + 1);
+        ttyProbeResolved = true;
+        ttyProbeBuffer = "";
+
+        if (firstLine.startsWith(TMUX_CLIENT_TTY_MARKER)) {
+          const ttyMatch = firstLine
+            .slice(TMUX_CLIENT_TTY_MARKER.length)
+            .match(/\/dev\/[^\s]+/);
+          const tty = ttyMatch?.[0]?.trim() ?? "";
+          if (tty.length > 0) {
+            tmuxClientTarget = tty;
+          }
+        } else {
+          sendJson({ type: "output", data: firstLine });
+        }
+
+        if (remainder) {
+          sendJson({ type: "output", data: remainder });
+        }
       });
 
       ptyProcess.onExit((event) => {
@@ -932,6 +997,21 @@ export async function registerAgentRoutes(
       const heartbeatTimer = setInterval(() => {
         sendJson({ type: "heartbeat", ts: Date.now() });
       }, 20_000);
+      let lastTmuxStateKey: string | null = null;
+      const publishTmuxState = async (): Promise<void> => {
+        const target = tmuxClientTarget ?? tmuxTerminal.sessionTarget();
+        const state = await tmuxTerminal.getCopyModeState(target);
+        const nextKey = `${state.inCopyMode}:${state.scrollPosition ?? ""}`;
+        if (nextKey === lastTmuxStateKey) {
+          return;
+        }
+        lastTmuxStateKey = nextKey;
+        sendJson({ type: "tmux_state", ...state });
+      };
+      await publishTmuxState();
+      const tmuxStatePollTimer = setInterval(() => {
+        void publishTmuxState();
+      }, 250);
 
       socket.on("message", (buffer) => {
         const message = decodeClientMessage(buffer);
@@ -957,6 +1037,7 @@ export async function registerAgentRoutes(
 
       socket.on("close", () => {
         clearInterval(heartbeatTimer);
+        clearInterval(tmuxStatePollTimer);
         try {
           ptyProcess.kill();
         } catch {}

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -6,13 +6,14 @@ import type { Pool } from "pg";
 import type WebSocket from "ws";
 
 import type { AgentManager, AgentRecord } from "../agents/manager.js";
+import { getCopyModeAssistEnabled } from "../copy-mode-assist-settings.js";
 import {
   CLI_AGENT_TYPES,
   getEnabledAgentTypes,
 } from "../agent-type-settings.js";
 import { getSetting } from "../db/settings.js";
-import { runCommand } from "../shared/lib/run-command.js";
 import { spawn as spawnPty } from "../shared/terminal/bun-pty.js";
+import { CopyModeAssistManager } from "../terminal/copy-mode-assist-manager.js";
 import {
   type CopyModeObserverManager,
   type TerminalUiState,
@@ -28,7 +29,6 @@ import {
   parseOptionalStringArrayField,
 } from "./agent-startup.js";
 const AGENT_INITIAL_PROMPT_MAX_CHARS = 16_000;
-const COPY_MODE_ASSIST_ENABLED_KEY = "copy_mode_assist_enabled";
 const COPY_MODE_ASSIST_DISABLED_ERROR = "Copy mode assist is disabled.";
 const AGENT_LATEST_EVENT_TYPES = [
   "working",
@@ -71,7 +71,7 @@ type AgentRouteDeps = {
   issueTerminalToken: (agentId: string) => string;
   consumeTerminalToken: (agentId: string, token: string) => boolean;
   copyModeObserverManager: CopyModeObserverManager;
-  registerCopyModeAssistDisableHandler: (handler: () => Promise<void>) => void;
+  copyModeAssistManager: CopyModeAssistManager;
   onArchivedAgentsDeleted: (deletedIds: string[]) => void;
   onArchiveError: (agentId: string, error: unknown) => void;
   trackArchivePromise: (agentId: string, archivePromise: Promise<void>) => void;
@@ -136,104 +136,9 @@ export async function registerAgentRoutes(
   app: FastifyInstance,
   deps: AgentRouteDeps
 ): Promise<void> {
-  const activeAssistSessions = new Map<
-    string,
-    {
-      sessionName: string;
-      originalMouseMode: "on" | "off" | null;
-      connections: Set<string>;
-    }
-  >();
-  const activeAssistConnections = new Map<
-    string,
-    {
-      sessionName: string;
-      deactivate: () => void;
-    }
-  >();
-
-  // Ensure tmux's mouse mode is on so wheel/touch events drive tmux's
-  // copy-mode scrollback. tmux defaults to mouse=off on a fresh session;
-  // call once per attach. Best-effort: the agent works without it,
-  // scrolling just doesn't.
-  const enableTmuxMouseMode = async (
-    sessionName: string
-  ): Promise<"on" | "off" | null> => {
-    const terminal = new TmuxTerminal(sessionName);
-    const originalMode = await terminal.getMouseMode();
-    try {
-      await terminal.setMouseMode("on");
-    } catch {
-      // ignore — tmux may have raced with shutdown
-    }
-    return originalMode;
-  };
-
-  const restoreTmuxMouseMode = async (
-    sessionName: string,
-    originalMode: "on" | "off" | null
-  ): Promise<void> => {
-    try {
-      const terminal = new TmuxTerminal(sessionName);
-      await terminal.setMouseMode(originalMode ?? "off");
-    } catch {
-      // ignore — tmux may have raced with shutdown
-    }
-  };
-
-  const registerAssistConnection = (
-    connectionId: string,
-    sessionName: string,
-    originalMouseMode: "on" | "off" | null,
-    deactivate: () => void
-  ): void => {
-    const session = activeAssistSessions.get(sessionName) ?? {
-      sessionName,
-      originalMouseMode,
-      connections: new Set<string>(),
-    };
-    if (!activeAssistSessions.has(sessionName)) {
-      activeAssistSessions.set(sessionName, session);
-    }
-    session.connections.add(connectionId);
-    activeAssistConnections.set(connectionId, {
-      sessionName,
-      deactivate,
-    });
-  };
-
-  const unregisterAssistConnection = async (
-    connectionId: string
-  ): Promise<void> => {
-    const connection = activeAssistConnections.get(connectionId);
-    if (!connection) {
-      return;
-    }
-    activeAssistConnections.delete(connectionId);
-    connection.deactivate();
-    const session = activeAssistSessions.get(connection.sessionName);
-    if (!session) {
-      return;
-    }
-    session.connections.delete(connectionId);
-    if (session.connections.size > 0) {
-      return;
-    }
-    activeAssistSessions.delete(connection.sessionName);
-    await restoreTmuxMouseMode(session.sessionName, session.originalMouseMode);
-  };
-
   const isCopyModeAssistEnabled = async (): Promise<boolean> => {
-    const raw = await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY);
-    return raw === "true";
+    return getCopyModeAssistEnabled(deps.pool);
   };
-
-  deps.registerCopyModeAssistDisableHandler(async () => {
-    const connectionIds = [...activeAssistConnections.keys()];
-    await Promise.all(
-      connectionIds.map((id) => unregisterAssistConnection(id))
-    );
-  });
 
   app.get("/api/v1/agents", async () => {
     const agents = await deps.agentManager.listAgents();
@@ -1074,33 +979,29 @@ export async function registerAgentRoutes(
       }
 
       let tmuxSession: string;
-      let copyModeAssistEnabled = false;
-      let assistConnectionId: string | null = null;
+      const assistState = {
+        activeRef: { current: false },
+        connectionId: null as string | null,
+      };
       try {
         const access = await deps.agentManager.getTerminalAccess(agentId);
         if (access.mode !== "tmux") {
           throw new Error(access.message);
         }
         tmuxSession = access.sessionName;
-        copyModeAssistEnabled = await isCopyModeAssistEnabled();
-        if (copyModeAssistEnabled) {
-          assistConnectionId = randomUUID();
-          const originalMouseMode = await enableTmuxMouseMode(tmuxSession);
+        if (await isCopyModeAssistEnabled()) {
           const detachCopyModeViewer =
             deps.copyModeObserverManager.attachViewer(
               agentId,
               tmuxSession,
               randomUUID()
             );
-          registerAssistConnection(
-            assistConnectionId,
+          const assistConnection = await deps.copyModeAssistManager.attach(
             tmuxSession,
-            originalMouseMode,
-            () => {
-              copyModeAssistEnabled = false;
-              detachCopyModeViewer();
-            }
+            detachCopyModeViewer
           );
+          assistState.activeRef = assistConnection.activeRef;
+          assistState.connectionId = assistConnection.connectionId;
         }
       } catch (error) {
         const message =
@@ -1167,7 +1068,7 @@ export async function registerAgentRoutes(
         }
 
         if (message.type === "interaction") {
-          if (copyModeAssistEnabled) {
+          if (assistState.activeRef.current) {
             deps.copyModeObserverManager.noteInteraction(
               agentId,
               tmuxSession,
@@ -1179,8 +1080,8 @@ export async function registerAgentRoutes(
 
       socket.on("close", () => {
         clearInterval(heartbeatTimer);
-        if (assistConnectionId) {
-          void unregisterAssistConnection(assistConnectionId);
+        if (assistState.connectionId) {
+          void deps.copyModeAssistManager.detach(assistState.connectionId);
         }
         try {
           ptyProcess.kill();

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -28,6 +28,8 @@ import {
   parseOptionalStringArrayField,
 } from "./agent-startup.js";
 const AGENT_INITIAL_PROMPT_MAX_CHARS = 16_000;
+const COPY_MODE_ASSIST_ENABLED_KEY = "copy_mode_assist_enabled";
+const COPY_MODE_ASSIST_DISABLED_ERROR = "Copy mode assist is disabled.";
 const AGENT_LATEST_EVENT_TYPES = [
   "working",
   "blocked",
@@ -69,6 +71,7 @@ type AgentRouteDeps = {
   issueTerminalToken: (agentId: string) => string;
   consumeTerminalToken: (agentId: string, token: string) => boolean;
   copyModeObserverManager: CopyModeObserverManager;
+  registerCopyModeAssistDisableHandler: (handler: () => Promise<void>) => void;
   onArchivedAgentsDeleted: (deletedIds: string[]) => void;
   onArchiveError: (agentId: string, error: unknown) => void;
   trackArchivePromise: (agentId: string, archivePromise: Promise<void>) => void;
@@ -133,21 +136,104 @@ export async function registerAgentRoutes(
   app: FastifyInstance,
   deps: AgentRouteDeps
 ): Promise<void> {
+  const activeAssistSessions = new Map<
+    string,
+    {
+      sessionName: string;
+      originalMouseMode: "on" | "off" | null;
+      connections: Set<string>;
+    }
+  >();
+  const activeAssistConnections = new Map<
+    string,
+    {
+      sessionName: string;
+      deactivate: () => void;
+    }
+  >();
+
   // Ensure tmux's mouse mode is on so wheel/touch events drive tmux's
   // copy-mode scrollback. tmux defaults to mouse=off on a fresh session;
   // call once per attach. Best-effort: the agent works without it,
   // scrolling just doesn't.
-  const enableTmuxMouseMode = async (sessionName: string): Promise<void> => {
+  const enableTmuxMouseMode = async (
+    sessionName: string
+  ): Promise<"on" | "off" | null> => {
+    const terminal = new TmuxTerminal(sessionName);
+    const originalMode = await terminal.getMouseMode();
     try {
-      await runCommand(
-        "tmux",
-        ["set-option", "-t", sessionName, "mouse", "on"],
-        { allowedExitCodes: [0, 1] }
-      );
+      await terminal.setMouseMode("on");
+    } catch {
+      // ignore — tmux may have raced with shutdown
+    }
+    return originalMode;
+  };
+
+  const restoreTmuxMouseMode = async (
+    sessionName: string,
+    originalMode: "on" | "off" | null
+  ): Promise<void> => {
+    try {
+      const terminal = new TmuxTerminal(sessionName);
+      await terminal.setMouseMode(originalMode ?? "off");
     } catch {
       // ignore — tmux may have raced with shutdown
     }
   };
+
+  const registerAssistConnection = (
+    connectionId: string,
+    sessionName: string,
+    originalMouseMode: "on" | "off" | null,
+    deactivate: () => void
+  ): void => {
+    const session = activeAssistSessions.get(sessionName) ?? {
+      sessionName,
+      originalMouseMode,
+      connections: new Set<string>(),
+    };
+    if (!activeAssistSessions.has(sessionName)) {
+      activeAssistSessions.set(sessionName, session);
+    }
+    session.connections.add(connectionId);
+    activeAssistConnections.set(connectionId, {
+      sessionName,
+      deactivate,
+    });
+  };
+
+  const unregisterAssistConnection = async (
+    connectionId: string
+  ): Promise<void> => {
+    const connection = activeAssistConnections.get(connectionId);
+    if (!connection) {
+      return;
+    }
+    activeAssistConnections.delete(connectionId);
+    connection.deactivate();
+    const session = activeAssistSessions.get(connection.sessionName);
+    if (!session) {
+      return;
+    }
+    session.connections.delete(connectionId);
+    if (session.connections.size > 0) {
+      return;
+    }
+    activeAssistSessions.delete(connection.sessionName);
+    await restoreTmuxMouseMode(session.sessionName, session.originalMouseMode);
+  };
+
+  const isCopyModeAssistEnabled = async (): Promise<boolean> => {
+    const raw = await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY);
+    return raw === "true";
+  };
+
+  deps.registerCopyModeAssistDisableHandler(async () => {
+    const connectionIds = [...activeAssistConnections.keys()];
+    await Promise.all(
+      connectionIds.map((id) => unregisterAssistConnection(id))
+    );
+  });
 
   app.get("/api/v1/agents", async () => {
     const agents = await deps.agentManager.listAgents();
@@ -881,6 +967,11 @@ export async function registerAgentRoutes(
       const id = params.id ?? "";
 
       try {
+        if (!(await isCopyModeAssistEnabled())) {
+          return reply
+            .code(409)
+            .send({ error: COPY_MODE_ASSIST_DISABLED_ERROR });
+        }
         const access = await deps.agentManager.getTerminalAccess(id);
         if (access.mode !== "tmux") {
           return reply.code(409).send({ error: access.message });
@@ -905,6 +996,9 @@ export async function registerAgentRoutes(
     const id = params.id ?? "";
 
     try {
+      if (!(await isCopyModeAssistEnabled())) {
+        return reply.code(409).send({ error: COPY_MODE_ASSIST_DISABLED_ERROR });
+      }
       const access = await deps.agentManager.getTerminalAccess(id);
       if (access.mode !== "tmux") {
         return reply.code(409).send({ error: access.message });
@@ -933,6 +1027,11 @@ export async function registerAgentRoutes(
       }
 
       try {
+        if (!(await isCopyModeAssistEnabled())) {
+          return reply
+            .code(409)
+            .send({ error: COPY_MODE_ASSIST_DISABLED_ERROR });
+        }
         const access = await deps.agentManager.getTerminalAccess(id);
         if (access.mode !== "tmux") {
           return reply.code(409).send({ error: access.message });
@@ -975,13 +1074,34 @@ export async function registerAgentRoutes(
       }
 
       let tmuxSession: string;
+      let copyModeAssistEnabled = false;
+      let assistConnectionId: string | null = null;
       try {
         const access = await deps.agentManager.getTerminalAccess(agentId);
         if (access.mode !== "tmux") {
           throw new Error(access.message);
         }
         tmuxSession = access.sessionName;
-        await enableTmuxMouseMode(tmuxSession);
+        copyModeAssistEnabled = await isCopyModeAssistEnabled();
+        if (copyModeAssistEnabled) {
+          assistConnectionId = randomUUID();
+          const originalMouseMode = await enableTmuxMouseMode(tmuxSession);
+          const detachCopyModeViewer =
+            deps.copyModeObserverManager.attachViewer(
+              agentId,
+              tmuxSession,
+              randomUUID()
+            );
+          registerAssistConnection(
+            assistConnectionId,
+            tmuxSession,
+            originalMouseMode,
+            () => {
+              copyModeAssistEnabled = false;
+              detachCopyModeViewer();
+            }
+          );
+        }
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Terminal attach failed.";
@@ -989,11 +1109,6 @@ export async function registerAgentRoutes(
         socket.close(1011, "attach failed");
         return;
       }
-      const detachCopyModeViewer = deps.copyModeObserverManager.attachViewer(
-        agentId,
-        tmuxSession,
-        randomUUID()
-      );
       const cols = Number(query.cols ?? 140);
       const rows = Number(query.rows ?? 42);
       const ptyProcess = spawnPty(
@@ -1052,17 +1167,21 @@ export async function registerAgentRoutes(
         }
 
         if (message.type === "interaction") {
-          deps.copyModeObserverManager.noteInteraction(
-            agentId,
-            tmuxSession,
-            message.interaction
-          );
+          if (copyModeAssistEnabled) {
+            deps.copyModeObserverManager.noteInteraction(
+              agentId,
+              tmuxSession,
+              message.interaction
+            );
+          }
         }
       });
 
       socket.on("close", () => {
         clearInterval(heartbeatTimer);
-        detachCopyModeViewer();
+        if (assistConnectionId) {
+          void unregisterAssistConnection(assistConnectionId);
+        }
         try {
           ptyProcess.kill();
         } catch {}

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 import type { FastifyBaseLogger, FastifyInstance, FastifyReply } from "fastify";
 import type { Pool } from "pg";
@@ -12,6 +13,10 @@ import {
 import { getSetting } from "../db/settings.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import { spawn as spawnPty } from "../shared/terminal/bun-pty.js";
+import {
+  type CopyModeObserverManager,
+  type TerminalUiState,
+} from "../terminal/copy-mode-observer.js";
 import { TmuxTerminal } from "../terminal/tmux-terminal.js";
 import {
   type CreateAgentBody,
@@ -63,6 +68,7 @@ type AgentRouteDeps = {
   ) => () => void;
   issueTerminalToken: (agentId: string) => string;
   consumeTerminalToken: (agentId: string, token: string) => boolean;
+  copyModeObserverManager: CopyModeObserverManager;
   onArchivedAgentsDeleted: (deletedIds: string[]) => void;
   onArchiveError: (agentId: string, error: unknown) => void;
   trackArchivePromise: (agentId: string, archivePromise: Promise<void>) => void;
@@ -82,6 +88,7 @@ function decodeClientMessage(
 ):
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number }
+  | { type: "interaction"; interaction: "scroll" | "exit_copy_mode" }
   | null {
   try {
     const asString = typeof buffer === "string" ? buffer : buffer.toString();
@@ -90,6 +97,7 @@ function decodeClientMessage(
       data?: unknown;
       cols?: unknown;
       rows?: unknown;
+      interaction?: unknown;
     };
     if (parsed.type === "input" && typeof parsed.data === "string") {
       return { type: "input", data: parsed.data };
@@ -104,6 +112,13 @@ function decodeClientMessage(
         cols: parsed.cols,
         rows: parsed.rows,
       };
+    }
+    if (
+      parsed.type === "interaction" &&
+      (parsed.interaction === "scroll" ||
+        parsed.interaction === "exit_copy_mode")
+    ) {
+      return { type: "interaction", interaction: parsed.interaction };
     }
     return null;
   } catch {
@@ -137,8 +152,6 @@ export async function registerAgentRoutes(
       // ignore — tmux may have raced with shutdown
     }
   };
-
-  const TMUX_CLIENT_TTY_MARKER = "__DISPATCH_TMUX_CLIENT_TTY__";
 
   app.get("/api/v1/agents", async () => {
     const agents = await deps.agentManager.listAgents();
@@ -877,8 +890,68 @@ export async function registerAgentRoutes(
           return reply.code(409).send({ error: access.message });
         }
 
+        deps.copyModeObserverManager.noteInteraction(
+          id,
+          access.sessionName,
+          "exit_copy_mode"
+        );
         const terminal = new TmuxTerminal(access.sessionName);
         await terminal.exitCopyMode();
+        return reply.code(204).send();
+      } catch (error) {
+        return deps.handleAgentError(reply, error);
+      }
+    }
+  );
+
+  app.get("/api/v1/agents/:id/terminal/state", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    try {
+      const access = await deps.agentManager.getTerminalAccess(id);
+      if (access.mode !== "tmux") {
+        return reply.code(409).send({ error: access.message });
+      }
+
+      return {
+        terminalState: await deps.copyModeObserverManager.getState(
+          id,
+          access.sessionName
+        ),
+      };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+
+  app.post(
+    "/api/v1/agents/:id/terminal/interaction",
+    async (request, reply) => {
+      const params = request.params as { id?: string };
+      const body = request.body as { interaction?: unknown };
+      const id = params.id ?? "";
+
+      if (
+        body?.interaction !== "scroll" &&
+        body?.interaction !== "exit_copy_mode"
+      ) {
+        return reply
+          .code(400)
+          .send({ error: "interaction must be 'scroll' or 'exit_copy_mode'." });
+      }
+
+      try {
+        const access = await deps.agentManager.getTerminalAccess(id);
+        if (access.mode !== "tmux") {
+          return reply.code(409).send({ error: access.message });
+        }
+
+        deps.copyModeObserverManager.noteInteraction(
+          id,
+          access.sessionName,
+          body.interaction
+        );
         return reply.code(204).send();
       } catch (error) {
         return deps.handleAgentError(reply, error);
@@ -925,15 +998,18 @@ export async function registerAgentRoutes(
         socket.close(1011, "attach failed");
         return;
       }
-
-      const tmuxTerminal = new TmuxTerminal(tmuxSession);
+      const detachCopyModeViewer = deps.copyModeObserverManager.attachViewer(
+        agentId,
+        tmuxSession,
+        randomUUID()
+      );
       const cols = Number(query.cols ?? 140);
       const rows = Number(query.rows ?? 42);
       const ptyProcess = spawnPty(
         "sh",
         [
           "-lc",
-          `printf '${TMUX_CLIENT_TTY_MARKER}%s\n' "$(tty)"; exec tmux attach-session -t "$1"`,
+          `exec tmux attach-session -t "$1"`,
           "dispatch-terminal",
           tmuxSession,
         ],
@@ -949,44 +1025,8 @@ export async function registerAgentRoutes(
           socket.send(JSON.stringify(payload));
         }
       };
-
-      let tmuxClientTarget: string | null = null;
-      let ttyProbeResolved = false;
-      let ttyProbeBuffer = "";
       ptyProcess.onData((data) => {
-        if (ttyProbeResolved) {
-          sendJson({ type: "output", data });
-          return;
-        }
-
-        ttyProbeBuffer += data;
-        const markerLineEnd = ttyProbeBuffer.indexOf("\n");
-        if (markerLineEnd === -1) {
-          return;
-        }
-
-        const firstLine = ttyProbeBuffer
-          .slice(0, markerLineEnd)
-          .replace(/\r$/, "");
-        const remainder = ttyProbeBuffer.slice(markerLineEnd + 1);
-        ttyProbeResolved = true;
-        ttyProbeBuffer = "";
-
-        if (firstLine.startsWith(TMUX_CLIENT_TTY_MARKER)) {
-          const ttyMatch = firstLine
-            .slice(TMUX_CLIENT_TTY_MARKER.length)
-            .match(/\/dev\/[^\s]+/);
-          const tty = ttyMatch?.[0]?.trim() ?? "";
-          if (tty.length > 0) {
-            tmuxClientTarget = tty;
-          }
-        } else {
-          sendJson({ type: "output", data: firstLine });
-        }
-
-        if (remainder) {
-          sendJson({ type: "output", data: remainder });
-        }
+        sendJson({ type: "output", data });
       });
 
       ptyProcess.onExit((event) => {
@@ -997,21 +1037,6 @@ export async function registerAgentRoutes(
       const heartbeatTimer = setInterval(() => {
         sendJson({ type: "heartbeat", ts: Date.now() });
       }, 20_000);
-      let lastTmuxStateKey: string | null = null;
-      const publishTmuxState = async (): Promise<void> => {
-        const target = tmuxClientTarget ?? tmuxTerminal.sessionTarget();
-        const state = await tmuxTerminal.getCopyModeState(target);
-        const nextKey = `${state.inCopyMode}:${state.scrollPosition ?? ""}`;
-        if (nextKey === lastTmuxStateKey) {
-          return;
-        }
-        lastTmuxStateKey = nextKey;
-        sendJson({ type: "tmux_state", ...state });
-      };
-      await publishTmuxState();
-      const tmuxStatePollTimer = setInterval(() => {
-        void publishTmuxState();
-      }, 250);
 
       socket.on("message", (buffer) => {
         const message = decodeClientMessage(buffer);
@@ -1032,12 +1057,21 @@ export async function registerAgentRoutes(
           if (message.cols > 0 && message.rows > 0) {
             ptyProcess.resize(message.cols, message.rows);
           }
+          return;
+        }
+
+        if (message.type === "interaction") {
+          deps.copyModeObserverManager.noteInteraction(
+            agentId,
+            tmuxSession,
+            message.interaction
+          );
         }
       });
 
       socket.on("close", () => {
         clearInterval(heartbeatTimer);
-        clearInterval(tmuxStatePollTimer);
+        detachCopyModeViewer();
         try {
           ptyProcess.kill();
         } catch {}

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -23,7 +23,17 @@ import { shouldSkipAutomaticMacPathProbe } from "../shared/mac-path-privacy.js";
 
 const WORKTREE_LOCATION_KEY = "worktree_location";
 const INSTANCE_NAME_KEY = "instance_name";
+const COPY_MODE_ASSIST_ENABLED_KEY = "copy_mode_assist_enabled";
 const VALID_WORKTREE_LOCATIONS = ["sibling", "nested"] as const;
+
+function parseBooleanSetting(
+  value: string | null,
+  defaultValue: boolean
+): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return defaultValue;
+}
 
 function resolveTildePath(raw: string): string {
   if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
@@ -76,6 +86,8 @@ type SystemRouteDeps = {
   gitContextRefreshConcurrency: number;
   percentile: (sortedValues: number[], quantile: number) => number | null;
   toIso: (epochMs: number | null) => string | null;
+  publishUiEvent: (event: unknown) => void;
+  onCopyModeAssistDisabled: () => Promise<void>;
 };
 
 export async function registerSystemRoutes(
@@ -316,10 +328,15 @@ export async function registerSystemRoutes(
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
+    const copyModeAssistEnabled = parseBooleanSetting(
+      await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY),
+      false
+    );
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),
       instanceName,
+      copyModeAssistEnabled,
     };
   });
 
@@ -328,6 +345,7 @@ export async function registerSystemRoutes(
       worktreeLocation?: unknown;
       iconColor?: unknown;
       instanceName?: unknown;
+      copyModeAssistEnabled?: unknown;
     };
 
     if (body.worktreeLocation !== undefined) {
@@ -371,16 +389,45 @@ export async function registerSystemRoutes(
       }
     }
 
+    if (body.copyModeAssistEnabled !== undefined) {
+      if (typeof body.copyModeAssistEnabled !== "boolean") {
+        return reply.code(400).send({
+          error: "copyModeAssistEnabled must be a boolean.",
+        });
+      }
+      const previousValue = parseBooleanSetting(
+        await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY),
+        false
+      );
+      await setSetting(
+        deps.pool,
+        COPY_MODE_ASSIST_ENABLED_KEY,
+        String(body.copyModeAssistEnabled)
+      );
+      deps.publishUiEvent({
+        type: "app.settings_changed",
+        setting: "copyModeAssistEnabled",
+      });
+      if (previousValue && !body.copyModeAssistEnabled) {
+        await deps.onCopyModeAssistDisabled();
+      }
+    }
+
     const raw = await getSetting(deps.pool, WORKTREE_LOCATION_KEY);
     const worktreeLocation =
       raw && (VALID_WORKTREE_LOCATIONS as readonly string[]).includes(raw)
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
+    const copyModeAssistEnabled = parseBooleanSetting(
+      await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY),
+      false
+    );
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),
       instanceName,
+      copyModeAssistEnabled,
     };
   });
 

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -6,6 +6,11 @@ import { readdir, stat, unlink, writeFile } from "node:fs/promises";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import type { Pool } from "pg";
 
+import {
+  COPY_MODE_ASSIST_ENABLED_KEY,
+  getCopyModeAssistEnabled,
+  parseBooleanSetting,
+} from "../copy-mode-assist-settings.js";
 import { deleteSetting, getSetting, setSetting } from "../db/settings.js";
 import { JobService } from "../jobs/service.js";
 import {
@@ -23,17 +28,7 @@ import { shouldSkipAutomaticMacPathProbe } from "../shared/mac-path-privacy.js";
 
 const WORKTREE_LOCATION_KEY = "worktree_location";
 const INSTANCE_NAME_KEY = "instance_name";
-const COPY_MODE_ASSIST_ENABLED_KEY = "copy_mode_assist_enabled";
 const VALID_WORKTREE_LOCATIONS = ["sibling", "nested"] as const;
-
-function parseBooleanSetting(
-  value: string | null,
-  defaultValue: boolean
-): boolean {
-  if (value === "true") return true;
-  if (value === "false") return false;
-  return defaultValue;
-}
 
 function resolveTildePath(raw: string): string {
   if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
@@ -87,7 +82,9 @@ type SystemRouteDeps = {
   percentile: (sortedValues: number[], quantile: number) => number | null;
   toIso: (epochMs: number | null) => string | null;
   publishUiEvent: (event: unknown) => void;
-  onCopyModeAssistDisabled: () => Promise<void>;
+  copyModeAssistManager: {
+    disableAll: () => Promise<void>;
+  };
 };
 
 export async function registerSystemRoutes(
@@ -328,10 +325,7 @@ export async function registerSystemRoutes(
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
-    const copyModeAssistEnabled = parseBooleanSetting(
-      await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY),
-      false
-    );
+    const copyModeAssistEnabled = await getCopyModeAssistEnabled(deps.pool);
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),
@@ -404,12 +398,9 @@ export async function registerSystemRoutes(
         COPY_MODE_ASSIST_ENABLED_KEY,
         String(body.copyModeAssistEnabled)
       );
-      deps.publishUiEvent({
-        type: "app.settings_changed",
-        setting: "copyModeAssistEnabled",
-      });
+      deps.publishUiEvent({ type: "agents.settings_changed" });
       if (previousValue && !body.copyModeAssistEnabled) {
-        await deps.onCopyModeAssistDisabled();
+        await deps.copyModeAssistManager.disableAll();
       }
     }
 
@@ -419,10 +410,7 @@ export async function registerSystemRoutes(
         ? raw
         : "sibling";
     const instanceName = (await getSetting(deps.pool, INSTANCE_NAME_KEY)) ?? "";
-    const copyModeAssistEnabled = parseBooleanSetting(
-      await getSetting(deps.pool, COPY_MODE_ASSIST_ENABLED_KEY),
-      false
-    );
+    const copyModeAssistEnabled = await getCopyModeAssistEnabled(deps.pool);
     return {
       worktreeLocation,
       iconColor: deps.getCachedIconColor(),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -85,6 +85,7 @@ import {
 import { JobNotifier } from "./notifications/job-notifier.js";
 import { FocusTracker } from "./focus-tracker.js";
 import { CopyModeObserverManager } from "./terminal/copy-mode-observer.js";
+import { CopyModeAssistManager } from "./terminal/copy-mode-assist-manager.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { JobService } from "./jobs/service.js";
@@ -149,18 +150,14 @@ const agentManager = new AgentManager(pool, app.log, config);
 const focusTracker = new FocusTracker();
 const slackNotifier = new SlackNotifier(pool, app.log);
 slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
+const uiEventBroker = new UiEventBroker();
 const terminalTokenStore = new TerminalTokenStore(60_000);
 const copyModeObserverManager = new CopyModeObserverManager((event) =>
   uiEventBroker.publish(event as UiEvent)
 );
-let onCopyModeAssistDisabled = async () => {};
-const registerCopyModeAssistDisableHandler = (handler: () => Promise<void>) => {
-  onCopyModeAssistDisabled = handler;
-};
+const copyModeAssistManager = new CopyModeAssistManager();
 const jobService = new JobService(pool, agentManager, app.log, config);
 const jobNotifier = new JobNotifier(pool, app.log);
-
-const uiEventBroker = new UiEventBroker();
 const streamManager = new StreamManager(
   (agentId, event) => {
     uiEventBroker.publish(
@@ -460,7 +457,7 @@ async function registerRoutes() {
     percentile,
     toIso,
     publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
-    onCopyModeAssistDisabled: () => onCopyModeAssistDisabled(),
+    copyModeAssistManager,
   });
 
   await registerActivityRoutes(app, {
@@ -546,7 +543,7 @@ async function registerRoutes() {
     consumeTerminalToken: (agentId, token) =>
       terminalTokenStore.consume(agentId, token),
     copyModeObserverManager,
-    registerCopyModeAssistDisableHandler,
+    copyModeAssistManager,
     onArchivedAgentsDeleted: (deletedIds) =>
       agentLifecycleRuntime.onArchivedAgentsDeleted(deletedIds),
     onArchiveError: (agentId, error) =>

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -84,6 +84,7 @@ import {
 } from "./notifications/slack.js";
 import { JobNotifier } from "./notifications/job-notifier.js";
 import { FocusTracker } from "./focus-tracker.js";
+import { CopyModeObserverManager } from "./terminal/copy-mode-observer.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { JobService } from "./jobs/service.js";
@@ -149,6 +150,9 @@ const focusTracker = new FocusTracker();
 const slackNotifier = new SlackNotifier(pool, app.log);
 slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 const terminalTokenStore = new TerminalTokenStore(60_000);
+const copyModeObserverManager = new CopyModeObserverManager((event) =>
+  uiEventBroker.publish(event as UiEvent)
+);
 const jobService = new JobService(pool, agentManager, app.log, config);
 const jobNotifier = new JobNotifier(pool, app.log);
 
@@ -535,6 +539,7 @@ async function registerRoutes() {
     issueTerminalToken: (agentId) => terminalTokenStore.issue(agentId),
     consumeTerminalToken: (agentId, token) =>
       terminalTokenStore.consume(agentId, token),
+    copyModeObserverManager,
     onArchivedAgentsDeleted: (deletedIds) =>
       agentLifecycleRuntime.onArchivedAgentsDeleted(deletedIds),
     onArchiveError: (agentId, error) =>

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -153,6 +153,10 @@ const terminalTokenStore = new TerminalTokenStore(60_000);
 const copyModeObserverManager = new CopyModeObserverManager((event) =>
   uiEventBroker.publish(event as UiEvent)
 );
+let onCopyModeAssistDisabled = async () => {};
+const registerCopyModeAssistDisableHandler = (handler: () => Promise<void>) => {
+  onCopyModeAssistDisabled = handler;
+};
 const jobService = new JobService(pool, agentManager, app.log, config);
 const jobNotifier = new JobNotifier(pool, app.log);
 
@@ -455,6 +459,8 @@ async function registerRoutes() {
     gitContextRefreshConcurrency: GIT_CONTEXT_REFRESH_CONCURRENCY,
     percentile,
     toIso,
+    publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
+    onCopyModeAssistDisabled: () => onCopyModeAssistDisabled(),
   });
 
   await registerActivityRoutes(app, {
@@ -540,6 +546,7 @@ async function registerRoutes() {
     consumeTerminalToken: (agentId, token) =>
       terminalTokenStore.consume(agentId, token),
     copyModeObserverManager,
+    registerCopyModeAssistDisableHandler,
     onArchivedAgentsDeleted: (deletedIds) =>
       agentLifecycleRuntime.onArchivedAgentsDeleted(deletedIds),
     onArchiveError: (agentId, error) =>

--- a/apps/server/src/server/ui-events.ts
+++ b/apps/server/src/server/ui-events.ts
@@ -1,8 +1,14 @@
 import type { AgentRecord, FeedbackRecord } from "../agents/manager.js";
+import type { TerminalUiState } from "../terminal/copy-mode-observer.js";
 
 export type UiEvent =
   | { type: "snapshot"; agents: AgentRecord[] }
   | { type: "agent.upsert"; agent: AgentRecord }
+  | {
+      type: "agent.terminal_state_changed";
+      agentId: string;
+      terminalState: TerminalUiState;
+    }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }
   | { type: "media.seen"; agentId: string; keys: string[] }

--- a/apps/server/src/terminal/copy-mode-assist-manager.ts
+++ b/apps/server/src/terminal/copy-mode-assist-manager.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from "node:crypto";
+
+import { TmuxTerminal } from "./tmux-terminal.js";
+
+type ActiveAssistSession = {
+  connections: Set<string>;
+  originalMouseMode: "on" | "off" | null;
+};
+
+type ActiveAssistConnection = {
+  activeRef: { current: boolean };
+  deactivate: () => void;
+  sessionName: string;
+};
+
+export class CopyModeAssistManager {
+  private readonly sessions = new Map<string, ActiveAssistSession>();
+  private readonly connections = new Map<string, ActiveAssistConnection>();
+
+  async attach(
+    sessionName: string,
+    deactivate: () => void
+  ): Promise<{ activeRef: { current: boolean }; connectionId: string }> {
+    const connectionId = randomUUID();
+    const activeRef = { current: true };
+    let session = this.sessions.get(sessionName);
+
+    if (!session) {
+      const terminal = new TmuxTerminal(sessionName);
+      const originalMouseMode = await terminal.getMouseMode();
+      try {
+        await terminal.setMouseMode("on");
+      } catch {
+        // ignore — tmux may have raced with shutdown
+      }
+
+      session = {
+        connections: new Set(),
+        originalMouseMode,
+      };
+      this.sessions.set(sessionName, session);
+    }
+
+    session.connections.add(connectionId);
+    this.connections.set(connectionId, {
+      activeRef,
+      deactivate,
+      sessionName,
+    });
+
+    return { activeRef, connectionId };
+  }
+
+  async detach(connectionId: string): Promise<void> {
+    const connection = this.connections.get(connectionId);
+    if (!connection) return;
+
+    this.connections.delete(connectionId);
+    connection.activeRef.current = false;
+    connection.deactivate();
+
+    const session = this.sessions.get(connection.sessionName);
+    if (!session) return;
+
+    session.connections.delete(connectionId);
+    if (session.connections.size > 0) return;
+
+    this.sessions.delete(connection.sessionName);
+    try {
+      const terminal = new TmuxTerminal(connection.sessionName);
+      await terminal.setMouseMode(session.originalMouseMode ?? "off");
+    } catch {
+      // ignore — tmux may have raced with shutdown
+    }
+  }
+
+  async disableAll(): Promise<void> {
+    const connectionIds = [...this.connections.keys()];
+    await Promise.all(connectionIds.map((id) => this.detach(id)));
+  }
+}

--- a/apps/server/src/terminal/copy-mode-observer.ts
+++ b/apps/server/src/terminal/copy-mode-observer.ts
@@ -62,23 +62,7 @@ export class CopyModeObserverManager {
           clearTimeout(current.pollTimer);
           current.pollTimer = null;
         }
-        if (current.cleanupTimer) {
-          clearTimeout(current.cleanupTimer);
-        }
-        current.cleanupTimer = setTimeout(() => {
-          const latest = this.observers.get(sessionName);
-          if (!latest || latest.viewers.size > 0) {
-            return;
-          }
-          latest.cleanupTimer = null;
-          latest.boostedUntil = 0;
-          latest.exitPendingUntil = 0;
-          if (latest.pollTimer) {
-            clearTimeout(latest.pollTimer);
-            latest.pollTimer = null;
-          }
-          this.observers.delete(sessionName);
-        }, DETACH_GRACE_MS);
+        this.scheduleObserverCleanup(current);
       }
     };
   }
@@ -89,6 +73,7 @@ export class CopyModeObserverManager {
   ): Promise<TerminalUiState> {
     const observer = this.getOrCreateObserver(agentId, sessionName);
     await this.poll(observer);
+    this.scheduleObserverCleanup(observer);
     return observer.state;
   }
 
@@ -121,7 +106,10 @@ export class CopyModeObserverManager {
 
     if (observer.viewers.size > 0) {
       this.requestImmediatePoll(observer);
+      return;
     }
+
+    this.scheduleObserverCleanup(observer);
   }
 
   private getOrCreateObserver(
@@ -160,6 +148,31 @@ export class CopyModeObserverManager {
       observer.pollTimer = null;
     }
     void this.poll(observer);
+  }
+
+  private scheduleObserverCleanup(observer: SessionObserver): void {
+    if (observer.viewers.size > 0) {
+      return;
+    }
+
+    if (observer.cleanupTimer) {
+      clearTimeout(observer.cleanupTimer);
+    }
+
+    observer.cleanupTimer = setTimeout(() => {
+      const latest = this.observers.get(observer.sessionName);
+      if (!latest || latest.viewers.size > 0) {
+        return;
+      }
+      latest.cleanupTimer = null;
+      latest.boostedUntil = 0;
+      latest.exitPendingUntil = 0;
+      if (latest.pollTimer) {
+        clearTimeout(latest.pollTimer);
+        latest.pollTimer = null;
+      }
+      this.observers.delete(observer.sessionName);
+    }, DETACH_GRACE_MS);
   }
 
   private scheduleNextPoll(observer: SessionObserver): void {

--- a/apps/server/src/terminal/copy-mode-observer.ts
+++ b/apps/server/src/terminal/copy-mode-observer.ts
@@ -1,0 +1,245 @@
+import { TmuxTerminal } from "./tmux-terminal.js";
+
+export type TerminalCopyMode = "live" | "copy" | "exiting";
+
+export type TerminalUiState = {
+  copyMode: TerminalCopyMode;
+  lastObservedAt: number;
+};
+
+type InteractionType = "scroll" | "exit_copy_mode";
+
+type PublishTerminalState = (event: {
+  type: "agent.terminal_state_changed";
+  agentId: string;
+  terminalState: TerminalUiState;
+}) => void;
+
+type SessionObserver = {
+  agentId: string;
+  sessionName: string;
+  terminal: TmuxTerminal;
+  viewers: Set<string>;
+  state: TerminalUiState;
+  lastPublishedKey: string | null;
+  boostedUntil: number;
+  exitPendingUntil: number;
+  cleanupTimer: NodeJS.Timeout | null;
+  pollTimer: NodeJS.Timeout | null;
+  pollInFlight: Promise<void> | null;
+};
+
+const STABLE_POLL_MS = 1_250;
+const ACTIVE_POLL_MS = 250;
+const INTERACTION_BOOST_MS = 1_500;
+const EXIT_PENDING_MS = 2_000;
+const DETACH_GRACE_MS = 2_000;
+
+export class CopyModeObserverManager {
+  private readonly observers = new Map<string, SessionObserver>();
+
+  constructor(private readonly publishTerminalState: PublishTerminalState) {}
+
+  attachViewer(
+    agentId: string,
+    sessionName: string,
+    viewerId: string
+  ): () => void {
+    const observer = this.getOrCreateObserver(agentId, sessionName);
+    if (observer.cleanupTimer) {
+      clearTimeout(observer.cleanupTimer);
+      observer.cleanupTimer = null;
+    }
+    observer.viewers.add(viewerId);
+    this.requestImmediatePoll(observer);
+
+    return () => {
+      const current = this.observers.get(sessionName);
+      if (!current) return;
+      current.viewers.delete(viewerId);
+      if (current.viewers.size === 0) {
+        if (current.pollTimer) {
+          clearTimeout(current.pollTimer);
+          current.pollTimer = null;
+        }
+        if (current.cleanupTimer) {
+          clearTimeout(current.cleanupTimer);
+        }
+        current.cleanupTimer = setTimeout(() => {
+          const latest = this.observers.get(sessionName);
+          if (!latest || latest.viewers.size > 0) {
+            return;
+          }
+          latest.cleanupTimer = null;
+          latest.boostedUntil = 0;
+          latest.exitPendingUntil = 0;
+          if (latest.pollTimer) {
+            clearTimeout(latest.pollTimer);
+            latest.pollTimer = null;
+          }
+          this.observers.delete(sessionName);
+        }, DETACH_GRACE_MS);
+      }
+    };
+  }
+
+  async getState(
+    agentId: string,
+    sessionName: string
+  ): Promise<TerminalUiState> {
+    const observer = this.getOrCreateObserver(agentId, sessionName);
+    await this.poll(observer);
+    return observer.state;
+  }
+
+  noteInteraction(
+    agentId: string,
+    sessionName: string,
+    interaction: InteractionType
+  ): void {
+    const observer = this.getOrCreateObserver(agentId, sessionName);
+    const now = Date.now();
+    if (interaction === "scroll") {
+      observer.boostedUntil = Math.max(
+        observer.boostedUntil,
+        now + INTERACTION_BOOST_MS
+      );
+    } else {
+      observer.boostedUntil = Math.max(
+        observer.boostedUntil,
+        now + EXIT_PENDING_MS
+      );
+      observer.exitPendingUntil = Math.max(
+        observer.exitPendingUntil,
+        now + EXIT_PENDING_MS
+      );
+      this.updateState(observer, {
+        copyMode: "exiting",
+        lastObservedAt: observer.state.lastObservedAt || now,
+      });
+    }
+
+    if (observer.viewers.size > 0) {
+      this.requestImmediatePoll(observer);
+    }
+  }
+
+  private getOrCreateObserver(
+    agentId: string,
+    sessionName: string
+  ): SessionObserver {
+    const existing = this.observers.get(sessionName);
+    if (existing) {
+      existing.agentId = agentId;
+      return existing;
+    }
+
+    const observer: SessionObserver = {
+      agentId,
+      sessionName,
+      terminal: new TmuxTerminal(sessionName),
+      viewers: new Set(),
+      state: {
+        copyMode: "live",
+        lastObservedAt: 0,
+      },
+      lastPublishedKey: null,
+      boostedUntil: 0,
+      exitPendingUntil: 0,
+      cleanupTimer: null,
+      pollTimer: null,
+      pollInFlight: null,
+    };
+    this.observers.set(sessionName, observer);
+    return observer;
+  }
+
+  private requestImmediatePoll(observer: SessionObserver): void {
+    if (observer.pollTimer) {
+      clearTimeout(observer.pollTimer);
+      observer.pollTimer = null;
+    }
+    void this.poll(observer);
+  }
+
+  private scheduleNextPoll(observer: SessionObserver): void {
+    if (observer.viewers.size === 0) {
+      if (observer.pollTimer) {
+        clearTimeout(observer.pollTimer);
+        observer.pollTimer = null;
+      }
+      return;
+    }
+
+    if (observer.pollTimer) {
+      clearTimeout(observer.pollTimer);
+    }
+
+    const now = Date.now();
+    const shouldPollFast =
+      observer.state.copyMode !== "live" || observer.boostedUntil > now;
+    observer.pollTimer = setTimeout(
+      () => {
+        observer.pollTimer = null;
+        void this.poll(observer);
+      },
+      shouldPollFast ? ACTIVE_POLL_MS : STABLE_POLL_MS
+    );
+  }
+
+  private async poll(observer: SessionObserver): Promise<void> {
+    if (observer.pollInFlight) {
+      await observer.pollInFlight;
+      return;
+    }
+
+    observer.pollInFlight = (async () => {
+      const observedAt = Date.now();
+      const state = await observer.terminal.getCopyModeState();
+      const now = Date.now();
+
+      if (!state.inCopyMode) {
+        observer.exitPendingUntil = 0;
+        this.updateState(observer, {
+          copyMode: "live",
+          lastObservedAt: observedAt,
+        });
+      } else if (observer.exitPendingUntil > now) {
+        this.updateState(observer, {
+          copyMode: "exiting",
+          lastObservedAt: observedAt,
+        });
+      } else {
+        observer.exitPendingUntil = 0;
+        this.updateState(observer, {
+          copyMode: "copy",
+          lastObservedAt: observedAt,
+        });
+      }
+    })();
+
+    try {
+      await observer.pollInFlight;
+    } finally {
+      observer.pollInFlight = null;
+      this.scheduleNextPoll(observer);
+    }
+  }
+
+  private updateState(
+    observer: SessionObserver,
+    nextState: TerminalUiState
+  ): void {
+    observer.state = nextState;
+    const nextKey = nextState.copyMode;
+    if (nextKey === observer.lastPublishedKey) {
+      return;
+    }
+    observer.lastPublishedKey = nextKey;
+    this.publishTerminalState({
+      type: "agent.terminal_state_changed",
+      agentId: observer.agentId,
+      terminalState: nextState,
+    });
+  }
+}

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -15,10 +15,6 @@ export class TmuxTerminal {
     this.sessionName = sessionName;
   }
 
-  sessionTarget(): string {
-    return this.sessionName;
-  }
-
   async hasSession(): Promise<boolean> {
     const result = await runCommand(
       "tmux",
@@ -48,106 +44,23 @@ export class TmuxTerminal {
 
   async getCopyModeState(): Promise<{
     inCopyMode: boolean;
-    scrollPosition: number | null;
-  }>;
-  async getCopyModeState(target: string): Promise<{
-    inCopyMode: boolean;
-    scrollPosition: number | null;
-  }>;
-  async getCopyModeState(target = this.sessionName): Promise<{
-    inCopyMode: boolean;
-    scrollPosition: number | null;
   }> {
     try {
       const result = await runCommand(
         "tmux",
-        [
-          "display-message",
-          "-p",
-          "-t",
-          target,
-          `#{pane_in_mode}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{scroll_position}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_key_table}`,
-        ],
+        ["display-message", "-p", "-t", this.sessionName, "#{pane_in_mode}"],
         { allowedExitCodes: [0, 1] }
       );
 
       if (result.exitCode !== 0) {
-        return { inCopyMode: false, scrollPosition: null };
+        return { inCopyMode: false };
       }
 
-      return TmuxTerminal.parseCopyModeStateOutput(result.stdout);
+      return {
+        inCopyMode: result.stdout.trim() === "1",
+      };
     } catch {
-      return { inCopyMode: false, scrollPosition: null };
-    }
-  }
-
-  static parseCopyModeStateOutput(stdout: string): {
-    inCopyMode: boolean;
-    scrollPosition: number | null;
-  } {
-    const normalized = stdout.trim();
-    const [paneInModeRaw = "0", scrollPositionRaw = ""] = normalized.split(
-      TmuxTerminal.COPY_MODE_STATE_DELIMITER,
-      3
-    );
-    const scrollPositionValue = scrollPositionRaw.trim();
-    const parsedScrollPosition =
-      scrollPositionValue.length > 0
-        ? Number.parseInt(scrollPositionValue, 10)
-        : Number.NaN;
-
-    return {
-      inCopyMode: paneInModeRaw.trim() === "1",
-      scrollPosition: Number.isFinite(parsedScrollPosition)
-        ? parsedScrollPosition
-        : null,
-    };
-  }
-
-  async listClients(): Promise<
-    Array<{
-      tty: string;
-      createdAt: number | null;
-      activityAt: number | null;
-    }>
-  > {
-    try {
-      const result = await runCommand(
-        "tmux",
-        [
-          "list-clients",
-          "-t",
-          this.sessionName,
-          "-F",
-          `#{client_tty}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_created}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_activity}`,
-        ],
-        { allowedExitCodes: [0, 1] }
-      );
-
-      if (result.exitCode !== 0) {
-        return [];
-      }
-
-      return result.stdout
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0)
-        .map((line) => {
-          const [tty = "", createdAtRaw = "", activityAtRaw = ""] = line.split(
-            TmuxTerminal.COPY_MODE_STATE_DELIMITER,
-            3
-          );
-          const createdAt = Number.parseInt(createdAtRaw, 10);
-          const activityAt = Number.parseInt(activityAtRaw, 10);
-          return {
-            tty,
-            createdAt: Number.isFinite(createdAt) ? createdAt : null,
-            activityAt: Number.isFinite(activityAt) ? activityAt : null,
-          };
-        })
-        .filter((client) => client.tty.length > 0);
-    } catch {
-      return [];
+      return { inCopyMode: false };
     }
   }
 

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -6,12 +6,17 @@ import { runCommand } from "../shared/lib/run-command.js";
 export class TmuxTerminal {
   private static readonly SUBMIT_SETTLE_MS = 150;
   private static readonly RETRY_SUBMIT_BYTES = 4 * 1024;
+  private static readonly COPY_MODE_STATE_DELIMITER = ":::";
   private static readonly PASTED_TEXT_LINE =
     /^\[Pasted text #[0-9]+(?: \+[0-9]+ lines)?\]$/i;
   private readonly sessionName: string;
 
   constructor(sessionName: string) {
     this.sessionName = sessionName;
+  }
+
+  sessionTarget(): string {
+    return this.sessionName;
   }
 
   async hasSession(): Promise<boolean> {
@@ -39,6 +44,117 @@ export class TmuxTerminal {
     ]);
 
     return result.stdout;
+  }
+
+  async getCopyModeState(): Promise<{
+    inCopyMode: boolean;
+    scrollPosition: number | null;
+  }>;
+  async getCopyModeState(target: string): Promise<{
+    inCopyMode: boolean;
+    scrollPosition: number | null;
+  }>;
+  async getCopyModeState(target = this.sessionName): Promise<{
+    inCopyMode: boolean;
+    scrollPosition: number | null;
+  }> {
+    try {
+      const result = await runCommand(
+        "tmux",
+        [
+          "display-message",
+          "-p",
+          "-t",
+          target,
+          `#{pane_in_mode}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{scroll_position}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_key_table}`,
+        ],
+        { allowedExitCodes: [0, 1] }
+      );
+
+      if (result.exitCode !== 0) {
+        return { inCopyMode: false, scrollPosition: null };
+      }
+
+      return TmuxTerminal.parseCopyModeStateOutput(result.stdout);
+    } catch {
+      return { inCopyMode: false, scrollPosition: null };
+    }
+  }
+
+  static parseCopyModeStateOutput(stdout: string): {
+    inCopyMode: boolean;
+    scrollPosition: number | null;
+  } {
+    const normalized = stdout.trim();
+    const [paneInModeRaw = "0", scrollPositionRaw = ""] = normalized.split(
+      TmuxTerminal.COPY_MODE_STATE_DELIMITER,
+      3
+    );
+    const scrollPositionValue = scrollPositionRaw.trim();
+    const parsedScrollPosition =
+      scrollPositionValue.length > 0
+        ? Number.parseInt(scrollPositionValue, 10)
+        : Number.NaN;
+
+    return {
+      inCopyMode: paneInModeRaw.trim() === "1",
+      scrollPosition: Number.isFinite(parsedScrollPosition)
+        ? parsedScrollPosition
+        : null,
+    };
+  }
+
+  async listClients(): Promise<
+    Array<{
+      tty: string;
+      createdAt: number | null;
+      activityAt: number | null;
+    }>
+  > {
+    try {
+      const result = await runCommand(
+        "tmux",
+        [
+          "list-clients",
+          "-t",
+          this.sessionName,
+          "-F",
+          `#{client_tty}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_created}${TmuxTerminal.COPY_MODE_STATE_DELIMITER}#{client_activity}`,
+        ],
+        { allowedExitCodes: [0, 1] }
+      );
+
+      if (result.exitCode !== 0) {
+        return [];
+      }
+
+      return result.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((line) => {
+          const [tty = "", createdAtRaw = "", activityAtRaw = ""] = line.split(
+            TmuxTerminal.COPY_MODE_STATE_DELIMITER,
+            3
+          );
+          const createdAt = Number.parseInt(createdAtRaw, 10);
+          const activityAt = Number.parseInt(activityAtRaw, 10);
+          return {
+            tty,
+            createdAt: Number.isFinite(createdAt) ? createdAt : null,
+            activityAt: Number.isFinite(activityAt) ? activityAt : null,
+          };
+        })
+        .filter((client) => client.tty.length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  async exitCopyMode(): Promise<void> {
+    await runCommand("tmux", ["copy-mode", "-q", "-t", this.sessionName], {
+      allowedExitCodes: [0, 1],
+    });
   }
 
   private findLastPasteMarker(paneText: string): string | null {
@@ -89,9 +205,7 @@ export class TmuxTerminal {
     // If the pane is in tmux copy mode, paste-buffer + Enter does not reach
     // the program until copy mode is cancelled. Exit it first so injections
     // land on the live prompt.
-    await runCommand("tmux", ["copy-mode", "-q", "-t", this.sessionName], {
-      allowedExitCodes: [0, 1],
-    }).catch(() => undefined);
+    await this.exitCopyMode().catch(() => undefined);
     await runCommand("tmux", ["set-buffer", "-b", bufferName, sanitized]);
     try {
       await runCommand("tmux", [

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -157,6 +157,31 @@ export class TmuxTerminal {
     });
   }
 
+  async getMouseMode(): Promise<"on" | "off" | null> {
+    try {
+      const result = await runCommand(
+        "tmux",
+        ["show-options", "-qv", "-t", this.sessionName, "mouse"],
+        { allowedExitCodes: [0, 1] }
+      );
+      const value = result.stdout.trim();
+      if (value === "on" || value === "off") {
+        return value;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async setMouseMode(mode: "on" | "off"): Promise<void> {
+    await runCommand(
+      "tmux",
+      ["set-option", "-t", this.sessionName, "mouse", mode],
+      { allowedExitCodes: [0, 1] }
+    );
+  }
+
   private findLastPasteMarker(paneText: string): string | null {
     const lines = paneText
       .split("\n")

--- a/apps/server/test/api-validation.test.ts
+++ b/apps/server/test/api-validation.test.ts
@@ -269,21 +269,9 @@ describe("POST /api/v1/notifications/ack", () => {
 
 describe("POST /api/v1/agents/:id/terminal/interaction", () => {
   it("rejects exit_copy_mode on the generic interaction route", async () => {
-    const createRes = await app.inject({
-      method: "POST",
-      url: "/api/v1/agents",
-      payload: {
-        name: `unit-${Date.now()}`,
-        type: "terminal",
-        cwd: "/tmp",
-        useWorktree: false,
-      },
-    });
-    const agentId = createRes.json().agent.id as string;
-
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/agents/${agentId}/terminal/interaction`,
+      url: "/api/v1/agents/agt_validation_stub/terminal/interaction",
       payload: { interaction: "exit_copy_mode" },
     });
 

--- a/apps/server/test/api-validation.test.ts
+++ b/apps/server/test/api-validation.test.ts
@@ -267,6 +267,33 @@ describe("POST /api/v1/notifications/ack", () => {
   });
 });
 
+describe("POST /api/v1/agents/:id/terminal/interaction", () => {
+  it("rejects exit_copy_mode on the generic interaction route", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents",
+      payload: {
+        name: `unit-${Date.now()}`,
+        type: "terminal",
+        cwd: "/tmp",
+        useWorktree: false,
+      },
+    });
+    const agentId = createRes.json().agent.id as string;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${agentId}/terminal/interaction`,
+      payload: { interaction: "exit_copy_mode" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: "interaction must be 'scroll'.",
+    });
+  });
+});
+
 describe("POST /api/v1/focus", () => {
   it("rejects empty-string agentId", async () => {
     const res = await app.inject({

--- a/apps/server/test/copy-mode-observer.test.ts
+++ b/apps/server/test/copy-mode-observer.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCopyModeStateMock =
+  vi.fn<
+    () => Promise<{ inCopyMode: boolean; scrollPosition: number | null }>
+  >();
+
+vi.mock("../src/terminal/tmux-terminal.js", () => ({
+  TmuxTerminal: class {
+    constructor(_sessionName: string) {}
+
+    async getCopyModeState() {
+      return getCopyModeStateMock();
+    }
+  },
+}));
+
+const { CopyModeObserverManager } =
+  await import("../src/terminal/copy-mode-observer.js");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getCopyModeStateMock.mockReset();
+  getCopyModeStateMock.mockResolvedValue({
+    inCopyMode: false,
+    scrollPosition: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function flushObserver(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("CopyModeObserverManager", () => {
+  it("publishes only on copy-mode changes", async () => {
+    const events: Array<{
+      agentId: string;
+      terminalState: { copyMode: string };
+    }> = [];
+    const manager = new CopyModeObserverManager((event) => {
+      events.push(event);
+    });
+
+    const detach = manager.attachViewer("agent-1", "session-1", "viewer-1");
+    await flushObserver();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "agent.terminal_state_changed",
+        agentId: "agent-1",
+        terminalState: expect.objectContaining({ copyMode: "live" }),
+      }),
+    ]);
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(events).toHaveLength(1);
+    detach();
+  });
+
+  it("holds exiting until tmux confirms live mode", async () => {
+    let inCopyMode = true;
+    getCopyModeStateMock.mockImplementation(async () => ({
+      inCopyMode,
+      scrollPosition: null,
+    }));
+
+    const events: string[] = [];
+    const manager = new CopyModeObserverManager((event) => {
+      events.push(event.terminalState.copyMode);
+    });
+
+    const detach = manager.attachViewer("agent-1", "session-1", "viewer-1");
+    await flushObserver();
+    expect(events).toEqual(["copy"]);
+
+    manager.noteInteraction("agent-1", "session-1", "exit_copy_mode");
+    expect(events).toEqual(["copy", "exiting"]);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(events).toEqual(["copy", "exiting"]);
+
+    inCopyMode = false;
+    await vi.advanceTimersByTimeAsync(300);
+    expect(events).toEqual(["copy", "exiting", "live"]);
+    detach();
+  });
+
+  it("stops polling after the final viewer detaches", async () => {
+    const manager = new CopyModeObserverManager(() => {});
+
+    const detach = manager.attachViewer("agent-1", "session-1", "viewer-1");
+    await flushObserver();
+    expect(getCopyModeStateMock).toHaveBeenCalledTimes(1);
+
+    detach();
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(getCopyModeStateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves exit-pending state across a quick reattach", async () => {
+    let inCopyMode = true;
+    getCopyModeStateMock.mockImplementation(async () => ({
+      inCopyMode,
+      scrollPosition: null,
+    }));
+
+    const events: string[] = [];
+    const manager = new CopyModeObserverManager((event) => {
+      events.push(event.terminalState.copyMode);
+    });
+
+    const detachFirst = manager.attachViewer(
+      "agent-1",
+      "session-1",
+      "viewer-1"
+    );
+    await flushObserver();
+    expect(events).toEqual(["copy"]);
+
+    manager.noteInteraction("agent-1", "session-1", "exit_copy_mode");
+    expect(events).toEqual(["copy", "exiting"]);
+
+    detachFirst();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const detachSecond = manager.attachViewer(
+      "agent-1",
+      "session-1",
+      "viewer-2"
+    );
+    await flushObserver();
+    expect(events).toEqual(["copy", "exiting"]);
+
+    inCopyMode = false;
+    await vi.advanceTimersByTimeAsync(300);
+    expect(events).toEqual(["copy", "exiting", "live"]);
+    detachSecond();
+  });
+});

--- a/apps/server/test/copy-mode-observer.test.ts
+++ b/apps/server/test/copy-mode-observer.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const getCopyModeStateMock =
-  vi.fn<
-    () => Promise<{ inCopyMode: boolean; scrollPosition: number | null }>
-  >();
+const getCopyModeStateMock = vi.fn<() => Promise<{ inCopyMode: boolean }>>();
 
 vi.mock("../src/terminal/tmux-terminal.js", () => ({
   TmuxTerminal: class {
@@ -23,7 +20,6 @@ beforeEach(() => {
   getCopyModeStateMock.mockReset();
   getCopyModeStateMock.mockResolvedValue({
     inCopyMode: false,
-    scrollPosition: null,
   });
 });
 
@@ -66,7 +62,6 @@ describe("CopyModeObserverManager", () => {
     let inCopyMode = true;
     getCopyModeStateMock.mockImplementation(async () => ({
       inCopyMode,
-      scrollPosition: null,
     }));
 
     const events: string[] = [];
@@ -106,7 +101,6 @@ describe("CopyModeObserverManager", () => {
     let inCopyMode = true;
     getCopyModeStateMock.mockImplementation(async () => ({
       inCopyMode,
-      scrollPosition: null,
     }));
 
     const events: string[] = [];

--- a/apps/server/test/copy-mode-observer.test.ts
+++ b/apps/server/test/copy-mode-observer.test.ts
@@ -141,4 +141,17 @@ describe("CopyModeObserverManager", () => {
     expect(events).toEqual(["copy", "exiting", "live"]);
     detachSecond();
   });
+
+  it("evicts no-viewer observers created by state reads", async () => {
+    const manager = new CopyModeObserverManager(() => {});
+
+    await manager.getState("agent-1", "session-1");
+    expect(getCopyModeStateMock).toHaveBeenCalledTimes(1);
+
+    getCopyModeStateMock.mockClear();
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    await manager.getState("agent-1", "session-1");
+    expect(getCopyModeStateMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -275,6 +275,7 @@ export function AgentsView({
     terminalMode,
     terminalPlaceholderMessage,
     inCopyMode,
+    copyMode,
     statusMessage,
     terminalHostRef,
     ctrlPendingRef,
@@ -738,6 +739,7 @@ export function AgentsView({
                 terminalMode={terminalMode}
                 terminalPlaceholderMessage={terminalPlaceholderMessage}
                 inCopyMode={inCopyMode}
+                copyMode={copyMode}
                 exitCopyMode={() => {
                   void exitCopyMode();
                 }}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -274,6 +274,7 @@ export function AgentsView({
     connectedAgentId,
     terminalMode,
     terminalPlaceholderMessage,
+    inCopyMode,
     statusMessage,
     terminalHostRef,
     ctrlPendingRef,
@@ -281,6 +282,7 @@ export function AgentsView({
     ensureTerminalConnected,
     detachTerminal,
     sendTerminalInput,
+    exitCopyMode,
     resyncing,
   } = useTerminal({
     authState: "authenticated",
@@ -735,6 +737,10 @@ export function AgentsView({
                 statusMessage={statusMessage}
                 terminalMode={terminalMode}
                 terminalPlaceholderMessage={terminalPlaceholderMessage}
+                inCopyMode={inCopyMode}
+                exitCopyMode={() => {
+                  void exitCopyMode();
+                }}
                 terminalHostRef={terminalHostRef}
                 resyncing={resyncing}
                 archivePhase={

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -19,6 +19,7 @@ import {
   MediaSidebarContent,
   MEDIA_SIDEBAR_SETTLE_FALLBACK_MS,
 } from "@/components/app/media-sidebar";
+import { TerminalCopyModeBannerLayer } from "@/components/app/terminal-copy-mode-banner";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
 import { SidebarShell, type NavSection } from "@/components/app/sidebar-shell";
 import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
@@ -274,7 +275,6 @@ export function AgentsView({
     connectedAgentId,
     terminalMode,
     terminalPlaceholderMessage,
-    inCopyMode,
     copyMode,
     statusMessage,
     terminalHostRef,
@@ -683,74 +683,82 @@ export function AgentsView({
               }
             }}
           >
-            {!leftPanelOpen ? (
-              <div className="pointer-events-none absolute left-3 top-3 z-10">
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="pointer-events-auto"
-                  onClick={() => handleSetLeftPanelOpen(true)}
-                  title="Open sidebar"
-                >
-                  <PanelRightOpen className="h-4 w-4" />
-                </Button>
-              </div>
-            ) : null}
-
-            <div className="relative min-h-0 min-w-0 pb-14 pt-14">
-              {focusedAgent?.name ? (
-                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
-                  <div
-                    data-testid="current-session-name"
-                    className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
-                  >
-                    {focusedAgent.name}
-                  </div>
-                </div>
-              ) : null}
-              {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
-                <div className="pointer-events-none absolute right-3 top-3 z-10">
+            <div className="relative h-full min-h-0 min-w-0">
+              {!leftPanelOpen ? (
+                <div className="pointer-events-none absolute left-3 top-3 z-10">
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="pointer-events-auto relative"
-                    onClick={() => setMediaOpen(true)}
-                    title="Open media sidebar"
-                    data-testid="toggle-media-sidebar"
+                    className="pointer-events-auto"
+                    onClick={() => handleSetLeftPanelOpen(true)}
+                    title="Open sidebar"
                   >
-                    <PanelLeftOpen className="h-4 w-4" />
-                    {unseenMediaCount > 0 ? (
-                      <span className="absolute -right-1.5 -top-1.5 min-w-5 rounded-full border border-border bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
-                        {unseenMediaCount}
-                      </span>
-                    ) : null}
+                    <PanelRightOpen className="h-4 w-4" />
                   </Button>
                 </div>
               ) : null}
-              {connState === "reconnecting" ? (
-                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
-                  <div className="dispatch-reconnect-scan h-full w-1/3 will-change-transform bg-[linear-gradient(to_right,transparent,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)),transparent)] saturate-[1.35] brightness-[1.05] animate-[reconnect-scan_1350ms_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:translate-x-[140%]" />
+              <div className="relative h-full min-h-0 min-w-0 pb-14 pt-14">
+                {focusedAgent?.name ? (
+                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
+                    <div
+                      data-testid="current-session-name"
+                      className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
+                    >
+                      {focusedAgent.name}
+                    </div>
+                  </div>
+                ) : null}
+                {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
+                  <div className="pointer-events-none absolute right-3 top-3 z-10">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="pointer-events-auto relative"
+                      onClick={() => setMediaOpen(true)}
+                      title="Open media sidebar"
+                      data-testid="toggle-media-sidebar"
+                    >
+                      <PanelLeftOpen className="h-4 w-4" />
+                      {unseenMediaCount > 0 ? (
+                        <span className="absolute -right-1.5 -top-1.5 min-w-5 rounded-full border border-border bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+                          {unseenMediaCount}
+                        </span>
+                      ) : null}
+                    </Button>
+                  </div>
+                ) : null}
+                {connState === "reconnecting" ? (
+                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden">
+                    <div className="dispatch-reconnect-scan h-full w-1/3 will-change-transform bg-[linear-gradient(to_right,transparent,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)),transparent)] saturate-[1.35] brightness-[1.05] animate-[reconnect-scan_1350ms_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:translate-x-[140%]" />
+                  </div>
+                ) : null}
+                <TerminalPane
+                  isAttached={isAttached}
+                  connState={connState}
+                  statusMessage={statusMessage}
+                  terminalMode={terminalMode}
+                  terminalPlaceholderMessage={terminalPlaceholderMessage}
+                  terminalHostRef={terminalHostRef}
+                  resyncing={resyncing}
+                  archivePhase={
+                    selectedAgent?.status === "archiving"
+                      ? selectedAgent.archivePhase
+                      : null
+                  }
+                />
+              </div>
+
+              {!isMobile ? (
+                <div className="pointer-events-none absolute inset-x-2 bottom-2 z-20">
+                  <TerminalCopyModeBannerLayer
+                    visible={copyMode === "copy" || copyMode === "exiting"}
+                    copyMode={copyMode}
+                    onExitCopyMode={() => {
+                      void exitCopyMode();
+                    }}
+                  />
                 </div>
               ) : null}
-              <TerminalPane
-                isAttached={isAttached}
-                connState={connState}
-                statusMessage={statusMessage}
-                terminalMode={terminalMode}
-                terminalPlaceholderMessage={terminalPlaceholderMessage}
-                inCopyMode={inCopyMode}
-                copyMode={copyMode}
-                exitCopyMode={() => {
-                  void exitCopyMode();
-                }}
-                terminalHostRef={terminalHostRef}
-                resyncing={resyncing}
-                archivePhase={
-                  selectedAgent?.status === "archiving"
-                    ? selectedAgent.archivePhase
-                    : null
-                }
-              />
             </div>
 
             {!isMobile ? (
@@ -801,10 +809,14 @@ export function AgentsView({
             {isMobile ? (
               <MobileTerminalToolbar
                 onSendInput={sendTerminalInput}
+                onExitCopyMode={() => {
+                  void exitCopyMode();
+                }}
                 ctrlPendingRef={ctrlPendingRef}
                 isConnected={
                   connState === "connected" && Boolean(connectedAgentId)
                 }
+                copyMode={copyMode}
               />
             ) : null}
           </div>

--- a/apps/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/apps/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -7,6 +7,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { TerminalCopyModeBannerLayer } from "@/components/app/terminal-copy-mode-banner";
+import { type TerminalCopyMode } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import { soundCuesEnabledAtom } from "@/lib/store";
 import { playTapCue } from "@/lib/sound-cues";
@@ -14,14 +16,18 @@ import { cn } from "@/lib/utils";
 
 type MobileTerminalToolbarProps = {
   onSendInput: (data: string) => void;
+  onExitCopyMode: () => void;
   ctrlPendingRef: MutableRefObject<boolean>;
   isConnected: boolean;
+  copyMode: TerminalCopyMode | "unknown";
 };
 
 export function MobileTerminalToolbar({
   onSendInput,
+  onExitCopyMode,
   ctrlPendingRef,
   isConnected,
+  copyMode,
 }: MobileTerminalToolbarProps): JSX.Element {
   const [inputOpen, setInputOpen] = useState(false);
   const [ctrlActive, setCtrlActive] = useState(false);
@@ -122,9 +128,11 @@ export function MobileTerminalToolbar({
     setInputOpen(false);
   }, [isConnected, onSendInput, playTap]);
 
+  const pausedInput = copyMode === "copy" || copyMode === "exiting";
+
   return (
     <>
-      <div className="border-t-2 border-border bg-surface px-2 py-2 md:hidden">
+      <div className="relative border-t-2 border-border bg-surface px-2 py-2 md:hidden">
         <div className="flex min-h-[4.5rem] items-stretch gap-2">
           <div className="min-w-0 flex-1">
             <Button
@@ -277,6 +285,15 @@ export function MobileTerminalToolbar({
               Enter
             </Button>
           </div>
+        </div>
+
+        <div className="pointer-events-none absolute inset-x-2 bottom-[5.25rem]">
+          <TerminalCopyModeBannerLayer
+            visible={pausedInput}
+            copyMode={copyMode}
+            onExitCopyMode={onExitCopyMode}
+            disabled={!isConnected}
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowDownToLine,
   Bell,
@@ -24,6 +24,10 @@ import { ServiceStatus } from "@/components/app/service-status";
 import { type ServiceState } from "@/components/app/types";
 import { Checkbox } from "@/components/ui/checkbox";
 import { type IconColorId, ICON_COLOR_OPTIONS } from "@/hooks/use-icon-color";
+import {
+  AGENT_SETTINGS_QUERY_KEY,
+  useAgentSettings,
+} from "@/hooks/use-agent-settings";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useReleaseStream } from "@/hooks/use-release-stream";
 import { useRewriteLocalhostPins } from "@/hooks/use-rewrite-localhost-pins";
@@ -209,58 +213,58 @@ type WorktreeLocation = "sibling" | "nested";
 
 function CopyModeAssistSettings(): JSX.Element {
   const queryClient = useQueryClient();
-  const [enabled, setEnabled] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
+  const {
+    data: agentSettings,
+    error: queryError,
+    isLoading,
+  } = useAgentSettings();
 
-  useEffect(() => {
-    let cancelled = false;
-    void api<{ copyModeAssistEnabled: boolean }>("/api/v1/agents/settings")
-      .then((data) => {
-        if (cancelled) return;
-        setEnabled(data.copyModeAssistEnabled);
-        setError("");
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Failed to load copy mode setting."
+  const mutation = useMutation({
+    mutationFn: (nextEnabled: boolean) =>
+      api<{ copyModeAssistEnabled: boolean }>("/api/v1/agents/settings", {
+        method: "POST",
+        body: JSON.stringify({ copyModeAssistEnabled: nextEnabled }),
+      }),
+    onMutate: async (nextEnabled) => {
+      await queryClient.cancelQueries({ queryKey: AGENT_SETTINGS_QUERY_KEY });
+      const previousSettings = queryClient.getQueryData(
+        AGENT_SETTINGS_QUERY_KEY
+      );
+      queryClient.setQueryData(AGENT_SETTINGS_QUERY_KEY, (current) => ({
+        ...(typeof current === "object" && current ? current : {}),
+        copyModeAssistEnabled: nextEnabled,
+      }));
+      return { previousSettings };
+    },
+    onError: (_error, _nextEnabled, context) => {
+      if (context?.previousSettings !== undefined) {
+        queryClient.setQueryData(
+          AGENT_SETTINGS_QUERY_KEY,
+          context.previousSettings
         );
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: AGENT_SETTINGS_QUERY_KEY,
       });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    },
+  });
+
+  const enabled = agentSettings?.copyModeAssistEnabled ?? false;
+  const saving = mutation.isPending;
+  const errorMessage =
+    mutation.error instanceof Error
+      ? mutation.error.message
+      : queryError instanceof Error
+        ? queryError.message
+        : "";
 
   const handleChange = useCallback(
     async (nextEnabled: boolean) => {
-      const previous = enabled;
-      setEnabled(nextEnabled);
-      setSaving(true);
-      setError("");
-      try {
-        await api<{ copyModeAssistEnabled: boolean }>(
-          "/api/v1/agents/settings",
-          {
-            method: "POST",
-            body: JSON.stringify({ copyModeAssistEnabled: nextEnabled }),
-          }
-        );
-        await queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
-      } catch (err) {
-        setEnabled(previous);
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Failed to save copy mode setting."
-        );
-      } finally {
-        setSaving(false);
-      }
+      await mutation.mutateAsync(nextEnabled);
     },
-    [enabled, queryClient]
+    [mutation]
   );
 
   return (
@@ -276,13 +280,13 @@ function CopyModeAssistSettings(): JSX.Element {
       <label
         className={cn(
           "flex max-w-xl cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50",
-          saving && "pointer-events-none opacity-60"
+          (saving || isLoading) && "pointer-events-none opacity-60"
         )}
       >
         <Checkbox
           checked={enabled}
           onCheckedChange={(value) => void handleChange(value === true)}
-          disabled={saving}
+          disabled={saving || isLoading}
           data-testid="copy-mode-assist-toggle"
         />
         <div className="min-w-0">
@@ -295,7 +299,9 @@ function CopyModeAssistSettings(): JSX.Element {
           </div>
         </div>
       </label>
-      {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+      {errorMessage ? (
+        <p className="mt-2 text-xs text-destructive">{errorMessage}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowDownToLine,
   Bell,
@@ -205,6 +206,99 @@ function RewriteLocalhostPinsSettings(): JSX.Element {
 }
 
 type WorktreeLocation = "sibling" | "nested";
+
+function CopyModeAssistSettings(): JSX.Element {
+  const queryClient = useQueryClient();
+  const [enabled, setEnabled] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    void api<{ copyModeAssistEnabled: boolean }>("/api/v1/agents/settings")
+      .then((data) => {
+        if (cancelled) return;
+        setEnabled(data.copyModeAssistEnabled);
+        setError("");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load copy mode setting."
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    async (nextEnabled: boolean) => {
+      const previous = enabled;
+      setEnabled(nextEnabled);
+      setSaving(true);
+      setError("");
+      try {
+        await api<{ copyModeAssistEnabled: boolean }>(
+          "/api/v1/agents/settings",
+          {
+            method: "POST",
+            body: JSON.stringify({ copyModeAssistEnabled: nextEnabled }),
+          }
+        );
+        await queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
+      } catch (err) {
+        setEnabled(previous);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to save copy mode setting."
+        );
+      } finally {
+        setSaving(false);
+      }
+    },
+    [enabled, queryClient]
+  );
+
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Tmux scrollback assist
+      </div>
+      <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
+        Detect tmux copy mode, show the scrollback banner, and add a
+        return-to-live shortcut. When off, Dispatch does not change tmux mouse
+        mode or observe copy mode at all.
+      </p>
+      <label
+        className={cn(
+          "flex max-w-xl cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50",
+          saving && "pointer-events-none opacity-60"
+        )}
+      >
+        <Checkbox
+          checked={enabled}
+          onCheckedChange={(value) => void handleChange(value === true)}
+          disabled={saving}
+          data-testid="copy-mode-assist-toggle"
+        />
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            Enable tmux scrollback assist
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Off by default. Turn on the passive copy-mode banner and
+            return-to-live action.
+          </div>
+        </div>
+      </label>
+      {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}
 
 function WorktreeLocationSettings(): JSX.Element {
   const [worktreeLocation, setWorktreeLocation] =
@@ -682,6 +776,9 @@ export function SettingsContent({
         {activeSection === "agents" && (
           <div className="flex flex-col">
             <PersonalitySettings />
+            <div className="border-t border-border p-6">
+              <CopyModeAssistSettings />
+            </div>
             <div className="border-t border-border">
               <AgentTypeSettings
                 enabledAgentTypes={enabledAgentTypes}

--- a/apps/web/src/components/app/terminal-copy-mode-banner.tsx
+++ b/apps/web/src/components/app/terminal-copy-mode-banner.tsx
@@ -1,0 +1,85 @@
+import { type JSX } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { type TerminalCopyMode } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type TerminalCopyModeBannerProps = {
+  copyMode: TerminalCopyMode | "unknown";
+  onExitCopyMode: () => void;
+  className?: string;
+  compact?: boolean;
+  disabled?: boolean;
+};
+
+type TerminalCopyModeBannerLayerProps = TerminalCopyModeBannerProps & {
+  visible: boolean;
+};
+
+export function TerminalCopyModeBannerLayer({
+  visible,
+  ...props
+}: TerminalCopyModeBannerLayerProps): JSX.Element | null {
+  return (
+    <AnimatePresence initial={false}>
+      {visible ? (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 10 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+        >
+          <TerminalCopyModeBanner {...props} />
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+export function TerminalCopyModeBanner({
+  copyMode,
+  onExitCopyMode,
+  className,
+  compact = false,
+  disabled = false,
+}: TerminalCopyModeBannerProps): JSX.Element {
+  const exiting = copyMode === "exiting";
+
+  return (
+    <div
+      data-testid="terminal-copy-mode-banner"
+      className={cn(
+        "pointer-events-none flex items-center justify-between gap-4 border border-primary/35 bg-primary/30 text-foreground",
+        compact ? "px-4 py-3" : "px-4 py-3",
+        className
+      )}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-semibold">
+          {exiting
+            ? "Returning to live terminal…"
+            : "Scrollback mode. Typing is paused."}
+        </p>
+        <p className="text-xs text-foreground/75">
+          {exiting
+            ? "Waiting for tmux to confirm live mode."
+            : "Press Esc or return to live."}
+        </p>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost-primary"
+        className="pointer-events-auto shrink-0 rounded-none border border-primary/45 bg-primary/18 text-foreground hover:bg-primary/26"
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
+        onClick={onExitCopyMode}
+        disabled={disabled || exiting}
+      >
+        {exiting ? "Returning…" : "Return to live"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -11,6 +11,8 @@ type TerminalPaneProps = {
   statusMessage: string;
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
+  inCopyMode: boolean;
+  exitCopyMode: () => void;
   terminalHostRef: RefCallback<HTMLDivElement>;
   archivePhase: Agent["archivePhase"];
   resyncing: boolean;
@@ -22,6 +24,8 @@ export const TerminalPane = memo(function TerminalPane({
   statusMessage,
   terminalMode,
   terminalPlaceholderMessage,
+  inCopyMode,
+  exitCopyMode,
   terminalHostRef,
   archivePhase,
   resyncing,
@@ -44,6 +48,11 @@ export const TerminalPane = memo(function TerminalPane({
   const showEmptyState =
     connState === "disconnected" && !isAttached && !resyncing;
   const showInertState = terminalMode === "inert" && isAttached;
+  const showCopyModeBanner =
+    isAttached &&
+    connState === "connected" &&
+    terminalMode === "tmux" &&
+    inCopyMode;
 
   return (
     <div
@@ -136,6 +145,39 @@ export const TerminalPane = memo(function TerminalPane({
             <span>{statusMessage}</span>
           </div>
         </div>
+      ) : null}
+
+      {showCopyModeBanner ? (
+        <button
+          type="button"
+          data-testid="terminal-copy-mode-banner"
+          className="absolute inset-x-3 bottom-3 z-40 flex items-center justify-between gap-4 overflow-hidden rounded-xl border border-border/80 bg-[hsl(var(--surface)/0.94)] px-4 py-3 text-left text-foreground shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition hover:bg-[hsl(var(--surface)/0.98)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
+          onMouseDown={(event) => {
+            event.preventDefault();
+          }}
+          onClick={exitCopyMode}
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-primary via-primary to-chart-2"
+          />
+          <div className="flex min-w-0 items-start gap-3 pl-1">
+            <div className="mt-0.5 rounded-md border border-white/10 bg-white/5 p-1.5 text-primary">
+              <TerminalSquare className="h-3.5 w-3.5" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">
+                Viewing scrollback. Typed input is paused.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Press Esc to exit scrollback
+              </p>
+            </div>
+          </div>
+          <span className="shrink-0 rounded-md border border-white/10 bg-background/70 px-3 py-1.5 text-xs font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
+            Return to live
+          </span>
+        </button>
       ) : null}
 
       <div

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -1,7 +1,11 @@
 import { memo, type RefCallback, useEffect, useState } from "react";
 import { Archive, TerminalSquare } from "lucide-react";
 
-import { type Agent, type ConnState } from "@/components/app/types";
+import {
+  type Agent,
+  type ConnState,
+  type TerminalCopyMode,
+} from "@/components/app/types";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { cn } from "@/lib/utils";
 
@@ -12,6 +16,7 @@ type TerminalPaneProps = {
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
   inCopyMode: boolean;
+  copyMode: TerminalCopyMode | "unknown";
   exitCopyMode: () => void;
   terminalHostRef: RefCallback<HTMLDivElement>;
   archivePhase: Agent["archivePhase"];
@@ -25,6 +30,7 @@ export const TerminalPane = memo(function TerminalPane({
   terminalMode,
   terminalPlaceholderMessage,
   inCopyMode,
+  copyMode,
   exitCopyMode,
   terminalHostRef,
   archivePhase,
@@ -156,6 +162,7 @@ export const TerminalPane = memo(function TerminalPane({
             event.preventDefault();
           }}
           onClick={exitCopyMode}
+          disabled={copyMode === "exiting"}
         >
           <div
             aria-hidden="true"
@@ -167,15 +174,19 @@ export const TerminalPane = memo(function TerminalPane({
             </div>
             <div className="min-w-0">
               <p className="text-sm font-semibold">
-                Viewing scrollback. Typed input is paused.
+                {copyMode === "exiting"
+                  ? "Returning to live terminal…"
+                  : "Viewing scrollback. Typed input is paused."}
               </p>
               <p className="text-xs text-muted-foreground">
-                Press Esc to exit scrollback
+                {copyMode === "exiting"
+                  ? "Waiting for tmux to confirm live mode"
+                  : "Click to return to the live prompt"}
               </p>
             </div>
           </div>
           <span className="shrink-0 rounded-md border border-white/10 bg-background/70 px-3 py-1.5 text-xs font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
-            Return to live
+            {copyMode === "exiting" ? "Returning…" : "Return to live"}
           </span>
         </button>
       ) : null}

--- a/apps/web/src/components/app/terminal-pane.tsx
+++ b/apps/web/src/components/app/terminal-pane.tsx
@@ -1,11 +1,7 @@
 import { memo, type RefCallback, useEffect, useState } from "react";
 import { Archive, TerminalSquare } from "lucide-react";
 
-import {
-  type Agent,
-  type ConnState,
-  type TerminalCopyMode,
-} from "@/components/app/types";
+import { type Agent, type ConnState } from "@/components/app/types";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { cn } from "@/lib/utils";
 
@@ -15,9 +11,6 @@ type TerminalPaneProps = {
   statusMessage: string;
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
-  inCopyMode: boolean;
-  copyMode: TerminalCopyMode | "unknown";
-  exitCopyMode: () => void;
   terminalHostRef: RefCallback<HTMLDivElement>;
   archivePhase: Agent["archivePhase"];
   resyncing: boolean;
@@ -29,9 +22,6 @@ export const TerminalPane = memo(function TerminalPane({
   statusMessage,
   terminalMode,
   terminalPlaceholderMessage,
-  inCopyMode,
-  copyMode,
-  exitCopyMode,
   terminalHostRef,
   archivePhase,
   resyncing,
@@ -54,11 +44,6 @@ export const TerminalPane = memo(function TerminalPane({
   const showEmptyState =
     connState === "disconnected" && !isAttached && !resyncing;
   const showInertState = terminalMode === "inert" && isAttached;
-  const showCopyModeBanner =
-    isAttached &&
-    connState === "connected" &&
-    terminalMode === "tmux" &&
-    inCopyMode;
 
   return (
     <div
@@ -151,44 +136,6 @@ export const TerminalPane = memo(function TerminalPane({
             <span>{statusMessage}</span>
           </div>
         </div>
-      ) : null}
-
-      {showCopyModeBanner ? (
-        <button
-          type="button"
-          data-testid="terminal-copy-mode-banner"
-          className="absolute inset-x-3 bottom-3 z-40 flex items-center justify-between gap-4 overflow-hidden rounded-xl border border-border/80 bg-[hsl(var(--surface)/0.94)] px-4 py-3 text-left text-foreground shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition hover:bg-[hsl(var(--surface)/0.98)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
-          onMouseDown={(event) => {
-            event.preventDefault();
-          }}
-          onClick={exitCopyMode}
-          disabled={copyMode === "exiting"}
-        >
-          <div
-            aria-hidden="true"
-            className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-primary via-primary to-chart-2"
-          />
-          <div className="flex min-w-0 items-start gap-3 pl-1">
-            <div className="mt-0.5 rounded-md border border-white/10 bg-white/5 p-1.5 text-primary">
-              <TerminalSquare className="h-3.5 w-3.5" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-sm font-semibold">
-                {copyMode === "exiting"
-                  ? "Returning to live terminal…"
-                  : "Viewing scrollback. Typed input is paused."}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {copyMode === "exiting"
-                  ? "Waiting for tmux to confirm live mode"
-                  : "Click to return to the live prompt"}
-              </p>
-            </div>
-          </div>
-          <span className="shrink-0 rounded-md border border-white/10 bg-background/70 px-3 py-1.5 text-xs font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
-            {copyMode === "exiting" ? "Returning…" : "Return to live"}
-          </span>
-        </button>
       ) : null}
 
       <div

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -107,3 +107,10 @@ export type ConnState = "connected" | "reconnecting" | "disconnected";
 export type ServiceState = "ok" | "down" | "checking";
 export type AgentVisualState = "stopped" | "idle" | "active";
 export type AuthState = "loading" | "needs-login" | "authenticated" | "error";
+
+export type TerminalCopyMode = "live" | "copy" | "exiting";
+
+export type TerminalUiState = {
+  copyMode: TerminalCopyMode;
+  lastObservedAt: number;
+};

--- a/apps/web/src/hooks/use-agent-settings.ts
+++ b/apps/web/src/hooks/use-agent-settings.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+
+export type AgentSettings = {
+  copyModeAssistEnabled: boolean;
+};
+
+export const AGENT_SETTINGS_QUERY_KEY = ["agents-settings"] as const;
+
+export function useAgentSettings() {
+  return useQuery<AgentSettings>({
+    queryKey: AGENT_SETTINGS_QUERY_KEY,
+    queryFn: () => api<AgentSettings>("/api/v1/agents/settings"),
+    refetchOnWindowFocus: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -4,6 +4,7 @@ import {
   type Agent,
   type AuthState,
   type MediaFile,
+  type TerminalUiState,
 } from "@/components/app/types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
@@ -12,6 +13,11 @@ import { showWebNotification } from "@/lib/web-notifications";
 type UiEvent =
   | { type: "snapshot"; agents: Agent[] }
   | { type: "agent.upsert"; agent: Agent }
+  | {
+      type: "agent.terminal_state_changed";
+      agentId: string;
+      terminalState: TerminalUiState;
+    }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }
   | { type: "media.seen"; agentId: string; keys: string[] }
@@ -74,6 +80,14 @@ export function useSSE(authState: AuthState): void {
             next[index] = payload.agent;
             return sortAgentsByCreatedAtDesc(next);
           });
+          return;
+        }
+
+        if (payload.type === "agent.terminal_state_changed") {
+          queryClient.setQueryData<TerminalUiState>(
+            ["terminal-state", payload.agentId],
+            payload.terminalState
+          );
           return;
         }
 

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -13,7 +13,7 @@ import { showWebNotification } from "@/lib/web-notifications";
 type UiEvent =
   | { type: "snapshot"; agents: Agent[] }
   | { type: "agent.upsert"; agent: Agent }
-  | { type: "app.settings_changed"; setting: string }
+  | { type: "agents.settings_changed" }
   | {
       type: "agent.terminal_state_changed";
       agentId: string;
@@ -84,7 +84,7 @@ export function useSSE(authState: AuthState): void {
           return;
         }
 
-        if (payload.type === "app.settings_changed") {
+        if (payload.type === "agents.settings_changed") {
           void queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
           return;
         }

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -13,6 +13,7 @@ import { showWebNotification } from "@/lib/web-notifications";
 type UiEvent =
   | { type: "snapshot"; agents: Agent[] }
   | { type: "agent.upsert"; agent: Agent }
+  | { type: "app.settings_changed"; setting: string }
   | {
       type: "agent.terminal_state_changed";
       agentId: string;
@@ -80,6 +81,11 @@ export function useSSE(authState: AuthState): void {
             next[index] = payload.agent;
             return sortAgentsByCreatedAtDesc(next);
           });
+          return;
+        }
+
+        if (payload.type === "app.settings_changed") {
+          void queryClient.invalidateQueries({ queryKey: ["agents-settings"] });
           return;
         }
 

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -673,12 +673,18 @@ export function useTerminal(args: {
     resetTerminalSurface,
   ]);
 
-  const sendTerminalInput = useCallback((data: string) => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ type: "input", data }));
-    terminalRef.current?.focus();
-  }, []);
+  const sendTerminalInput = useCallback(
+    (data: string) => {
+      if (terminalMode === "tmux" && optimisticallyDismissingCopyMode) {
+        return;
+      }
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      ws.send(JSON.stringify({ type: "input", data }));
+      terminalRef.current?.focus();
+    },
+    [optimisticallyDismissingCopyMode, terminalMode]
+  );
 
   const exitCopyMode = useCallback(async () => {
     const agentId = connectedAgentIdRef.current;

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -18,6 +18,7 @@ import {
   type TerminalCopyMode,
   type TerminalUiState,
 } from "@/components/app/types";
+import { useAgentSettings } from "@/hooks/use-agent-settings";
 import { api } from "@/lib/api";
 import { recordWSReconnect } from "@/lib/energy-metrics";
 import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
@@ -34,10 +35,6 @@ type TerminalSocketMessage =
   | { type: "output"; data: string }
   | { type: "error"; message: string }
   | { type: "exit"; exitCode?: number };
-
-type AgentSettingsResponse = {
-  copyModeAssistEnabled: boolean;
-};
 
 function isTerminalSessionGone(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -177,13 +174,10 @@ export function useTerminal(args: {
   deferMediaResizeRef.current = deferMediaResize;
   const lastInteractionHintAtRef = useRef(0);
 
-  const { data: agentSettings } = useQuery<AgentSettingsResponse>({
-    queryKey: ["agents-settings"],
-    queryFn: () => api<AgentSettingsResponse>("/api/v1/agents/settings"),
-    refetchOnWindowFocus: false,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
+  const { data: agentSettings } = useAgentSettings();
   const copyModeAssistEnabled = agentSettings?.copyModeAssistEnabled ?? false;
+  const copyModeAssistEnabledRef = useRef(copyModeAssistEnabled);
+  copyModeAssistEnabledRef.current = copyModeAssistEnabled;
 
   const { data: terminalState } = useQuery<TerminalUiState>({
     queryKey: ["terminal-state", connectedAgentId],
@@ -710,7 +704,11 @@ export function useTerminal(args: {
 
   const noteScrollInteraction = useCallback(() => {
     const agentId = connectedAgentIdRef.current;
-    if (!copyModeAssistEnabled || !agentId || terminalMode !== "tmux") {
+    if (
+      !copyModeAssistEnabledRef.current ||
+      !agentId ||
+      terminalMode !== "tmux"
+    ) {
       return;
     }
     const now = Date.now();
@@ -729,7 +727,7 @@ export function useTerminal(args: {
       method: "POST",
       body: JSON.stringify({ interaction: "scroll" }),
     }).catch(() => {});
-  }, [copyModeAssistEnabled, terminalMode]);
+  }, [terminalMode]);
 
   const exitCopyMode = useCallback(async () => {
     const agentId = connectedAgentIdRef.current;
@@ -853,6 +851,7 @@ export function useTerminal(args: {
     const TOUCH_SCROLL_SENSITIVITY_PX = 30;
     const onTouchStart = (e: TouchEvent) => {
       if (!isTouchDevice || e.touches.length !== 1) return;
+      if (!copyModeAssistEnabledRef.current) return;
       touchY = e.touches[0].clientY;
       touchAccum = 0;
     };
@@ -861,6 +860,7 @@ export function useTerminal(args: {
     // wheel codes to tmux, which scrolls its own scrollback in copy-mode.
     const onTouchMove = (e: TouchEvent) => {
       if (!isTouchDevice || e.touches.length !== 1) return;
+      if (!copyModeAssistEnabledRef.current) return;
       if (!screenEl) return;
       const currentY = e.touches[0].clientY;
       const delta = touchY - currentY;
@@ -911,12 +911,10 @@ export function useTerminal(args: {
       dispatchingMouseDown = false;
     };
 
-    if (copyModeAssistEnabled) {
-      host.addEventListener("touchstart", onTouchStart, { passive: true });
-      host.addEventListener("touchmove", onTouchMove, { passive: true });
-    }
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: true });
     const onWheel = () => noteScrollInteractionRef.current();
-    if (screenEl && copyModeAssistEnabled) {
+    if (screenEl) {
       screenEl.addEventListener("mousedown", onMouseDown, true);
       screenEl.addEventListener("wheel", onWheel, { passive: true });
     }
@@ -967,11 +965,9 @@ export function useTerminal(args: {
       resizeObserver.disconnect();
       host.removeEventListener("copy", handleCopy, true);
       host.removeEventListener("paste", handlePaste, true);
-      if (copyModeAssistEnabled) {
-        host.removeEventListener("touchstart", onTouchStart);
-        host.removeEventListener("touchmove", onTouchMove);
-      }
-      if (screenEl && copyModeAssistEnabled) {
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      if (screenEl) {
         screenEl.removeEventListener("mousedown", onMouseDown, true);
         screenEl.removeEventListener("wheel", onWheel);
       }
@@ -984,13 +980,7 @@ export function useTerminal(args: {
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [
-    authState,
-    copyModeAssistEnabled,
-    invalidateAttachAttempt,
-    requestFit,
-    terminalHostElement,
-  ]);
+  }, [authState, invalidateAttachAttempt, requestFit, terminalHostElement]);
 
   // Reconnect on visibility/focus.
   useEffect(() => {

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -29,6 +29,11 @@ const SOCKET_PROBE_TIMEOUT_MS = 1_500;
 type TerminalSocketMessage =
   | { type: "heartbeat"; ts: number }
   | { type: "output"; data: string }
+  | {
+      type: "tmux_state";
+      inCopyMode: boolean;
+      scrollPosition: number | null;
+    }
   | { type: "error"; message: string }
   | { type: "exit"; exitCode?: number };
 
@@ -76,6 +81,8 @@ export function useTerminal(args: {
   connectedAgentId: string | null;
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
+  inCopyMode: boolean;
+  scrollPosition: number | null;
   statusMessage: string;
   terminalHostRef: RefCallback<HTMLDivElement>;
   ctrlPendingRef: MutableRefObject<boolean>;
@@ -87,6 +94,7 @@ export function useTerminal(args: {
   ) => Promise<void>;
   detachTerminal: () => void;
   sendTerminalInput: (data: string) => void;
+  exitCopyMode: () => Promise<void>;
   resyncing: boolean;
 } {
   const {
@@ -109,6 +117,14 @@ export function useTerminal(args: {
   const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<
     string | null
   >(null);
+  const [tmuxCopyModeState, setTmuxCopyModeState] = useState({
+    inCopyMode: false,
+    scrollPosition: null as number | null,
+  });
+  const [
+    optimisticallyDismissingCopyMode,
+    setOptimisticallyDismissingCopyMode,
+  ] = useState(false);
   const [statusMessage, setStatusMessage] = useState("Starting...");
   // True while requestFit's auto-RESYNC is in flight. Lets the UI show a
   // calm "Resizing…" overlay instead of the empty / reconnect overlays
@@ -207,6 +223,11 @@ export function useTerminal(args: {
       lastErrorMessage: null,
       sessionGone: false,
     };
+  }, []);
+
+  const resetTmuxCopyModeState = useCallback(() => {
+    setTmuxCopyModeState({ inCopyMode: false, scrollPosition: null });
+    setOptimisticallyDismissingCopyMode(false);
   }, []);
 
   const markSocketHealthy = useCallback(
@@ -327,6 +348,7 @@ export function useTerminal(args: {
   const closeSocket = useCallback(
     (announce = true) => {
       closeSocketTransport();
+      resetTmuxCopyModeState();
       setConnectedAgentId(null);
       setTerminalMode(null);
       setTerminalPlaceholderMessage(null);
@@ -336,7 +358,7 @@ export function useTerminal(args: {
         setConnState("disconnected");
       }
     },
-    [closeSocketTransport]
+    [closeSocketTransport, resetTmuxCopyModeState]
   );
 
   const ensureTerminalConnected = useCallback(
@@ -476,6 +498,7 @@ export function useTerminal(args: {
           }
 
           if (terminalSession.mode === "inert") {
+            resetTmuxCopyModeState();
             restoreConnectedState(agent, "inert", terminalSession.message);
             return;
           }
@@ -520,6 +543,20 @@ export function useTerminal(args: {
             if (payload.type === "output") {
               markSocketHealthy("output");
               terminalRef.current?.write(payload.data);
+              return;
+            }
+
+            if (payload.type === "tmux_state") {
+              setTmuxCopyModeState({
+                inCopyMode: payload.inCopyMode,
+                scrollPosition: payload.scrollPosition,
+              });
+              setOptimisticallyDismissingCopyMode((current) => {
+                if (!current) {
+                  return current;
+                }
+                return false;
+              });
               return;
             }
 
@@ -613,6 +650,7 @@ export function useTerminal(args: {
       markSocketHealthy,
       noteTerminalError,
       probeSocket,
+      resetTmuxCopyModeState,
       resetTerminalSurface,
       restoreConnectedState,
       selectedAgentId,
@@ -641,6 +679,28 @@ export function useTerminal(args: {
     ws.send(JSON.stringify({ type: "input", data }));
     terminalRef.current?.focus();
   }, []);
+
+  const exitCopyMode = useCallback(async () => {
+    const agentId = connectedAgentIdRef.current;
+    if (!agentId || terminalMode !== "tmux") {
+      return;
+    }
+
+    setOptimisticallyDismissingCopyMode(true);
+    terminalRef.current?.focus();
+    requestAnimationFrame(() => {
+      terminalRef.current?.focus();
+    });
+    try {
+      await api<null>(`/api/v1/agents/${agentId}/terminal/copy-mode/exit`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+    } catch (error) {
+      setOptimisticallyDismissingCopyMode(false);
+      throw error;
+    }
+  }, [terminalMode]);
 
   // Keep a ref so the xterm init effect can read the current theme without
   // depending on it (we don't want to re-create the terminal on theme change).
@@ -979,6 +1039,9 @@ export function useTerminal(args: {
       connectedAgentId,
       terminalMode,
       terminalPlaceholderMessage,
+      inCopyMode:
+        tmuxCopyModeState.inCopyMode && !optimisticallyDismissingCopyMode,
+      scrollPosition: tmuxCopyModeState.scrollPosition,
       statusMessage,
       terminalHostRef: setTerminalHostRef,
       ctrlPendingRef,
@@ -986,6 +1049,7 @@ export function useTerminal(args: {
       ensureTerminalConnected,
       detachTerminal,
       sendTerminalInput,
+      exitCopyMode,
       setTerminalHostRef,
       resyncing,
     }),
@@ -994,11 +1058,14 @@ export function useTerminal(args: {
       connectedAgentId,
       terminalMode,
       terminalPlaceholderMessage,
+      tmuxCopyModeState,
+      optimisticallyDismissingCopyMode,
       statusMessage,
       focusTerminal,
       ensureTerminalConnected,
       detachTerminal,
       sendTerminalInput,
+      exitCopyMode,
       setTerminalHostRef,
       resyncing,
     ]

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -134,7 +134,6 @@ export function useTerminal(args: {
     setTerminalHostElement(node);
   }, []);
   const terminalRef = useRef<XTerm | null>(null);
-  const suppressTerminalInputRef = useRef(false);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const fitDebounceRef = useRef<number | null>(null);
   const ctrlPendingRef = useRef(false);
@@ -200,8 +199,6 @@ export function useTerminal(args: {
       ? "exiting"
       : serverCopyMode;
   copyModeRef.current = copyMode;
-  suppressTerminalInputRef.current =
-    terminalMode === "tmux" && (copyMode === "copy" || copyMode === "exiting");
 
   const sendResize = useCallback(() => {
     const ws = wsRef.current;
@@ -690,9 +687,6 @@ export function useTerminal(args: {
   ]);
 
   const sendTerminalInput = useCallback((data: string) => {
-    if (suppressTerminalInputRef.current) {
-      return;
-    }
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
     ws.send(JSON.stringify({ type: "input", data }));
@@ -812,11 +806,7 @@ export function useTerminal(args: {
         .then((res) => {
           if (!res.ok) throw new Error(`clipboard upload: ${res.status}`);
           const ws = wsRef.current;
-          if (
-            ws &&
-            ws.readyState === WebSocket.OPEN &&
-            !suppressTerminalInputRef.current
-          ) {
+          if (ws && ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ type: "input", data: "\x16" }));
           }
         })
@@ -914,7 +904,6 @@ export function useTerminal(args: {
         void exitCopyModeRef.current();
         return;
       }
-      if (suppressTerminalInputRef.current) return;
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
       if (ctrlPendingRef.current && data.length === 1) {

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -142,6 +142,7 @@ export function useTerminal(args: {
     setTerminalHostElement(node);
   }, []);
   const terminalRef = useRef<XTerm | null>(null);
+  const suppressTerminalInputRef = useRef(false);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const fitDebounceRef = useRef<number | null>(null);
   const ctrlPendingRef = useRef(false);
@@ -176,6 +177,8 @@ export function useTerminal(args: {
   agentsRef.current = agents;
   const deferMediaResizeRef = useRef(deferMediaResize);
   deferMediaResizeRef.current = deferMediaResize;
+  suppressTerminalInputRef.current =
+    terminalMode === "tmux" && optimisticallyDismissingCopyMode;
 
   const sendResize = useCallback(() => {
     const ws = wsRef.current;
@@ -673,18 +676,15 @@ export function useTerminal(args: {
     resetTerminalSurface,
   ]);
 
-  const sendTerminalInput = useCallback(
-    (data: string) => {
-      if (terminalMode === "tmux" && optimisticallyDismissingCopyMode) {
-        return;
-      }
-      const ws = wsRef.current;
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
-      ws.send(JSON.stringify({ type: "input", data }));
-      terminalRef.current?.focus();
-    },
-    [optimisticallyDismissingCopyMode, terminalMode]
-  );
+  const sendTerminalInput = useCallback((data: string) => {
+    if (suppressTerminalInputRef.current) {
+      return;
+    }
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ type: "input", data }));
+    terminalRef.current?.focus();
+  }, []);
 
   const exitCopyMode = useCallback(async () => {
     const agentId = connectedAgentIdRef.current;
@@ -774,7 +774,11 @@ export function useTerminal(args: {
         .then((res) => {
           if (!res.ok) throw new Error(`clipboard upload: ${res.status}`);
           const ws = wsRef.current;
-          if (ws && ws.readyState === WebSocket.OPEN) {
+          if (
+            ws &&
+            ws.readyState === WebSocket.OPEN &&
+            !suppressTerminalInputRef.current
+          ) {
             ws.send(JSON.stringify({ type: "input", data: "\x16" }));
           }
         })
@@ -866,6 +870,7 @@ export function useTerminal(args: {
     }
 
     const disposable = term.onData((data) => {
+      if (suppressTerminalInputRef.current) return;
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
       if (ctrlPendingRef.current && data.length === 1) {

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
@@ -14,6 +15,8 @@ import {
   type Agent,
   type AuthState,
   type ConnState,
+  type TerminalCopyMode,
+  type TerminalUiState,
 } from "@/components/app/types";
 import { api } from "@/lib/api";
 import { recordWSReconnect } from "@/lib/energy-metrics";
@@ -29,11 +32,6 @@ const SOCKET_PROBE_TIMEOUT_MS = 1_500;
 type TerminalSocketMessage =
   | { type: "heartbeat"; ts: number }
   | { type: "output"; data: string }
-  | {
-      type: "tmux_state";
-      inCopyMode: boolean;
-      scrollPosition: number | null;
-    }
   | { type: "error"; message: string }
   | { type: "exit"; exitCode?: number };
 
@@ -82,7 +80,7 @@ export function useTerminal(args: {
   terminalMode: "tmux" | "inert" | null;
   terminalPlaceholderMessage: string | null;
   inCopyMode: boolean;
-  scrollPosition: number | null;
+  copyMode: TerminalCopyMode | "unknown";
   statusMessage: string;
   terminalHostRef: RefCallback<HTMLDivElement>;
   ctrlPendingRef: MutableRefObject<boolean>;
@@ -108,6 +106,7 @@ export function useTerminal(args: {
     mediaResizeSettleKey,
     feedbackOpen,
   } = args;
+  const queryClient = useQueryClient();
 
   const [connState, setConnState] = useState<ConnState>("disconnected");
   const [connectedAgentId, setConnectedAgentId] = useState<string | null>(null);
@@ -117,14 +116,7 @@ export function useTerminal(args: {
   const [terminalPlaceholderMessage, setTerminalPlaceholderMessage] = useState<
     string | null
   >(null);
-  const [tmuxCopyModeState, setTmuxCopyModeState] = useState({
-    inCopyMode: false,
-    scrollPosition: null as number | null,
-  });
-  const [
-    optimisticallyDismissingCopyMode,
-    setOptimisticallyDismissingCopyMode,
-  ] = useState(false);
+  const [exitPending, setExitPending] = useState(false);
   const [statusMessage, setStatusMessage] = useState("Starting...");
   // True while requestFit's auto-RESYNC is in flight. Lets the UI show a
   // calm "Resizing…" overlay instead of the empty / reconnect overlays
@@ -146,6 +138,9 @@ export function useTerminal(args: {
   const fitAddonRef = useRef<FitAddon | null>(null);
   const fitDebounceRef = useRef<number | null>(null);
   const ctrlPendingRef = useRef(false);
+  const copyModeRef = useRef<TerminalCopyMode | "unknown">("live");
+  const exitCopyModeRef = useRef<() => Promise<void>>(async () => {});
+  const noteScrollInteractionRef = useRef<() => void>(() => {});
   // Filled in via effect once detachTerminal/ensureTerminalConnected exist —
   // lets requestFit trigger an auto-RESYNC without needing those defined
   // earlier in the hook body.
@@ -177,8 +172,36 @@ export function useTerminal(args: {
   agentsRef.current = agents;
   const deferMediaResizeRef = useRef(deferMediaResize);
   deferMediaResizeRef.current = deferMediaResize;
+  const lastInteractionHintAtRef = useRef(0);
+
+  const { data: terminalState } = useQuery<TerminalUiState>({
+    queryKey: ["terminal-state", connectedAgentId],
+    queryFn: async () => {
+      if (!connectedAgentId) {
+        return { copyMode: "live", lastObservedAt: 0 };
+      }
+      const payload = await api<{ terminalState: TerminalUiState }>(
+        `/api/v1/agents/${connectedAgentId}/terminal/state`
+      );
+      return payload.terminalState;
+    },
+    enabled:
+      terminalMode === "tmux" &&
+      connState === "connected" &&
+      connectedAgentId !== null,
+    refetchOnWindowFocus: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+  const serverCopyMode =
+    terminalMode !== "tmux" ? "live" : (terminalState?.copyMode ?? "unknown");
+  const copyMode: TerminalCopyMode | "unknown" =
+    exitPending &&
+    (serverCopyMode === "unknown" || serverCopyMode === "exiting")
+      ? "exiting"
+      : serverCopyMode;
+  copyModeRef.current = copyMode;
   suppressTerminalInputRef.current =
-    terminalMode === "tmux" && optimisticallyDismissingCopyMode;
+    terminalMode === "tmux" && (copyMode === "copy" || copyMode === "exiting");
 
   const sendResize = useCallback(() => {
     const ws = wsRef.current;
@@ -228,9 +251,8 @@ export function useTerminal(args: {
     };
   }, []);
 
-  const resetTmuxCopyModeState = useCallback(() => {
-    setTmuxCopyModeState({ inCopyMode: false, scrollPosition: null });
-    setOptimisticallyDismissingCopyMode(false);
+  const resetTerminalState = useCallback(() => {
+    setExitPending(false);
   }, []);
 
   const markSocketHealthy = useCallback(
@@ -351,7 +373,7 @@ export function useTerminal(args: {
   const closeSocket = useCallback(
     (announce = true) => {
       closeSocketTransport();
-      resetTmuxCopyModeState();
+      resetTerminalState();
       setConnectedAgentId(null);
       setTerminalMode(null);
       setTerminalPlaceholderMessage(null);
@@ -361,7 +383,7 @@ export function useTerminal(args: {
         setConnState("disconnected");
       }
     },
-    [closeSocketTransport, resetTmuxCopyModeState]
+    [closeSocketTransport, resetTerminalState]
   );
 
   const ensureTerminalConnected = useCallback(
@@ -501,7 +523,7 @@ export function useTerminal(args: {
           }
 
           if (terminalSession.mode === "inert") {
-            resetTmuxCopyModeState();
+            resetTerminalState();
             restoreConnectedState(agent, "inert", terminalSession.message);
             return;
           }
@@ -528,6 +550,10 @@ export function useTerminal(args: {
             markSocketHealthy("open");
             restoreConnectedState(agent, "tmux");
             terminalRef.current?.focus();
+            void queryClient.invalidateQueries({
+              queryKey: ["terminal-state", agent.id],
+              exact: true,
+            });
           });
 
           ws.addEventListener("message", (event) => {
@@ -546,20 +572,6 @@ export function useTerminal(args: {
             if (payload.type === "output") {
               markSocketHealthy("output");
               terminalRef.current?.write(payload.data);
-              return;
-            }
-
-            if (payload.type === "tmux_state") {
-              setTmuxCopyModeState({
-                inCopyMode: payload.inCopyMode,
-                scrollPosition: payload.scrollPosition,
-              });
-              setOptimisticallyDismissingCopyMode((current) => {
-                if (!current) {
-                  return current;
-                }
-                return false;
-              });
               return;
             }
 
@@ -653,7 +665,8 @@ export function useTerminal(args: {
       markSocketHealthy,
       noteTerminalError,
       probeSocket,
-      resetTmuxCopyModeState,
+      queryClient,
+      resetTerminalState,
       resetTerminalSurface,
       restoreConnectedState,
       selectedAgentId,
@@ -686,13 +699,36 @@ export function useTerminal(args: {
     terminalRef.current?.focus();
   }, []);
 
-  const exitCopyMode = useCallback(async () => {
+  const noteScrollInteraction = useCallback(() => {
     const agentId = connectedAgentIdRef.current;
     if (!agentId || terminalMode !== "tmux") {
       return;
     }
+    const now = Date.now();
+    if (now - lastInteractionHintAtRef.current < 300) {
+      return;
+    }
+    lastInteractionHintAtRef.current = now;
 
-    setOptimisticallyDismissingCopyMode(true);
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "interaction", interaction: "scroll" }));
+      return;
+    }
+
+    void api<null>(`/api/v1/agents/${agentId}/terminal/interaction`, {
+      method: "POST",
+      body: JSON.stringify({ interaction: "scroll" }),
+    }).catch(() => {});
+  }, [terminalMode]);
+
+  const exitCopyMode = useCallback(async () => {
+    const agentId = connectedAgentIdRef.current;
+    if (!agentId || terminalMode !== "tmux" || copyMode === "live") {
+      return;
+    }
+
+    setExitPending(true);
     terminalRef.current?.focus();
     requestAnimationFrame(() => {
       terminalRef.current?.focus();
@@ -703,10 +739,12 @@ export function useTerminal(args: {
         body: JSON.stringify({}),
       });
     } catch (error) {
-      setOptimisticallyDismissingCopyMode(false);
+      setExitPending(false);
       throw error;
     }
-  }, [terminalMode]);
+  }, [copyMode, terminalMode]);
+  exitCopyModeRef.current = exitCopyMode;
+  noteScrollInteractionRef.current = noteScrollInteraction;
 
   // Keep a ref so the xterm init effect can read the current theme without
   // depending on it (we don't want to re-create the terminal on theme change).
@@ -865,11 +903,17 @@ export function useTerminal(args: {
 
     host.addEventListener("touchstart", onTouchStart, { passive: true });
     host.addEventListener("touchmove", onTouchMove, { passive: true });
+    const onWheel = () => noteScrollInteractionRef.current();
     if (screenEl) {
       screenEl.addEventListener("mousedown", onMouseDown, true);
+      screenEl.addEventListener("wheel", onWheel, { passive: true });
     }
 
     const disposable = term.onData((data) => {
+      if (copyModeRef.current === "copy" && data === "\x1b") {
+        void exitCopyModeRef.current();
+        return;
+      }
       if (suppressTerminalInputRef.current) return;
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -916,6 +960,7 @@ export function useTerminal(args: {
       host.removeEventListener("touchmove", onTouchMove);
       if (screenEl) {
         screenEl.removeEventListener("mousedown", onMouseDown, true);
+        screenEl.removeEventListener("wheel", onWheel);
       }
       window.removeEventListener("resize", onResize);
       try {
@@ -929,6 +974,16 @@ export function useTerminal(args: {
   }, [authState, invalidateAttachAttempt, requestFit, terminalHostElement]);
 
   // Reconnect on visibility/focus.
+  useEffect(() => {
+    if (
+      terminalMode !== "tmux" ||
+      serverCopyMode === "live" ||
+      serverCopyMode === "copy"
+    ) {
+      setExitPending(false);
+    }
+  }, [serverCopyMode, terminalMode]);
+
   useEffect(() => {
     const requestForegroundReconnect = () => {
       const targetAgentId =
@@ -1050,9 +1105,8 @@ export function useTerminal(args: {
       connectedAgentId,
       terminalMode,
       terminalPlaceholderMessage,
-      inCopyMode:
-        tmuxCopyModeState.inCopyMode && !optimisticallyDismissingCopyMode,
-      scrollPosition: tmuxCopyModeState.scrollPosition,
+      inCopyMode: copyMode === "copy" || copyMode === "exiting",
+      copyMode,
       statusMessage,
       terminalHostRef: setTerminalHostRef,
       ctrlPendingRef,
@@ -1066,11 +1120,10 @@ export function useTerminal(args: {
     }),
     [
       connState,
+      copyMode,
       connectedAgentId,
       terminalMode,
       terminalPlaceholderMessage,
-      tmuxCopyModeState,
-      optimisticallyDismissingCopyMode,
       statusMessage,
       focusTerminal,
       ensureTerminalConnected,

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -35,6 +35,10 @@ type TerminalSocketMessage =
   | { type: "error"; message: string }
   | { type: "exit"; exitCode?: number };
 
+type AgentSettingsResponse = {
+  copyModeAssistEnabled: boolean;
+};
+
 function isTerminalSessionGone(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
@@ -173,6 +177,14 @@ export function useTerminal(args: {
   deferMediaResizeRef.current = deferMediaResize;
   const lastInteractionHintAtRef = useRef(0);
 
+  const { data: agentSettings } = useQuery<AgentSettingsResponse>({
+    queryKey: ["agents-settings"],
+    queryFn: () => api<AgentSettingsResponse>("/api/v1/agents/settings"),
+    refetchOnWindowFocus: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+  const copyModeAssistEnabled = agentSettings?.copyModeAssistEnabled ?? false;
+
   const { data: terminalState } = useQuery<TerminalUiState>({
     queryKey: ["terminal-state", connectedAgentId],
     queryFn: async () => {
@@ -185,6 +197,7 @@ export function useTerminal(args: {
       return payload.terminalState;
     },
     enabled:
+      copyModeAssistEnabled &&
       terminalMode === "tmux" &&
       connState === "connected" &&
       connectedAgentId !== null,
@@ -192,7 +205,9 @@ export function useTerminal(args: {
     staleTime: Number.POSITIVE_INFINITY,
   });
   const serverCopyMode =
-    terminalMode !== "tmux" ? "live" : (terminalState?.copyMode ?? "unknown");
+    terminalMode !== "tmux" || !copyModeAssistEnabled
+      ? "live"
+      : (terminalState?.copyMode ?? "unknown");
   const copyMode: TerminalCopyMode | "unknown" =
     exitPending &&
     (serverCopyMode === "unknown" || serverCopyMode === "exiting")
@@ -695,7 +710,7 @@ export function useTerminal(args: {
 
   const noteScrollInteraction = useCallback(() => {
     const agentId = connectedAgentIdRef.current;
-    if (!agentId || terminalMode !== "tmux") {
+    if (!copyModeAssistEnabled || !agentId || terminalMode !== "tmux") {
       return;
     }
     const now = Date.now();
@@ -714,11 +729,16 @@ export function useTerminal(args: {
       method: "POST",
       body: JSON.stringify({ interaction: "scroll" }),
     }).catch(() => {});
-  }, [terminalMode]);
+  }, [copyModeAssistEnabled, terminalMode]);
 
   const exitCopyMode = useCallback(async () => {
     const agentId = connectedAgentIdRef.current;
-    if (!agentId || terminalMode !== "tmux" || copyMode === "live") {
+    if (
+      !copyModeAssistEnabled ||
+      !agentId ||
+      terminalMode !== "tmux" ||
+      copyMode === "live"
+    ) {
       return;
     }
 
@@ -736,7 +756,7 @@ export function useTerminal(args: {
       setExitPending(false);
       throw error;
     }
-  }, [copyMode, terminalMode]);
+  }, [copyMode, copyModeAssistEnabled, terminalMode]);
   exitCopyModeRef.current = exitCopyMode;
   noteScrollInteractionRef.current = noteScrollInteraction;
 
@@ -891,10 +911,12 @@ export function useTerminal(args: {
       dispatchingMouseDown = false;
     };
 
-    host.addEventListener("touchstart", onTouchStart, { passive: true });
-    host.addEventListener("touchmove", onTouchMove, { passive: true });
+    if (copyModeAssistEnabled) {
+      host.addEventListener("touchstart", onTouchStart, { passive: true });
+      host.addEventListener("touchmove", onTouchMove, { passive: true });
+    }
     const onWheel = () => noteScrollInteractionRef.current();
-    if (screenEl) {
+    if (screenEl && copyModeAssistEnabled) {
       screenEl.addEventListener("mousedown", onMouseDown, true);
       screenEl.addEventListener("wheel", onWheel, { passive: true });
     }
@@ -945,9 +967,11 @@ export function useTerminal(args: {
       resizeObserver.disconnect();
       host.removeEventListener("copy", handleCopy, true);
       host.removeEventListener("paste", handlePaste, true);
-      host.removeEventListener("touchstart", onTouchStart);
-      host.removeEventListener("touchmove", onTouchMove);
-      if (screenEl) {
+      if (copyModeAssistEnabled) {
+        host.removeEventListener("touchstart", onTouchStart);
+        host.removeEventListener("touchmove", onTouchMove);
+      }
+      if (screenEl && copyModeAssistEnabled) {
         screenEl.removeEventListener("mousedown", onMouseDown, true);
         screenEl.removeEventListener("wheel", onWheel);
       }
@@ -960,7 +984,13 @@ export function useTerminal(args: {
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [authState, invalidateAttachAttempt, requestFit, terminalHostElement]);
+  }, [
+    authState,
+    copyModeAssistEnabled,
+    invalidateAttachAttempt,
+    requestFit,
+    terminalHostElement,
+  ]);
 
   // Reconnect on visibility/focus.
   useEffect(() => {

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -357,7 +357,9 @@ test.describe("Terminal live connection", () => {
 
     const clickStartedAt = Date.now();
     await banner.click();
-    await expect(banner).toBeHidden({ timeout: 150 });
+    await expect(banner).toContainText("Returning to live terminal…", {
+      timeout: 300,
+    });
     expect(Date.now() - clickStartedAt).toBeLessThan(250);
     await page.keyboard.type("xyz");
     await page.waitForTimeout(150);
@@ -373,6 +375,7 @@ test.describe("Terminal live connection", () => {
     expect(releaseExitRoute).not.toBeNull();
     releaseExitRoute?.();
     await waitForTmuxCopyMode(tmuxSession, false);
+    await expect(banner).toBeHidden({ timeout: 1_000 });
     await expect(page.locator(".xterm-helper-textarea")).toBeFocused();
     await expect
       .poll(async () =>

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -17,13 +17,13 @@ function authHeaders(): Record<string, string> {
 async function createAndStartAgent(
   request: APIRequestContext,
   name: string
-): Promise<{ id: string; name: string }> {
+): Promise<{ id: string; name: string; tmuxSession: string | null }> {
   const createRes = await request.post("/api/v1/agents", {
     headers: authHeaders(),
     data: { name, type: "terminal", cwd: "/tmp", useWorktree: false },
   });
   const { agent } = (await createRes.json()) as {
-    agent: { id: string; name: string };
+    agent: { id: string; name: string; tmuxSession: string | null };
   };
 
   await waitForAgentRunning(request, agent.id);
@@ -79,6 +79,32 @@ async function waitForAgentCardRunning(
       timeout: timeoutMs,
     }
   );
+}
+
+function readTmuxPaneInMode(sessionName: string): boolean {
+  return (
+    execSync(
+      `tmux display-message -p -t ${JSON.stringify(sessionName)} '#{pane_in_mode}'`,
+      {
+        encoding: "utf8",
+      }
+    ).trim() === "1"
+  );
+}
+
+async function waitForTmuxCopyMode(
+  sessionName: string,
+  expected: boolean,
+  timeoutMs = 5_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (readTmuxPaneInMode(sessionName) === expected) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  expect(readTmuxPaneInMode(sessionName)).toBe(expected);
 }
 
 async function simulateHidden(page: Page): Promise<void> {
@@ -264,6 +290,49 @@ test.describe("Terminal live connection", () => {
 
     await waitForTerminalConnected(page, agent.name, 5_000);
     await expect.poll(() => tokenRequests).toBe(initialTokenRequests);
+  });
+
+  test("shows a copy-mode banner and returns to live immediately", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    expect(agent.tmuxSession).toBeTruthy();
+    const tmuxSession = agent.tmuxSession!;
+
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await waitForTerminalConnected(page, agent.name, 5_000);
+
+    execSync(`tmux copy-mode -t ${JSON.stringify(tmuxSession)}`);
+
+    const banner = page.getByTestId("terminal-copy-mode-banner");
+    await expect(banner).toBeVisible({ timeout: 2_000 });
+    await expect(banner).toContainText(
+      "Viewing scrollback. Typed input is paused."
+    );
+    await waitForTmuxCopyMode(tmuxSession, true);
+
+    const clickStartedAt = Date.now();
+    await banner.click();
+    await expect(banner).toBeHidden({ timeout: 150 });
+    expect(Date.now() - clickStartedAt).toBeLessThan(250);
+    await waitForTmuxCopyMode(tmuxSession, false);
+    await expect(page.locator(".xterm-helper-textarea")).toBeFocused();
+
+    execSync(`tmux copy-mode -t ${JSON.stringify(tmuxSession)}`);
+    await expect(banner).toBeVisible({ timeout: 2_000 });
+    await waitForTmuxCopyMode(tmuxSession, true);
+
+    await page.locator(".xterm-screen").click();
+    await page.keyboard.press("Escape");
+    await expect(banner).toBeHidden({ timeout: 1_000 });
+    await waitForTmuxCopyMode(tmuxSession, false);
   });
 
   test("terminal-features not duplicated across attaches", async ({

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -302,6 +302,32 @@ test.describe("Terminal live connection", () => {
     expect(agent.tmuxSession).toBeTruthy();
     const tmuxSession = agent.tmuxSession!;
 
+    await page.addInitScript(() => {
+      const sentInput: string[] = [];
+      (
+        window as typeof window & { __sentTerminalInput?: string[] }
+      ).__sentTerminalInput = sentInput;
+      const originalSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function patchedSend(
+        data: string | ArrayBufferLike | Blob | ArrayBufferView
+      ) {
+        if (typeof data === "string") {
+          try {
+            const payload = JSON.parse(data) as {
+              type?: string;
+              data?: string;
+            };
+            if (payload.type === "input" && typeof payload.data === "string") {
+              sentInput.push(payload.data);
+            }
+          } catch {
+            // ignore non-JSON websocket frames
+          }
+        }
+        return originalSend.call(this, data);
+      };
+    });
+
     await loadApp(page);
 
     const agentCard = page.getByTestId(`agent-card-${agent.id}`);
@@ -318,12 +344,46 @@ test.describe("Terminal live connection", () => {
     );
     await waitForTmuxCopyMode(tmuxSession, true);
 
+    let releaseExitRoute: (() => void) | null = null;
+    await page.route(
+      `**/api/v1/agents/${agent.id}/terminal/copy-mode/exit`,
+      async (route) => {
+        await new Promise<void>((resolve) => {
+          releaseExitRoute = resolve;
+        });
+        await route.continue();
+      }
+    );
+
     const clickStartedAt = Date.now();
     await banner.click();
     await expect(banner).toBeHidden({ timeout: 150 });
     expect(Date.now() - clickStartedAt).toBeLessThan(250);
+    await page.keyboard.type("xyz");
+    await page.waitForTimeout(150);
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as typeof window & { __sentTerminalInput?: string[] })
+              .__sentTerminalInput ?? []
+        )
+      )
+      .not.toContain("x");
+    expect(releaseExitRoute).not.toBeNull();
+    releaseExitRoute?.();
     await waitForTmuxCopyMode(tmuxSession, false);
     await expect(page.locator(".xterm-helper-textarea")).toBeFocused();
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as typeof window & { __sentTerminalInput?: string[] })
+              .__sentTerminalInput ?? []
+        )
+      )
+      .not.toContain("x");
+    await page.unroute(`**/api/v1/agents/${agent.id}/terminal/copy-mode/exit`);
 
     execSync(`tmux copy-mode -t ${JSON.stringify(tmuxSession)}`);
     await expect(banner).toBeVisible({ timeout: 2_000 });


### PR DESCRIPTION
## Summary
- add tmux copy-mode assist that detects scrollback/copy mode, shows a shared desktop/mobile banner, and provides a return-to-live action without changing normal terminal behavior
- move copy-mode state ownership to the server with a shared tmux-session observer, SSE updates, and hardened interaction handling across reconnects and multiple viewers
- add an opt-in `Enable tmux scrollback assist` setting that makes the feature fully inert when off, including mouse-mode restore/teardown and shared settings cache updates across clients
- clean up the architecture after review with a dedicated `CopyModeAssistManager`, shared copy-mode settings helpers, a shared `useAgentSettings()` hook, and a specific `agents.settings_changed` SSE event

## Validation
- `pnpm run check`
- `pnpm run test`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- Playwright validation on the live dev stack confirming banner behavior and the Settings -> Agents toggle sync path
- architecture review approved after recheck
- backend security review approved after recheck
