### PR TITLE
Add Cursor CLI as a new agent type

### DIFF
--- a/apps/server/src/agent-type-settings.ts
+++ b/apps/server/src/agent-type-settings.ts
@@ -3,10 +3,10 @@ import type { Pool } from "pg";
 import { getSetting, setSetting } from "./db/settings.js";
 
 export const AGENT_TYPES = [
-  "codex",
   "claude",
-  "opencode",
+  "codex",
   "cursor",
+  "opencode",
   "terminal",
 ] as const;
 export type AgentType = (typeof AGENT_TYPES)[number];
@@ -14,10 +14,10 @@ export type AgentType = (typeof AGENT_TYPES)[number];
 // Agent types that run an AI CLI — eligible for jobs, review assignment, and
 // persona launches. Terminal agents are excluded because they don't run a CLI.
 export const CLI_AGENT_TYPES = [
-  "codex",
   "claude",
-  "opencode",
+  "codex",
   "cursor",
+  "opencode",
 ] as const;
 export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
 

--- a/apps/server/src/agent-type-settings.ts
+++ b/apps/server/src/agent-type-settings.ts
@@ -2,12 +2,23 @@ import type { Pool } from "pg";
 
 import { getSetting, setSetting } from "./db/settings.js";
 
-export const AGENT_TYPES = ["codex", "claude", "opencode", "terminal"] as const;
+export const AGENT_TYPES = [
+  "codex",
+  "claude",
+  "opencode",
+  "cursor",
+  "terminal",
+] as const;
 export type AgentType = (typeof AGENT_TYPES)[number];
 
 // Agent types that run an AI CLI — eligible for jobs, review assignment, and
 // persona launches. Terminal agents are excluded because they don't run a CLI.
