### PR TITLE
feat: add `includeDiff` option to persona review launches

### DIFF
--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -127,12 +127,17 @@ export async function loadPersonaBySlug(
  * This ensures consistent severity definitions and feedback hygiene
  * regardless of what the repo-specific persona markdown contains.
  */
-const STANDARD_FEEDBACK_GUIDANCE = `
+function buildStandardFeedbackGuidance(includeDiff: boolean): string {
+  const scopeLine = includeDiff
+    ? "- Only flag issues that are within the scope of the changes (the diff below). Do not flag pre-existing issues unless directly caused or worsened by the new changes."
+    : "- Only flag issues that are within the scope of the work under review described in the parent context. Do not flag pre-existing issues unless directly caused or worsened by the work under review.";
+
+  return `
 ## Feedback Guidelines (from Dispatch)
 
 ### How to submit feedback
 - Call \`dispatch_feedback\` for each finding with: severity, description, and a concrete suggestion. Include file path and line number when applicable.
-- Only flag issues that are within the scope of the changes (the diff below). Do not flag pre-existing issues unless directly caused or worsened by the new changes.
+${scopeLine}
 
 ### Review lifecycle
 - Call \`review_status\` with a short message when you begin reviewing. Ping it again at meaningful phase changes (e.g. "Reading diff", "Running tests") so the parent can see what you're working on.
@@ -150,6 +155,7 @@ const STANDARD_FEEDBACK_GUIDANCE = `
 ### Info feedback limits — STRICT
 Do NOT submit positive affirmations, praise, or "good job" feedback. Feedback like "Good defense-in-depth...", "Good design decision...", or "This is well-structured..." is noise and will be ignored — do not submit it. The \`info\` severity is ONLY for non-obvious decisions that a future contributor might mistakenly undo. Limit to at most 2 items per review. If you have nothing critical to preserve, submit zero info items.
 `.trim();
+}
 
 /**
  * Round-trip guidance appended when the review was launched with
@@ -171,6 +177,8 @@ This is a two-round review. You have a round-1 obligation (already described abo
 export type AssemblePersonaPromptOptions = {
   /** When true, appends the recheck round-trip guidance block. */
   allowRecheck?: boolean;
