### PR TITLE
Fire hotkeys from inside text inputs and the terminal

### DIFF
--- a/apps/web/src/lib/hotkeys/keymap.ts
+++ b/apps/web/src/lib/hotkeys/keymap.ts
@@ -12,13 +12,15 @@
 // Shifted symbol keys (e.g. ">", "<") are matched on KeyboardEvent.key, so
 // the binding works across keyboard layouts where the physical position of
 // the symbol differs.
+//
+// Hotkeys fire from anywhere in the page, including text inputs and the
+// terminal. To suppress firing inside a particular subtree (e.g. an open
+// modal that owns its own keyboard shortcuts), mark that subtree's root
+// with `data-hotkey-disable="true"`.
 
 export type HotkeyDef = {
   combo: string;
   description: string;
-  // When true, the hotkey fires even if focus is inside an editable element
-  // (inputs, textareas, contenteditable, xterm). Default false.
-  allowInInputs?: boolean;
 };
 
 export const HOTKEYS = {
@@ -33,17 +35,14 @@ export const HOTKEYS = {
   "focus-prev-agent": {
     combo: "mod+shift+up",
     description: "Focus previous agent",
-    allowInInputs: true,
   },
   "focus-next-agent": {
     combo: "mod+shift+down",
     description: "Focus next agent",
-    allowInInputs: true,
   },
   "open-command-palette": {
     combo: "mod+k",
     description: "Open command palette",
-    allowInInputs: true,
   },
 } satisfies Record<string, HotkeyDef>;
 

--- a/apps/web/src/lib/hotkeys/use-hotkey.ts
+++ b/apps/web/src/lib/hotkeys/use-hotkey.ts
@@ -51,18 +51,10 @@ function parseCombo(combo: string): Parsed {
   return parsed;
 }
 
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
-  if (target.isContentEditable) return true;
-  return false;
-}
-
-// Stronger opt-out than `allowInInputs`: when an ancestor element marks itself
-// with data-hotkey-disable="true", *no* hotkey fires from inside that scope —
-// even ones that opted into firing in inputs. Used to keep palette/global
-// shortcuts from triggering on top of an open modal that owns its own input.
+// Opt-out marker: when an ancestor element has data-hotkey-disable="true",
+// no hotkey fires from inside that scope. Applied to the base DialogContent
+// so global shortcuts don't trigger on top of an open modal that owns its
+// own input.
 function isHotkeyDisabledScope(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   return !!target.closest('[data-hotkey-disable="true"]');
@@ -136,12 +128,10 @@ export function useHotkey(
     if (!enabled) return;
     const def: HotkeyDef = HOTKEYS[id];
     const parsed = parseCombo(def.combo);
-    const allowInInputs = def.allowInInputs ?? false;
 
     const onKeyDown = (e: KeyboardEvent): void => {
       if (!comboMatches(parsed, e)) return;
       if (isHotkeyDisabledScope(e.target)) return;
-      if (!allowInInputs && isEditableTarget(e.target)) return;
       e.preventDefault();
       e.stopPropagation();
       handlerRef.current(e);


### PR DESCRIPTION
## Summary

Follow-up to #483. The default of `allowInInputs: false` meant the sidebar-toggle hotkeys (`Cmd+Shift+>`, `Cmd+Shift+<`) silently no-op'd whenever the terminal had keyboard focus — i.e. most of the time, since xterm.js takes focus by default. `Cmd+K` and the agent-cycle hotkeys worked because they were opted in, but the asymmetry was confusing.

All current hotkeys are modifier+key combos that don't conflict with typing, so this drops the `allowInInputs` field entirely. The `data-hotkey-disable` scope check (already on the base `DialogContent`) stays as the only opt-out, which keeps modal stacking blocked. When we eventually add a single-letter shortcut, the field can come back.

## Test plan

- [ ] On `/agents/<an-agent>`, place focus inside the terminal and press `Cmd+Shift+>` — media sidebar toggles in drawer mode.
- [ ] Same context, press `Cmd+Shift+<` — agent sidebar toggles.
- [ ] Open Create Agent dialog, focus the Name input, press `Cmd+Shift+>` — palette/sidebar do NOT fire (data-hotkey-disable still wins).
- [ ] `Cmd+K` still toggles the palette open and closed from anywhere.
- [ ] `pnpm run check` and `pnpm run finalize:web` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)