### PR TITLE
Automatic update checks + actionable toast (Phase 1)

### DIFF
--- a/apps/server/src/release-auto-check.ts
+++ b/apps/server/src/release-auto-check.ts
@@ -1,0 +1,198 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import { getSetting, setSetting } from "./db/settings.js";
+import {
+  computeReleaseInfo,
+  type ComputeReleaseInfoDeps,
+  type ReleaseInfoSnapshot,
+} from "./release-info.js";
+
+export const AUTOMATIC_UPDATE_MODE_KEY = "automatic_update_mode";
+export const AUTOMATIC_UPDATE_MODES = ["off", "check"] as const;
+export type AutomaticUpdateMode = (typeof AUTOMATIC_UPDATE_MODES)[number];
+
+const DEFAULT_MODE: AutomaticUpdateMode = "check";
+const STARTUP_DELAY_MS = 45_000;
+const RECURRING_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Read the automatic-update mode, treating "unset" as the default and
+ * persisting that default on first read so the operator UI can render the
+ * stored value without ambiguity. Spec rule: existing installs default to
+ * "check" the first time the setting is read or updated.
+ */
+export async function readAutomaticUpdateMode(
+  pool: Pool
+): Promise<AutomaticUpdateMode> {
+  const raw = await getSetting(pool, AUTOMATIC_UPDATE_MODE_KEY);
+  if (raw === null || raw === undefined) {
+    await setSetting(pool, AUTOMATIC_UPDATE_MODE_KEY, DEFAULT_MODE);
+    return DEFAULT_MODE;
+  }
+  return isValidMode(raw) ? raw : DEFAULT_MODE;
+}
+
+export async function writeAutomaticUpdateMode(
+  pool: Pool,
+  mode: AutomaticUpdateMode
+): Promise<void> {
+  await setSetting(pool, AUTOMATIC_UPDATE_MODE_KEY, mode);
+}
+
+export function isValidMode(value: unknown): value is AutomaticUpdateMode {
+  return (
+    typeof value === "string" &&
+    (AUTOMATIC_UPDATE_MODES as readonly string[]).includes(value)
+  );
+}
+
+type Logger = Pick<FastifyBaseLogger, "info" | "warn" | "error">;
+
+export type AutoCheckBroadcaster = (
+  snapshot: ReleaseInfoSnapshot | null
+) => void;
+
+export type AutoCheckRuntimeDeps = {
+  pool: Pool;
+  computeDeps: ComputeReleaseInfoDeps;
+  /** Returns true when an apply job is in flight; the timer skips checks
+   *  during apply so the UI doesn't flap between "available / installing". */
+  isApplyInProgress: () => boolean;
+  /** Called whenever the cached snapshot changes, including transitions
+   *  to null (cleared on apply). The broker handles SSE fanout; this
+   *  module just emits on every mutation so all clients stay in sync.
+   *  Per-tag toast suppression is the client's job (sonner id + the
+   *  dismissed-by-tag localStorage atom). */
+  broadcast: AutoCheckBroadcaster;
+  logger: Logger;
+};
+
+export type AutoCheckRuntime = ReturnType<typeof createAutoCheckRuntime>;
+
+/**
+ * Encapsulates the auto-check scheduler, in-memory snapshot, and the
+ * broadcast policy. Constructed once per server process. Tests inject their
+ * own deps and drive `runAutoCheckOnce` directly.
+ */
+export function createAutoCheckRuntime(deps: AutoCheckRuntimeDeps) {
+  let snapshot: ReleaseInfoSnapshot | null = null;
+  let inflight: Promise<RunResult> | null = null;
+  let startupTimer: ReturnType<typeof setTimeout> | null = null;
+  let recurringTimer: ReturnType<typeof setInterval> | null = null;
+
+  type RunResult =
+    | { ok: true; snapshot: ReleaseInfoSnapshot }
+    | { ok: false; reason: string }
+    | { ok: "skipped"; reason: string };
+
+  function getSnapshot(): ReleaseInfoSnapshot | null {
+    return snapshot;
+  }
+
+  function emitBroadcast(): void {
+    try {
+      deps.broadcast(snapshot);
+    } catch (err) {
+      deps.logger.warn({ err }, "auto-update: broadcast hook threw");
+    }
+  }
+
+  function setSnapshotForWriteThrough(next: ReleaseInfoSnapshot): void {
+    snapshot = next;
+    // Broadcast on every mutation so all connected clients (including
+    // tabs other than the one that triggered the manual check) stay in
+    // sync with the server cache. Per-tag toast suppression is handled
+    // client-side via sonner toast id + dismissedReleaseToastAtomFamily.
+    emitBroadcast();
+  }
+
+  /**
+   * Drop the snapshot if it advertises an update for `tag`. Called when an
+   * apply job for that tag starts so the UI doesn't keep showing
+   * "v0.18.42 available" while v0.18.42 is in flight. A snapshot for a
+   * different (newer) tag is left intact — that update is still meaningful.
+   */
+  function clearSnapshotIfMatchesTag(tag: string | null): void {
+    if (!tag || !snapshot) return;
+    if (snapshot.latestTag === tag) {
+      snapshot = null;
+      emitBroadcast();
+    }
+  }
+
+  function runAutoCheckOnce(reason: string): Promise<RunResult> {
+    if (inflight) {
+      return inflight;
+    }
+    // Inflight is set synchronously below so a second caller arriving
+    // before the first await observes the in-flight state and coalesces
+    // onto the same promise.
+    const promise = (async (): Promise<RunResult> => {
+      if (deps.isApplyInProgress()) {
+        return { ok: "skipped", reason: "apply in progress" };
+      }
+      const mode = await readAutomaticUpdateMode(deps.pool).catch(
+        () => DEFAULT_MODE
+      );
+      if (mode === "off") {
+        return { ok: "skipped", reason: "mode=off" };
+      }
+
+      deps.logger.info({ reason }, "auto-update: running release check");
+      const result = await computeReleaseInfo(deps.computeDeps, {
+        logger: deps.logger,
+      });
+      if (!result.ok) {
+        deps.logger.warn(
+          { error: result.error },
+          "auto-update: release check failed; keeping previous snapshot"
+        );
+        return { ok: false, reason: result.error };
+      }
+      snapshot = result.snapshot;
+      emitBroadcast();
+      return { ok: true, snapshot: result.snapshot };
+    })();
+    inflight = promise;
+    void promise.finally(() => {
+      if (inflight === promise) {
+        inflight = null;
+      }
+    });
+    return promise;
+  }
+
+  function startScheduler(): void {
+    if (startupTimer || recurringTimer) return;
+    startupTimer = setTimeout(() => {
+      void runAutoCheckOnce("startup");
+    }, STARTUP_DELAY_MS);
+    startupTimer.unref?.();
+
+    recurringTimer = setInterval(() => {
+      void runAutoCheckOnce("interval");
+    }, RECURRING_INTERVAL_MS);
+    recurringTimer.unref?.();
+  }
+
+  function stopScheduler(): void {
+    if (startupTimer) {
+      clearTimeout(startupTimer);
+      startupTimer = null;
+    }
+    if (recurringTimer) {
+      clearInterval(recurringTimer);
+      recurringTimer = null;
+    }
+  }
+
+  return {
+    getSnapshot,
+    setSnapshotForWriteThrough,
+    clearSnapshotIfMatchesTag,
+    runAutoCheckOnce,
+    startScheduler,
+    stopScheduler,
+  };
+}

--- a/apps/server/src/release-auto-check.ts
+++ b/apps/server/src/release-auto-check.ts
@@ -7,6 +7,7 @@ import {
   type ComputeReleaseInfoDeps,
   type ReleaseInfoSnapshot,
 } from "./release-info.js";
+import { pruneCacheExcept } from "./release-tarball-cache.js";
 
 export const AUTOMATIC_UPDATE_MODE_KEY = "automatic_update_mode";
 export const AUTOMATIC_UPDATE_MODES = ["off", "check"] as const;
@@ -152,6 +153,26 @@ export function createAutoCheckRuntime(deps: AutoCheckRuntimeDeps) {
       }
       snapshot = result.snapshot;
       emitBroadcast();
+
+      // Prune the local release-tarball cache to the tags we still
+      // need: the install's current tag, plus the latest discovered
+      // tag (the one a future apply would target). Without this,
+      // long-lived installs that keep checking but never upgrade
+      // accumulate one tarball per newly shipped release indefinitely.
+      // Skip if an apply started during the compute window — its own
+      // post-deploy prune will run with the right keep-set.
+      if (!deps.isApplyInProgress()) {
+        const tagsToKeep = [
+          result.snapshot.currentTag,
+          result.snapshot.latestTag,
+        ].filter((t): t is string => t !== null);
+        if (tagsToKeep.length > 0) {
+          await pruneCacheExcept(tagsToKeep).catch((err) => {
+            deps.logger.warn({ err }, "auto-update: cache prune failed");
+          });
+        }
+      }
+
       return { ok: true, snapshot: result.snapshot };
     })();
     inflight = promise;

