### PR TITLE
Fix inert terminal access without tmux metadata

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -722,16 +722,16 @@ export class AgentManager {
       throw new AgentError("Agent is not running.", 409);
     }
 
-    if (!agent.tmuxSession) {
-      throw new AgentError("Agent is missing tmux session metadata.", 500);
-    }
-
     if (this.config.agentRuntime === "inert") {
       return {
         mode: "inert",
         message:
           "Agent is running in inert mode. No tmux session or CLI process is attached in this environment.",
       };
+    }
+
+    if (!agent.tmuxSession) {
+      throw new AgentError("Agent is missing tmux session metadata.", 500);
     }
 
     const hasSession = await this.runtime.hasSession(agent.tmuxSession);

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -869,6 +869,23 @@ describe("AgentManager", () => {
       expect(access.mode).toBe("inert");
       expect(access.message).toContain("inert mode");
     });
+
+    it("should return inert terminal metadata even without tmux session metadata", async () => {
+      const inertManager = new AgentManager(pool, noopLogger, inertTestConfig);
+      const agent = await inertManager.createAgent({
+        cwd: "/tmp",
+        useWorktree: false,
+      });
+
+      await pool.query("UPDATE agents SET tmux_session = NULL WHERE id = $1", [
+        agent.id,
+      ]);
+
+      const access = await inertManager.getTerminalAccess(agent.id);
+
+      expect(access.mode).toBe("inert");
+      expect(access.message).toContain("inert mode");
+    });
   });
 
   describe("upsertLatestEvent", () => {


### PR DESCRIPTION
## Summary
- return inert terminal metadata before checking tmux session presence
- keep tmux metadata enforcement for live runtimes
- add a regression test covering inert agents with a null `tmux_session`

## Testing
- `pnpm run check`
- `pnpm run test`

## Context
In inert mode, seeded agents can have `tmux_session = NULL`. Clicking one of those agents should show the inert terminal placeholder instead of failing terminal access with a 500.