### PR TITLE
Persist reviewer recheck preference per workspace

### DIFF
--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronDown } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useAtom } from "jotai";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
@@ -38,6 +39,7 @@ import {
   type AgentType,
   isCliAgentType,
 } from "@/lib/agent-types";
+import { reviewAllowRecheckPrefAtom } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
 type PersonaSummary = {
@@ -68,6 +70,10 @@ export function PersonaLauncher({
 }): JSX.Element {
   const queryClient = useQueryClient();
   const cwd = agent.worktreePath ?? agent.cwd;
+  const allowRecheckAtom = useMemo(
+    () => reviewAllowRecheckPrefAtom(cwd.trim()),
+    [cwd]
+  );
   const reviewerTypes = enabledAgentTypes.filter(isCliAgentType);
   const showReviewAgentTypePicker = reviewerTypes.length > 1;
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -75,7 +81,8 @@ export function PersonaLauncher({
   const [selectedAgentType, setSelectedAgentType] = useState<AgentType>(
     defaultReviewAgentType(agent)
   );
-  const [allowRecheck, setAllowRecheck] = useState(false);
+  const [allowRecheck, setAllowRecheck] = useAtom(allowRecheckAtom);
+  const [launchError, setLaunchError] = useState<string | null>(null);
   const [isLaunching, setIsLaunching] = useState(false);
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
@@ -122,7 +129,7 @@ export function PersonaLauncher({
   const openDialog = (agentType = defaultReviewAgentType(agent)) => {
     setSelectedAgentType(agentType);
     setSelectedPersona(null);
-    setAllowRecheck(false);
+    setLaunchError(null);
     setTypeDropdownOpen(false);
     setDialogOpen(true);
   };
@@ -148,6 +155,7 @@ export function PersonaLauncher({
   const launchPersona = async () => {
     if (!selectedPersona || isLaunching) return;
     setIsLaunching(true);
+    setLaunchError(null);
     try {
       await persistReviewAgentType(selectedAgentType);
       await api(`/api/v1/agents/${agent.id}/launch-review`, {
@@ -159,6 +167,10 @@ export function PersonaLauncher({
         }),
       });
       setDialogOpen(false);
+    } catch (err) {
+      setLaunchError(
+        err instanceof Error ? err.message : "Review launch failed. Try again."
+      );
     } finally {
       setIsLaunching(false);
     }
@@ -316,6 +328,7 @@ export function PersonaLauncher({
                                   value={agentType}
                                   onSelect={() => {
                                     setSelectedAgentType(agentType);
+                                    setLaunchError(null);
                                     setTypeDropdownOpen(false);
                                     requestAnimationFrame(() =>
                                       typeTriggerRef.current?.focus()
@@ -372,7 +385,10 @@ export function PersonaLauncher({
                           <button
                             key={persona.slug}
                             type="button"
-                            onClick={() => setSelectedPersona(persona.slug)}
+                            onClick={() => {
+                              setSelectedPersona(persona.slug);
+                              setLaunchError(null);
+                            }}
                             className={cn(
                               "flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left transition-colors",
                               isSelected
@@ -413,6 +429,14 @@ export function PersonaLauncher({
               </div>
 
               <div className="flex justify-end gap-2 pt-3">
+                {launchError ? (
+                  <p
+                    className="mr-auto max-w-[28rem] text-sm text-destructive"
+                    data-testid="launch-reviewer-error"
+                  >
+                    {launchError}
+                  </p>
+                ) : null}
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,7 +1,7 @@
 import { Check, ChevronDown } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useAtom } from "jotai";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type Agent } from "@/components/app/types";
@@ -82,8 +82,6 @@ export function PersonaLauncher({
     defaultReviewAgentType(agent)
   );
   const [allowRecheck, setAllowRecheck] = useAtom(allowRecheckAtom);
-  const [launchError, setLaunchError] = useState<string | null>(null);
-  const [isLaunching, setIsLaunching] = useState(false);
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
@@ -100,6 +98,23 @@ export function PersonaLauncher({
 
   const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
   useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
+
+  const launchMutation = useMutation({
+    mutationFn: async (persona: string) => {
+      await persistReviewAgentType(selectedAgentType);
+      await api(`/api/v1/agents/${agent.id}/launch-review`, {
+        method: "POST",
+        body: JSON.stringify({
+          persona,
+          agentType: selectedAgentType,
+          allowRecheck,
+        }),
+      });
+    },
+    onSuccess: () => {
+      setDialogOpen(false);
+    },
+  });
 
   if (personas.length === 0) {
     return (
@@ -129,7 +144,7 @@ export function PersonaLauncher({
   const openDialog = (agentType = defaultReviewAgentType(agent)) => {
     setSelectedAgentType(agentType);
     setSelectedPersona(null);
-    setLaunchError(null);
+    launchMutation.reset();
     setTypeDropdownOpen(false);
     setDialogOpen(true);
   };
@@ -152,34 +167,13 @@ export function PersonaLauncher({
     );
   };
 
-  const launchPersona = async () => {
-    if (!selectedPersona || isLaunching) return;
-    setIsLaunching(true);
-    setLaunchError(null);
-    try {
-      await persistReviewAgentType(selectedAgentType);
-      await api(`/api/v1/agents/${agent.id}/launch-review`, {
-        method: "POST",
-        body: JSON.stringify({
-          persona: selectedPersona,
-          agentType: selectedAgentType,
-          allowRecheck,
-        }),
-      });
-      setDialogOpen(false);
-    } catch (err) {
-      setLaunchError(
-        err instanceof Error ? err.message : "Review launch failed. Try again."
-      );
-    } finally {
-      setIsLaunching(false);
-    }
-  };
+  const launchErrorMessage =
+    launchMutation.error instanceof Error ? launchMutation.error.message : null;
 
   const reviewButton = (
     <Button
       variant="ghost"
-      disabled={disabled || isLaunching}
+      disabled={disabled || launchMutation.isPending}
       className={cn(
         "gap-1.5 border border-white/[0.12] bg-white/[0.06] text-muted-foreground backdrop-blur-md hover:bg-white/[0.1] hover:text-foreground disabled:pointer-events-auto",
         showReviewAgentTypePicker && "rounded-r-none border-r-0"
@@ -212,7 +206,7 @@ export function PersonaLauncher({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
-                disabled={disabled || isLaunching}
+                disabled={disabled || launchMutation.isPending}
                 className="rounded-l-none border border-white/[0.12] bg-white/[0.06] backdrop-blur-md px-1 text-muted-foreground hover:bg-white/[0.1] hover:text-foreground"
                 data-testid="launch-reviewer-type-dropdown"
               >
@@ -328,7 +322,7 @@ export function PersonaLauncher({
                                   value={agentType}
                                   onSelect={() => {
                                     setSelectedAgentType(agentType);
-                                    setLaunchError(null);
+                                    launchMutation.reset();
                                     setTypeDropdownOpen(false);
                                     requestAnimationFrame(() =>
                                       typeTriggerRef.current?.focus()
@@ -356,9 +350,10 @@ export function PersonaLauncher({
                   <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
                     <Checkbox
                       checked={allowRecheck}
-                      onCheckedChange={() =>
-                        setAllowRecheck((current) => !current)
-                      }
+                      onCheckedChange={() => {
+                        launchMutation.reset();
+                        setAllowRecheck((current) => !current);
+                      }}
                       className="mt-0.5"
                       data-testid="launch-reviewer-allow-recheck"
                     />
@@ -387,7 +382,7 @@ export function PersonaLauncher({
                             type="button"
                             onClick={() => {
                               setSelectedPersona(persona.slug);
-                              setLaunchError(null);
+                              launchMutation.reset();
                             }}
                             className={cn(
                               "flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left transition-colors",
@@ -429,12 +424,12 @@ export function PersonaLauncher({
               </div>
 
               <div className="flex justify-end gap-2 pt-3">
-                {launchError ? (
+                {launchErrorMessage ? (
                   <p
                     className="mr-auto max-w-[28rem] text-sm text-destructive"
                     data-testid="launch-reviewer-error"
                   >
-                    {launchError}
+                    {launchErrorMessage}
                   </p>
                 ) : null}
                 <Button
@@ -447,9 +442,10 @@ export function PersonaLauncher({
                 <Button
                   type="button"
                   variant="primary"
-                  disabled={!selectedPersona || isLaunching}
+                  disabled={!selectedPersona || launchMutation.isPending}
                   onClick={() => {
-                    void launchPersona();
+                    if (!selectedPersona) return;
+                    void launchMutation.mutateAsync(selectedPersona);
                   }}
                   data-testid="launch-reviewer-submit"
                 >

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -75,6 +75,10 @@ export const createNewBranchPrefAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage<boolean>(`dispatch:createNewBranch:${cwd}`, true)
 );
 
+export const reviewAllowRecheckPrefAtom = atomFamily((cwd: string) =>
+  atomWithLocalStorage<boolean>(`dispatch:reviewAllowRecheck:${cwd}`, false)
+);
+
 // Per-tag dismissal flag for the "release available" toast. Dismissing
 // vX.Y.Z prevents that toast from re-showing for the same tag, but a
 // newer tag still triggers a fresh toast on its own atom.

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -125,6 +125,16 @@ test.describe("Persona recheck UI", () => {
     const recheckToggle = page.getByTestId("launch-reviewer-allow-recheck");
     await recheckToggle.click();
     await expect(recheckToggle).toHaveAttribute("data-state", "checked");
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Launch Review" })
+    ).not.toBeVisible();
+
+    await page.getByTestId("launch-reviewer-button").click();
+    await expect(
+      page.getByRole("heading", { name: "Launch Review" })
+    ).toBeVisible();
+    await expect(recheckToggle).toHaveAttribute("data-state", "checked");
     await page
       .getByTestId("launch-reviewer-persona-architecture-review")
       .click();
@@ -135,5 +145,45 @@ test.describe("Persona recheck UI", () => {
       persona: "architecture-review",
       allowRecheck: true,
     });
+  });
+
+  test("launcher shows an error when review launch fails", async ({
+    page,
+    request,
+  }) => {
+    const agent = await createAgentViaAPI(request, {
+      name: `e2e-agent-${Date.now()}`,
+      cwd: process.cwd(),
+      useWorktree: false,
+    });
+
+    await page.route(
+      `**/api/v1/agents/${agent.id}/launch-review`,
+      async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "Launch review failed on the server.",
+          }),
+        });
+      }
+    );
+
+    await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+
+    await page.getByTestId("launch-reviewer-button").click();
+    await page
+      .getByTestId("launch-reviewer-persona-architecture-review")
+      .click();
+    await page.getByTestId("launch-reviewer-submit").click();
+
+    await expect(page.getByTestId("launch-reviewer-error")).toHaveText(
+      "Launch review failed on the server."
+    );
+    await expect(
+      page.getByRole("heading", { name: "Launch Review" })
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- persist the Launch Review recheck option per working directory using a cwd-keyed jotai atom
- preserve that preference when reopening the dialog and add inline error feedback when review launch fails
- extend Playwright coverage for both persisted reopen behavior and failed-launch error handling

## Testing
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e