--- a/apps/server/src/release-info.ts
+++ b/apps/server/src/release-info.ts
@@ -1,0 +1,288 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import { getSetting } from "./db/settings.js";
+import { readReleaseStore } from "./release-store.js";
+import {
+  inspectAssistedUpdateMetadata,
+  isAssistedUpdateRequired,
+  type AssistedUpdateMetadata,
+} from "./release-metadata.js";
+import {
+  evaluatePendingMigrations,
+  toSummary,
+  type PendingMigrationSummary,
+} from "./update-migrations-evaluator.js";
+import { runCommand } from "./shared/lib/run-command.js";
+import type { ReleaseProgress } from "./server/release-runtime.js";
+
+const RELEASE_CHANNEL_KEY = "release_channel";
+
+export type ReleaseChannel = "stable" | "latest";
+
+/**
+ * Snapshot returned by computeReleaseInfo. Subset of the legacy
+ * /api/v1/release/info response that's safe to share across UI clients —
+ * intentionally excludes the admin-only fields (unreleasedCount, commits,
+ * refMissing, isAdmin) since those are per-viewer enrichments. The route
+ * handler computes those on the fly when the requesting user is admin.
+ */
+export type ReleaseInfoSnapshot = {
+  currentTag: string | null;
+  channel: ReleaseChannel;
+  latestTag: string | null;
+  absoluteLatestTag: string | null;
+  updateAvailable: boolean;
+  latestRelease: { tag: string; publishedAt: string; url: string } | null;
+  assisted: AssistedUpdateMetadata | null;
+  assistedRequired: boolean;
+  pendingMigrations: PendingMigrationSummary[];
+  migrationsError: string | null;
+  computedAt: string;
+};
+
+export type ComputeReleaseInfoDeps = {
+  pool: Pool;
+  serverDir: string;
+  getGitHubRepo: () => Promise<string>;
+  parseGhJson: <T>(stdout: string) => T;
+  compareSemver: (a: string, b: string) => number;
+  getAppVersionInfo: () => Promise<{
+    version: string | null;
+  }>;
+  fetchLatestReleaseMetadata: (tag: string) => Promise<{
+    tag: string;
+    publishedAt: string;
+    url: string;
+    body?: string | null;
+  } | null>;
+};
+
+export type ComputeReleaseInfoOptions = {
+  /** Optional sink for per-step progress (used by the route handler to
+   *  stream into a per-client SSE channel). The auto-checker leaves this
+   *  unset, since there's no human waiting on a progress bar. */
+  onProgress?: (progress: ReleaseProgress | null) => void;
+  /** Logger for structured warnings/info. */
+  logger?:
+    | FastifyBaseLogger
+    | {
+        info: (...args: unknown[]) => void;
+        warn: (...args: unknown[]) => void;
+        error: (...args: unknown[]) => void;
+      };
+};
+
+export type ComputeReleaseInfoResult =
+  | { ok: true; snapshot: ReleaseInfoSnapshot }
+  | { ok: false; error: string };
+
+/**
+ * Pure-ish core of /api/v1/release/info. Fetches the channel-filtered latest
+ * tag, classifies the release (assisted required/recommended/normal +
+ * pending migrations), and returns a snapshot. Heavy: includes a tarball
+ * download for migration evaluation when an update is available.
+ *
+ * The route handler wraps this with admin-only enrichment (unreleased
+ * commits, refMissing) and per-client progress streaming. The auto-checker
+ * calls this directly with no progress sink.
+ */
+export async function computeReleaseInfo(
+  deps: ComputeReleaseInfoDeps,
+  opts: ComputeReleaseInfoOptions = {}
+): Promise<ComputeReleaseInfoResult> {
+  const { onProgress, logger } = opts;
+  const log = logger ?? null;
+  const emit = (progress: ReleaseProgress | null): void => {
+    onProgress?.(progress);
+  };
+
+  emit({
+    step: "fetching-tags",
+    label: "Fetching release tags",
+    detail: "Checking origin for the latest available releases.",
+  });
+
+  try {
+    await runCommand("git", [
+      "-C",
+      deps.serverDir,
+      "fetch",
+      "origin",
+      "--tags",
+      "--quiet",
+    ]);
+
+    const currentTag = await deriveCurrentTag(deps);
+    const channelRaw = await getSetting(deps.pool, RELEASE_CHANNEL_KEY);
+    const channel: ReleaseChannel =
+      channelRaw === "latest" ? "latest" : "stable";
+
+    let latestTag: string | null = null;
+    let absoluteLatestTag: string | null = null;
+    try {
+      emit({
+        step: "loading-release-list",
+        label: "Looking up latest release",
+        detail: `Selecting the newest ${channel} release from GitHub.`,
+      });
+      const repo = await deps.getGitHubRepo();
+      const ghResult = await runCommand("gh", [
+        "release",
+        "list",
+        "--repo",
+        repo,
+        "--limit",
+        "10",
+        "--json",
+        "tagName,isPrerelease",
+      ]);
+      const allReleases = deps.parseGhJson<
+        Array<{ tagName: string; isPrerelease: boolean }>
+      >(ghResult.stdout);
+      absoluteLatestTag = allReleases[0]?.tagName ?? null;
+      latestTag =
+        channel === "stable"
+          ? (allReleases.find((r) => !r.isPrerelease)?.tagName ?? null)
+          : (allReleases[0]?.tagName ?? null);
+    } catch {
+      const tagsResult = await runCommand("git", [
+        "-C",
+        deps.serverDir,
+        "tag",
+        "--sort=-version:refname",
+      ]);
+      const fallbackTag =
+        tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
+      latestTag = fallbackTag;
+      absoluteLatestTag = fallbackTag;
+    }
+
+    const updateAvailable = !!(
+      currentTag &&
+      latestTag &&
+      deps.compareSemver(latestTag, currentTag) > 0
+    );
+
+    let latestRelease: {
+      tag: string;
+      publishedAt: string;
+      url: string;
+    } | null = null;
+    let assisted: AssistedUpdateMetadata | null = null;
+    let assistedMetadataError: string | null = null;
+    if (latestTag && updateAvailable) {
+      emit({
+        step: "loading-release-notes",
+        label: `Inspecting ${latestTag}`,
+        detail: "Loading release metadata and assisted-update requirements.",
+      });
+      const fullRelease = await deps.fetchLatestReleaseMetadata(latestTag);
+      latestRelease = fullRelease
+        ? {
+            tag: fullRelease.tag,
+            publishedAt: fullRelease.publishedAt,
+            url: fullRelease.url,
+          }
+        : null;
+      const inspected = inspectAssistedUpdateMetadata(
+        fullRelease?.body ?? null
+      );
+      if (inspected.state === "invalid") {
+        assistedMetadataError = inspected.error;
+      } else if (inspected.state === "valid") {
+        assisted = inspected.metadata;
+      }
+    }
+
+    if (assistedMetadataError) {
+      return {
+        ok: false,
+        error: `Latest release has malformed assisted-update metadata: ${assistedMetadataError}`,
+      };
+    }
+
+    let pendingMigrations: PendingMigrationSummary[] = [];
+    let migrationsError: string | null = null;
+    if (latestTag && updateAvailable) {
+      log?.info?.(
+        { tag: latestTag },
+        "release-info: evaluating pending migrations"
+      );
+      try {
+        const repo = await deps.getGitHubRepo();
+        const evaluation = await evaluatePendingMigrations(latestTag, {
+          repo,
+          onProgress: ({ message, bytesReceived, totalBytes }) => {
+            emit({
+              step:
+                bytesReceived !== undefined
+                  ? "downloading-release-package"
+                  : "inspecting-release-package",
+              label:
+                bytesReceived !== undefined
+                  ? "Downloading release package"
+                  : "Inspecting release package",
+              detail: message,
+              bytesReceived: bytesReceived ?? null,
+              totalBytes: totalBytes ?? null,
+            });
+          },
+        });
+        pendingMigrations = evaluation.pending.map((m) =>
+          toSummary(m.manifest)
+        );
+        if (evaluation.errors.length > 0) {
+          migrationsError = evaluation.errors
+            .map((e) => `${e.filename}: ${e.error}`)
+            .join("; ");
+        }
+      } catch (err) {
+        migrationsError =
+          err instanceof Error ? err.message : "migration evaluation failed";
+        log?.error?.(
+          { err, tag: latestTag },
+          "release-info: migration evaluation failed; falling back to assisted recommendation"
+        );
+      }
+    }
+
+    const assistedRequired =
+      pendingMigrations.length > 0 ||
+      (migrationsError !== null && updateAvailable) ||
+      isAssistedUpdateRequired(assisted, currentTag);
+
+    return {
+      ok: true,
+      snapshot: {
+        currentTag,
+        channel,
+        latestTag,
+        absoluteLatestTag,
+        updateAvailable,
+        latestRelease,
+        assisted,
+        assistedRequired,
+        pendingMigrations,
+        migrationsError,
+        computedAt: new Date().toISOString(),
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  } finally {
+    emit(null);
+  }
+}
+
+async function deriveCurrentTag(
+  deps: Pick<ComputeReleaseInfoDeps, "getAppVersionInfo">
+): Promise<string | null> {
+  const record = await readReleaseStore();
+  if (record?.tag) return record.tag;
+  const version = (await deps.getAppVersionInfo()).version?.trim() ?? null;
+  return version && /^\d+\.\d+\.\d+$/.test(version) ? `v${version}` : null;
+}

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -311,7 +311,15 @@ export async function registerReleaseRoutes(
         error: `mode must be one of: ${AUTOMATIC_UPDATE_MODES.join(", ")}`,
       });
     }
-    await writeAutomaticUpdateMode(deps.pool, body!.mode as never);
+    const nextMode = body!.mode as never;
+    await writeAutomaticUpdateMode(deps.pool, nextMode);
+    // Flipping into "check" mode is an explicit "I want to know about
+    // updates" signal — fire a check immediately rather than waiting up
+    // to 6h for the next interval. The auto-check runtime's single
+    // flight handles overlap if a check is already running.
+    if (nextMode === "check") {
+      void deps.autoCheck.runAutoCheckOnce("mode-enabled");
+    }
     return { mode: body!.mode };
   });
 
@@ -332,6 +340,13 @@ export async function registerReleaseRoutes(
       });
     }
     await setSetting(deps.pool, RELEASE_CHANNEL_KEY, body.channel as string);
+    // The cached snapshot was computed for the previous channel; it's
+    // stale the moment the operator switches. Fire an immediate
+    // background check for the new channel so the page (and toast)
+    // pick up the right state without waiting up to 6h for the next
+    // interval. Fire-and-forget — the broadcast on completion drives
+    // the UI, the HTTP response just confirms the setting persisted.
+    void deps.autoCheck.runAutoCheckOnce("channel-change");
     return { channel: body.channel };
   });
 

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -17,8 +17,18 @@ import { readReleaseStore } from "../release-store.js";
 import {
   inspectAssistedUpdateMetadata,
   isAssistedUpdateRequired,
-  type AssistedUpdateMetadata,
 } from "../release-metadata.js";