+  /** When false, omits the git diff section from the prompt. Defaults to true. */
+  includeDiff?: boolean;
 };
 
 export function assemblePersonaPrompt(
@@ -179,6 +187,8 @@ export function assemblePersonaPrompt(
   diff: string,
   options: AssemblePersonaPromptOptions = {}
 ): string {
+  const includeDiff = options.includeDiff !== false;
+
   // Strip legacy {{context}} and {{diff}} placeholders if present — Dispatch
   // now appends these sections automatically so persona files don't need them.
   const personaBody = persona.body
@@ -187,13 +197,15 @@ export function assemblePersonaPrompt(
 
   const sections: string[] = [
     personaBody.trimEnd(),
-    STANDARD_FEEDBACK_GUIDANCE,
+    buildStandardFeedbackGuidance(includeDiff),
   ];
   if (options.allowRecheck) {
     sections.push(RECHECK_ROUND_TRIP_GUIDANCE);
   }
   sections.push(`## Context from parent agent\n${context}`);
-  sections.push(`## Changes to review\n${truncateDiffForPrompt(diff)}`);
+  if (includeDiff) {
+    sections.push(`## Changes to review\n${truncateDiffForPrompt(diff)}`);
+  }
 
   return sections.join("\n\n");
 }

--- a/apps/server/src/routes/persona-reviews.ts
+++ b/apps/server/src/routes/persona-reviews.ts
@@ -23,6 +23,7 @@ type PersonaReviewRouteDeps = {
       context: string;
       agentType?: (typeof CLI_AGENT_TYPES)[number];
       allowRecheck?: boolean;
+      includeDiff?: boolean;
     }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
   mcpCancelRecheck: (
@@ -67,6 +68,7 @@ export async function registerPersonaReviewRoutes(
       persona?: unknown;
       agentType?: unknown;
       allowRecheck?: unknown;
+      includeDiff?: unknown;
     } | null;
     const agentId = params.id ?? "";
 
@@ -96,6 +98,14 @@ export async function registerPersonaReviewRoutes(
         .code(400)
         .send({ error: "allowRecheck is required and must be a boolean." });
     }
+    if (
+      body.includeDiff !== undefined &&
+      typeof body.includeDiff !== "boolean"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "includeDiff must be a boolean when provided." });
+    }
 
     try {
       const access = await deps.agentManager.getTerminalAccess(agentId);
@@ -105,9 +115,10 @@ export async function registerPersonaReviewRoutes(
           .send({ error: "Agent does not have an active tmux session." });
       }
 
+      const includeDiff = body.includeDiff !== false;
       const prompt = [
         `Use the dispatch_launch_persona MCP tool to launch the "${body.persona}" persona on your current work.`,
-        `Use agentType: "${body.agentType}" and allowRecheck: ${body.allowRecheck ? "true" : "false"}.`,
+        `Use agentType: "${body.agentType}", allowRecheck: ${body.allowRecheck ? "true" : "false"}, and includeDiff: ${includeDiff ? "true" : "false"}.`,
         "Treat this as an author-requested review for the current worktree/branch.",
         "After launch, if recheck is enabled, do not emit a terminal dispatch_event yet — you will receive a terminal prompt here when the reviewer reports back, and again after round 2.",
         "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
@@ -126,6 +137,7 @@ export async function registerPersonaReviewRoutes(
       persona?: unknown;
       agentType?: unknown;
       allowRecheck?: unknown;
+      includeDiff?: unknown;
       context?: unknown;
     } | null;
     const agentId = params.id ?? "";
@@ -159,6 +171,14 @@ export async function registerPersonaReviewRoutes(
       return reply
         .code(400)
         .send({ error: "allowRecheck must be a boolean when provided." });
+    }
+    if (
+      body.includeDiff !== undefined &&
+      typeof body.includeDiff !== "boolean"
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "includeDiff must be a boolean when provided." });
     }
     if (body.context !== undefined && typeof body.context !== "string") {
       return reply
@@ -194,6 +214,7 @@ export async function registerPersonaReviewRoutes(
         context,
         agentType: requestedAgentType,
         allowRecheck: body.allowRecheck === true,
+        includeDiff: body.includeDiff !== false,
       });
       const agent = await deps.agentManager.getAgent(result.agentId);
       return {

--- a/apps/server/src/routes/persona-reviews.ts
+++ b/apps/server/src/routes/persona-reviews.ts
@@ -185,6 +185,16 @@ export async function registerPersonaReviewRoutes(
         .code(400)
         .send({ error: "context must be a string when provided." });
     }
+    if (
+      body.includeDiff === false &&
+      (!body.context ||
+        (typeof body.context === "string" && !body.context.trim()))
+    ) {
+      return reply.code(400).send({
+        error:
+          "context is required when includeDiff is false — the reviewer needs an explicit description of what to review.",
+      });
+    }
 
     try {
       const parent = await deps.agentManager.getAgent(agentId);

--- a/apps/server/src/routes/persona-reviews.ts
+++ b/apps/server/src/routes/persona-reviews.ts
@@ -201,11 +201,14 @@ export async function registerPersonaReviewRoutes(
         }
       }
 
+      const includeDiffVal = body.includeDiff !== false;
       const context =
         body.context?.trim() ||
         [
           `Review the current work for agent "${parent.name}".`,
-          "Inspect the current diff, changed files, and surrounding code.",
+          includeDiffVal
+            ? "Inspect the current diff, changed files, and surrounding code."
+            : "Inspect the described work and surrounding code.",
           "Focus on actionable bugs, regressions, and missing validation.",
         ].join(" ");
 
@@ -214,7 +217,7 @@ export async function registerPersonaReviewRoutes(
         context,
         agentType: requestedAgentType,
         allowRecheck: body.allowRecheck === true,
-        includeDiff: body.includeDiff !== false,
+        includeDiff: includeDiffVal,
       });
       const agent = await deps.agentManager.getAgent(result.agentId);
       return {

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -520,6 +520,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         context: string;
         agentType?: (typeof CLI_AGENT_TYPES)[number];
         allowRecheck?: boolean;
+        includeDiff?: boolean;
       }
     ): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
       const parent = await agentManager.getAgent(agentId);
@@ -572,9 +573,13 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         );
       }
 
-      const diff = await buildPersonaReviewDiff(parentCwd, runCommand);
+      const includeDiff = opts.includeDiff !== false;
+      const diff = includeDiff
+        ? await buildPersonaReviewDiff(parentCwd, runCommand)
+        : "";
       const prompt = assemblePersonaPrompt(persona, opts.context, diff, {
         allowRecheck: opts.allowRecheck,
+        includeDiff,
       });
 
       const personaArgs: string[] = ["--append-system-prompt", prompt];

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -329,6 +329,7 @@ export type McpRequestContext = {
       context: string;
       agentType?: LaunchPersonaAgentType;
       allowRecheck?: boolean;
+      includeDiff?: boolean;
     }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
   getFeedback?: (
@@ -1066,6 +1067,12 @@ async function createDispatchMcpServer(
             .describe(
               "Opt into a single round-trip review: the reviewer stays alive after its initial verdict and performs a second pass once you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters."
             ),
+          includeDiff: z
+            .boolean()
+            .default(true)
+            .describe(
+              "Whether to include the git diff in the persona prompt. Set to false for non-code reviews (PRDs, docs, media) where the diff is not the review target."
+            ),
         },
       },
       async (args) => {
@@ -1075,6 +1082,7 @@ async function createDispatchMcpServer(
             context: args.context,
             agentType: args.agentType,
             allowRecheck: args.allowRecheck,
+            includeDiff: args.includeDiff,
           });
           const text = buildLaunchPersonaResponseText(
             result.persona,

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -206,6 +206,50 @@ describe("assemblePersonaPrompt", () => {
     });
     expect(result).not.toContain("Recheck round-trip");
   });