-export const CLI_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export const CLI_AGENT_TYPES = [
+  "codex",
+  "claude",
+  "opencode",
+  "cursor",
+] as const;
 export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
 
 export function isCliAgentType(value: unknown): value is CliAgentType {

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -40,6 +40,8 @@ import { type Reconciler, createReconciler } from "./reconciler.js";
 import { type AgentRuntime, createAgentRuntime } from "./runtime.js";
 import {
   buildAgentCommand,
+  buildCursorRulesFile,
+  buildLaunchGuidance,
   buildStartupPrompt,
 } from "./tmux/command-builder.js";
 import {
@@ -572,6 +574,26 @@ export class AgentManager {
           startupPrompt,
           personality?.prompt ?? null
         );
+        // For cursor agents, build the rules file content that the setup
+        // script writes to .cursor/rules/dispatch.mdc. This carries the same
+        // launch guidance + personality that other agent types receive via CLI flags.
+        let cursorRulesContent: string | undefined;
+        if (type === "cursor") {
+          const guidance = buildLaunchGuidance(id, {
+            jobRunId: input.jobRunId,
+            suggestSessionRename: shouldSuggestSessionRename(name, id, {
+              persona: input.persona,
+              jobRunId: input.jobRunId,
+            }),
+            autoReview:
+              !input.persona && !input.jobRunId && (input.autoReview ?? false),
+          });
+          cursorRulesContent = buildCursorRulesFile(
+            guidance,
+            personality?.prompt ?? null
+          );
+        }
+
         // Generate a setup script that handles worktree creation, env copy,
         // dep install, and then exec's into the agent CLI — all visible in the terminal.
         // Stderr/exit-capture wrapping is applied by the runtime, not the script.
@@ -587,6 +609,7 @@ export class AgentManager {
           agentName: name,
           agentCommand,
           jobRunId: input.jobRunId,
+          cursorRulesContent,
         });
 
         await this.runtime.launch({

--- a/apps/server/src/agents/tmux/command-builder.ts
+++ b/apps/server/src/agents/tmux/command-builder.ts
@@ -13,11 +13,12 @@ import { agentIdFromSessionName } from "./session-name.js";
 
 const CLI_BY_AGENT_TYPE: Record<
   Exclude<AgentType, "terminal">,
-  keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin">
+  keyof Pick<AppConfig, "codexBin" | "claudeBin" | "opencodeBin" | "cursorBin">
 > = {
   codex: "codexBin",
   claude: "claudeBin",
   opencode: "opencodeBin",
+  cursor: "cursorBin",
 };
 
 const DISPATCH_API_URL_ENV = "DISPATCH_API_URL";
@@ -127,46 +128,17 @@ export function buildStartupPrompt(
 }
 
 /**
- * Build the bash invocation that launches the agent CLI inside its tmux
- * session. Returns a shell-ready string.
- *
- * Encodes the per-CLI launch quirks (claude/opencode/codex MCP wiring,
- * resume vs. new session flags, terminal-only fallback to `bash -il`).
- *
- * Reads from the host environment (not threaded through `AppConfig`):
- * - `process.env.HOME` — appended to PATH so the agent can find tools in
- *   `~/.local/bin`. Falls back gracefully when unset.
- * - `process.platform` + `process.env.DISPATCH_COPY_DISPLAY` — Linux only;
- *   forwards the X display so xclip can paste browser-clipboard images.
- * - `process.env.TLS_CA` — when TLS is enabled, sets `NODE_EXTRA_CA_CERTS`
- *   so the agent's MCP loopback connection trusts the server cert.
- *
- * These are stubbable via `vi.stubEnv` for testing.
- *
- * Security note: every interpolated value flows through `shellEscape`,
- * since this string lands directly in `tmux new-session … bash -c …`.
+ * Build the numbered launch guidance text shared by all CLI agent types.
  */
-export function buildAgentCommand(
-  config: AppConfig,
-  type: AgentType,
-  role: AgentRole,
-  args: string[],
-  mediaDir: string,
-  sessionName: string,
-  fullAccess: boolean,
-  cliSessionId?: string,
-  resume?: boolean,
-  jobRunId?: string,
-  suggestSessionRename?: boolean,
-  autoReview?: boolean,
-  initialPrompt?: string,
-  personalityPrompt?: string | null
+export function buildLaunchGuidance(
+  agentId: string,
+  opts: {
+    jobRunId?: string;
+    suggestSessionRename?: boolean;
+    autoReview?: boolean;
+  }
 ): string {
-  const agentId = agentIdFromSessionName(sessionName);
-  // Lean startup guidance shared by both agent types. Full behavioral specs live in
-  // AGENTS.md (auto-loaded by Codex) and CLAUDE.md (auto-loaded by Claude Code).
-  // Rules are built as an array and numbered on output so the agent sees a scannable
-  // list rather than a run-on paragraph.
+  const { jobRunId, suggestSessionRename, autoReview } = opts;
   const rules: string[] = [];
 
   if (jobRunId) {
@@ -215,7 +187,73 @@ export function buildAgentCommand(
   const header = jobRunId
     ? "Dispatch job startup rules:"
     : "Dispatch startup rules:";
-  const launchGuidance = `[dispatch:${agentId}] ${header}\n${numbered}`;
+  return `[dispatch:${agentId}] ${header}\n${numbered}`;
+}
+
+/**
+ * Build the `.cursor/rules/dispatch.mdc` content for Cursor agents.
+ * Contains the same launch guidance and personality that other agent types
+ * receive via CLI flags, formatted as a Cursor rules file.
+ */
+export function buildCursorRulesFile(
+  launchGuidance: string,
+  personalityPrompt?: string | null
+): string {
+  const sections = [launchGuidance, personalityPrompt].filter(Boolean);
+  const body = sections.join("\n\n");
+  return [
+    "---",
+    "description: Dispatch agent guidance",
+    "alwaysApply: true",
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Build the bash invocation that launches the agent CLI inside its tmux
+ * session. Returns a shell-ready string.
+ *
+ * Encodes the per-CLI launch quirks (claude/opencode/codex MCP wiring,
+ * resume vs. new session flags, terminal-only fallback to `bash -il`).
+ *
+ * Reads from the host environment (not threaded through `AppConfig`):
+ * - `process.env.HOME` — appended to PATH so the agent can find tools in
+ *   `~/.local/bin`. Falls back gracefully when unset.
+ * - `process.platform` + `process.env.DISPATCH_COPY_DISPLAY` — Linux only;
+ *   forwards the X display so xclip can paste browser-clipboard images.
+ * - `process.env.TLS_CA` — when TLS is enabled, sets `NODE_EXTRA_CA_CERTS`
+ *   so the agent's MCP loopback connection trusts the server cert.
+ *
+ * These are stubbable via `vi.stubEnv` for testing.
+ *
+ * Security note: every interpolated value flows through `shellEscape`,
+ * since this string lands directly in `tmux new-session … bash -c …`.
+ */
+export function buildAgentCommand(
+  config: AppConfig,
+  type: AgentType,
+  role: AgentRole,
+  args: string[],
+  mediaDir: string,
+  sessionName: string,
+  fullAccess: boolean,
+  cliSessionId?: string,
+  resume?: boolean,
+  jobRunId?: string,
+  suggestSessionRename?: boolean,
+  autoReview?: boolean,
+  initialPrompt?: string,
+  personalityPrompt?: string | null
+): string {
+  const agentId = agentIdFromSessionName(sessionName);
+  const launchGuidance = buildLaunchGuidance(agentId, {
+    jobRunId,
+    suggestSessionRename,
+    autoReview,
+  });
 
   const userLocalBin = process.env.HOME
     ? path.join(process.env.HOME, ".local/bin")
@@ -366,6 +404,33 @@ export function buildAgentCommand(
     }
     const escaped = passthroughArgs.map((arg) => shellEscape(arg)).join(" ");
     return `${envPrefix} ${shellEscape(cliBin)} ${escaped} ${flagParts}`;
+  }
+
+  if (type === "cursor") {
+    // MCP + guidance are handled via files written in the setup script
+    // (.cursor/mcp.json and .cursor/rules/dispatch.mdc), not CLI flags.
+    const flagParts: string[] = [];
+    if (fullAccess) {
+      flagParts.push("--force", "--approve-mcps");
+    }
+    if (resume && cliSessionId) {
+      flagParts.push("--resume", shellEscape(cliSessionId));
+    }
+    const cursorPromptParts = [appendedSystemPrompt, initialPrompt].filter(
+      Boolean
+    );
+    const startupPrompt = cursorPromptParts.join("\n\n");
+    if (passthroughArgs.length > 0) {
+      const escaped = passthroughArgs.map((arg) => shellEscape(arg)).join(" ");
+      flagParts.push(escaped);
+    }
+    if (startupPrompt) {
+      return `${envPrefix} ${shellEscape(cliBin)} ${flagParts.join(" ")} ${shellEscape(startupPrompt)}`.trim();
+    }
+    const flags = flagParts.join(" ");
+    return flags
+      ? `${envPrefix} ${shellEscape(cliBin)} ${flags}`
+      : `${envPrefix} ${shellEscape(cliBin)}`;
   }
 
   // Codex: positional arg — AGENTS.md is auto-loaded by Codex CLI and provides authority.

--- a/apps/server/src/agents/tmux/runtime.ts
+++ b/apps/server/src/agents/tmux/runtime.ts
@@ -15,7 +15,13 @@ const STOP_GRACE_MS = 1200;
 const PROCESS_INSPECT_TIMEOUT_MS = 800;
 
 /** Basenames the cwd resolver recognises as "the agent CLI" (worth pid-walking into). */
-const AGENT_CLI_BASENAMES = new Set(["claude", "codex", "opencode"]);
+const AGENT_CLI_BASENAMES = new Set([
+  "claude",
+  "codex",
+  "opencode",
+  "cursor",
+  "agent",
+]);
 
 // ── Path conventions (runtime-internal) ─────────────────────────────────
 //

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -317,11 +317,12 @@ export function generateSetupScript(
     );
 
     if (params.cursorRulesContent) {
+      const b64 = Buffer.from(params.cursorRulesContent, "utf-8").toString(
+        "base64"
+      );
       lines.push(
         `# --- Write Cursor rules file ---`,
-        `cat > "$EFFECTIVE_CWD/.cursor/rules/dispatch.mdc" <<'DISPATCH_RULES_EOF'`,
-        params.cursorRulesContent,
-        `DISPATCH_RULES_EOF`,
+        `echo ${shellEscape(b64)} | base64 -d > "$EFFECTIVE_CWD/.cursor/rules/dispatch.mdc"`,
         `ok "Wrote dispatch guidance to .cursor/rules/dispatch.mdc"`,
         ``
       );

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -20,6 +20,8 @@ export type SetupScriptParams = {
   agentName: string;
   agentCommand: string;
   jobRunId?: string;
+  /** For cursor agents: the .cursor/rules/dispatch.mdc content. */
+  cursorRulesContent?: string;
 };
 
 /**
@@ -291,6 +293,39 @@ export function generateSetupScript(
       `ok "Configured dispatch MCP in opencode.json"`,
       ``
     );
+  }
+
+  // Cursor: write .cursor/mcp.json (MCP server) and .cursor/rules/dispatch.mdc (guidance).
+  if (agentType === "cursor") {
+    const mcpUrl = dispatchMcpUrl(config, agentId, params.jobRunId);
+    const dispatchMcpToken = params.jobRunId
+      ? createJobMcpToken(authToken, params.jobRunId, agentId)
+      : createAgentMcpToken(authToken, agentId);
+    const mcpEntry = JSON.stringify({
+      type: "http",
+      url: mcpUrl,
+      headers: { Authorization: `Bearer ${dispatchMcpToken}` },
+    });
+    lines.push(
+      `# --- Configure Cursor MCP ---`,
+      `mkdir -p "$EFFECTIVE_CWD/.cursor/rules"`,
+      `CURSOR_MCP_CFG="$EFFECTIVE_CWD/.cursor/mcp.json"`,
+      `MCP_ENTRY=${shellEscape(mcpEntry)}`,
+      `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcpServers = { ...(cfg.mcpServers ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$CURSOR_MCP_CFG" "$MCP_ENTRY"`,
+      `ok "Configured dispatch MCP in .cursor/mcp.json"`,
+      ``
+    );
+
+    if (params.cursorRulesContent) {
+      lines.push(
+        `# --- Write Cursor rules file ---`,
+        `cat > "$EFFECTIVE_CWD/.cursor/rules/dispatch.mdc" <<'DISPATCH_RULES_EOF'`,
+        params.cursorRulesContent,
+        `DISPATCH_RULES_EOF`,
+        `ok "Wrote dispatch guidance to .cursor/rules/dispatch.mdc"`,
+        ``
+      );
+    }
   }
 
   lines.push(

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -308,7 +308,18 @@ export function generateSetupScript(
     });
     lines.push(
       `# --- Configure Cursor MCP ---`,
+      `# Guard against symlinked .cursor directory escaping the worktree.`,
+      `if [ -L "$EFFECTIVE_CWD/.cursor" ]; then`,
+      `  echo "ERROR: $EFFECTIVE_CWD/.cursor is a symlink — refusing to write config outside the worktree" >&2`,
+      `  exit 1`,
+      `fi`,
       `mkdir -p "$EFFECTIVE_CWD/.cursor/rules"`,
+      `CURSOR_REAL=$(cd "$EFFECTIVE_CWD/.cursor" && pwd -P)`,
+      `EFFECTIVE_REAL=$(cd "$EFFECTIVE_CWD" && pwd -P)`,
+      `case "$CURSOR_REAL" in "$EFFECTIVE_REAL"/*) ;; *)`,
+      `  echo "ERROR: .cursor resolved to $CURSOR_REAL which is outside $EFFECTIVE_REAL — refusing to write" >&2`,
+      `  exit 1`,
+      `esac`,
       `CURSOR_MCP_CFG="$EFFECTIVE_CWD/.cursor/mcp.json"`,
       `MCP_ENTRY=${shellEscape(mcpEntry)}`,
       `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcpServers = { ...(cfg.mcpServers ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$CURSOR_MCP_CFG" "$MCP_ENTRY"`,

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -349,5 +349,5 @@ export async function harvestTokenUsage(
   } else if (agent.type === "claude") {
     await harvestClaudeTokenUsage(pool, agent, logger);
   }
-  // opencode: no token tracking support yet
+  // opencode, cursor: no token tracking support yet
 }

--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -7,7 +7,7 @@ export type AgentStatus =
   | "error"
   | "unknown";
 
-export type AgentType = "codex" | "claude" | "opencode" | "terminal";
+export type AgentType = "codex" | "claude" | "opencode" | "cursor" | "terminal";
 
 export type AgentRole = "standard" | "assisted_update";
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -21,6 +21,7 @@ export type AppConfig = {
   codexBin: string;
   claudeBin: string;
   opencodeBin: string;
+  cursorBin: string;
   agentRuntime: "tmux" | "inert";
   sessionPrefix: string;
   tls: TlsConfig | null;
@@ -87,6 +88,8 @@ export function loadConfig(): AppConfig {
       process.env.DISPATCH_OPENCODE_BIN ??
       process.env.OPENCODE_BIN ??
       "opencode",
+    cursorBin:
+      process.env.DISPATCH_CURSOR_BIN ?? process.env.CURSOR_BIN ?? "agent",
     agentRuntime: resolveAgentRuntime(),
     sessionPrefix: process.env.DISPATCH_SESSION_PREFIX ?? "dispatch",
     tls: loadTls(),

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -24,7 +24,7 @@ export type JobRunStatus =
   | "needs_input"
   | "timed_out"
   | "crashed";
-export type JobAgentType = "claude" | "codex" | "opencode";
+export type JobAgentType = "claude" | "codex" | "opencode" | "cursor";
 
 export type JobRecord = {
   id: string;

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -9,6 +9,8 @@ import type { AgentManager, AgentRecord } from "../agents/manager.js";
 import type { DiffStatsRefresher } from "../agents/diff-stats-refresher.js";
 import { getCopyModeAssistEnabled } from "../copy-mode-assist-settings.js";
 import {
+  AGENT_TYPES,
+  type AgentType,
   CLI_AGENT_TYPES,
   getEnabledAgentTypes,
 } from "../agent-type-settings.js";
@@ -515,14 +517,10 @@ export async function registerAgentRoutes(
 
     if (
       body.type !== undefined &&
-      body.type !== "codex" &&
-      body.type !== "claude" &&
-      body.type !== "opencode" &&
-      body.type !== "terminal"
+      !AGENT_TYPES.includes(body.type as AgentType)
     ) {
       return reply.code(400).send({
-        error:
-          "type must be codex, claude, opencode, or terminal when provided.",
+        error: `type must be ${AGENT_TYPES.join(", ")} when provided.`,
       });
     }
 
@@ -559,14 +557,10 @@ export async function registerAgentRoutes(
       });
     }
 
-    const agentType =
-      body.type === "claude"
-        ? "claude"
-        : body.type === "opencode"
-          ? "opencode"
-          : body.type === "terminal"
-            ? "terminal"
-            : "codex";
+    const agentType: AgentType =
+      body.type && AGENT_TYPES.includes(body.type as AgentType)
+        ? (body.type as AgentType)
+        : "codex";
     const enabledAgentTypes = await getEnabledAgentTypes(deps.pool);
     if (!enabledAgentTypes.includes(agentType)) {
       return reply

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -140,7 +140,12 @@ export type JobTools = {
   }) => Promise<Record<string, unknown>>;
 };
 
-const LAUNCH_PERSONA_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+const LAUNCH_PERSONA_AGENT_TYPES = [
+  "codex",
+  "claude",
+  "opencode",
+  "cursor",
+] as const;
 type LaunchPersonaAgentType = (typeof LAUNCH_PERSONA_AGENT_TYPES)[number];
 
 // ── Tool sets per agent type ──────────────────────────────────────────

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -141,10 +141,10 @@ export type JobTools = {
 };
 
 const LAUNCH_PERSONA_AGENT_TYPES = [
-  "codex",
   "claude",
-  "opencode",
+  "codex",
   "cursor",
+  "opencode",
 ] as const;
 type LaunchPersonaAgentType = (typeof LAUNCH_PERSONA_AGENT_TYPES)[number];
 

--- a/apps/web/src/components/app/agent-type-icon.tsx
+++ b/apps/web/src/components/app/agent-type-icon.tsx
@@ -1,5 +1,5 @@
 import { Terminal as TerminalIcon } from "lucide-react";
-import { siClaude } from "simple-icons";
+import { siClaude, siCursor } from "simple-icons";
 
 import { cn } from "@/lib/utils";
 
@@ -25,12 +25,15 @@ const CODEX_LOGO_PATH =
 
 function normalizeAgentType(
   type?: string | null
-): "codex" | "claude" | "opencode" | "terminal" | "unknown" {
+): "codex" | "claude" | "opencode" | "cursor" | "terminal" | "unknown" {
   if (type === "claude") {
     return "claude";
   }
   if (type === "opencode") {
     return "opencode";
+  }
+  if (type === "cursor") {
+    return "cursor";
   }
   if (type === "terminal") {
     return "terminal";
@@ -52,9 +55,11 @@ export function AgentTypeIcon({
       ? "Claude"
       : normalizedType === "opencode"
         ? "OpenCode"
-        : normalizedType === "terminal"
-          ? "Terminal"
-          : "Codex";
+        : normalizedType === "cursor"
+          ? "Cursor"
+          : normalizedType === "terminal"
+            ? "Terminal"
+            : "Codex";
   const statusClass = eventType ? eventColorClass[eventType] : "";
   const baseClass = statusClass
     ? "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors duration-300"
@@ -90,9 +95,15 @@ export function AgentTypeIcon({
   }
 
   const logoPath =
-    normalizedType === "claude" ? siClaude.path : CODEX_LOGO_PATH;
+    normalizedType === "claude"
+      ? siClaude.path
+      : normalizedType === "cursor"
+        ? siCursor.path
+        : CODEX_LOGO_PATH;
   const viewBox =
-    normalizedType === "claude" ? "0 0 24 24" : "0 0 158.7128 157.296";
+    normalizedType === "claude" || normalizedType === "cursor"
+      ? "0 0 24 24"
+      : "0 0 158.7128 157.296";
 
   return (
     <span

--- a/apps/web/src/components/app/agent-type-settings.tsx
+++ b/apps/web/src/components/app/agent-type-settings.tsx
@@ -4,19 +4,67 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import {
-  AGENT_TYPES,
   AGENT_TYPE_LABELS,
   type AgentType,
+  CLI_AGENT_TYPES,
 } from "@/lib/agent-types";
 
 type AgentTypeSettingsResponse = {
   enabledAgentTypes: AgentType[];
 };
 
+const AGENT_TYPE_DESCRIPTIONS: Record<AgentType, string> = {
+  claude: "Claude Code CLI by Anthropic.",
+  codex: "Codex CLI by OpenAI.",
+  cursor: "Cursor Agent CLI by Anysphere.",
+  opencode: "OpenCode CLI — open-source terminal agent.",
+  terminal: "Raw shell session with no AI agent.",
+};
+
 type AgentTypeSettingsProps = {
   enabledAgentTypes: AgentType[];
   onChange: (agentTypes: AgentType[]) => void;
 };
+
+function AgentTypeRow({
+  agentType,
+  checked,
+  disabled,
+  onToggle,
+}: {
+  agentType: AgentType;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}): JSX.Element {
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors",
+        disabled
+          ? "cursor-not-allowed opacity-60"
+          : "cursor-pointer hover:bg-muted/50"
+      )}
+    >
+      <Checkbox
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onToggle}
+        data-testid={`agent-type-toggle-${agentType}`}
+      />
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground">
+          {AGENT_TYPE_LABELS[agentType]}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {disabled
+            ? "At least one type must stay enabled."
+            : AGENT_TYPE_DESCRIPTIONS[agentType]}
+        </div>
+      </div>
+    </label>
+  );
+}
 
 export function AgentTypeSettings({
   enabledAgentTypes,
@@ -110,38 +158,34 @@ export function AgentTypeSettings({
       </div>
 
       <div className="max-w-lg space-y-2">
-        {AGENT_TYPES.map((agentType) => {
+        {CLI_AGENT_TYPES.map((agentType) => {
           const checked = agentTypes.includes(agentType);
           const disabled = checked && agentTypes.length === 1;
           return (
-            <label
+            <AgentTypeRow
               key={agentType}
-              className={cn(
-                "flex items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors",
-                disabled
-                  ? "cursor-not-allowed opacity-60"
-                  : "cursor-pointer hover:bg-muted/50"
-              )}
-            >
-              <Checkbox
-                checked={checked}
-                disabled={disabled}
-                onCheckedChange={() => void toggleAgentType(agentType)}
-                data-testid={`agent-type-toggle-${agentType}`}
-              />
-              <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground">
-                  {AGENT_TYPE_LABELS[agentType]}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {disabled
-                    ? "At least one agent type must stay enabled."
-                    : "Available in the create-agent dialog."}
-                </div>
-              </div>
-            </label>
+              agentType={agentType}
+              checked={checked}
+              disabled={disabled}
+              onToggle={() => void toggleAgentType(agentType)}
+            />
           );
         })}
+      </div>
+
+      <div>
+        <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+          Other
+        </div>
+      </div>
+
+      <div className="max-w-lg space-y-2">
+        <AgentTypeRow
+          agentType="terminal"
+          checked={agentTypes.includes("terminal")}
+          disabled={agentTypes.includes("terminal") && agentTypes.length === 1}
+          onToggle={() => void toggleAgentType("terminal")}
+        />
       </div>
 
       {error ? <p className="text-sm text-destructive">{error}</p> : null}

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -51,7 +51,9 @@ type PersonaSummary = {
 function defaultReviewAgentType(agent: Agent): AgentType {
   return (
     agent.reviewAgentType ??
-    (agent.type === "claude" || agent.type === "opencode"
+    (agent.type === "claude" ||
+    agent.type === "opencode" ||
+    agent.type === "cursor"
       ? agent.type
       : "codex")
   );

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -51,7 +51,7 @@ export type Agent = {
   persona?: string | null;
   parentAgentId?: string | null;
   personaContext?: string | null;
-  reviewAgentType?: "codex" | "claude" | "opencode" | null;
+  reviewAgentType?: "codex" | "claude" | "opencode" | "cursor" | null;
   review?: {
     status: string;
     message: string | null;

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -10,7 +10,7 @@ export type JobRunStatus =
   | "needs_input"
   | "timed_out"
   | "crashed";
-export type JobAgentType = "claude" | "codex" | "opencode";
+export type JobAgentType = "claude" | "codex" | "opencode" | "cursor";
 export type JobRunTriggerSource = "manual" | "scheduled";
 
 export type JobNotifyConfig = {

--- a/apps/web/src/lib/agent-types.ts
+++ b/apps/web/src/lib/agent-types.ts
@@ -1,28 +1,28 @@
 export const AGENT_TYPES = [
-  "codex",
   "claude",
-  "opencode",
+  "codex",
   "cursor",
+  "opencode",
   "terminal",
 ] as const;
 
 export type AgentType = (typeof AGENT_TYPES)[number];
 
 export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
-  codex: "Codex",
   claude: "Claude",
-  opencode: "OpenCode",
+  codex: "Codex",
   cursor: "Cursor",
+  opencode: "OpenCode",
   terminal: "Terminal",
 };
 
 // Agent types that run an AI CLI — eligible for reviews, jobs, and personas.
 // Terminal agents are excluded because there's no CLI to drive them.
 export const CLI_AGENT_TYPES = [
-  "codex",
   "claude",
-  "opencode",
+  "codex",
   "cursor",
+  "opencode",
 ] as const;
 export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
 

--- a/apps/web/src/lib/agent-types.ts
+++ b/apps/web/src/lib/agent-types.ts
@@ -1,4 +1,10 @@
-export const AGENT_TYPES = ["codex", "claude", "opencode", "terminal"] as const;
+export const AGENT_TYPES = [
+  "codex",
+  "claude",
+  "opencode",
+  "cursor",
+  "terminal",
+] as const;
 
 export type AgentType = (typeof AGENT_TYPES)[number];
 
@@ -6,12 +12,18 @@ export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   codex: "Codex",
   claude: "Claude",
   opencode: "OpenCode",
+  cursor: "Cursor",
   terminal: "Terminal",
 };
 
 // Agent types that run an AI CLI — eligible for reviews, jobs, and personas.
 // Terminal agents are excluded because there's no CLI to drive them.
-export const CLI_AGENT_TYPES = ["codex", "claude", "opencode"] as const;
+export const CLI_AGENT_TYPES = [
+  "codex",
+  "claude",
+  "opencode",
+  "cursor",
+] as const;
 export type CliAgentType = (typeof CLI_AGENT_TYPES)[number];
 
 export function isCliAgentType(value: string): value is CliAgentType {

--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -23,25 +23,25 @@ test.describe("Create agent dialog", () => {
     const form = page.getByTestId("create-agent-form");
     await expect(form).toBeVisible();
 
-    // The type select should default to "Codex"
+    // The type select should default to "Claude" (first alphabetically)
     const typeTrigger = form.getByRole("combobox").first();
-    await expect(typeTrigger).toContainText("Codex");
+    await expect(typeTrigger).toContainText("Claude");
 
     // Click to open the dropdown
     await typeTrigger.click();
 
     // The dropdown options should be visible
-    const claudeOption = page.getByRole("option", { name: "Claude" });
-    await expect(claudeOption).toBeVisible({ timeout: 3_000 });
+    const codexOption = page.getByRole("option", { name: "Codex" });
+    await expect(codexOption).toBeVisible({ timeout: 3_000 });
     await expect(page.getByRole("option", { name: "OpenCode" })).toBeVisible({
       timeout: 3_000,
     });
 
-    // Select "Claude"
-    await claudeOption.click();
+    // Select "Codex"
+    await codexOption.click();
 
-    // The trigger should now show "Claude"
-    await expect(typeTrigger).toContainText("Claude");
+    // The trigger should now show "Codex"
+    await expect(typeTrigger).toContainText("Codex");
 
     // Close dialog
     await page.getByTestId("create-agent-cancel").click();


### PR DESCRIPTION
## Summary

- Adds `cursor` as a fourth CLI agent type alongside claude, codex, and opencode
- The Cursor CLI (`agent` binary) supports interactive terminal sessions, MCP via config file, session resume, and auto-approve flags
- MCP config is merge-written to `.cursor/mcp.json` in the worktree (preserves existing entries)
- Launch guidance + personality written to `.cursor/rules/dispatch.mdc` (Cursor auto-loads these)
- Refactored `buildLaunchGuidance()` out of `buildAgentCommand()` so both the command builder and setup script can reuse it
- Refactored route validation to use `AGENT_TYPES` const instead of hardcoded type checks
- Token harvesting stubbed — no known Cursor session log format yet

## Test plan

- [x] Type checking passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] 926 unit tests pass (`pnpm run test`)
- [x] 139 E2E tests pass (`pnpm run test:e2e`)
- [x] Live tested: created a Cursor agent in the UI, agent ran a session, used MCP tools, and opened a PR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)