### PR TITLE
Add keyboard hotkeys + Cmd+K command palette

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import {
-  ArrowDown,
-  ArrowUp,
-  PanelLeft,
-  PanelLeftOpen,
-  PanelRight,
-  PanelRightOpen,
-  Plus,
-} from "lucide-react";
+import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
 import { useAtom } from "jotai";
 
 import { AgentListContent } from "@/components/app/agent-sidebar";
@@ -52,11 +44,8 @@ import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
-import {
-  CommandPalette,
-  type CommandAction,
-} from "@/components/app/command-palette";
-import { useHotkey } from "@/lib/hotkeys/use-hotkey";
+import { CommandPalette } from "@/components/app/command-palette";
+import { useAgentHotkeys } from "@/hooks/use-agent-hotkeys";
 import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
@@ -166,9 +155,6 @@ export function AgentsView({
   const [expandedAgentId, setExpandedAgentId] = useState<string | null>(() =>
     readExpandedAgentId()
   );
-  const [paletteOpen, setPaletteOpen] = useState(false);
-
-  useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
 
   const feedbackItemId =
     itemId !== undefined && Number.isInteger(Number(itemId))
@@ -244,36 +230,6 @@ export function AgentsView({
       isPinned: !(prev.isPinned ?? false),
     }));
   }, [setDesktopMediaSidebarState]);