+
+  it("includes the diff section by default (includeDiff unset)", () => {
+    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff");
+    expect(result).toContain("## Changes to review\nthe-diff");
+    expect(result).toContain("the scope of the changes (the diff below)");
+  });
+
+  it("includes the diff section when includeDiff is true", () => {
+    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff", {
+      includeDiff: true,
+    });
+    expect(result).toContain("## Changes to review\nthe-diff");
+    expect(result).toContain("the scope of the changes (the diff below)");
+  });
+
+  it("omits the diff section when includeDiff is false", () => {
+    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff", {
+      includeDiff: false,
+    });
+    expect(result).not.toContain("## Changes to review");
+    expect(result).not.toContain("the-diff");
+  });
+
+  it("adapts guidance wording when includeDiff is false", () => {
+    const result = assemblePersonaPrompt(basePersona, "ctx", "", {
+      includeDiff: false,
+    });
+    expect(result).not.toContain("the diff below");
+    expect(result).toContain(
+      "the scope of the work under review described in the parent context"
+    );
+  });
+
+  it("still includes context section when includeDiff is false", () => {
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "Review the PRD for gaps",
+      "",
+      { includeDiff: false }
+    );
+    expect(result).toContain(
+      "## Context from parent agent\nReview the PRD for gaps"
+    );
+  });
 });
 
 // ── loadPersonas / loadPersonaBySlug (filesystem) ───────────────────

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -199,11 +199,12 @@ Query params: `cwd=/path/to/repo`. The server tries the worktree root first, the
 {
   "persona": "backend-security-review",
   "agentType": "claude",
-  "allowRecheck": true
+  "allowRecheck": true,
+  "includeDiff": true
 }
 ```
 
-Sends a server-built prompt into the parent agent's tmux session asking it to call the `dispatch_launch_persona` MCP tool with the given options. Requires the parent to be in `tmux` access mode; returns 409 otherwise. `agentType` must be one of the CLI types (`codex`, `claude`, `opencode`); `persona` must match the slug pattern `[a-zA-Z0-9_-]+`.
+Sends a server-built prompt into the parent agent's tmux session asking it to call the `dispatch_launch_persona` MCP tool with the given options. Requires the parent to be in `tmux` access mode; returns 409 otherwise. `agentType` must be one of the CLI types (`codex`, `claude`, `opencode`); `persona` must match the slug pattern `[a-zA-Z0-9_-]+`. `includeDiff` defaults to `true`; set to `false` for non-code reviews (PRDs, docs, media) where the git diff is not the review target.
 
 ### `POST /agents/:id/persona-reviews`
 
@@ -212,6 +213,7 @@ Sends a server-built prompt into the parent agent's tmux session asking it to ca
   "persona": "backend-security-review",
   "agentType": "claude",
   "allowRecheck": true,
+  "includeDiff": true,
   "context": "Review the auth middleware refactor in apps/server/src/auth/."
 }
 ```


### PR DESCRIPTION
## Summary

- Adds `includeDiff` boolean (default `true`) to `dispatch_launch_persona` MCP tool, REST routes (`/launch-review`, `/persona-reviews`), and the underlying handler
- When `false`, skips git diff generation and omits the "Changes to review" section from the persona prompt
- Adapts feedback guidance wording so it references "the work under review described in the parent context" instead of "the diff below" when no diff is included

Closes DIS-136

## Test plan

- [x] Unit tests cover both `includeDiff: true` and `includeDiff: false` paths in `assemblePersonaPrompt`
- [x] Existing tests still pass (no behavior change when `includeDiff` is omitted)
- [x] TypeScript type check passes
- [x] E2E tests pass (138 passed)
- [ ] Manual: launch a persona with `includeDiff: false` and verify no diff section in prompt
- [ ] Manual: launch a persona without `includeDiff` and verify diff is still included (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)