### PR TITLE
Fix worktree diff stats base fallback

### DIFF
--- a/apps/server/src/agents/diff-stats-refresher.ts
+++ b/apps/server/src/agents/diff-stats-refresher.ts
@@ -9,6 +9,8 @@ export type DiffStatsAgent = {
   baseBranch: string | null;
 };
 
+const DEFAULT_WORKTREE_BASE_BRANCH = "main";
+
 export type DiffStatsChangedEvent = {
   type: "agent.diff_state_changed";
   agentId: string;
@@ -117,13 +119,14 @@ export class DiffStatsRefresher {
       if (!path) {
         nextStats = null;
       } else {
-        // Pass `agent.baseBranch` straight through — `getDiffStats` runs
-        // it through the shared `resolveBaseRef` chain, so we don't bake a
-        // second fallback policy in here.
-        nextStats = await this.computeDiffStats(
-          path,
-          agent?.baseBranch ?? null
-        );
+        // Managed worktree agents default to `main` elsewhere in Dispatch,
+        // but older rows may still have a null baseBranch persisted. Keep
+        // non-worktree agents on the shared resolver fallback chain while
+        // forcing worktree-backed agents onto the intended default base.
+        const baseRef =
+          agent?.baseBranch ??
+          (agent?.worktreePath ? DEFAULT_WORKTREE_BASE_BRANCH : null);
+        nextStats = await this.computeDiffStats(path, baseRef);
       }
     } catch (err) {
       this.logger?.warn(

--- a/apps/server/test/diff-stats-refresher.test.ts
+++ b/apps/server/test/diff-stats-refresher.test.ts
@@ -311,16 +311,17 @@ describe("DiffStatsRefresher", () => {
     expect(refresher.getStats("a1")).toBeNull();
   });
 
-  it("passes agent.baseBranch through to the compute callback", async () => {
-    // The refresher no longer applies its own base-ref fallback — that
-    // policy lives in the shared resolver inside getDiffStats. Confirm
-    // we forward agent.baseBranch (including null) verbatim.
+  it("defaults worktree-backed agents to main when baseBranch is missing", async () => {
     const agents = setupAgents([
       [
         "with-base",
         { worktreePath: "/tmp/wt", cwd: null, baseBranch: "trunk" },
       ],
       ["no-base", { worktreePath: "/tmp/wt", cwd: null, baseBranch: null }],
+      [
+        "repo-no-base",
+        { worktreePath: null, cwd: "/tmp/repo", baseBranch: null },
+      ],
     ]);
     const compute = vi.fn(
       async (): Promise<DiffStats> => ({
@@ -340,7 +341,10 @@ describe("DiffStatsRefresher", () => {
     expect(compute).toHaveBeenCalledWith("/tmp/wt", "trunk");
 
     await refresher.signal("no-base");
-    expect(compute).toHaveBeenCalledWith("/tmp/wt", null);
+    expect(compute).toHaveBeenCalledWith("/tmp/wt", "main");
+
+    await refresher.signal("repo-no-base");
+    expect(compute).toHaveBeenCalledWith("/tmp/repo", null);
   });
 
   it("swallows compute errors and leaves the cache unchanged", async () => {

--- a/apps/web/src/hooks/use-agent-diff-stats.ts
+++ b/apps/web/src/hooks/use-agent-diff-stats.ts
@@ -19,7 +19,7 @@ export function diffStatsQueryKey(agentId: string): [string, string] {
  * after returning from another tab. `refresh()` is the tap-to-refresh
  * entry point. Polling stops automatically when `enabled` flips false.
  */
-const DIFF_STATS_POLL_INTERVAL_MS = 30_000;
+const DIFF_STATS_POLL_INTERVAL_MS = 10_000;
 const DIFF_STATS_STALE_TIME_MS = 15_000;
 
 export function useAgentDiffStats(


### PR DESCRIPTION
## Summary
- default managed worktree diff stats to `main` when agent metadata has no `baseBranch`
- keep non-worktree agents on the existing shared base-ref fallback chain
- reduce expanded-agent diff polling from 30s to 10s

## Testing
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e