### PR TITLE
Prefer origin/main for diff stats base

### DIFF
--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -16,6 +16,8 @@ export type ResolveBaseRefOptions = {
  * fallback chain used elsewhere in the agent flow:
  *
  *   1. `preferred` (e.g. `agent.baseBranch`) if it resolves
+ *      Special case: prefer `origin/main` over local `main` so stale
+ *      primary-checkout branches do not inflate worktree diff stats.
  *   2. the current branch's `@{upstream}`
  *   3. `origin/main`
  *   4. `main`
@@ -36,8 +38,12 @@ export async function resolveBaseRef(
   if (preferred && preferred.trim()) {
     const candidate = preferred.trim();
     if (isSafeRef(candidate)) {
-      const found = await refExists(run, worktreePath, candidate);
-      if (found) return found;
+      const candidates =
+        candidate === "main" ? ["origin/main", "main"] : [candidate];
+      for (const ref of candidates) {
+        const found = await refExists(run, worktreePath, ref);
+        if (found) return found;
+      }
     }
   }
 

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -232,6 +232,32 @@ describe("getDiffStats", () => {
     expect(result).toMatchObject({ added: 3, deleted: 1, files: 1 });
   });
 
+  it("prefers origin/main over local main when baseRef is main", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet origin/main`) {
+        return ok("origin/main");
+      }
+      if (key === `-C ${worktreePath} merge-base HEAD origin/main`) {
+        return ok(MERGE_BASE_SHA);
+      }
+      if (key === `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`) {
+        return ok("49\t6\tsrc/base-ref.ts");
+      }
+      if (key === `-C ${worktreePath} ls-files --others --exclude-standard`) {
+        return ok("");
+      }
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet main`) {
+        throw new Error("resolveBaseRef should not consult local main first");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 49, deleted: 6, files: 1 });
+  });
+
   it("returns null when git fails outright", async () => {
     const runCommand = vi.fn(async () => {
       throw new Error("git: command not found");


### PR DESCRIPTION
## Summary
- prefer `origin/main` before local `main` when resolving the diff-stats base ref
- avoid inflated agent diff stats when a local primary branch is stale
- add a regression test covering the stale-local-main case

## Validation
- `pnpm vitest apps/server/test/diff-stats.test.ts`
- `pnpm run check`