### PR TITLE
Refresh copy mode banner UX; restore unconditional tmux mouse mode

### DIFF
--- a/apps/server/src/agents/tmux/runtime.ts
+++ b/apps/server/src/agents/tmux/runtime.ts
@@ -64,6 +64,23 @@ export function createTmuxRuntime(logger: FastifyBaseLogger): AgentRuntime {
         ["set-option", "-t", input.sessionName, "status", "off"],
         { allowedExitCodes: [0, 1] }
       );
+      // ⚠️ CRITICAL — DO NOT remove or gate this without explicit
+      // instruction. Tmux scroll is critical functionality.
+      //
+      // Enable mouse mode at session creation so wheel/touch scroll
+      // forwards to tmux as SGR mouse codes. This is required for any
+      // scroll on mobile (xterm has no native touch handling) and is
+      // load-bearing for desktop wheel scroll inside tmux's alternate
+      // screen too. Setting it once at launch keeps it independent of
+      // the copy-mode-assist toggle, which historically tied scroll to
+      // the toggle's on-state and silently broke scroll for everyone
+      // who left it off. The toggle controls *only* the banner UI / the
+      // passive copy-mode observer — never scroll plumbing.
+      await runCommand(
+        "tmux",
+        ["set-option", "-t", input.sessionName, "mouse", "on"],
+        { allowedExitCodes: [0, 1] }
+      );
       // Allow DCS passthrough so agent CLIs that wrap escape sequences
       // (e.g. synchronized output) can reach the outer terminal directly.
       await runCommand(

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -989,6 +989,12 @@ export async function registerAgentRoutes(
           throw new Error(access.message);
         }
         tmuxSession = access.sessionName;
+        // ⚠️ CRITICAL — this gate controls ONLY the copy-mode banner UI
+        // and the passive observer. Tmux mouse mode (the actual scroll
+        // mechanism) is enabled unconditionally at session launch in
+        // runtime.ts. Do NOT pull mouse-mode setup, wheel listeners, or
+        // any scroll plumbing inside this if-block — that's how PR #459
+        // silently broke scroll for everyone with the toggle off.
         if (await isCopyModeAssistEnabled()) {
           const detachCopyModeViewer =
             deps.copyModeObserverManager.attachViewer(

--- a/apps/server/src/terminal/copy-mode-assist-manager.ts
+++ b/apps/server/src/terminal/copy-mode-assist-manager.ts
@@ -2,6 +2,28 @@ import { randomUUID } from "node:crypto";
 
 import { TmuxTerminal } from "./tmux-terminal.js";
 
+// Manages the *observer / banner* side of copy-mode assist — tracks
+// active viewer connections and the original tmux mouse-mode value so
+// per-attach overrides can be restored.
+//
+// ⚠️ CRITICAL — DO NOT couple terminal scroll behavior to this manager
+// without explicit instruction.
+//
+// Tmux scroll on mobile/desktop is critical functionality. Mouse mode
+// is enabled unconditionally at tmux session launch (see runtime.ts),
+// and the touch→wheel synthesis on the frontend (see
+// apps/web/src/hooks/use-terminal.ts) runs unconditionally too. Both
+// must stay independent of the assist toggle: the toggle controls
+// *only* the banner UI and the passive copy-mode observer.
+//
+// Background: PR #459 originally regressed scroll by moving the
+// unconditional `enableTmuxMouseMode` call inside the assist toggle's
+// if-block. With the toggle off, mouse mode never got enabled and
+// touch scroll silently died. If you find yourself adding a
+// `copyModeAssistEnabled` (or related) check around anything that
+// touches mouse mode, scroll listeners, or wheel synthesis — STOP.
+// You're about to repeat the same regression.
+
 type ActiveAssistSession = {
   connections: Set<string>;
   originalMouseMode: "on" | "off" | null;

--- a/apps/web/src/components/app/mobile-terminal-toolbar.tsx
+++ b/apps/web/src/components/app/mobile-terminal-toolbar.tsx
@@ -287,7 +287,10 @@ export function MobileTerminalToolbar({
           </div>
         </div>
 
-        <div className="pointer-events-none absolute inset-x-2 bottom-[5.25rem]">
+        {/* Float the banner above the keyboard shortcut bar's top edge —
+            clears it visually with empty space, instead of sitting flush
+            against the bar's border. */}
+        <div className="pointer-events-none absolute inset-x-2 bottom-[6.5rem]">
           <TerminalCopyModeBannerLayer
             visible={pausedInput}
             copyMode={copyMode}

--- a/apps/web/src/components/app/terminal-copy-mode-banner.tsx
+++ b/apps/web/src/components/app/terminal-copy-mode-banner.tsx
@@ -1,8 +1,8 @@
 import { type JSX } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, Pause } from "lucide-react";
 
 import { type TerminalCopyMode } from "@/components/app/types";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 type TerminalCopyModeBannerProps = {
@@ -37,49 +37,102 @@ export function TerminalCopyModeBannerLayer({
   );
 }
 
+const SUNSET_BODY: React.CSSProperties = {
+  background:
+    "linear-gradient(90deg, hsl(var(--destructive) / 0.07) 0%, hsl(var(--status-waiting) / 0.07) 50%, hsl(var(--primary) / 0.07) 100%)",
+  borderColor: "hsl(var(--status-waiting) / 0.40)",
+  boxShadow:
+    "0 8px 28px rgba(0,0,0,0.35), 0 0 28px hsl(var(--status-waiting) / 0.20), 0 0 28px hsl(var(--destructive) / 0.14), inset 0 1px 0 rgba(255,255,255,0.04)",
+};
+
+const SUNSET_ICON_BG = "hsl(var(--status-waiting) / 0.20)";
+const SUNSET_ICON_RING = "hsl(var(--status-waiting) / 0.25)";
+const SUNSET_ICON_COLOR = "hsl(var(--status-waiting))";
+
 export function TerminalCopyModeBanner({
   copyMode,
   onExitCopyMode,
   className,
-  compact = false,
   disabled = false,
 }: TerminalCopyModeBannerProps): JSX.Element {
   const exiting = copyMode === "exiting";
 
+  // Render the active layout always (with opacity-0 in the exiting state)
+  // so the pill keeps a stable width when the message swaps. The exiting
+  // message is overlaid via an absolutely positioned span.
   return (
-    <div
+    <button
+      type="button"
       data-testid="terminal-copy-mode-banner"
+      onClick={onExitCopyMode}
+      onMouseDown={(event) => {
+        event.preventDefault();
+      }}
+      disabled={disabled || exiting}
+      style={SUNSET_BODY}
       className={cn(
-        "pointer-events-none flex items-center justify-between gap-4 border border-primary/35 bg-primary/30 text-foreground",
-        compact ? "px-4 py-3" : "px-4 py-3",
+        "pointer-events-auto group relative flex w-full items-center justify-center gap-3 whitespace-nowrap rounded-full border py-2.5 px-3 text-foreground",
+        "backdrop-blur-[4px]",
+        "transition-all hover:brightness-110",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-default disabled:opacity-90 disabled:hover:brightness-100",
         className
       )}
     >
-      <div className="min-w-0">
-        <p className="text-sm font-semibold">
-          {exiting
-            ? "Returning to live terminal…"
-            : "Scrollback mode. Typing is paused."}
-        </p>
-        <p className="text-xs text-foreground/75">
-          {exiting
-            ? "Waiting for tmux to confirm live mode."
-            : "Press Esc or return to live."}
-        </p>
-      </div>
-      <Button
-        type="button"
-        size="sm"
-        variant="ghost-primary"
-        className="pointer-events-auto shrink-0 rounded-none border border-primary/45 bg-primary/18 text-foreground hover:bg-primary/26"
-        onMouseDown={(event) => {
-          event.preventDefault();
-        }}
-        onClick={onExitCopyMode}
-        disabled={disabled || exiting}
+      {/* Content cluster sits centered inside the full-width banner. The
+          banner itself spans terminal width (justify-center on the button
+          + w-full on its wrapper) so the click/tap target is large, while
+          the icon+copy+kbd stay grouped together visually. */}
+      <span
+        className={cn(
+          "flex min-w-0 items-center gap-3 transition-opacity md:gap-5",
+          exiting && "opacity-0"
+        )}
+        aria-hidden={exiting}
       >
-        {exiting ? "Returning…" : "Return to live"}
-      </Button>
-    </div>
+        <span
+          className="grid h-6 w-6 shrink-0 place-items-center rounded-full"
+          style={{
+            background: SUNSET_ICON_BG,
+            color: SUNSET_ICON_COLOR,
+            boxShadow: `inset 0 0 0 1px ${SUNSET_ICON_RING}`,
+          }}
+        >
+          <Pause className="h-3 w-3 fill-current" />
+        </span>
+        <p className="min-w-0 truncate text-xs font-medium">
+          <span className="font-semibold">Input paused</span>
+          <span className="px-1.5 text-foreground/40 md:px-2.5">·</span>
+          <span className="text-foreground/70">
+            scroll
+            <ChevronDown
+              className="ml-0.5 mr-1.5 inline-block h-3 w-3 align-[-2px] md:mr-2"
+              aria-hidden
+            />
+            <span className="px-1 text-foreground/40 md:px-2">·</span>
+            <span className="md:hidden">tap</span>
+            <span className="hidden md:inline">click</span>
+            <span className="px-1 text-foreground/40 md:px-2">·</span>
+          </span>
+        </p>
+        <kbd
+          aria-hidden
+          className="shrink-0 rounded border border-foreground/25 bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium tracking-[0.08em] text-foreground/85 transition-all group-hover:border-foreground/40 group-hover:bg-foreground/15 group-hover:text-foreground"
+        >
+          Esc
+        </kbd>
+      </span>
+
+      {/* Exiting message overlays the same width as the active layout. */}
+      <span
+        className={cn(
+          "pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-medium tracking-tight transition-opacity",
+          exiting ? "opacity-100" : "opacity-0"
+        )}
+        aria-live="polite"
+      >
+        Returning to live…
+      </span>
+    </button>
   );
 }

--- a/apps/web/src/components/app/terminal-copy-mode-banner.tsx
+++ b/apps/web/src/components/app/terminal-copy-mode-banner.tsx
@@ -110,8 +110,12 @@ export function TerminalCopyModeBanner({
               aria-hidden
             />
             <span className="px-1 text-foreground/40 md:px-2">·</span>
-            <span className="md:hidden">tap</span>
-            <span className="hidden md:inline">click</span>
+            {/* Switch verb based on the user's actual primary input mode
+                (touch vs. mouse) instead of viewport width — so it stays
+                correct on iPads in landscape, touch-enabled laptops, and
+                narrow desktop split views. */}
+            <span className="[@media(pointer:fine)]:hidden">tap</span>
+            <span className="hidden [@media(pointer:fine)]:inline">click</span>
             <span className="px-1 text-foreground/40 md:px-2">·</span>
           </span>
         </p>
@@ -123,12 +127,15 @@ export function TerminalCopyModeBanner({
         </kbd>
       </span>
 
-      {/* Exiting message overlays the same width as the active layout. */}
+      {/* Exiting message overlays the same width as the active layout.
+          aria-hidden when not exiting so screen readers don't announce
+          this string alongside the active "Input paused …" copy. */}
       <span
         className={cn(
           "pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-medium tracking-tight transition-opacity",
           exiting ? "opacity-100" : "opacity-0"
         )}
+        aria-hidden={!exiting}
         aria-live="polite"
       >
         Returning to live…

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -863,18 +863,26 @@ export function useTerminal(args: {
     let touchY = 0;
     let touchAccum = 0;
     const TOUCH_SCROLL_SENSITIVITY_PX = 30;
+    // ⚠️ CRITICAL — DO NOT add a copyModeAssistEnabled (or similar)
+    // gate to these touch handlers. Tmux scroll on mobile is critical
+    // functionality and is independent of the assist toggle.
+    //
+    // xterm has no native touch handling, so this synthesis is the ONLY
+    // path that makes touch scroll work at all. tmux mouse mode is
+    // enabled unconditionally at session launch (see
+    // apps/server/src/agents/tmux/runtime.ts), so the synthetic wheel
+    // events are forwarded to tmux as SGR mouse codes regardless of the
+    // toggle. The toggle controls *only* the banner UI / the passive
+    // copy-mode observer. PR #459 originally tied this synthesis to the
+    // toggle and silently killed scroll for everyone with the toggle
+    // off — do not repeat that mistake.
     const onTouchStart = (e: TouchEvent) => {
       if (!isTouchDevice || e.touches.length !== 1) return;
-      if (!copyModeAssistEnabledRef.current) return;
       touchY = e.touches[0].clientY;
       touchAccum = 0;
     };
-    // Translate one-finger touch drags into wheel events on xterm's screen
-    // element. With tmux mouse mode on, xterm forwards those as SGR mouse
-    // wheel codes to tmux, which scrolls its own scrollback in copy-mode.
     const onTouchMove = (e: TouchEvent) => {
       if (!isTouchDevice || e.touches.length !== 1) return;
-      if (!copyModeAssistEnabledRef.current) return;
       if (!screenEl) return;
       const currentY = e.touches[0].clientY;
       const delta = touchY - currentY;


### PR DESCRIPTION
## Summary

Two related changes that came out of the same investigation.

### 1. Copy mode banner redesign

The terminal copy-mode banner gets a new look: a frosted full-width pill with a Sunset gradient body (destructive → amber → primary), a pause icon, and a centered content cluster. Width is stable across the `copy` ↔ `exiting` transition — the active layout stays mounted as a sizing template while the "Returning to live…" message cross-fades in over the same footprint.

- Banner is now the click/tap target. The inline "Return to live" button is gone — the cursor pointer + hover brightening + `<kbd>Esc</kbd>` chip on the right convey the affordances.
- Copy: **`Input paused · scroll ⌄ · click · Esc`** (mobile shows `tap`).
- ChevronDown icon next to "scroll" reads as "scroll **down**" — the natural exit gesture given the user is already scrolling.
- Backdrop blur dialed to 4px and gradient stops to ~7% per color so terminal text behind reads as soft-focused-but-recognizable, not erased.
- Mobile banner repositioned `bottom-[6.5rem]` to clear the keyboard shortcut bar with visible empty space above it.

### 2. Scroll regression fix

While testing the new banner, the assist toggle's off-state turned out to silently kill terminal scroll on mobile. Root cause from `git log -S enableTmuxMouseMode`:

- `c6b4aec` ("Remove enhanced terminal mode") deliberately added an unconditional `enableTmuxMouseMode(sessionName)` call per attach: *"Ensure tmux's mouse mode is on so wheel/touch events drive tmux's copy-mode scrollback. tmux defaults to mouse=off on a fresh session; call once per attach."*
- `932ce33` ("Add copy mode assist setting UI") moved that call **inside** the new toggle's `if` block.
- `22d8b5a` (refactor) preserved the bug under the new manager API.

Tmux mouse mode (the actual scroll mechanism) had been load-bearing for scroll on mobile — xterm has no native touch handling, so the touch→wheel synthesis is the only path, and it depends on tmux mouse mode being on to forward wheel events as SGR codes. Coupling that to the banner-feature toggle silently disabled scroll for everyone with the toggle off.

This PR restores the original behavior by setting `tmux set-option mouse on` **once at session launch** in `runtime.ts`, alongside the existing `status off` and `allow-passthrough on`. The assist toggle now controls *only* the banner UI and the passive copy-mode observer, never the scroll plumbing.

### 3. Comment guardrails

To prevent the same regression from recurring, explicit `⚠️ CRITICAL — DO NOT couple scroll behavior to this toggle` comments were added at every load-bearing spot:

- `apps/server/src/agents/tmux/runtime.ts` — at the launch-time `set-option mouse on`.
- `apps/server/src/terminal/copy-mode-assist-manager.ts` — file-level header.
- `apps/server/src/routes/agents.ts` — at the toggle's `if (await isCopyModeAssistEnabled())` gate.
- `apps/web/src/hooks/use-terminal.ts` — at the touch→wheel synthesis handlers.

## Test plan

- [x] `pnpm run check` — type-check across server, web, scripts.
- [x] `pnpm --filter @dispatch/server test` — 830 passed / 8 skipped.
- [x] `pnpm run finalize:web` — production build clean.
- [ ] Manual mobile verification: spawn a fresh agent on `live: true` dev stack, attach, scroll up to enter copy mode, verify banner appears at the new height with full-width layout, return via scroll-down / tap-banner / Esc.
- [ ] Manual desktop verification: same flow at desktop width, confirm banner spans full terminal width with cluster centered.
- [ ] Manual scroll-with-toggle-off verification: disable the assist toggle in settings, spawn a fresh agent, confirm touch scroll still works (tmux mouse mode is on regardless).