### PR TITLE
Add Solarized Light, Catppuccin Mocha, Daylight themes; group picker by mode

### DIFF
--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -31,7 +31,7 @@ import {
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { useReleaseStream } from "@/hooks/use-release-stream";
 import { useRewriteLocalhostPins } from "@/hooks/use-rewrite-localhost-pins";
-import { type ThemeId, THEMES } from "@/hooks/use-theme";
+import { DEFAULT_THEME_ID, type ThemeId, THEMES } from "@/hooks/use-theme";
 import { Input } from "@/components/ui/input";
 import { type AgentType } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
@@ -433,38 +433,56 @@ function AppearanceSettings({
         <p className="mb-3 text-sm text-muted-foreground">
           Choose a color theme for the interface.
         </p>
-        <div className="grid gap-3 sm:grid-cols-2">
-          {THEMES.map((t) => (
-            <button
-              key={t.id}
-              onClick={() => setTheme(t.id)}
-              className={cn(
-                "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
-                theme === t.id
-                  ? "border-primary bg-primary/10"
-                  : "border-border hover:border-muted-foreground/30"
-              )}
-            >
-              <div className="mt-0.5 flex gap-1">
-                {t.swatches.map((color, i) => (
-                  <span
-                    key={i}
-                    className="block h-4 w-4 rounded-full border border-white/10"
-                    style={{ backgroundColor: color }}
-                  />
+        {(["dark", "light"] as const).map((mode) => {
+          const items = THEMES.filter((t) => t.mode === mode);
+          if (items.length === 0) return null;
+          return (
+            <div key={mode} className="mb-4 last:mb-0">
+              <div className="mb-2 text-[10px] uppercase tracking-widest text-muted-foreground/80">
+                {mode === "dark" ? "Dark" : "Light"}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {items.map((t) => (
+                  <button
+                    key={t.id}
+                    onClick={() => setTheme(t.id)}
+                    className={cn(
+                      "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
+                      theme === t.id
+                        ? "border-primary bg-primary/10"
+                        : "border-border hover:border-muted-foreground/30"
+                    )}
+                  >
+                    <div className="mt-0.5 flex gap-1">
+                      {t.swatches.map((color, i) => (
+                        <span
+                          key={i}
+                          className="block h-4 w-4 rounded-full border border-white/10"
+                          style={{ backgroundColor: color }}
+                        />
+                      ))}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <div className="text-sm font-medium text-foreground">
+                          {t.label}
+                        </div>
+                        {t.id === DEFAULT_THEME_ID && (
+                          <span className="rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+                            Default
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {t.description}
+                      </div>
+                    </div>
+                  </button>
                 ))}
               </div>
-              <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground">
-                  {t.label}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {t.description}
-                </div>
-              </div>
-            </button>
-          ))}
-        </div>
+            </div>
+          );
+        })}
       </div>
 
       <div>

--- a/apps/web/src/hooks/use-theme.ts
+++ b/apps/web/src/hooks/use-theme.ts
@@ -5,6 +5,9 @@ export type ThemeId =
   | "cool-navy"
   | "oled-black"
   | "solarized-dark"
+  | "solarized-light"
+  | "catppuccin-mocha"
+  | "daylight"
   | "light"
   | "vaporwave"
   | "matrix"
@@ -41,6 +44,7 @@ export type ThemeDefinition = {
   id: ThemeId;
   label: string;
   description: string;
+  mode: "light" | "dark";
   swatches: string[];
   terminal: TerminalPalette;
 };
@@ -149,6 +153,86 @@ const MATRIX: TerminalPalette = {
   brightWhite: "#effff2",
 };
 
+/** Solarized Light — warm cream paper with the canonical Solarized accents */
+const SOLARIZED_LIGHT: TerminalPalette = {
+  minimumContrastRatio: 4.5,
+  foreground: "#586e75",
+  background: "#fdf6e3",
+  cursor: "#586e75",
+  cursorAccent: "#fdf6e3",
+  selectionBackground: "#eee8d5",
+  selectionInactiveBackground: "#eee8d5",
+  black: "#073642",
+  red: "#dc322f",
+  green: "#859900",
+  yellow: "#b58900",
+  blue: "#268bd2",
+  magenta: "#d33682",
+  cyan: "#2aa198",
+  white: "#eee8d5",
+  brightBlack: "#002b36",
+  brightRed: "#cb4b16",
+  brightGreen: "#586e75",
+  brightYellow: "#657b83",
+  brightBlue: "#839496",
+  brightMagenta: "#6c71c4",
+  brightCyan: "#93a1a1",
+  brightWhite: "#fdf6e3",
+};
+
+/** Catppuccin Mocha — muted pastel palette on a soft dark base */
+const CATPPUCCIN_MOCHA: TerminalPalette = {
+  foreground: "#cdd6f4",
+  background: "#1e1e2e",
+  cursor: "#f5e0dc",
+  cursorAccent: "#1e1e2e",
+  selectionBackground: "#585b70",
+  selectionInactiveBackground: "#45475a",
+  black: "#45475a",
+  red: "#f38ba8",
+  green: "#a6e3a1",
+  yellow: "#f9e2af",
+  blue: "#89b4fa",
+  magenta: "#f5c2e7",
+  cyan: "#94e2d5",
+  white: "#bac2de",
+  brightBlack: "#585b70",
+  brightRed: "#f38ba8",
+  brightGreen: "#a6e3a1",
+  brightYellow: "#f9e2af",
+  brightBlue: "#89b4fa",
+  brightMagenta: "#f5c2e7",
+  brightCyan: "#94e2d5",
+  brightWhite: "#a6adc8",
+};
+
+/** Daylight — high-contrast pure white tuned for outdoor / sunlit screens */
+const DAYLIGHT: TerminalPalette = {
+  minimumContrastRatio: 7,
+  foreground: "#0a0c10",
+  background: "#ffffff",
+  cursor: "#0a0c10",
+  cursorAccent: "#ffffff",
+  selectionBackground: "#c4d4ff",
+  selectionInactiveBackground: "#d8def0",
+  black: "#0a0c10",
+  red: "#c8102e",
+  green: "#0d7d4d",
+  yellow: "#a14400",
+  blue: "#0050d8",
+  magenta: "#8a1a8c",
+  cyan: "#006d77",
+  white: "#1f2328",
+  brightBlack: "#5a6171",
+  brightRed: "#b00020",
+  brightGreen: "#0a6840",
+  brightYellow: "#8a3700",
+  brightBlue: "#003ea3",
+  brightMagenta: "#6e0e80",
+  brightCyan: "#005159",
+  brightWhite: "#0a0c10",
+};
+
 /** Mytra — matte black, machined steel, and indigo-violet light */
 const MYTRA: TerminalPalette = {
   minimumContrastRatio: 4.5,
@@ -178,9 +262,18 @@ const MYTRA: TerminalPalette = {
 
 export const THEMES: ThemeDefinition[] = [
   {
+    id: "catppuccin-mocha",
+    label: "Catppuccin Mocha",
+    description: "Muted pastel mauve & blue on a soft dark base",
+    mode: "dark",
+    swatches: ["#1e1e2e", "#cba6f7", "#89b4fa", "#f5c2e7"],
+    terminal: CATPPUCCIN_MOCHA,
+  },
+  {
     id: "cool-navy",
     label: "Cool Navy",
     description: "Cool navy with cyan & pink accents",
+    mode: "dark",
     swatches: ["#0e1014", "#58b8ff", "#ff5db1", "#f1e84f"],
     terminal: {
       ...MONOKAI,
@@ -190,9 +283,18 @@ export const THEMES: ThemeDefinition[] = [
     },
   },
   {
+    id: "daylight",
+    label: "Daylight",
+    description: "High-contrast bright theme tuned for outdoor screens",
+    mode: "light",
+    swatches: ["#ffffff", "#0050d8", "#c8102e", "#0d7d4d"],
+    terminal: DAYLIGHT,
+  },
+  {
     id: "light",
     label: "Light",
     description: "Primer-inspired IDE light theme",
+    mode: "light",
     swatches: ["#e6eaef", "#0d7d4d", "#1f2328", "#d1d9e0"],
     terminal: MONOKAI,
   },
@@ -200,20 +302,15 @@ export const THEMES: ThemeDefinition[] = [
     id: "matrix",
     label: "Matrix",
     description: "Phosphor green on near-black terminal glass",
+    mode: "dark",
     swatches: ["#020403", "#0a0f0b", "#1fa34a", "#6bff8f"],
     terminal: MATRIX,
-  },
-  {
-    id: "mytra",
-    label: "Mytra",
-    description: "Matte black with machined steel and indigo-violet light",
-    swatches: ["#020202", "#20242c", "#5c6778", "#6c63ff"],
-    terminal: MYTRA,
   },
   {
     id: "midnight",
     label: "Midnight",
     description: "OLED black with vibrant cyan & pink",
+    mode: "dark",
     swatches: ["#000000", "#58b8ff", "#ff5db1", "#f1e84f"],
     terminal: {
       ...MONOKAI,
@@ -223,9 +320,18 @@ export const THEMES: ThemeDefinition[] = [
     },
   },
   {
+    id: "mytra",
+    label: "Mytra",
+    description: "Matte black with machined steel and indigo-violet light",
+    mode: "dark",
+    swatches: ["#020202", "#20242c", "#5c6778", "#6c63ff"],
+    terminal: MYTRA,
+  },
+  {
     id: "oled-black",
     label: "OLED Black",
     description: "True black for OLED screens",
+    mode: "dark",
     swatches: ["#000000", "#34d399", "#f0f0f0", "#222222"],
     terminal: {
       ...MONOKAI,
@@ -238,13 +344,23 @@ export const THEMES: ThemeDefinition[] = [
     id: "solarized-dark",
     label: "Solarized Dark",
     description: "Classic Ethan Schoonover palette",
+    mode: "dark",
     swatches: ["#002b36", "#268bd2", "#859900", "#b58900"],
     terminal: SOLARIZED_DARK,
+  },
+  {
+    id: "solarized-light",
+    label: "Solarized Light",
+    description: "Warm cream paper, restrained accents",
+    mode: "light",
+    swatches: ["#fdf6e3", "#268bd2", "#cb4b16", "#859900"],
+    terminal: SOLARIZED_LIGHT,
   },
   {
     id: "vaporwave",
     label: "Vaporwave",
     description: "Neon pink & cyan on deep purple",
+    mode: "dark",
     swatches: ["#1a0a2e", "#ff71ce", "#01cdfe", "#b967ff"],
     terminal: VAPORWAVE,
   },
@@ -252,10 +368,13 @@ export const THEMES: ThemeDefinition[] = [
     id: "default",
     label: "Warm Dark",
     description: "Warm charcoal with emerald accents",
+    mode: "dark",
     swatches: ["#141210", "#0d8358", "#f5f0f0", "#4d3e2e"],
     terminal: MONOKAI,
   },
 ];
+
+export const DEFAULT_THEME_ID: ThemeId = "cool-navy";
 
 export function getTerminalPalette(themeId: ThemeId): TerminalPalette {
   return THEMES.find((t) => t.id === themeId)?.terminal ?? MONOKAI;
@@ -264,10 +383,10 @@ export function getTerminalPalette(themeId: ThemeId): TerminalPalette {
 const STORAGE_KEY = "dispatch:theme";
 
 function getStoredTheme(): ThemeId {
-  if (typeof window === "undefined") return "cool-navy";
+  if (typeof window === "undefined") return DEFAULT_THEME_ID;
   const stored = window.localStorage.getItem(STORAGE_KEY);
   if (stored && THEMES.some((t) => t.id === stored)) return stored as ThemeId;
-  return "cool-navy";
+  return DEFAULT_THEME_ID;
 }
 
 function applyTheme(themeId: ThemeId): void {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -368,6 +368,126 @@
   --log-stream-border: 228 14% 18%;
 }
 
+[data-theme="solarized-light"] {
+  --background: 44 87% 94%;
+  --foreground: 192 81% 14%;
+  --card: 46 42% 88%;
+  --card-foreground: 192 81% 14%;
+  --popover: 44 87% 96%;
+  --popover-foreground: 192 81% 14%;
+  --primary: 205 82% 45%;
+  --primary-foreground: 44 87% 94%;
+  --muted: 46 42% 88%;
+  --muted-foreground: 196 13% 45%;
+  --accent: 46 42% 88%;
+  --accent-foreground: 192 81% 14%;
+  --destructive: 1 71% 52%;
+  --destructive-foreground: 44 87% 94%;
+  --border: 46 30% 80%;
+  --input: 46 30% 80%;
+  --ring: 205 82% 45%;
+
+  --status-working: 68 100% 30%;
+  --status-blocked: 1 71% 52%;
+  --status-waiting: 45 100% 35%;
+  --status-done: 205 82% 45%;
+  --status-idle: 196 13% 45%;
+  --status-reviewing: 237 43% 52%;
+
+  --chart-1: 205 82% 45%;
+  --chart-2: 45 100% 35%;
+  --chart-3: 68 100% 30%;
+  --chart-4: 331 64% 52%;
+  --chart-5: 205 70% 38%;
+  --chart-6: 68 80% 25%;
+
+  --surface: 46 42% 88%;
+  --log-stream-bg: 46 42% 88%;
+  --log-stream-foreground: 196 13% 35%;
+  --log-stream-muted-foreground: 196 13% 50%;
+  --log-stream-border: 46 30% 80%;
+}
+
+[data-theme="catppuccin-mocha"] {
+  --background: 240 21% 15%;
+  --foreground: 226 64% 88%;
+  --card: 240 23% 12%;
+  --card-foreground: 226 64% 88%;
+  --popover: 237 16% 23%;
+  --popover-foreground: 226 64% 88%;
+  --primary: 267 84% 81%;
+  --primary-foreground: 240 21% 15%;
+  --muted: 237 16% 23%;
+  --muted-foreground: 227 23% 72%;
+  --accent: 237 16% 23%;
+  --accent-foreground: 226 64% 88%;
+  --destructive: 343 81% 75%;
+  --destructive-foreground: 240 21% 15%;
+  --border: 234 13% 31%;
+  --input: 234 13% 31%;
+  --ring: 267 84% 81%;
+
+  --status-working: 115 54% 76%;
+  --status-blocked: 343 81% 75%;
+  --status-waiting: 41 86% 83%;
+  --status-done: 217 92% 76%;
+  --status-idle: 231 11% 47%;
+  --status-reviewing: 267 84% 81%;
+
+  --chart-1: 217 92% 76%;
+  --chart-2: 41 86% 83%;
+  --chart-3: 170 57% 73%;
+  --chart-4: 267 84% 81%;
+  --chart-5: 217 70% 60%;
+  --chart-6: 41 70% 65%;
+
+  --surface: 240 23% 12%;
+  --log-stream-bg: 240 23% 12%;
+  --log-stream-foreground: 115 54% 76%;
+  --log-stream-muted-foreground: 227 23% 72%;
+  --log-stream-border: 234 13% 31%;
+}
+
+[data-theme="daylight"] {
+  --background: 0 0% 100%;
+  --foreground: 220 24% 8%;
+  --card: 220 14% 96%;
+  --card-foreground: 220 24% 8%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 220 24% 8%;
+  --primary: 217 100% 42%;
+  --primary-foreground: 0 0% 100%;
+  --muted: 220 14% 92%;
+  --muted-foreground: 220 14% 30%;
+  --accent: 220 14% 92%;
+  --accent-foreground: 220 24% 8%;
+  --destructive: 350 86% 42%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 220 14% 80%;
+  --input: 220 14% 80%;
+  --ring: 217 100% 42%;
+
+  --status-working: 153 80% 27%;
+  --status-blocked: 350 86% 42%;
+  --status-waiting: 30 100% 35%;
+  --status-done: 217 100% 42%;
+  --status-idle: 220 14% 40%;
+  --status-reviewing: 270 70% 35%;
+
+  --chart-1: 217 100% 42%;
+  --chart-2: 30 100% 35%;
+  --chart-3: 153 80% 27%;
+  --chart-4: 270 70% 35%;
+  --chart-5: 217 80% 30%;
+  --chart-6: 30 80% 28%;
+
+  --surface: 220 14% 96%;
+  --log-stream-bg: 0 0% 100%;
+  --log-stream-foreground: 153 80% 22%;
+  --log-stream-muted-foreground: 220 14% 30%;
+  --log-stream-border: 220 14% 80%;
+}
+
 * {
   @apply border-border;
 }
@@ -388,7 +508,7 @@ body {
    Themes with custom body::before (mytra, matrix) override this. */
 html:not([data-theme="mytra"]):not([data-theme="matrix"]):not(
     [data-theme="light"]
-  )
+  ):not([data-theme="solarized-light"]):not([data-theme="daylight"])
   body::before {
   content: "";
   position: fixed;


### PR DESCRIPTION
## Summary

- Three new themes:
  - **Solarized Light** — warm cream paper with the canonical Solarized accents (pairs with existing Solarized Dark).
  - **Catppuccin Mocha** — muted pastel mauve & blue on a soft dark base.
  - **Daylight** — high-contrast bright theme tuned for outdoor / sunlit screens; saturated accents that hold up under glare (`minimumContrastRatio: 7` on the terminal palette).
- Theme picker reorganized into **Dark** and **Light** sections, alphabetical within each.
- New `DEFAULT_THEME_ID` constant ties the picker's `Default` badge to the same value `getStoredTheme()` falls back to (currently Cool Navy).
- Solarized Light and Daylight added to the glass-atmosphere exclusion list alongside the existing Light theme.

## Test plan

- [ ] `pnpm run check` passes
- [ ] `pnpm run finalize:web` builds clean
- [ ] Open Settings → Theme: Dark and Light sections render with correct headers; Default badge sits on Cool Navy
- [ ] Switch to Solarized Light, Catppuccin Mocha, and Daylight and confirm the whole shell repaints (sidebar, agent list, status pills, terminal preview)
- [ ] Pre-existing themes still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)