### PR TITLE
fix(web): refocus terminal when window is foregrounded

### DIFF
--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -1039,9 +1039,15 @@ export function useTerminal(args: {
       if (isMobile) return;
       if (copyModeRef.current === "copy") return;
       const active = document.activeElement;
-      if (active && active !== document.body && !host.contains(active)) {
-        return;
-      }
+      // Treat body / documentElement / null as "nothing else holds focus" —
+      // some browsers report the root element instead of body when no
+      // interactive control owns focus after the window is foregrounded.
+      const focusElsewhere =
+        active &&
+        active !== document.body &&
+        active !== document.documentElement &&
+        !host.contains(active);
+      if (focusElsewhere) return;
       term.focus();
     };
 

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -1028,14 +1028,33 @@ export function useTerminal(args: {
       void ensureTerminalConnected(false, false, targetAgentId);
     };
 
+    // Re-focus the terminal when the window/tab is foregrounded so the user
+    // can type immediately. Gated to avoid stealing focus from other inputs
+    // (dialogs, search, sidebar fields) that the browser may have restored.
+    const tryFocusTerminalOnForeground = () => {
+      const term = terminalRef.current;
+      const host = terminalHostRef.current;
+      if (!term || !host) return;
+      if (terminalMode !== "tmux") return;
+      if (isMobile) return;
+      if (copyModeRef.current === "copy") return;
+      const active = document.activeElement;
+      if (active && active !== document.body && !host.contains(active)) {
+        return;
+      }
+      term.focus();
+    };
+
     const onVisible = () => {
       if (!document.hidden) {
         requestForegroundReconnect();
+        tryFocusTerminalOnForeground();
       }
     };
 
     const onFocus = () => {
       requestForegroundReconnect();
+      tryFocusTerminalOnForeground();
     };
 
     const onOnline = () => {
@@ -1056,7 +1075,13 @@ export function useTerminal(args: {
       window.removeEventListener("focus", onFocus);
       window.removeEventListener("online", onOnline);
     };
-  }, [clearReconnectTimer, ensureTerminalConnected, selectedAgentId]);
+  }, [
+    clearReconnectTimer,
+    ensureTerminalConnected,
+    isMobile,
+    selectedAgentId,
+    terminalMode,
+  ]);
 
   // Fit on layout change. The actual fit is debounced and reads the host's
   // settled size, so we don't need a hand-tuned timer to "wait for" the CSS

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -292,6 +292,67 @@ test.describe("Terminal live connection", () => {
     await expect.poll(() => tokenRequests).toBe(initialTokenRequests);
   });
 
+  test("re-focuses terminal when window is foregrounded", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await waitForTerminalConnected(page, agent.name, 5_000);
+    await expect(page.locator(".xterm-helper-textarea")).toBeFocused();
+
+    // Move focus away from the terminal, mimicking what the browser often
+    // does when the app loses focus and is later re-foregrounded.
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement | null)?.blur?.();
+      document.body.focus();
+    });
+    await expect(page.locator(".xterm-helper-textarea")).not.toBeFocused();
+
+    await simulateVisibleWithFocus(page);
+
+    await expect(page.locator(".xterm-helper-textarea")).toBeFocused({
+      timeout: 1_000,
+    });
+  });
+
+  test("does not steal focus from another input on foreground", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await waitForTerminalConnected(page, agent.name, 5_000);
+
+    // Plant a focused text input outside the terminal host.
+    await page.evaluate(() => {
+      const input = document.createElement("input");
+      input.id = "e2e-decoy-input";
+      input.type = "text";
+      document.body.appendChild(input);
+      input.focus();
+    });
+    await expect(page.locator("#e2e-decoy-input")).toBeFocused();
+
+    await simulateVisibleWithFocus(page);
+    await page.waitForTimeout(150);
+
+    await expect(page.locator("#e2e-decoy-input")).toBeFocused();
+    await expect(page.locator(".xterm-helper-textarea")).not.toBeFocused();
+  });
+
   test("shows a copy-mode banner and returns to live immediately", async ({
     page,
     request,

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -353,6 +353,36 @@ test.describe("Terminal live connection", () => {
     await expect(page.locator(".xterm-helper-textarea")).not.toBeFocused();
   });
 
+  test("does not steal focus from a portal-backed dialog input on foreground", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await waitForTerminalConnected(page, agent.name, 5_000);
+
+    // Open the real create-agent dialog (portal-backed via Radix). This
+    // exercises the same focus-trap structure a user would hit if Cmd-Tab
+    // happened with a dialog open, instead of a decoy input on body.
+    await page.getByTestId("create-agent-button").click();
+    const nameInput = page.getByTestId("create-agent-name");
+    await expect(nameInput).toBeVisible();
+    await nameInput.focus();
+    await expect(nameInput).toBeFocused();
+
+    await simulateVisibleWithFocus(page);
+    await page.waitForTimeout(150);
+
+    await expect(nameInput).toBeFocused();
+    await expect(page.locator(".xterm-helper-textarea")).not.toBeFocused();
+  });
+
   test("shows a copy-mode banner and returns to live immediately", async ({
     page,
     request,


### PR DESCRIPTION
## Summary
- Auto-focus the terminal when the window/tab is foregrounded so users can start typing immediately, instead of having to click into the terminal twice.
- Gated to avoid stealing focus from other inputs (dialogs, search, sidebar fields) that the browser may have restored: skips when the terminal isn't mounted, `terminalMode !== "tmux"`, on mobile, in copy mode, or when `document.activeElement` is anything other than `body` / inside the terminal host.
- The existing `focus`/`visibilitychange` handler in `use-terminal.ts` already reconnected the WS — this attaches the focus call alongside it.

## Test plan
- [ ] Cmd-Tab away from Dispatch and back — first keystroke goes to the terminal, no double-click required.
- [ ] Open a dialog or focus a search input, Cmd-Tab away/back — focus stays on that input, doesn't jump to the terminal.
- [ ] In copy mode, Cmd-Tab away/back — auto-focus is skipped (selection/scrollback isn't disrupted).
- [ ] On mobile (touch device), Cmd-Tab away/back — auto-focus skipped (no soft keyboard pop).
- [ ] `pnpm run test:e2e` (live runtime): `re-focuses terminal when window is foregrounded` and `does not steal focus from another input on foreground` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)