### PR TITLE
feat: size-adaptive persona review diffs with canonical base ref

### DIFF
--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+import type { ReviewDiffResult } from "./review-diff.js";
+
 export type PersonaDefinition = {
   /** Filename without extension (used as persona ID) */
   slug: string;
@@ -21,19 +23,7 @@ type PersonaFrontmatter = {
 };
 
 const PERSONAS_DIR = ".dispatch/personas";
-export const MAX_DIFF_BYTES = 50 * 1024;
-
-export function truncateDiffForPrompt(diff: string): string {
-  if (Buffer.byteLength(diff, "utf-8") <= MAX_DIFF_BYTES) {
-    return diff;
-  }
-
-  const decoder = new TextDecoder("utf-8", { fatal: false });
-  return (
-    decoder.decode(Buffer.from(diff, "utf-8").subarray(0, MAX_DIFF_BYTES)) +
-    "\n\n[... diff truncated at 50KB ...]"
-  );
-}
+export const INLINE_DIFF_THRESHOLD_BYTES = 15 * 1024;
 
 export function parseFrontmatter(content: string): {
   frontmatter: PersonaFrontmatter;
@@ -181,10 +171,66 @@ export type AssemblePersonaPromptOptions = {
   includeDiff?: boolean;
 };
 
+function buildDiffGuidance(result: ReviewDiffResult): string {
+  const { baseRef } = result;
+  const sizeKB = Math.round(result.diffByteSize / 1024);
+  const hasStat =
+    !!result.stat ||
+    !!result.uncommittedStat ||
+    result.untrackedFiles.length > 0;
+
+  const lines = [
+    hasStat
+      ? `The full diff is too large to include inline (~${sizeKB}KB). A file-level summary is below — use the provided git commands to inspect specific files in the worktree.`
+      : `The full diff is too large to include inline (~${sizeKB}KB). Use the git commands below to inspect changes in the worktree.`,
+    "",
+  ];
+
+  if (result.stat) {
+    lines.push(
+      `**Committed changes (vs ${baseRef}):**`,
+      "```",
+      result.stat,
+      "```",
+      ""
+    );
+  }
+
+  if (result.uncommittedStat) {
+    lines.push(
+      "**Uncommitted working tree changes:**",
+      "```",
+      result.uncommittedStat,
+      "```",
+      ""
+    );
+  }
+
+  if (result.untrackedFiles.length > 0) {
+    lines.push(
+      "**Untracked files:**",
+      ...result.untrackedFiles.map((f) => `- ${f}`),
+      ""
+    );
+  }
+
+  lines.push(
+    "### How to inspect changes",
+    "```bash",
+    `git diff ${baseRef}...HEAD -- <path>     # committed changes for one file`,
+    `git diff ${baseRef}...HEAD               # full committed diff`,
+    `git diff HEAD                            # uncommitted working tree changes`,
+    `git ls-files --others --exclude-standard # untracked files`,
+    "```"
+  );
+
+  return lines.join("\n");
+}
+
 export function assemblePersonaPrompt(
   persona: PersonaDefinition,
   context: string,
-  diff: string,
+  diffResult: ReviewDiffResult | null,
   options: AssemblePersonaPromptOptions = {}
 ): string {
   const includeDiff = options.includeDiff !== false;
@@ -203,8 +249,12 @@ export function assemblePersonaPrompt(
     sections.push(RECHECK_ROUND_TRIP_GUIDANCE);
   }
   sections.push(`## Context from parent agent\n${context}`);
-  if (includeDiff) {
-    sections.push(`## Changes to review\n${truncateDiffForPrompt(diff)}`);
+  if (includeDiff && diffResult) {
+    if (diffResult.diffByteSize <= INLINE_DIFF_THRESHOLD_BYTES) {
+      sections.push(`## Changes to review\n${diffResult.diff}`);
+    } else {
+      sections.push(`## Changes to review\n${buildDiffGuidance(diffResult)}`);
+    }
   }
 
   return sections.join("\n\n");

--- a/apps/server/src/personas/review-diff.ts
+++ b/apps/server/src/personas/review-diff.ts
@@ -12,33 +12,41 @@ function trimTrailingWhitespace(value: string): string {
   return value.replace(/\s+$/u, "");
 }
 
+export type ReviewDiffResult = {
+  diff: string;
+  /** `git diff --stat <baseRef>...HEAD` — committed changes only. */
+  stat: string;
+  /** `git diff --stat HEAD` — uncommitted working tree changes. */
+  uncommittedStat: string;
+  /** Untracked file paths (from `git ls-files --others`). */
+  untrackedFiles: string[];
+  baseRef: string;
+  diffByteSize: number;
+};
+
 export async function buildPersonaReviewDiff(
   cwd: string,
+  baseRef: string,
   runCommand: RunCommandFn
-): Promise<string> {
-  let baseBranch = "main";
-  let baseBranchDetected = true;
+): Promise<ReviewDiffResult> {
+  const baseName = baseRef.replace(/^origin\//, "");
 
   try {
-    const headRef = await runCommand(
-      "git",
-      ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
-      { cwd }
-    );
-    baseBranch = headRef.stdout.trim().replace(/^origin\//, "");
-  } catch {
-    baseBranchDetected = false;
-  }
-
-  try {
-    const [committedResult, uncommittedResult, untrackedResult] =
-      await Promise.all([
-        runCommand("git", ["diff", `${baseBranch}...HEAD`], { cwd }),
-        runCommand("git", ["diff", "HEAD"], { cwd }),
-        runCommand("git", ["ls-files", "--others", "--exclude-standard"], {
-          cwd,
-        }),
-      ]);
+    const [
+      committedResult,
+      uncommittedResult,
+      untrackedResult,
+      statResult,
+      uncommittedStatResult,
+    ] = await Promise.all([
+      runCommand("git", ["diff", `${baseRef}...HEAD`], { cwd }),
+      runCommand("git", ["diff", "HEAD"], { cwd }),
+      runCommand("git", ["ls-files", "--others", "--exclude-standard"], {
+        cwd,
+      }),
+      runCommand("git", ["diff", "--stat", `${baseRef}...HEAD`], { cwd }),
+      runCommand("git", ["diff", "--stat", "HEAD"], { cwd }),
+    ]);
 
     const committedDiff = trimTrailingWhitespace(committedResult.stdout);
     const uncommittedDiff = trimTrailingWhitespace(uncommittedResult.stdout);
@@ -46,18 +54,16 @@ export async function buildPersonaReviewDiff(
       .split("\n")
       .map((line) => line.trim())
       .filter(Boolean);
+    const stat = trimTrailingWhitespace(statResult.stdout);
+    const uncommittedStat = trimTrailingWhitespace(
+      uncommittedStatResult.stdout
+    );
 
     const sections: string[] = [];
 
-    if (!baseBranchDetected) {
-      sections.push(
-        `(Note: base branch detection failed; committed diff was generated against "${baseBranch}". If this looks wrong, the repo may use a different default branch.)`
-      );
-    }
-
     if (committedDiff) {
       sections.push(
-        `### Committed changes since ${baseBranch}\n${committedDiff}`
+        `### Committed changes since ${baseName}\n${committedDiff}`
       );
     }
 
@@ -72,11 +78,33 @@ export async function buildPersonaReviewDiff(
     }
 
     if (sections.length === 0) {
-      return "(no committed or uncommitted changes detected)";
+      return {
+        diff: "(no committed or uncommitted changes detected)",
+        stat: "",
+        uncommittedStat: "",
+        untrackedFiles: [],
+        baseRef,
+        diffByteSize: 0,
+      };
     }
 
-    return sections.join("\n\n");
+    const diff = sections.join("\n\n");
+    return {
+      diff,
+      stat,
+      uncommittedStat,
+      untrackedFiles,
+      baseRef,
+      diffByteSize: Buffer.byteLength(diff, "utf-8"),
+    };
   } catch {
-    return "(unable to generate diff)";
+    return {
+      diff: "(unable to generate diff)",
+      stat: "",
+      uncommittedStat: "",
+      untrackedFiles: [],
+      baseRef,
+      diffByteSize: 0,
+    };
   }
 }

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -37,6 +37,7 @@ import {
   buildReviewerRecheckReadyPrompt,
 } from "../reviews/injection-prompts.js";
 import { isPinType, validatePinValue } from "../pins.js";
+import { resolveBaseRef } from "../shared/git/base-ref.js";
 import {
   resolveRepoRoot,
   resolveWorktreeRoot,
@@ -574,10 +575,17 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       }
 
       const includeDiff = opts.includeDiff !== false;
-      const diff = includeDiff
-        ? await buildPersonaReviewDiff(parentCwd, runCommand)
-        : "";
-      const prompt = assemblePersonaPrompt(persona, opts.context, diff, {
+      let diffResult = null;
+      if (includeDiff) {
+        const baseRef =
+          (await resolveBaseRef(parentCwd, parent.baseBranch)) ?? "origin/main";
+        diffResult = await buildPersonaReviewDiff(
+          parentCwd,
+          baseRef,
+          runCommand
+        );
+      }
+      const prompt = assemblePersonaPrompt(persona, opts.context, diffResult, {
         allowRecheck: opts.allowRecheck,
         includeDiff,
       });

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -5,11 +5,27 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
   assemblePersonaPrompt,
+  INLINE_DIFF_THRESHOLD_BYTES,
   loadPersonaBySlug,
   loadPersonas,
   parseFrontmatter,
 } from "../src/personas/loader.js";
 import type { PersonaDefinition } from "../src/personas/loader.js";
+import type { ReviewDiffResult } from "../src/personas/review-diff.js";
+
+function makeDiffResult(
+  diff: string,
+  overrides: Partial<ReviewDiffResult> = {}
+): ReviewDiffResult {
+  return {
+    diff,
+    stat: overrides.stat ?? "",
+    uncommittedStat: overrides.uncommittedStat ?? "",
+    untrackedFiles: overrides.untrackedFiles ?? [],
+    baseRef: overrides.baseRef ?? "origin/main",
+    diffByteSize: overrides.diffByteSize ?? Buffer.byteLength(diff, "utf-8"),
+  };
+}
 
 // ── parseFrontmatter ────────────────────────────────────────────────
 
@@ -103,7 +119,7 @@ describe("assemblePersonaPrompt", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "Built a widget",
-      "diff --git a/foo"
+      makeDiffResult("diff --git a/foo")
     );
 
     expect(result).toContain("# You are a Test Reviewer");
@@ -113,7 +129,11 @@ describe("assemblePersonaPrompt", () => {
   });
 
   it("orders sections correctly: persona body, guidelines, context, diff", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "diff");
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("diff")
+    );
 
     const bodyIdx = result.indexOf("# You are a Test Reviewer");
     const guidelinesIdx = result.indexOf("## Feedback Guidelines");
@@ -130,35 +150,89 @@ describe("assemblePersonaPrompt", () => {
       ...basePersona,
       body: "# Reviewer\n\n## Context\n{{context}}\n\n## Diff\n{{diff}}",
     };
-    const result = assemblePersonaPrompt(persona, "my context", "my diff");
+    const result = assemblePersonaPrompt(
+      persona,
+      "my context",
+      makeDiffResult("my diff")
+    );
 
-    // Placeholders should be gone from the persona body section
     expect(result).not.toMatch(/\{\{context\}\}/);
     expect(result).not.toMatch(/\{\{diff\}\}/);
-    // But the actual values appear in the injected sections
     expect(result).toContain("## Context from parent agent\nmy context");
     expect(result).toContain("## Changes to review\nmy diff");
   });
 
-  it("truncates diffs exceeding 50KB", () => {
+  it("uses stat summary + git commands for large diffs", () => {
     const largeDiff = "a".repeat(60 * 1024);
-    const result = assemblePersonaPrompt(basePersona, "ctx", largeDiff);
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult(largeDiff, {
+        stat: " a.ts | 10 +\n 1 file changed",
+        baseRef: "origin/main",
+      })
+    );
 
-    expect(result).toContain("[... diff truncated at 50KB ...]");
-    // The full 60KB string should not be present
     expect(result).not.toContain(largeDiff);
+    expect(result).toContain("too large to include inline");
+    expect(result).toContain("a.ts | 10 +");
+    expect(result).toContain("git diff origin/main...HEAD -- <path>");
+    expect(result).toContain("git diff origin/main...HEAD");
   });
 
-  it("does not truncate diffs under 50KB", () => {
-    const smallDiff = "b".repeat(40 * 1024);
-    const result = assemblePersonaPrompt(basePersona, "ctx", smallDiff);
+  it("includes uncommitted stat and untracked files for large diffs without committed changes", () => {
+    const largeDiff = "a".repeat(60 * 1024);
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult(largeDiff, {
+        stat: "",
+        uncommittedStat: " b.ts | 5 +\n 1 file changed",
+        untrackedFiles: ["new-feature.ts", "config.json"],
+        baseRef: "origin/main",
+      })
+    );
 
-    expect(result).not.toContain("[... diff truncated");
+    expect(result).toContain("too large to include inline");
+    expect(result).toContain("Uncommitted working tree changes");
+    expect(result).toContain("b.ts | 5 +");
+    expect(result).toContain("Untracked files");
+    expect(result).toContain("- new-feature.ts");
+    expect(result).toContain("- config.json");
+    expect(result).not.toContain("Committed changes");
+  });
+
+  it("omits file-level summary preamble when no stat sources exist for large diffs", () => {
+    const largeDiff = "a".repeat(60 * 1024);
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult(largeDiff, {
+        stat: "",
+        uncommittedStat: "",
+        untrackedFiles: [],
+      })
+    );
+
+    expect(result).toContain("too large to include inline");
+    expect(result).not.toContain("file-level summary is below");
+    expect(result).toContain("git commands below");
+  });
+
+  it("inlines small diffs under the threshold", () => {
+    const smallDiff = "b".repeat(Math.floor(INLINE_DIFF_THRESHOLD_BYTES * 0.8));
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult(smallDiff)
+    );
+
+    expect(result).not.toContain("too large to include inline");
     expect(result).toContain(smallDiff);
   });
 
   it("includes standard severity levels", () => {
-    const result = assemblePersonaPrompt(basePersona, "", "");
+    const result = assemblePersonaPrompt(basePersona, "", null);
 
     expect(result).toContain("**critical**");
     expect(result).toContain("**high**");
@@ -168,26 +242,28 @@ describe("assemblePersonaPrompt", () => {
   });
 
   it("includes info feedback limits", () => {
-    const result = assemblePersonaPrompt(basePersona, "", "");
+    const result = assemblePersonaPrompt(basePersona, "", null);
     expect(result).toContain("Info feedback limits");
     expect(result).toContain("Do NOT submit positive affirmations");
   });
 
   it("omits the recheck round-trip block by default", () => {
-    const result = assemblePersonaPrompt(basePersona, "", "");
+    const result = assemblePersonaPrompt(basePersona, "", null);
     expect(result).not.toContain("Recheck round-trip");
   });
 
   it("appends the recheck round-trip block when allowRecheck is true", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "diff", {
-      allowRecheck: true,
-    });
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("diff"),
+      { allowRecheck: true }
+    );
 
     expect(result).toContain("Recheck round-trip");
     expect(result).toContain("dispatch_complete_review");
     expect(result).toContain("respondsToFeedbackId");
     expect(result).toContain("dispatch_get_recheck_context");
-    // Round-trip transitions are pushed via terminal injection, not polled.
     expect(result).not.toContain("dispatch_await_recheck");
     expect(result).not.toContain("pollAgainInSeconds");
     expect(result).toMatch(/push a short prompt/i);
@@ -201,36 +277,49 @@ describe("assemblePersonaPrompt", () => {
   });
 
   it("omits the recheck round-trip block when allowRecheck is false", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "diff", {
-      allowRecheck: false,
-    });
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("diff"),
+      { allowRecheck: false }
+    );
     expect(result).not.toContain("Recheck round-trip");
   });
 
   it("includes the diff section by default (includeDiff unset)", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff");
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("the-diff")
+    );
     expect(result).toContain("## Changes to review\nthe-diff");
     expect(result).toContain("the scope of the changes (the diff below)");
   });
 
   it("includes the diff section when includeDiff is true", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff", {
-      includeDiff: true,
-    });
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("the-diff"),
+      { includeDiff: true }
+    );
     expect(result).toContain("## Changes to review\nthe-diff");
     expect(result).toContain("the scope of the changes (the diff below)");
   });
 
   it("omits the diff section when includeDiff is false", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "the-diff", {
-      includeDiff: false,
-    });
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("the-diff"),
+      { includeDiff: false }
+    );
     expect(result).not.toContain("## Changes to review");
     expect(result).not.toContain("the-diff");
   });
 
   it("adapts guidance wording when includeDiff is false", () => {
-    const result = assemblePersonaPrompt(basePersona, "ctx", "", {
+    const result = assemblePersonaPrompt(basePersona, "ctx", null, {
       includeDiff: false,
     });
     expect(result).not.toContain("the diff below");
@@ -243,12 +332,18 @@ describe("assemblePersonaPrompt", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "Review the PRD for gaps",
-      "",
+      null,
       { includeDiff: false }
     );
     expect(result).toContain(
       "## Context from parent agent\nReview the PRD for gaps"
     );
+  });
+
+  it("handles null diffResult gracefully when includeDiff is true", () => {
+    const result = assemblePersonaPrompt(basePersona, "ctx", null);
+    expect(result).not.toContain("## Changes to review");
+    expect(result).toContain("## Context from parent agent");
   });
 });
 

