### PR TITLE
DIS-139: Live diff stats badge on agent sidebar

### DIFF
--- a/apps/server/src/agents/diff-stats-refresher.ts
+++ b/apps/server/src/agents/diff-stats-refresher.ts
@@ -5,6 +5,7 @@ import {
 
 export type DiffStatsAgent = {
   worktreePath: string | null;
+  cwd: string | null;
   baseBranch: string | null;
 };
 
@@ -108,15 +109,20 @@ export class DiffStatsRefresher {
     let nextStats: DiffStats | null = null;
     try {
       const agent = await this.getAgent(agentId);
-      if (!agent || !agent.worktreePath) {
+      // Prefer the dispatch-managed worktreePath (set on `useWorktree=true`
+      // creates), but fall back to the agent's cwd so any agent pointed at
+      // a git working tree gets stats. `getDiffStats` returns null when
+      // the path isn't inside a repo, so this is safe.
+      const path = agent?.worktreePath ?? agent?.cwd ?? null;
+      if (!path) {
         nextStats = null;
       } else {
         // Pass `agent.baseBranch` straight through — `getDiffStats` runs
         // it through the shared `resolveBaseRef` chain, so we don't bake a
         // second fallback policy in here.
         nextStats = await this.computeDiffStats(
-          agent.worktreePath,
-          agent.baseBranch
+          path,
+          agent?.baseBranch ?? null
         );
       }
     } catch (err) {

--- a/apps/server/src/agents/diff-stats-refresher.ts
+++ b/apps/server/src/agents/diff-stats-refresher.ts
@@ -1,0 +1,152 @@
+import {
+  getDiffStats as defaultGetDiffStats,
+  type DiffStats,
+} from "../shared/git/diff-stats.js";
+
+export type DiffStatsAgent = {
+  worktreePath: string | null;
+  baseBranch: string | null;
+};
+
+export type DiffStatsChangedEvent = {
+  type: "agent.diff_state_changed";
+  agentId: string;
+  diffStats: DiffStats | null;
+};
+
+type ComputeDiffStats = (
+  worktreePath: string,
+  baseRef: string
+) => Promise<DiffStats | null>;
+
+type WarnLogger = {
+  warn: (...args: unknown[]) => void;
+};
+
+export type DiffStatsRefresherOptions = {
+  getAgent: (id: string) => Promise<DiffStatsAgent | null>;
+  publishEvent: (event: DiffStatsChangedEvent) => void;
+  computeDiffStats?: ComputeDiffStats;
+  freshnessMs?: number;
+  defaultBaseRef?: string;
+  logger?: WarnLogger;
+};
+
+const DEFAULT_FRESHNESS_MS = 3_000;
+
+/**
+ * In-memory cache + signal funnel for per-agent diff stats. Three callers
+ * share the same throttle: agent status transitions, the GET diff-stats
+ * route, and tap-to-refresh. The freshness window collapses bursts and the
+ * in-flight map dedupes simultaneous signals so we don't fan out git
+ * subprocesses across tabs.
+ *
+ * `signal` returns a promise that resolves once the (possibly shared)
+ * compute settles, so callers can await if they care. Status-event callers
+ * just fire-and-forget.
+ */
+export class DiffStatsRefresher {
+  private readonly cache = new Map<string, DiffStats | null>();
+  private readonly inFlight = new Map<string, Promise<void>>();
+  private readonly lastSignaledAt = new Map<string, number>();
+
+  private readonly getAgent: (id: string) => Promise<DiffStatsAgent | null>;
+  private readonly publishEvent: (event: DiffStatsChangedEvent) => void;
+  private readonly computeDiffStats: ComputeDiffStats;
+  private readonly freshnessMs: number;
+  private readonly defaultBaseRef: string;
+  private readonly logger: WarnLogger | null;
+
+  constructor(options: DiffStatsRefresherOptions) {
+    this.getAgent = options.getAgent;
+    this.publishEvent = options.publishEvent;
+    this.computeDiffStats = options.computeDiffStats ?? defaultGetDiffStats;
+    this.freshnessMs = options.freshnessMs ?? DEFAULT_FRESHNESS_MS;
+    this.defaultBaseRef = options.defaultBaseRef ?? "main";
+    this.logger = options.logger ?? null;
+  }
+
+  /**
+   * Schedule a refresh for the given agent. No-op when a recent compute is
+   * still warm; shares the in-flight promise when one is running.
+   */
+  signal(agentId: string): Promise<void> {
+    const existing = this.inFlight.get(agentId);
+    if (existing) return existing;
+
+    const last = this.lastSignaledAt.get(agentId) ?? 0;
+    const now = Date.now();
+    if (now - last < this.freshnessMs) {
+      return Promise.resolve();
+    }
+    this.lastSignaledAt.set(agentId, now);
+
+    const promise = this.refresh(agentId).finally(() => {
+      this.inFlight.delete(agentId);
+    });
+    this.inFlight.set(agentId, promise);
+    return promise;
+  }
+
+  /**
+   * Read the cached value without triggering a refresh. Returns `null`
+   * both when nothing is cached and when the cached value itself is null
+   * (no worktree). Callers that need to distinguish should check via the
+   * route + signal flow.
+   */
+  getStats(agentId: string): DiffStats | null {
+    return this.cache.get(agentId) ?? null;
+  }
+
+  /**
+   * Drop any cached state for an agent (archive/delete cleanup).
+   */
+  clear(agentId: string): void {
+    this.cache.delete(agentId);
+    this.lastSignaledAt.delete(agentId);
+    this.inFlight.delete(agentId);
+  }
+
+  private async refresh(agentId: string): Promise<void> {
+    let nextStats: DiffStats | null = null;
+    try {
+      const agent = await this.getAgent(agentId);
+      if (!agent || !agent.worktreePath) {
+        nextStats = null;
+      } else {
+        const baseRef =
+          agent.baseBranch && agent.baseBranch.trim()
+            ? agent.baseBranch
+            : this.defaultBaseRef;
+        nextStats = await this.computeDiffStats(agent.worktreePath, baseRef);
+      }
+    } catch (err) {
+      this.logger?.warn(
+        { err, agentId },
+        "Diff stats refresh failed; leaving cache unchanged"
+      );
+      return;
+    }
+
+    const previous = this.cache.has(agentId)
+      ? this.cache.get(agentId)
+      : undefined;
+    this.cache.set(agentId, nextStats);
+    if (statsEqual(previous, nextStats)) return;
+    this.publishEvent({
+      type: "agent.diff_state_changed",
+      agentId,
+      diffStats: nextStats,
+    });
+  }
+}
+
+function statsEqual(
+  a: DiffStats | null | undefined,
+  b: DiffStats | null | undefined
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a === null || b === null) return a === b;
+  return a.added === b.added && a.deleted === b.deleted && a.files === b.files;
+}

--- a/apps/server/src/agents/diff-stats-refresher.ts
+++ b/apps/server/src/agents/diff-stats-refresher.ts
@@ -16,7 +16,7 @@ export type DiffStatsChangedEvent = {
 
 type ComputeDiffStats = (
   worktreePath: string,
-  baseRef: string
+  baseRef: string | null
 ) => Promise<DiffStats | null>;
 
 type WarnLogger = {
@@ -28,7 +28,6 @@ export type DiffStatsRefresherOptions = {
   publishEvent: (event: DiffStatsChangedEvent) => void;
   computeDiffStats?: ComputeDiffStats;
   freshnessMs?: number;
-  defaultBaseRef?: string;
   logger?: WarnLogger;
 };
 
@@ -54,7 +53,6 @@ export class DiffStatsRefresher {
   private readonly publishEvent: (event: DiffStatsChangedEvent) => void;
   private readonly computeDiffStats: ComputeDiffStats;
   private readonly freshnessMs: number;
-  private readonly defaultBaseRef: string;
   private readonly logger: WarnLogger | null;
 
   constructor(options: DiffStatsRefresherOptions) {
@@ -62,7 +60,6 @@ export class DiffStatsRefresher {
     this.publishEvent = options.publishEvent;
     this.computeDiffStats = options.computeDiffStats ?? defaultGetDiffStats;
     this.freshnessMs = options.freshnessMs ?? DEFAULT_FRESHNESS_MS;
-    this.defaultBaseRef = options.defaultBaseRef ?? "main";
     this.logger = options.logger ?? null;
   }
 
@@ -114,11 +111,13 @@ export class DiffStatsRefresher {
       if (!agent || !agent.worktreePath) {
         nextStats = null;
       } else {
-        const baseRef =
-          agent.baseBranch && agent.baseBranch.trim()
-            ? agent.baseBranch
-            : this.defaultBaseRef;
-        nextStats = await this.computeDiffStats(agent.worktreePath, baseRef);
+        // Pass `agent.baseBranch` straight through — `getDiffStats` runs
+        // it through the shared `resolveBaseRef` chain, so we don't bake a
+        // second fallback policy in here.
+        nextStats = await this.computeDiffStats(
+          agent.worktreePath,
+          agent.baseBranch
+        );
       }
     } catch (err) {
       this.logger?.warn(

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -176,6 +176,16 @@ type StopAgentInput = {
   force?: boolean;
 };
 
+/**
+ * Subset of `DiffStatsRefresher` the manager calls into. Defined as a
+ * narrow interface so the manager doesn't import the refresher class
+ * directly — keeps the refresher's wiring at the server-composition level.
+ */
+export type DiffStatsRefresherHandle = {
+  signal: (agentId: string) => Promise<void>;
+  clear: (agentId: string) => void;
+};
+
 export class AgentManager {
   private readonly pool: Pool;
   private readonly logger: FastifyBaseLogger;
@@ -184,6 +194,7 @@ export class AgentManager {
   private readonly eventBus: AgentEventBus;
   private readonly runtime: AgentRuntime;
   private readonly reconciler: Reconciler;
+  private diffStatsRefresher: DiffStatsRefresherHandle | null = null;
 
   constructor(pool: Pool, logger: FastifyBaseLogger, config: AppConfig) {
     this.pool = pool;
@@ -208,6 +219,15 @@ export class AgentManager {
   /** Register a callback invoked after every upsertLatestEvent. */
   onLatestEvent(listener: AgentEventListener): void {
     this.eventBus.subscribe(listener);
+  }
+
+  /**
+   * Inject the diff-stats refresher singleton. Wired post-construction so
+   * the manager and refresher can each take a reference to the other
+   * without a circular constructor dance.
+   */
+  attachDiffStatsRefresher(refresher: DiffStatsRefresherHandle): void {
+    this.diffStatsRefresher = refresher;
   }
 
   async listAgents(): Promise<AgentRecord[]> {
@@ -980,6 +1000,7 @@ export class AgentManager {
         [id]
       );
       durations.db = Date.now() - tDb;
+      this.diffStatsRefresher?.clear(id);
 
       // Cascade: archive child agents (persona agents spawned by this parent)
       const tCascade = Date.now();
@@ -1080,6 +1101,7 @@ export class AgentManager {
       [id]
     );
     durations.db = Date.now() - tDb;
+    this.diffStatsRefresher?.clear(id);
 
     // Cascade to any children (recursive to handle multi-level nesting)
     const children = await this.pool.query<{ id: string }>(
@@ -1136,6 +1158,10 @@ export class AgentManager {
       throw new AgentError("Agent not found.", 404);
     }
     this.eventBus.publish(agent);
+    // Fire-and-forget: refresher swallows its own errors, throttles bursts,
+    // and dedupes concurrent signals. We just nudge it on every status
+    // transition so the diff badge tracks scope as work lands.
+    void this.diffStatsRefresher?.signal(id);
     return agent;
   }
 

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -796,16 +796,12 @@ export async function registerAgentRoutes(
       return reply.code(404).send({ error: "Agent not found." });
     }
 
-    // No worktree → no diff to compute. Return null so the client renders
-    // nothing rather than hanging waiting for a value that never arrives.
-    if (!agent.worktreePath) {
-      return { diffStats: null };
-    }
-
     // Side effect: nudge the refresher so the in-memory cache catches up
     // even if the client reached this endpoint before the next status
-    // event fires. The refresher's freshness window absorbs duplicate
-    // signals from multiple tabs hitting this route at once.
+    // event fires. The refresher uses worktreePath ?? cwd internally and
+    // returns null for paths that aren't inside a git repo, so any agent
+    // is safe to query — the freshness window absorbs duplicate signals
+    // from multiple tabs hitting this route at once.
     void deps.diffStatsRefresher.signal(id);
 
     return { diffStats: deps.diffStatsRefresher.getStats(id) };

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -6,6 +6,7 @@ import type { Pool } from "pg";
 import type WebSocket from "ws";
 
 import type { AgentManager, AgentRecord } from "../agents/manager.js";
+import type { DiffStatsRefresher } from "../agents/diff-stats-refresher.js";
 import { getCopyModeAssistEnabled } from "../copy-mode-assist-settings.js";
 import {
   CLI_AGENT_TYPES,
@@ -72,6 +73,7 @@ type AgentRouteDeps = {
   consumeTerminalToken: (agentId: string, token: string) => boolean;
   copyModeObserverManager: CopyModeObserverManager;
   copyModeAssistManager: CopyModeAssistManager;
+  diffStatsRefresher: DiffStatsRefresher;
   onArchivedAgentsDeleted: (deletedIds: string[]) => void;
   onArchiveError: (agentId: string, error: unknown) => void;
   trackArchivePromise: (agentId: string, archivePromise: Promise<void>) => void;
@@ -783,6 +785,30 @@ export async function registerAgentRoutes(
     } catch (error) {
       return deps.handleAgentError(reply, error);
     }
+  });
+
+  app.get("/api/v1/agents/:id/diff-stats", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    // No worktree → no diff to compute. Return null so the client renders
+    // nothing rather than hanging waiting for a value that never arrives.
+    if (!agent.worktreePath) {
+      return { diffStats: null };
+    }
+
+    // Side effect: nudge the refresher so the in-memory cache catches up
+    // even if the client reached this endpoint before the next status
+    // event fires. The refresher's freshness window absorbs duplicate
+    // signals from multiple tabs hitting this route at once.
+    void deps.diffStatsRefresher.signal(id);
+
+    return { diffStats: deps.diffStatsRefresher.getStats(id) };
   });
 
   app.delete("/api/v1/agents/:id", async (request, reply) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -139,6 +139,7 @@ import {
   VALID_ICON_COLORS,
 } from "./server/static-theme.js";
 import { UiEventBroker, type UiEvent } from "./server/ui-events.js";
+import { DiffStatsRefresher } from "./agents/diff-stats-refresher.js";
 
 const config = loadConfig();
 const app = Fastify({
@@ -151,6 +152,19 @@ const focusTracker = new FocusTracker();
 const slackNotifier = new SlackNotifier(pool, app.log);
 slackNotifier.setFocusCheck((agentId) => focusTracker.isFocused(agentId));
 const uiEventBroker = new UiEventBroker();
+const diffStatsRefresher = new DiffStatsRefresher({
+  getAgent: async (id) => {
+    const agent = await agentManager.getAgent(id);
+    if (!agent) return null;
+    return {
+      worktreePath: agent.worktreePath,
+      baseBranch: agent.baseBranch,
+    };
+  },
+  publishEvent: (event) => uiEventBroker.publish(event),
+  logger: app.log,
+});
+agentManager.attachDiffStatsRefresher(diffStatsRefresher);
 const terminalTokenStore = new TerminalTokenStore(60_000);
 const copyModeObserverManager = new CopyModeObserverManager((event) =>
   uiEventBroker.publish(event as UiEvent)
@@ -544,6 +558,7 @@ async function registerRoutes() {
       terminalTokenStore.consume(agentId, token),
     copyModeObserverManager,
     copyModeAssistManager,
+    diffStatsRefresher,
     onArchivedAgentsDeleted: (deletedIds) =>
       agentLifecycleRuntime.onArchivedAgentsDeleted(deletedIds),
     onArchiveError: (agentId, error) =>

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -158,6 +158,7 @@ const diffStatsRefresher = new DiffStatsRefresher({
     if (!agent) return null;
     return {
       worktreePath: agent.worktreePath,
+      cwd: agent.cwd,
       baseBranch: agent.baseBranch,
     };
   },

--- a/apps/server/src/server/ui-events.ts
+++ b/apps/server/src/server/ui-events.ts
@@ -1,4 +1,5 @@
 import type { AgentRecord, FeedbackRecord } from "../agents/manager.js";
+import type { DiffStats } from "../shared/git/diff-stats.js";
 import type { TerminalUiState } from "../terminal/copy-mode-observer.js";
 
 export type UiEvent =
@@ -8,6 +9,11 @@ export type UiEvent =
       type: "agent.terminal_state_changed";
       agentId: string;
       terminalState: TerminalUiState;
+    }
+  | {
+      type: "agent.diff_state_changed";
+      agentId: string;
+      diffStats: DiffStats | null;
     }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -1,0 +1,79 @@
+import { runCommand, type RunCommandResult } from "../lib/run-command.js";
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; allowedExitCodes?: number[]; timeoutMs?: number }
+) => Promise<RunCommandResult>;
+
+export type ResolveBaseRefOptions = {
+  /** Override for tests. */
+  runCommand?: CommandRunner;
+};
+
+/**
+ * Resolve a usable base ref for the given worktree, applying the same
+ * fallback chain used elsewhere in the agent flow:
+ *
+ *   1. `preferred` (e.g. `agent.baseBranch`) if it resolves
+ *   2. the current branch's `@{upstream}`
+ *   3. `origin/main`
+ *   4. `main`
+ *
+ * Returns the first ref that `git rev-parse --verify --quiet` accepts, or
+ * `null` if none do. The function does NOT fetch from origin; callers that
+ * need a fresh remote tip should fetch separately before calling. Centralising
+ * the fallback here keeps base-ref behaviour consistent across the diff-stats
+ * refresher and the worktree-status check.
+ */
+export async function resolveBaseRef(
+  worktreePath: string,
+  preferred: string | null | undefined,
+  options: ResolveBaseRefOptions = {}
+): Promise<string | null> {
+  const run = options.runCommand ?? runCommand;
+
+  if (preferred && preferred.trim()) {
+    const found = await refExists(run, worktreePath, preferred.trim());
+    if (found) return found;
+  }
+
+  try {
+    const upstream = await run(
+      "git",
+      ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+      { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
+    );
+    if (upstream.exitCode === 0) {
+      const trimmed = upstream.stdout.trim();
+      if (trimmed) {
+        const found = await refExists(run, worktreePath, trimmed);
+        if (found) return found;
+      }
+    }
+  } catch {
+    // No upstream configured — fall through to the origin/main / main chain.
+  }
+
+  return (
+    (await refExists(run, worktreePath, "origin/main")) ??
+    (await refExists(run, worktreePath, "main"))
+  );
+}
+
+async function refExists(
+  run: CommandRunner,
+  worktreePath: string,
+  ref: string
+): Promise<string | null> {
+  try {
+    const result = await run(
+      "git",
+      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
+      { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
+    );
+    return result.exitCode === 0 && result.stdout.trim() ? ref : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -78,13 +78,16 @@ async function refExists(
   worktreePath: string,
   ref: string
 ): Promise<string | null> {
+  // The `isSafeRef` guard at every entry point keeps `-`-prefixed values
+  // from reaching git as flags. We tried adding a `--` end-of-options
+  // separator here as defense in depth, but `git rev-parse --verify`
+  // refuses to resolve refs that follow `--` — so the safety check is
+  // load-bearing on its own.
   if (!isSafeRef(ref)) return null;
   try {
     const result = await run(
       "git",
-      // `--` ends git's option parsing so the ref argument can't be
-      // interpreted as a flag even if the safety check above is bypassed.
-      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", "--", ref],
+      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
       { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
     );
     return result.exitCode === 0 && result.stdout.trim() ? ref : null;

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -34,8 +34,11 @@ export async function resolveBaseRef(
   const run = options.runCommand ?? runCommand;
 
   if (preferred && preferred.trim()) {
-    const found = await refExists(run, worktreePath, preferred.trim());
-    if (found) return found;
+    const candidate = preferred.trim();
+    if (isSafeRef(candidate)) {
+      const found = await refExists(run, worktreePath, candidate);
+      if (found) return found;
+    }
   }
 
   try {
@@ -46,7 +49,7 @@ export async function resolveBaseRef(
     );
     if (upstream.exitCode === 0) {
       const trimmed = upstream.stdout.trim();
-      if (trimmed) {
+      if (trimmed && isSafeRef(trimmed)) {
         const found = await refExists(run, worktreePath, trimmed);
         if (found) return found;
       }
@@ -61,15 +64,27 @@ export async function resolveBaseRef(
   );
 }
 
+/**
+ * Reject ref strings that could be mistaken for git options. We rely on
+ * this guard plus the explicit `--` separator at the call site so a
+ * crafted base-branch value (e.g. `--all`) can't reach git as a flag.
+ */
+function isSafeRef(ref: string): boolean {
+  return ref.length > 0 && !ref.startsWith("-");
+}
+
 async function refExists(
   run: CommandRunner,
   worktreePath: string,
   ref: string
 ): Promise<string | null> {
+  if (!isSafeRef(ref)) return null;
   try {
     const result = await run(
       "git",
-      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
+      // `--` ends git's option parsing so the ref argument can't be
+      // interpreted as a flag even if the safety check above is bypassed.
+      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", "--", ref],
       { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
     );
     return result.exitCode === 0 && result.stdout.trim() ? ref : null;

--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
+import { resolveBaseRef } from "./base-ref.js";
 import { runCommand, type RunCommandResult } from "../lib/run-command.js";
 
 export type DiffStats = {
@@ -27,37 +28,45 @@ export type GetDiffStatsOptions = {
 
 /**
  * Compute a GitHub-PR-style summary of the diff between an agent's worktree
- * and its base branch — committed changes (merge-base..HEAD), uncommitted
- * changes (staged + unstaged vs HEAD), and untracked new files.
+ * and its base branch.
  *
- * Returns `null` when the base ref can't be resolved or git fails outright.
- * Returns zeros when the worktree is genuinely clean. Binary files (and
- * untracked files larger than 1MB) contribute to the file count but not to
- * the line counts — same convention GitHub uses.
+ * Strategy: resolve the base ref (with the same fallback chain the rest of
+ * the agent flow uses), find the merge-base with HEAD, then take a single
+ * `git diff <merge-base> --numstat`. That single diff captures committed,
+ * staged, and unstaged tracked-file changes as one net result, so a file
+ * edited in commits AND in the working tree contributes its true combined
+ * line count rather than the committed-only slice. Untracked new files are
+ * layered on top by counting their lines directly.
+ *
+ * Returns `null` when no base ref resolves or git fails outright. Returns
+ * zeros when the worktree is genuinely clean. Binary files (and untracked
+ * files larger than 1MB) contribute to the file count but not to the line
+ * counts — same convention GitHub uses.
  */
 export async function getDiffStats(
   worktreePath: string,
-  baseRef: string,
+  baseRef: string | null,
   options: GetDiffStatsOptions = {}
 ): Promise<DiffStats | null> {
   const run = options.runCommand ?? runCommand;
   try {
-    const baseCheck = await run(
+    const resolvedBase = await resolveBaseRef(worktreePath, baseRef, {
+      runCommand: run,
+    });
+    if (!resolvedBase) return null;
+
+    const mergeBase = await run(
       "git",
-      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", baseRef],
+      ["-C", worktreePath, "merge-base", "HEAD", resolvedBase],
       { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
     );
-    if (baseCheck.exitCode !== 0 || !baseCheck.stdout.trim()) {
+    if (mergeBase.exitCode !== 0 || !mergeBase.stdout.trim()) {
       return null;
     }
+    const mergeBaseSha = mergeBase.stdout.trim();
 
-    const [committed, uncommitted, untracked] = await Promise.all([
-      run(
-        "git",
-        ["-C", worktreePath, "diff", `${baseRef}...HEAD`, "--numstat"],
-        { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
-      ),
-      run("git", ["-C", worktreePath, "diff", "HEAD", "--numstat"], {
+    const [tracked, untracked] = await Promise.all([
+      run("git", ["-C", worktreePath, "diff", mergeBaseSha, "--numstat"], {
         allowedExitCodes: [0],
         timeoutMs: GIT_TIMEOUT_MS,
       }),
@@ -72,20 +81,18 @@ export async function getDiffStats(
     let deleted = 0;
     const seenFiles = new Set<string>();
 
-    for (const result of [committed, uncommitted]) {
-      for (const line of result.stdout.split("\n")) {
-        if (!line) continue;
-        const parts = line.split("\t");
-        if (parts.length < 3) continue;
-        const [a, d, ...rest] = parts;
-        const filePath = rest.join("\t");
-        if (!filePath) continue;
-        if (seenFiles.has(filePath)) continue;
-        seenFiles.add(filePath);
-        if (a === "-" && d === "-") continue;
-        added += Number.parseInt(a, 10) || 0;
-        deleted += Number.parseInt(d, 10) || 0;
-      }
+    for (const line of tracked.stdout.split("\n")) {
+      if (!line) continue;
+      const parts = line.split("\t");
+      if (parts.length < 3) continue;
+      const [a, d, ...rest] = parts;
+      const filePath = rest.join("\t");
+      if (!filePath) continue;
+      if (seenFiles.has(filePath)) continue;
+      seenFiles.add(filePath);
+      if (a === "-" && d === "-") continue;
+      added += Number.parseInt(a, 10) || 0;
+      deleted += Number.parseInt(d, 10) || 0;
     }
 
     for (const filePath of untracked.stdout.split("\n")) {

--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { resolveBaseRef } from "./base-ref.js";
@@ -120,7 +120,11 @@ async function countUntrackedLines(
 ): Promise<number> {
   const fullPath = path.join(worktreePath, filePath);
   try {
-    const info = await stat(fullPath);
+    // `lstat` does NOT follow symlinks. Untracked symlinks pointing outside
+    // the worktree would otherwise let the badge act as a small file-content
+    // oracle for arbitrary paths the server can read. Skip them entirely —
+    // they still count as 1 file via the seenFiles set above.
+    const info = await lstat(fullPath);
     if (!info.isFile()) return 0;
     if (info.size === 0) return 0;
     if (info.size > UNTRACKED_LINE_COUNT_MAX_BYTES) return 0;

--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -1,0 +1,140 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { runCommand, type RunCommandResult } from "../lib/run-command.js";
+
+export type DiffStats = {
+  added: number;
+  deleted: number;
+  files: number;
+  computedAt: number;
+};
+
+const UNTRACKED_LINE_COUNT_MAX_BYTES = 1_000_000;
+const GIT_TIMEOUT_MS = 15_000;
+const BINARY_PROBE_BYTES = 8 * 1024;
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; allowedExitCodes?: number[]; timeoutMs?: number }
+) => Promise<RunCommandResult>;
+
+export type GetDiffStatsOptions = {
+  /** Override for tests. */
+  runCommand?: CommandRunner;
+};
+
+/**
+ * Compute a GitHub-PR-style summary of the diff between an agent's worktree
+ * and its base branch — committed changes (merge-base..HEAD), uncommitted
+ * changes (staged + unstaged vs HEAD), and untracked new files.
+ *
+ * Returns `null` when the base ref can't be resolved or git fails outright.
+ * Returns zeros when the worktree is genuinely clean. Binary files (and
+ * untracked files larger than 1MB) contribute to the file count but not to
+ * the line counts — same convention GitHub uses.
+ */
+export async function getDiffStats(
+  worktreePath: string,
+  baseRef: string,
+  options: GetDiffStatsOptions = {}
+): Promise<DiffStats | null> {
+  const run = options.runCommand ?? runCommand;
+  try {
+    const baseCheck = await run(
+      "git",
+      ["-C", worktreePath, "rev-parse", "--verify", "--quiet", baseRef],
+      { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
+    );
+    if (baseCheck.exitCode !== 0 || !baseCheck.stdout.trim()) {
+      return null;
+    }
+
+    const [committed, uncommitted, untracked] = await Promise.all([
+      run(
+        "git",
+        ["-C", worktreePath, "diff", `${baseRef}...HEAD`, "--numstat"],
+        { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
+      ),
+      run("git", ["-C", worktreePath, "diff", "HEAD", "--numstat"], {
+        allowedExitCodes: [0],
+        timeoutMs: GIT_TIMEOUT_MS,
+      }),
+      run(
+        "git",
+        ["-C", worktreePath, "ls-files", "--others", "--exclude-standard"],
+        { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
+      ),
+    ]);
+
+    let added = 0;
+    let deleted = 0;
+    const seenFiles = new Set<string>();
+
+    for (const result of [committed, uncommitted]) {
+      for (const line of result.stdout.split("\n")) {
+        if (!line) continue;
+        const parts = line.split("\t");
+        if (parts.length < 3) continue;
+        const [a, d, ...rest] = parts;
+        const filePath = rest.join("\t");
+        if (!filePath) continue;
+        if (seenFiles.has(filePath)) continue;
+        seenFiles.add(filePath);
+        if (a === "-" && d === "-") continue;
+        added += Number.parseInt(a, 10) || 0;
+        deleted += Number.parseInt(d, 10) || 0;
+      }
+    }
+
+    for (const filePath of untracked.stdout.split("\n")) {
+      if (!filePath) continue;
+      if (seenFiles.has(filePath)) continue;
+      seenFiles.add(filePath);
+      const lines = await countUntrackedLines(worktreePath, filePath);
+      added += lines;
+    }
+
+    return {
+      added,
+      deleted,
+      files: seenFiles.size,
+      computedAt: Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function countUntrackedLines(
+  worktreePath: string,
+  filePath: string
+): Promise<number> {
+  const fullPath = path.join(worktreePath, filePath);
+  try {
+    const info = await stat(fullPath);
+    if (!info.isFile()) return 0;
+    if (info.size === 0) return 0;
+    if (info.size > UNTRACKED_LINE_COUNT_MAX_BYTES) return 0;
+    const buffer = await readFile(fullPath);
+    if (looksBinary(buffer)) return 0;
+    return countLines(buffer.toString("utf8"));
+  } catch {
+    return 0;
+  }
+}
+
+function looksBinary(buffer: Buffer): boolean {
+  const probeLength = Math.min(buffer.length, BINARY_PROBE_BYTES);
+  for (let i = 0; i < probeLength; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+function countLines(content: string): number {
+  if (content.length === 0) return 0;
+  const parts = content.split("\n");
+  return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}

--- a/apps/server/src/shared/git/worktree-status.ts
+++ b/apps/server/src/shared/git/worktree-status.ts
@@ -1,3 +1,4 @@
+import { resolveBaseRef } from "./base-ref.js";
 import { runCommand } from "../lib/run-command.js";
 
 export type WorktreeStatus = {
@@ -138,11 +139,9 @@ export async function getUnmergedChanges(
       { allowedExitCodes: [0, 1, 128], timeoutMs: 15_000 }
     );
 
-    // Resolve the base ref: prefer upstream, fall back to origin/main → main
-    const baseRef =
-      (upstreamRef ? await resolveRef(worktreePath, upstreamRef) : null) ??
-      (await resolveRef(worktreePath, "origin/main")) ??
-      (await resolveRef(worktreePath, "main"));
+    // Resolve the base ref through the shared fallback chain: prefer
+    // upstream, then `@{upstream}`, then `origin/main`, then `main`.
+    const baseRef = await resolveBaseRef(worktreePath, upstreamRef);
     if (!baseRef) {
       return { hasUnmergedCommits: false, changedFiles: [] };
     }
@@ -212,21 +211,4 @@ export async function getUncommittedChanges(
   } catch {
     return { hasUncommittedChanges: false, uncommittedFiles: [] };
   }
-}
-
-/**
- * Verify a ref name exists in the worktree's repo. Returns the input ref
- * unchanged on success, `null` if `git rev-parse` can't resolve it.
- * Module-private — used as a fallback chain inside `getUnmergedChanges`.
- */
-async function resolveRef(
-  worktreePath: string,
-  ref: string
-): Promise<string | null> {
-  const result = await runCommand(
-    "git",
-    ["-C", worktreePath, "rev-parse", "--verify", "--quiet", ref],
-    { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
-  );
-  return result.exitCode === 0 && result.stdout.trim() ? ref : null;
 }

--- a/apps/server/test/diff-stats-refresher.test.ts
+++ b/apps/server/test/diff-stats-refresher.test.ts
@@ -267,12 +267,16 @@ describe("DiffStatsRefresher", () => {
     expect(compute).toHaveBeenCalledTimes(2);
   });
 
-  it("falls back to the configured default base ref when agent.baseBranch is null", async () => {
+  it("passes agent.baseBranch through to the compute callback", async () => {
+    // The refresher no longer applies its own base-ref fallback — that
+    // policy lives in the shared resolver inside getDiffStats. Confirm
+    // we forward agent.baseBranch (including null) verbatim.
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: null }],
+      ["with-base", { worktreePath: "/tmp/wt", baseBranch: "trunk" }],
+      ["no-base", { worktreePath: "/tmp/wt", baseBranch: null }],
     ]);
     const compute = vi.fn(
-      async (_path: string, baseRef: string): Promise<DiffStats> => ({
+      async (): Promise<DiffStats> => ({
         added: 0,
         deleted: 0,
         files: 0,
@@ -283,11 +287,13 @@ describe("DiffStatsRefresher", () => {
       getAgent: async (id) => agents.get(id) ?? null,
       publishEvent: () => {},
       computeDiffStats: compute,
-      defaultBaseRef: "trunk",
     });
 
-    await refresher.signal("a1");
+    await refresher.signal("with-base");
     expect(compute).toHaveBeenCalledWith("/tmp/wt", "trunk");
+
+    await refresher.signal("no-base");
+    expect(compute).toHaveBeenCalledWith("/tmp/wt", null);
   });
 
   it("swallows compute errors and leaves the cache unchanged", async () => {

--- a/apps/server/test/diff-stats-refresher.test.ts
+++ b/apps/server/test/diff-stats-refresher.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 describe("DiffStatsRefresher", () => {
   it("publishes a change event when stats first arrive", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const events: DiffStatsChangedEvent[] = [];
     const compute = vi.fn(
@@ -62,7 +62,7 @@ describe("DiffStatsRefresher", () => {
 
   it("treats a second signal within the freshness window as a no-op", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const compute = vi.fn(
       async (): Promise<DiffStats> => ({
@@ -88,7 +88,7 @@ describe("DiffStatsRefresher", () => {
 
   it("recomputes after the freshness window has passed", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const compute = vi.fn(
       async (): Promise<DiffStats> => ({
@@ -114,7 +114,7 @@ describe("DiffStatsRefresher", () => {
 
   it("does not republish when stats are unchanged", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const events: DiffStatsChangedEvent[] = [];
     const compute = vi.fn(
@@ -141,7 +141,7 @@ describe("DiffStatsRefresher", () => {
 
   it("publishes again when stats actually change", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const events: DiffStatsChangedEvent[] = [];
     let call = 0;
@@ -171,7 +171,7 @@ describe("DiffStatsRefresher", () => {
 
   it("dedupes simultaneous signals via the in-flight promise", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     let resolveCompute: ((value: DiffStats) => void) | null = null;
     const compute = vi.fn(
@@ -208,7 +208,7 @@ describe("DiffStatsRefresher", () => {
 
   it("publishes null and clears state when worktreePath is missing", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const events: DiffStatsChangedEvent[] = [];
     const compute = vi.fn(
@@ -229,7 +229,7 @@ describe("DiffStatsRefresher", () => {
     await refresher.signal("a1");
     expect(events).toHaveLength(1);
 
-    agents.set("a1", { worktreePath: null, baseBranch: null });
+    agents.set("a1", { worktreePath: null, cwd: null, baseBranch: null });
     vi.setSystemTime(new Date("2026-05-02T00:00:02Z"));
     await refresher.signal("a1");
 
@@ -240,7 +240,7 @@ describe("DiffStatsRefresher", () => {
 
   it("clear() drops the cached value and re-allows immediate signals", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const compute = vi.fn(
       async (): Promise<DiffStats> => ({
@@ -267,13 +267,60 @@ describe("DiffStatsRefresher", () => {
     expect(compute).toHaveBeenCalledTimes(2);
   });
 
+  it("falls back to agent.cwd when worktreePath is null", async () => {
+    // Agents created with useWorktree=false have no dispatch-managed
+    // worktreePath, but their cwd may still be inside a git repo —
+    // compute against that path so any git working tree gets stats.
+    const agents = setupAgents([
+      ["a1", { worktreePath: null, cwd: "/some/repo", baseBranch: "main" }],
+    ]);
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 7,
+        deleted: 0,
+        files: 1,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+    });
+
+    await refresher.signal("a1");
+    expect(compute).toHaveBeenCalledWith("/some/repo", "main");
+  });
+
+  it("publishes null when both worktreePath and cwd are missing", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: null, cwd: null, baseBranch: null }],
+    ]);
+    const compute = vi.fn();
+    const events: DiffStatsChangedEvent[] = [];
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+    });
+
+    await refresher.signal("a1");
+    expect(compute).not.toHaveBeenCalled();
+    // Cache primes to null on the first signal but no event fires for the
+    // null→null transition; verify state directly.
+    expect(refresher.getStats("a1")).toBeNull();
+  });
+
   it("passes agent.baseBranch through to the compute callback", async () => {
     // The refresher no longer applies its own base-ref fallback — that
     // policy lives in the shared resolver inside getDiffStats. Confirm
     // we forward agent.baseBranch (including null) verbatim.
     const agents = setupAgents([
-      ["with-base", { worktreePath: "/tmp/wt", baseBranch: "trunk" }],
-      ["no-base", { worktreePath: "/tmp/wt", baseBranch: null }],
+      [
+        "with-base",
+        { worktreePath: "/tmp/wt", cwd: null, baseBranch: "trunk" },
+      ],
+      ["no-base", { worktreePath: "/tmp/wt", cwd: null, baseBranch: null }],
     ]);
     const compute = vi.fn(
       async (): Promise<DiffStats> => ({
@@ -298,7 +345,7 @@ describe("DiffStatsRefresher", () => {
 
   it("swallows compute errors and leaves the cache unchanged", async () => {
     const agents = setupAgents([
-      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+      ["a1", { worktreePath: "/tmp/wt", cwd: null, baseBranch: "main" }],
     ]);
     const events: DiffStatsChangedEvent[] = [];
     const initial: DiffStats = {

--- a/apps/server/test/diff-stats-refresher.test.ts
+++ b/apps/server/test/diff-stats-refresher.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DiffStatsRefresher,
+  type DiffStatsAgent,
+  type DiffStatsChangedEvent,
+} from "../src/agents/diff-stats-refresher.js";
+import type { DiffStats } from "../src/shared/git/diff-stats.js";
+
+type AgentMap = Map<string, DiffStatsAgent>;
+
+function setupAgents(entries: Array<[string, DiffStatsAgent]>): AgentMap {
+  return new Map(entries);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DiffStatsRefresher", () => {
+  it("publishes a change event when stats first arrive", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const events: DiffStatsChangedEvent[] = [];
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+      freshnessMs: 3_000,
+    });
+
+    await refresher.signal("a1");
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "agent.diff_state_changed",
+        agentId: "a1",
+        diffStats: expect.objectContaining({ added: 5, deleted: 1, files: 2 }),
+      }),
+    ]);
+    expect(refresher.getStats("a1")).toMatchObject({
+      added: 5,
+      deleted: 1,
+      files: 2,
+    });
+  });
+
+  it("treats a second signal within the freshness window as a no-op", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+      freshnessMs: 3_000,
+    });
+
+    await refresher.signal("a1");
+    vi.setSystemTime(new Date("2026-05-02T00:00:01Z")); // 1s later
+    await refresher.signal("a1");
+
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes after the freshness window has passed", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+      freshnessMs: 3_000,
+    });
+
+    await refresher.signal("a1");
+    vi.setSystemTime(new Date("2026-05-02T00:00:04Z")); // 4s later
+    await refresher.signal("a1");
+
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not republish when stats are unchanged", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const events: DiffStatsChangedEvent[] = [];
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+      freshnessMs: 1_000,
+    });
+
+    await refresher.signal("a1");
+    vi.setSystemTime(new Date("2026-05-02T00:00:02Z"));
+    await refresher.signal("a1");
+
+    expect(events).toHaveLength(1);
+  });
+
+  it("publishes again when stats actually change", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const events: DiffStatsChangedEvent[] = [];
+    let call = 0;
+    const compute = vi.fn(async (): Promise<DiffStats> => {
+      call += 1;
+      return {
+        added: call === 1 ? 5 : 12,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      };
+    });
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+      freshnessMs: 1_000,
+    });
+
+    await refresher.signal("a1");
+    vi.setSystemTime(new Date("2026-05-02T00:00:02Z"));
+    await refresher.signal("a1");
+
+    expect(events).toHaveLength(2);
+    expect(events[1].diffStats).toMatchObject({ added: 12 });
+  });
+
+  it("dedupes simultaneous signals via the in-flight promise", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    let resolveCompute: ((value: DiffStats) => void) | null = null;
+    const compute = vi.fn(
+      () =>
+        new Promise<DiffStats>((resolve) => {
+          resolveCompute = resolve;
+        })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+      freshnessMs: 3_000,
+    });
+
+    const a = refresher.signal("a1");
+    const b = refresher.signal("a1");
+    const c = refresher.signal("a1");
+
+    // Let getAgent resolve so refresh() reaches the compute call.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    resolveCompute?.({
+      added: 1,
+      deleted: 0,
+      files: 1,
+      computedAt: Date.now(),
+    });
+    await Promise.all([a, b, c]);
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes null and clears state when worktreePath is missing", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const events: DiffStatsChangedEvent[] = [];
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+      freshnessMs: 1_000,
+    });
+
+    await refresher.signal("a1");
+    expect(events).toHaveLength(1);
+
+    agents.set("a1", { worktreePath: null, baseBranch: null });
+    vi.setSystemTime(new Date("2026-05-02T00:00:02Z"));
+    await refresher.signal("a1");
+
+    expect(events).toHaveLength(2);
+    expect(events[1].diffStats).toBeNull();
+    expect(refresher.getStats("a1")).toBeNull();
+  });
+
+  it("clear() drops the cached value and re-allows immediate signals", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 5,
+        deleted: 1,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+      freshnessMs: 3_000,
+    });
+
+    await refresher.signal("a1");
+    expect(refresher.getStats("a1")).not.toBeNull();
+    refresher.clear("a1");
+    expect(refresher.getStats("a1")).toBeNull();
+    // freshness gate is keyed off lastSignaledAt, which clear() resets,
+    // so the next signal recomputes immediately.
+    await refresher.signal("a1");
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the configured default base ref when agent.baseBranch is null", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: null }],
+    ]);
+    const compute = vi.fn(
+      async (_path: string, baseRef: string): Promise<DiffStats> => ({
+        added: 0,
+        deleted: 0,
+        files: 0,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+      defaultBaseRef: "trunk",
+    });
+
+    await refresher.signal("a1");
+    expect(compute).toHaveBeenCalledWith("/tmp/wt", "trunk");
+  });
+
+  it("swallows compute errors and leaves the cache unchanged", async () => {
+    const agents = setupAgents([
+      ["a1", { worktreePath: "/tmp/wt", baseBranch: "main" }],
+    ]);
+    const events: DiffStatsChangedEvent[] = [];
+    const initial: DiffStats = {
+      added: 5,
+      deleted: 1,
+      files: 2,
+      computedAt: Date.now(),
+    };
+    let call = 0;
+    const compute = vi.fn(async () => {
+      call += 1;
+      if (call === 1) return initial;
+      throw new Error("git exploded");
+    });
+    const warn = vi.fn();
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: (event) => events.push(event),
+      computeDiffStats: compute,
+      freshnessMs: 1_000,
+      logger: { warn },
+    });
+
+    await refresher.signal("a1");
+    expect(refresher.getStats("a1")).toMatchObject({ added: 5 });
+
+    vi.setSystemTime(new Date("2026-05-02T00:00:02Z"));
+    await refresher.signal("a1");
+
+    expect(refresher.getStats("a1")).toMatchObject({ added: 5 });
+    expect(events).toHaveLength(1);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -10,24 +10,39 @@ import { getDiffStats } from "../src/shared/git/diff-stats.js";
 type CommandKey = string;
 type CommandHandler = () => RunCommandResult;
 
+const MERGE_BASE_SHA = "abcd1234";
+
 function ok(stdout = ""): RunCommandResult {
   return { exitCode: 0, stdout, stderr: "" };
 }
 
+function fail(stdout = ""): RunCommandResult {
+  return { exitCode: 1, stdout, stderr: "" };
+}
+
+/**
+ * Build a runCommand mock that satisfies the standard sequence:
+ *   1. resolveBaseRef → `git rev-parse --verify --quiet <baseRef>` (success)
+ *   2. `git merge-base HEAD <baseRef>` → MERGE_BASE_SHA
+ *   3. `git diff <merge-base> --numstat`
+ *   4. `git ls-files --others --exclude-standard`
+ *
+ * Callers can override any of those keys via `handlers`.
+ */
 function withCommands(
   worktreePath: string,
   baseRef: string,
   handlers: Record<CommandKey, CommandHandler>
 ) {
   const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet ${baseRef}`;
-  const committedKey = `-C ${worktreePath} diff ${baseRef}...HEAD --numstat`;
-  const uncommittedKey = `-C ${worktreePath} diff HEAD --numstat`;
+  const mergeBaseKey = `-C ${worktreePath} merge-base HEAD ${baseRef}`;
+  const trackedKey = `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`;
   const untrackedKey = `-C ${worktreePath} ls-files --others --exclude-standard`;
 
   const merged: Record<CommandKey, CommandHandler> = {
-    [baseCheckKey]: () => ok("abc123"),
-    [committedKey]: () => ok(""),
-    [uncommittedKey]: () => ok(""),
+    [baseCheckKey]: () => ok(baseRef),
+    [mergeBaseKey]: () => ok(MERGE_BASE_SHA),
+    [trackedKey]: () => ok(""),
     [untrackedKey]: () => ok(""),
     ...handlers,
   };
@@ -53,12 +68,15 @@ describe("getDiffStats", () => {
     await rm(tempRoot, { recursive: true, force: true });
   });
 
-  it("returns null when base ref can't be resolved", async () => {
+  it("returns null when no base ref resolves through the fallback chain", async () => {
     const worktreePath = tempRoot;
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (key === `-C ${worktreePath} rev-parse --verify --quiet main`) {
-        return { exitCode: 1, stdout: "", stderr: "" };
+      if (
+        key.includes("rev-parse --verify --quiet") ||
+        key.includes("rev-parse --abbrev-ref @{upstream}")
+      ) {
+        return fail("");
       }
       throw new Error(`Unexpected command: ${key}`);
     });
@@ -67,10 +85,20 @@ describe("getDiffStats", () => {
     expect(result).toBeNull();
   });
 
-  it("counts committed-only changes", async () => {
+  it("returns null when merge-base can't be computed", async () => {
     const worktreePath = tempRoot;
     const runCommand = withCommands(worktreePath, "main", {
-      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+      [`-C ${worktreePath} merge-base HEAD main`]: () => fail(""),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toBeNull();
+  });
+
+  it("counts a single tracked diff (committed-only scenario)", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
         ok("10\t2\tsrc/foo.ts\n5\t0\tsrc/bar.ts"),
     });
 
@@ -78,14 +106,19 @@ describe("getDiffStats", () => {
     expect(result).toMatchObject({ added: 15, deleted: 2, files: 2 });
   });
 
-  it("counts uncommitted-only changes", async () => {
+  it("captures committed AND uncommitted edits to the same file as one net diff", async () => {
+    // Regression: the previous two-stream approach deduped by path and
+    // dropped the uncommitted slice when a file appeared in both. With a
+    // single `git diff <merge-base> --numstat`, git reports the net diff
+    // for the file in one row — so the badge tracks the true current state.
     const worktreePath = tempRoot;
     const runCommand = withCommands(worktreePath, "main", {
-      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("3\t1\tsrc/baz.ts"),
+      [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
+        ok("13\t2\tsrc/foo.ts"),
     });
 
     const result = await getDiffStats(worktreePath, "main", { runCommand });
-    expect(result).toMatchObject({ added: 3, deleted: 1, files: 1 });
+    expect(result).toMatchObject({ added: 13, deleted: 2, files: 1 });
   });
 
   it("counts untracked files (line counts of new files, capped by binary detection)", async () => {
@@ -107,43 +140,15 @@ describe("getDiffStats", () => {
     expect(result).toMatchObject({ added: 3, deleted: 0, files: 2 });
   });
 
-  it("treats binary committed files as 1 file with 0 lines", async () => {
+  it("treats binary tracked files as 1 file with 0 lines", async () => {
     const worktreePath = tempRoot;
     const runCommand = withCommands(worktreePath, "main", {
-      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+      [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
         ok("-\t-\tassets/logo.png\n4\t1\tsrc/foo.ts"),
     });
 
     const result = await getDiffStats(worktreePath, "main", { runCommand });
     expect(result).toMatchObject({ added: 4, deleted: 1, files: 2 });
-  });
-
-  it("dedupes a file that appears in both committed and uncommitted diffs", async () => {
-    const worktreePath = tempRoot;
-    const runCommand = withCommands(worktreePath, "main", {
-      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
-        ok("10\t2\tsrc/foo.ts"),
-      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("3\t0\tsrc/foo.ts"),
-    });
-
-    const result = await getDiffStats(worktreePath, "main", { runCommand });
-    expect(result).toMatchObject({ added: 10, deleted: 2, files: 1 });
-  });
-
-  it("mixed committed + uncommitted + untracked", async () => {
-    const worktreePath = tempRoot;
-    await writeFile(path.join(worktreePath, "new.ts"), "x\ny\n");
-
-    const runCommand = withCommands(worktreePath, "main", {
-      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
-        ok("10\t2\tsrc/foo.ts"),
-      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("4\t1\tsrc/bar.ts"),
-      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
-        ok("new.ts"),
-    });
-
-    const result = await getDiffStats(worktreePath, "main", { runCommand });
-    expect(result).toMatchObject({ added: 16, deleted: 3, files: 3 });
   });
 
   it("returns zeros when there are no changes", async () => {
@@ -179,6 +184,52 @@ describe("getDiffStats", () => {
 
     const result = await getDiffStats(worktreePath, "main", { runCommand });
     expect(result).toMatchObject({ added: 0, deleted: 0, files: 1 });
+  });
+
+  it("includes both tracked and untracked files in the file count", async () => {
+    const worktreePath = tempRoot;
+    await writeFile(path.join(worktreePath, "new.ts"), "x\ny\n");
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
+        ok("10\t2\tsrc/foo.ts\n4\t1\tsrc/bar.ts"),
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("new.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 16, deleted: 3, files: 3 });
+  });
+
+  it("falls back to origin/main when the requested baseRef does not resolve", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet feature-x`) {
+        return fail("");
+      }
+      if (key === `-C ${worktreePath} rev-parse --abbrev-ref @{upstream}`) {
+        return { exitCode: 128, stdout: "", stderr: "no upstream" };
+      }
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet origin/main`) {
+        return ok("origin/main");
+      }
+      if (key === `-C ${worktreePath} merge-base HEAD origin/main`) {
+        return ok(MERGE_BASE_SHA);
+      }
+      if (key === `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`) {
+        return ok("3\t1\tsrc/foo.ts");
+      }
+      if (key === `-C ${worktreePath} ls-files --others --exclude-standard`) {
+        return ok("");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await getDiffStats(worktreePath, "feature-x", {
+      runCommand,
+    });
+    expect(result).toMatchObject({ added: 3, deleted: 1, files: 1 });
   });
 
   it("returns null when git fails outright", async () => {

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -1,0 +1,192 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RunCommandResult } from "../src/shared/lib/run-command.js";
+import { getDiffStats } from "../src/shared/git/diff-stats.js";
+
+type CommandKey = string;
+type CommandHandler = () => RunCommandResult;
+
+function ok(stdout = ""): RunCommandResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function withCommands(
+  worktreePath: string,
+  baseRef: string,
+  handlers: Record<CommandKey, CommandHandler>
+) {
+  const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet ${baseRef}`;
+  const committedKey = `-C ${worktreePath} diff ${baseRef}...HEAD --numstat`;
+  const uncommittedKey = `-C ${worktreePath} diff HEAD --numstat`;
+  const untrackedKey = `-C ${worktreePath} ls-files --others --exclude-standard`;
+
+  const merged: Record<CommandKey, CommandHandler> = {
+    [baseCheckKey]: () => ok("abc123"),
+    [committedKey]: () => ok(""),
+    [uncommittedKey]: () => ok(""),
+    [untrackedKey]: () => ok(""),
+    ...handlers,
+  };
+
+  return vi.fn(async (_command: string, args: string[]) => {
+    const key = args.join(" ");
+    const handler = merged[key];
+    if (!handler) {
+      throw new Error(`Unexpected command: ${key}`);
+    }
+    return handler();
+  });
+}
+
+describe("getDiffStats", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "dispatch-diffstats-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("returns null when base ref can't be resolved", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet main`) {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toBeNull();
+  });
+
+  it("counts committed-only changes", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+        ok("10\t2\tsrc/foo.ts\n5\t0\tsrc/bar.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 15, deleted: 2, files: 2 });
+  });
+
+  it("counts uncommitted-only changes", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("3\t1\tsrc/baz.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 3, deleted: 1, files: 1 });
+  });
+
+  it("counts untracked files (line counts of new files, capped by binary detection)", async () => {
+    const worktreePath = tempRoot;
+    await writeFile(path.join(worktreePath, "new.ts"), "a\nb\nc\n");
+    await writeFile(
+      path.join(worktreePath, "blob.bin"),
+      Buffer.from([0, 1, 2, 0, 5, 6])
+    );
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("new.ts\nblob.bin"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    // new.ts contributes 3 lines, blob.bin is binary (0-byte detected) so
+    // contributes 0 lines but still 1 file. Total: added=3, files=2.
+    expect(result).toMatchObject({ added: 3, deleted: 0, files: 2 });
+  });
+
+  it("treats binary committed files as 1 file with 0 lines", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+        ok("-\t-\tassets/logo.png\n4\t1\tsrc/foo.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 4, deleted: 1, files: 2 });
+  });
+
+  it("dedupes a file that appears in both committed and uncommitted diffs", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+        ok("10\t2\tsrc/foo.ts"),
+      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("3\t0\tsrc/foo.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 10, deleted: 2, files: 1 });
+  });
+
+  it("mixed committed + uncommitted + untracked", async () => {
+    const worktreePath = tempRoot;
+    await writeFile(path.join(worktreePath, "new.ts"), "x\ny\n");
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff main...HEAD --numstat`]: () =>
+        ok("10\t2\tsrc/foo.ts"),
+      [`-C ${worktreePath} diff HEAD --numstat`]: () => ok("4\t1\tsrc/bar.ts"),
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("new.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 16, deleted: 3, files: 3 });
+  });
+
+  it("returns zeros when there are no changes", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = withCommands(worktreePath, "main", {});
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 0, deleted: 0, files: 0 });
+  });
+
+  it("counts a single-line file without a trailing newline", async () => {
+    const worktreePath = tempRoot;
+    await writeFile(path.join(worktreePath, "single.ts"), "no-newline-here");
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("single.ts"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 1, deleted: 0, files: 1 });
+  });
+
+  it("skips line counting for untracked files larger than 1MB but still counts as 1 file", async () => {
+    const worktreePath = tempRoot;
+    const big = "x\n".repeat(600_000); // ~1.2MB
+    await mkdir(path.join(worktreePath, "big"), { recursive: true });
+    await writeFile(path.join(worktreePath, "big/data.txt"), big);
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("big/data.txt"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 0, deleted: 0, files: 1 });
+  });
+
+  it("returns null when git fails outright", async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error("git: command not found");
+    });
+
+    const result = await getDiffStats(tempRoot, "main", { runCommand });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -34,7 +34,7 @@ function withCommands(
   baseRef: string,
   handlers: Record<CommandKey, CommandHandler>
 ) {
-  const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet ${baseRef}`;
+  const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet -- ${baseRef}`;
   const mergeBaseKey = `-C ${worktreePath} merge-base HEAD ${baseRef}`;
   const trackedKey = `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`;
   const untrackedKey = `-C ${worktreePath} ls-files --others --exclude-standard`;
@@ -205,13 +205,17 @@ describe("getDiffStats", () => {
     const worktreePath = tempRoot;
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (key === `-C ${worktreePath} rev-parse --verify --quiet feature-x`) {
+      if (
+        key === `-C ${worktreePath} rev-parse --verify --quiet -- feature-x`
+      ) {
         return fail("");
       }
       if (key === `-C ${worktreePath} rev-parse --abbrev-ref @{upstream}`) {
         return { exitCode: 128, stdout: "", stderr: "no upstream" };
       }
-      if (key === `-C ${worktreePath} rev-parse --verify --quiet origin/main`) {
+      if (
+        key === `-C ${worktreePath} rev-parse --verify --quiet -- origin/main`
+      ) {
         return ok("origin/main");
       }
       if (key === `-C ${worktreePath} merge-base HEAD origin/main`) {
@@ -239,5 +243,74 @@ describe("getDiffStats", () => {
 
     const result = await getDiffStats(tempRoot, "main", { runCommand });
     expect(result).toBeNull();
+  });
+
+  it("rejects refs that start with `-` so a crafted base branch can't be parsed as a git option", async () => {
+    // Defense: even if a `-`-prefixed ref reached this layer, resolveBaseRef
+    // must refuse it BEFORE shelling out. Verify by asserting we never see
+    // the bad ref in any git argv.
+    const seen: string[][] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      seen.push(args);
+      // Make every fallback fail so we end up returning null overall.
+      return fail("");
+    });
+
+    const result = await getDiffStats(tempRoot, "--all", { runCommand });
+    expect(result).toBeNull();
+    for (const args of seen) {
+      expect(args).not.toContain("--all");
+    }
+  });
+
+  it("invokes rev-parse with `--` so refs cannot be reinterpreted as flags", async () => {
+    const seenArgs: string[][] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      seenArgs.push(args);
+      const key = args.join(" ");
+      if (key === `-C ${tempRoot} rev-parse --verify --quiet -- main`) {
+        return ok("main");
+      }
+      if (key === `-C ${tempRoot} merge-base HEAD main`) {
+        return ok(MERGE_BASE_SHA);
+      }
+      if (key === `-C ${tempRoot} diff ${MERGE_BASE_SHA} --numstat`) {
+        return ok("");
+      }
+      if (key === `-C ${tempRoot} ls-files --others --exclude-standard`) {
+        return ok("");
+      }
+      return fail("");
+    });
+
+    await getDiffStats(tempRoot, "main", { runCommand });
+
+    const revParseCalls = seenArgs.filter(
+      (args) => args.includes("rev-parse") && args.includes("--verify")
+    );
+    expect(revParseCalls.length).toBeGreaterThan(0);
+    for (const args of revParseCalls) {
+      const refIndex = args.indexOf("--quiet") + 1;
+      expect(args[refIndex]).toBe("--");
+    }
+  });
+
+  it("does not follow symlinks for untracked-file line counting", async () => {
+    // A symlinked untracked file would otherwise let the badge act as a
+    // tiny content oracle for files outside the worktree. Confirm the
+    // symlink contributes 1 file but 0 lines.
+    const { symlink } = await import("node:fs/promises");
+    const worktreePath = tempRoot;
+    const target = path.join(os.tmpdir(), "outside-the-worktree.txt");
+    await writeFile(target, "secret line 1\nsecret line 2\n");
+    await symlink(target, path.join(worktreePath, "link.txt"));
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("link.txt"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 0, deleted: 0, files: 1 });
   });
 });

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -34,7 +34,7 @@ function withCommands(
   baseRef: string,
   handlers: Record<CommandKey, CommandHandler>
 ) {
-  const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet -- ${baseRef}`;
+  const baseCheckKey = `-C ${worktreePath} rev-parse --verify --quiet ${baseRef}`;
   const mergeBaseKey = `-C ${worktreePath} merge-base HEAD ${baseRef}`;
   const trackedKey = `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`;
   const untrackedKey = `-C ${worktreePath} ls-files --others --exclude-standard`;
@@ -205,17 +205,13 @@ describe("getDiffStats", () => {
     const worktreePath = tempRoot;
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (
-        key === `-C ${worktreePath} rev-parse --verify --quiet -- feature-x`
-      ) {
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet feature-x`) {
         return fail("");
       }
       if (key === `-C ${worktreePath} rev-parse --abbrev-ref @{upstream}`) {
         return { exitCode: 128, stdout: "", stderr: "no upstream" };
       }
-      if (
-        key === `-C ${worktreePath} rev-parse --verify --quiet -- origin/main`
-      ) {
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet origin/main`) {
         return ok("origin/main");
       }
       if (key === `-C ${worktreePath} merge-base HEAD origin/main`) {
@@ -260,38 +256,6 @@ describe("getDiffStats", () => {
     expect(result).toBeNull();
     for (const args of seen) {
       expect(args).not.toContain("--all");
-    }
-  });
-
-  it("invokes rev-parse with `--` so refs cannot be reinterpreted as flags", async () => {
-    const seenArgs: string[][] = [];
-    const runCommand = vi.fn(async (_command: string, args: string[]) => {
-      seenArgs.push(args);
-      const key = args.join(" ");
-      if (key === `-C ${tempRoot} rev-parse --verify --quiet -- main`) {
-        return ok("main");
-      }
-      if (key === `-C ${tempRoot} merge-base HEAD main`) {
-        return ok(MERGE_BASE_SHA);
-      }
-      if (key === `-C ${tempRoot} diff ${MERGE_BASE_SHA} --numstat`) {
-        return ok("");
-      }
-      if (key === `-C ${tempRoot} ls-files --others --exclude-standard`) {
-        return ok("");
-      }
-      return fail("");
-    });
-
-    await getDiffStats(tempRoot, "main", { runCommand });
-
-    const revParseCalls = seenArgs.filter(
-      (args) => args.includes("rev-parse") && args.includes("--verify")
-    );
-    expect(revParseCalls.length).toBeGreaterThan(0);
-    for (const args of revParseCalls) {
-      const refIndex = args.indexOf("--quiet") + 1;
-      expect(args[refIndex]).toBe("--");
     }
   });
 

--- a/apps/server/test/worktree-status.test.ts
+++ b/apps/server/test/worktree-status.test.ts
@@ -115,15 +115,7 @@ describe("getUnmergedChanges", () => {
       { match: ["-C", "/wt", "fetch"], result: ok() },
       // origin/main resolves
       {
-        match: [
-          "-C",
-          "/wt",
-          "rev-parse",
-          "--verify",
-          "--quiet",
-          "--",
-          "origin/main",
-        ],
+        match: ["-C", "/wt", "rev-parse", "--verify", "--quiet", "origin/main"],
         result: ok("origin/main"),
       },
       // merge-tree returns the same hash as the base tree → already merged
@@ -146,15 +138,7 @@ describe("getUnmergedChanges", () => {
       { match: ["-C", "/wt", "rev-parse", "--abbrev-ref"], result: fail() },
       { match: ["-C", "/wt", "fetch"], result: ok() },
       {
-        match: [
-          "-C",
-          "/wt",
-          "rev-parse",
-          "--verify",
-          "--quiet",
-          "--",
-          "origin/main",
-        ],
+        match: ["-C", "/wt", "rev-parse", "--verify", "--quiet", "origin/main"],
         result: ok("origin/main"),
       },
       {
@@ -190,7 +174,6 @@ describe("getUnmergedChanges", () => {
           "rev-parse",
           "--verify",
           "--quiet",
-          "--",
           "origin/feature-x",
         ],
         result: ok("origin/feature-x"),

--- a/apps/server/test/worktree-status.test.ts
+++ b/apps/server/test/worktree-status.test.ts
@@ -115,7 +115,15 @@ describe("getUnmergedChanges", () => {
       { match: ["-C", "/wt", "fetch"], result: ok() },
       // origin/main resolves
       {
-        match: ["-C", "/wt", "rev-parse", "--verify", "--quiet", "origin/main"],
+        match: [
+          "-C",
+          "/wt",
+          "rev-parse",
+          "--verify",
+          "--quiet",
+          "--",
+          "origin/main",
+        ],
         result: ok("origin/main"),
       },
       // merge-tree returns the same hash as the base tree → already merged
@@ -138,7 +146,15 @@ describe("getUnmergedChanges", () => {
       { match: ["-C", "/wt", "rev-parse", "--abbrev-ref"], result: fail() },
       { match: ["-C", "/wt", "fetch"], result: ok() },
       {
-        match: ["-C", "/wt", "rev-parse", "--verify", "--quiet", "origin/main"],
+        match: [
+          "-C",
+          "/wt",
+          "rev-parse",
+          "--verify",
+          "--quiet",
+          "--",
+          "origin/main",
+        ],
         result: ok("origin/main"),
       },
       {
@@ -174,6 +190,7 @@ describe("getUnmergedChanges", () => {
           "rev-parse",
           "--verify",
           "--quiet",
+          "--",
           "origin/feature-x",
         ],
         result: ok("origin/feature-x"),

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -17,6 +17,8 @@ import {
 
 import { AgentMeta, FrontTruncatedValue } from "@/components/app/agent-meta";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
+import { DiffStatBadge } from "@/components/app/diff-stat-badge";
+import { useAgentDiffStats } from "@/hooks/use-agent-diff-stats";
 import {
   latestEventLabel,
   latestEventColor,
@@ -156,6 +158,10 @@ export function AgentCard({
   const isAssistedUpdateAgent = agent.role === "assisted_update";
   const isTerminalAgent = agent.type === "terminal";
   const sidebarBaseBranch = agent.baseBranch ?? "main";
+  const { diffStats, refresh: refreshDiffStats } = useAgentDiffStats(
+    agent.id,
+    isExpanded && Boolean(agent.worktreePath)
+  );
 
   return (
     <React.Fragment>
@@ -391,7 +397,14 @@ export function AgentCard({
             >
               <div className="flex flex-col gap-3 px-0 pb-0.5 pt-0.5">
                 <div className="space-y-1.5">
-                  <div className="space-y-2 rounded-xl border border-border/60 bg-background/25 px-3 py-3 text-xs text-muted-foreground">
+                  <div className="relative space-y-2 rounded-xl border border-border/60 bg-background/25 px-3 py-3 text-xs text-muted-foreground">
+                    <div className="absolute right-3 top-3">
+                      <DiffStatBadge
+                        diffStats={diffStats}
+                        latestEventAt={agent.latestEvent?.updatedAt ?? null}
+                        onRefresh={refreshDiffStats}
+                      />
+                    </div>
                     {agent.gitContext?.isWorktree ? (
                       <>
                         <CompactMetaRow

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -160,7 +160,7 @@ export function AgentCard({
   const sidebarBaseBranch = agent.baseBranch ?? "main";
   const { diffStats, refresh: refreshDiffStats } = useAgentDiffStats(
     agent.id,
-    isExpanded && Boolean(agent.worktreePath)
+    isExpanded
   );
 
   return (

--- a/apps/web/src/components/app/diff-stat-badge.tsx
+++ b/apps/web/src/components/app/diff-stat-badge.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { DiffStats } from "@/components/app/types";
+import { cn } from "@/lib/utils";
+
+const STALE_AFTER_MS = 30_000;
+const FLASH_DURATION_MS = 600;
+
+function formatCount(n: number): string {
+  if (n < 1_000) return String(n);
+  const thousands = n / 1_000;
+  return `${thousands.toFixed(thousands < 10 ? 1 : 0)}K`;
+}
+
+export type DiffStatBadgeProps = {
+  diffStats: DiffStats | null | undefined;
+  /**
+   * Latest agent event timestamp (ISO). Used together with `computedAt`
+   * to detect when the agent has reported activity since the last
+   * compute — a hint that the cached value may be stale.
+   */
+  latestEventAt: string | null | undefined;
+  onRefresh: () => void;
+};
+
+export function DiffStatBadge({
+  diffStats,
+  latestEventAt,
+  onRefresh,
+}: DiffStatBadgeProps): JSX.Element | null {
+  const [flash, setFlash] = useState(false);
+  const lastSig = useRef<string | null>(null);
+
+  const sig = diffStats
+    ? `${diffStats.added}:${diffStats.deleted}:${diffStats.files}`
+    : null;
+
+  useEffect(() => {
+    if (sig === null) {
+      lastSig.current = null;
+      return;
+    }
+    if (lastSig.current !== null && lastSig.current !== sig) {
+      setFlash(true);
+      const timer = window.setTimeout(() => setFlash(false), FLASH_DURATION_MS);
+      lastSig.current = sig;
+      return () => window.clearTimeout(timer);
+    }
+    lastSig.current = sig;
+  }, [sig]);
+
+  if (!diffStats) return null;
+  if (diffStats.added === 0 && diffStats.deleted === 0) return null;
+
+  const eventAtMs = latestEventAt ? Date.parse(latestEventAt) : NaN;
+  const stale =
+    Number.isFinite(eventAtMs) &&
+    eventAtMs > diffStats.computedAt &&
+    Date.now() - diffStats.computedAt > STALE_AFTER_MS;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-agent-control="true"
+          data-testid="diff-stat-badge"
+          onClick={(event) => {
+            event.stopPropagation();
+            onRefresh();
+          }}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] leading-none transition-colors",
+            "border-border bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+            stale && "opacity-60",
+            flash && "border-status-working/60 bg-status-working/15"
+          )}
+          aria-label="Refresh diff stats"
+        >
+          <span className="text-status-done">
+            +{formatCount(diffStats.added)}
+          </span>
+          <span className="text-status-blocked">
+            −{formatCount(diffStats.deleted)}
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div>
+          {diffStats.files} file{diffStats.files === 1 ? "" : "s"} changed
+        </div>
+        <div className="text-muted-foreground">
+          +{diffStats.added} −{diffStats.deleted}
+        </div>
+        {stale ? (
+          <div className="mt-1 text-[10px] text-muted-foreground/80">
+            Tap to refresh
+          </div>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/app/diff-stat-badge.tsx
+++ b/apps/web/src/components/app/diff-stat-badge.tsx
@@ -82,7 +82,7 @@ export function DiffStatBadge({
           )}
           aria-label="Refresh diff stats"
         >
-          <span className="text-status-done">
+          <span className="text-status-working">
             +{formatCount(diffStats.added)}
           </span>
           <span className="text-status-blocked">

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -114,3 +114,10 @@ export type TerminalUiState = {
   copyMode: TerminalCopyMode;
   lastObservedAt: number;
 };
+
+export type DiffStats = {
+  added: number;
+  deleted: number;
+  files: number;
+  computedAt: number;
+};

--- a/apps/web/src/hooks/use-agent-diff-stats.ts
+++ b/apps/web/src/hooks/use-agent-diff-stats.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { DiffStats } from "@/components/app/types";
+import { api } from "@/lib/api";
+
+type DiffStatsResponse = { diffStats: DiffStats | null };
+
+export function diffStatsQueryKey(agentId: string): [string, string] {
+  return ["agent-diff", agentId];
+}
+
+/**
+ * Server-pushed diff stats for one agent. The fetch on mount also nudges
+ * the server-side refresher (which fans the result out via SSE), so live
+ * updates flow through `agent.diff_state_changed` rather than polling.
+ * `refresh()` is the tap-to-refresh entry point.
+ */
+export function useAgentDiffStats(
+  agentId: string,
+  enabled: boolean
+): {
+  diffStats: DiffStats | null | undefined;
+  refresh: () => void;
+} {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<DiffStats | null>({
+    queryKey: diffStatsQueryKey(agentId),
+    queryFn: async () => {
+      const payload = await api<DiffStatsResponse>(
+        `/api/v1/agents/${agentId}/diff-stats`
+      );
+      return payload.diffStats;
+    },
+    enabled,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+  });
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: diffStatsQueryKey(agentId),
+    });
+  }, [agentId, queryClient]);
+
+  return { diffStats: query.data, refresh };
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   type Agent,
   type AuthState,
+  type DiffStats,
   type MediaFile,
   type TerminalUiState,
 } from "@/components/app/types";
+import { diffStatsQueryKey } from "@/hooks/use-agent-diff-stats";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
 import { showWebNotification } from "@/lib/web-notifications";
@@ -18,6 +20,11 @@ type UiEvent =
       type: "agent.terminal_state_changed";
       agentId: string;
       terminalState: TerminalUiState;
+    }
+  | {
+      type: "agent.diff_state_changed";
+      agentId: string;
+      diffStats: DiffStats | null;
     }
   | { type: "agent.deleted"; agentId: string }
   | { type: "media.changed"; agentId: string }
@@ -93,6 +100,14 @@ export function useSSE(authState: AuthState): void {
           queryClient.setQueryData<TerminalUiState>(
             ["terminal-state", payload.agentId],
             payload.terminalState
+          );
+          return;
+        }
+
+        if (payload.type === "agent.diff_state_changed") {
+          queryClient.setQueryData<DiffStats | null>(
+            diffStatsQueryKey(payload.agentId),
+            payload.diffStats
           );
           return;
         }


### PR DESCRIPTION
## Summary

Adds a GitHub-style `+N −M` badge inside the expanded agent sidebar card, pinned to the top-right of the folder/repo info container. The badge shows the agent's branch diff vs its base branch (committed + uncommitted + untracked, matching GitHub PR semantics including new files).

- Backend: `getDiffStats(worktreePath, baseRef)` (`apps/server/src/shared/git/diff-stats.ts`) and `DiffStatsRefresher` (`apps/server/src/agents/diff-stats-refresher.ts`) — one signal funnel for status events, GET route, and tap-to-refresh, with per-agent `FRESHNESS_MS=3000` guard, in-flight dedup, and change-coalesced SSE publish via the new `agent.diff_state_changed` event.
- Frontend: `useAgentDiffStats` hook + `<DiffStatBadge>` component placed inside the expanded card. Hidden on null/zero, truncated above 1000 (`+1.2K −340`), tooltip with file count, tap-to-refresh, brief flash on update, "stale" affordance.
- Decoupled from the agent DTO so diff updates don't fan out re-renders to all `useAgent(id)` consumers.

## Test plan
- [x] `pnpm run check` (server + web type checks)
- [x] `pnpm run test` (server: 21 new tests covering committed/uncommitted/untracked/binary/dedup/no-worktree/zero changes; refresher: freshness, in-flight dedup, change detection, clear, error swallowing)
- [x] `pnpm run finalize:web`
- [x] `pnpm run test:e2e` (138/145 pass, 7 pre-existing skips)
- [x] Playwright UI validation: badge appears in expanded card top-right, hidden when collapsed, tooltip shows file count + raw numbers, tap-to-refresh refetches without selecting the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)