### PR TITLE
Refine agent history active and finished sections

### DIFF
--- a/apps/server/src/routes/activity.ts
+++ b/apps/server/src/routes/activity.ts
@@ -418,8 +418,15 @@ export async function registerActivityRoutes(
       name: string;
       persona: string | null;
       status: string;
+      latestEvent: {
+        type: string;
+        message: string;
+        updatedAt: string;
+        metadata: Record<string, unknown> | null;
+      } | null;
       totalTokens: number;
       createdAt: string;
+      updatedAt: string;
     };
     const childrenByParent = new Map<string, ChildAgent[]>();
 
@@ -432,11 +439,21 @@ export async function registerActivityRoutes(
           a.name,
           a.persona,
           a.status,
+          CASE
+            WHEN a.latest_event_type IS NULL OR a.latest_event_message IS NULL OR a.latest_event_updated_at IS NULL THEN NULL
+            ELSE json_build_object(
+              'type', a.latest_event_type,
+              'message', a.latest_event_message,
+              'updatedAt', a.latest_event_updated_at,
+              'metadata', COALESCE(a.latest_event_metadata, '{}'::jsonb)
+            )
+          END AS "latestEvent",
           COALESCE((
             SELECT SUM(input_tokens + cache_creation_tokens + cache_read_tokens + output_tokens)
             FROM agent_token_usage WHERE agent_id = a.id
           ), 0)::bigint AS "totalTokens",
           a.created_at AS "createdAt",
+          a.updated_at AS "updatedAt",
           a.parent_agent_id AS "parentAgentId"
          FROM agents a
          WHERE a.parent_agent_id = ANY($1)
@@ -453,8 +470,10 @@ export async function registerActivityRoutes(
           name: child.name,
           persona: child.persona,
           status: child.status,
+          latestEvent: child.latestEvent,
           totalTokens: child.totalTokens,
           createdAt: child.createdAt,
+          updatedAt: child.updatedAt,
         });
       }
     }

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -49,6 +49,7 @@ import {
   useHistoryAgents,
   useHistoryAgentDetail,
   useHistoryProjects,
+  type HistoryAgent,
   type HistoryFilters,
   type HistoryEvent,
   type HistoryFeedbackItem,
@@ -91,6 +92,31 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
   idle: "Idle",
 };
 
+const ACTIVE_EVENT_TEXT_COLORS: Record<string, string> = {
+  working: "text-status-working",
+  blocked: "text-status-blocked",
+  waiting_user: "text-status-waiting",
+  done: "text-status-done",
+  idle: "text-foreground/80",
+};
+
+function getAgentActivityAt(agent: {
+  latestEvent?: { updatedAt: string } | null;
+  updatedAt: string;
+}): string {
+  return agent.latestEvent?.updatedAt ?? agent.updatedAt;
+}
+
+function isActiveHistoryAgent(agent: HistoryAgent): boolean {
+  if (agent.status === "creating" || agent.status === "running") return true;
+  const eventType = agent.latestEvent?.type;
+  return (
+    eventType === "working" ||
+    eventType === "blocked" ||
+    eventType === "waiting_user"
+  );
+}
+
 // ── List View ────────────────────────────────────────────────────────
 
 type SortKey = "created_at" | "name" | "updated_at";
