### PR TITLE
Rebuild diff stat ticker with slot-counter

### DIFF
--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -14,6 +14,7 @@ export type DiffStats = {
 const UNTRACKED_LINE_COUNT_MAX_BYTES = 1_000_000;
 const GIT_TIMEOUT_MS = 15_000;
 const BINARY_PROBE_BYTES = 8 * 1024;
+const DIFF_STATS_EXCLUDED_PATHS = new Set(["pnpm-lock.yaml"]);
 
 type CommandRunner = (
   command: string,
@@ -88,6 +89,7 @@ export async function getDiffStats(
       const [a, d, ...rest] = parts;
       const filePath = rest.join("\t");
       if (!filePath) continue;
+      if (shouldIgnoreDiffStatsPath(filePath)) continue;
       if (seenFiles.has(filePath)) continue;
       seenFiles.add(filePath);
       if (a === "-" && d === "-") continue;
@@ -97,6 +99,7 @@ export async function getDiffStats(
 
     for (const filePath of untracked.stdout.split("\n")) {
       if (!filePath) continue;
+      if (shouldIgnoreDiffStatsPath(filePath)) continue;
       if (seenFiles.has(filePath)) continue;
       seenFiles.add(filePath);
       const lines = await countUntrackedLines(worktreePath, filePath);
@@ -148,4 +151,8 @@ function countLines(content: string): number {
   if (content.length === 0) return 0;
   const parts = content.split("\n");
   return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}
+
+function shouldIgnoreDiffStatsPath(filePath: string): boolean {
+  return DIFF_STATS_EXCLUDED_PATHS.has(filePath);
 }

--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -14,7 +14,21 @@ export type DiffStats = {
 const UNTRACKED_LINE_COUNT_MAX_BYTES = 1_000_000;
 const GIT_TIMEOUT_MS = 15_000;
 const BINARY_PROBE_BYTES = 8 * 1024;
-const DIFF_STATS_EXCLUDED_PATHS = new Set(["pnpm-lock.yaml"]);
+const DIFF_STATS_EXCLUDED_BASENAMES = new Set([
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lockb",
+  "bun.lock",
+  "Cargo.lock",
+  "Gemfile.lock",
+  "poetry.lock",
+  "uv.lock",
+  "Podfile.lock",
+  "Package.resolved",
+  "composer.lock",
+  "mix.lock",
+]);
 
 type CommandRunner = (
   command: string,
@@ -154,5 +168,5 @@ function countLines(content: string): number {
 }
 
 function shouldIgnoreDiffStatsPath(filePath: string): boolean {
-  return DIFF_STATS_EXCLUDED_PATHS.has(filePath);
+  return DIFF_STATS_EXCLUDED_BASENAMES.has(path.basename(filePath));
 }

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -201,16 +201,23 @@ describe("getDiffStats", () => {
     expect(result).toMatchObject({ added: 16, deleted: 3, files: 3 });
   });
 
-  it("excludes pnpm-lock.yaml from tracked and untracked diff counts", async () => {
+  it("excludes common lockfiles from tracked and untracked diff counts", async () => {
     const worktreePath = tempRoot;
     await writeFile(path.join(worktreePath, "pnpm-lock.yaml"), "ignored\n");
+    await mkdir(path.join(worktreePath, "nested"), { recursive: true });
+    await writeFile(
+      path.join(worktreePath, "nested", "Cargo.lock"),
+      "ignored\n"
+    );
     await writeFile(path.join(worktreePath, "notes.txt"), "keep\nme\n");
 
     const runCommand = withCommands(worktreePath, "main", {
       [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
-        ok("100\t250\tpnpm-lock.yaml\n4\t1\tsrc/foo.ts"),
+        ok(
+          "100\t250\tpnpm-lock.yaml\n50\t20\tnested/Cargo.lock\n4\t1\tsrc/foo.ts"
+        ),
       [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
-        ok("pnpm-lock.yaml\nnotes.txt"),
+        ok("pnpm-lock.yaml\nnested/Cargo.lock\nnotes.txt"),
     });
 
     const result = await getDiffStats(worktreePath, "main", { runCommand });

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -201,6 +201,22 @@ describe("getDiffStats", () => {
     expect(result).toMatchObject({ added: 16, deleted: 3, files: 3 });
   });
 
+  it("excludes pnpm-lock.yaml from tracked and untracked diff counts", async () => {
+    const worktreePath = tempRoot;
+    await writeFile(path.join(worktreePath, "pnpm-lock.yaml"), "ignored\n");
+    await writeFile(path.join(worktreePath, "notes.txt"), "keep\nme\n");
+
+    const runCommand = withCommands(worktreePath, "main", {
+      [`-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`]: () =>
+        ok("100\t250\tpnpm-lock.yaml\n4\t1\tsrc/foo.ts"),
+      [`-C ${worktreePath} ls-files --others --exclude-standard`]: () =>
+        ok("pnpm-lock.yaml\nnotes.txt"),
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 6, deleted: 1, files: 2 });
+  });
+
   it("falls back to origin/main when the requested baseRef does not resolve", async () => {
     const worktreePath = tempRoot;
     const runCommand = vi.fn(async (_command: string, args: string[]) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.0",
+    "react-slot-counter": "^3.3.3",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "simple-icons": "^16.11.0",

--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from "react";
-
-import { DiffStatBadge } from "@/components/app/diff-stat-badge";
-import type { DiffStats } from "@/components/app/types";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import { useEffect } from "react";
 import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
+
+// Canvas for one-off component experiments. Add sections below as needed and
+// remove them once the work ships — this page intentionally stays empty
+// between projects so it's always ready for the next variant exploration.
 
 function ThemePicker({
   theme,
@@ -15,8 +13,8 @@ function ThemePicker({
   setTheme: (id: ThemeId) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="mr-1 text-xs uppercase tracking-wide text-muted-foreground">
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-muted-foreground uppercase tracking-wide mr-1">
         Theme
       </span>
       {THEMES.map((t) => (
@@ -46,56 +44,8 @@ function ThemePicker({
   );
 }
 
-function buildDiffStats(
-  added: number,
-  deleted: number,
-  files: number
-): DiffStats {
-  return {
-    added,
-    deleted,
-    files,
-    computedAt: Date.now(),
-  };
-}
-
-function clampCount(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.trunc(value));
-}
-
-function randomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function DemoField({
-  label,
-  value,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  onChange: (value: number) => void;
-}) {
-  return (
-    <label className="space-y-2">
-      <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-        {label}
-      </div>
-      <Input
-        type="number"
-        min={0}
-        value={String(value)}
-        onChange={(event) => onChange(clampCount(Number(event.target.value)))}
-        className="h-10 bg-background/70"
-      />
-    </label>
-  );
-}
-
 export function DesignLab() {
   const { theme, setTheme } = useTheme();
-  const [stats, setStats] = useState<DiffStats>(() => buildDiffStats(12, 3, 2));
 
   useEffect(() => {
     const style = document.createElement("style");
@@ -107,179 +57,33 @@ export function DesignLab() {
     };
   }, []);
 
-  const applyStats = (added: number, deleted: number, files: number) => {
-    setStats(
-      buildDiffStats(clampCount(added), clampCount(deleted), clampCount(files))
-    );
-  };
-
-  const applyRandomJump = (size: "default" | "large" = "default") => {
-    const nextAdded =
-      size === "large"
-        ? clampCount(stats.added + randomInt(180, 520))
-        : clampCount(stats.added + randomInt(60, 220));
-    const nextDeleted =
-      size === "large"
-        ? clampCount(stats.deleted + randomInt(120, 360))
-        : clampCount(stats.deleted + randomInt(30, 140));
-    const nextFiles = clampCount(
-      Math.max(stats.files, 1) + randomInt(1, size === "large" ? 18 : 9)
-    );
-
-    applyStats(nextAdded, nextDeleted, nextFiles);
-  };
-
-  const applyRandomDrop = () => {
-    applyStats(
-      Math.max(0, stats.added - randomInt(40, 320)),
-      Math.max(0, stats.deleted - randomInt(20, 180)),
-      Math.max(1, stats.files - randomInt(1, 6))
-    );
-  };
-
   return (
-    <TooltipProvider>
-      <div className="min-h-screen bg-[radial-gradient(circle_at_top,hsl(var(--muted))/0.55,transparent_45%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background))_60%,hsl(var(--muted))/0.22)] p-8">
-        <div className="mx-auto max-w-[1400px]">
-          <header className="mb-8">
-            <h1 className="mb-1 text-3xl font-bold tracking-tight text-foreground">
-              Design Lab
-            </h1>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Interactive sandbox for the diff stat ticker. Use the controls to
-              force small rolls, larger jumps, and four-digit values.
-            </p>
-          </header>
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-[1400px] mx-auto">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground mb-1">
+            Design Lab
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Sandbox for previewing component variations against different
+            themes. Currently empty — add experiments as sections below.
+          </p>
+        </header>
 
-          <div className="sticky top-0 z-10 -mx-2 mb-8 flex flex-wrap items-center gap-6 rounded-xl border border-border bg-background/80 px-4 py-3 backdrop-blur">
-            <ThemePicker theme={theme} setTheme={setTheme} />
-          </div>
+        <div className="sticky top-0 z-10 -mx-2 mb-8 rounded-xl border border-border bg-background/80 backdrop-blur px-4 py-3 flex items-center gap-6 flex-wrap">
+          <ThemePicker theme={theme} setTheme={setTheme} />
+        </div>
 
-          <div className="grid gap-6 lg:grid-cols-[minmax(360px,520px)_1fr]">
-            <section className="rounded-[28px] border border-border/70 bg-card/70 p-6 shadow-[0_24px_80px_rgba(0,0,0,0.12)]">
-              <div className="mb-4 flex items-center justify-between gap-4">
-                <div>
-                  <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                    Live Preview
-                  </div>
-                  <h2 className="mt-1 text-xl font-semibold text-foreground">
-                    Diff stat badge
-                  </h2>
-                </div>
-              </div>
-
-              <div className="rounded-2xl border border-border/60 bg-background/55 p-4">
-                <div className="relative space-y-2 rounded-xl border border-border/60 bg-background/35 px-3 py-3 text-xs text-muted-foreground">
-                  <div className="absolute right-3 top-3">
-                    <DiffStatBadge
-                      diffStats={stats}
-                      latestEventAt={null}
-                      onRefresh={() => {}}
-                    />
-                  </div>
-                  <div className="pr-32">
-                    <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground/75">
-                      Mock Agent
-                    </div>
-                    <div className="mt-1 text-sm font-semibold text-foreground">
-                      diff ticker sandbox
-                    </div>
-                    <div className="mt-2 text-xs text-muted-foreground">
-                      This uses the real badge component and only changes the
-                      raw incoming values.
-                    </div>
-                    {stats.added === 0 && stats.deleted === 0 ? (
-                      <div className="mt-2 text-xs text-muted-foreground/80">
-                        Badge hidden because both line counts are 0.
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-[28px] border border-border/70 bg-card/65 p-6">
-              <div className="mb-5">
-                <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                  Controls
-                </div>
-                <h2 className="mt-1 text-xl font-semibold text-foreground">
-                  Force any change
-                </h2>
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-3">
-                <DemoField
-                  label="Added"
-                  value={stats.added}
-                  onChange={(value) =>
-                    applyStats(value, stats.deleted, stats.files)
-                  }
-                />
-                <DemoField
-                  label="Deleted"
-                  value={stats.deleted}
-                  onChange={(value) =>
-                    applyStats(stats.added, value, stats.files)
-                  }
-                />
-                <DemoField
-                  label="Files"
-                  value={stats.files}
-                  onChange={(value) =>
-                    applyStats(stats.added, stats.deleted, value)
-                  }
-                />
-              </div>
-
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button variant="primary" onClick={() => applyRandomJump()}>
-                  Random increase
-                </Button>
-                <Button variant="primary" onClick={() => applyRandomDrop()}>
-                  Random decrease
-                </Button>
-                <Button
-                  variant="default"
-                  onClick={() => applyRandomJump("large")}
-                >
-                  Random large jump
-                </Button>
-              </div>
-
-              <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                <Button variant="ghost" onClick={() => applyStats(8, 1, 1)}>
-                  Small roll
-                </Button>
-                <Button variant="ghost" onClick={() => applyStats(19, 4, 2)}>
-                  Multi-digit roll
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => applyStats(248, 137, 11)}
-                >
-                  Hundreds jump
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => applyStats(412, 196, 17)}
-                >
-                  Downward run
-                </Button>
-                <Button variant="ghost" onClick={() => applyStats(999, 4, 7)}>
-                  999 edge
-                </Button>
-                <Button variant="ghost" onClick={() => applyStats(1_000, 4, 7)}>
-                  Four digits
-                </Button>
-                <Button variant="ghost" onClick={() => applyStats(12, 3, 2)}>
-                  Reset
-                </Button>
-              </div>
-            </section>
-          </div>
+        <div className="rounded-xl border border-dashed border-border bg-card/30 px-8 py-16 text-center">
+          <p className="text-sm text-muted-foreground">
+            No active experiments. Add a section to{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              apps/web/src/components/app/design-lab.tsx
+            </code>{" "}
+            to preview a component.
+          </p>
         </div>
       </div>
-    </TooltipProvider>
+    </div>
   );
 }

--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from "react";
-import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
+import { useEffect, useState } from "react";
 
-// Canvas for one-off component experiments. Add sections below as needed and
-// remove them once the work ships — this page intentionally stays empty
-// between projects so it's always ready for the next variant exploration.
+import { DiffStatBadge } from "@/components/app/diff-stat-badge";
+import type { DiffStats } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
 
 function ThemePicker({
   theme,
@@ -13,8 +15,8 @@ function ThemePicker({
   setTheme: (id: ThemeId) => void;
 }) {
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <span className="text-xs text-muted-foreground uppercase tracking-wide mr-1">
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="mr-1 text-xs uppercase tracking-wide text-muted-foreground">
         Theme
       </span>
       {THEMES.map((t) => (
@@ -44,8 +46,56 @@ function ThemePicker({
   );
 }
 
+function buildDiffStats(
+  added: number,
+  deleted: number,
+  files: number
+): DiffStats {
+  return {
+    added,
+    deleted,
+    files,
+    computedAt: Date.now(),
+  };
+}
+
+function clampCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function DemoField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="space-y-2">
+      <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+        {label}
+      </div>
+      <Input
+        type="number"
+        min={0}
+        value={String(value)}
+        onChange={(event) => onChange(clampCount(Number(event.target.value)))}
+        className="h-10 bg-background/70"
+      />
+    </label>
+  );
+}
+
 export function DesignLab() {
   const { theme, setTheme } = useTheme();
+  const [stats, setStats] = useState<DiffStats>(() => buildDiffStats(12, 3, 2));
 
   useEffect(() => {
     const style = document.createElement("style");
@@ -57,33 +107,179 @@ export function DesignLab() {
     };
   }, []);
 
+  const applyStats = (added: number, deleted: number, files: number) => {
+    setStats(
+      buildDiffStats(clampCount(added), clampCount(deleted), clampCount(files))
+    );
+  };
+
+  const applyRandomJump = (size: "default" | "large" = "default") => {
+    const nextAdded =
+      size === "large"
+        ? clampCount(stats.added + randomInt(180, 520))
+        : clampCount(stats.added + randomInt(60, 220));
+    const nextDeleted =
+      size === "large"
+        ? clampCount(stats.deleted + randomInt(120, 360))
+        : clampCount(stats.deleted + randomInt(30, 140));
+    const nextFiles = clampCount(
+      Math.max(stats.files, 1) + randomInt(1, size === "large" ? 18 : 9)
+    );
+
+    applyStats(nextAdded, nextDeleted, nextFiles);
+  };
+
+  const applyRandomDrop = () => {
+    applyStats(
+      Math.max(0, stats.added - randomInt(40, 320)),
+      Math.max(0, stats.deleted - randomInt(20, 180)),
+      Math.max(1, stats.files - randomInt(1, 6))
+    );
+  };
+
   return (
-    <div className="min-h-screen bg-background p-8">
-      <div className="max-w-[1400px] mx-auto">
-        <header className="mb-8">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground mb-1">
-            Design Lab
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Sandbox for previewing component variations against different
-            themes. Currently empty — add experiments as sections below.
-          </p>
-        </header>
+    <TooltipProvider>
+      <div className="min-h-screen bg-[radial-gradient(circle_at_top,hsl(var(--muted))/0.55,transparent_45%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background))_60%,hsl(var(--muted))/0.22)] p-8">
+        <div className="mx-auto max-w-[1400px]">
+          <header className="mb-8">
+            <h1 className="mb-1 text-3xl font-bold tracking-tight text-foreground">
+              Design Lab
+            </h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Interactive sandbox for the diff stat ticker. Use the controls to
+              force small rolls, larger jumps, and four-digit values.
+            </p>
+          </header>
 
-        <div className="sticky top-0 z-10 -mx-2 mb-8 rounded-xl border border-border bg-background/80 backdrop-blur px-4 py-3 flex items-center gap-6 flex-wrap">
-          <ThemePicker theme={theme} setTheme={setTheme} />
-        </div>
+          <div className="sticky top-0 z-10 -mx-2 mb-8 flex flex-wrap items-center gap-6 rounded-xl border border-border bg-background/80 px-4 py-3 backdrop-blur">
+            <ThemePicker theme={theme} setTheme={setTheme} />
+          </div>
 
-        <div className="rounded-xl border border-dashed border-border bg-card/30 px-8 py-16 text-center">
-          <p className="text-sm text-muted-foreground">
-            No active experiments. Add a section to{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">
-              apps/web/src/components/app/design-lab.tsx
-            </code>{" "}
-            to preview a component.
-          </p>
+          <div className="grid gap-6 lg:grid-cols-[minmax(360px,520px)_1fr]">
+            <section className="rounded-[28px] border border-border/70 bg-card/70 p-6 shadow-[0_24px_80px_rgba(0,0,0,0.12)]">
+              <div className="mb-4 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                    Live Preview
+                  </div>
+                  <h2 className="mt-1 text-xl font-semibold text-foreground">
+                    Diff stat badge
+                  </h2>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-border/60 bg-background/55 p-4">
+                <div className="relative space-y-2 rounded-xl border border-border/60 bg-background/35 px-3 py-3 text-xs text-muted-foreground">
+                  <div className="absolute right-3 top-3">
+                    <DiffStatBadge
+                      diffStats={stats}
+                      latestEventAt={null}
+                      onRefresh={() => {}}
+                    />
+                  </div>
+                  <div className="pr-32">
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground/75">
+                      Mock Agent
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-foreground">
+                      diff ticker sandbox
+                    </div>
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      This uses the real badge component and only changes the
+                      raw incoming values.
+                    </div>
+                    {stats.added === 0 && stats.deleted === 0 ? (
+                      <div className="mt-2 text-xs text-muted-foreground/80">
+                        Badge hidden because both line counts are 0.
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-[28px] border border-border/70 bg-card/65 p-6">
+              <div className="mb-5">
+                <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                  Controls
+                </div>
+                <h2 className="mt-1 text-xl font-semibold text-foreground">
+                  Force any change
+                </h2>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <DemoField
+                  label="Added"
+                  value={stats.added}
+                  onChange={(value) =>
+                    applyStats(value, stats.deleted, stats.files)
+                  }
+                />
+                <DemoField
+                  label="Deleted"
+                  value={stats.deleted}
+                  onChange={(value) =>
+                    applyStats(stats.added, value, stats.files)
+                  }
+                />
+                <DemoField
+                  label="Files"
+                  value={stats.files}
+                  onChange={(value) =>
+                    applyStats(stats.added, stats.deleted, value)
+                  }
+                />
+              </div>
+
+              <div className="mt-6 flex flex-wrap gap-2">
+                <Button variant="primary" onClick={() => applyRandomJump()}>
+                  Random increase
+                </Button>
+                <Button variant="primary" onClick={() => applyRandomDrop()}>
+                  Random decrease
+                </Button>
+                <Button
+                  variant="default"
+                  onClick={() => applyRandomJump("large")}
+                >
+                  Random large jump
+                </Button>
+              </div>
+
+              <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                <Button variant="ghost" onClick={() => applyStats(8, 1, 1)}>
+                  Small roll
+                </Button>
+                <Button variant="ghost" onClick={() => applyStats(19, 4, 2)}>
+                  Multi-digit roll
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => applyStats(248, 137, 11)}
+                >
+                  Hundreds jump
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => applyStats(412, 196, 17)}
+                >
+                  Downward run
+                </Button>
+                <Button variant="ghost" onClick={() => applyStats(999, 4, 7)}>
+                  999 edge
+                </Button>
+                <Button variant="ghost" onClick={() => applyStats(1_000, 4, 7)}>
+                  Four digits
+                </Button>
+                <Button variant="ghost" onClick={() => applyStats(12, 3, 2)}>
+                  Reset
+                </Button>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/apps/web/src/components/app/diff-stat-badge.tsx
+++ b/apps/web/src/components/app/diff-stat-badge.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import SlotCounter from "react-slot-counter";
 
 import {
   Tooltip,
@@ -10,103 +11,18 @@ import { cn } from "@/lib/utils";
 
 const STALE_AFTER_MS = 30_000;
 const FLASH_DURATION_MS = 600;
-const MIN_TICK_DURATION_MS = 280;
-const MAX_TICK_DURATION_MS = FLASH_DURATION_MS;
-
-function formatCount(n: number): string {
-  if (n < 1_000) return String(n);
-  const thousands = n / 1_000;
-  return `${thousands.toFixed(thousands < 10 ? 1 : 0)}K`;
-}
-
-function getTickDuration(from: number, to: number): number {
-  const delta = Math.abs(to - from);
-  return Math.max(
-    MIN_TICK_DURATION_MS,
-    Math.min(MAX_TICK_DURATION_MS, 220 + delta * 14)
-  );
-}
-
-function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const update = () => setPrefersReducedMotion(mediaQuery.matches);
-
-    update();
-    mediaQuery.addEventListener("change", update);
-    return () => mediaQuery.removeEventListener("change", update);
-  }, []);
-
-  return prefersReducedMotion;
-}
-
-function useAnimatedCount(value: number): number {
-  const [displayValue, setDisplayValue] = useState(value);
-  const displayValueRef = useRef(value);
-  const prefersReducedMotion = usePrefersReducedMotion();
-
-  useEffect(() => {
-    const from = displayValueRef.current;
-
-    if (from === value) {
-      setDisplayValue(value);
-      displayValueRef.current = value;
-      return;
-    }
-
-    if (prefersReducedMotion || formatCount(from) !== formatCount(value)) {
-      setDisplayValue(value);
-      displayValueRef.current = value;
-      return;
-    }
-
-    const duration = getTickDuration(from, value);
-    const startedAt = performance.now();
-    let frame = 0;
-
-    const tick = (now: number) => {
-      const elapsed = now - startedAt;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = 1 - Math.pow(1 - progress, 3);
-      const nextValue = Math.round(from + (value - from) * eased);
-
-      displayValueRef.current = nextValue;
-      setDisplayValue((current) =>
-        current === nextValue ? current : nextValue
-      );
-
-      if (progress < 1) {
-        frame = window.requestAnimationFrame(tick);
-      }
-    };
-
-    frame = window.requestAnimationFrame(tick);
-    return () => window.cancelAnimationFrame(frame);
-  }, [prefersReducedMotion, value]);
-
-  return displayValue;
-}
-
-function AnimatedDiffCount({
-  prefix,
-  value,
-  toneClassName,
-}: {
-  prefix: string;
-  value: number;
-  toneClassName: string;
-}) {
-  const animatedValue = useAnimatedCount(value);
-
-  return (
-    <span className={cn("tabular-nums", toneClassName)}>
-      {prefix}
-      {formatCount(animatedValue)}
-    </span>
-  );
-}
+const slotCounterProps = {
+  animateUnchanged: false,
+  useMonospaceWidth: true,
+  hasInfiniteList: true,
+  duration: 0.45,
+  delay: 0.04,
+  dummyCharacterCount: 0,
+  containerClassName: "inline-flex items-center",
+  charClassName: "h-[1em]",
+  numberClassName: "tabular-nums",
+  separatorClassName: "tabular-nums",
+} as const;
 
 export type DiffStatBadgeProps = {
   diffStats: DiffStats | null | undefined;
@@ -119,17 +35,45 @@ export type DiffStatBadgeProps = {
   onRefresh: () => void;
 };
 
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener("change", updatePreference);
+
+    return () => mediaQuery.removeEventListener("change", updatePreference);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
 export function DiffStatBadge({
   diffStats,
   latestEventAt,
   onRefresh,
 }: DiffStatBadgeProps): JSX.Element | null {
   const [flash, setFlash] = useState(false);
+  const flashTimer = useRef<number | null>(null);
   const lastSig = useRef<string | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
-  const sig = diffStats
-    ? `${diffStats.added}:${diffStats.deleted}:${diffStats.files}`
-    : null;
+  const sig = diffStats ? `${diffStats.added}:${diffStats.deleted}` : null;
+
+  const triggerFlash = () => {
+    if (flashTimer.current !== null) {
+      window.clearTimeout(flashTimer.current);
+    }
+
+    setFlash(true);
+    flashTimer.current = window.setTimeout(() => {
+      setFlash(false);
+      flashTimer.current = null;
+    }, FLASH_DURATION_MS);
+  };
 
   useEffect(() => {
     if (sig === null) {
@@ -137,13 +81,21 @@ export function DiffStatBadge({
       return;
     }
     if (lastSig.current !== null && lastSig.current !== sig) {
-      setFlash(true);
-      const timer = window.setTimeout(() => setFlash(false), FLASH_DURATION_MS);
+      triggerFlash();
       lastSig.current = sig;
-      return () => window.clearTimeout(timer);
+      return;
     }
     lastSig.current = sig;
   }, [sig]);
+
+  useEffect(
+    () => () => {
+      if (flashTimer.current !== null) {
+        window.clearTimeout(flashTimer.current);
+      }
+    },
+    []
+  );
 
   if (!diffStats) return null;
   if (diffStats.added === 0 && diffStats.deleted === 0) return null;
@@ -163,6 +115,7 @@ export function DiffStatBadge({
           data-testid="diff-stat-badge"
           onClick={(event) => {
             event.stopPropagation();
+            triggerFlash();
             onRefresh();
           }}
           className={cn(
@@ -173,16 +126,30 @@ export function DiffStatBadge({
           )}
           aria-label="Refresh diff stats"
         >
-          <AnimatedDiffCount
-            prefix="+"
-            value={diffStats.added}
-            toneClassName="text-status-working"
-          />
-          <AnimatedDiffCount
-            prefix="−"
-            value={diffStats.deleted}
-            toneClassName="text-status-blocked"
-          />
+          <span className="inline-flex items-center tabular-nums text-status-working">
+            <span>+</span>
+            {prefersReducedMotion ? (
+              <span>{diffStats.added}</span>
+            ) : (
+              <SlotCounter
+                value={diffStats.added}
+                direction="bottom-up"
+                {...slotCounterProps}
+              />
+            )}
+          </span>
+          <span className="inline-flex items-center tabular-nums text-status-blocked">
+            <span>−</span>
+            {prefersReducedMotion ? (
+              <span>{diffStats.deleted}</span>
+            ) : (
+              <SlotCounter
+                value={diffStats.deleted}
+                direction="top-down"
+                {...slotCounterProps}
+              />
+            )}
+          </span>
         </button>
       </TooltipTrigger>
       <TooltipContent>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       react-router-dom:
         specifier: ^7.14.0
         version: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-slot-counter:
+        specifier: ^3.3.3
+        version: 3.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1)
@@ -7186,6 +7189,16 @@ packages:
       react-dom:
         optional: true
 
+  react-slot-counter@3.3.3:
+    resolution:
+      {
+        integrity: sha512-sB5qwYmDFgYZsiG6zloSjzvJzYeeZgV5f/tHWdb8tKB+Jq6+NanvUV5Qbrii34TVP+ZFBeoI33VVvGLCVpiCsw==,
+      }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
+
   react-style-singleton@2.2.3:
     resolution:
       {
@@ -13406,6 +13419,11 @@ snapshots:
       react: 18.3.1
       set-cookie-parser: 2.7.2
     optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-slot-counter@3.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):


### PR DESCRIPTION
## Summary
- rebuild the diff stat badge to use `react-slot-counter` directly from raw numeric props while keeping the existing badge shell behaviors
- simplify the design lab to drive the real badge with raw value changes and clearer test controls
- exclude `pnpm-lock.yaml` from diff stat aggregation and cover that behavior with a server test

## Notes
- preserves the update flash and adds click acknowledgement on manual refresh
- restores reduced-motion behavior by falling back to plain numeric text
- frontend UX reviewer approved the final pass in Dispatch