### PR TITLE
Persist review base branch defaults

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -381,7 +381,9 @@ export class AgentManager {
       }
       throw err;
     }
-    normalizedBaseBranch = normalizedBaseBranch ?? "main";
+    if (useWorktree) {
+      normalizedBaseBranch = normalizedBaseBranch ?? "main";
+    }
 
     // Compute worktree params for the setup script
     let worktreeBranchName: string | undefined;

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -381,6 +381,7 @@ export class AgentManager {
       }
       throw err;
     }
+    normalizedBaseBranch = normalizedBaseBranch ?? "main";
 
     // Compute worktree params for the setup script
     let worktreeBranchName: string | undefined;

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -580,11 +580,19 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const includeDiff = opts.includeDiff !== false;
       let diffResult = null;
       if (includeDiff) {
-        await refreshRemoteBaseRef(parentCwd, parent.baseBranch, {
+        const reviewBaseBranch =
+          parent.baseBranch ??
+          (parent.worktreePath && parent.worktreeBranch ? "main" : null);
+        const allowUpstreamFallback = reviewBaseBranch == null;
+        await refreshRemoteBaseRef(parentCwd, reviewBaseBranch, {
           runCommand,
+          allowUpstreamFallback,
         });
         const baseRef =
-          (await resolveBaseRef(parentCwd, parent.baseBranch)) ?? "origin/main";
+          (await resolveBaseRef(parentCwd, reviewBaseBranch, {
+            runCommand,
+            allowUpstreamFallback,
+          })) ?? "origin/main";
         diffResult = await buildPersonaReviewDiff(
           parentCwd,
           baseRef,

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -9,6 +9,8 @@ type CommandRunner = (
 export type ResolveBaseRefOptions = {
   /** Override for tests. */
   runCommand?: CommandRunner;
+  /** When false, do not infer the target branch from @{upstream}. */
+  allowUpstreamFallback?: boolean;
 };
 
 function normalizeBranchName(ref: string | null | undefined): string | null {
@@ -20,13 +22,38 @@ function normalizeBranchName(ref: string | null | undefined): string | null {
 }
 
 async function resolveTargetBranch(
-  _run: CommandRunner,
-  _worktreePath: string,
-  preferred: string | null | undefined
+  run: CommandRunner,
+  worktreePath: string,
+  preferred: string | null | undefined,
+  options: ResolveBaseRefOptions = {}
 ): Promise<string> {
   const preferredBranch = normalizeBranchName(preferred);
   if (preferredBranch) {
     return preferredBranch;
+  }
+
+  if (options.allowUpstreamFallback !== false) {
+    try {
+      const upstream = await run(
+        "git",
+        ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
+        { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
+      );
+      if (upstream.exitCode === 0) {
+        const upstreamRef = upstream.stdout.trim();
+        // Review diff refreshes only the origin tracking refs that Dispatch
+        // worktrees are created against. Non-origin upstreams intentionally
+        // fall through to the origin/main default below.
+        if (upstreamRef.startsWith("origin/")) {
+          const upstreamBranch = normalizeBranchName(upstreamRef);
+          if (upstreamBranch) {
+            return upstreamBranch;
+          }
+        }
+      }
+    } catch {
+      // No upstream configured — fall through to origin/main.
+    }
   }
 
   return "main";
@@ -45,7 +72,12 @@ export async function refreshRemoteBaseRef(
   options: ResolveBaseRefOptions = {}
 ): Promise<void> {
   const run = options.runCommand ?? runCommand;
-  const remoteBranch = await resolveTargetBranch(run, worktreePath, preferred);
+  const remoteBranch = await resolveTargetBranch(
+    run,
+    worktreePath,
+    preferred,
+    options
+  );
 
   try {
     await run(
@@ -65,8 +97,9 @@ export async function refreshRemoteBaseRef(
  *   1. `preferred` (e.g. `agent.baseBranch`) if it resolves
  *      Special case: prefer `origin/main` over local `main` so stale
  *      primary-checkout branches do not inflate worktree diff stats.
- *   2. `origin/main`
- *   3. `main`
+ *   2. the current branch's `@{upstream}` (unless disabled by the caller)
+ *   3. `origin/main`
+ *   4. `main`
  *
  * Returns the first ref that `git rev-parse --verify --quiet` accepts, or
  * `null` if none do. The function does NOT fetch from origin; callers that
@@ -80,7 +113,12 @@ export async function resolveBaseRef(
   options: ResolveBaseRefOptions = {}
 ): Promise<string | null> {
   const run = options.runCommand ?? runCommand;
-  const branchName = await resolveTargetBranch(run, worktreePath, preferred);
+  const branchName = await resolveTargetBranch(
+    run,
+    worktreePath,
+    preferred,
+    options
+  );
   for (const ref of candidateRefsForBranch(branchName)) {
     const found = await refExists(run, worktreePath, ref);
     if (found) return found;

--- a/apps/server/src/shared/git/base-ref.ts
+++ b/apps/server/src/shared/git/base-ref.ts
@@ -20,35 +20,13 @@ function normalizeBranchName(ref: string | null | undefined): string | null {
 }
 
 async function resolveTargetBranch(
-  run: CommandRunner,
-  worktreePath: string,
+  _run: CommandRunner,
+  _worktreePath: string,
   preferred: string | null | undefined
 ): Promise<string> {
   const preferredBranch = normalizeBranchName(preferred);
   if (preferredBranch) {
     return preferredBranch;
-  }
-
-  try {
-    const upstream = await run(
-      "git",
-      ["-C", worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"],
-      { allowedExitCodes: [0, 128], timeoutMs: 5_000 }
-    );
-    if (upstream.exitCode === 0) {
-      const upstreamRef = upstream.stdout.trim();
-      // Review diff refreshes only the origin tracking refs that Dispatch
-      // worktrees are created against. Non-origin upstreams intentionally
-      // fall through to the origin/main default below.
-      if (upstreamRef.startsWith("origin/")) {
-        const upstreamBranch = normalizeBranchName(upstreamRef);
-        if (upstreamBranch) {
-          return upstreamBranch;
-        }
-      }
-    }
-  } catch {
-    // No upstream configured — fall through to origin/main.
   }
 
   return "main";
@@ -87,9 +65,8 @@ export async function refreshRemoteBaseRef(
  *   1. `preferred` (e.g. `agent.baseBranch`) if it resolves
  *      Special case: prefer `origin/main` over local `main` so stale
  *      primary-checkout branches do not inflate worktree diff stats.
- *   2. the current branch's `@{upstream}`
- *   3. `origin/main`
- *   4. `main`
+ *   2. `origin/main`
+ *   3. `main`
  *
  * Returns the first ref that `git rev-parse --verify --quiet` accepts, or
  * `null` if none do. The function does NOT fetch from origin; callers that

--- a/apps/server/test/base-ref.test.ts
+++ b/apps/server/test/base-ref.test.ts
@@ -40,14 +40,33 @@ describe("refreshRemoteBaseRef", () => {
     expect(calls).toContain("-C /wt fetch origin release/2026.05 --quiet");
   });
 
-  it("falls back to origin/main when baseBranch is missing", async () => {
+  it("falls back to the upstream branch when baseBranch is missing", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return ok("origin/release/x\n");
+      }
+      return ok("");
+    });
+
+    await refreshRemoteBaseRef("/wt", null, { runCommand });
+
+    expect(calls).toContain("-C /wt fetch origin release/x --quiet");
+  });
+
+  it("can disable upstream fallback and force origin/main semantics", async () => {
     const calls: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       calls.push(args.join(" "));
       return ok("");
     });
 
-    await refreshRemoteBaseRef("/wt", null, { runCommand });
+    await refreshRemoteBaseRef("/wt", null, {
+      runCommand,
+      allowUpstreamFallback: false,
+    });
 
     expect(calls).toContain("-C /wt fetch origin main --quiet");
     expect(calls).not.toContain("-C /wt rev-parse --abbrev-ref @{upstream}");
@@ -69,7 +88,29 @@ describe("refreshRemoteBaseRef", () => {
 });
 
 describe("resolveBaseRef", () => {
-  it("falls back to origin/main when preferred baseBranch is missing", async () => {
+  it("falls back to the upstream branch when preferred baseBranch is missing", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
+        return ok("origin/release/x\n");
+      }
+      if (key === "-C /wt rev-parse --verify --quiet origin/release/x") {
+        return ok("origin/release/x");
+      }
+      if (key === "-C /wt rev-parse --verify --quiet release/x") {
+        return fail("");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await resolveBaseRef("/wt", null, { runCommand });
+
+    expect(result).toBe("origin/release/x");
+  });
+
+  it("can disable upstream fallback and force origin/main resolution", async () => {
     const calls: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       const key = args.join(" ");
@@ -83,7 +124,10 @@ describe("resolveBaseRef", () => {
       throw new Error(`Unexpected command: ${key}`);
     });
 
-    const result = await resolveBaseRef("/wt", null, { runCommand });
+    const result = await resolveBaseRef("/wt", null, {
+      runCommand,
+      allowUpstreamFallback: false,
+    });
 
     expect(result).toBe("origin/main");
     expect(calls).not.toContain("-C /wt rev-parse --abbrev-ref @{upstream}");

--- a/apps/server/test/base-ref.test.ts
+++ b/apps/server/test/base-ref.test.ts
@@ -40,53 +40,17 @@ describe("refreshRemoteBaseRef", () => {
     expect(calls).toContain("-C /wt fetch origin release/2026.05 --quiet");
   });
 
-  it("falls back to the upstream branch when baseBranch is missing", async () => {
+  it("falls back to origin/main when baseBranch is missing", async () => {
     const calls: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
-      const key = args.join(" ");
-      calls.push(key);
-      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
-        return ok("origin/release/x\n");
-      }
-      return ok("");
-    });
-
-    await refreshRemoteBaseRef("/wt", null, { runCommand });
-
-    expect(calls).toContain("-C /wt fetch origin release/x --quiet");
-  });
-
-  it("falls back to origin/main when upstream tracks a non-origin remote", async () => {
-    const calls: string[] = [];
-    const runCommand = vi.fn(async (_command: string, args: string[]) => {
-      const key = args.join(" ");
-      calls.push(key);
-      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
-        return ok("fork/release/x\n");
-      }
+      calls.push(args.join(" "));
       return ok("");
     });
 
     await refreshRemoteBaseRef("/wt", null, { runCommand });
 
     expect(calls).toContain("-C /wt fetch origin main --quiet");
-    expect(calls).not.toContain("-C /wt fetch origin fork/release/x --quiet");
-  });
-
-  it("falls back to origin/main when no base branch or upstream is available", async () => {
-    const calls: string[] = [];
-    const runCommand = vi.fn(async (_command: string, args: string[]) => {
-      const key = args.join(" ");
-      calls.push(key);
-      if (key === "-C /wt rev-parse --abbrev-ref @{upstream}") {
-        return { exitCode: 128, stdout: "", stderr: "no upstream" };
-      }
-      return ok("");
-    });
-
-    await refreshRemoteBaseRef("/wt", null, { runCommand });
-
-    expect(calls).toContain("-C /wt fetch origin main --quiet");
+    expect(calls).not.toContain("-C /wt rev-parse --abbrev-ref @{upstream}");
   });
 
   it("swallows fetch failures so review can fall back to local tracking refs", async () => {
@@ -105,6 +69,27 @@ describe("refreshRemoteBaseRef", () => {
 });
 
 describe("resolveBaseRef", () => {
+  it("falls back to origin/main when preferred baseBranch is missing", async () => {
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      calls.push(key);
+      if (key === "-C /wt rev-parse --verify --quiet origin/main") {
+        return ok("origin/main");
+      }
+      if (key === "-C /wt rev-parse --verify --quiet main") {
+        return fail("");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await resolveBaseRef("/wt", null, { runCommand });
+
+    expect(result).toBe("origin/main");
+    expect(calls).not.toContain("-C /wt rev-parse --abbrev-ref @{upstream}");
+    expect(calls).not.toContain("-C /wt rev-parse --verify --quiet main");
+  });
+
   it("prefers origin/main over local main when preferred is main", async () => {
     const calls: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -318,12 +318,12 @@ describe("AgentManager", () => {
       expect(agent.baseBranch).toBe("feature/foo");
     });
 
-    it("should default baseBranch to null when not provided", async () => {
+    it("should default baseBranch to main when not provided", async () => {
       const agent = await manager.createAgent({
         cwd: "/tmp",
         useWorktree: false,
       });
-      expect(agent.baseBranch).toBeNull();
+      expect(agent.baseBranch).toBe("main");
     });
 
     it("should reject non-absolute paths", async () => {

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -318,10 +318,18 @@ describe("AgentManager", () => {
       expect(agent.baseBranch).toBe("feature/foo");
     });
 
-    it("should default baseBranch to main when not provided", async () => {
+    it("should default baseBranch to null when not provided for non-worktree agents", async () => {
       const agent = await manager.createAgent({
         cwd: "/tmp",
         useWorktree: false,
+      });
+      expect(agent.baseBranch).toBeNull();
+    });
+
+    it("should default baseBranch to main for worktree agents when not provided", async () => {
+      const agent = await manager.createAgent({
+        cwd: "/tmp",
+        useWorktree: true,
       });
       expect(agent.baseBranch).toBe("main");
     });

--- a/e2e/base-branch.spec.ts
+++ b/e2e/base-branch.spec.ts
@@ -116,7 +116,7 @@ test.describe("Agent base branch", () => {
     expect(body.agent.baseBranch).toBe("feature/foo");
   });
 
-  test("POST /api/v1/agents defaults baseBranch to main", async ({
+  test("POST /api/v1/agents defaults baseBranch to null", async ({
     request,
   }) => {
     const res = await request.post("/api/v1/agents", {
@@ -124,7 +124,7 @@ test.describe("Agent base branch", () => {
       data: { cwd: "/tmp", useWorktree: false },
     });
     const body = (await res.json()) as { agent: { baseBranch: string | null } };
-    expect(body.agent.baseBranch).toBe("main");
+    expect(body.agent.baseBranch).toBeNull();
   });
 
   test("create_pr MCP tool defaults baseBranch from agent metadata", async ({

--- a/e2e/base-branch.spec.ts
+++ b/e2e/base-branch.spec.ts
@@ -116,7 +116,7 @@ test.describe("Agent base branch", () => {
     expect(body.agent.baseBranch).toBe("feature/foo");
   });
 
-  test("POST /api/v1/agents defaults baseBranch to null", async ({
+  test("POST /api/v1/agents defaults baseBranch to main", async ({
     request,
   }) => {
     const res = await request.post("/api/v1/agents", {
@@ -124,7 +124,7 @@ test.describe("Agent base branch", () => {
       data: { cwd: "/tmp", useWorktree: false },
     });
     const body = (await res.json()) as { agent: { baseBranch: string | null } };
-    expect(body.agent.baseBranch).toBeNull();
+    expect(body.agent.baseBranch).toBe("main");
   });
 
   test("create_pr MCP tool defaults baseBranch from agent metadata", async ({


### PR DESCRIPTION
## Summary
- persist the effective base branch (`main` when omitted) when creating agents
- stop using `@{upstream}` as the fallback review base when `baseBranch` is missing
- update backend and e2e coverage for the new default behavior

## Validation
- pnpm run check
- pnpm run test
- pnpm run test:e2e