### PR TITLE
Fix legacy worktree diff stats path fallback

### DIFF
--- a/apps/server/src/agents/diff-stats-refresher.ts
+++ b/apps/server/src/agents/diff-stats-refresher.ts
@@ -7,6 +7,10 @@ export type DiffStatsAgent = {
   worktreePath: string | null;
   cwd: string | null;
   baseBranch: string | null;
+  gitContext?: {
+    worktreePath: string;
+    isWorktree: boolean;
+  } | null;
 };
 
 const DEFAULT_WORKTREE_BASE_BRANCH = "main";
@@ -111,11 +115,15 @@ export class DiffStatsRefresher {
     let nextStats: DiffStats | null = null;
     try {
       const agent = await this.getAgent(agentId);
-      // Prefer the dispatch-managed worktreePath (set on `useWorktree=true`
-      // creates), but fall back to the agent's cwd so any agent pointed at
-      // a git working tree gets stats. `getDiffStats` returns null when
-      // the path isn't inside a repo, so this is safe.
-      const path = agent?.worktreePath ?? agent?.cwd ?? null;
+      // Prefer the dispatch-managed worktreePath. Older rows can be missing
+      // that column while still having a populated gitContext from a prior
+      // probe, so use the probed worktree path before falling back to cwd.
+      // `getDiffStats` returns null when the path isn't inside a repo.
+      const gitContextWorktreePath = agent?.gitContext?.isWorktree
+        ? agent.gitContext.worktreePath
+        : null;
+      const path =
+        agent?.worktreePath ?? gitContextWorktreePath ?? agent?.cwd ?? null;
       if (!path) {
         nextStats = null;
       } else {
@@ -125,7 +133,9 @@ export class DiffStatsRefresher {
         // forcing worktree-backed agents onto the intended default base.
         const baseRef =
           agent?.baseBranch ??
-          (agent?.worktreePath ? DEFAULT_WORKTREE_BASE_BRANCH : null);
+          (agent?.worktreePath || gitContextWorktreePath
+            ? DEFAULT_WORKTREE_BASE_BRANCH
+            : null);
         nextStats = await this.computeDiffStats(path, baseRef);
       }
     } catch (err) {

--- a/apps/server/test/diff-stats-refresher.test.ts
+++ b/apps/server/test/diff-stats-refresher.test.ts
@@ -292,6 +292,39 @@ describe("DiffStatsRefresher", () => {
     expect(compute).toHaveBeenCalledWith("/some/repo", "main");
   });
 
+  it("prefers gitContext.worktreePath over cwd for legacy worktree rows", async () => {
+    const agents = setupAgents([
+      [
+        "a1",
+        {
+          worktreePath: null,
+          cwd: "/shared/repo",
+          baseBranch: null,
+          gitContext: {
+            worktreePath: "/actual/worktree",
+            isWorktree: true,
+          },
+        },
+      ],
+    ]);
+    const compute = vi.fn(
+      async (): Promise<DiffStats> => ({
+        added: 7,
+        deleted: 3,
+        files: 2,
+        computedAt: Date.now(),
+      })
+    );
+    const refresher = new DiffStatsRefresher({
+      getAgent: async (id) => agents.get(id) ?? null,
+      publishEvent: () => {},
+      computeDiffStats: compute,
+    });
+
+    await refresher.signal("a1");
+    expect(compute).toHaveBeenCalledWith("/actual/worktree", "main");
+  });
+
   it("publishes null when both worktreePath and cwd are missing", async () => {
     const agents = setupAgents([
       ["a1", { worktreePath: null, cwd: null, baseBranch: null }],


### PR DESCRIPTION
## Summary
- prefer `gitContext.worktreePath` over shared `cwd` when refreshing agent diff stats for legacy worktree rows
- keep the `main` base-branch fallback for worktree-backed agents resolved through either persisted worktree metadata or gitContext
- add a regression test covering legacy rows with null `worktreePath` and populated `gitContext`

## Validation
- `pnpm vitest apps/server/test/diff-stats-refresher.test.ts`
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e` *(fails in existing `e2e/agent-crud.spec.ts` with `socket hang up` / `ECONNREFUSED` after the isolated server dies; failures are transport-level, not diff-stats assertions)*