### PR TITLE
Remove active agents from activity history

### DIFF
--- a/apps/server/src/routes/activity.ts
+++ b/apps/server/src/routes/activity.ts
@@ -315,7 +315,9 @@ export async function registerActivityRoutes(
     const result = await deps.pool.query<{ project: string }>(
       `SELECT DISTINCT COALESCE(git_context->>'repoRoot', cwd) AS project
        FROM agents
-       WHERE COALESCE(git_context->>'repoRoot', cwd) IS NOT NULL
+       WHERE parent_agent_id IS NULL
+         AND deleted_at IS NOT NULL
+         AND COALESCE(git_context->>'repoRoot', cwd) IS NOT NULL
        ORDER BY project`
     );
     return { projects: result.rows.map((row) => row.project) };

--- a/apps/server/src/routes/activity.ts
+++ b/apps/server/src/routes/activity.ts
@@ -340,7 +340,10 @@ export async function registerActivityRoutes(
     const order =
       typeof query.order === "string" && query.order === "asc" ? "ASC" : "DESC";
 
-    const conditions: string[] = ["a.parent_agent_id IS NULL"];
+    const conditions: string[] = [
+      "a.parent_agent_id IS NULL",
+      "a.deleted_at IS NOT NULL",
+    ];
     const params: unknown[] = [];
     if (search) {
       params.push(`%${deps.escapeLike(search)}%`);

--- a/apps/web/src/components/app/agent-history-tab.tsx
+++ b/apps/web/src/components/app/agent-history-tab.tsx
@@ -49,7 +49,6 @@ import {
   useHistoryAgents,
   useHistoryAgentDetail,
   useHistoryProjects,
-  type HistoryAgent,
   type HistoryFilters,
   type HistoryEvent,
   type HistoryFeedbackItem,
@@ -92,29 +91,11 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
   idle: "Idle",
 };
 
-const ACTIVE_EVENT_TEXT_COLORS: Record<string, string> = {
-  working: "text-status-working",
-  blocked: "text-status-blocked",
-  waiting_user: "text-status-waiting",
-  done: "text-status-done",
-  idle: "text-foreground/80",
-};
-
 function getAgentActivityAt(agent: {
   latestEvent?: { updatedAt: string } | null;
   updatedAt: string;
 }): string {
   return agent.latestEvent?.updatedAt ?? agent.updatedAt;
-}
-
-function isActiveHistoryAgent(agent: HistoryAgent): boolean {
-  if (agent.status === "creating" || agent.status === "running") return true;
-  const eventType = agent.latestEvent?.type;
-  return (
-    eventType === "working" ||
-    eventType === "blocked" ||
-    eventType === "waiting_user"
-  );
 }
 
 // ── List View ────────────────────────────────────────────────────────
@@ -170,15 +151,6 @@ function AgentHistoryList({
 
   const { data, isLoading } = useHistoryAgents(filters);
   const { data: projects } = useHistoryProjects();
-  const activeAgents = useMemo(
-    () => data?.agents.filter(isActiveHistoryAgent) ?? [],
-    [data?.agents]
-  );
-  const finishedAgents = useMemo(
-    () => data?.agents.filter((agent) => !isActiveHistoryAgent(agent)) ?? [],
-    [data?.agents]
-  );
-
   const toggleSort = useCallback(
     (key: SortKey) => {
       if (sort === key) {
@@ -196,68 +168,6 @@ function AgentHistoryList({
 
   return (
     <div className="mx-auto flex h-full max-w-5xl flex-col px-3 sm:px-5 md:px-8">
-      {activeAgents.length > 0 && (
-        <section className="mt-4 mb-6 rounded-xl border border-border/60 bg-muted/10">
-          <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 sm:px-5">
-            <div>
-              <h2 className="text-sm font-medium text-foreground">Active</h2>
-            </div>
-            <Badge className="h-5 px-1.5 text-[10px]">
-              {activeAgents.length}
-            </Badge>
-          </div>
-          <div className="divide-y divide-border/40">
-            {activeAgents.map((agent) => {
-              const latestEvent = agent.latestEvent;
-              return (
-                <button
-                  key={agent.id}
-                  type="button"
-                  onClick={() => onSelect(agent.id)}
-                  className="flex w-full items-start gap-3 px-3 py-3.5 text-left transition-colors hover:bg-muted/30 sm:px-5"
-                >
-                  <div className="mt-0.5 flex items-center gap-2">
-                    <AgentTypeIcon type={agent.type} />
-                    <Badge
-                      className={cn(
-                        "h-5 border border-current bg-transparent px-1.5 text-[10px]",
-                        latestEvent
-                          ? (ACTIVE_EVENT_TEXT_COLORS[latestEvent.type] ??
-                              "text-muted-foreground")
-                          : "text-muted-foreground"
-                      )}
-                    >
-                      {latestEvent
-                        ? (EVENT_TYPE_LABELS[latestEvent.type] ??
-                          latestEvent.type)
-                        : "Active"}
-                    </Badge>
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate text-sm font-medium text-foreground">
-                        {agent.name}
-                      </span>
-                      <span className="hidden text-[11px] text-muted-foreground sm:inline">
-                        {shortProjectName(
-                          agent.gitContext?.repoRoot ?? agent.cwd
-                        )}
-                      </span>
-                    </div>
-                    <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
-                      {latestEvent?.message ?? "Agent is still in progress"}
-                    </p>
-                  </div>
-                  <div className="shrink-0 text-right text-[11px] text-foreground">
-                    {formatRelativeTime(getAgentActivityAt(agent))}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
       {/* Search + filters */}
       <div className="space-y-2 pt-4 pb-2">
         <div className="relative">
@@ -397,7 +307,7 @@ function AgentHistoryList({
                 </tr>
               ))}
 
-            {finishedAgents.map((agent) => {
+            {data?.agents.map((agent) => {
               const hasChildren = agent.children.length > 0;
               const isExpanded = expandedIds.has(agent.id);
               return (
@@ -501,17 +411,15 @@ function AgentHistoryList({
               );
             })}
 
-            {data && finishedAgents.length === 0 && !isLoading && (
+            {data && data.agents.length === 0 && !isLoading && (
               <tr>
                 <td
                   colSpan={5}
                   className="px-5 py-12 text-center text-sm text-muted-foreground"
                 >
                   {hasActiveFilters
-                    ? "No finished agents match the current filters."
-                    : activeAgents.length > 0
-                      ? "No finished agents in this view yet."
-                      : "No agents found."}
+                    ? "No agents match the current filters."
+                    : "No agents found."}
                 </td>
               </tr>
             )}


### PR DESCRIPTION
## Summary
- filter the history API to archived top-level agents only
- remove the active-agents section from the history tab UI
- keep history counts and empty states aligned with archived-only results

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test
- pnpm run test:e2e