### PR TITLE
Fix agents not naming their sessions on startup

### DIFF
--- a/apps/server/src/agents/auto-rename-prompter.ts
+++ b/apps/server/src/agents/auto-rename-prompter.ts
@@ -1,7 +1,7 @@
 import type { FastifyBaseLogger } from "fastify";
 
 import { shouldSuggestSessionRename } from "./tmux/session-name.js";
-import type { AgentLatestEventInput, AgentRecord } from "./types.js";
+import type { AgentRecord } from "./types.js";
 
 /**
  * The canned prompt sent to an agent when we ask it to set a descriptive
@@ -10,15 +10,6 @@ import type { AgentLatestEventInput, AgentRecord } from "./types.js";
  */
 export const RENAME_PROMPT =
   "Please set a short, descriptive name for this session that reflects the work you're doing — call the `dispatch_rename_session` MCP tool with the new name. Then continue with whatever you were doing.";
-
-function isTerminalEventType(value: AgentLatestEventInput["type"]): boolean {
-  return (
-    value === "blocked" ||
-    value === "waiting_user" ||
-    value === "done" ||
-    value === "idle"
-  );
-}
 
 type InjectAgentPrompt = (
   agentId: string,
@@ -33,31 +24,20 @@ type AutoRenamePrompterDeps = {
 
 /**
  * Returns an `onLatestEvent` listener that auto-injects the rename prompt
- * the first time an agent transitions terminal → working, gated on the
- * session name still matching its default placeholder. One-shot per agent
- * (per process lifetime). Terminal-type and persona agents are skipped —
- * they have no Claude session to receive the prompt or already carry a
- * meaningful name.
+ * the first time an agent emits a "working" event while its session name
+ * is still the default placeholder. One-shot per agent (per process
+ * lifetime). Terminal-type and persona agents are skipped — they have no
+ * Claude session to receive the prompt or already carry a meaningful name.
+ *
+ * Agents start with an `idle` system event, so the first agent-initiated
+ * "working" event naturally triggers the prompt.
  */
 export function createAutoRenamePrompter(deps: AutoRenamePrompterDeps) {
-  const state = new Map<
-    string,
-    { lastEventType: AgentLatestEventInput["type"]; prompted: boolean }
-  >();
+  const prompted = new Set<string>();
 
   return function onLatestEvent(agent: AgentRecord): void {
-    const newType = agent.latestEvent?.type;
-    if (!newType) return;
-
-    const entry = state.get(agent.id);
-    const prevType = entry?.lastEventType;
-    const alreadyPrompted = entry?.prompted ?? false;
-
-    state.set(agent.id, { lastEventType: newType, prompted: alreadyPrompted });
-
-    if (alreadyPrompted) return;
-    if (newType !== "working") return;
-    if (!prevType || !isTerminalEventType(prevType)) return;
+    if (agent.latestEvent?.type !== "working") return;
+    if (prompted.has(agent.id)) return;
     if (agent.type === "terminal") return;
     if (
       !shouldSuggestSessionRename(agent.name, agent.id, {
@@ -67,7 +47,7 @@ export function createAutoRenamePrompter(deps: AutoRenamePrompterDeps) {
       return;
     }
 
-    state.set(agent.id, { lastEventType: newType, prompted: true });
+    prompted.add(agent.id);
 
     void deps
       .injectAgentPrompt(agent.id, RENAME_PROMPT)

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -537,7 +537,7 @@ export class AgentManager {
         id,
         type === "terminal"
           ? { type: "idle", message: "Terminal session started." }
-          : { type: "working", message: "Session started." }
+          : { type: "idle", message: "Session started." }
       );
     } else {
       try {
@@ -651,7 +651,7 @@ export class AgentManager {
       id,
       agent.type === "terminal"
         ? { type: "idle", message: "Terminal session started." }
-        : { type: "working", message: "Session started." }
+        : { type: "idle", message: "Session started." }
     );
 
     // Clean up setup script
@@ -704,7 +704,7 @@ export class AgentManager {
     if (hasSession) {
       await this.setAgentStatus(id, "running", null, tmuxSession);
       await this.setSystemLatestEvent(id, {
-        type: "working",
+        type: "idle",
         message: "Session attached to existing tmux session.",
       });
       return (await this.getAgent(id)) as AgentRecord;
@@ -783,7 +783,7 @@ export class AgentManager {
               message: "Terminal session resumed.",
             }
           : {
-              type: "working",
+              type: "idle",
               message: shouldResume ? "Session resumed." : "Session started.",
             }
       );


### PR DESCRIPTION
## Summary
- Agents started with a system "working" event, so the auto-rename prompter (which required a terminal→working transition) never fired for new agents — they'd skip naming their session entirely.
- Now agents start with an `idle` system event, and the prompter simply fires on the first "working" event when the name is still a default placeholder.
- Simplified the prompter from a `Map` tracking event transitions to a `Set` of already-prompted agent IDs.

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Unit tests pass (926 tests)
- [x] E2E tests pass (139 tests)
- [ ] Dogfood: launch a new agent and confirm it names itself without manual prompting