### PR TITLE
Fix post-create routing race; harden agent E2E; drop Status log rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,6 @@
 - **Hard requirements:**
   - Do not send a final response unless `done`, `waiting_user`, `blocked`, or `idle` has been emitted in the same turn.
   - If `dispatch_event` fails, report that failure explicitly in the response.
-  - Include a `Status log` section in the final response with the result from each `dispatch_event` call.
   - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,6 @@ dispatch/
 - **Hard requirements:**
   - Do not send a final response unless `done`, `waiting_user`, `blocked`, or `idle` has been emitted in the same turn.
   - If `dispatch_event` fails, report that failure explicitly in the response.
-  - Include a `Status log` section in the final response with the result from each `dispatch_event` call.
   - Keep messages short (under ~80 chars) — they are displayed in a narrow sidebar.
 
 ## UI Validation

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
 import { useAtom } from "jotai";
 
@@ -40,6 +41,7 @@ import {
   agentRoute,
 } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
+import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
@@ -117,6 +119,7 @@ export function AgentsView({
   onNavigateSection,
 }: AgentsViewProps): JSX.Element {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { agentId: routeAgentId, itemId, summaryAgentId } = useParams();
 
   const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<
@@ -602,12 +605,31 @@ export function AgentsView({
       setCreateOpen(false);
       setRequestedCreateType(null);
       setLastUsedAgentType(agentType);
+      // Align with SSE `agent.upsert`: the POST already finished, but the next
+      // render can briefly see `/agents/:id` before the SSE round-trip updates
+      // React Query — that used to satisfy the "unknown agent" redirect effect.
+      queryClient.setQueryData<Agent[]>(["agents"], (old) => {
+        if (!old) return [agent];
+        const index = old.findIndex((a) => a.id === agent.id);
+        if (index === -1) {
+          return sortAgentsByCreatedAtDesc([agent, ...old]);
+        }
+        const next = [...old];
+        next[index] = agent;
+        return sortAgentsByCreatedAtDesc(next);
+      });
       navigate(agentRoute(agent.id));
       ensureAuxExpanded(agent.id);
       refreshMedia(agent.id);
       await ensureTerminalConnected(true, true, agent.id);
     },
-    [ensureAuxExpanded, ensureTerminalConnected, navigate, refreshMedia]
+    [
+      ensureAuxExpanded,
+      ensureTerminalConnected,
+      navigate,
+      queryClient,
+      refreshMedia,
+    ]
   );
 
   const handleCreateOpenChange = useCallback((open: boolean) => {

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -10,6 +10,10 @@ const AUTH_HEADER = {
   Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
 };
 
+function pathnameTerminalTokenMatch(pathname: string): boolean {
+  return /\/api\/v1\/agents\/[^/]+\/terminal\/token$/u.test(pathname);
+}
+
 test.describe("Agent CRUD", () => {
   test.afterEach(async ({ request }) => {
     await cleanupE2EAgents(request);
@@ -84,17 +88,50 @@ test.describe("Agent CRUD", () => {
       timeout: 5_000,
     });
 
-    // Submit
+    // Wait for lifecycle network work up front: the sidebar can show the agent
+    // before React Query validates the `/agents/:id` route against the cached
+    // list — that briefly redirects to `/agents` and leaves the terminal
+    // disconnected unless we synchronize on the attach handshake.
+    const createResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" &&
+        new URL(resp.url()).pathname === "/api/v1/agents" &&
+        resp.status() === 201,
+      { timeout: 15_000 }
+    );
+    const terminalTokenPromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" &&
+        pathnameTerminalTokenMatch(new URL(resp.url()).pathname) &&
+        resp.ok(),
+      { timeout: 30_000 }
+    );
+
     await page.getByTestId("create-agent-submit").click();
+
+    const createResponse = await createResponsePromise;
+    const { agent: createdAgent } = (await createResponse.json()) as {
+      agent: { id: string };
+    };
+    await terminalTokenPromise;
 
     // Dialog should close
     await expect(form).not.toBeVisible({ timeout: 5_000 });
 
     // Agent should appear in the sidebar
     const sidebar = page.getByTestId("agent-sidebar");
-    await expect(sidebar.getByText(agentName)).toBeVisible({ timeout: 5_000 });
+    await expect(sidebar.getByText(agentName)).toBeVisible({ timeout: 10_000 });
+
+    const escapedAgentId = createdAgent.id.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    );
+    await expect(page).toHaveURL(new RegExp(`/agents/${escapedAgentId}`), {
+      timeout: 15_000,
+    });
+
     await expect(page.getByTestId("terminal-inert-state")).toBeVisible({
-      timeout: 5_000,
+      timeout: 10_000,
     });
     await expect(page.getByTestId("terminal-inert-state")).toContainText(
       "Agent running in inert mode"


### PR DESCRIPTION
## Summary
- **Web:** After agent creation succeeds, upsert the returned agent into the React Query `["agents"]` cache (same semantics as SSE `agent.upsert`) **before** `navigate()`, so `/agents/:id` is validated immediately and we avoid the effect that bounced to `/agents` and detached the terminal.
- **E2E:** Harden “create agent via UI” by waiting on `POST /api/v1/agents` and `POST …/terminal/token` responses, asserting URL stability, then the inert terminal state.
- **Docs:** Drop the mandated final-response **Status log** bullet from `AGENTS.md` and `CLAUDE.md` (agents still emit `dispatch_event`; only the prose table requirement is gone).

## Testing
- `pnpm run finalize:web`
- `bash scripts/e2e-isolated.sh e2e/agent-crud.spec.ts --grep 'create agent via UI'`