-
-  useHotkey("toggle-media-sidebar", () => {
-    if (!isMobile && !sidebarAgentId) return;
-    setMediaOpen(!mediaOpen);
-  });
-
-  useHotkey("toggle-agent-sidebar", () => {
-    handleSetLeftPanelOpen(!leftPanelOpen);
-  });
-
-  const cycleAgent = useCallback(
-    (direction: -1 | 1) => {
-      const cycleAgents = agents.filter((a) => !a.parentAgentId);
-      if (cycleAgents.length === 0) return;
-      const currentIdx = validatedSelectedAgentId
-        ? cycleAgents.findIndex((a) => a.id === validatedSelectedAgentId)
-        : -1;
-      const nextIdx =
-        currentIdx === -1
-          ? direction === 1
-            ? 0
-            : cycleAgents.length - 1
-          : (currentIdx + direction + cycleAgents.length) % cycleAgents.length;
-      navigate(agentRoute(cycleAgents[nextIdx].id));
-    },
-    [agents, navigate, validatedSelectedAgentId]
-  );
-
-  useHotkey("focus-prev-agent", () => cycleAgent(-1));
-  useHotkey("focus-next-agent", () => cycleAgent(1));
 
   const finishMediaResizeSettle = useCallback(() => {
     if (mediaResizeTimerRef.current) {
@@ -514,63 +470,17 @@ export function AgentsView({
     setCreateOpen(true);
   }, []);
 
-  const paletteActions = useMemo<CommandAction[]>(
-    () => [
-      {
-        id: "new-agent",
-        title: "New agent",
-        keywords: ["create", "spawn", "add"],
-        icon: Plus,
-        run: () => openCreateDialog(),
-      },
-      {
-        id: "toggle-media-sidebar",
-        title: "Toggle media sidebar",
-        keywords: ["pins", "media", "right"],
-        hotkey: "toggle-media-sidebar",
-        icon: mediaOpen ? PanelRight : PanelRightOpen,
-        disabled: !isMobile && !sidebarAgentId,
-        run: () => {
-          if (!isMobile && !sidebarAgentId) return;
-          setMediaOpen(!mediaOpen);
-        },
-      },
-      {
-        id: "toggle-agent-sidebar",
-        title: "Toggle agent sidebar",
-        keywords: ["agents", "left", "list"],
-        hotkey: "toggle-agent-sidebar",
-        icon: leftPanelOpen ? PanelLeft : PanelLeftOpen,
-        run: () => handleSetLeftPanelOpen(!leftPanelOpen),
-      },
-      {
-        id: "focus-next-agent",
-        title: "Focus next agent",
-        keywords: ["cycle", "switch", "down"],
-        hotkey: "focus-next-agent",
-        icon: ArrowDown,
-        run: () => cycleAgent(1),
-      },
-      {
-        id: "focus-prev-agent",
-        title: "Focus previous agent",
-        keywords: ["cycle", "switch", "up"],
-        hotkey: "focus-prev-agent",
-        icon: ArrowUp,
-        run: () => cycleAgent(-1),
-      },
-    ],
-    [
-      cycleAgent,
-      handleSetLeftPanelOpen,
-      isMobile,
-      leftPanelOpen,
-      mediaOpen,
-      openCreateDialog,
-      setMediaOpen,
-      sidebarAgentId,
-    ]
-  );
+  const { paletteOpen, setPaletteOpen, paletteActions } = useAgentHotkeys({
+    agents,
+    isMobile,
+    sidebarAgentId,
+    validatedSelectedAgentId,
+    mediaOpen,
+    setMediaOpen,
+    leftPanelOpen,
+    handleSetLeftPanelOpen,
+    openCreateDialog,
+  });
 
   const closeFeedbackDetail = useCallback(() => {
     if (validatedSelectedAgentId) {

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -44,6 +44,7 @@ import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
+import { useHotkey } from "@/lib/hotkeys/use-hotkey";
 import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
@@ -228,6 +229,36 @@ export function AgentsView({
       isPinned: !(prev.isPinned ?? false),
     }));
   }, [setDesktopMediaSidebarState]);
+
+  useHotkey("toggle-media-sidebar", () => {
+    if (!isMobile && !sidebarAgentId) return;
+    setMediaOpen(!mediaOpen);
+  });
+
+  useHotkey("toggle-agent-sidebar", () => {
+    handleSetLeftPanelOpen(!leftPanelOpen);
+  });
+
+  const cycleAgent = useCallback(
+    (direction: -1 | 1) => {
+      const cycleAgents = agents.filter((a) => !a.parentAgentId);
+      if (cycleAgents.length === 0) return;
+      const currentIdx = validatedSelectedAgentId
+        ? cycleAgents.findIndex((a) => a.id === validatedSelectedAgentId)
+        : -1;
+      const nextIdx =
+        currentIdx === -1
+          ? direction === 1
+            ? 0
+            : cycleAgents.length - 1
+          : (currentIdx + direction + cycleAgents.length) % cycleAgents.length;
+      navigate(agentRoute(cycleAgents[nextIdx].id));
+    },
+    [agents, navigate, validatedSelectedAgentId]
+  );
+
+  useHotkey("focus-prev-agent", () => cycleAgent(-1));
+  useHotkey("focus-next-agent", () => cycleAgent(1));
 
   const finishMediaResizeSettle = useCallback(() => {
     if (mediaResizeTimerRef.current) {

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -529,6 +529,7 @@ export function AgentsView({
         keywords: ["pins", "media", "right"],
         hotkey: "toggle-media-sidebar",
         icon: mediaOpen ? PanelRight : PanelRightOpen,
+        disabled: !isMobile && !sidebarAgentId,
         run: () => {
           if (!isMobile && !sidebarAgentId) return;
           setMediaOpen(!mediaOpen);

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  PanelLeft,
+  PanelLeftOpen,
+  PanelRight,
+  PanelRightOpen,
+  Plus,
+} from "lucide-react";
 import { useAtom } from "jotai";
 
 import { AgentListContent } from "@/components/app/agent-sidebar";
@@ -44,6 +52,10 @@ import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
+import {
+  CommandPalette,
+  type CommandAction,
+} from "@/components/app/command-palette";
 import { useHotkey } from "@/lib/hotkeys/use-hotkey";
 import {
   inactiveMediaSidebarStateAtom,
@@ -154,6 +166,9 @@ export function AgentsView({
   const [expandedAgentId, setExpandedAgentId] = useState<string | null>(() =>
     readExpandedAgentId()
   );
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
 
   const feedbackItemId =
     itemId !== undefined && Number.isInteger(Number(itemId))
@@ -498,6 +513,63 @@ export function AgentsView({
     setRequestedCreateType(typeOverride ?? null);
     setCreateOpen(true);
   }, []);
+
+  const paletteActions = useMemo<CommandAction[]>(
+    () => [
+      {
+        id: "new-agent",
+        title: "New agent",
+        keywords: ["create", "spawn", "add"],
+        icon: Plus,
+        run: () => openCreateDialog(),
+      },
+      {
+        id: "toggle-media-sidebar",
+        title: "Toggle media sidebar",
+        keywords: ["pins", "media", "right"],
+        hotkey: "toggle-media-sidebar",
+        icon: mediaOpen ? PanelRight : PanelRightOpen,
+        run: () => {
+          if (!isMobile && !sidebarAgentId) return;
+          setMediaOpen(!mediaOpen);
+        },
+      },
+      {
+        id: "toggle-agent-sidebar",
+        title: "Toggle agent sidebar",
+        keywords: ["agents", "left", "list"],
+        hotkey: "toggle-agent-sidebar",
+        icon: leftPanelOpen ? PanelLeft : PanelLeftOpen,
+        run: () => handleSetLeftPanelOpen(!leftPanelOpen),
+      },
+      {
+        id: "focus-next-agent",
+        title: "Focus next agent",
+        keywords: ["cycle", "switch", "down"],
+        hotkey: "focus-next-agent",
+        icon: ArrowDown,
+        run: () => cycleAgent(1),
+      },
+      {
+        id: "focus-prev-agent",
+        title: "Focus previous agent",
+        keywords: ["cycle", "switch", "up"],
+        hotkey: "focus-prev-agent",
+        icon: ArrowUp,
+        run: () => cycleAgent(-1),
+      },
+    ],
+    [
+      cycleAgent,
+      handleSetLeftPanelOpen,
+      isMobile,
+      leftPanelOpen,
+      mediaOpen,
+      openCreateDialog,
+      setMediaOpen,
+      sidebarAgentId,
+    ]
+  );
 
   const closeFeedbackDetail = useCallback(() => {
     if (validatedSelectedAgentId) {
@@ -954,6 +1026,12 @@ export function AgentsView({
           />
         </GlassSidebar>
       ) : null}
+
+      <CommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        actions={paletteActions}
+      />
 
       <CreateAgentDialog
         open={createOpen}

--- a/apps/web/src/components/app/command-palette.tsx
+++ b/apps/web/src/components/app/command-palette.tsx
@@ -26,6 +26,7 @@ export type CommandAction = {
   keywords?: string[];
   hotkey?: HotkeyId;
   icon?: LucideIcon;
+  disabled?: boolean;
   run: () => void;
 };
 
@@ -137,6 +138,7 @@ function CommandPaletteItem({
     <CommandPrimitive.Item
       value={value}
       onSelect={onSelect}
+      disabled={action.disabled}
       className={cn(
         "group relative flex cursor-default select-none items-center gap-3 rounded-lg px-2 py-2 text-sm outline-none",
         "transition-colors duration-100",

--- a/apps/web/src/components/app/command-palette.tsx
+++ b/apps/web/src/components/app/command-palette.tsx
@@ -1,0 +1,177 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Search, type LucideIcon } from "lucide-react";
+import { Command as CommandPrimitive } from "cmdk";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { glassOverlay } from "@/lib/glass";
+import { formatHotkeyForKbd } from "@/lib/hotkeys/format";
+import { type HotkeyId } from "@/lib/hotkeys/keymap";
+import { cn } from "@/lib/utils";
+
+export type CommandAction = {
+  id: string;
+  title: string;
+  keywords?: string[];
+  hotkey?: HotkeyId;
+  icon?: LucideIcon;
+  run: () => void;
+};
+
+type CommandPaletteProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  actions: CommandAction[];
+};
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  actions,
+}: CommandPaletteProps): JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed left-1/2 top-[18%] z-[70] flex w-[min(600px,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl",
+            glassOverlay,
+            "shadow-[0_24px_80px_-12px_rgba(0,0,0,0.6),0_0_60px_-12px_hsl(var(--primary)/0.35)]",
+            "ring-1 ring-primary/20"
+          )}
+        >
+          <DialogTitle className="sr-only">Command palette</DialogTitle>
+          <DialogDescription className="sr-only">
+            Search for a command or pick one from the list.
+          </DialogDescription>
+
+          {/* Subtle gradient hairline on top — picks up the active theme primary */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent" />
+
+          <Command label="Command palette" className="bg-transparent">
+            <div className="flex items-center gap-2 border-b border-primary/15 px-4">
+              <Search
+                className="h-4 w-4 shrink-0 text-primary/80"
+                aria-hidden
+              />
+              <CommandPrimitive.Input
+                autoFocus
+                placeholder="Type a command…"
+                className={cn(
+                  "flex h-12 w-full bg-transparent py-3 text-sm outline-none",
+                  "placeholder:text-muted-foreground/70"
+                )}
+              />
+            </div>
+
+            <CommandList className="max-h-[360px] p-1">
+              <CommandEmpty>No commands found.</CommandEmpty>
+              <CommandGroup className="text-foreground">
+                {actions.map((action) => (
+                  <CommandPaletteItem
+                    key={action.id}
+                    action={action}
+                    onSelect={() => {
+                      onOpenChange(false);
+                      action.run();
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  );
+}
+
+function HotkeyBadge({ id }: { id: HotkeyId }): JSX.Element {
+  const { modifiers, key } = formatHotkeyForKbd(id);
+  return (
+    <kbd
+      className={cn(
+        "ml-2 inline-flex h-6 items-center justify-center rounded-md px-2",
+        "border border-white/[0.14] bg-white/[0.06]",
+        "font-mono text-xs font-semibold leading-none tracking-wide text-muted-foreground",
+        "transition-colors duration-100",
+        "group-data-[selected=true]:border-primary/40 group-data-[selected=true]:bg-primary/15 group-data-[selected=true]:text-primary"
+      )}
+    >
+      {modifiers ? (
+        <>
+          <span>{modifiers}</span>
+          <span className="mx-1.5 text-muted-foreground/60 group-data-[selected=true]:text-primary/70">
+            +
+          </span>
+        </>
+      ) : null}
+      <span>{key}</span>
+    </kbd>
+  );
+}
+
+function CommandPaletteItem({
+  action,
+  onSelect,
+}: {
+  action: CommandAction;
+  onSelect: () => void;
+}): JSX.Element {
+  const Icon = action.icon;
+  const value = [action.title, ...(action.keywords ?? [])].join(" ");
+
+  return (
+    <CommandPrimitive.Item
+      value={value}
+      onSelect={onSelect}
+      className={cn(
+        "group relative flex cursor-default select-none items-center gap-3 rounded-lg px-2 py-2 text-sm outline-none",
+        "transition-colors duration-100",
+        "data-[selected=true]:bg-primary/10",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50"
+      )}
+    >
+      {/* Left accent strip — only shows on selected */}
+      <span
+        aria-hidden
+        className={cn(
+          "absolute inset-y-1 left-0 w-[3px] rounded-full bg-primary opacity-0 transition-opacity",
+          "group-data-[selected=true]:opacity-100"
+        )}
+      />
+
+      {Icon ? (
+        <span
+          className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+            "border border-primary/20 bg-primary/[0.08] text-primary/80",
+            "transition-colors duration-100",
+            "group-data-[selected=true]:border-primary/50 group-data-[selected=true]:bg-primary/20 group-data-[selected=true]:text-primary",
+            "group-data-[selected=true]:shadow-[0_0_18px_-2px_hsl(var(--primary)/0.45)]"
+          )}
+        >
+          <Icon className="h-4 w-4" aria-hidden />
+        </span>
+      ) : null}
+
+      <span className="flex-1 truncate text-foreground/90 group-data-[selected=true]:text-foreground">
+        {action.title}
+      </span>
+
+      {action.hotkey ? <HotkeyBadge id={action.hotkey} /> : null}
+    </CommandPrimitive.Item>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -32,6 +32,7 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      data-hotkey-disable="true"
       className={cn(
         "fixed left-1/2 top-1/2 z-[70] flex flex-col w-[min(560px,calc(100vw-2rem))] max-h-[80vh] -translate-x-1/2 -translate-y-1/2 gap-3 overflow-hidden rounded-xl p-4",
         glassOverlay,

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -1,0 +1,146 @@
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowDown,
+  ArrowUp,
+  PanelLeft,
+  PanelLeftOpen,
+  PanelRight,
+  PanelRightOpen,
+  Plus,
+} from "lucide-react";
+
+import { type CommandAction } from "@/components/app/command-palette";
+import { type Agent } from "@/components/app/types";
+import { agentRoute } from "@/lib/agent-routes";
+import { useHotkey } from "@/lib/hotkeys/use-hotkey";
+
+type UseAgentHotkeysArgs = {
+  agents: Agent[];
+  isMobile: boolean;
+  sidebarAgentId: string | null;
+  validatedSelectedAgentId: string | null;
+  mediaOpen: boolean;
+  setMediaOpen: (open: boolean) => void;
+  leftPanelOpen: boolean;
+  handleSetLeftPanelOpen: (open: boolean) => void;
+  openCreateDialog: () => void;
+};
+
+export type UseAgentHotkeysResult = {
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+  paletteActions: CommandAction[];
+};
+
+/**
+ * Wires every agent-view hotkey + the Cmd+K command palette in one place.
+ * Returns the palette open state and action list to render. Hotkey effects
+ * register internally — the caller only owns the rendered <CommandPalette />.
+ */
+export function useAgentHotkeys({
+  agents,
+  isMobile,
+  sidebarAgentId,
+  validatedSelectedAgentId,
+  mediaOpen,
+  setMediaOpen,
+  leftPanelOpen,
+  handleSetLeftPanelOpen,
+  openCreateDialog,
+}: UseAgentHotkeysArgs): UseAgentHotkeysResult {
+  const navigate = useNavigate();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
+
+  useHotkey("toggle-media-sidebar", () => {
+    if (!isMobile && !sidebarAgentId) return;
+    setMediaOpen(!mediaOpen);
+  });
+
+  useHotkey("toggle-agent-sidebar", () => {
+    handleSetLeftPanelOpen(!leftPanelOpen);
+  });
+
+  const cycleAgent = useCallback(
+    (direction: -1 | 1) => {
+      const cycleAgents = agents.filter((a) => !a.parentAgentId);
+      if (cycleAgents.length === 0) return;
+      const currentIdx = validatedSelectedAgentId
+        ? cycleAgents.findIndex((a) => a.id === validatedSelectedAgentId)
+        : -1;
+      const nextIdx =
+        currentIdx === -1
+          ? direction === 1
+            ? 0
+            : cycleAgents.length - 1
+          : (currentIdx + direction + cycleAgents.length) % cycleAgents.length;
+      navigate(agentRoute(cycleAgents[nextIdx].id));
+    },
+    [agents, navigate, validatedSelectedAgentId]
+  );
+
+  useHotkey("focus-prev-agent", () => cycleAgent(-1));
+  useHotkey("focus-next-agent", () => cycleAgent(1));
+
+  const paletteActions = useMemo<CommandAction[]>(
+    () => [
+      {
+        id: "new-agent",
+        title: "New agent",
+        keywords: ["create", "spawn", "add"],
+        icon: Plus,
+        run: () => openCreateDialog(),
+      },
+      {
+        id: "toggle-media-sidebar",
+        title: "Toggle media sidebar",
+        keywords: ["pins", "media", "right"],
+        hotkey: "toggle-media-sidebar",
+        icon: mediaOpen ? PanelRight : PanelRightOpen,
+        disabled: !isMobile && !sidebarAgentId,
+        run: () => {
+          if (!isMobile && !sidebarAgentId) return;
+          setMediaOpen(!mediaOpen);
+        },
+      },
+      {
+        id: "toggle-agent-sidebar",
+        title: "Toggle agent sidebar",
+        keywords: ["agents", "left", "list"],
+        hotkey: "toggle-agent-sidebar",
+        icon: leftPanelOpen ? PanelLeft : PanelLeftOpen,
+        run: () => handleSetLeftPanelOpen(!leftPanelOpen),
+      },
+      {
+        id: "focus-next-agent",
+        title: "Focus next agent",
+        keywords: ["cycle", "switch", "down"],
+        hotkey: "focus-next-agent",
+        icon: ArrowDown,
+        run: () => cycleAgent(1),
+      },
+      {
+        id: "focus-prev-agent",
+        title: "Focus previous agent",
+        keywords: ["cycle", "switch", "up"],
+        hotkey: "focus-prev-agent",
+        icon: ArrowUp,
+        run: () => cycleAgent(-1),
+      },
+    ],
+    [
+      cycleAgent,
+      handleSetLeftPanelOpen,
+      isMobile,
+      leftPanelOpen,
+      mediaOpen,
+      openCreateDialog,
+      setMediaOpen,
+      sidebarAgentId,
+    ]
+  );
+
+  return { paletteOpen, setPaletteOpen, paletteActions };
+}

--- a/apps/web/src/lib/hotkeys/format.ts
+++ b/apps/web/src/lib/hotkeys/format.ts
@@ -1,0 +1,91 @@
+import { HOTKEYS, type HotkeyId } from "./keymap";
+
+const IS_MAC =
+  typeof navigator !== "undefined"
+    ? /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+    : false;
+
+const TOKEN_DISPLAY_MAC: Record<string, string> = {
+  mod: "⌘",
+  cmd: "⌘",
+  meta: "⌘",
+  ctrl: "⌃",
+  shift: "⇧",
+  alt: "⌥",
+  option: "⌥",
+  up: "↑",
+  down: "↓",
+  left: "←",
+  right: "→",
+  esc: "Esc",
+  enter: "↵",
+  return: "↵",
+  space: "Space",
+};
+
+const TOKEN_DISPLAY_OTHER: Record<string, string> = {
+  mod: "Ctrl",
+  cmd: "Ctrl",
+  meta: "Win",
+  ctrl: "Ctrl",
+  shift: "Shift",
+  alt: "Alt",
+  option: "Alt",
+  up: "↑",
+  down: "↓",
+  left: "←",
+  right: "→",
+  esc: "Esc",
+  enter: "Enter",
+  return: "Enter",
+  space: "Space",
+};
+
+function displayToken(token: string): string {
+  const map = IS_MAC ? TOKEN_DISPLAY_MAC : TOKEN_DISPLAY_OTHER;
+  return map[token] ?? token.toUpperCase();
+}
+
+export function formatCombo(combo: string): string {
+  const parts = formatComboParts(combo);
+  return IS_MAC ? parts.join("") : parts.join("+");
+}
+
+export function formatComboParts(combo: string): string[] {
+  return combo
+    .toLowerCase()
+    .split("+")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(displayToken);
+}
+
+export function formatHotkey(id: HotkeyId): string {
+  return formatCombo(HOTKEYS[id].combo);
+}
+
+export function formatHotkeyParts(id: HotkeyId): string[] {
+  return formatComboParts(HOTKEYS[id].combo);
+}
+
+/**
+ * Splits a hotkey into a modifier cluster and the trigger key, ready for a
+ * kbd-style display like `⌘⇧ + >`.
+ *
+ * On macOS modifier glyphs are joined tight (e.g. "⌘⇧"); on other platforms
+ * they're "+" joined ("Ctrl+Shift") since the names need a separator.
+ */
+export function formatHotkeyForKbd(id: HotkeyId): {
+  modifiers: string | null;
+  key: string;
+} {
+  const parts = formatComboParts(HOTKEYS[id].combo);
+  if (parts.length === 0) return { modifiers: null, key: "" };
+  if (parts.length === 1) return { modifiers: null, key: parts[0] };
+  const key = parts[parts.length - 1];
+  const mods = parts.slice(0, -1);
+  return {
+    modifiers: IS_MAC ? mods.join("") : mods.join("+"),
+    key,
+  };
+}

--- a/apps/web/src/lib/hotkeys/keymap.ts
+++ b/apps/web/src/lib/hotkeys/keymap.ts
@@ -1,0 +1,45 @@
+// Single source of truth for app-level keyboard shortcuts.
+//
+// Each hotkey has a stable id so handlers reference the binding indirectly —
+// the combo can change in one place without touching wiring.
+//
+// Combo grammar: "+"-separated tokens, case-insensitive. Recognized tokens:
+//   mod    → Cmd on macOS, Ctrl elsewhere (use this for cross-platform)
+//   ctrl   → Ctrl key (literal, both platforms)
+//   shift, alt (a.k.a. option), meta (a.k.a. cmd)
+//   any other token is the key (matched against KeyboardEvent.key, lowercased)
+//
+// Shifted symbol keys (e.g. ">", "<") are matched on KeyboardEvent.key, so
+// the binding works across keyboard layouts where the physical position of
+// the symbol differs.
+
+export type HotkeyDef = {
+  combo: string;
+  description: string;
+  // When true, the hotkey fires even if focus is inside an editable element
+  // (inputs, textareas, contenteditable, xterm). Default false.
+  allowInInputs?: boolean;
+};
+
+export const HOTKEYS = {
+  "toggle-media-sidebar": {
+    combo: "mod+shift+>",
+    description: "Toggle media sidebar",
+  },
+  "toggle-agent-sidebar": {
+    combo: "mod+shift+<",
+    description: "Toggle agent sidebar",
+  },
+  "focus-prev-agent": {
+    combo: "mod+shift+up",
+    description: "Focus previous agent",
+    allowInInputs: true,
+  },
+  "focus-next-agent": {
+    combo: "mod+shift+down",
+    description: "Focus next agent",
+    allowInInputs: true,
+  },
+} satisfies Record<string, HotkeyDef>;
+
+export type HotkeyId = keyof typeof HOTKEYS;

--- a/apps/web/src/lib/hotkeys/keymap.ts
+++ b/apps/web/src/lib/hotkeys/keymap.ts
@@ -40,6 +40,11 @@ export const HOTKEYS = {
     description: "Focus next agent",
     allowInInputs: true,
   },
+  "open-command-palette": {
+    combo: "mod+k",
+    description: "Open command palette",
+    allowInInputs: true,
+  },
 } satisfies Record<string, HotkeyDef>;
 
 export type HotkeyId = keyof typeof HOTKEYS;

--- a/apps/web/src/lib/hotkeys/use-hotkey.ts
+++ b/apps/web/src/lib/hotkeys/use-hotkey.ts
@@ -56,8 +56,16 @@ function isEditableTarget(target: EventTarget | null): boolean {
   const tag = target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
   if (target.isContentEditable) return true;
-  if (target.closest('[data-hotkey-disable="true"]')) return true;
   return false;
+}
+
+// Stronger opt-out than `allowInInputs`: when an ancestor element marks itself
+// with data-hotkey-disable="true", *no* hotkey fires from inside that scope —
+// even ones that opted into firing in inputs. Used to keep palette/global
+// shortcuts from triggering on top of an open modal that owns its own input.
+function isHotkeyDisabledScope(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return !!target.closest('[data-hotkey-disable="true"]');
 }
 
 // Browsers on macOS report the unshifted character for KeyboardEvent.key when
@@ -132,6 +140,7 @@ export function useHotkey(
 
     const onKeyDown = (e: KeyboardEvent): void => {
       if (!comboMatches(parsed, e)) return;
+      if (isHotkeyDisabledScope(e.target)) return;
       if (!allowInInputs && isEditableTarget(e.target)) return;
       e.preventDefault();
       e.stopPropagation();

--- a/apps/web/src/lib/hotkeys/use-hotkey.ts
+++ b/apps/web/src/lib/hotkeys/use-hotkey.ts
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+
+import { HOTKEYS, type HotkeyDef, type HotkeyId } from "./keymap";
+
+const IS_MAC =
+  typeof navigator !== "undefined"
+    ? /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+    : false;
+
+type Parsed = {
+  needMod: boolean;
+  needCtrl: boolean;
+  needShift: boolean;
+  needAlt: boolean;
+  needMeta: boolean;
+  key: string;
+};
+
+// Aliases that map readable keymap tokens to the lowercased KeyboardEvent.key
+// they should match. Unlisted tokens pass through unchanged.
+const KEY_ALIASES: Record<string, string> = {
+  up: "arrowup",
+  down: "arrowdown",
+  left: "arrowleft",
+  right: "arrowright",
+  esc: "escape",
+  space: " ",
+  enter: "enter",
+  return: "enter",
+};
+
+function parseCombo(combo: string): Parsed {
+  const parsed: Parsed = {
+    needMod: false,
+    needCtrl: false,
+    needShift: false,
+    needAlt: false,
+    needMeta: false,
+    key: "",
+  };
+  for (const raw of combo.toLowerCase().split("+")) {
+    const token = raw.trim();
+    if (!token) continue;
+    if (token === "mod") parsed.needMod = true;
+    else if (token === "ctrl") parsed.needCtrl = true;
+    else if (token === "shift") parsed.needShift = true;
+    else if (token === "alt" || token === "option") parsed.needAlt = true;
+    else if (token === "meta" || token === "cmd") parsed.needMeta = true;
+    else parsed.key = KEY_ALIASES[token] ?? token;
+  }
+  return parsed;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  if (target.closest('[data-hotkey-disable="true"]')) return true;
+  return false;
+}
+
+// Browsers on macOS report the unshifted character for KeyboardEvent.key when
+// Cmd is held (e.g. Cmd+Shift+. arrives as key=".", not ">"). To stay
+// layout-flexible while supporting the common US-layout binding, we accept
+// either the shifted symbol or its unshifted base when Shift is required.
+const US_SHIFT_FALLBACK: Record<string, string> = {
+  ">": ".",
+  "<": ",",
+  "?": "/",
+  ":": ";",
+  '"': "'",
+  "{": "[",
+  "}": "]",
+  "|": "\\",
+  "+": "=",
+  _: "-",
+  "(": "9",
+  ")": "0",
+  "!": "1",
+  "@": "2",
+  "#": "3",
+  $: "4",
+  "%": "5",
+  "^": "6",
+  "&": "7",
+  "*": "8",
+  "~": "`",
+};
+
+function comboMatches(parsed: Parsed, e: KeyboardEvent): boolean {
+  const modPressed = IS_MAC ? e.metaKey : e.ctrlKey;
+  if (parsed.needMod !== modPressed) return false;
+  if (parsed.needShift !== e.shiftKey) return false;
+  if (parsed.needAlt !== e.altKey) return false;
+  if (parsed.needCtrl && !e.ctrlKey) return false;
+  if (parsed.needMeta && !e.metaKey) return false;
+
+  const eKey = e.key.toLowerCase();
+  if (eKey === parsed.key) return true;
+  if (parsed.needShift) {
+    const unshifted = US_SHIFT_FALLBACK[parsed.key];
+    if (unshifted && eKey === unshifted) return true;
+  }
+  return false;
+}
+
+export type UseHotkeyOptions = {
+  enabled?: boolean;
+};
+
+/**
+ * Bind a handler to a hotkey id from `keymap.ts`. Listener is registered at
+ * the document level in capture phase, so it runs before nested handlers
+ * (e.g. xterm.js inside the terminal).
+ */
+export function useHotkey(
+  id: HotkeyId,
+  handler: (e: KeyboardEvent) => void,
+  options: UseHotkeyOptions = {}
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const { enabled = true } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const def: HotkeyDef = HOTKEYS[id];
+    const parsed = parseCombo(def.combo);
+    const allowInInputs = def.allowInInputs ?? false;
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (!comboMatches(parsed, e)) return;
+      if (!allowInInputs && isEditableTarget(e.target)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      handlerRef.current(e);
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [id, enabled]);
+}


### PR DESCRIPTION
## Summary

- Introduces a small keyed-by-id hotkey system (`apps/web/src/lib/hotkeys/`): central keymap, `useHotkey` hook (capture-phase listener so it fires before xterm, `mod` ↔ Cmd/Ctrl normalization, default skip in inputs), and shortcut-formatting helpers.
- Wires four sidebar/cycle hotkeys on the agents view: `mod+Shift+>` toggle media sidebar, `mod+Shift+<` toggle agent sidebar, `mod+Shift+↑/↓` focus previous/next top-level agent (filters review agents, wraps).
- Adds a Cmd+K command palette (`command-palette.tsx`) with five actions — New agent, Toggle media sidebar, Toggle agent sidebar, Focus next/prev agent — each handler mirroring the underlying button or hotkey. Visual styling is fully driven by `--primary` so it adapts across themes; selected row gets a primary left-edge accent and glowing icon. Shortcut hints render as `⌘⇧ + >` (Mac) / `Ctrl+Shift+>` (Win/Linux) inside a single `kbd` badge per row.

Adding a new hotkey is a one-entry change in `keymap.ts` plus a `useHotkey(...)` call. Adding a new palette action is a single object in the `paletteActions` list.

## Test plan

- [ ] On the agents view, press `Cmd+Shift+>` — media sidebar toggles in drawer mode (overlay, terminal not resized).
- [ ] Press `Cmd+Shift+<` — agent sidebar toggles closed/open.
- [ ] Press `Cmd+Shift+↓` repeatedly — focus cycles through top-level agents and wraps; review agents are skipped.
- [ ] Press `Cmd+Shift+↑` from the first agent — wraps to the last top-level agent.
- [ ] Press `Cmd+K` — palette opens, autofocuses the search input, lists 5 actions with shortcut badges.
- [ ] Type to filter, arrow-keys to navigate, Enter to run. Esc closes.
- [ ] Switch themes (cool-navy / vaporwave / matrix) and re-open the palette — accents track `--primary`.
- [ ] From inside the terminal (xterm focused), confirm `Cmd+K` and `Cmd+Shift+↑/↓` still fire.
- [ ] `pnpm run check` and `pnpm run finalize:web` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)