### PR TITLE
Refresh persona review base before diff generation

### DIFF
--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -171,6 +171,18 @@ export type AssemblePersonaPromptOptions = {
   includeDiff?: boolean;
 };
 
+function buildDiffCommands(baseRef: string): string {
+  return [
+    "### How to inspect changes locally",
+    "```bash",
+    `git diff ${baseRef}...HEAD -- <path>     # committed changes for one file`,
+    `git diff ${baseRef}...HEAD               # full committed diff`,
+    "git diff HEAD                            # uncommitted working tree changes",
+    "git ls-files --others --exclude-standard # untracked files",
+    "```",
+  ].join("\n");
+}
+
 function buildDiffGuidance(result: ReviewDiffResult): string {
   const { baseRef } = result;
   const sizeKB = Math.round(result.diffByteSize / 1024);
@@ -214,15 +226,7 @@ function buildDiffGuidance(result: ReviewDiffResult): string {
     );
   }
 
-  lines.push(
-    "### How to inspect changes",
-    "```bash",
-    `git diff ${baseRef}...HEAD -- <path>     # committed changes for one file`,
-    `git diff ${baseRef}...HEAD               # full committed diff`,
-    `git diff HEAD                            # uncommitted working tree changes`,
-    `git ls-files --others --exclude-standard # untracked files`,
-    "```"
-  );
+  lines.push(buildDiffCommands(baseRef));
 
   return lines.join("\n");
 }