+import {
+  computeReleaseInfo,
+  type ComputeReleaseInfoDeps,
+} from "../release-info.js";
+import {
+  AUTOMATIC_UPDATE_MODES,
+  isValidMode,
+  readAutomaticUpdateMode,
+  writeAutomaticUpdateMode,
+  type AutoCheckRuntime,
+} from "../release-auto-check.js";
 import {
   buildAssistedUpdateContext,
   applyAssistedPhase,
@@ -38,6 +48,65 @@ import {
   toSummary,
   type PendingMigrationSummary,
 } from "../update-migrations-evaluator.js";
+
+/**
+ * Per-viewer admin enrichment for /api/v1/release/info. Excluded from the
+ * shared snapshot because it depends on the requesting user's GitHub repo
+ * permission. Sees no auth context — the caller passes the precomputed
+ * isAdmin flag so we don't hit gh twice in one request.
+ */
+async function computeAdminExtras(input: {
+  isAdmin: boolean;
+  compareTag: string | null;
+  serverDir: string;
+}): Promise<{
+  unreleasedCount: number;
+  commits: Array<{ sha: string; subject: string }>;
+  refMissing: boolean;
+}> {
+  if (!input.isAdmin || !input.compareTag) {
+    return { unreleasedCount: 0, commits: [], refMissing: false };
+  }
+  const refCheck = await runCommand(
+    "git",
+    ["-C", input.serverDir, "rev-parse", "--verify", input.compareTag],
+    { allowedExitCodes: [0, 128] }
+  );
+  if (refCheck.exitCode !== 0) {
+    return { unreleasedCount: 0, commits: [], refMissing: true };
+  }
+  const countResult = await runCommand("git", [
+    "-C",
+    input.serverDir,
+    "rev-list",
+    `${input.compareTag}..origin/main`,
+    "--count",
+  ]);
+  const unreleasedCount = Number(countResult.stdout) || 0;
+  if (unreleasedCount === 0) {
+    return { unreleasedCount: 0, commits: [], refMissing: false };
+  }
+  const logResult = await runCommand("git", [
+    "-C",
+    input.serverDir,
+    "log",
+    `${input.compareTag}..origin/main`,
+    "--no-merges",
+    "--format=%H\t%s",
+    "--max-count=20",
+  ]);
+  const commits = logResult.stdout
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => {
+      const tab = line.indexOf("\t");
+      return {
+        sha: line.slice(0, tab).slice(0, 7),
+        subject: line.slice(tab + 1),
+      };
+    });
+  return { unreleasedCount, commits, refMissing: false };
+}
 import { runCommand } from "../shared/lib/run-command.js";
 import type {
   ReleaseJob,
@@ -113,19 +182,13 @@ type ReleaseRouteDeps = {
     agent: T
   ) => T & { hasStream: boolean };
   handleAgentError: (reply: FastifyReply, error: unknown) => FastifyReply;
+  autoCheck: AutoCheckRuntime;
 };
 
 export async function registerReleaseRoutes(
   app: FastifyInstance,
   deps: ReleaseRouteDeps
 ): Promise<void> {
-  const deriveCurrentTag = async (): Promise<string | null> => {
-    const record = await readReleaseStore();
-    if (record?.tag) return record.tag;
-    const version = (await deps.getAppVersionInfo()).version?.trim() ?? null;
-    return version && /^\d+\.\d+\.\d+$/.test(version) ? `v${version}` : null;
-  };
-
   const getReleaseStreamClientId = (request: FastifyRequest): string | null => {
     const header = request.headers["x-dispatch-release-client-id"];
     if (typeof header !== "string") return null;
@@ -153,250 +216,88 @@ export async function registerReleaseRoutes(
     return { tag: record?.tag ?? null, deployedAt: record?.deployedAt ?? null };
   });
 
+  const computeDeps: ComputeReleaseInfoDeps = {
+    pool: deps.pool,
+    serverDir: deps.serverDir,
+    getGitHubRepo: deps.getGitHubRepo,
+    parseGhJson: deps.parseGhJson,
+    compareSemver: deps.compareSemver,
+    getAppVersionInfo: async () => {
+      const info = await deps.getAppVersionInfo();
+      return { version: info.version };
+    },
+    fetchLatestReleaseMetadata: deps.fetchLatestReleaseMetadata,
+  };
+
   app.get("/api/v1/release/info", async (request, reply) => {
     const releaseStreamClientId = getReleaseStreamClientId(request);
-    emitInfoProgress(releaseStreamClientId, {
-      step: "fetching-tags",
-      label: "Fetching release tags",
-      detail: "Checking origin for the latest available releases.",
+    const result = await computeReleaseInfo(computeDeps, {
+      logger: request.log,
+      onProgress: (progress) =>
+        emitInfoProgress(releaseStreamClientId, progress),
     });
-    try {
-      await runCommand("git", [
-        "-C",
-        deps.serverDir,
-        "fetch",
-        "origin",
-        "--tags",
-        "--quiet",
-      ]);
-
-      const currentTag = await deriveCurrentTag();
-      const isAdmin = await deps.checkIsAdmin();
-      const channelRaw = await getSetting(deps.pool, RELEASE_CHANNEL_KEY);
-      const channel = channelRaw === "latest" ? "latest" : "stable";
-
-      let latestTag: string | null = null;
-      let absoluteLatestTag: string | null = null;
-      try {
-        emitInfoProgress(releaseStreamClientId, {
-          step: "loading-release-list",
-          label: "Looking up latest release",
-          detail: `Selecting the newest ${channel} release from GitHub.`,
-        });
-        const repo = await deps.getGitHubRepo();
-        const ghResult = await runCommand("gh", [
-          "release",
-          "list",
-          "--repo",
-          repo,
-          "--limit",
-          "10",
-          "--json",
-          "tagName,isPrerelease",
-        ]);
-        const allReleases = deps.parseGhJson<
-          Array<{ tagName: string; isPrerelease: boolean }>
-        >(ghResult.stdout);
-        absoluteLatestTag = allReleases[0]?.tagName ?? null;
-        latestTag =
-          channel === "stable"
-            ? (allReleases.find((r) => !r.isPrerelease)?.tagName ?? null)
-            : (allReleases[0]?.tagName ?? null);
-      } catch {
-        const tagsResult = await runCommand("git", [
-          "-C",
-          deps.serverDir,
-          "tag",
-          "--sort=-version:refname",
-        ]);
-        const fallbackTag =
-          tagsResult.stdout.split("\n").find((t) => t.startsWith("v")) ?? null;
-        latestTag = fallbackTag;
-        absoluteLatestTag = fallbackTag;
-      }
-
-      const updateAvailable = !!(
-        currentTag &&
-        latestTag &&
-        deps.compareSemver(latestTag, currentTag) > 0
-      );
-      request.log.info(
-        {
-          currentTag,
-          latestTag,
-          absoluteLatestTag,
-          updateAvailable,
-          channel,
-          releaseStreamClientId,
-          isAdmin,
-        },
-        "release/info: computed release availability"
-      );
-
-      let latestRelease: {
-        tag: string;
-        publishedAt: string;
-        url: string;
-      } | null = null;
-      let assistedMetadata: AssistedUpdateMetadata | null = null;
-      let assistedMetadataError: string | null = null;
-      if (latestTag && updateAvailable) {
-        emitInfoProgress(releaseStreamClientId, {
-          step: "loading-release-notes",
-          label: `Inspecting ${latestTag}`,
-          detail: "Loading release metadata and assisted-update requirements.",
-        });
-        const fullRelease = await deps.fetchLatestReleaseMetadata(latestTag);
-        latestRelease = fullRelease
-          ? {
-              tag: fullRelease.tag,
-              publishedAt: fullRelease.publishedAt,
-              url: fullRelease.url,
-            }
-          : null;
-        const inspected = inspectAssistedUpdateMetadata(
-          fullRelease?.body ?? null
-        );
-        if (inspected.state === "invalid") {
-          assistedMetadataError = inspected.error;
-        } else if (inspected.state === "valid") {
-          assistedMetadata = inspected.metadata;
-        }
-      }
-      if (assistedMetadataError) {
-        return reply.code(500).send({
-          error: `Latest release has malformed assisted-update metadata: ${assistedMetadataError}`,
-        });
-      }
-
-      let pendingMigrations: PendingMigrationSummary[] = [];
-      let migrationsError: string | null = null;
-      if (latestTag && updateAvailable) {
-        request.log.info(
-          { tag: latestTag },
-          "release/info: evaluating pending migrations for update check"
-        );
-        try {
-          const repo = await deps.getGitHubRepo();
-          const evaluation = await evaluatePendingMigrations(latestTag, {
-            repo,
-            onProgress: ({ message, bytesReceived, totalBytes }) => {
-              request.log.info(
-                { tag: latestTag, message, bytesReceived, totalBytes },
-                "release/info: migration evaluation progress"
-              );
-              emitInfoProgress(releaseStreamClientId, {
-                step:
-                  bytesReceived !== undefined
-                    ? "downloading-release-package"
-                    : "inspecting-release-package",
-                label:
-                  bytesReceived !== undefined
-                    ? "Downloading release package"
-                    : "Inspecting release package",
-                detail: message,
-                bytesReceived: bytesReceived ?? null,
-                totalBytes: totalBytes ?? null,
-              });
-            },
-          });
-          pendingMigrations = evaluation.pending.map((m) =>
-            toSummary(m.manifest)
-          );
-          if (evaluation.errors.length > 0) {
-            migrationsError = evaluation.errors
-              .map((e) => `${e.filename}: ${e.error}`)
-              .join("; ");
-          }
-          request.log.info(
-            {
-              tag: latestTag,
-              pendingMigrationCount: pendingMigrations.length,
-              evaluationErrorCount: evaluation.errors.length,
-              migrationsError,
-            },
-            "release/info: migration evaluation complete"
-          );
-        } catch (err) {
-          migrationsError =
-            err instanceof Error ? err.message : "migration evaluation failed";
-          request.log.error(
-            { err, tag: latestTag },
-            "release/info: migration evaluation failed; UI will surface error and offer standard update fallback"
-          );
-        }
-      }
-      const assistedRequired =
-        pendingMigrations.length > 0 ||
-        (migrationsError !== null && updateAvailable) ||
-        isAssistedUpdateRequired(assistedMetadata, currentTag);
-
-      let unreleasedCount = 0;
-      let commits: Array<{ sha: string; subject: string }> = [];
-      let refMissing = false;
-      const compareTag = absoluteLatestTag ?? currentTag;
-      if (isAdmin && compareTag) {
-        const refCheck = await runCommand(
-          "git",
-          ["-C", deps.serverDir, "rev-parse", "--verify", compareTag],
-          { allowedExitCodes: [0, 128] }
-        );
-        if (refCheck.exitCode !== 0) {
-          refMissing = true;
-        } else {
-          const countResult = await runCommand("git", [
-            "-C",
-            deps.serverDir,
-            "rev-list",
-            `${compareTag}..origin/main`,
-            "--count",
-          ]);
-          unreleasedCount = Number(countResult.stdout) || 0;
-          if (unreleasedCount > 0) {
-            const logResult = await runCommand("git", [
-              "-C",
-              deps.serverDir,
-              "log",
-              `${compareTag}..origin/main`,
-              "--no-merges",
-              "--format=%H\t%s",
-              "--max-count=20",
-            ]);
-            commits = logResult.stdout
-              .split("\n")
-              .filter((line) => line.trim())
-              .map((line) => {
-                const tab = line.indexOf("\t");
-                return {
-                  sha: line.slice(0, tab).slice(0, 7),
-                  subject: line.slice(tab + 1),
-                };
-              });
-          }
-        }
-      }
-
-      return {
-        currentTag,
-        channel,
-        isAdmin,
-        latestTag,
-        updateAvailable,
-        latestRelease,
-        unreleasedCount,
-        commits,
-        refMissing,
-        assisted: assistedMetadata,
-        assistedRequired,
-        pendingMigrations,
-        migrationsError,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown error";
-      return reply.code(500).send({ error: message });
-    } finally {
-      emitInfoProgress(releaseStreamClientId, null);
+    if (!result.ok) {
+      return reply.code(500).send({ error: result.error });
     }
+    const { snapshot } = result;
+    request.log.info(
+      {
+        currentTag: snapshot.currentTag,
+        latestTag: snapshot.latestTag,
+        updateAvailable: snapshot.updateAvailable,
+        channel: snapshot.channel,
+        releaseStreamClientId,
+      },
+      "release/info: computed release availability"
+    );
+
+    // Write-through into the auto-check cache so the toast/cached-info
+    // endpoint reflects the freshest classification the operator just saw.
+    deps.autoCheck.setSnapshotForWriteThrough(snapshot);
+
+    const isAdmin = await deps.checkIsAdmin();
+    const extras = await computeAdminExtras({
+      isAdmin,
+      compareTag: snapshot.absoluteLatestTag ?? snapshot.currentTag,
+      serverDir: deps.serverDir,
+    });
+
+    return {
+      currentTag: snapshot.currentTag,
+      channel: snapshot.channel,
+      isAdmin,
+      latestTag: snapshot.latestTag,
+      updateAvailable: snapshot.updateAvailable,
+      latestRelease: snapshot.latestRelease,
+      unreleasedCount: extras.unreleasedCount,
+      commits: extras.commits,
+      refMissing: extras.refMissing,
+      assisted: snapshot.assisted,
+      assistedRequired: snapshot.assistedRequired,
+      pendingMigrations: snapshot.pendingMigrations,
+      migrationsError: snapshot.migrationsError,
+    };
+  });
+
+  app.get("/api/v1/release/cached-info", async () => {
+    const snapshot = deps.autoCheck.getSnapshot();
+    return { snapshot };
+  });
+
+  app.get("/api/v1/release/auto-update-mode", async () => {
+    const mode = await readAutomaticUpdateMode(deps.pool);
+    return { mode };
+  });
+
+  app.post("/api/v1/release/auto-update-mode", async (request, reply) => {
+    const body = request.body as { mode?: unknown } | undefined;
+    if (!isValidMode(body?.mode)) {
+      return reply.code(400).send({
+        error: `mode must be one of: ${AUTOMATIC_UPDATE_MODES.join(", ")}`,
+      });
+    }
+    await writeAutomaticUpdateMode(deps.pool, body!.mode as never);
+    return { mode: body!.mode };
   });
 
   app.get("/api/v1/release/channel", async () => {

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -252,8 +252,23 @@ export async function registerReleaseRoutes(
     );
 
     // Write-through into the auto-check cache so the toast/cached-info
-    // endpoint reflects the freshest classification the operator just saw.
-    deps.autoCheck.setSnapshotForWriteThrough(snapshot);
+    // endpoint reflects the freshest classification the operator just saw —
+    // EXCEPT when an apply for this exact tag is in flight. In that case
+    // re-populating would broadcast `release.cached_info_changed` to every
+    // connected client and re-advertise the in-flight tag as "available",
+    // undoing the clear-on-apply protection. The requesting client still
+    // gets the fresh data in the response body either way.
+    const activeJob = deps.getActiveReleaseJob();
+    const isApplyingSnapshotTag =
+      activeJob !== null &&
+      (activeJob.jobType === "update" ||
+        activeJob.jobType === "update-assisted") &&
+      activeJob.tag !== null &&
+      activeJob.tag === snapshot.latestTag &&
+      !isTerminalPhase(activeJob.phase as AssistedPhase);
+    if (!isApplyingSnapshotTag) {
+      deps.autoCheck.setSnapshotForWriteThrough(snapshot);
+    }
 
     const isAdmin = await deps.checkIsAdmin();
     const extras = await computeAdminExtras({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -105,6 +105,7 @@ import { registerMcpRoutes } from "./routes/mcp.js";
 import { registerPersonaReviewRoutes } from "./routes/persona-reviews.js";
 import { registerPersonalityRoutes } from "./routes/personalities.js";
 import { registerReleaseRoutes } from "./routes/release.js";
+import { createAutoCheckRuntime } from "./release-auto-check.js";
 import { registerStaticRoutes } from "./routes/static.js";
 import { registerSystemRoutes } from "./routes/system.js";
 import {
@@ -226,6 +227,30 @@ const releaseRuntime = createReleaseRuntime({
   createReleaseLogStreamProcessor: (sinks, onLine) =>
     new ReleaseLogStreamProcessor(sinks, onLine),
 });
+const autoCheckRuntime = createAutoCheckRuntime({
+  pool,
+  computeDeps: {
+    pool,
+    serverDir,
+    getGitHubRepo: releaseRuntime.getGitHubRepo,
+    parseGhJson: releaseRuntime.parseGhJson,
+    compareSemver: releaseRuntime.compareSemver,
+    getAppVersionInfo: async () => {
+      const info = await releaseRuntime.getAppVersionInfo();
+      return { version: info.version };
+    },
+    fetchLatestReleaseMetadata: releaseRuntime.fetchLatestReleaseMetadata,
+  },
+  isApplyInProgress: releaseRuntime.hasActiveUpdateJob,
+  broadcast: (snapshot) => {
+    uiEventBroker.publish({
+      type: "release.cached_info_changed",
+      snapshot,
+    });
+  },
+  logger: app.log,
+});
+
 const agentLifecycleRuntime = createAgentLifecycleRuntime({
   agentManager,
   streamManager,
@@ -459,6 +484,12 @@ async function registerRoutes() {
     validWorktreeLocations: VALID_WORKTREE_LOCATIONS,
     getActiveReleaseJob: releaseRuntime.getActiveReleaseJob,
     setActiveReleaseJob: (job) => {
+      // When an apply starts for the same tag the snapshot advertises,
+      // clear the snapshot so the UI doesn't keep showing "vX available"
+      // alongside the in-flight install.
+      if (job && job.tag) {
+        autoCheckRuntime.clearSnapshotIfMatchesTag(job.tag);
+      }
       releaseRuntime.setActiveReleaseJob(job as ReleaseJob | null);
     },
     getActiveAssistedUpdateLaunch: releaseRuntime.getActiveAssistedUpdateLaunch,
@@ -486,6 +517,7 @@ async function registerRoutes() {
     publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
     withStreamFlag,
     handleAgentError,
+    autoCheck: autoCheckRuntime,
   });
 
   await registerMediaRoutes(app, {
@@ -606,6 +638,7 @@ export async function initializeApp(options?: {
     }
     agentLifecycleRuntime.startReconcileLoop();
     authRuntime.startSessionCleanupTimer();
+    autoCheckRuntime.startScheduler();
   }
   if (!routesRegistered) {
     await registerRoutes();
@@ -645,6 +678,7 @@ async function cleanupAppResources(): Promise<void> {
   streamManager.stopAll();
   agentLifecycleRuntime.stopReconcileLoop();
   authRuntime.stopSessionCleanupTimer();
+  autoCheckRuntime.stopScheduler();
 
   notificationRuntime.clearPendingWebNotifications();
 

--- a/apps/server/src/server/release-runtime.ts
+++ b/apps/server/src/server/release-runtime.ts
@@ -891,10 +891,22 @@ Suggested workflow:
     }
   }
 
+  function hasActiveUpdateJob(): boolean {
+    if (!activeReleaseJob) return false;
+    if (
+      activeReleaseJob.jobType !== "update" &&
+      activeReleaseJob.jobType !== "update-assisted"
+    ) {
+      return false;
+    }
+    return !deps.isTerminalPhase(activeReleaseJob.phase as AssistedPhase);
+  }
+
   return {
     RELEASE_VERSION_TYPES,
     getAppVersionInfo,
     getActiveReleaseJob: () => activeReleaseJob,
+    hasActiveUpdateJob,
     setActiveReleaseJob: (job: ReleaseJob | null) => {
       activeReleaseJob = job;
     },

--- a/apps/server/src/server/ui-events.ts
+++ b/apps/server/src/server/ui-events.ts
@@ -1,4 +1,5 @@
 import type { AgentRecord, FeedbackRecord } from "../agents/manager.js";
+import type { ReleaseInfoSnapshot } from "../release-info.js";
 import type { DiffStats } from "../shared/git/diff-stats.js";
 import type { TerminalUiState } from "../terminal/copy-mode-observer.js";
 
@@ -38,6 +39,10 @@ export type UiEvent =
       agentName: string;
       eventType: string;
       message: string;
+    }
+  | {
+      type: "release.cached_info_changed";
+      snapshot: ReleaseInfoSnapshot | null;
     };
 
 export class UiEventBroker {

--- a/apps/server/test/release-auto-check.test.ts
+++ b/apps/server/test/release-auto-check.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { computeMock, getSettingMock, setSettingMock } = vi.hoisted(() => ({
+  computeMock: vi.fn(),
+  getSettingMock: vi.fn(),
+  setSettingMock: vi.fn(),
+}));
+
+vi.mock("../src/release-info.js", () => ({
+  computeReleaseInfo: computeMock,
+}));
+
+vi.mock("../src/db/settings.js", () => ({
+  getSetting: getSettingMock,
+  setSetting: setSettingMock,
+}));
+
+import {
+  createAutoCheckRuntime,
+  readAutomaticUpdateMode,
+} from "../src/release-auto-check.js";
+
+const fakePool = {} as never;
+
+const fakeComputeDeps = {
+  pool: fakePool,
+  serverDir: "/srv",
+  getGitHubRepo: async () => "owner/repo",
+  parseGhJson: <T>(_: string): T => ({}) as T,
+  compareSemver: () => 0,
+  getAppVersionInfo: async () => ({ version: "0.0.1" }),
+  fetchLatestReleaseMetadata: async () => null,
+};
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const baseSnapshot = {
+  currentTag: "v0.18.41",
+  channel: "stable" as const,
+  latestTag: "v0.18.42",
+  absoluteLatestTag: "v0.18.42",
+  updateAvailable: true,
+  latestRelease: null,
+  assisted: null,
+  assistedRequired: false,
+  pendingMigrations: [],
+  migrationsError: null,
+  computedAt: "2026-05-03T00:00:00Z",
+};
+
+describe("readAutomaticUpdateMode default-on", () => {
+  beforeEach(() => {
+    getSettingMock.mockReset();
+    setSettingMock.mockReset();
+  });
+
+  it("returns 'check' and persists when unset", async () => {
+    getSettingMock.mockResolvedValueOnce(null);
+    const mode = await readAutomaticUpdateMode(fakePool);
+    expect(mode).toBe("check");
+    expect(setSettingMock).toHaveBeenCalledWith(
+      fakePool,
+      "automatic_update_mode",
+      "check"
+    );
+  });
+
+  it("returns the stored value when set", async () => {
+    getSettingMock.mockResolvedValueOnce("off");
+    const mode = await readAutomaticUpdateMode(fakePool);
+    expect(mode).toBe("off");
+    expect(setSettingMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to default for unrecognized values", async () => {
+    getSettingMock.mockResolvedValueOnce("garbage");
+    const mode = await readAutomaticUpdateMode(fakePool);
+    expect(mode).toBe("check");
+  });
+});
+
+describe("createAutoCheckRuntime.runAutoCheckOnce", () => {
+  beforeEach(() => {
+    computeMock.mockReset();
+    getSettingMock.mockReset();
+    setSettingMock.mockReset();
+  });
+
+  it("skips when mode=off", async () => {
+    getSettingMock.mockResolvedValueOnce("off");
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    const result = await runtime.runAutoCheckOnce("test");
+    expect(result.ok).toBe("skipped");
+    expect(computeMock).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("skips when an apply is in progress", async () => {
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => true,
+      broadcast,
+      logger: noopLogger,
+    });
+    const result = await runtime.runAutoCheckOnce("test");
+    expect(result.ok).toBe("skipped");
+    expect(computeMock).not.toHaveBeenCalled();
+  });
+
+  it("broadcasts the new snapshot on every successful check", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock.mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot });
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    const result = await runtime.runAutoCheckOnce("startup");
+    expect(result.ok).toBe(true);
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith(baseSnapshot);
+    expect(runtime.getSnapshot()).toEqual(baseSnapshot);
+  });
+
+  it("broadcasts every check so clients see updateAvailable=false transitions", async () => {
+    getSettingMock.mockResolvedValue("check");
+    const upToDate = { ...baseSnapshot, updateAvailable: false };
+    computeMock
+      .mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot })
+      .mockResolvedValueOnce({ ok: true, snapshot: upToDate });
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    await runtime.runAutoCheckOnce("interval");
+    expect(broadcast).toHaveBeenCalledTimes(2);
+    expect(broadcast).toHaveBeenLastCalledWith(upToDate);
+  });
+
+  it("keeps prior snapshot when a check fails and does not broadcast", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock
+      .mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot })
+      .mockResolvedValueOnce({ ok: false, error: "network down" });
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    const failed = await runtime.runAutoCheckOnce("interval");
+    expect(failed.ok).toBe(false);
+    expect(runtime.getSnapshot()).toEqual(baseSnapshot);
+    expect(broadcast).toHaveBeenCalledTimes(1);
+  });
+
+  it("broadcasts on write-through from a manual check", async () => {
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    runtime.setSnapshotForWriteThrough(baseSnapshot);
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith(baseSnapshot);
+    expect(runtime.getSnapshot()).toEqual(baseSnapshot);
+  });
+
+  it("clears snapshot AND broadcasts null on apply for the same tag", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock.mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot });
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    broadcast.mockClear();
+    runtime.clearSnapshotIfMatchesTag("v0.18.42");
+    expect(runtime.getSnapshot()).toBeNull();
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith(null);
+  });
+
+  it("preserves snapshot and does not broadcast on apply for a different tag", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock.mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot });
+    const broadcast = vi.fn();
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast,
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    broadcast.mockClear();
+    runtime.clearSnapshotIfMatchesTag("v0.17.99");
+    expect(runtime.getSnapshot()).toEqual(baseSnapshot);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent runs into one in-flight check", async () => {
+    getSettingMock.mockResolvedValue("check");
+    // Slow-resolving compute so the two callers overlap.
+    computeMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setImmediate(() => resolve({ ok: true, snapshot: baseSnapshot }));
+        })
+    );
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast: () => {},
+      logger: noopLogger,
+    });
+    const a = runtime.runAutoCheckOnce("a");
+    const b = runtime.runAutoCheckOnce("b");
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(resA).toBe(resB);
+    expect(computeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/test/release-auto-check.test.ts
+++ b/apps/server/test/release-auto-check.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { computeMock, getSettingMock, setSettingMock } = vi.hoisted(() => ({
-  computeMock: vi.fn(),
-  getSettingMock: vi.fn(),
-  setSettingMock: vi.fn(),
-}));
+const { computeMock, getSettingMock, setSettingMock, pruneCacheMock } =
+  vi.hoisted(() => ({
+    computeMock: vi.fn(),
+    getSettingMock: vi.fn(),
+    setSettingMock: vi.fn(),
+    pruneCacheMock: vi.fn(async () => {}),
+  }));
 
 vi.mock("../src/release-info.js", () => ({
   computeReleaseInfo: computeMock,
@@ -13,6 +15,14 @@ vi.mock("../src/release-info.js", () => ({
 vi.mock("../src/db/settings.js", () => ({
   getSetting: getSettingMock,
   setSetting: setSettingMock,
+}));
+
+// Stub the tarball-cache prune so unit tests don't touch the host's real
+// `~/.dispatch/cache/` directory. The auto-check now calls it after
+// every successful check; without this mock, running the suite would
+// remove the user's actual cached release tarballs.
+vi.mock("../src/release-tarball-cache.js", () => ({
+  pruneCacheExcept: pruneCacheMock,
 }));
 
 import {
@@ -88,6 +98,8 @@ describe("createAutoCheckRuntime.runAutoCheckOnce", () => {
     computeMock.mockReset();
     getSettingMock.mockReset();
     setSettingMock.mockReset();
+    pruneCacheMock.mockReset();
+    pruneCacheMock.mockImplementation(async () => {});
   });
 
   it("skips when mode=off", async () => {
@@ -211,6 +223,40 @@ describe("createAutoCheckRuntime.runAutoCheckOnce", () => {
     expect(runtime.getSnapshot()).toBeNull();
     expect(broadcast).toHaveBeenCalledTimes(1);
     expect(broadcast).toHaveBeenCalledWith(null);
+  });
+
+  it("prunes the tarball cache to currentTag + latestTag after a successful check", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock.mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot });
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      isApplyInProgress: () => false,
+      broadcast: () => {},
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    expect(pruneCacheMock).toHaveBeenCalledTimes(1);
+    expect(pruneCacheMock).toHaveBeenCalledWith(["v0.18.41", "v0.18.42"]);
+  });
+
+  it("skips pruning when an apply starts during the compute window", async () => {
+    getSettingMock.mockResolvedValue("check");
+    computeMock.mockResolvedValueOnce({ ok: true, snapshot: baseSnapshot });
+    let applyInProgress = false;
+    const runtime = createAutoCheckRuntime({
+      pool: fakePool,
+      computeDeps: fakeComputeDeps,
+      // Toggle to true once the compute resolves but before the prune
+      // step decides whether to fire.
+      isApplyInProgress: () => applyInProgress,
+      broadcast: () => {
+        applyInProgress = true;
+      },
+      logger: noopLogger,
+    });
+    await runtime.runAutoCheckOnce("startup");
+    expect(pruneCacheMock).not.toHaveBeenCalled();
   });
 
   it("preserves snapshot and does not broadcast on apply for a different tag", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { type IdeType, sanitizeEnabledIdes } from "@/lib/ide-types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { agentRoute } from "@/lib/agent-routes";
+import { ReleaseAvailableToast } from "@/components/app/release-available-toast";
 import { UpdateAvailableToast } from "@/components/app/update-available-toast";
 import { Toaster } from "sonner";
 
@@ -241,6 +242,7 @@ export function DashboardLayout(): JSX.Element {
   return (
     <>
       <Outlet context={context} />
+      <ReleaseAvailableToast />
       <UpdateAvailableToast />
       {/* Color tokens, close button, and action button styling live in
           `index.css` under `[data-sonner-toaster]` — `richColors` is what

--- a/apps/web/src/components/app/release-available-toast.tsx
+++ b/apps/web/src/components/app/release-available-toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useNavigate } from "react-router-dom";
 import { ArrowDownToLine, ShieldAlert } from "lucide-react";
@@ -80,9 +80,36 @@ export function ReleaseAvailableToast(): null {
   const dismissed = useAtomValue(dismissedAtom);
   const setDismissed = useSetAtom(dismissedAtom);
 
+  // Track the tag of the toast that's currently visible on screen so we
+  // can dismiss it explicitly when the snapshot transitions out of the
+  // "show" state — instead of via effect cleanup, which would dismiss
+  // and recreate on every dep change and produce a visible flicker.
+  const shownTagRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!snapshot || !snapshot.updateAvailable || !tag) return;
-    if (dismissed) return;
+    const wantsToShow =
+      snapshot !== null &&
+      snapshot.updateAvailable &&
+      tag !== null &&
+      !dismissed;
+
+    // Tag changed (or we no longer want to show): retire the prior toast.
+    const prevTag = shownTagRef.current;
+    if (prevTag !== null && prevTag !== tag) {
+      toast.dismiss(`${TOAST_ID_PREFIX}${prevTag}`);
+      shownTagRef.current = null;
+    }
+
+    if (!wantsToShow) {
+      // Conditions no longer met for the *current* tag (e.g. user
+      // dismissed, or updateAvailable flipped to false). Make sure
+      // anything we previously rendered is gone.
+      if (prevTag !== null && prevTag === tag) {
+        toast.dismiss(`${TOAST_ID_PREFIX}${tag}`);
+        shownTagRef.current = null;
+      }
+      return;
+    }
 
     const variant = classifyVariant(snapshot);
     const { title, primaryLabel, secondaryLabel } = copyForVariant(
@@ -91,6 +118,9 @@ export function ReleaseAvailableToast(): null {
     );
     const toastId = `${TOAST_ID_PREFIX}${tag}`;
 
+    // Sonner dedupes by id — calling toast(...) again with the same id
+    // updates the existing toast in place rather than creating a new
+    // one, so re-renders don't flicker.
     toast(title, {
       id: toastId,
       duration: Infinity,
@@ -135,14 +165,19 @@ export function ReleaseAvailableToast(): null {
           setDismissed(true);
         },
       },
-      onDismiss: () => {
-        setDismissed(true);
-      },
+      // Intentionally no `onDismiss` callback. Sonner fires it for BOTH
+      // user-initiated dismissals AND programmatic `toast.dismiss(id)`,
+      // so wiring it to setDismissed would treat every transition as a
+      // user dismissal. The cancel button above is the canonical
+      // "user said Later" signal.
     });
 
-    return () => {
-      toast.dismiss(toastId);
-    };
+    shownTagRef.current = tag;
+
+    // No effect-cleanup dismissal — transitions are handled at the top of
+    // the next effect run via shownTagRef. This avoids the
+    // dismiss-and-recreate flicker that happens when React Query produces
+    // a new snapshot reference with identical content.
   }, [snapshot, tag, dismissed, navigate, setDismissed]);
 
   return null;

--- a/apps/web/src/components/app/release-available-toast.tsx
+++ b/apps/web/src/components/app/release-available-toast.tsx
@@ -102,17 +102,30 @@ export function ReleaseAvailableToast(): null {
         ),
       action: {
         label: primaryLabel,
-        onClick: () => {
+        onClick: async () => {
           if (variant === "standard") {
-            void api("/api/v1/release/update", {
-              method: "POST",
-              body: JSON.stringify({ tag }),
-            }).catch(() => {});
+            // Await the apply-start request so a 5xx / network failure
+            // surfaces as an error toast rather than vanishing silently
+            // alongside the dismissal of this one. On success the
+            // operator lands on /settings/updates to watch the takeover.
+            try {
+              await api("/api/v1/release/update", {
+                method: "POST",
+                body: JSON.stringify({ tag }),
+              });
+            } catch (err) {
+              toast.error(
+                err instanceof Error
+                  ? `Couldn't start update: ${err.message}`
+                  : "Couldn't start update"
+              );
+              return;
+            }
           }
-          // Both standard and assisted variants land on the Updates page —
-          // standard so the operator can watch the apply-flow takeover,
-          // assisted so they review the migration list before launching
-          // the agent. Per spec, "Review update" must NOT auto-launch.
+          // Standard: navigate so the operator sees the apply-flow takeover.
+          // Assisted: per spec, "Review update" must NOT auto-launch — it
+          // just routes to the page so the operator can review migrations
+          // and explicitly start the agent.
           navigate("/settings/updates");
         },
       },

--- a/apps/web/src/components/app/release-available-toast.tsx
+++ b/apps/web/src/components/app/release-available-toast.tsx
@@ -118,10 +118,21 @@ export function ReleaseAvailableToast(): null {
     );
     const toastId = `${TOAST_ID_PREFIX}${tag}`;
 
-    // Sonner dedupes by id — calling toast(...) again with the same id
-    // updates the existing toast in place rather than creating a new
-    // one, so re-renders don't flicker.
-    toast(title, {
+    // Sonner dedupes by id — calling the same variant function again
+    // with the same id updates the existing toast in place rather than
+    // creating a new one, so re-renders don't flicker.
+    //
+    // Variant mapping ties the toast's color treatment to the spec's
+    // assisted-update classification, picking up the
+    // info/warning/success/error tokens defined in index.css under
+    // `[data-sonner-toaster][data-sonner-theme]`:
+    //   - standard   → toast.info     (informational, blue surface)
+    //   - recommended → toast.warning (operator should pay attention,
+    //                                  amber surface)
+    //   - required   → toast.warning (same surface; ShieldAlert icon
+    //                                  carries the stronger signal)
+    const toastFn = variant === "standard" ? toast.info : toast.warning;
+    toastFn(title, {
       id: toastId,
       duration: Infinity,
       icon:

--- a/apps/web/src/components/app/release-available-toast.tsx
+++ b/apps/web/src/components/app/release-available-toast.tsx
@@ -1,0 +1,136 @@
+import { useEffect } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useNavigate } from "react-router-dom";
+import { ArrowDownToLine, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  useCachedReleaseInfo,
+  type ReleaseInfoSnapshot,
+} from "@/hooks/use-cached-release-info";
+import { dismissedReleaseToastAtomFamily } from "@/lib/store";
+import { api } from "@/lib/api";
+
+const TOAST_ID_PREFIX = "release-available-";
+
+type Variant = "standard" | "recommended" | "required";
+
+function classifyVariant(snapshot: ReleaseInfoSnapshot): Variant {
+  // "required" wins over "recommended" so the stronger framing reaches the
+  // operator when both signals are present (e.g. mode=recommended plus an
+  // unrelated migration evaluation error).
+  if (
+    snapshot.assistedRequired ||
+    (snapshot.pendingMigrations?.length ?? 0) > 0 ||
+    snapshot.assisted?.mode === "required" ||
+    snapshot.migrationsError
+  ) {
+    return "required";
+  }
+  if (snapshot.assisted?.mode === "recommended") {
+    return "recommended";
+  }
+  return "standard";
+}
+
+function copyForVariant(
+  variant: Variant,
+  tag: string
+): { title: string; primaryLabel: string; secondaryLabel: string } {
+  if (variant === "required") {
+    return {
+      title: `Dispatch ${tag} needs guided update steps`,
+      primaryLabel: "Review update",
+      secondaryLabel: "Later",
+    };
+  }
+  if (variant === "recommended") {
+    return {
+      title: `Dispatch ${tag} is available — guided update recommended`,
+      primaryLabel: "Review update",
+      secondaryLabel: "Later",
+    };
+  }
+  return {
+    title: `Dispatch ${tag} is available`,
+    primaryLabel: "Update now",
+    secondaryLabel: "Later",
+  };
+}
+
+/**
+ * Subscribes to the cached release-info snapshot and surfaces any unseen
+ * "update available" event as a sticky sonner toast. Returns no JSX —
+ * the global <Toaster /> handles render. Mounted once at the app root.
+ *
+ * Dismissal is per-tag: clicking "Later" sets a localStorage flag for
+ * that exact tag, so a newer release still surfaces a fresh toast.
+ *
+ * Naming: distinct from the older UpdateAvailableToast, which fires when
+ * the running tab detects the *server* has a newer version than the page
+ * was loaded against (a separate stale-tab signal, not a release
+ * discovery).
+ */
+export function ReleaseAvailableToast(): null {
+  const navigate = useNavigate();
+  const { data } = useCachedReleaseInfo();
+  const snapshot = data?.snapshot ?? null;
+  const tag = snapshot?.updateAvailable ? snapshot.latestTag : null;
+  const dismissedAtom = dismissedReleaseToastAtomFamily(tag ?? "__none__");
+  const dismissed = useAtomValue(dismissedAtom);
+  const setDismissed = useSetAtom(dismissedAtom);
+
+  useEffect(() => {
+    if (!snapshot || !snapshot.updateAvailable || !tag) return;
+    if (dismissed) return;
+
+    const variant = classifyVariant(snapshot);
+    const { title, primaryLabel, secondaryLabel } = copyForVariant(
+      variant,
+      tag
+    );
+    const toastId = `${TOAST_ID_PREFIX}${tag}`;
+
+    toast(title, {
+      id: toastId,
+      duration: Infinity,
+      icon:
+        variant === "required" ? (
+          <ShieldAlert className="h-4 w-4" />
+        ) : (
+          <ArrowDownToLine className="h-4 w-4" />
+        ),
+      action: {
+        label: primaryLabel,
+        onClick: () => {
+          if (variant === "standard") {
+            void api("/api/v1/release/update", {
+              method: "POST",
+              body: JSON.stringify({ tag }),
+            }).catch(() => {});
+          }
+          // Both standard and assisted variants land on the Updates page —
+          // standard so the operator can watch the apply-flow takeover,
+          // assisted so they review the migration list before launching
+          // the agent. Per spec, "Review update" must NOT auto-launch.
+          navigate("/settings/updates");
+        },
+      },
+      cancel: {
+        label: secondaryLabel,
+        onClick: () => {
+          setDismissed(true);
+        },
+      },
+      onDismiss: () => {
+        setDismissed(true);
+      },
+    });
+
+    return () => {
+      toast.dismiss(toastId);
+    };
+  }, [snapshot, tag, dismissed, navigate, setDismissed]);
+
+  return null;
+}

--- a/apps/web/src/components/app/release-available-toast.tsx
+++ b/apps/web/src/components/app/release-available-toast.tsx
@@ -118,21 +118,16 @@ export function ReleaseAvailableToast(): null {
     );
     const toastId = `${TOAST_ID_PREFIX}${tag}`;
 
-    // Sonner dedupes by id — calling the same variant function again
-    // with the same id updates the existing toast in place rather than
-    // creating a new one, so re-renders don't flicker.
+    // Sonner dedupes by id — calling toast.info again with the same id
+    // updates the existing toast in place rather than creating a new
+    // one, so re-renders don't flicker.
     //
-    // Variant mapping ties the toast's color treatment to the spec's
-    // assisted-update classification, picking up the
-    // info/warning/success/error tokens defined in index.css under
-    // `[data-sonner-toaster][data-sonner-theme]`:
-    //   - standard   → toast.info     (informational, blue surface)
-    //   - recommended → toast.warning (operator should pay attention,
-    //                                  amber surface)
-    //   - required   → toast.warning (same surface; ShieldAlert icon
-    //                                  carries the stronger signal)
-    const toastFn = variant === "standard" ? toast.info : toast.warning;
-    toastFn(title, {
+    // All three variants use the info surface (blue) — an update being
+    // available is informational, not a warning or error. The
+    // distinction between standard / recommended / required is carried
+    // by the title copy and the icon swap (ArrowDownToLine vs
+    // ShieldAlert for the required case).
+    toast.info(title, {
       id: toastId,
       duration: Infinity,
       icon:

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -237,8 +237,17 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   // component renders — admin-only fields live on ReleaseInfo and aren't
   // read here, so the union type is intentionally narrow on purpose: any
   // future admin-only addition will require an explicit type widening.
+  //
+  // The cached snapshot is filtered to the current `channel`: if the
+  // user just switched Stable→Latest (or vice versa) the snapshot from
+  // the previous channel is stale and should not render until a fresh
+  // check for the new channel populates it.
+  const cachedSnapshotForChannel =
+    cachedSnapshot && cachedSnapshot.channel === channel
+      ? cachedSnapshot
+      : null;
   const displayInfo: ReleaseInfo | ReleaseInfoSnapshot | null =
-    info ?? cachedSnapshot;
+    info ?? cachedSnapshotForChannel;
 
   // Fetch version info + channel on mount
   useEffect(() => {

--- a/apps/web/src/components/app/release-manager.tsx
+++ b/apps/web/src/components/app/release-manager.tsx
@@ -27,6 +27,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { OperationLog, PhaseProgress } from "@/components/app/release-shared";
 import {
   AssistedUpdateGate,
@@ -42,6 +49,10 @@ import {
 } from "@/hooks/use-release-stream";
 import { api } from "@/lib/api";
 import { agentRoute } from "@/lib/agent-routes";
+import {
+  useCachedReleaseInfo,
+  type ReleaseInfoSnapshot,
+} from "@/hooks/use-cached-release-info";
 import { clearCachesAndReload, reloadApp } from "@/lib/pwa-update";
 import { cn } from "@/lib/utils";
 
@@ -161,7 +172,9 @@ function progressPercent(progress: ReleaseProgress | null): number | null {
   return Math.min(100, (progress.bytesReceived / progress.totalBytes) * 100);
 }
 
-function describeForceTriggers(info: ReleaseInfo): string {
+function describeForceTriggers(
+  info: ReleaseInfo | ReleaseInfoSnapshot
+): string {
   const migrationCount = info.pendingMigrations?.length ?? 0;
   // Migrations are the concrete signal — when present the user already
   // sees them spelled out in the gate card, so the dialog references the
@@ -202,6 +215,10 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const [notesExpanded, setNotesExpanded] = useState(false);
   const [channel, setChannel] = useState<ReleaseChannel>("stable");
   const [channelSaving, setChannelSaving] = useState(false);
+  const [autoUpdateMode, setAutoUpdateMode] = useState<"off" | "check">(
+    "check"
+  );
+  const [autoUpdateSaving, setAutoUpdateSaving] = useState(false);
   const [info, setInfo] = useState<ReleaseInfo | null>(null);
   const [infoLoading, setInfoLoading] = useState(false);
   const [infoError, setInfoError] = useState<string | null>(null);
@@ -210,6 +227,18 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
   const [forceConfirmOpen, setForceConfirmOpen] = useState(false);
   const [lastCheckMessage, setLastCheckMessage] = useState<string | null>(null);
   const reloadingRef = useRef(false);
+
+  const cachedInfoQuery = useCachedReleaseInfo();
+  const cachedSnapshot = cachedInfoQuery.data?.snapshot ?? null;
+
+  // Prefer the live ReleaseInfo from a manual check (which carries admin
+  // enrichment) when present; otherwise fall back to the cached snapshot
+  // from the server's auto-check. Both shapes share every field this
+  // component renders — admin-only fields live on ReleaseInfo and aren't
+  // read here, so the union type is intentionally narrow on purpose: any
+  // future admin-only addition will require an explicit type widening.
+  const displayInfo: ReleaseInfo | ReleaseInfoSnapshot | null =
+    info ?? cachedSnapshot;
 
   // Fetch version info + channel on mount
   useEffect(() => {
@@ -224,10 +253,33 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
         if (!cancelled) setChannel(data.channel);
       })
       .catch(() => {});
+    void api<{ mode: "off" | "check" }>("/api/v1/release/auto-update-mode")
+      .then((data) => {
+        if (!cancelled) setAutoUpdateMode(data.mode);
+      })
+      .catch(() => {});
     return () => {
       cancelled = true;
     };
   }, []);
+
+  const handleAutoUpdateModeChange = useCallback(
+    async (next: "off" | "check") => {
+      setAutoUpdateMode(next);
+      setAutoUpdateSaving(true);
+      try {
+        await api("/api/v1/release/auto-update-mode", {
+          method: "POST",
+          body: JSON.stringify({ mode: next }),
+        });
+      } catch {
+        setAutoUpdateMode((prev) => (prev === "off" ? "check" : "off"));
+      } finally {
+        setAutoUpdateSaving(false);
+      }
+    },
+    []
+  );
 
   const handleChannelChange = useCallback(async (value: ReleaseChannel) => {
     setChannel(value);
@@ -521,6 +573,45 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
         </div>
       </div>
 
+      {/* Automatic updates */}
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Automatic updates
+        </div>
+        <p className="mb-3 text-sm text-muted-foreground">
+          When on, Dispatch periodically checks for new releases and notifies
+          you. Updates never install automatically.
+        </p>
+        <div
+          className={cn(
+            "inline-block min-w-[14rem]",
+            autoUpdateSaving && "opacity-50 pointer-events-none"
+          )}
+        >
+          <Select
+            value={autoUpdateMode}
+            onValueChange={(value) =>
+              void handleAutoUpdateModeChange(value as "off" | "check")
+            }
+          >
+            <SelectTrigger
+              data-testid="auto-update-mode-select"
+              className="w-full"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="off" data-testid="auto-update-mode-off">
+                Off
+              </SelectItem>
+              <SelectItem value="check" data-testid="auto-update-mode-check">
+                Automatically check
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
       {/* Check for updates */}
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -576,28 +667,28 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
           </div>
         )}
 
-        {info && (
+        {displayInfo && (
           <>
-            {info.updateAvailable && info.latestTag ? (
+            {displayInfo.updateAvailable && displayInfo.latestTag ? (
               <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-2">
                   <ArrowDownToLine className="h-4 w-4 text-blue-400" />
                   <span className="text-sm text-foreground">
                     <span className="font-mono font-semibold">
-                      {info.latestTag}
+                      {displayInfo.latestTag}
                     </span>{" "}
                     available
                   </span>
-                  {info.latestRelease?.publishedAt && (
+                  {displayInfo.latestRelease?.publishedAt && (
                     <span className="text-xs text-muted-foreground">
-                      · {formatDate(info.latestRelease.publishedAt)}
+                      · {formatDate(displayInfo.latestRelease.publishedAt)}
                     </span>
                   )}
                 </div>
 
-                {info.latestRelease?.url && (
+                {displayInfo.latestRelease?.url && (
                   <a
-                    href={info.latestRelease.url}
+                    href={displayInfo.latestRelease.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1.5 self-start text-xs text-blue-400 hover:underline"
@@ -613,7 +704,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                   </div>
                 )}
 
-                {info.migrationsError && (
+                {displayInfo.migrationsError && (
                   <div
                     className="flex items-start gap-2 rounded border border-amber-500/30 bg-amber-500/[0.08] px-3 py-2 text-sm text-amber-200"
                     data-testid="migration-eval-warning"
@@ -624,7 +715,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                         Could not evaluate update migrations
                       </span>
                       <span className="max-h-24 overflow-y-auto break-all text-xs text-amber-200/80">
-                        {info.migrationsError}
+                        {displayInfo.migrationsError}
                       </span>
                       <span className="text-xs text-amber-200/60">
                         Standard update is still available — the assisted flow
@@ -640,41 +731,42 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                   unapplied install-update migrations; assisted-metadata card
                   shows when the release declares mode=required/recommended.
                 */}
-                {info.pendingMigrations &&
-                  info.pendingMigrations.length > 0 && (
+                {displayInfo.pendingMigrations &&
+                  displayInfo.pendingMigrations.length > 0 && (
                     <PendingMigrationsGate
-                      tag={info.latestTag}
-                      pendingMigrations={info.pendingMigrations}
+                      tag={displayInfo.latestTag}
+                      pendingMigrations={displayInfo.pendingMigrations}
                     />
                   )}
-                {info.assisted && info.assisted.mode !== "normal" && (
-                  <AssistedUpdateGate
-                    tag={info.latestTag}
-                    metadata={info.assisted}
-                    required={info.assistedRequired === true}
-                  />
-                )}
+                {displayInfo.assisted &&
+                  displayInfo.assisted.mode !== "normal" && (
+                    <AssistedUpdateGate
+                      tag={displayInfo.latestTag}
+                      metadata={displayInfo.assisted}
+                      required={displayInfo.assistedRequired === true}
+                    />
+                  )}
 
                 {(() => {
                   const assistedPreferred =
-                    info.assistedRequired === true ||
-                    (info.pendingMigrations?.length ?? 0) > 0 ||
-                    info.assisted?.mode === "recommended";
+                    displayInfo.assistedRequired === true ||
+                    (displayInfo.pendingMigrations?.length ?? 0) > 0 ||
+                    displayInfo.assisted?.mode === "recommended";
                   return (
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 self-start">
                       <UpdateActions
-                        tag={info.latestTag}
+                        tag={displayInfo.latestTag}
                         assistedPreferred={assistedPreferred}
                         forceRequired={
-                          info.assistedRequired === true ||
-                          (info.pendingMigrations?.length ?? 0) > 0
+                          displayInfo.assistedRequired === true ||
+                          (displayInfo.pendingMigrations?.length ?? 0) > 0
                         }
                         assistedLaunching={assistedUpdateLaunching}
                         onStandardUpdate={() =>
-                          void handleUpdate(info.latestTag!)
+                          void handleUpdate(displayInfo.latestTag!)
                         }
                         onAssistedUpdate={() =>
-                          void handleAssistedUpdate(info.latestTag!)
+                          void handleAssistedUpdate(displayInfo.latestTag!)
                         }
                         onForceStandardUpdate={() => setForceConfirmOpen(true)}
                       />
@@ -734,7 +826,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
         </div>
       </div>
 
-      {info?.updateAvailable && info.latestTag && (
+      {displayInfo?.updateAvailable && displayInfo.latestTag && (
         <Dialog open={forceConfirmOpen} onOpenChange={setForceConfirmOpen}>
           <DialogContent>
             <DialogHeader>
@@ -745,10 +837,10 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
               <span>
                 <span className="font-mono text-amber-100">
-                  {info.latestTag}
+                  {displayInfo.latestTag}
                 </span>{" "}
-                {describeForceTriggers(info)}. This may leave your install in a
-                non-working state.
+                {describeForceTriggers(displayInfo)}. This may leave your
+                install in a non-working state.
               </span>
             </div>
 
@@ -757,7 +849,7 @@ export function UpdatesSection({ stream }: UpdatesSectionProps): JSX.Element {
                 variant="primary"
                 onClick={() => {
                   setForceConfirmOpen(false);
-                  void handleUpdate(info.latestTag!, { force: true });
+                  void handleUpdate(displayInfo.latestTag!, { force: true });
                 }}
                 data-testid="force-standard-update-confirm"
               >

--- a/apps/web/src/hooks/use-cached-release-info.ts
+++ b/apps/web/src/hooks/use-cached-release-info.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import type {
+  AssistedUpdateMetadata,
+  PendingMigration,
+  ReleaseChannel,
+} from "@/hooks/use-release-stream";
+
+/**
+ * Snapshot returned by GET /api/v1/release/cached-info — the in-memory
+ * result of the most recent successful release check (manual or
+ * automatic). Excludes the per-viewer admin enrichment that the live
+ * /api/v1/release/info endpoint adds (unreleasedCount, commits, etc.) since
+ * the snapshot is shared across UI clients.
+ */
+export type ReleaseInfoSnapshot = {
+  currentTag: string | null;
+  channel: ReleaseChannel;
+  latestTag: string | null;
+  absoluteLatestTag: string | null;
+  updateAvailable: boolean;
+  latestRelease: { tag: string; publishedAt: string; url: string } | null;
+  assisted: AssistedUpdateMetadata | null;
+  assistedRequired: boolean;
+  pendingMigrations: PendingMigration[];
+  migrationsError: string | null;
+  computedAt: string;
+};
+
+export const CACHED_RELEASE_INFO_QUERY_KEY = [
+  "release",
+  "cached-info",
+] as const;
+
+type CachedInfoResponse = {
+  snapshot: ReleaseInfoSnapshot | null;
+};
+
+export function useCachedReleaseInfo() {
+  return useQuery<CachedInfoResponse>({
+    queryKey: CACHED_RELEASE_INFO_QUERY_KEY,
+    queryFn: () => api<CachedInfoResponse>("/api/v1/release/cached-info"),
+    staleTime: Infinity,
+  });
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -79,9 +79,15 @@ export function useSSE(authState: AuthState): void {
             sortAgentsByCreatedAtDesc(payload.agents)
           );
           // A snapshot means a fresh SSE connection (initial or reconnect).
-          // Invalidate job queries so they refetch — the snapshot only
-          // carries agents, so jobs could be stale after a reconnect.
+          // Invalidate the queries that aren't carried in the snapshot
+          // payload — jobs and the cached release info — so they refetch.
+          // Without this, a tab that was hidden/disconnected during a
+          // `release.cached_info_changed` event would keep stale release
+          // state forever (the query has staleTime: Infinity).
           void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+          void queryClient.invalidateQueries({
+            queryKey: CACHED_RELEASE_INFO_QUERY_KEY,
+          });
           return;
         }
 

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -11,6 +11,10 @@ import { diffStatsQueryKey } from "@/hooks/use-agent-diff-stats";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
 import { showWebNotification } from "@/lib/web-notifications";
+import {
+  CACHED_RELEASE_INFO_QUERY_KEY,
+  type ReleaseInfoSnapshot,
+} from "@/hooks/use-cached-release-info";
 
 type UiEvent =
   | { type: "snapshot"; agents: Agent[] }
@@ -41,6 +45,10 @@ type UiEvent =
       agentName: string;
       eventType: string;
       message: string;
+    }
+  | {
+      type: "release.cached_info_changed";
+      snapshot: ReleaseInfoSnapshot | null;
     };
 
 function patchAgentHasStream(
@@ -176,6 +184,13 @@ export function useSSE(authState: AuthState): void {
               keepalive: true,
             }).catch(() => {});
           }
+          return;
+        }
+
+        if (payload.type === "release.cached_info_changed") {
+          queryClient.setQueryData(CACHED_RELEASE_INFO_QUERY_KEY, {
+            snapshot: payload.snapshot,
+          });
           return;
         }
       } catch {}

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -52,6 +52,13 @@ export const createNewBranchPrefAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage<boolean>(`dispatch:createNewBranch:${cwd}`, true)
 );
 
+// Per-tag dismissal flag for the "release available" toast. Dismissing
+// vX.Y.Z prevents that toast from re-showing for the same tag, but a
+// newer tag still triggers a fresh toast on its own atom.
+export const dismissedReleaseToastAtomFamily = atomFamily((tag: string) =>
+  atomWithLocalStorage<boolean>(`dispatch:dismissedReleaseToast:${tag}`, false)
+);
+
 export type MediaSidebarTab = "pins" | "media";
 
 export type MediaSidebarState = {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -17,6 +17,29 @@ function atomWithLocalStorage<T>(key: string, initialValue: T) {
     })()
   );
 
+  // Subscribe to cross-tab `storage` events while any consumer of this
+  // atom is mounted, so a write in tab A propagates to tab B without a
+  // reload. Same-tab writes still go through the derived setter below.
+  // (`storage` only fires for changes from *other* tabs, so there's no
+  // self-echo to worry about.)
+  baseAtom.onMount = (setSelf) => {
+    if (typeof window === "undefined") return;
+    const handle = (event: StorageEvent) => {
+      if (event.key !== key) return;
+      if (event.newValue === null) {
+        setSelf(initialValue);
+        return;
+      }
+      try {
+        setSelf(JSON.parse(event.newValue) as T);
+      } catch {
+        // Ignore malformed payloads from other tabs — keep current state.
+      }
+    };
+    window.addEventListener("storage", handle);
+    return () => window.removeEventListener("storage", handle);
+  };
+
   const derivedAtom = atom(
     (get) => get(baseAtom),
     (_get, set, update: T | ((prev: T) => T)) => {

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -27,7 +27,7 @@ Vite frontend — all on auto-selected free ports.
 Commands:
   up        Start DB + API server + Vite frontend
   down      Stop all dev services and remove the DB container
-  restart   Tear down and re-create the environment
+  restart   Restart the API + Vite servers, keeping the DB intact
   status    Show which services are running
   logs      Show recent output (default: api; use --vite or --db)
   url       Print the dev server URL
@@ -388,6 +388,62 @@ cmd_down() {
   echo "Dev environment torn down (suffix: ${SUFFIX})."
 }
 
+# Returns 0 when the postgres container for the loaded state is
+# running and healthy. Caller is expected to have invoked load_state.
+db_container_running() {
+  if [ "${DEV_NO_DB:-0}" = "1" ] || [ -z "${DEV_CONTAINER_SUFFIX:-}" ]; then
+    return 1
+  fi
+  local container_name="dispatch-postgres-${DEV_CONTAINER_SUFFIX}"
+  docker ps -q -f "name=${container_name}" 2>/dev/null | grep -q .
+}
+
+# Soft restart: cycle API + Vite while leaving the DB container running.
+# Falls back to a full teardown + cmd_up if there's no usable state or
+# the DB isn't actually running.
+cmd_restart() {
+  if ! load_state 2>/dev/null; then
+    echo "No state file found for suffix '${SUFFIX}'. Falling back to a fresh up."
+    cmd_up
+    return
+  fi
+  if [ "${DEV_NO_DB:-0}" != "1" ] && ! db_container_running; then
+    echo "DB container is gone — falling back to a fresh up (this will reseed)."
+    cmd_down 2>/dev/null || true
+    cmd_up
+    return
+  fi
+
+  # Stop the app processes only — DB stays up.
+  stop_service "${DEV_API_PID:-}" "API server"
+  stop_service "${DEV_VITE_PID:-}" "Vite server"
+
+  # Re-launch on the same ports so any open browser tabs reconnect
+  # without a manual refresh, and so the DATABASE_URL we assemble
+  # below still points at the running container.
+  RESTART_DB_PORT="${DEV_DB_PORT:-}"
+  RESTART_API_PORT="${DEV_API_PORT:-}"
+  RESTART_VITE_PORT="${DEV_VITE_PORT:-}"
+
+  # Restore the OPT_* flags from saved state so cmd_up branches
+  # consistently with the previous run.
+  [ "$OPT_LIVE" = "0" ] && [ "${DEV_LIVE:-0}" = "1" ] && OPT_LIVE="1"
+  [ "$OPT_NO_DB" = "0" ] && [ "${DEV_NO_DB:-0}" = "1" ] && OPT_NO_DB="1"
+  [ -z "$OPT_CWD" ] && [ -n "${DEV_CWD:-}" ] && OPT_CWD="$DEV_CWD"
+
+  # Always skip seeding on restart — the DB already has the data the
+  # last seed produced, and re-running would either duplicate rows or
+  # crash on existing-row constraints.
+  OPT_NO_SEED="1"
+
+  # Drop the live state file so cmd_up's "stack already running" check
+  # falls through to the fresh-up path. Logs are preserved (handy for
+  # before/after diff after picking up code changes).
+  rm -f "$(state_file)"
+
+  cmd_up
+}
+
 cmd_status() {
   if ! load_state; then
     echo "No dev environment found for suffix '${SUFFIX}'."
@@ -534,21 +590,7 @@ SUFFIX="$(resolve_suffix)"
 case "$CMD" in
   up)       cmd_up ;;
   down)     cmd_down ;;
-  restart)
-    # Restore flags and ports from previous state if not explicitly set
-    if load_state 2>/dev/null; then
-      [ "$OPT_LIVE" = "0" ] && [ "${DEV_LIVE:-0}" = "1" ] && OPT_LIVE="1"
-      [ "$OPT_NO_DB" = "0" ] && [ "${DEV_NO_DB:-0}" = "1" ] && OPT_NO_DB="1"
-      [ "$OPT_NO_SEED" = "0" ] && [ "${DEV_NO_SEED:-0}" = "1" ] && OPT_NO_SEED="1"
-      [ -z "$OPT_CWD" ] && [ -n "${DEV_CWD:-}" ] && OPT_CWD="$DEV_CWD"
-      # Preserve ports so restart reuses them
-      RESTART_DB_PORT="${DEV_DB_PORT:-}"
-      RESTART_API_PORT="${DEV_API_PORT:-}"
-      RESTART_VITE_PORT="${DEV_VITE_PORT:-}"
-    fi
-    cmd_down 2>/dev/null || true
-    cmd_up
-    ;;
+  restart)  cmd_restart ;;
   status)   cmd_status ;;
   logs)     cmd_logs ;;
   url)      cmd_url ;;

--- a/bin/dispatch-dev
+++ b/bin/dispatch-dev
@@ -436,12 +436,30 @@ cmd_restart() {
   # crash on existing-row constraints.
   OPT_NO_SEED="1"
 
-  # Drop the live state file so cmd_up's "stack already running" check
-  # falls through to the fresh-up path. Logs are preserved (handy for
-  # before/after diff after picking up code changes).
-  rm -f "$(state_file)"
+  # Move the state file aside (instead of deleting it) so that if
+  # cmd_up fails — port conflict, runtime crash, missing dep — the
+  # caller can still `dispatch-dev down` and find the still-running
+  # postgres container. cmd_up writes a fresh state on success; on
+  # failure the EXIT trap restores the backup.
+  local sf="$(state_file)"
+  local sf_backup="${sf}.restart-backup"
+  mv "$sf" "$sf_backup"
+
+  # `set -e` will abort the function on cmd_up failure, so the trap
+  # is the only place the backup gets restored on error. On success
+  # we clear the trap and remove the backup explicitly.
+  # shellcheck disable=SC2064
+  trap "
+    if [ -f \"$sf_backup\" ] && [ ! -f \"$sf\" ]; then
+      mv \"$sf_backup\" \"$sf\"
+      echo 'Restart aborted; restored prior state file so dispatch-dev down can clean up.' >&2
+    fi
+  " EXIT
 
   cmd_up
+
+  rm -f "$sf_backup"
+  trap - EXIT
 }
 
 cmd_status() {


### PR DESCRIPTION
## Summary

Phase 1 of the Automatic Updates feature. Dispatch now runs background release-availability checks and surfaces newly discovered updates as a sticky toast. Phase 1 explicitly does **not** auto-install — updates are still triggered by the user.

- New `Automatic updates` dropdown in **Settings → Updates** (`Off` / `Automatically check`, default-on, persisted in the existing settings table).
- Server runs a release check 45s after startup and every 6h thereafter; result is broadcast to all connected clients on every snapshot mutation (success, manual write-through, clear-on-apply).
- New `ReleaseAvailableToast` (sonner) with three variants — standard / recommended / required — keyed off the existing assisted-update classification. Per-tag dismissal persists across reload and across open tabs.
- Updates page renders any cached snapshot on mount instead of waiting for a manual click.

## Reviews

Three persona reviews ran with recheck enabled — all rounds resolved:

- **architecture-review** — final verdict: addressed (round 2). Round-1 fixes broadened the SSE event to carry the full snapshot on every transition, narrowed the auto-check skip to `update`/`update-assisted` jobs only, and dropped fake admin defaults from the cached-snapshot seed. Round-2 fix invalidates cached release info on SSE bootstrap so disconnected tabs self-heal.
- **backend-security-review** — final verdict: **approve**. Found and fixed one real cache-flap-during-apply bug: `GET /api/v1/release/info` no longer write-throughs (and broadcasts) when the snapshot's `latestTag` matches a non-terminal in-flight `update`/`update-assisted` job. Confirmed no other auth / input-validation / XSS issues.
- **frontend-ux-review** — final verdict: **approve**. Fixed three issues: cached snapshots are scoped to the current channel so a Stable card doesn't render after switching to Latest; the toast's `Update now` action awaits the POST and surfaces a `toast.error` on failure instead of fire-and-forget; `atomWithLocalStorage` now subscribes to cross-tab `storage` events so dismissals propagate to all open tabs.

## Test plan

- [ ] `pnpm run check` (server tsc + web tsc + scripts)
- [ ] `pnpm run finalize:web` (web check + production build)
- [ ] `pnpm --filter @dispatch/server run test` (vitest, includes 13 new auto-check unit tests)
- [ ] `pnpm run test:e2e` (Playwright)
- [ ] Manually toggle `Settings → Updates → Automatic updates` and confirm persistence via `GET /api/v1/release/auto-update-mode`
- [ ] Confirm the post-startup check fires by grepping API logs for `"reason":"startup","msg":"auto-update: running release check"` (~45s after API listen)
- [ ] Drive the toast variants via Playwright route-mock on `/api/v1/release/cached-info`; verify dismissal sticks across reload and propagates to a second tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)