### PR TITLE
Fix mac release notarization keychain path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,22 +245,24 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
+          KEYCHAIN_PATH="$HOME/Library/Keychains/build.keychain-db"
           xcrun notarytool store-credentials dispatch-release-notary \
             --apple-id "$APPLE_ID" \
             --team-id "$APPLE_TEAM_ID" \
             --password "$APPLE_NOTARY_PASSWORD" \
-            --keychain build.keychain
+            --keychain "$KEYCHAIN_PATH"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Bun binaries
-        run: pnpm run build:bun
+        run: |
+          export DISPATCH_NOTARY_KEYCHAIN="$HOME/Library/Keychains/build.keychain-db"
+          pnpm run build:bun
         env:
           DISPATCH_CODESIGN_IDENTITY: "Developer ID Application: Brad Harris (ML8BQ6D727)"
           DISPATCH_MACOS_BUNDLE_ID: dev.bradharris.dispatch
           DISPATCH_NOTARIZE_MACOS_BINARIES: "1"
-          DISPATCH_NOTARY_KEYCHAIN: build.keychain
           DISPATCH_NOTARY_KEYCHAIN_PROFILE: dispatch-release-notary
 
       - name: Pack release artifact


### PR DESCRIPTION
## Summary
- fix the mac release workflow to pass `notarytool` the actual keychain file path
- export the same keychain path into `DISPATCH_NOTARY_KEYCHAIN` for the later notarization submit step
- keep the recent keychain-profile approach instead of reverting it

## Why
The failing run shows `xcrun notarytool store-credentials ... --keychain build.keychain` exiting with:

`The value 'build.keychain' is invalid for '--keychain <keychain>': The file couldn’t be opened because it doesn’t exist.`

`security create-keychain` accepts the logical name `build.keychain`, but `notarytool --keychain` expects the on-disk keychain file path, which on this runner is `$HOME/Library/Keychains/build.keychain-db`.

## Validation
- `pnpm run check`
- `pnpm run test:e2e` was not relevant to this workflow-only change and also surfaced an unrelated existing failure in `e2e/agent-crud.spec.ts` (`agent created via API appears in sidebar after SSE update`)