@@ -251,7 +255,9 @@ export function assemblePersonaPrompt(
   sections.push(`## Context from parent agent\n${context}`);
   if (includeDiff && diffResult) {
     if (diffResult.diffByteSize <= INLINE_DIFF_THRESHOLD_BYTES) {
-      sections.push(`## Changes to review\n${diffResult.diff}`);
+      sections.push(
+        `## Changes to review\n${diffResult.diff}\n\n${buildDiffCommands(diffResult.baseRef)}`
+      );
     } else {
       sections.push(`## Changes to review\n${buildDiffGuidance(diffResult)}`);
     }

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -37,7 +37,10 @@ import {
   buildReviewerRecheckReadyPrompt,
 } from "../reviews/injection-prompts.js";
 import { isPinType, validatePinValue } from "../pins.js";
-import { resolveBaseRef } from "../shared/git/base-ref.js";
+import {
+  refreshRemoteBaseRef,
+  resolveBaseRef,
+} from "../shared/git/base-ref.js";
 import {
   resolveRepoRoot,
   resolveWorktreeRoot,
@@ -577,6 +580,9 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const includeDiff = opts.includeDiff !== false;
       let diffResult = null;
       if (includeDiff) {
+        await refreshRemoteBaseRef(parentCwd, parent.baseBranch, {
+          runCommand,
+        });
         const baseRef =
           (await resolveBaseRef(parentCwd, parent.baseBranch)) ?? "origin/main";
         diffResult = await buildPersonaReviewDiff(

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -11,6 +11,54 @@ export type ResolveBaseRefOptions = {
   runCommand?: CommandRunner;
 };
 
+function preferredRemoteBranch(
+  preferred: string | null | undefined
+): string | null {
+  const candidate = preferred?.trim();
+  if (!candidate || !isSafeRef(candidate)) return null;
+  return candidate.startsWith("origin/")
+    ? candidate.slice("origin/".length)
+    : candidate;
+}
+
+export async function refreshRemoteBaseRef(
+  worktreePath: string,
+  preferred: string | null | undefined,
+  options: ResolveBaseRefOptions = {}
+): Promise<void> {
+  const run = options.runCommand ?? runCommand;
+
+  let remoteBranch = preferredRemoteBranch(preferred);
+  if (!remoteBranch) {
+    try {
+      const upstream = await run(
+        "git",
+        ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+        { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
+      );
+      if (upstream.exitCode === 0) {
+        remoteBranch = preferredRemoteBranch(upstream.stdout);
+      }
+    } catch {
+      // No upstream configured — fall through to origin/main.
+    }
+  }
+
+  if (!remoteBranch) {
+    remoteBranch = "main";
+  }
+
+  try {
+    await run(
+      "git",
+      ["-C", worktreePath, "fetch", "origin", remoteBranch, "--quiet"],
+      { allowedExitCodes: [0, 1, 128], timeoutMs: 15_000 }
+    );
+  } catch {
+    // Keep the existing local tracking refs as a fallback.
+  }
+}
+
 /**
  * Resolve a usable base ref for the given worktree, applying the same
  * fallback chain used elsewhere in the agent flow:

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -11,14 +11,54 @@ export type ResolveBaseRefOptions = {
   runCommand?: CommandRunner;
 };
 
-function preferredRemoteBranch(
-  preferred: string | null | undefined
-): string | null {
-  const candidate = preferred?.trim();
+function normalizeBranchName(ref: string | null | undefined): string | null {
+  const candidate = ref?.trim();
   if (!candidate || !isSafeRef(candidate)) return null;
   return candidate.startsWith("origin/")
     ? candidate.slice("origin/".length)
     : candidate;
+}
+
+async function resolveTargetBranch(
+  run: CommandRunner,
+  worktreePath: string,
+  preferred: string | null | undefined
+): Promise<string> {
+  const preferredBranch = normalizeBranchName(preferred);
+  if (preferredBranch) {
+    return preferredBranch;
+  }
+
+  try {
+    const upstream = await run(
+      "git",
+      ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+      { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
+    );
+    if (upstream.exitCode === 0) {
+      const upstreamRef = upstream.stdout.trim();
+      // Review diff refreshes only the origin tracking refs that Dispatch
+      // worktrees are created against. Non-origin upstreams intentionally
+      // fall through to the origin/main default below.
+      if (upstreamRef.startsWith("origin/")) {
+        const upstreamBranch = normalizeBranchName(upstreamRef);
+        if (upstreamBranch) {
+          return upstreamBranch;
+        }
+      }
+    }
+  } catch {
+    // No upstream configured — fall through to origin/main.
+  }
+
+  return "main";
+}
+
+function candidateRefsForBranch(branchName: string): string[] {
+  if (branchName === "main") {
+    return ["origin/main", "main"];
+  }
+  return [`origin/${branchName}`, branchName];
 }
 
 export async function refreshRemoteBaseRef(
@@ -27,26 +67,7 @@ export async function refreshRemoteBaseRef(
   options: ResolveBaseRefOptions = {}
 ): Promise<void> {
   const run = options.runCommand ?? runCommand;
-
-  let remoteBranch = preferredRemoteBranch(preferred);
-  if (!remoteBranch) {
-    try {
-      const upstream = await run(
-        "git",
-        ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
-        { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
-      );
-      if (upstream.exitCode === 0) {
-        remoteBranch = preferredRemoteBranch(upstream.stdout);
-      }
-    } catch {
-      // No upstream configured — fall through to origin/main.
-    }
-  }
-
-  if (!remoteBranch) {
-    remoteBranch = "main";
-  }
+  const remoteBranch = await resolveTargetBranch(run, worktreePath, preferred);
 
   try {
     await run(
@@ -55,7 +76,7 @@ export async function refreshRemoteBaseRef(
       { allowedExitCodes: [0, 1, 128], timeoutMs: 15_000 }
     );
   } catch {
-    // Keep the existing local tracking refs as a fallback.
+    // Keep the existing local tracking refs as a fallback if refresh fails.
   }
 }
 
@@ -82,34 +103,10 @@ export async function resolveBaseRef(
   options: ResolveBaseRefOptions = {}
 ): Promise<string | null> {
   const run = options.runCommand ?? runCommand;
-
-  if (preferred && preferred.trim()) {
-    const candidate = preferred.trim();
-    if (isSafeRef(candidate)) {
-      const candidates =
-        candidate === "main" ? ["origin/main", "main"] : [candidate];
-      for (const ref of candidates) {
-        const found = await refExists(run, worktreePath, ref);
-        if (found) return found;
-      }
-    }
-  }
-
-  try {
-    const upstream = await run(
-      "git",
-      ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
-      { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
-    );
-    if (upstream.exitCode === 0) {
-      const trimmed = upstream.stdout.trim();
-      if (trimmed && isSafeRef(trimmed)) {
-        const found = await refExists(run, worktreePath, trimmed);
-        if (found) return found;
-      }
-    }
-  } catch {
-    // No upstream configured — fall through to the origin/main / main chain.
+  const branchName = await resolveTargetBranch(run, worktreePath, preferred);
+  for (const ref of candidateRefsForBranch(branchName)) {
+    const found = await refExists(run, worktreePath, ref);
+    if (found) return found;
   }
 
   return (

--- a/apps/server/test/base-ref.test.ts
+++ b/apps/server/test/base-ref.test.ts
@@ -56,6 +56,23 @@ describe("refreshRemoteBaseRef", () => {
     expect(calls).toContain("-C /wt fetch origin release/x --quiet");
   });
 
+  it("falls back to origin/main when upstream tracks a non-origin remote", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return ok("fork/release/x\n");
+      }
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", null, { runCommand });
+
+    expect(calls).toContain("-C /wt fetch origin main --quiet");
+    expect(calls).not.toContain("-C /wt fetch origin fork/release/x --quiet");
+  });
+
   it("falls back to origin/main when no base branch or upstream is available", async () => {
     const calls: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
@@ -109,5 +126,29 @@ describe("resolveBaseRef", () => {
 
     expect(result).toBe("origin/main");
     expect(calls).not.toContain("-C /wt rev-parse --verify --quiet main");
+  });
+
+  it("prefers origin/<branch> over the local branch when both are available", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --verify --quiet origin/release/2026.05") {
+        return ok("origin/release/2026.05");
+      }
+      if (key === "-C /wt rev-parse --verify --quiet release/2026.05") {
+        throw new Error("resolveBaseRef should prefer origin/<branch> first");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await resolveBaseRef("/wt", "release/2026.05", {
+      runCommand,
+    });
+
+    expect(result).toBe("origin/release/2026.05");
+    expect(calls).not.toContain(
+      "-C /wt rev-parse --verify --quiet release/2026.05"
+    );
   });
 });

--- a/apps/server/test/base-ref.test.ts
+++ b/apps/server/test/base-ref.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  refreshRemoteBaseRef,
+  resolveBaseRef,
+} from "../src/shared/git/base-ref.js";
+
+function ok(stdout = "") {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function fail(stdout = "") {
+  return { exitCode: 1, stdout, stderr: "" };
+}
+
+describe("refreshRemoteBaseRef", () => {
+  it("fetches the configured base branch from origin", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      calls.push(args.join(" "));
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", "main", { runCommand });
+
+    expect(calls).toContain("-C /wt fetch origin main --quiet");
+  });
+
+  it("strips the origin/ prefix when a remote ref is provided", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      calls.push(args.join(" "));
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", "origin/release/2026.05", {
+      runCommand,
+    });
+
+    expect(calls).toContain("-C /wt fetch origin release/2026.05 --quiet");
+  });
+
+  it("falls back to the upstream branch when baseBranch is missing", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return ok("origin/release/x\n");
+      }
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", null, { runCommand });
+
+    expect(calls).toContain("-C /wt fetch origin release/x --quiet");
+  });
+
+  it("falls back to origin/main when no base branch or upstream is available", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return { exitCode: 128, stdout: "", stderr: "no upstream" };
+      }
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", null, { runCommand });
+
+    expect(calls).toContain("-C /wt fetch origin main --quiet");
+  });
+
+  it("swallows fetch failures so review can fall back to local tracking refs", async () => {
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === "-C /wt fetch origin main --quiet") {
+        throw new Error("network down");
+      }
+      return ok("");
+    });
+
+    await expect(
+      refreshRemoteBaseRef("/wt", "main", { runCommand })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("resolveBaseRef", () => {
+  it("prefers origin/main over local main when preferred is main", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --verify --quiet origin/main") {
+        return ok("origin/main");
+      }
+      if (key === "-C /wt rev-parse --verify --quiet main") {
+        return fail("");
+      }
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return { exitCode: 128, stdout: "", stderr: "no upstream" };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await resolveBaseRef("/wt", "main", { runCommand });
+
+    expect(result).toBe("origin/main");
+    expect(calls).not.toContain("-C /wt rev-parse --verify --quiet main");
+  });
+});

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -119,13 +119,14 @@ describe("assemblePersonaPrompt", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "Built a widget",
-      makeDiffResult("diff --git a/foo")
+      makeDiffResult("diff --git a/foo", { baseRef: "origin/main" })
     );
 
     expect(result).toContain("# You are a Test Reviewer");
     expect(result).toContain("## Feedback Guidelines (from Dispatch)");
     expect(result).toContain("## Context from parent agent\nBuilt a widget");
     expect(result).toContain("## Changes to review\ndiff --git a/foo");
+    expect(result).toContain("git diff origin/main...HEAD");
   });
 
   it("orders sections correctly: persona body, guidelines, context, diff", () => {
@@ -224,11 +225,13 @@ describe("assemblePersonaPrompt", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "ctx",
-      makeDiffResult(smallDiff)
+      makeDiffResult(smallDiff, { baseRef: "origin/main" })
     );
 
     expect(result).not.toContain("too large to include inline");
     expect(result).toContain(smallDiff);
+    expect(result).toContain("git diff origin/main...HEAD -- <path>");
+    expect(result).toContain("git diff HEAD");
   });
 
   it("includes standard severity levels", () => {
@@ -290,21 +293,23 @@ describe("assemblePersonaPrompt", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "ctx",
-      makeDiffResult("the-diff")
+      makeDiffResult("the-diff", { baseRef: "origin/main" })
     );
     expect(result).toContain("## Changes to review\nthe-diff");
     expect(result).toContain("the scope of the changes (the diff below)");
+    expect(result).toContain("git diff origin/main...HEAD");
   });
 
   it("includes the diff section when includeDiff is true", () => {
     const result = assemblePersonaPrompt(
       basePersona,
       "ctx",
-      makeDiffResult("the-diff"),
+      makeDiffResult("the-diff", { baseRef: "origin/main" }),
       { includeDiff: true }
     );
     expect(result).toContain("## Changes to review\nthe-diff");
     expect(result).toContain("the scope of the changes (the diff below)");
+    expect(result).toContain("git diff origin/main...HEAD");
   });
 
   it("omits the diff section when includeDiff is false", () => {

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -974,11 +974,12 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             loads the persona definition from the repo and spawns a new child
             agent with the persona's instructions, the parent's context, and (by
             default) a diff of the current changes against the agent's base
-            branch. Small diffs are included inline; large diffs (over ~15 KB)
-            are replaced with a file-level summary and <Code>git diff</Code>{" "}
-            commands the reviewer can run in the worktree to inspect specific
-            files. The child reviews the work, pings progress with{" "}
-            <Code>review_status</Code>, submits findings via{" "}
+            branch. Reviewers always get the exact local <Code>git diff</Code>{" "}
+            commands to reproduce what they are seeing. Small diffs are also
+            included inline; large diffs (over ~15 KB) are replaced with a
+            file-level summary plus those commands so the reviewer can inspect
+            specific files in the worktree. The child reviews the work, pings
+            progress with <Code>review_status</Code>, submits findings via{" "}
             <Code>dispatch_feedback</Code>, and finishes with{" "}
             <Code>dispatch_complete_review</Code>. Pass{" "}
             <Code>includeDiff: false</Code> for non-code reviews (PRDs, docs,


### PR DESCRIPTION
## Summary
- fetch the remote base branch before generating persona review diffs
- always include canonical local git diff commands in persona prompts, even for inline diffs
- add tests for base-ref refresh and prompt diff guidance

## Validation
- pnpm run check
- pnpm run test
- pnpm run finalize:web
- pnpm run test:e2e