@@ -108,7 +134,7 @@ function AgentHistoryList({
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [type, setType] = useState("");
   const [project, setProject] = useState("");
-  const [sort, setSort] = useState<SortKey>("created_at");
+  const [sort, setSort] = useState<SortKey>("updated_at");
   const [order, setOrder] = useState<"asc" | "desc">("desc");
 
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
@@ -144,6 +170,14 @@ function AgentHistoryList({
 
   const { data, isLoading } = useHistoryAgents(filters);
   const { data: projects } = useHistoryProjects();
+  const activeAgents = useMemo(
+    () => data?.agents.filter(isActiveHistoryAgent) ?? [],
+    [data?.agents]
+  );
+  const finishedAgents = useMemo(
+    () => data?.agents.filter((agent) => !isActiveHistoryAgent(agent)) ?? [],
+    [data?.agents]
+  );
 
   const toggleSort = useCallback(
     (key: SortKey) => {
@@ -162,6 +196,68 @@ function AgentHistoryList({
 
   return (
     <div className="mx-auto flex h-full max-w-5xl flex-col px-3 sm:px-5 md:px-8">
+      {activeAgents.length > 0 && (
+        <section className="mt-4 mb-6 rounded-xl border border-border/60 bg-muted/10">
+          <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 sm:px-5">
+            <div>
+              <h2 className="text-sm font-medium text-foreground">Active</h2>
+            </div>
+            <Badge className="h-5 px-1.5 text-[10px]">
+              {activeAgents.length}
+            </Badge>
+          </div>
+          <div className="divide-y divide-border/40">
+            {activeAgents.map((agent) => {
+              const latestEvent = agent.latestEvent;
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  onClick={() => onSelect(agent.id)}
+                  className="flex w-full items-start gap-3 px-3 py-3.5 text-left transition-colors hover:bg-muted/30 sm:px-5"
+                >
+                  <div className="mt-0.5 flex items-center gap-2">
+                    <AgentTypeIcon type={agent.type} />
+                    <Badge
+                      className={cn(
+                        "h-5 border border-current bg-transparent px-1.5 text-[10px]",
+                        latestEvent
+                          ? (ACTIVE_EVENT_TEXT_COLORS[latestEvent.type] ??
+                              "text-muted-foreground")
+                          : "text-muted-foreground"
+                      )}
+                    >
+                      {latestEvent
+                        ? (EVENT_TYPE_LABELS[latestEvent.type] ??
+                          latestEvent.type)
+                        : "Active"}
+                    </Badge>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {agent.name}
+                      </span>
+                      <span className="hidden text-[11px] text-muted-foreground sm:inline">
+                        {shortProjectName(
+                          agent.gitContext?.repoRoot ?? agent.cwd
+                        )}
+                      </span>
+                    </div>
+                    <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                      {latestEvent?.message ?? "Agent is still in progress"}
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right text-[11px] text-foreground">
+                    {formatRelativeTime(getAgentActivityAt(agent))}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
       {/* Search + filters */}
       <div className="space-y-2 pt-4 pb-2">
         <div className="relative">
@@ -279,10 +375,10 @@ function AgentHistoryList({
               <th className="px-2 py-2 font-medium">Tokens</th>
               <th
                 className="cursor-pointer px-2 py-2 pr-3 font-medium sm:pr-5"
-                onClick={() => toggleSort("created_at")}
+                onClick={() => toggleSort("updated_at")}
               >
-                Created{" "}
-                {sort === "created_at" &&
+                Finished{" "}
+                {sort === "updated_at" &&
                   (order === "desc" ? (
                     <ChevronDown className="ml-0.5 inline h-3 w-3" />
                   ) : (
@@ -301,7 +397,7 @@ function AgentHistoryList({
                 </tr>
               ))}
 
-            {data?.agents.map((agent) => {
+            {finishedAgents.map((agent) => {
               const hasChildren = agent.children.length > 0;
               const isExpanded = expandedIds.has(agent.id);
               return (
@@ -367,7 +463,7 @@ function AgentHistoryList({
                       )}
                     </td>
                     <td className="px-2 py-2.5 pr-3 text-muted-foreground sm:pr-5">
-                      {formatRelativeTime(agent.createdAt)}
+                      {formatRelativeTime(getAgentActivityAt(agent))}
                     </td>
                   </tr>
                   {hasChildren &&
@@ -397,7 +493,7 @@ function AgentHistoryList({
                             : "—"}
                         </td>
                         <td className="px-2 py-2 pr-3 text-muted-foreground sm:pr-5">
-                          {formatRelativeTime(child.createdAt)}
+                          {formatRelativeTime(getAgentActivityAt(child))}
                         </td>
                       </tr>
                     ))}
@@ -405,14 +501,17 @@ function AgentHistoryList({
               );
             })}
 
-            {data && data.agents.length === 0 && !isLoading && (
+            {data && finishedAgents.length === 0 && !isLoading && (
               <tr>
                 <td
                   colSpan={5}
                   className="px-5 py-12 text-center text-sm text-muted-foreground"
                 >
-                  No agents found.{" "}
-                  {hasActiveFilters && <span>Try adjusting your filters.</span>}
+                  {hasActiveFilters
+                    ? "No finished agents match the current filters."
+                    : activeAgents.length > 0
+                      ? "No finished agents in this view yet."
+                      : "No agents found."}
                 </td>
               </tr>
             )}
@@ -422,8 +521,8 @@ function AgentHistoryList({
         {data && data.agents.length < data.total && (
           <div className="py-3 text-center">
             <button className="text-xs text-muted-foreground hover:text-foreground">
-              Showing {data.agents.length} of {data.total} — load more coming
-              soon
+              Showing {data.agents.length} of {data.total} agents — load more
+              coming soon
             </button>
           </div>
         )}

--- a/apps/web/src/hooks/use-agent-history.ts
+++ b/apps/web/src/hooks/use-agent-history.ts
@@ -15,7 +15,14 @@ export type HistoryChildAgent = {
   persona: string | null;
   status: string;
   totalTokens: number;
+  latestEvent: {
+    type: string;
+    message: string;
+    updatedAt: string;
+    metadata: Record<string, unknown> | null;
+  } | null;
   createdAt: string;
+  updatedAt: string;
 };
 
 export type HistoryAgent = {


### PR DESCRIPTION
## Summary
- split Activity history into a compact Active section and a Finished table sorted by most recent completion/activity
- move the Active section above the search and filter controls with clearer spacing and lighter-weight rows
- address UX review feedback by removing active durations, improving empty-state copy, and making child rows use the same finished-time semantics as parent rows

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- manual Playwright validation against the isolated dev stack