--- a/apps/server/test/persona-review-diff.test.ts
+++ b/apps/server/test/persona-review-diff.test.ts
@@ -6,10 +6,7 @@ describe("buildPersonaReviewDiff", () => {
   it("includes committed and uncommitted changes", async () => {
     const runCommand = async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
-        return { stdout: "origin/main\n" };
-      }
-      if (key === "diff main...HEAD") {
+      if (key === "diff origin/main...HEAD") {
         return { stdout: "diff --git a/a.ts b/a.ts\n" };
       }
       if (key === "diff HEAD") {
@@ -18,24 +15,40 @@ describe("buildPersonaReviewDiff", () => {
       if (key === "ls-files --others --exclude-standard") {
         return { stdout: "" };
       }
+      if (key === "diff --stat origin/main...HEAD") {
+        return { stdout: " a.ts | 1 +\n 1 file changed\n" };
+      }
+      if (key === "diff --stat HEAD") {
+        return { stdout: " b.ts | 2 +\n 1 file changed\n" };
+      }
       throw new Error(`Unexpected command: ${key}`);
     };
 
-    const result = await buildPersonaReviewDiff("/repo", runCommand);
+    const result = await buildPersonaReviewDiff(
+      "/repo",
+      "origin/main",
+      runCommand
+    );
 
-    expect(result).toContain("### Committed changes since main");
-    expect(result).toContain("diff --git a/a.ts b/a.ts");
-    expect(result).toContain("### Uncommitted working tree changes");
-    expect(result).toContain("diff --git a/b.ts b/b.ts");
+    expect(result.diff).toContain("### Committed changes since main");
+    expect(result.diff).toContain("diff --git a/a.ts b/a.ts");
+    expect(result.diff).toContain("### Uncommitted working tree changes");
+    expect(result.diff).toContain("diff --git a/b.ts b/b.ts");
+    expect(result.baseRef).toBe("origin/main");
+    expect(result.stat).toContain("a.ts");
+    expect(result.uncommittedStat).toContain("b.ts");
+    expect(result.diffByteSize).toBeGreaterThan(0);
   });
 
   it("includes untracked files in the review context", async () => {
     const runCommand = async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
-        return { stdout: "origin/main\n" };
-      }
-      if (key === "diff main...HEAD" || key === "diff HEAD") {
+      if (
+        key === "diff origin/main...HEAD" ||
+        key === "diff HEAD" ||
+        key === "diff --stat origin/main...HEAD" ||
+        key === "diff --stat HEAD"
+      ) {
         return { stdout: "" };
       }
       if (key === "ls-files --others --exclude-standard") {
@@ -44,54 +57,76 @@ describe("buildPersonaReviewDiff", () => {
       throw new Error(`Unexpected command: ${key}`);
     };
 
-    const result = await buildPersonaReviewDiff("/repo", runCommand);
-
-    expect(result).toContain("### Untracked files");
-    expect(result).toContain("- new-file.ts");
-    expect(result).toContain("- notes.md");
-  });
-
-  it("notes when base branch detection fails", async () => {
-    const runCommand = async (_command: string, args: string[]) => {
-      const key = args.join(" ");
-      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
-        throw new Error("no origin head");
-      }
-      if (
-        key === "diff main...HEAD" ||
-        key === "diff HEAD" ||
-        key === "ls-files --others --exclude-standard"
-      ) {
-        return { stdout: "" };
-      }
-      throw new Error(`Unexpected command: ${key}`);
-    };
-
-    const result = await buildPersonaReviewDiff("/repo", runCommand);
-
-    expect(result).toContain(
-      'base branch detection failed; committed diff was generated against "main"'
+    const result = await buildPersonaReviewDiff(
+      "/repo",
+      "origin/main",
+      runCommand
     );
+
+    expect(result.diff).toContain("### Untracked files");
+    expect(result.diff).toContain("- new-file.ts");
+    expect(result.diff).toContain("- notes.md");
+    expect(result.untrackedFiles).toEqual(["new-file.ts", "notes.md"]);
   });
 
   it("returns a fallback when no changes are detected", async () => {
     const runCommand = async (_command: string, args: string[]) => {
       const key = args.join(" ");
-      if (key === "symbolic-ref refs/remotes/origin/HEAD --short") {
-        return { stdout: "origin/main\n" };
-      }
       if (
-        key === "diff main...HEAD" ||
+        key === "diff origin/main...HEAD" ||
         key === "diff HEAD" ||
-        key === "ls-files --others --exclude-standard"
+        key === "ls-files --others --exclude-standard" ||
+        key === "diff --stat origin/main...HEAD" ||
+        key === "diff --stat HEAD"
       ) {
         return { stdout: "" };
       }
       throw new Error(`Unexpected command: ${key}`);
     };
 
-    const result = await buildPersonaReviewDiff("/repo", runCommand);
+    const result = await buildPersonaReviewDiff(
+      "/repo",
+      "origin/main",
+      runCommand
+    );
 
-    expect(result).toBe("(no committed or uncommitted changes detected)");
+    expect(result.diff).toBe("(no committed or uncommitted changes detected)");
+    expect(result.diffByteSize).toBe(0);
+  });
+
+  it("uses the provided baseRef for diff commands", async () => {
+    const commands: string[] = [];
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      commands.push(key);
+      return { stdout: "" };
+    };
+
+    await buildPersonaReviewDiff("/repo", "origin/develop", runCommand);
+
+    expect(commands).toContain("diff origin/develop...HEAD");
+    expect(commands).toContain("diff --stat origin/develop...HEAD");
+  });
+
+  it("strips origin/ prefix for section headers", async () => {
+    const runCommand = async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "diff origin/main...HEAD") {
+        return { stdout: "diff --git a/x.ts b/x.ts\n" };
+      }
+      if (key === "diff --stat origin/main...HEAD") {
+        return { stdout: " x.ts | 1 +\n" };
+      }
+      return { stdout: "" };
+    };
+
+    const result = await buildPersonaReviewDiff(
+      "/repo",
+      "origin/main",
+      runCommand
+    );
+
+    expect(result.diff).toContain("### Committed changes since main");
+    expect(result.diff).not.toContain("since origin/main");
   });
 });


### PR DESCRIPTION
## Summary

- Replace the hard 50KB diff truncation in persona review prompts with a size-adaptive strategy: small diffs (<15KB) are inlined as before, large diffs get a `--stat` summary + exact git commands with the resolved base ref baked in — no more wasted context or agents guessing what to diff against.
- Fix inconsistent base-ref resolution by using the canonical `resolveBaseRef` fallback chain (`parent.baseBranch` → `@{upstream}` → `origin/main` → `main`) instead of ad-hoc `symbolic-ref` detection.
- Large-diff guidance now includes committed stat, uncommitted stat, and untracked file list so reviewers always get a file-level roadmap regardless of whether the work is committed or WIP.
- `includeDiff: false` path unchanged — no diff content for non-code reviews (media, PRDs, docs).

## Test plan

- [x] Unit tests updated for new `ReviewDiffResult` type and size-adaptive assembly (916 tests passing)
- [x] Type check passes (`pnpm run check`)
- [x] E2E tests pass (138 passed, 10 skipped)
- [x] Product review: caught empty stat for uncommitted-heavy diffs → fixed, approved on recheck
- [x] Architecture review: approved (no in-scope findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)