### PR TITLE
feat(web): add Pins tab to Agent History detail view

### DIFF
--- a/apps/server/src/routes/activity.ts
+++ b/apps/server/src/routes/activity.ts
@@ -494,6 +494,7 @@ export async function registerActivityRoutes(
           )
         END AS "latestEvent",
         git_context AS "gitContext",
+        pins,
         created_at AS "createdAt",
         updated_at AS "updatedAt"
        FROM agents WHERE id = $1`,

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -43,6 +43,8 @@ import {
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { StatCard } from "@/components/app/stat-card";
 import { MediaLightbox, stripTimestamp } from "@/components/app/media-lightbox";
+import { PinItem } from "@/components/app/pins-panel";
+import { type AgentPin } from "@/components/app/types";
 import {
   useHistoryAgents,
   useHistoryAgentDetail,
@@ -763,18 +765,22 @@ function FeedbackTimeline({ feedback }: { feedback: HistoryFeedbackItem[] }) {
   );
 }
 
-type DetailTab = "events" | "media" | "feedback";
+type DetailTab = "events" | "media" | "pins" | "feedback";
 
 function DetailTabs({
   events,
   media,
+  pins,
   feedback,
   agentId,
+  workspaceRoot,
 }: {
   events: HistoryEvent[];
   media: HistoryMedia[];
+  pins: AgentPin[];
   feedback: HistoryFeedbackItem[];
   agentId: string;
+  workspaceRoot: string | null;
 }) {
   const [tab, setTab] = useState<DetailTab>("events");
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
@@ -800,6 +806,7 @@ function DetailTabs({
   const tabs: Array<{ key: DetailTab; label: string; count: number }> = [
     { key: "events", label: "Events", count: events.length },
     { key: "media", label: "Media", count: media.length },
+    { key: "pins", label: "Pins", count: pins.length },
     { key: "feedback", label: "Feedback", count: feedback.length },
   ];
 
@@ -880,6 +887,23 @@ function DetailTabs({
           {tab === "media" && media.length === 0 && (
             <p className="py-6 text-center text-xs text-muted-foreground">
               No media captured.
+            </p>
+          )}
+
+          {tab === "pins" && pins.length > 0 && (
+            <div className="divide-y divide-border rounded-md border border-border">
+              {pins.map((pin) => (
+                <PinItem
+                  key={pin.label.toLowerCase()}
+                  pin={pin}
+                  workspaceRoot={workspaceRoot}
+                />
+              ))}
+            </div>
+          )}
+          {tab === "pins" && pins.length === 0 && (
+            <p className="py-6 text-center text-xs text-muted-foreground">
+              No pins recorded.
             </p>
           )}
 
@@ -1067,12 +1091,14 @@ function AgentHistoryDetail({
         </div>
       )}
 
-      {/* Tabbed: Events / Media */}
+      {/* Tabbed: Events / Media / Pins / Feedback */}
       <DetailTabs
         events={events}
         media={media}
+        pins={agent.pins ?? []}
         feedback={feedback}
         agentId={agentId}
+        workspaceRoot={agent.gitContext?.repoRoot ?? agent.cwd}
       />
     </div>
   );

--- a/apps/web/src/components/app/pins-panel.tsx
+++ b/apps/web/src/components/app/pins-panel.tsx
@@ -282,7 +282,7 @@ function PinValueRow({
   );
 }
 
-function PinItem({
+export function PinItem({
   pin,
   workspaceRoot,
 }: {

--- a/apps/web/src/hooks/use-agent-history.ts
+++ b/apps/web/src/hooks/use-agent-history.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { getRangeBounds, type ActivityRange } from "@/hooks/use-activity";
+import { type AgentPin } from "@/components/app/types";
 
 const HISTORY_QUERY_OPTIONS = {
   staleTime: 60_000,
@@ -97,7 +98,9 @@ export type HistoryFeedbackItem = {
 };
 
 export type HistoryAgentDetail = {
-  agent: Omit<HistoryAgent, "durationMs" | "totalTokens">;
+  agent: Omit<HistoryAgent, "durationMs" | "totalTokens"> & {
+    pins: AgentPin[];
+  };
   events: HistoryEvent[];
   tokenUsage: HistoryTokenUsage;
   media: HistoryMedia[];


### PR DESCRIPTION
## Summary
- Adds a **Pins** tab to the Agent History detail view alongside Events, Media, and Feedback
- Includes the `pins` JSONB column in the `/api/v1/history/agents/:id` API response
- Reuses the existing `PinItem` component from the sidebar (now exported) for consistent rendering
- All pin types render correctly: PR, URL, port, filename, string, markdown, code

## Test plan
- [x] TypeScript type checks pass (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] All 138 E2E tests pass (`pnpm run test:e2e`)
- [x] Visual verification with Playwright against dev server with seeded pin data
- [ ] Verify Pins tab renders for historical agents with real pin data