### PR TITLE
Prototype diff stat ticker in design lab

### DIFF
--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,17 +1,4 @@
-import { useEffect, useState } from "react";
-
-import { DiffStatBadge } from "@/components/app/diff-stat-badge";
-import type { DiffStats } from "@/components/app/types";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import { useEffect } from "react";
 import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
 
 // Canvas for one-off component experiments. Add sections below as needed and
@@ -57,24 +44,8 @@ function ThemePicker({
   );
 }
 
-const BASE_DIFF_STATS: DiffStats = {
-  added: 24,
-  deleted: 8,
-  files: 3,
-  computedAt: Date.now(),
-};
-
-function cloneDiffStats(diffStats: DiffStats): DiffStats {
-  return {
-    ...diffStats,
-    computedAt: Date.now(),
-  };
-}
-
 export function DesignLab() {
   const { theme, setTheme } = useTheme();
-  const [diffStats, setDiffStats] = useState<DiffStats>(BASE_DIFF_STATS);
-  const [autoplay, setAutoplay] = useState(false);
 
   useEffect(() => {
     const style = document.createElement("style");
@@ -86,41 +57,6 @@ export function DesignLab() {
     };
   }, []);
 
-  useEffect(() => {
-    if (!autoplay) return;
-
-    const interval = window.setInterval(() => {
-      setDiffStats((current) => {
-        const nextAdded = Math.max(
-          0,
-          current.added +
-            Math.floor(Math.random() * 15) -
-            Math.floor(Math.random() * 6)
-        );
-        const nextDeleted = Math.max(
-          0,
-          current.deleted +
-            Math.floor(Math.random() * 10) -
-            Math.floor(Math.random() * 5)
-        );
-
-        return cloneDiffStats({
-          added: nextAdded,
-          deleted: nextDeleted,
-          files: Math.max(
-            1,
-            current.files +
-              Math.floor(Math.random() * 3) -
-              Math.floor(Math.random() * 2)
-          ),
-          computedAt: current.computedAt,
-        });
-      });
-    }, 1400);
-
-    return () => window.clearInterval(interval);
-  }, [autoplay]);
-
   return (
     <div className="min-h-screen bg-background p-8">
       <div className="max-w-[1400px] mx-auto">
@@ -130,7 +66,7 @@ export function DesignLab() {
           </h1>
           <p className="text-sm text-muted-foreground">
             Sandbox for previewing component variations against different
-            themes. Diff stat ticker prototype below uses fake agent data.
+            themes. Currently empty — add experiments as sections below.
           </p>
         </header>
 
@@ -138,141 +74,15 @@ export function DesignLab() {
           <ThemePicker theme={theme} setTheme={setTheme} />
         </div>
 
-        <TooltipProvider delayDuration={120}>
-          <Card className="border-border/70">
-            <CardHeader>
-              <CardTitle>Diff Stat Ticker</CardTitle>
-              <CardDescription>
-                Prototype for animating added and deleted line counts as
-                incremental ticker values instead of a static flash.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="flex flex-wrap items-center gap-3">
-                <div className="rounded-2xl border border-border/80 bg-background/80 px-4 py-3">
-                  <DiffStatBadge
-                    diffStats={diffStats}
-                    latestEventAt={new Date(
-                      diffStats.computedAt + 5_000
-                    ).toISOString()}
-                    onRefresh={() => {
-                      setDiffStats((current) => cloneDiffStats(current));
-                    }}
-                  />
-                </div>
-                <div className="grid gap-1 text-xs text-muted-foreground">
-                  <div className="font-mono text-foreground tabular-nums">
-                    +{diffStats.added} −{diffStats.deleted} across{" "}
-                    {diffStats.files} files
-                  </div>
-                  <div>
-                    Refresh keeps the current values, while the controls below
-                    push simulated diff updates through the shared badge.
-                  </div>
-                </div>
-              </div>
-
-              <div
-                className="flex flex-wrap items-center gap-2"
-                data-testid="diff-ticker-controls"
-              >
-                <Button
-                  size="sm"
-                  variant="ghost-primary"
-                  data-testid="diff-ticker-bump-small"
-                  onClick={() =>
-                    setDiffStats((current) =>
-                      cloneDiffStats({
-                        ...current,
-                        added: current.added + 9,
-                        deleted: current.deleted + 2,
-                        files: Math.max(current.files, 3),
-                      })
-                    )
-                  }
-                >
-                  Small bump
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost-primary"
-                  data-testid="diff-ticker-bump-large"
-                  onClick={() =>
-                    setDiffStats((current) =>
-                      cloneDiffStats({
-                        ...current,
-                        added: current.added + 34,
-                        deleted: current.deleted + 11,
-                        files: current.files + 2,
-                      })
-                    )
-                  }
-                >
-                  Large bump
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost-destructive"
-                  data-testid="diff-ticker-pullback"
-                  onClick={() =>
-                    setDiffStats((current) =>
-                      cloneDiffStats({
-                        ...current,
-                        added: Math.max(4, current.added - 18),
-                        deleted: Math.max(1, current.deleted - 6),
-                        files: Math.max(1, current.files - 1),
-                      })
-                    )
-                  }
-                >
-                  Pull back
-                </Button>
-                <Button
-                  size="sm"
-                  data-testid="diff-ticker-reset"
-                  onClick={() => setDiffStats(cloneDiffStats(BASE_DIFF_STATS))}
-                >
-                  Reset
-                </Button>
-                <label className="ml-2 inline-flex items-center gap-2 text-xs text-muted-foreground">
-                  <Checkbox
-                    checked={autoplay}
-                    data-testid="diff-ticker-autoplay"
-                    onCheckedChange={(checked) => setAutoplay(checked === true)}
-                  />
-                  Autoplay
-                </label>
-              </div>
-
-              <div className="grid gap-3 md:grid-cols-3">
-                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
-                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                    Added
-                  </div>
-                  <div className="mt-2 font-mono text-3xl tabular-nums text-status-working">
-                    +{diffStats.added}
-                  </div>
-                </div>
-                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
-                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                    Deleted
-                  </div>
-                  <div className="mt-2 font-mono text-3xl tabular-nums text-status-blocked">
-                    −{diffStats.deleted}
-                  </div>
-                </div>
-                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
-                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                    Files
-                  </div>
-                  <div className="mt-2 font-mono text-3xl tabular-nums text-foreground">
-                    {diffStats.files}
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TooltipProvider>
+        <div className="rounded-xl border border-dashed border-border bg-card/30 px-8 py-16 text-center">
+          <p className="text-sm text-muted-foreground">
+            No active experiments. Add a section to{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              apps/web/src/components/app/design-lab.tsx
+            </code>{" "}
+            to preview a component.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,4 +1,17 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+
+import { DiffStatBadge } from "@/components/app/diff-stat-badge";
+import type { DiffStats } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
 
 // Canvas for one-off component experiments. Add sections below as needed and
@@ -44,8 +57,24 @@ function ThemePicker({
   );
 }
 
+const BASE_DIFF_STATS: DiffStats = {
+  added: 24,
+  deleted: 8,
+  files: 3,
+  computedAt: Date.now(),
+};
+
+function cloneDiffStats(diffStats: DiffStats): DiffStats {
+  return {
+    ...diffStats,
+    computedAt: Date.now(),
+  };
+}
+
 export function DesignLab() {
   const { theme, setTheme } = useTheme();
+  const [diffStats, setDiffStats] = useState<DiffStats>(BASE_DIFF_STATS);
+  const [autoplay, setAutoplay] = useState(false);
 
   useEffect(() => {
     const style = document.createElement("style");
@@ -57,6 +86,41 @@ export function DesignLab() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!autoplay) return;
+
+    const interval = window.setInterval(() => {
+      setDiffStats((current) => {
+        const nextAdded = Math.max(
+          0,
+          current.added +
+            Math.floor(Math.random() * 15) -
+            Math.floor(Math.random() * 6)
+        );
+        const nextDeleted = Math.max(
+          0,
+          current.deleted +
+            Math.floor(Math.random() * 10) -
+            Math.floor(Math.random() * 5)
+        );
+
+        return cloneDiffStats({
+          added: nextAdded,
+          deleted: nextDeleted,
+          files: Math.max(
+            1,
+            current.files +
+              Math.floor(Math.random() * 3) -
+              Math.floor(Math.random() * 2)
+          ),
+          computedAt: current.computedAt,
+        });
+      });
+    }, 1400);
+
+    return () => window.clearInterval(interval);
+  }, [autoplay]);
+
   return (
     <div className="min-h-screen bg-background p-8">
       <div className="max-w-[1400px] mx-auto">
@@ -66,7 +130,7 @@ export function DesignLab() {
           </h1>
           <p className="text-sm text-muted-foreground">
             Sandbox for previewing component variations against different
-            themes. Currently empty — add experiments as sections below.
+            themes. Diff stat ticker prototype below uses fake agent data.
           </p>
         </header>
 
@@ -74,15 +138,141 @@ export function DesignLab() {
           <ThemePicker theme={theme} setTheme={setTheme} />
         </div>
 
-        <div className="rounded-xl border border-dashed border-border bg-card/30 px-8 py-16 text-center">
-          <p className="text-sm text-muted-foreground">
-            No active experiments. Add a section to{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">
-              apps/web/src/components/app/design-lab.tsx
-            </code>{" "}
-            to preview a component.
-          </p>
-        </div>
+        <TooltipProvider delayDuration={120}>
+          <Card className="border-border/70">
+            <CardHeader>
+              <CardTitle>Diff Stat Ticker</CardTitle>
+              <CardDescription>
+                Prototype for animating added and deleted line counts as
+                incremental ticker values instead of a static flash.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="rounded-2xl border border-border/80 bg-background/80 px-4 py-3">
+                  <DiffStatBadge
+                    diffStats={diffStats}
+                    latestEventAt={new Date(
+                      diffStats.computedAt + 5_000
+                    ).toISOString()}
+                    onRefresh={() => {
+                      setDiffStats((current) => cloneDiffStats(current));
+                    }}
+                  />
+                </div>
+                <div className="grid gap-1 text-xs text-muted-foreground">
+                  <div className="font-mono text-foreground tabular-nums">
+                    +{diffStats.added} −{diffStats.deleted} across{" "}
+                    {diffStats.files} files
+                  </div>
+                  <div>
+                    Refresh keeps the current values, while the controls below
+                    push simulated diff updates through the shared badge.
+                  </div>
+                </div>
+              </div>
+
+              <div
+                className="flex flex-wrap items-center gap-2"
+                data-testid="diff-ticker-controls"
+              >
+                <Button
+                  size="sm"
+                  variant="ghost-primary"
+                  data-testid="diff-ticker-bump-small"
+                  onClick={() =>
+                    setDiffStats((current) =>
+                      cloneDiffStats({
+                        ...current,
+                        added: current.added + 9,
+                        deleted: current.deleted + 2,
+                        files: Math.max(current.files, 3),
+                      })
+                    )
+                  }
+                >
+                  Small bump
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost-primary"
+                  data-testid="diff-ticker-bump-large"
+                  onClick={() =>
+                    setDiffStats((current) =>
+                      cloneDiffStats({
+                        ...current,
+                        added: current.added + 34,
+                        deleted: current.deleted + 11,
+                        files: current.files + 2,
+                      })
+                    )
+                  }
+                >
+                  Large bump
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost-destructive"
+                  data-testid="diff-ticker-pullback"
+                  onClick={() =>
+                    setDiffStats((current) =>
+                      cloneDiffStats({
+                        ...current,
+                        added: Math.max(4, current.added - 18),
+                        deleted: Math.max(1, current.deleted - 6),
+                        files: Math.max(1, current.files - 1),
+                      })
+                    )
+                  }
+                >
+                  Pull back
+                </Button>
+                <Button
+                  size="sm"
+                  data-testid="diff-ticker-reset"
+                  onClick={() => setDiffStats(cloneDiffStats(BASE_DIFF_STATS))}
+                >
+                  Reset
+                </Button>
+                <label className="ml-2 inline-flex items-center gap-2 text-xs text-muted-foreground">
+                  <Checkbox
+                    checked={autoplay}
+                    data-testid="diff-ticker-autoplay"
+                    onCheckedChange={(checked) => setAutoplay(checked === true)}
+                  />
+                  Autoplay
+                </label>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
+                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Added
+                  </div>
+                  <div className="mt-2 font-mono text-3xl tabular-nums text-status-working">
+                    +{diffStats.added}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
+                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Deleted
+                  </div>
+                  <div className="mt-2 font-mono text-3xl tabular-nums text-status-blocked">
+                    −{diffStats.deleted}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-border/70 bg-background/50 p-4">
+                  <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Files
+                  </div>
+                  <div className="mt-2 font-mono text-3xl tabular-nums text-foreground">
+                    {diffStats.files}
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TooltipProvider>
       </div>
     </div>
   );

--- a/apps/web/src/components/app/diff-stat-badge.tsx
+++ b/apps/web/src/components/app/diff-stat-badge.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 const STALE_AFTER_MS = 30_000;
 const FLASH_DURATION_MS = 600;
 const MIN_TICK_DURATION_MS = 280;
-const MAX_TICK_DURATION_MS = 900;
+const MAX_TICK_DURATION_MS = FLASH_DURATION_MS;
 
 function formatCount(n: number): string {
   if (n < 1_000) return String(n);
@@ -27,16 +27,38 @@ function getTickDuration(from: number, to: number): number {
   );
 }
 
-function useAnimatedCount(value: number): number {
-  const [displayValue, setDisplayValue] = useState(value);
-  const previousValue = useRef(value);
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useEffect(() => {
-    const from = previousValue.current;
-    previousValue.current = value;
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function useAnimatedCount(value: number): number {
+  const [displayValue, setDisplayValue] = useState(value);
+  const displayValueRef = useRef(value);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const from = displayValueRef.current;
 
     if (from === value) {
       setDisplayValue(value);
+      displayValueRef.current = value;
+      return;
+    }
+
+    if (prefersReducedMotion || formatCount(from) !== formatCount(value)) {
+      setDisplayValue(value);
+      displayValueRef.current = value;
       return;
     }
 
@@ -50,6 +72,7 @@ function useAnimatedCount(value: number): number {
       const eased = 1 - Math.pow(1 - progress, 3);
       const nextValue = Math.round(from + (value - from) * eased);
 
+      displayValueRef.current = nextValue;
       setDisplayValue((current) =>
         current === nextValue ? current : nextValue
       );
@@ -61,7 +84,7 @@ function useAnimatedCount(value: number): number {
 
     frame = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(frame);
-  }, [value]);
+  }, [prefersReducedMotion, value]);
 
   return displayValue;
 }

--- a/apps/web/src/components/app/diff-stat-badge.tsx
+++ b/apps/web/src/components/app/diff-stat-badge.tsx
@@ -10,11 +10,79 @@ import { cn } from "@/lib/utils";
 
 const STALE_AFTER_MS = 30_000;
 const FLASH_DURATION_MS = 600;
+const MIN_TICK_DURATION_MS = 280;
+const MAX_TICK_DURATION_MS = 900;
 
 function formatCount(n: number): string {
   if (n < 1_000) return String(n);
   const thousands = n / 1_000;
   return `${thousands.toFixed(thousands < 10 ? 1 : 0)}K`;
+}
+
+function getTickDuration(from: number, to: number): number {
+  const delta = Math.abs(to - from);
+  return Math.max(
+    MIN_TICK_DURATION_MS,
+    Math.min(MAX_TICK_DURATION_MS, 220 + delta * 14)
+  );
+}
+
+function useAnimatedCount(value: number): number {
+  const [displayValue, setDisplayValue] = useState(value);
+  const previousValue = useRef(value);
+
+  useEffect(() => {
+    const from = previousValue.current;
+    previousValue.current = value;
+
+    if (from === value) {
+      setDisplayValue(value);
+      return;
+    }
+
+    const duration = getTickDuration(from, value);
+    const startedAt = performance.now();
+    let frame = 0;
+
+    const tick = (now: number) => {
+      const elapsed = now - startedAt;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const nextValue = Math.round(from + (value - from) * eased);
+
+      setDisplayValue((current) =>
+        current === nextValue ? current : nextValue
+      );
+
+      if (progress < 1) {
+        frame = window.requestAnimationFrame(tick);
+      }
+    };
+
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, [value]);
+
+  return displayValue;
+}
+
+function AnimatedDiffCount({
+  prefix,
+  value,
+  toneClassName,
+}: {
+  prefix: string;
+  value: number;
+  toneClassName: string;
+}) {
+  const animatedValue = useAnimatedCount(value);
+
+  return (
+    <span className={cn("tabular-nums", toneClassName)}>
+      {prefix}
+      {formatCount(animatedValue)}
+    </span>
+  );
 }
 
 export type DiffStatBadgeProps = {
@@ -82,12 +150,16 @@ export function DiffStatBadge({
           )}
           aria-label="Refresh diff stats"
         >
-          <span className="text-status-working">
-            +{formatCount(diffStats.added)}
-          </span>
-          <span className="text-status-blocked">
-            −{formatCount(diffStats.deleted)}
-          </span>
+          <AnimatedDiffCount
+            prefix="+"
+            value={diffStats.added}
+            toneClassName="text-status-working"
+          />
+          <AnimatedDiffCount
+            prefix="−"
+            value={diffStats.deleted}
+            toneClassName="text-status-blocked"
+          />
         </button>
       </TooltipTrigger>
       <TooltipContent>


### PR DESCRIPTION
## Summary
- animate diff stat badge counts with a ticker-style increment/decrement effect
- add a design lab prototype harness with fake diff data controls and autoplay
- keep the existing diff stat flash behavior while validating the design lab flow in Playwright

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e