### PR TITLE
Improve update check progress and release detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ artifacts/
 test-results/
 playwright-report/
 .dispatch/config.json
+.dispatch/dev-cache/
 .dispatch/worktrees/
 opencode.json
 apps/server/src/generated/runtime-assets/

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -119,6 +119,13 @@ export async function registerReleaseRoutes(
   app: FastifyInstance,
   deps: ReleaseRouteDeps
 ): Promise<void> {
+  const deriveCurrentTag = async (): Promise<string | null> => {
+    const record = await readReleaseStore();
+    if (record?.tag) return record.tag;
+    const version = (await deps.getAppVersionInfo()).version?.trim() ?? null;
+    return version && /^\d+\.\d+\.\d+$/.test(version) ? `v${version}` : null;
+  };
+
   const getReleaseStreamClientId = (request: FastifyRequest): string | null => {
     const header = request.headers["x-dispatch-release-client-id"];
     if (typeof header !== "string") return null;
@@ -163,8 +170,7 @@ export async function registerReleaseRoutes(
         "--quiet",
       ]);
 
-      const record = await readReleaseStore();
-      const currentTag = record?.tag ?? null;
+      const currentTag = await deriveCurrentTag();
       const isAdmin = await deps.checkIsAdmin();
       const channelRaw = await getSetting(deps.pool, RELEASE_CHANNEL_KEY);
       const channel = channelRaw === "latest" ? "latest" : "stable";
@@ -214,6 +220,18 @@ export async function registerReleaseRoutes(
         latestTag &&
         deps.compareSemver(latestTag, currentTag) > 0
       );
+      request.log.info(
+        {
+          currentTag,
+          latestTag,
+          absoluteLatestTag,
+          updateAvailable,
+          channel,
+          releaseStreamClientId,
+          isAdmin,
+        },
+        "release/info: computed release availability"
+      );
 
       let latestRelease: {
         tag: string;
@@ -253,12 +271,20 @@ export async function registerReleaseRoutes(
 
       let pendingMigrations: PendingMigrationSummary[] = [];
       let migrationsError: string | null = null;
-      if (latestTag && updateAvailable && isAdmin) {
+      if (latestTag && updateAvailable) {
+        request.log.info(
+          { tag: latestTag },
+          "release/info: evaluating pending migrations for update check"
+        );
         try {
           const repo = await deps.getGitHubRepo();
           const evaluation = await evaluatePendingMigrations(latestTag, {
             repo,
             onProgress: ({ message, bytesReceived, totalBytes }) => {
+              request.log.info(
+                { tag: latestTag, message, bytesReceived, totalBytes },
+                "release/info: migration evaluation progress"
+              );
               emitInfoProgress(releaseStreamClientId, {
                 step:
                   bytesReceived !== undefined
@@ -282,6 +308,15 @@ export async function registerReleaseRoutes(
               .map((e) => `${e.filename}: ${e.error}`)
               .join("; ");
           }
+          request.log.info(
+            {
+              tag: latestTag,
+              pendingMigrationCount: pendingMigrations.length,
+              evaluationErrorCount: evaluation.errors.length,
+              migrationsError,
+            },
+            "release/info: migration evaluation complete"
+          );
         } catch (err) {
           migrationsError =
             err instanceof Error ? err.message : "migration evaluation failed";

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -1,4 +1,9 @@
-import type { FastifyBaseLogger, FastifyInstance, FastifyReply } from "fastify";
+import type {
+  FastifyBaseLogger,
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
 import type { Pool } from "pg";
 
 import type { AgentManager, AgentRecord } from "../agents/manager.js";
@@ -36,6 +41,8 @@ import {
 import { runCommand } from "../shared/lib/run-command.js";
 import type {
   ReleaseJob,
+  ReleaseProgress,
+  ReleaseStreamClient,
   ReleaseStreamEvent,
   ReleaseVersionType,
 } from "../server/release-runtime.js";
@@ -57,7 +64,7 @@ type ReleaseRouteDeps = {
   setActiveReleaseJob: (job: ReleaseJob | null) => void;
   getActiveAssistedUpdateLaunch: () => boolean;
   setActiveAssistedUpdateLaunch: (active: boolean) => void;
-  releaseStreamClients: Set<NodeJS.WritableStream>;
+  releaseStreamClients: Set<ReleaseStreamClient>;
   getAppVersionInfo: () => Promise<{
     releaseTag: string | null;
     version: string | null;
@@ -90,6 +97,10 @@ type ReleaseRouteDeps = {
   }) => string;
   hasActiveAssistedUpdateAgent: () => Promise<boolean>;
   broadcastReleaseEvent: (event: ReleaseStreamEvent) => void;
+  sendReleaseEventToClient: (
+    clientId: string,
+    event: ReleaseStreamEvent
+  ) => void;
   appendReleaseLog: (job: ReleaseJob, line: string) => void;
   rehydrateActiveAssistedJob: () => Promise<void>;
   runReleaseJob: (job: ReleaseJob) => Promise<void>;
@@ -108,6 +119,24 @@ export async function registerReleaseRoutes(
   app: FastifyInstance,
   deps: ReleaseRouteDeps
 ): Promise<void> {
+  const getReleaseStreamClientId = (request: FastifyRequest): string | null => {
+    const header = request.headers["x-dispatch-release-client-id"];
+    if (typeof header !== "string") return null;
+    const trimmed = header.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const emitInfoProgress = (
+    clientId: string | null,
+    progress: ReleaseProgress | null
+  ): void => {
+    if (!clientId) return;
+    deps.sendReleaseEventToClient(clientId, {
+      type: "info-progress",
+      progress,
+    });
+  };
+
   app.get("/api/v1/app/version", async () => {
     return deps.getAppVersionInfo();
   });
@@ -118,6 +147,12 @@ export async function registerReleaseRoutes(
   });
 
   app.get("/api/v1/release/info", async (request, reply) => {
+    const releaseStreamClientId = getReleaseStreamClientId(request);
+    emitInfoProgress(releaseStreamClientId, {
+      step: "fetching-tags",
+      label: "Fetching release tags",
+      detail: "Checking origin for the latest available releases.",
+    });
     try {
       await runCommand("git", [
         "-C",
@@ -137,6 +172,11 @@ export async function registerReleaseRoutes(
       let latestTag: string | null = null;
       let absoluteLatestTag: string | null = null;
       try {
+        emitInfoProgress(releaseStreamClientId, {
+          step: "loading-release-list",
+          label: "Looking up latest release",
+          detail: `Selecting the newest ${channel} release from GitHub.`,
+        });
         const repo = await deps.getGitHubRepo();
         const ghResult = await runCommand("gh", [
           "release",
@@ -183,6 +223,11 @@ export async function registerReleaseRoutes(
       let assistedMetadata: AssistedUpdateMetadata | null = null;
       let assistedMetadataError: string | null = null;
       if (latestTag && updateAvailable) {
+        emitInfoProgress(releaseStreamClientId, {
+          step: "loading-release-notes",
+          label: `Inspecting ${latestTag}`,
+          detail: "Loading release metadata and assisted-update requirements.",
+        });
         const fullRelease = await deps.fetchLatestReleaseMetadata(latestTag);
         latestRelease = fullRelease
           ? {
@@ -208,11 +253,26 @@ export async function registerReleaseRoutes(
 
       let pendingMigrations: PendingMigrationSummary[] = [];
       let migrationsError: string | null = null;
-      if (latestTag && updateAvailable) {
+      if (latestTag && updateAvailable && isAdmin) {
         try {
           const repo = await deps.getGitHubRepo();
           const evaluation = await evaluatePendingMigrations(latestTag, {
             repo,
+            onProgress: ({ message, bytesReceived, totalBytes }) => {
+              emitInfoProgress(releaseStreamClientId, {
+                step:
+                  bytesReceived !== undefined
+                    ? "downloading-release-package"
+                    : "inspecting-release-package",
+                label:
+                  bytesReceived !== undefined
+                    ? "Downloading release package"
+                    : "Inspecting release package",
+                detail: message,
+                bytesReceived: bytesReceived ?? null,
+                totalBytes: totalBytes ?? null,
+              });
+            },
           });
           pendingMigrations = evaluation.pending.map((m) =>
             toSummary(m.manifest)
@@ -299,6 +359,8 @@ export async function registerReleaseRoutes(
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       return reply.code(500).send({ error: message });
+    } finally {
+      emitInfoProgress(releaseStreamClientId, null);
     }
   });
 
@@ -423,6 +485,7 @@ export async function registerReleaseRoutes(
       runUrl: null,
       tag: null,
       error: null,
+      progress: null,
     };
     deps.setActiveReleaseJob(job);
     void deps.runReleaseJob(job);
@@ -562,6 +625,7 @@ export async function registerReleaseRoutes(
       runUrl: null,
       tag,
       error: null,
+      progress: null,
     };
     deps.setActiveReleaseJob(job);
     void deps.runUpdateJob(job);
@@ -730,6 +794,7 @@ export async function registerReleaseRoutes(
           runUrl: null,
           tag: body.tag,
           error: null,
+          progress: null,
           assisted: { ...assistedState, agentId: agent.id },
         });
         deps.broadcastReleaseEvent({
@@ -827,7 +892,15 @@ export async function registerReleaseRoutes(
     return { ok: true };
   });
 
-  app.get("/api/v1/release/stream", async (_request, reply) => {
+  app.get("/api/v1/release/stream", async (request, reply) => {
+    const clientId =
+      typeof request.query === "object" &&
+      request.query !== null &&
+      "clientId" in request.query &&
+      typeof request.query.clientId === "string" &&
+      request.query.clientId.trim().length > 0
+        ? request.query.clientId.trim()
+        : "default";
     reply.raw.setHeader("Content-Type", "text/event-stream");
     reply.raw.setHeader("Cache-Control", "no-cache, no-transform");
     reply.raw.setHeader("Connection", "keep-alive");
@@ -835,7 +908,8 @@ export async function registerReleaseRoutes(
     reply.hijack();
 
     const stream = reply.raw;
-    deps.releaseStreamClients.add(stream);
+    const client = { clientId, stream };
+    deps.releaseStreamClients.add(client);
     const heartbeat = setInterval(() => {
       stream.write(": keepalive\n\n");
     }, 20_000);
@@ -854,7 +928,7 @@ export async function registerReleaseRoutes(
 
     stream.on("close", () => {
       clearInterval(heartbeat);
-      deps.releaseStreamClients.delete(stream);
+      deps.releaseStreamClients.delete(client);
     });
   });
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -473,6 +473,7 @@ async function registerRoutes() {
     buildAssistedUpdatePrompt: releaseRuntime.buildAssistedUpdatePrompt,
     hasActiveAssistedUpdateAgent: releaseRuntime.hasActiveAssistedUpdateAgent,
     broadcastReleaseEvent: releaseRuntime.broadcastReleaseEvent,
+    sendReleaseEventToClient: releaseRuntime.sendReleaseEventToClient,
     appendReleaseLog: releaseRuntime.appendReleaseLog,
     rehydrateActiveAssistedJob: releaseRuntime.rehydrateActiveAssistedJob,
     runReleaseJob: releaseRuntime.runReleaseJob,

--- a/apps/server/src/server/release-runtime.ts
+++ b/apps/server/src/server/release-runtime.ts
@@ -30,6 +30,13 @@ type CreatePhase = "preflight" | "triggering" | "watching" | "done" | "failed";
 type UpdatePhase = "fetching" | "deploying" | "restarting" | "done" | "failed";
 type AssistedReleasePhase = AssistedPhase;
 type ReleasePhase = CreatePhase | UpdatePhase | AssistedReleasePhase;
+export type ReleaseProgress = {
+  step: string;
+  label: string;
+  detail?: string | null;
+  bytesReceived?: number | null;
+  totalBytes?: number | null;
+};
 
 type CommonReleaseJobFields = {
   startedAt: string;
@@ -37,6 +44,7 @@ type CommonReleaseJobFields = {
   runUrl: string | null;
   tag: string | null;
   error: string | null;
+  progress: ReleaseProgress | null;
 };
 
 export type ReleaseJob =
@@ -62,10 +70,17 @@ export type ReleaseStreamEvent =
   | { type: "log"; line: string }
   | { type: "log.replace"; line: string }
   | { type: "log.rewind"; count: number }
+  | { type: "progress"; progress: ReleaseProgress | null }
+  | { type: "info-progress"; progress: ReleaseProgress | null }
   | { type: "phase"; phase: ReleasePhase; error?: string }
   | { type: "runUrl"; url: string }
   | { type: "tag"; tag: string }
   | { type: "assisted"; state: AssistedUpdateState };
+
+export type ReleaseStreamClient = {
+  clientId: string;
+  stream: NodeJS.WritableStream;
+};
 
 type GitHubReleaseMetadata = {
   tag: string;
@@ -89,7 +104,11 @@ type CreateReleaseRuntimeDeps = {
   ensureCachedTarball: (input: {
     tag: string;
     repo: string;
-    onProgress: (input: { message: string }) => void;
+    onProgress: (input: {
+      message: string;
+      bytesReceived?: number;
+      totalBytes?: number | null;
+    }) => void;
   }) => Promise<{ path: string }>;
   pruneCacheExcept: (tags: string[]) => Promise<void>;
   unlinkCachedTarball: (tag: string) => Promise<void>;
@@ -106,7 +125,7 @@ type CreateReleaseRuntimeDeps = {
 export function createReleaseRuntime(deps: CreateReleaseRuntimeDeps) {
   let activeReleaseJob: ReleaseJob | null = null;
   let activeAssistedUpdateLaunch = false;
-  const releaseStreamClients = new Set<NodeJS.WritableStream>();
+  const releaseStreamClients = new Set<ReleaseStreamClient>();
   let cachedIsAdmin: boolean | null = null;
 
   async function getAppVersionInfo(): Promise<{
@@ -167,6 +186,7 @@ export function createReleaseRuntime(deps: CreateReleaseRuntimeDeps) {
       runUrl: null,
       tag: state.tag,
       error: state.error,
+      progress: null,
       assisted: state,
     };
   }
@@ -251,7 +271,22 @@ Suggested workflow:
     const payload = `data: ${JSON.stringify(event)}\n\n`;
     for (const client of releaseStreamClients) {
       try {
-        client.write(payload);
+        client.stream.write(payload);
+      } catch {
+        releaseStreamClients.delete(client);
+      }
+    }
+  }
+
+  function sendReleaseEventToClient(
+    clientId: string,
+    event: ReleaseStreamEvent
+  ): void {
+    const payload = `data: ${JSON.stringify(event)}\n\n`;
+    for (const client of releaseStreamClients) {
+      if (client.clientId !== clientId) continue;
+      try {
+        client.stream.write(payload);
       } catch {
         releaseStreamClients.delete(client);
       }
@@ -287,6 +322,14 @@ Suggested workflow:
   ): void {
     job.phase = phase;
     broadcastReleaseEvent({ type: "phase", phase, error });
+  }
+
+  function setReleaseProgress(
+    job: ReleaseJob,
+    progress: ReleaseProgress | null
+  ): void {
+    job.progress = progress;
+    broadcastReleaseEvent({ type: "progress", progress });
   }
 
   function streamProcess(
@@ -350,7 +393,8 @@ Suggested workflow:
   }
 
   async function checkIsAdmin(): Promise<boolean> {
-    if (cachedIsAdmin !== null) return cachedIsAdmin;
+    const canCacheResult = process.env.VITEST !== "true";
+    if (canCacheResult && cachedIsAdmin !== null) return cachedIsAdmin;
     try {
       await deps.runCommand("gh", ["--version"]);
       const repo = await getGitHubRepo();
@@ -363,11 +407,17 @@ Suggested workflow:
         "--jq",
         ".viewerPermission",
       ]);
-      cachedIsAdmin = result.stdout.trim() === "ADMIN";
+      const isAdmin = result.stdout.trim() === "ADMIN";
+      if (canCacheResult) {
+        cachedIsAdmin = isAdmin;
+      }
+      return isAdmin;
     } catch {
-      cachedIsAdmin = false;
+      if (canCacheResult) {
+        cachedIsAdmin = false;
+      }
+      return false;
     }
-    return cachedIsAdmin;
   }
 
   function parseGhJson<T>(stdout: string): T {
@@ -448,7 +498,22 @@ Suggested workflow:
       cached = await deps.ensureCachedTarball({
         tag,
         repo,
-        onProgress: ({ message }) => appendReleaseLog(job, message),
+        onProgress: ({ message, bytesReceived, totalBytes }) => {
+          appendReleaseLog(job, message);
+          setReleaseProgress(job, {
+            step:
+              bytesReceived !== undefined
+                ? "downloading-artifact"
+                : "preparing-artifact",
+            label:
+              bytesReceived !== undefined
+                ? "Downloading release package"
+                : "Preparing release package",
+            detail: message,
+            bytesReceived: bytesReceived ?? null,
+            totalBytes: totalBytes ?? null,
+          });
+        },
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -457,9 +522,19 @@ Suggested workflow:
     }
 
     appendReleaseLog(job, `==> checking out ${tag} (for version metadata)`);
+    setReleaseProgress(job, {
+      step: "checking-out-tag",
+      label: `Loading ${tag}`,
+      detail: "Checking out the target release for validation.",
+    });
     await deps.runCommand("git", ["-C", deps.serverDir, "checkout", tag]);
 
     appendReleaseLog(job, "==> validating artifact contents");
+    setReleaseProgress(job, {
+      step: "validating-artifact",
+      label: "Validating release package",
+      detail: "Inspecting the downloaded artifact before extraction.",
+    });
     let listing: Awaited<ReturnType<RunCommand>>;
     try {
       listing = await deps.runCommand("tar", ["tzf", cached.path]);
@@ -481,6 +556,11 @@ Suggested workflow:
     }
 
     appendReleaseLog(job, "==> extracting pre-built artifact");
+    setReleaseProgress(job, {
+      step: "extracting-artifact",
+      label: "Installing release package",
+      detail: "Extracting the pre-built release into the install directory.",
+    });
     try {
       await deps.runCommand("tar", [
         "xzf",
@@ -587,9 +667,19 @@ Suggested workflow:
     if (!usedArtifact) {
       appendReleaseLog(job, "==> falling back to build from source");
       appendReleaseLog(job, `==> checking out ${tag}`);
+      setReleaseProgress(job, {
+        step: "checking-out-source",
+        label: `Loading ${tag}`,
+        detail: "Preparing the source checkout for a local build.",
+      });
       await deps.runCommand("git", ["-C", deps.serverDir, "checkout", tag]);
       await assertCommandOnPath(job, "pnpm", "build Dispatch from source");
       appendReleaseLog(job, "==> installing dependencies");
+      setReleaseProgress(job, {
+        step: "installing-dependencies",
+        label: "Installing dependencies",
+        detail: "Preparing the source build environment.",
+      });
       await streamProcess(
         "pnpm",
         ["install", "--frozen-lockfile"],
@@ -597,6 +687,11 @@ Suggested workflow:
         job
       );
       appendReleaseLog(job, "==> building from source");
+      setReleaseProgress(job, {
+        step: "building-release",
+        label: "Building release",
+        detail: "Compiling Dispatch from source because no artifact was used.",
+      });
       await streamProcess(
         "pnpm",
         ["run", "build:bun"],
@@ -605,11 +700,26 @@ Suggested workflow:
       );
     }
 
+    setReleaseProgress(job, {
+      step: "verifying-runtime",
+      label: "Verifying runtime",
+      detail: "Checking the installed release binary before restart.",
+    });
     await assertCurrentReleaseBinary(job);
+    setReleaseProgress(job, {
+      step: "recording-release",
+      label: "Recording deployed version",
+      detail: `Saving ${tag} as the active release.`,
+    });
     await deps.writeReleaseStore({ tag, deployedAt: new Date().toISOString() });
     appendReleaseLog(job, `==> wrote release record for ${tag}`);
     setReleasePhase(job, "restarting");
     appendReleaseLog(job, "==> restarting service");
+    setReleaseProgress(job, {
+      step: "restarting-service",
+      label: "Restarting Dispatch",
+      detail: "Waiting for the service to come back on the new version.",
+    });
 
     if (process.platform === "linux") {
       spawn("systemctl", ["--user", "restart", "dispatch"], {
@@ -634,6 +744,11 @@ Suggested workflow:
       const tag = job.tag!;
       setReleasePhase(job, "fetching");
       appendReleaseLog(job, "==> fetching tags from origin");
+      setReleaseProgress(job, {
+        step: "fetching-tags",
+        label: "Fetching release tags",
+        detail: "Checking the latest tags from origin before update.",
+      });
       await deps.runCommand("git", [
         "-C",
         deps.serverDir,
@@ -643,6 +758,11 @@ Suggested workflow:
       ]);
 
       try {
+        setReleaseProgress(job, {
+          step: "resolving-tag",
+          label: `Resolving ${tag}`,
+          detail: "Confirming the requested tag exists locally.",
+        });
         await deps.runCommand("git", [
           "-C",
           deps.serverDir,
@@ -660,6 +780,7 @@ Suggested workflow:
       if (activeReleaseJob) {
         activeReleaseJob.error = error;
       }
+      setReleaseProgress(job, null);
       setReleasePhase(job, "failed", error);
     }
   }
@@ -789,6 +910,7 @@ Suggested workflow:
     hasActiveAssistedUpdateAgent,
     buildAssistedUpdatePrompt,
     broadcastReleaseEvent,
+    sendReleaseEventToClient,
     appendReleaseLog,
     runUpdateJob,
     runReleaseJob,

--- a/apps/server/test/dispatch-dev.test.ts
+++ b/apps/server/test/dispatch-dev.test.ts
@@ -72,12 +72,16 @@ describe("dispatch-dev", () => {
     expect(state).toMatch(/DEV_API_PORT=\d+/);
     expect(state).toMatch(/DEV_API_PID=\d+/);
     expect(state).toMatch(/DEV_DB_PORT=\d+/);
+    expect(state).toContain(
+      `DEV_RELEASE_CACHE_DIR=${REPO_ROOT}/.dispatch/dev-cache/release-${SUFFIX}`
+    );
 
     // --- status ---
     const statusOutput = run("status");
     expect(statusOutput).toContain("db:   running");
     expect(statusOutput).toContain("api:  running");
     expect(statusOutput).toContain("vite:");
+    expect(statusOutput).toContain("release cache:");
 
     // --- url ---
     const urlOutput = run("url");

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -203,7 +203,23 @@ describe("release metadata route handling", () => {
     });
   });
 
-  it("does not evaluate pending migrations on /release/info for non-admin viewers", async () => {
+  it("evaluates pending migrations on /release/info for authenticated viewers without repo admin access", async () => {
+    evaluateMock.mockResolvedValueOnce({
+      pending: [
+        {
+          filename: "001-example.yaml",
+          order: 1,
+          manifest: {
+            id: "example",
+            title: "Example migration",
+            summary: "Requires a manual follow-up step.",
+          },
+        },
+      ],
+      all: [],
+      appliedIds: new Set(),
+      errors: [],
+    });
     mockReleaseCommands({
       viewerPermission: "WRITE",
       releaseList: [{ tagName: "v0.19.0", isPrerelease: false }],
@@ -223,10 +239,46 @@ describe("release metadata route handling", () => {
       isAdmin: false,
       latestTag: "v0.19.0",
       updateAvailable: true,
-      pendingMigrations: [],
+      pendingMigrations: [
+        {
+          id: "example",
+          title: "Example migration",
+          summary: "Requires a manual follow-up step.",
+        },
+      ],
       migrationsError: null,
+      assistedRequired: true,
     });
-    expect(evaluateMock).not.toHaveBeenCalled();
+    expect(evaluateMock).toHaveBeenCalledWith(
+      "v0.19.0",
+      expect.objectContaining({ repo: "selfcontained/dispatch" })
+    );
+  });
+
+  it("falls back to the packaged app version when no release tag is recorded", async () => {
+    await rm(releaseStorePath, { force: true });
+    mockReleaseCommands({
+      releaseList: [{ tagName: "v0.18.36", isPrerelease: false }],
+      releaseViews: {
+        "v0.18.36": validReleaseView({
+          body: "no fenced metadata",
+          tag: "v0.18.36",
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/info",
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      currentTag: "v0.18.35",
+      latestTag: "v0.18.36",
+      updateAvailable: true,
+    });
   });
 
   it("rejects /release/update when the target release requires assisted flow", async () => {

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -203,6 +203,32 @@ describe("release metadata route handling", () => {
     });
   });
 
+  it("does not evaluate pending migrations on /release/info for non-admin viewers", async () => {
+    mockReleaseCommands({
+      viewerPermission: "WRITE",
+      releaseList: [{ tagName: "v0.19.0", isPrerelease: false }],
+      releaseViews: {
+        "v0.19.0": validReleaseView({ body: "no fenced metadata" }),
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/release/info",
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      isAdmin: false,
+      latestTag: "v0.19.0",
+      updateAvailable: true,
+      pendingMigrations: [],
+      migrationsError: null,
+    });
+    expect(evaluateMock).not.toHaveBeenCalled();
+  });
+
   it("rejects /release/update when the target release requires assisted flow", async () => {
     mockReleaseCommands({
       releaseViews: {
@@ -741,9 +767,11 @@ function validReleaseView({
 function mockReleaseCommands({
   releaseList = [],
   releaseViews = {},
+  viewerPermission = "ADMIN",
 }: {
   releaseList?: Array<{ tagName: string; isPrerelease: boolean }>;
   releaseViews?: Record<string, string>;
+  viewerPermission?: string;
 }) {
   runCommandMock.mockImplementation(
     async (
@@ -780,7 +808,7 @@ function mockReleaseCommands({
         args[1] === "view" &&
         args.includes("--jq")
       ) {
-        return { exitCode: 0, stdout: "ADMIN\n", stderr: "" };
+        return { exitCode: 0, stdout: `${viewerPermission}\n`, stderr: "" };
       }
       if (cmd === "gh" && args[0] === "release" && args[1] === "list") {
         return {

--- a/apps/server/test/release-routes.test.ts
+++ b/apps/server/test/release-routes.test.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 
 import {
@@ -53,6 +54,15 @@ let createSession: typeof import("../src/auth.js").createSession;
 let sessionCookie: string;
 let tempRoot: string;
 let releaseStorePath: string;
+const rootPackageVersion = (
+  JSON.parse(
+    readFileSync(
+      path.resolve(import.meta.dirname, "../../../package.json"),
+      "utf8"
+    )
+  ) as { version: string }
+).version;
+const packagedCurrentTag = `v${rootPackageVersion}`;
 
 const uncaughtExceptionFilter = (err: Error): void => {
   if (
@@ -275,9 +285,9 @@ describe("release metadata route handling", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({
-      currentTag: "v0.18.35",
+      currentTag: packagedCurrentTag,
       latestTag: "v0.18.36",
-      updateAvailable: true,
+      updateAvailable: compareSemverForTest("v0.18.36", packagedCurrentTag) > 0,
     });
   });
 
@@ -901,4 +911,20 @@ function mockReleaseCommands({
       throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
     }
   );
+}
+
+function compareSemverForTest(a: string, b: string): number {
+  const parse = (value: string): number[] =>
+    value
+      .replace(/^v/, "")
+      .split(".")
+      .map((part) => Number(part));
+  const left = parse(a);
+  const right = parse(b);
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = (left[index] ?? 0) - (right[index] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  return 0;
 }

--- a/apps/server/test/release-runtime.test.ts
+++ b/apps/server/test/release-runtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createReleaseRuntime } from "../src/server/release-runtime.js";
+
+describe("release runtime stream targeting", () => {
+  it("sends targeted release events only to the matching stream client", () => {
+    const runtime = createReleaseRuntime({
+      pool: { query: vi.fn() } as never,
+      config: { tls: false, port: 6767 } as never,
+      serverDir: "/tmp/dispatch",
+      runCommand: vi.fn(),
+      readReleaseStore: vi.fn(),
+      writeReleaseStore: vi.fn(),
+      readAssistedUpdateState: vi.fn(),
+      isTerminalPhase: vi.fn(),
+      ensureCachedTarball: vi.fn(),
+      pruneCacheExcept: vi.fn(),
+      unlinkCachedTarball: vi.fn(),
+      createReleaseLogStreamProcessor: vi.fn(),
+    });
+
+    const writeA = vi.fn();
+    const writeB = vi.fn();
+    runtime.releaseStreamClients.add({
+      clientId: "client-a",
+      stream: { write: writeA } as never,
+    });
+    runtime.releaseStreamClients.add({
+      clientId: "client-b",
+      stream: { write: writeB } as never,
+    });
+
+    runtime.sendReleaseEventToClient("client-b", {
+      type: "info-progress",
+      progress: {
+        step: "downloading-release-package",
+        label: "Downloading release package",
+        bytesReceived: 32,
+        totalBytes: 64,
+      },
+    });
+
+    expect(writeA).not.toHaveBeenCalled();
+    expect(writeB).toHaveBeenCalledTimes(1);
+    expect(writeB.mock.calls[0]?.[0]).toContain('"type":"info-progress"');
+  });
+});

--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -155,6 +155,7 @@ export function ReleasesAdmin({ stream }: ReleasesAdminProps): JSX.Element {
       runUrl: null,
       tag: null,
       error: null,
+      progress: null,
     });
     connectStream();
   };

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -37,6 +37,7 @@ import {
   type ReleaseChannel,
   type ReleaseInfo,
   type ReleaseJob,
+  type ReleaseProgress,
   type UseReleaseStreamResult,
 } from "@/hooks/use-release-stream";
 import { api } from "@/lib/api";
@@ -53,7 +54,6 @@ type AppVersionInfo = {
 };
 
 const UPDATE_PHASES = ["fetching", "deploying", "restarting", "done"] as const;
-
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString(undefined, {
     month: "short",
@@ -70,6 +70,81 @@ function cleanError(raw: string): string {
     return stderr.replace(/^fatal:\s*/i, "");
   }
   return raw;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function formatProgressLabel(job: ReleaseJob): string | null {
+  const progress = job.progress;
+  if (!progress) return null;
+
+  if (
+    progress.bytesReceived !== null &&
+    progress.bytesReceived !== undefined &&
+    progress.totalBytes !== null &&
+    progress.totalBytes !== undefined &&
+    progress.totalBytes > 0
+  ) {
+    const percent = Math.min(
+      100,
+      Math.round((progress.bytesReceived / progress.totalBytes) * 100)
+    );
+    return `${percent}% · ${formatBytes(progress.bytesReceived)} / ${formatBytes(
+      progress.totalBytes
+    )}`;
+  }
+
+  if (
+    progress.bytesReceived !== null &&
+    progress.bytesReceived !== undefined &&
+    progress.bytesReceived > 0
+  ) {
+    return `${formatBytes(progress.bytesReceived)} downloaded`;
+  }
+
+  return null;
+}
+
+function formatInlineProgress(progress: ReleaseProgress | null): string | null {
+  if (!progress) return null;
+
+  const progressParts = [progress.label];
+  if (
+    progress.bytesReceived !== null &&
+    progress.bytesReceived !== undefined &&
+    progress.totalBytes !== null &&
+    progress.totalBytes !== undefined &&
+    progress.totalBytes > 0
+  ) {
+    const percent = Math.min(
+      100,
+      Math.round((progress.bytesReceived / progress.totalBytes) * 100)
+    );
+    progressParts.push(
+      `${percent}% · ${formatBytes(progress.bytesReceived)} / ${formatBytes(
+        progress.totalBytes
+      )}`
+    );
+  } else if (
+    progress.bytesReceived !== null &&
+    progress.bytesReceived !== undefined &&
+    progress.bytesReceived > 0
+  ) {
+    progressParts.push(`${formatBytes(progress.bytesReceived)} downloaded`);
+  }
+
+  return progressParts.join(" · ");
 }
 
 function describeForceTriggers(info: ReleaseInfo): string {
@@ -99,7 +174,15 @@ type UpdatesSectionProps = {
 
 export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const navigate = useNavigate();
-  const { status, job, postRestartPolling, connectStream, setJob } = stream;
+  const {
+    status,
+    job,
+    infoProgress,
+    postRestartPolling,
+    streamClientId,
+    connectStream,
+    setJob,
+  } = stream;
 
   const [versionInfo, setVersionInfo] = useState<AppVersionInfo | null>(null);
   const [notesExpanded, setNotesExpanded] = useState(false);
@@ -111,6 +194,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [assistedUpdateLaunching, setAssistedUpdateLaunching] = useState(false);
   const [forceConfirmOpen, setForceConfirmOpen] = useState(false);
+  const [lastCheckMessage, setLastCheckMessage] = useState<string | null>(null);
   const reloadingRef = useRef(false);
 
   // Fetch version info + channel on mount
@@ -153,14 +237,23 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
     setInfoLoading(true);
     setInfoError(null);
     setInfo(null);
+    setLastCheckMessage(null);
     try {
-      const res = await fetch("/api/v1/release/info");
+      const res = await fetch("/api/v1/release/info", {
+        headers: {
+          "X-Dispatch-Release-Client-Id": streamClientId,
+        },
+      });
       if (!res.ok) {
         const err = (await res.json()) as { error?: string };
         setInfoError(cleanError(err.error ?? "Failed to check for updates"));
         return;
       }
-      setInfo((await res.json()) as ReleaseInfo);
+      const nextInfo = (await res.json()) as ReleaseInfo;
+      setInfo(nextInfo);
+      if (!nextInfo.updateAvailable) {
+        setLastCheckMessage("Up to date");
+      }
     } catch (err) {
       setInfoError(
         err instanceof Error
@@ -171,6 +264,14 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
       setInfoLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (lastCheckMessage === null) return;
+    const timeout = window.setTimeout(() => {
+      setLastCheckMessage(null);
+    }, 3000);
+    return () => window.clearTimeout(timeout);
+  }, [lastCheckMessage]);
 
   const handleUpdate = async (tag: string, options?: { force?: boolean }) => {
     setUpdateError(null);
@@ -193,6 +294,11 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
       runUrl: null,
       tag,
       error: null,
+      progress: {
+        step: "starting-update",
+        label: "Starting update",
+        detail: "Preparing the update job and connecting to progress events.",
+      },
     });
     connectStream();
   };
@@ -403,23 +509,41 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
 
       {/* Check for updates */}
       <div className="flex flex-col gap-4">
-        {!info && !infoLoading && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           <Button
             size="sm"
             variant="default"
             onClick={() => void handleCheckForUpdates()}
+            disabled={infoLoading}
             className="self-start text-muted-foreground hover:text-foreground"
           >
             Check for updates
           </Button>
-        )}
-
-        {infoLoading && (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <ActivityBars size={14} />
-            Checking...
-          </div>
-        )}
+          {(infoLoading || lastCheckMessage) && (
+            <div className="flex min-w-0 items-center gap-2 text-sm">
+              {infoLoading && (
+                <ActivityBars
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+              )}
+              {!infoLoading && lastCheckMessage === "Up to date" && (
+                <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+              )}
+              <span
+                className={cn(
+                  "truncate",
+                  infoLoading ? "text-muted-foreground" : "text-foreground"
+                )}
+              >
+                {infoLoading
+                  ? (formatInlineProgress(infoProgress) ??
+                    "Checking for updates")
+                  : lastCheckMessage}
+              </span>
+            </div>
+          )}
+        </div>
 
         {infoError && (
           <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -537,12 +661,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                   );
                 })()}
               </div>
-            ) : (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                Up to date
-              </div>
-            )}
+            ) : null}
           </>
         )}
       </div>
@@ -788,6 +907,44 @@ export function OperationTakeover({
     <div className="flex h-full min-h-0 flex-col md:flex-row">
       {/* Left column — controls */}
       <div className="flex md:w-[360px] shrink-0 flex-col gap-6 overflow-y-auto border-b md:border-b-0 md:border-r border-white/[0.12] p-4 md:p-6">
+        {job.progress && (
+          <div className="rounded-lg border border-white/[0.12] bg-white/[0.04] p-3">
+            <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+              Current step
+            </div>
+            <div className="mt-2 text-sm font-medium text-foreground">
+              {job.progress.label}
+            </div>
+            {job.progress.detail && (
+              <div className="mt-1 text-xs text-muted-foreground">
+                {job.progress.detail}
+              </div>
+            )}
+            {formatProgressLabel(job) && (
+              <div className="mt-2 text-xs font-medium text-blue-300">
+                {formatProgressLabel(job)}
+              </div>
+            )}
+            {job.progress.totalBytes &&
+              job.progress.bytesReceived !== null &&
+              job.progress.bytesReceived !== undefined &&
+              job.progress.totalBytes > 0 && (
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-white/[0.08]">
+                  <div
+                    className="h-full rounded-full bg-blue-400 transition-[width] duration-200"
+                    style={{
+                      width: `${Math.min(
+                        100,
+                        (job.progress.bytesReceived / job.progress.totalBytes) *
+                          100
+                      )}%`,
+                    }}
+                  />
+                </div>
+              )}
+          </div>
+        )}
+
         <PhaseProgress
           job={job}
           phasesOrder={phasesOrder}

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -147,6 +147,20 @@ function formatInlineProgress(progress: ReleaseProgress | null): string | null {
   return progressParts.join(" · ");
 }
 
+function progressPercent(progress: ReleaseProgress | null): number | null {
+  if (
+    !progress ||
+    progress.bytesReceived === null ||
+    progress.bytesReceived === undefined ||
+    progress.totalBytes === null ||
+    progress.totalBytes === undefined ||
+    progress.totalBytes <= 0
+  ) {
+    return null;
+  }
+  return Math.min(100, (progress.bytesReceived / progress.totalBytes) * 100);
+}
+
 function describeForceTriggers(info: ReleaseInfo): string {
   const migrationCount = info.pendingMigrations?.length ?? 0;
   // Migrations are the concrete signal — when present the user already
@@ -544,6 +558,17 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
             </div>
           )}
         </div>
+
+        {infoLoading && progressPercent(infoProgress) !== null && (
+          <div className="max-w-[40rem]">
+            <div className="h-1.5 overflow-hidden rounded-full bg-white/[0.08]">
+              <div
+                className="h-full rounded-full bg-blue-400 transition-[width] duration-200"
+                style={{ width: `${progressPercent(infoProgress)}%` }}
+              />
+            </div>
+          </div>
+        )}
 
         {infoError && (
           <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/apps/web/src/hooks/use-release-stream.ts
+++ b/apps/web/src/hooks/use-release-stream.ts
@@ -139,12 +139,21 @@ export type ReleaseStatus = {
   deployedAt: string | null;
 };
 
+export type ReleaseProgress = {
+  step: string;
+  label: string;
+  detail?: string | null;
+  bytesReceived?: number | null;
+  totalBytes?: number | null;
+};
+
 type CommonReleaseJobFields = {
   startedAt: string;
   log: string[];
   runUrl: string | null;
   tag: string | null;
   error: string | null;
+  progress: ReleaseProgress | null;
 };
 
 export type ReleaseJob =
@@ -175,6 +184,8 @@ type ReleaseStreamEvent =
   | { type: "log"; line: string }
   | { type: "log.replace"; line: string }
   | { type: "log.rewind"; count: number }
+  | { type: "progress"; progress: ReleaseProgress | null }
+  | { type: "info-progress"; progress: ReleaseProgress | null }
   | { type: "phase"; phase: ReleasePhase; error?: string }
   | { type: "runUrl"; url: string }
   | { type: "tag"; tag: string }
@@ -188,7 +199,10 @@ type ReleaseStreamEvent =
  */
 function applyStreamEvent(
   prev: ReleaseJob | null,
-  event: Exclude<ReleaseStreamEvent, { type: "snapshot" }>
+  event: Exclude<
+    ReleaseStreamEvent,
+    { type: "snapshot" } | { type: "info-progress" }
+  >
 ): ReleaseJob | null {
   if (!prev) return prev;
   switch (event.type) {
@@ -218,6 +232,8 @@ function applyStreamEvent(
       }
       return { ...prev, phase: event.phase as AssistedReleasePhase, error };
     }
+    case "progress":
+      return { ...prev, progress: event.progress };
     case "runUrl":
       return { ...prev, runUrl: event.url };
     case "tag":
@@ -234,7 +250,9 @@ function applyStreamEvent(
 export type UseReleaseStreamResult = {
   status: ReleaseStatus | null;
   job: ReleaseJob | null;
+  infoProgress: ReleaseProgress | null;
   postRestartPolling: boolean;
+  streamClientId: string;
   connectStream: () => void;
   fetchStatus: () => Promise<void>;
   setJob: React.Dispatch<React.SetStateAction<ReleaseJob | null>>;
@@ -243,10 +261,16 @@ export type UseReleaseStreamResult = {
 export function useReleaseStream(): UseReleaseStreamResult {
   const [status, setStatus] = useState<ReleaseStatus | null>(null);
   const [job, setJob] = useState<ReleaseJob | null>(null);
+  const [infoProgress, setInfoProgress] = useState<ReleaseProgress | null>(
+    null
+  );
   const [postRestartPolling, setPostRestartPolling] = useState(false);
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const healthPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const clientIdRef = useRef<string>(
+    globalThis.crypto?.randomUUID?.() ?? `release-${Date.now()}`
+  );
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -293,13 +317,19 @@ export function useReleaseStream(): UseReleaseStreamResult {
 
   const connectStream = useCallback(() => {
     eventSourceRef.current?.close();
-    const es = new EventSource("/api/v1/release/stream");
+    const es = new EventSource(
+      `/api/v1/release/stream?clientId=${encodeURIComponent(clientIdRef.current)}`
+    );
     eventSourceRef.current = es;
 
     es.onmessage = (e) => {
       const event = JSON.parse(e.data as string) as ReleaseStreamEvent;
       if (event.type === "snapshot") {
         setJob(event.job);
+        return;
+      }
+      if (event.type === "info-progress") {
+        setInfoProgress(event.progress);
         return;
       }
       setJob((prev) => applyStreamEvent(prev, event));
@@ -332,7 +362,9 @@ export function useReleaseStream(): UseReleaseStreamResult {
   return {
     status,
     job,
+    infoProgress,
     postRestartPolling,
+    streamClientId: clientIdRef.current,
     connectStream,
     fetchStatus,
     setJob,

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -332,8 +332,9 @@ cmd_up() {
   (
     cd "${cwd}/apps/web"
     # Tell Vite's proxy where the API server is
-    DISPATCH_PORT="$DEV_API_PORT" \
-    DISPATCH_VITE_CACHE_DIR="$vite_cache_dir" \
+    env \
+      DISPATCH_PORT="$DEV_API_PORT" \
+      DISPATCH_VITE_CACHE_DIR="$vite_cache_dir" \
       pnpm exec vite --port "$DEV_VITE_PORT" >> "$(log_dir)/vite.log" 2>&1 &
     echo $! > "$(log_dir)/vite.pid"
   )

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -79,6 +79,10 @@ log_dir() {
   echo "/tmp/dispatch-dev-${SUFFIX}"
 }
 
+release_cache_dir() {
+  echo "${DEV_CWD}/.dispatch/dev-cache/release-${SUFFIX}"
+}
+
 save_state() {
   cat > "$(state_file)" <<EOF
 DEV_SUFFIX=${SUFFIX}
@@ -94,6 +98,7 @@ DEV_NO_DB=${DEV_NO_DB:-0}
 DEV_LIVE=${OPT_LIVE:-0}
 DEV_NO_SEED=${OPT_NO_SEED:-0}
 DEV_DISPLAY_HOST=${DEV_DISPLAY_HOST:-127.0.0.1}
+DEV_RELEASE_CACHE_DIR=${DEV_RELEASE_CACHE_DIR:-}
 EOF
 }
 
@@ -179,6 +184,7 @@ cmd_up() {
 
   mkdir -p "$(log_dir)"
   DEV_CWD="$cwd"
+  DEV_RELEASE_CACHE_DIR="$(release_cache_dir)"
 
   # --- Database ---
   DEV_NO_DB="$OPT_NO_DB"
@@ -252,6 +258,7 @@ cmd_up() {
     # Keep the release store out of ~/.dispatch/ — a stale version there
     # surfaces the update-available toast against the dev build.
     export DISPATCH_RELEASE_STORE_PATH="$(log_dir)/release.json"
+    export DISPATCH_RELEASE_CACHE_DIR="$DEV_RELEASE_CACHE_DIR"
 
     if [ "$OPT_NO_DB" != "1" ]; then
       export DATABASE_URL="postgres://dispatch:dispatch@127.0.0.1:${DEV_DB_PORT}/dispatch_${DEV_CONTAINER_SUFFIX}"
@@ -349,6 +356,7 @@ cmd_up() {
   fi
   echo "  api: http://${DEV_DISPLAY_HOST}:${DEV_API_PORT}"
   echo "  web: http://${DEV_DISPLAY_HOST}:${DEV_VITE_PORT}"
+  echo "  release cache: ${DEV_RELEASE_CACHE_DIR}"
   echo ""
   echo "Cleanup: dispatch-dev down${OPT_SUFFIX:+ --suffix $SUFFIX}"
 }
@@ -413,6 +421,10 @@ cmd_status() {
     else
       echo "vite: not started"
     fi
+  fi
+
+  if [ -n "${DEV_RELEASE_CACHE_DIR:-}" ]; then
+    echo "release cache: ${DEV_RELEASE_CACHE_DIR}"
   fi
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -398,10 +398,15 @@ export async function deleteAgentViaAPI(
   );
   // Archive is async — poll until the agent is actually gone
   for (let i = 0; i < 50; i++) {
-    const res = await request.get(`${API}/agents/${agentId}`, {
-      headers: authHeaders(),
-    });
-    if (res.status() === 404) return;
+    try {
+      const res = await request.get(`${API}/agents/${agentId}`, {
+        headers: authHeaders(),
+      });
+      if (res.status() === 404) return;
+    } catch {
+      // The isolated API server can briefly drop connections during teardown.
+      // Treat that as retryable instead of failing the whole suite cleanup.
+    }
     await new Promise((r) => setTimeout(r, 100));
   }
 }


### PR DESCRIPTION
## Summary
- add inline progress rendering for update checks and improve release detection when no deployed release tag is recorded
- restore check-time migration evaluation for authenticated viewers and add logging around `/api/v1/release/info`
- keep dispatch-dev using a worktree-local release cache for isolated update testing

## Validation
- pnpm run check
- pnpm run test
- pnpm run finalize:web
- pnpm run test:e2e