### PR TITLE
Fix empty persona review diffs for non-worktree agents

### DIFF
--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -45,6 +45,7 @@ import {
   resolveRepoRoot,
   resolveWorktreeRoot,
 } from "../shared/git/git-context.js";
+import { getPrStatus } from "../shared/github/pr.js";
 import { resolveHeadSha } from "../shared/git/worktree.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import type {
@@ -580,9 +581,21 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const includeDiff = opts.includeDiff !== false;
       let diffResult = null;
       if (includeDiff) {
-        const reviewBaseBranch =
+        let reviewBaseBranch: string | null =
           parent.baseBranch ??
           (parent.worktreePath && parent.worktreeBranch ? "main" : null);
+
+        if (reviewBaseBranch == null) {
+          try {
+            const pr = await getPrStatus({ cwd: parentCwd }, runCommand);
+            if (pr.baseRefName) {
+              reviewBaseBranch = pr.baseRefName;
+            }
+          } catch {
+            // No PR or gh CLI unavailable — fall through to existing fallback.
+          }
+        }
+
         const allowUpstreamFallback = reviewBaseBranch == null;
         await refreshRemoteBaseRef(parentCwd, reviewBaseBranch, {
           runCommand,


### PR DESCRIPTION
## Summary

- When a non-worktree agent (e.g., one attached to an existing PR branch) launches a persona review, the diff base resolved to the agent's own remote tracking branch, producing an empty diff
- Adds a PR-aware fallback that queries `gh pr view` for the branch's merge target (`baseRefName`) before falling back to the existing upstream heuristic
- Uses the existing `getPrStatus()` helper — no new dependencies or schema changes

## Test plan

- [x] `pnpm run check` — type check passes
- [x] `pnpm run test` — 926 unit tests pass
- [x] `pnpm run test:e2e` — 139 E2E tests pass
- [x] Security review — approved (no findings)
- [x] Architecture review — approved (1 low-severity future-proofing note, acknowledged)
- [ ] Manual: create agent on existing PR branch without worktree, launch persona review, confirm diff references the PR's base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)