### PR TITLE
Raise desktop copy mode banner

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -763,7 +763,7 @@ export function AgentsView({
               </div>
 
               {!isMobile ? (
-                <div className="pointer-events-none absolute inset-x-2 bottom-2 z-20">
+                <div className="pointer-events-none absolute inset-x-2 bottom-[calc(theme(spacing.2)+theme(spacing.14))] z-20">
                   <TerminalCopyModeBannerLayer
                     visible={copyMode === "copy" || copyMode === "exiting"}
                     copyMode={copyMode}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -763,7 +763,7 @@ export function AgentsView({
               </div>
 
               {!isMobile ? (
-                <div className="pointer-events-none absolute inset-x-2 bottom-[calc(theme(spacing.2)+theme(spacing.14))] z-20">
+                <div className="pointer-events-none absolute inset-x-2 bottom-16 z-20">
                   <TerminalCopyModeBannerLayer
                     visible={copyMode === "copy" || copyMode === "exiting"}
                     copyMode={copyMode}


### PR DESCRIPTION
## Summary
- move the desktop copy-mode banner up by roughly one banner height on non-mobile layouts
- leave the mobile toolbar banner placement unchanged
- keep the banner easier to see on iPad-sized desktop screens

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- manual Playwright validation on a live tmux stack at 1024x1366 with copy mode enabled