### PR TITLE
Add agent templates — split quick-launch from job automation

### DIFF
--- a/.dispatch/personas/release-readiness-review.md
+++ b/.dispatch/personas/release-readiness-review.md
@@ -1,0 +1,66 @@
+---
+name: Release Readiness Review
+description: Reviews PRs for safe releasability — migration compatibility, rollback safety, deployment risk, and impact on running servers
+feedbackFormat: findings
+---
+
+# You are a Release Readiness Reviewer
+
+Your job is to assess whether a PR can be safely released to production. You are not reviewing code quality — other reviewers handle that. You focus on what happens when this code hits a running server: will migrations apply cleanly, can we roll back, will existing agents break, does the release need coordination or a maintenance window?
+
+## Focus Areas
+
+### Database Migrations
+
+- Are migrations additive (safe) or destructive (column drops, renames, NOT NULL on existing rows)?
+- Can the migration run while the server is handling traffic, or does it require downtime?
+- Does the migration lock large tables for extended periods?
+- Is the migration idempotent (safe to re-run if the deploy retries)?
+- If the release is rolled back, does the old code work with the new schema? (Forward-compatible schema changes are safe; breaking changes are not.)
+- Are there data migrations (DO blocks, UPDATE statements) that could fail on unexpected data or take a long time on large tables?
+- Is the migration number correct (no gaps, no conflicts with production)?
+
+### Rollback Safety
+
+- If we revert to the previous release after deploying, what breaks?
+- Are there new columns that old code doesn't know about? (Usually safe — old code ignores them.)
+- Are there removed or renamed columns that old code depends on? (Unsafe — old code will crash.)
+- Are there new API endpoints that clients may have already discovered? (Usually safe to remove on rollback.)
+- Are there changed API response shapes that existing clients depend on?
+
+### Running Server Impact
+
+- Will existing agent sessions break when the server restarts with this code?
+- Are there new required environment variables or config that must be set before deploy?
+- Does the release change the SSE event schema in ways that break connected clients?
+- Are there changes to the MCP tool contracts that running agents depend on?
+- Does the release change file paths, directory structures, or naming conventions that existing data depends on?
+
+### PR Size and Risk
+
+- Is the PR large enough that it should be split for safer incremental release?
+- Are there independent changes bundled together that could be released separately to reduce blast radius?
+- If the PR must ship as one unit, what is the minimum verification needed before considering it stable?
+
+### Assisted Update Considerations
+
+- Does this release need assisted update handling (new migrations, breaking changes, config requirements)?
+- If so, is `release-notes/next-assisted-update.json` present and correct?
+- Are there checks that the assisted update agent should run post-deploy?
+
+## Scope — IMPORTANT
+
+Your review MUST focus exclusively on the code that was changed in the diff. You may read surrounding code, migration history, and schema to understand context, but only provide feedback on release risks introduced by this change. Do not flag pre-existing deployment concerns unless this diff materially worsens them.
+
+- Do not review code quality, naming, architecture, or test coverage — those are handled by other reviewers.
+- Do not flag theoretical risks that require unlikely preconditions. Focus on realistic deployment scenarios.
+- If you find zero release risks, approve the review. A clean bill of release health is a valid outcome.
+
+## How to review
+
+1. Read the diff to understand the full scope of changes. Pay special attention to migration files, schema changes, API route changes, and SSE event changes.
+2. Check the migration files against the current schema. Read `apps/server/src/db/migrations/` to understand the migration sequence and verify numbering.
+3. Assess rollback safety: imagine reverting to the commit before this PR. What breaks?
+4. Assess runtime impact: imagine a running server with active agents restarting with this code. What changes?
+5. Submit findings via `dispatch_feedback` (see Feedback Guidelines below for severity levels and limits).
+6. **Only submit feedback for actual release risks.** Do not submit code quality observations. Every feedback item should identify a concrete deployment concern.

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1040,6 +1040,7 @@ export class AgentManager {
               cwd: agent.worktreePath,
               deleteBranch: dispatchOwnsBranch,
               force: true,
+              originalBranch: agent.worktreeBranch,
             });
             durations.worktreeCleanup = Date.now() - tCleanup;
             this.logger.info(

--- a/apps/server/src/db/migrations/0021_templates.sql
+++ b/apps/server/src/db/migrations/0021_templates.sql
@@ -1,0 +1,55 @@
+-- Templates: reusable agent launch configurations
+CREATE TABLE IF NOT EXISTS templates (
+  id TEXT PRIMARY KEY,
+  directory TEXT NOT NULL,
+  name TEXT NOT NULL,
+  prompt TEXT,
+  agent_type TEXT NOT NULL DEFAULT 'claude',
+  use_worktree BOOLEAN NOT NULL DEFAULT false,
+  base_branch TEXT,
+  branch_name TEXT,
+  full_access BOOLEAN NOT NULL DEFAULT false,
+  callable BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (directory, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_templates_directory ON templates(directory);
+CREATE INDEX IF NOT EXISTS idx_templates_callable ON templates(callable) WHERE callable = true;
+
+-- Link jobs to backing templates
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS template_id TEXT REFERENCES templates(id) ON DELETE SET NULL;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS default_args JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Migrate every existing job into a backing template.
+-- On-demand (no schedule) callable jobs -> callable template.
+-- Scheduled jobs -> hidden backing template (callable = false).
+DO $$
+DECLARE
+  rec RECORD;
+  tmpl_id TEXT;
+BEGIN
+  FOR rec IN SELECT * FROM jobs WHERE template_id IS NULL LOOP
+    tmpl_id := 'tmpl_' || REPLACE(rec.id::text, '-', '');
+
+    INSERT INTO templates (id, directory, name, prompt, agent_type, use_worktree, base_branch, branch_name, full_access, callable, created_at, updated_at)
+    VALUES (
+      tmpl_id,
+      rec.directory,
+      rec.name,
+      rec.prompt,
+      rec.agent_type,
+      rec.use_worktree,
+      rec.base_branch,
+      rec.branch_name,
+      rec.full_access,
+      CASE WHEN rec.schedule IS NULL THEN rec.callable ELSE false END,
+      rec.created_at,
+      rec.updated_at
+    )
+    ON CONFLICT (directory, name) DO NOTHING;
+
+    UPDATE jobs SET template_id = tmpl_id WHERE id = rec.id AND template_id IS NULL;
+  END LOOP;
+END $$;

--- a/apps/server/src/db/migrations/0021_templates.sql
+++ b/apps/server/src/db/migrations/0021_templates.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS templates (
   id TEXT PRIMARY KEY,
   directory TEXT NOT NULL,
   name TEXT NOT NULL,
+  description TEXT,
   prompt TEXT,
   agent_type TEXT NOT NULL DEFAULT 'claude',
   use_worktree BOOLEAN NOT NULL DEFAULT false,

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -6,6 +6,7 @@ import { Cron } from "croner";
 
 import type { AgentManager } from "../agents/manager.js";
 import type { AppConfig } from "../config.js";
+import { sanitizeAgentName } from "../shared/lib/agent-strings.js";
 import { runCommand } from "../shared/lib/run-command.js";
 import {
   JobStore,
@@ -269,7 +270,8 @@ export class JobService {
       );
     }
 
-    // Create a backing template for this job (hidden from Cmd+K by default)
+    // Create a backing template for this job (hidden from Cmd+K by default).
+    // If job creation fails, clean up the template to avoid orphans.
     const template = await this.templateStore.createTemplate({
       name: displayName,
       directory: input.directory,
@@ -283,26 +285,39 @@ export class JobService {
       callable: false,
     });
 
-    const job = await this.store.createJob({
-      name: displayName,
-      directory: input.directory,
-      prompt: input.prompt ?? null,
-      schedule,
-      timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-      needsInputTimeoutMs:
-        input.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
-      agentType: input.agentType ?? "claude",
-      useWorktree: input.useWorktree ?? false,
-      baseBranch: input.baseBranch ?? null,
-      branchName: input.branchName ?? null,
-      fullAccess: input.fullAccess ?? false,
-      autoArchive: input.autoArchive ?? true,
-      callable: input.callable ?? false,
-      singleton: input.singleton ?? true,
-      templateId: template.id,
-      defaultArgs: {},
-      enabled: input.enabled ?? false,
-    });
+    let job: JobRecord;
+    try {
+      job = await this.store.createJob({
+        name: displayName,
+        directory: input.directory,
+        prompt: input.prompt ?? null,
+        schedule,
+        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        needsInputTimeoutMs:
+          input.needsInputTimeoutMs ?? DEFAULT_NEEDS_INPUT_TIMEOUT_MS,
+        agentType: input.agentType ?? "claude",
+        useWorktree: input.useWorktree ?? false,
+        baseBranch: input.baseBranch ?? null,
+        branchName: input.branchName ?? null,
+        fullAccess: input.fullAccess ?? false,
+        autoArchive: input.autoArchive ?? true,
+        callable: input.callable ?? false,
+        singleton: input.singleton ?? true,
+        templateId: template.id,
+        defaultArgs: {},
+        enabled: input.enabled ?? false,
+      });
+    } catch (error) {
+      await this.templateStore
+        .deleteTemplate(template.id)
+        .catch((cleanupErr) =>
+          this.logger.warn(
+            { templateId: template.id, error: cleanupErr },
+            "Failed to clean up orphaned template after job creation failure"
+          )
+        );
+      throw error;
+    }
 
     if (job.enabled && job.schedule) {
       this.scheduleJob(job);
@@ -850,10 +865,6 @@ function buildJobPrompt(job: JobRecord, runId: string): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function sanitizeAgentName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 60);
 }
 
 function normalizeOptionalString(

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -16,6 +16,11 @@ import {
   type JobWithLatestRun,
 } from "./store.js";
 import {
+  TemplateStore,
+  substituteArgs,
+  type TemplateRecord,
+} from "../templates/store.js";
+import {
   getNextRun,
   validateCronExpression,
   validateCronInterval,
@@ -46,6 +51,7 @@ export type AddJobInput = {
   autoArchive?: boolean;
   callable?: boolean;
   singleton?: boolean;
+  defaultArgs?: Record<string, string>;
   enabled?: boolean;
 };
 
@@ -75,6 +81,7 @@ const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 
 export class JobService {
   private readonly store: JobStore;
+  private readonly templateStore: TemplateStore;
   private readonly monitors = new Map<string, Promise<JobRunRecord>>();
   private readonly schedulers = new Map<string, Cron>();
   private readonly onRunStateChangeCallbacks: JobRunCallback[] = [];
@@ -87,6 +94,7 @@ export class JobService {
     private readonly config: AppConfig
   ) {
     this.store = new JobStore(pool);
+    this.templateStore = new TemplateStore(pool);
   }
 
   /** Register a callback that fires when a job run reaches a notable state. */
@@ -110,10 +118,28 @@ export class JobService {
   async runJob(input: RunJobInput): Promise<RunJobResult> {
     const job = await this.getJobOrThrow(input.directory, input.name);
 
-    if (!job.prompt) {
+    // Resolve agent config from backing template (fallback to job for legacy rows)
+    const template = job.templateId
+      ? await this.templateStore.getTemplate(job.templateId)
+      : null;
+    const agentConfig = template ?? job;
+
+    const rawPrompt = agentConfig.prompt;
+    if (!rawPrompt) {
       throw new Error(
         `Job "${job.name}" has no prompt configured. Add a prompt in the job settings.`
       );
+    }
+
+    // Substitute default args into prompt if the template has placeholders
+    let resolvedPrompt: string;
+    try {
+      resolvedPrompt =
+        template && Object.keys(job.defaultArgs).length > 0
+          ? substituteArgs(rawPrompt, job.defaultArgs)
+          : rawPrompt;
+    } catch {
+      resolvedPrompt = rawPrompt;
     }
 
     if (job.singleton) {
@@ -125,24 +151,29 @@ export class JobService {
       }
     }
 
-    // Everything below reads from the DB record only
     let run = await this.store.createRun(
       job.id,
       buildRunConfig(job, input.triggerSource ?? "manual")
     );
     this.emitRunStateChange(run);
-    const prompt = buildJobPrompt(job, run.id);
+
+    const jobLikeForPrompt = { ...job, prompt: resolvedPrompt };
+    const prompt = buildJobPrompt(jobLikeForPrompt, run.id);
 
     try {
       const agent = await this.agentManager.createAgent({
         name: `job-${sanitizeAgentName(job.name)}-${run.id.slice(0, 8)}`,
-        type: job.agentType,
+        type: agentConfig.agentType,
         cwd: job.directory,
-        agentArgs: buildAgentArgs(job.agentType, prompt, job.fullAccess),
-        fullAccess: job.fullAccess,
-        useWorktree: job.useWorktree,
-        baseBranch: job.baseBranch ?? undefined,
-        worktreeBranch: job.branchName ?? undefined,
+        agentArgs: buildAgentArgs(
+          agentConfig.agentType,
+          prompt,
+          agentConfig.fullAccess
+        ),
+        fullAccess: agentConfig.fullAccess,
+        useWorktree: agentConfig.useWorktree,
+        baseBranch: agentConfig.baseBranch ?? undefined,
+        worktreeBranch: agentConfig.branchName ?? undefined,
         jobRunId: run.id,
       });
       run = await this.store.attachAgent(run.id, agent.id);
@@ -238,6 +269,19 @@ export class JobService {
       );
     }
 
+    // Create a backing template for this job (hidden from Cmd+K by default)
+    const template = await this.templateStore.createTemplate({
+      name: displayName,
+      directory: input.directory,
+      prompt: input.prompt ?? null,
+      agentType: input.agentType ?? "claude",
+      useWorktree: input.useWorktree ?? false,
+      baseBranch: input.baseBranch ?? null,
+      branchName: input.branchName ?? null,
+      fullAccess: input.fullAccess ?? false,
+      callable: false,
+    });
+
     const job = await this.store.createJob({
       name: displayName,
       directory: input.directory,
@@ -254,6 +298,8 @@ export class JobService {
       autoArchive: input.autoArchive ?? true,
       callable: input.callable ?? false,
       singleton: input.singleton ?? true,
+      templateId: template.id,
+      defaultArgs: {},
       enabled: input.enabled ?? false,
     });
 
@@ -313,6 +359,39 @@ export class JobService {
     if (input.enabled !== undefined) config.enabled = input.enabled;
 
     const updated = await this.store.updateJobConfig(existing.id, config);
+
+    // Propagate agent-config changes to the backing template
+    if (updated.templateId) {
+      const templateUpdates: Record<string, unknown> = {};
+      if (input.prompt !== undefined) templateUpdates.prompt = input.prompt;
+      if (input.agentType !== undefined)
+        templateUpdates.agentType = input.agentType;
+      if (input.useWorktree !== undefined)
+        templateUpdates.useWorktree = input.useWorktree;
+      if (input.baseBranch !== undefined)
+        templateUpdates.baseBranch = input.baseBranch;
+      if (input.branchName !== undefined)
+        templateUpdates.branchName = input.branchName;
+      if (input.fullAccess !== undefined)
+        templateUpdates.fullAccess = input.fullAccess;
+      if (displayName !== undefined && displayName !== existing.name) {
+        templateUpdates.name = displayName;
+      }
+      if (Object.keys(templateUpdates).length > 0) {
+        await this.templateStore
+          .updateTemplate(
+            updated.templateId,
+            templateUpdates as Parameters<TemplateStore["updateTemplate"]>[1]
+          )
+          .catch((err) => {
+            this.logger.warn(
+              { err, templateId: updated.templateId },
+              "Failed to propagate update to backing template"
+            );
+          });
+      }
+    }
+
     if (updated.enabled && updated.schedule) {
       this.scheduleJob(updated);
     } else {
@@ -379,6 +458,24 @@ export class JobService {
     }
     this.stopScheduler(job.id);
     const removed = await this.store.deleteJob(job.id);
+
+    // Clean up the backing template if no other jobs reference it
+    if (removed.templateId) {
+      const hasOtherJobs = await this.templateStore.hasJobsReferencing(
+        removed.templateId
+      );
+      if (!hasOtherJobs) {
+        await this.templateStore
+          .deleteTemplate(removed.templateId)
+          .catch((err) => {
+            this.logger.warn(
+              { err, templateId: removed.templateId },
+              "Failed to clean up backing template"
+            );
+          });
+      }
+    }
+
     this.logger.info(
       { jobId: removed.id, name: removed.name },
       "Job removed from configuration"

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -273,6 +273,7 @@ export class JobService {
     const template = await this.templateStore.createTemplate({
       name: displayName,
       directory: input.directory,
+      description: null,
       prompt: input.prompt ?? null,
       agentType: input.agentType ?? "claude",
       useWorktree: input.useWorktree ?? false,

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -44,6 +44,8 @@ export type JobRecord = {
   autoArchive: boolean;
   callable: boolean;
   singleton: boolean;
+  templateId: string | null;
+  defaultArgs: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 };
@@ -103,6 +105,8 @@ export type JobConfigUpdate = {
   autoArchive?: boolean;
   callable?: boolean;
   singleton?: boolean;
+  templateId?: string | null;
+  defaultArgs?: Record<string, string>;
   enabled?: boolean;
 };
 
@@ -124,14 +128,16 @@ export class JobStore {
     autoArchive: boolean;
     callable: boolean;
     singleton: boolean;
+    templateId?: string | null;
+    defaultArgs?: Record<string, string>;
     enabled: boolean;
   }): Promise<JobRecord> {
     const id = randomUUID();
     try {
       const result = await this.pool.query(
         `
-        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, base_branch, branch_name, auto_archive, callable, singleton, enabled)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, base_branch, branch_name, auto_archive, callable, singleton, template_id, default_args, enabled)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb, $18)
         RETURNING ${this.jobColumns()}
         `,
         [
@@ -150,6 +156,8 @@ export class JobStore {
           input.autoArchive,
           input.callable,
           input.singleton,
+          input.templateId ?? null,
+          JSON.stringify(input.defaultArgs ?? {}),
           input.enabled,
         ]
       );
@@ -383,6 +391,8 @@ export class JobStore {
         j.auto_archive AS "autoArchive",
         j.callable,
         j.singleton,
+        j.template_id AS "templateId",
+        j.default_args AS "defaultArgs",
         j.created_at AS "createdAt",
         j.updated_at AS "updatedAt",
         lr.id AS "lastRunId",
@@ -557,6 +567,8 @@ export class JobStore {
             auto_archive = COALESCE($17, auto_archive),
             callable = COALESCE($18, callable),
             singleton = COALESCE($19, singleton),
+            template_id = CASE WHEN $20 THEN $21 ELSE template_id END,
+            default_args = CASE WHEN $22 THEN $23::jsonb ELSE default_args END,
             updated_at = NOW()
         WHERE id = $1
         RETURNING ${this.jobColumns()}
@@ -581,6 +593,10 @@ export class JobStore {
           input.autoArchive,
           input.callable,
           input.singleton,
+          Object.prototype.hasOwnProperty.call(input, "templateId"),
+          input.templateId ?? null,
+          Object.prototype.hasOwnProperty.call(input, "defaultArgs"),
+          input.defaultArgs ? JSON.stringify(input.defaultArgs) : "{}",
         ]
       );
       if (!result.rows[0]) throw new Error(`Job ${jobId} not found.`);
@@ -665,6 +681,8 @@ export class JobStore {
       auto_archive AS "autoArchive",
       callable,
       singleton,
+      template_id AS "templateId",
+      default_args AS "defaultArgs",
       created_at AS "createdAt",
       updated_at AS "updatedAt"
     `;

--- a/apps/server/src/routes/jobs.ts
+++ b/apps/server/src/routes/jobs.ts
@@ -34,6 +34,7 @@ const AddJobBodySchema = JobEnableDisableBodySchema.extend({
   autoArchive: z.boolean().optional(),
   callable: z.boolean().optional(),
   singleton: z.boolean().optional(),
+  defaultArgs: z.record(z.string(), z.string()).optional(),
   enabled: z.boolean().optional(),
 });
 const JobHistoryParamsSchema = z.object({

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -1,0 +1,148 @@
+import os from "node:os";
+import path from "node:path";
+
+import type { FastifyInstance } from "fastify";
+import * as z from "zod/v4";
+
+import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
+import type { TemplateService } from "../templates/service.js";
+import { parseTemplateArgs } from "../templates/store.js";
+
+const directoryField = z
+  .string()
+  .min(1, "Template directory is required.")
+  .transform(resolveTilde);
+
+const AddTemplateBodySchema = z.object({
+  name: z.string().min(1, "Template name is required."),
+  directory: directoryField,
+  prompt: z.string().nullable().optional(),
+  agentType: z.enum(CLI_AGENT_TYPES).optional(),
+  useWorktree: z.boolean().optional(),
+  baseBranch: z.string().nullable().optional(),
+  branchName: z.string().nullable().optional(),
+  fullAccess: z.boolean().optional(),
+  callable: z.boolean().optional(),
+});
+
+const UpdateTemplateBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  prompt: z.string().nullable().optional(),
+  agentType: z.enum(CLI_AGENT_TYPES).optional(),
+  useWorktree: z.boolean().optional(),
+  baseBranch: z.string().nullable().optional(),
+  branchName: z.string().nullable().optional(),
+  fullAccess: z.boolean().optional(),
+  callable: z.boolean().optional(),
+});
+
+const LaunchBodySchema = z.object({
+  args: z.record(z.string(), z.string()).optional(),
+  directory: directoryField.optional(),
+});
+
+function resolveTilde(value: string): string {
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  if (value === "~") return os.homedir();
+  return value;
+}
+
+type TemplateRouteDeps = {
+  templateService: TemplateService;
+  publishUiEvent: (event: unknown) => void;
+};
+
+export async function registerTemplateRoutes(
+  app: FastifyInstance,
+  deps: TemplateRouteDeps
+): Promise<void> {
+  app.get("/api/v1/templates", async () => {
+    return await deps.templateService.listTemplates();
+  });
+
+  app.get<{ Params: { id: string } }>(
+    "/api/v1/templates/:id",
+    async (request, reply) => {
+      const template = await deps.templateService.getTemplate(
+        request.params.id
+      );
+      if (!template) {
+        return reply.code(404).send({ error: "Template not found." });
+      }
+      const args = template.prompt ? parseTemplateArgs(template.prompt) : [];
+      return { ...template, args };
+    }
+  );
+
+  app.post("/api/v1/templates", async (request, reply) => {
+    const parsed = AddTemplateBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0].message });
+    }
+    try {
+      const result = await deps.templateService.addTemplate(parsed.data);
+      deps.publishUiEvent({ type: "template.changed" });
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  app.patch<{ Params: { id: string } }>(
+    "/api/v1/templates/:id",
+    async (request, reply) => {
+      const parsed = UpdateTemplateBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues[0].message });
+      }
+      try {
+        const result = await deps.templateService.updateTemplate(
+          request.params.id,
+          parsed.data
+        );
+        deps.publishUiEvent({ type: "template.changed" });
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return reply.code(500).send({ error: message });
+      }
+    }
+  );
+
+  app.delete<{ Params: { id: string } }>(
+    "/api/v1/templates/:id",
+    async (request, reply) => {
+      try {
+        const result = await deps.templateService.removeTemplate(
+          request.params.id
+        );
+        deps.publishUiEvent({ type: "template.changed" });
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return reply.code(500).send({ error: message });
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    "/api/v1/templates/:id/launch",
+    async (request, reply) => {
+      const parsed = LaunchBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues[0].message });
+      }
+      try {
+        const result = await deps.templateService.launchTemplate({
+          templateId: request.params.id,
+          ...parsed.data,
+        });
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return reply.code(500).send({ error: message });
+      }
+    }
+  );
+}

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -16,6 +16,7 @@ const directoryField = z
 const AddTemplateBodySchema = z.object({
   name: z.string().min(1, "Template name is required."),
   directory: directoryField,
+  description: z.string().nullable().optional(),
   prompt: z.string().nullable().optional(),
   agentType: z.enum(CLI_AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
@@ -27,6 +28,8 @@ const AddTemplateBodySchema = z.object({
 
 const UpdateTemplateBodySchema = z.object({
   name: z.string().min(1).optional(),
+  directory: directoryField.optional(),
+  description: z.string().nullable().optional(),
   prompt: z.string().nullable().optional(),
   agentType: z.enum(CLI_AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
@@ -138,7 +141,11 @@ export async function registerTemplateRoutes(
           templateId: request.params.id,
           ...parsed.data,
         });
-        return result;
+        deps.publishUiEvent({
+          type: "agent.upsert",
+          agent: result.agent,
+        });
+        return { agent: result.agent };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return reply.code(500).send({ error: message });

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -50,6 +50,15 @@ function resolveTilde(value: string): string {
   return value;
 }
 
+function classifyErrorCode(message: string): number {
+  if (message.includes("not found")) return 404;
+  if (message.includes("already exists") || message.includes("referenced by"))
+    return 409;
+  if (message.includes("Missing required") || message.includes("no prompt"))
+    return 400;
+  return 500;
+}
+
 type TemplateRouteDeps = {
   templateService: TemplateService;
   publishUiEvent: (event: unknown) => void;
@@ -88,7 +97,7 @@ export async function registerTemplateRoutes(
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      return reply.code(500).send({ error: message });
+      return reply.code(classifyErrorCode(message)).send({ error: message });
     }
   });
 
@@ -108,7 +117,7 @@ export async function registerTemplateRoutes(
         return result;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return reply.code(500).send({ error: message });
+        return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }
   );
@@ -124,13 +133,7 @@ export async function registerTemplateRoutes(
         return result;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        if (message.includes("not found")) {
-          return reply.code(404).send({ error: message });
-        }
-        if (message.includes("referenced by")) {
-          return reply.code(409).send({ error: message });
-        }
-        return reply.code(500).send({ error: message });
+        return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }
   );
@@ -154,7 +157,7 @@ export async function registerTemplateRoutes(
         return { agent: result.agent };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return reply.code(500).send({ error: message });
+        return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }
   );

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -124,6 +124,12 @@ export async function registerTemplateRoutes(
         return result;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("not found")) {
+          return reply.code(404).send({ error: message });
+        }
+        if (message.includes("referenced by")) {
+          return reply.code(409).send({ error: message });
+        }
         return reply.code(500).send({ error: message });
       }
     }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -89,6 +89,7 @@ import { CopyModeAssistManager } from "./terminal/copy-mode-assist-manager.js";
 import { TerminalTokenStore } from "./terminal/token-store.js";
 import { AGENT_TYPES, setEnabledAgentTypes } from "./agent-type-settings.js";
 import { JobService } from "./jobs/service.js";
+import { TemplateService } from "./templates/service.js";
 import { ReleaseLogStreamProcessor } from "./release-log-stream.js";
 import {
   packageVersion,
@@ -100,6 +101,7 @@ import { MAX_STARTUP_FILE_COUNT } from "./routes/agent-startup.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerFeedbackRoutes } from "./routes/feedback.js";
 import { registerJobRoutes } from "./routes/jobs.js";
+import { registerTemplateRoutes } from "./routes/templates.js";
 import { registerMediaRoutes } from "./routes/media.js";
 import { registerMcpRoutes } from "./routes/mcp.js";
 import { registerPersonaReviewRoutes } from "./routes/persona-reviews.js";
@@ -169,6 +171,7 @@ const copyModeObserverManager = new CopyModeObserverManager((event) =>
 );
 const copyModeAssistManager = new CopyModeAssistManager();
 const jobService = new JobService(pool, agentManager, app.log, config);
+const templateService = new TemplateService(pool, agentManager, app.log);
 const jobNotifier = new JobNotifier(pool, app.log);
 const streamManager = new StreamManager(
   (agentId, event) => {
@@ -423,6 +426,11 @@ async function registerRoutes() {
 
   await registerJobRoutes(app, {
     jobService,
+    publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
+  });
+
+  await registerTemplateRoutes(app, {
+    templateService,
     publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
   });
 

--- a/apps/server/src/server/ui-events.ts
+++ b/apps/server/src/server/ui-events.ts
@@ -32,6 +32,7 @@ export type UiEvent =
       feedback: FeedbackRecord;
     }
   | { type: "job.changed" }
+  | { type: "template.changed" }
   | {
       type: "notification";
       notificationId: string;

--- a/apps/server/src/shared/git/worktree.ts
+++ b/apps/server/src/shared/git/worktree.ts
@@ -63,6 +63,11 @@ export type CleanupGitWorktreeInput = {
   updateBaseBranch?: boolean;
   deleteBranch?: boolean;
   force?: boolean;
+  /** The branch originally created for this worktree (from DB). If the agent
+   *  switched branches, this may differ from the current HEAD branch. When set
+   *  and different from the current branch, cleanup will also delete it — but
+   *  only if it has no commits beyond its upstream (no work to lose). */
+  originalBranch?: string | null;
 };
 
 export type CleanupGitWorktreeResult = {
@@ -263,6 +268,52 @@ export async function cleanupGitWorktree(
       branchName,
     ]);
     deletedBranch = true;
+  }
+
+  // If the agent switched branches, the originally-created worktree branch
+  // is still sitting around. Delete it too, but only if it has zero commits
+  // ahead of its upstream so we never destroy actual work.
+  const originalBranch = input.originalBranch?.trim() || null;
+  if (
+    originalBranch &&
+    originalBranch !== branchName &&
+    (input.deleteBranch ?? false)
+  ) {
+    const exists = await commandRunner(
+      "git",
+      [
+        "-C",
+        repoRoot,
+        "show-ref",
+        "--verify",
+        "--quiet",
+        `refs/heads/${originalBranch}`,
+      ],
+      { allowedExitCodes: [0, 1] }
+    );
+    if (exists.exitCode === 0) {
+      const ahead = await commandRunner(
+        "git",
+        [
+          "-C",
+          repoRoot,
+          "rev-list",
+          "--count",
+          `${originalBranch}@{upstream}..${originalBranch}`,
+        ],
+        { allowedExitCodes: [0, 128] }
+      );
+      const commitCount = parseInt(ahead.stdout || "0", 10);
+      if (ahead.exitCode === 0 && commitCount === 0) {
+        await commandRunner("git", [
+          "-C",
+          repoRoot,
+          "branch",
+          "-d",
+          originalBranch,
+        ]);
+      }
+    }
   }
 
   return {

--- a/apps/server/src/shared/lib/agent-strings.ts
+++ b/apps/server/src/shared/lib/agent-strings.ts
@@ -21,3 +21,7 @@ export function sanitizeAgentString(s: string | undefined): string | undefined {
     ? stripped.slice(0, MAX_NOTE_BYTES)
     : stripped;
 }
+
+export function sanitizeAgentName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 60);
+}

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -4,6 +4,7 @@ import type { Pool } from "pg";
 import type { AgentManager } from "../agents/manager.js";
 import type { AgentRecord } from "../agents/types.js";
 import type { JobAgentType } from "../jobs/store.js";
+import { sanitizeAgentName } from "../shared/lib/agent-strings.js";
 import {
   TemplateStore,
   parseTemplateArgs,
@@ -175,8 +176,4 @@ export class TemplateService {
       templateName: template.name,
     };
   }
-}
-
-function sanitizeAgentName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 60);
 }

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -141,7 +141,7 @@ export class TemplateService {
     }
 
     const initialPins = parsedArgs
-      .filter((a) => args[a.key] || args[a.name])
+      .filter((a) => args[a.key] != null || args[a.name] != null)
       .map((a) => ({
         label: a.name,
         value: args[a.key] ?? args[a.name],

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -1,0 +1,176 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import type { AgentManager } from "../agents/manager.js";
+import type { JobAgentType } from "../jobs/store.js";
+import {
+  TemplateStore,
+  parseTemplateArgs,
+  substituteArgs,
+  type TemplateRecord,
+} from "./store.js";
+
+export type AddTemplateInput = {
+  name: string;
+  directory: string;
+  prompt?: string | null;
+  agentType?: JobAgentType;
+  useWorktree?: boolean;
+  baseBranch?: string | null;
+  branchName?: string | null;
+  fullAccess?: boolean;
+  callable?: boolean;
+};
+
+export type LaunchTemplateInput = {
+  templateId: string;
+  args?: Record<string, string>;
+  directory?: string;
+};
+
+export type LaunchResult = {
+  agentId: string;
+  templateId: string;
+  templateName: string;
+};
+
+export class TemplateService {
+  readonly store: TemplateStore;
+
+  constructor(
+    pool: Pool,
+    private readonly agentManager: AgentManager,
+    private readonly logger: FastifyBaseLogger
+  ) {
+    this.store = new TemplateStore(pool);
+  }
+
+  async addTemplate(input: AddTemplateInput): Promise<TemplateRecord> {
+    const template = await this.store.createTemplate({
+      name: input.name.trim(),
+      directory: input.directory,
+      prompt: input.prompt ?? null,
+      agentType: input.agentType ?? "claude",
+      useWorktree: input.useWorktree ?? false,
+      baseBranch: input.baseBranch ?? null,
+      branchName: input.branchName ?? null,
+      fullAccess: input.fullAccess ?? false,
+      callable: input.callable ?? true,
+    });
+    this.logger.info(
+      { templateId: template.id, name: template.name },
+      "Template added"
+    );
+    return template;
+  }
+
+  async updateTemplate(
+    id: string,
+    input: Partial<AddTemplateInput>
+  ): Promise<TemplateRecord> {
+    const updates: Parameters<TemplateStore["updateTemplate"]>[1] = {};
+    if (input.name !== undefined) updates.name = input.name.trim();
+    if (input.prompt !== undefined) updates.prompt = input.prompt;
+    if (input.agentType !== undefined) updates.agentType = input.agentType;
+    if (input.useWorktree !== undefined)
+      updates.useWorktree = input.useWorktree;
+    if (input.baseBranch !== undefined) updates.baseBranch = input.baseBranch;
+    if (input.branchName !== undefined) updates.branchName = input.branchName;
+    if (input.fullAccess !== undefined) updates.fullAccess = input.fullAccess;
+    if (input.callable !== undefined) updates.callable = input.callable;
+
+    const updated = await this.store.updateTemplate(id, updates);
+    this.logger.info(
+      { templateId: updated.id, name: updated.name },
+      "Template updated"
+    );
+    return updated;
+  }
+
+  async removeTemplate(id: string): Promise<TemplateRecord> {
+    const hasJobs = await this.store.hasJobsReferencing(id);
+    if (hasJobs) {
+      throw new Error(
+        `Cannot delete template — it is referenced by one or more jobs. Delete the jobs first.`
+      );
+    }
+    const removed = await this.store.deleteTemplate(id);
+    this.logger.info(
+      { templateId: removed.id, name: removed.name },
+      "Template removed"
+    );
+    return removed;
+  }
+
+  async listTemplates(filter?: {
+    callable?: boolean;
+  }): Promise<TemplateRecord[]> {
+    return await this.store.listTemplates(filter);
+  }
+
+  async getTemplate(id: string): Promise<TemplateRecord | null> {
+    return await this.store.getTemplate(id);
+  }
+
+  async launchTemplate(input: LaunchTemplateInput): Promise<LaunchResult> {
+    const template = await this.store.getTemplate(input.templateId);
+    if (!template) {
+      throw new Error(`Template ${input.templateId} not found.`);
+    }
+    if (!template.prompt) {
+      throw new Error(
+        `Template "${template.name}" has no prompt configured. Add a prompt before launching.`
+      );
+    }
+
+    const parsedArgs = parseTemplateArgs(template.prompt);
+    const args = input.args ?? {};
+
+    let finalPrompt: string;
+    if (parsedArgs.length > 0) {
+      finalPrompt = substituteArgs(template.prompt, args);
+    } else {
+      finalPrompt = template.prompt;
+    }
+
+    const initialPins = parsedArgs
+      .filter((a) => args[a.key] || args[a.name])
+      .map((a) => ({
+        label: a.name,
+        value: args[a.key] ?? args[a.name],
+        type: "string" as const,
+      }));
+
+    const cwd = input.directory ?? template.directory;
+    const agent = await this.agentManager.createAgent({
+      name: sanitizeAgentName(template.name),
+      type: template.agentType,
+      cwd,
+      initialPrompt: finalPrompt,
+      fullAccess: template.fullAccess,
+      useWorktree: template.useWorktree,
+      baseBranch: template.baseBranch ?? undefined,
+      worktreeBranch: template.branchName ?? undefined,
+      initialPins,
+    });
+
+    this.logger.info(
+      {
+        templateId: template.id,
+        templateName: template.name,
+        agentId: agent.id,
+      },
+      "Template launched"
+    );
+
+    return {
+      agentId: agent.id,
+      templateId: template.id,
+      templateName: template.name,
+    };
+  }
+}
+
+function sanitizeAgentName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 60);
+}

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -2,6 +2,7 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Pool } from "pg";
 
 import type { AgentManager } from "../agents/manager.js";
+import type { AgentRecord } from "../agents/types.js";
 import type { JobAgentType } from "../jobs/store.js";
 import {
   TemplateStore,
@@ -13,6 +14,7 @@ import {
 export type AddTemplateInput = {
   name: string;
   directory: string;
+  description?: string | null;
   prompt?: string | null;
   agentType?: JobAgentType;
   useWorktree?: boolean;
@@ -29,7 +31,7 @@ export type LaunchTemplateInput = {
 };
 
 export type LaunchResult = {
-  agentId: string;
+  agent: AgentRecord;
   templateId: string;
   templateName: string;
 };
@@ -49,6 +51,7 @@ export class TemplateService {
     const template = await this.store.createTemplate({
       name: input.name.trim(),
       directory: input.directory,
+      description: input.description ?? null,
       prompt: input.prompt ?? null,
       agentType: input.agentType ?? "claude",
       useWorktree: input.useWorktree ?? false,
@@ -70,6 +73,9 @@ export class TemplateService {
   ): Promise<TemplateRecord> {
     const updates: Parameters<TemplateStore["updateTemplate"]>[1] = {};
     if (input.name !== undefined) updates.name = input.name.trim();
+    if (input.description !== undefined)
+      updates.description = input.description;
+    if (input.directory !== undefined) updates.directory = input.directory;
     if (input.prompt !== undefined) updates.prompt = input.prompt;
     if (input.agentType !== undefined) updates.agentType = input.agentType;
     if (input.useWorktree !== undefined)
@@ -164,7 +170,7 @@ export class TemplateService {
     );
 
     return {
-      agentId: agent.id,
+      agent,
       templateId: template.id,
       templateName: template.name,
     };

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import type { Pool } from "pg";
+
+import type { JobAgentType } from "../jobs/store.js";
+
+export type TemplateRecord = {
+  id: string;
+  directory: string;
+  name: string;
+  prompt: string | null;
+  agentType: JobAgentType;
+  useWorktree: boolean;
+  baseBranch: string | null;
+  branchName: string | null;
+  fullAccess: boolean;
+  callable: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TemplateConfigUpdate = {
+  name?: string;
+  prompt?: string | null;
+  agentType?: JobAgentType;
+  useWorktree?: boolean;
+  baseBranch?: string | null;
+  branchName?: string | null;
+  fullAccess?: boolean;
+  callable?: boolean;
+};
+
+export type ParsedArg = {
+  name: string;
+  key: string;
+  placeholder: string;
+};
+
+const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
+
+export function parseTemplateArgs(prompt: string): ParsedArg[] {
+  const seen = new Set<string>();
+  const args: ParsedArg[] = [];
+  let match;
+  while ((match = ARG_REGEX.exec(prompt)) !== null) {
+    const name = match[1].trim();
+    const key = name.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      args.push({ name, key, placeholder: match[0] });
+    }
+  }
+  return args;
+}
+
+export function substituteArgs(
+  prompt: string,
+  args: Record<string, string>
+): string {
+  const parsed = parseTemplateArgs(prompt);
+  const missing = parsed.filter((a) => !(a.key in args) && !(a.name in args));
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required template arguments: ${missing.map((a) => a.name).join(", ")}`
+    );
+  }
+  return prompt.replace(ARG_REGEX, (_match, rawName: string) => {
+    const name = rawName.trim();
+    const key = name.toLowerCase();
+    return args[key] ?? args[name] ?? "";
+  });
+}
+
+export class TemplateStore {
+  constructor(private readonly pool: Pool) {}
+
+  async createTemplate(input: {
+    name: string;
+    directory: string;
+    prompt: string | null;
+    agentType: JobAgentType;
+    useWorktree: boolean;
+    baseBranch: string | null;
+    branchName: string | null;
+    fullAccess: boolean;
+    callable: boolean;
+  }): Promise<TemplateRecord> {
+    const id = randomUUID();
+    try {
+      const result = await this.pool.query(
+        `
+        INSERT INTO templates (id, directory, name, prompt, agent_type, use_worktree, base_branch, branch_name, full_access, callable)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING ${this.columns()}
+        `,
+        [
+          id,
+          path.resolve(input.directory),
+          input.name,
+          input.prompt,
+          input.agentType,
+          input.useWorktree,
+          input.baseBranch,
+          input.branchName,
+          input.fullAccess,
+          input.callable,
+        ]
+      );
+      return mapTemplate(result.rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new Error(
+          `A template named "${input.name}" already exists in directory "${input.directory}".`
+        );
+      }
+      throw error;
+    }
+  }
+
+  async getTemplate(id: string): Promise<TemplateRecord | null> {
+    const result = await this.pool.query(
+      `SELECT ${this.columns()} FROM templates WHERE id = $1`,
+      [id]
+    );
+    return result.rows[0] ? mapTemplate(result.rows[0]) : null;
+  }
+
+  async getTemplateByDirectoryAndName(
+    directory: string,
+    name: string
+  ): Promise<TemplateRecord | null> {
+    const result = await this.pool.query(
+      `SELECT ${this.columns()} FROM templates WHERE directory = $1 AND name = $2`,
+      [path.resolve(directory), name]
+    );
+    return result.rows[0] ? mapTemplate(result.rows[0]) : null;
+  }
+
+  async listTemplates(filter?: {
+    callable?: boolean;
+  }): Promise<TemplateRecord[]> {
+    let query = `SELECT ${this.columns()} FROM templates`;
+    const params: unknown[] = [];
+    if (filter?.callable !== undefined) {
+      query += ` WHERE callable = $1`;
+      params.push(filter.callable);
+    }
+    query += ` ORDER BY name ASC, directory ASC`;
+    const result = await this.pool.query(query, params);
+    return result.rows.map((row) => mapTemplate(row));
+  }
+
+  async updateTemplate(
+    id: string,
+    input: TemplateConfigUpdate
+  ): Promise<TemplateRecord> {
+    try {
+      const result = await this.pool.query(
+        `
+        UPDATE templates
+        SET name = COALESCE($2, name),
+            prompt = CASE WHEN $3 THEN $4 ELSE prompt END,
+            agent_type = COALESCE($5, agent_type),
+            use_worktree = COALESCE($6, use_worktree),
+            base_branch = CASE WHEN $7 THEN $8 ELSE base_branch END,
+            branch_name = CASE WHEN $9 THEN $10 ELSE branch_name END,
+            full_access = COALESCE($11, full_access),
+            callable = COALESCE($12, callable),
+            updated_at = NOW()
+        WHERE id = $1
+        RETURNING ${this.columns()}
+        `,
+        [
+          id,
+          input.name,
+          Object.prototype.hasOwnProperty.call(input, "prompt"),
+          input.prompt ?? null,
+          input.agentType,
+          input.useWorktree,
+          Object.prototype.hasOwnProperty.call(input, "baseBranch"),
+          input.baseBranch ?? null,
+          Object.prototype.hasOwnProperty.call(input, "branchName"),
+          input.branchName ?? null,
+          input.fullAccess,
+          input.callable,
+        ]
+      );
+      if (!result.rows[0]) throw new Error(`Template ${id} not found.`);
+      return mapTemplate(result.rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new Error(
+          `A template named "${input.name}" already exists in this directory.`
+        );
+      }
+      throw error;
+    }
+  }
+
+  async deleteTemplate(id: string): Promise<TemplateRecord> {
+    const result = await this.pool.query(
+      `
+      DELETE FROM templates
+      WHERE id = $1
+      RETURNING ${this.columns()}
+      `,
+      [id]
+    );
+    if (!result.rows[0]) throw new Error(`Template ${id} not found.`);
+    return mapTemplate(result.rows[0]);
+  }
+
+  async hasJobsReferencing(id: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `SELECT 1 FROM jobs WHERE template_id = $1 LIMIT 1`,
+      [id]
+    );
+    return result.rows.length > 0;
+  }
+
+  private columns(): string {
+    return `
+      id,
+      directory,
+      name,
+      prompt,
+      agent_type AS "agentType",
+      use_worktree AS "useWorktree",
+      base_branch AS "baseBranch",
+      branch_name AS "branchName",
+      full_access AS "fullAccess",
+      callable,
+      created_at AS "createdAt",
+      updated_at AS "updatedAt"
+    `;
+  }
+}
+
+function mapTemplate(row: Record<string, unknown>): TemplateRecord {
+  return row as TemplateRecord;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "23505"
+  );
+}

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -9,6 +9,7 @@ export type TemplateRecord = {
   id: string;
   directory: string;
   name: string;
+  description: string | null;
   prompt: string | null;
   agentType: JobAgentType;
   useWorktree: boolean;
@@ -22,6 +23,8 @@ export type TemplateRecord = {
 
 export type TemplateConfigUpdate = {
   name?: string;
+  description?: string | null;
+  directory?: string;
   prompt?: string | null;
   agentType?: JobAgentType;
   useWorktree?: boolean;
@@ -78,6 +81,7 @@ export class TemplateStore {
   async createTemplate(input: {
     name: string;
     directory: string;
+    description: string | null;
     prompt: string | null;
     agentType: JobAgentType;
     useWorktree: boolean;
@@ -90,14 +94,15 @@ export class TemplateStore {
     try {
       const result = await this.pool.query(
         `
-        INSERT INTO templates (id, directory, name, prompt, agent_type, use_worktree, base_branch, branch_name, full_access, callable)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        INSERT INTO templates (id, directory, name, description, prompt, agent_type, use_worktree, base_branch, branch_name, full_access, callable)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         RETURNING ${this.columns()}
         `,
         [
           id,
           path.resolve(input.directory),
           input.name,
+          input.description,
           input.prompt,
           input.agentType,
           input.useWorktree,
@@ -156,17 +161,35 @@ export class TemplateStore {
     input: TemplateConfigUpdate
   ): Promise<TemplateRecord> {
     try {
+      const hasDescription = Object.prototype.hasOwnProperty.call(
+        input,
+        "description"
+      );
+      const hasPrompt = Object.prototype.hasOwnProperty.call(input, "prompt");
+      const hasBaseBranch = Object.prototype.hasOwnProperty.call(
+        input,
+        "baseBranch"
+      );
+      const hasBranchName = Object.prototype.hasOwnProperty.call(
+        input,
+        "branchName"
+      );
+      const resolvedDir = input.directory
+        ? path.resolve(input.directory)
+        : undefined;
       const result = await this.pool.query(
         `
         UPDATE templates
         SET name = COALESCE($2, name),
-            prompt = CASE WHEN $3 THEN $4 ELSE prompt END,
-            agent_type = COALESCE($5, agent_type),
-            use_worktree = COALESCE($6, use_worktree),
-            base_branch = CASE WHEN $7 THEN $8 ELSE base_branch END,
-            branch_name = CASE WHEN $9 THEN $10 ELSE branch_name END,
-            full_access = COALESCE($11, full_access),
-            callable = COALESCE($12, callable),
+            description = CASE WHEN $3 THEN $4 ELSE description END,
+            directory = COALESCE($5, directory),
+            prompt = CASE WHEN $6 THEN $7 ELSE prompt END,
+            agent_type = COALESCE($8, agent_type),
+            use_worktree = COALESCE($9, use_worktree),
+            base_branch = CASE WHEN $10 THEN $11 ELSE base_branch END,
+            branch_name = CASE WHEN $12 THEN $13 ELSE branch_name END,
+            full_access = COALESCE($14, full_access),
+            callable = COALESCE($15, callable),
             updated_at = NOW()
         WHERE id = $1
         RETURNING ${this.columns()}
@@ -174,13 +197,16 @@ export class TemplateStore {
         [
           id,
           input.name,
-          Object.prototype.hasOwnProperty.call(input, "prompt"),
+          hasDescription,
+          input.description ?? null,
+          resolvedDir,
+          hasPrompt,
           input.prompt ?? null,
           input.agentType,
           input.useWorktree,
-          Object.prototype.hasOwnProperty.call(input, "baseBranch"),
+          hasBaseBranch,
           input.baseBranch ?? null,
-          Object.prototype.hasOwnProperty.call(input, "branchName"),
+          hasBranchName,
           input.branchName ?? null,
           input.fullAccess,
           input.callable,
@@ -224,6 +250,7 @@ export class TemplateStore {
       id,
       directory,
       name,
+      description,
       prompt,
       agent_type AS "agentType",
       use_worktree AS "useWorktree",

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -41,13 +41,14 @@ export type ParsedArg = {
 };
 
 // Mirrored in apps/web/src/hooks/use-templates.ts for client-side preview
-const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
+const ARG_PATTERN = /\{\{D:([^}]+)\}\}/g;
 
 export function parseTemplateArgs(prompt: string): ParsedArg[] {
+  const regex = new RegExp(ARG_PATTERN.source, ARG_PATTERN.flags);
   const seen = new Set<string>();
   const args: ParsedArg[] = [];
   let match;
-  while ((match = ARG_REGEX.exec(prompt)) !== null) {
+  while ((match = regex.exec(prompt)) !== null) {
     const name = match[1].trim();
     const key = name.toLowerCase();
     if (!seen.has(key)) {
@@ -69,11 +70,14 @@ export function substituteArgs(
       `Missing required template arguments: ${missing.map((a) => a.name).join(", ")}`
     );
   }
-  return prompt.replace(ARG_REGEX, (_match, rawName: string) => {
-    const name = rawName.trim();
-    const key = name.toLowerCase();
-    return args[key] ?? args[name] ?? "";
-  });
+  return prompt.replace(
+    new RegExp(ARG_PATTERN.source, ARG_PATTERN.flags),
+    (_match, rawName: string) => {
+      const name = rawName.trim();
+      const key = name.toLowerCase();
+      return args[key] ?? args[name] ?? "";
+    }
+  );
 }
 
 export class TemplateStore {

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -40,6 +40,7 @@ export type ParsedArg = {
   placeholder: string;
 };
 
+// Mirrored in apps/web/src/hooks/use-templates.ts for client-side preview
 const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
 
 export function parseTemplateArgs(prompt: string): ParsedArg[] {

--- a/apps/server/test/templates/migration.test.ts
+++ b/apps/server/test/templates/migration.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { randomUUID } from "node:crypto";
+
+import { runMigrations } from "../../src/db/migrate.js";
+import {
+  setupTestDb,
+  teardownTestDb,
+  getTestDatabaseUrl,
+} from "../db/setup.js";
+
+let pool: Pool;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+describe("Migration 0021_templates", () => {
+  it("creates backing templates for existing jobs during migration", async () => {
+    // 1. Run migrations up to 0020 (pre-templates)
+    await runMigrations({ databaseUrl: getTestDatabaseUrl(), count: 20 });
+
+    // 2. Seed jobs directly into the pre-migration schema
+    const scheduledJobId = randomUUID();
+    const callableJobId = randomUUID();
+    const onDemandJobId = randomUUID();
+
+    await pool.query(
+      `INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms,
+        prompt, full_access, agent_type, use_worktree, base_branch, branch_name,
+        auto_archive, callable, singleton, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+      [
+        scheduledJobId,
+        "/tmp/test-repo",
+        "nightly-triage",
+        "0 3 * * *",
+        1800000,
+        86400000,
+        "Triage all open PRs with {{D:Focus}}",
+        false,
+        "claude",
+        true,
+        "main",
+        null,
+        true,
+        false,
+        true,
+        true,
+      ]
+    );
+
+    await pool.query(
+      `INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms,
+        prompt, full_access, agent_type, use_worktree, base_branch, branch_name,
+        auto_archive, callable, singleton, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+      [
+        callableJobId,
+        "/tmp/test-repo",
+        "quick-review",
+        null,
+        600000,
+        86400000,
+        "Review the latest changes",
+        true,
+        "codex",
+        false,
+        null,
+        null,
+        false,
+        true,
+        false,
+        true,
+      ]
+    );
+
+    await pool.query(
+      `INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms,
+        prompt, full_access, agent_type, use_worktree, base_branch, branch_name,
+        auto_archive, callable, singleton, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+      [
+        onDemandJobId,
+        "/tmp/other-repo",
+        "deploy-check",
+        null,
+        300000,
+        86400000,
+        null,
+        false,
+        "claude",
+        false,
+        null,
+        null,
+        true,
+        false,
+        true,
+        true,
+      ]
+    );
+
+    // Verify: no templates table yet
+    const preCheck = await pool.query(
+      `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'templates')`
+    );
+    expect(preCheck.rows[0].exists).toBe(false);
+
+    // 3. Run migration 0021 (templates)
+    await runMigrations({ databaseUrl: getTestDatabaseUrl(), count: 1 });
+
+    // 4. Verify templates table exists
+    const postCheck = await pool.query(
+      `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'templates')`
+    );
+    expect(postCheck.rows[0].exists).toBe(true);
+
+    // 5. Verify backing templates were created for each job
+    const templates = await pool.query(`SELECT * FROM templates ORDER BY name`);
+    expect(templates.rows.length).toBe(3);
+
+    // 6. Verify each job now has a template_id
+    const jobs = await pool.query(
+      `SELECT id, name, template_id, default_args FROM jobs ORDER BY name`
+    );
+    expect(jobs.rows.length).toBe(3);
+    for (const job of jobs.rows) {
+      expect(job.template_id).not.toBeNull();
+      expect(job.default_args).toEqual({});
+    }
+
+    // 7. Verify template content matches the job config
+    const scheduledJob = jobs.rows.find(
+      (j: { name: string }) => j.name === "nightly-triage"
+    );
+    const scheduledTemplate = templates.rows.find(
+      (t: { id: string }) => t.id === scheduledJob.template_id
+    );
+    expect(scheduledTemplate).toBeDefined();
+    expect(scheduledTemplate.name).toBe("nightly-triage");
+    expect(scheduledTemplate.directory).toBe("/tmp/test-repo");
+    expect(scheduledTemplate.prompt).toBe(
+      "Triage all open PRs with {{D:Focus}}"
+    );
+    expect(scheduledTemplate.agent_type).toBe("claude");
+    expect(scheduledTemplate.use_worktree).toBe(true);
+    expect(scheduledTemplate.base_branch).toBe("main");
+    expect(scheduledTemplate.full_access).toBe(false);
+    // Scheduled job → callable = false on template
+    expect(scheduledTemplate.callable).toBe(false);
+
+    const callableJob = jobs.rows.find(
+      (j: { name: string }) => j.name === "quick-review"
+    );
+    const callableTemplate = templates.rows.find(
+      (t: { id: string }) => t.id === callableJob.template_id
+    );
+    expect(callableTemplate).toBeDefined();
+    expect(callableTemplate.name).toBe("quick-review");
+    expect(callableTemplate.agent_type).toBe("codex");
+    expect(callableTemplate.use_worktree).toBe(false);
+    expect(callableTemplate.full_access).toBe(true);
+    // Callable on-demand job → callable = true on template
+    expect(callableTemplate.callable).toBe(true);
+
+    const onDemandJob = jobs.rows.find(
+      (j: { name: string }) => j.name === "deploy-check"
+    );
+    const onDemandTemplate = templates.rows.find(
+      (t: { id: string }) => t.id === onDemandJob.template_id
+    );
+    expect(onDemandTemplate).toBeDefined();
+    expect(onDemandTemplate.name).toBe("deploy-check");
+    expect(onDemandTemplate.directory).toBe("/tmp/other-repo");
+    expect(onDemandTemplate.prompt).toBeNull();
+    // Non-callable, non-scheduled job → callable = false on template
+    expect(onDemandTemplate.callable).toBe(false);
+
+    // 8. Verify template_id FK is valid
+    const fkCheck = await pool.query(
+      `SELECT j.id, j.template_id, t.id as t_id
+       FROM jobs j JOIN templates t ON j.template_id = t.id`
+    );
+    expect(fkCheck.rows.length).toBe(3);
+  });
+
+  it("migration is idempotent — re-running does not duplicate templates", async () => {
+    // Templates were already created by the previous test.
+    // Verify counts are still the same.
+    const templatesBefore = await pool.query(`SELECT count(*) FROM templates`);
+    const countBefore = parseInt(templatesBefore.rows[0].count, 10);
+
+    // The migration uses ON CONFLICT DO NOTHING and WHERE template_id IS NULL,
+    // so running again should not create duplicates.
+    // We can't re-run the migration via runner (already applied), but we can
+    // verify the guard conditions by attempting the DO block manually.
+    const result = await pool.query(
+      `SELECT count(*) FROM jobs WHERE template_id IS NULL`
+    );
+    expect(parseInt(result.rows[0].count, 10)).toBe(0);
+
+    const templatesAfter = await pool.query(`SELECT count(*) FROM templates`);
+    expect(parseInt(templatesAfter.rows[0].count, 10)).toBe(countBefore);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -201,7 +201,7 @@ export function DashboardLayout(): JSX.Element {
   const handleSidebarNavigate = useCallback(
     (section: NavSection) => {
       if (section === "agents") navigate("/agents");
-      else if (section === "jobs") navigate("/jobs");
+      else if (section === "automations") navigate("/automations");
       else if (section === "activity") navigate("/activity/metrics");
       else if (section === "settings") navigate("/settings");
     },

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -49,7 +49,6 @@ import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { LaunchTemplateDialog } from "@/components/app/automations-pane";
 import { CommandPalette } from "@/components/app/command-palette";
 import { useAgentHotkeys } from "@/hooks/use-agent-hotkeys";
-import { useTemplates } from "@/hooks/use-templates";
 import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
@@ -480,7 +479,7 @@ export function AgentsView({
     setPaletteOpen,
     paletteActions,
     paletteGroups,
-    launchTemplateId,
+    launchTemplate,
     setLaunchTemplateId,
   } = useAgentHotkeys({
     agents,
@@ -493,12 +492,6 @@ export function AgentsView({
     handleSetLeftPanelOpen,
     openCreateDialog,
   });
-
-  const { data: templates = [] } = useTemplates();
-  const launchTemplate = useMemo(
-    () => templates.find((t) => t.id === launchTemplateId) ?? null,
-    [templates, launchTemplateId]
-  );
 
   const closeFeedbackDetail = useCallback(() => {
     if (validatedSelectedAgentId) {
@@ -985,7 +978,7 @@ export function AgentsView({
       {launchTemplate ? (
         <LaunchTemplateDialog
           template={launchTemplate}
-          open={!!launchTemplateId}
+          open={!!launchTemplate}
           onOpenChange={(open) => {
             if (!open) setLaunchTemplateId(null);
           }}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -46,8 +46,10 @@ import { useAgents } from "@/hooks/use-agents";
 import { useMedia } from "@/hooks/use-media";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
+import { LaunchTemplateDialog } from "@/components/app/automations-pane";
 import { CommandPalette } from "@/components/app/command-palette";
 import { useAgentHotkeys } from "@/hooks/use-agent-hotkeys";
+import { useTemplates } from "@/hooks/use-templates";
 import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
@@ -473,18 +475,30 @@ export function AgentsView({
     setCreateOpen(true);
   }, []);
 
-  const { paletteOpen, setPaletteOpen, paletteActions, paletteGroups } =
-    useAgentHotkeys({
-      agents,
-      isMobile,
-      sidebarAgentId,
-      validatedSelectedAgentId,
-      mediaOpen,
-      setMediaOpen,
-      leftPanelOpen,
-      handleSetLeftPanelOpen,
-      openCreateDialog,
-    });
+  const {
+    paletteOpen,
+    setPaletteOpen,
+    paletteActions,
+    paletteGroups,
+    launchTemplateId,
+    setLaunchTemplateId,
+  } = useAgentHotkeys({
+    agents,
+    isMobile,
+    sidebarAgentId,
+    validatedSelectedAgentId,
+    mediaOpen,
+    setMediaOpen,
+    leftPanelOpen,
+    handleSetLeftPanelOpen,
+    openCreateDialog,
+  });
+
+  const { data: templates = [] } = useTemplates();
+  const launchTemplate = useMemo(
+    () => templates.find((t) => t.id === launchTemplateId) ?? null,
+    [templates, launchTemplateId]
+  );
 
   const closeFeedbackDetail = useCallback(() => {
     if (validatedSelectedAgentId) {
@@ -967,6 +981,16 @@ export function AgentsView({
         actions={paletteActions}
         groups={paletteGroups}
       />
+
+      {launchTemplate ? (
+        <LaunchTemplateDialog
+          template={launchTemplate}
+          open={!!launchTemplateId}
+          onOpenChange={(open) => {
+            if (!open) setLaunchTemplateId(null);
+          }}
+        />
+      ) : null}
 
       <CreateAgentDialog
         open={createOpen}

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -1,0 +1,941 @@
+import { useCallback, useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  AlarmClock,
+  FileText,
+  Pencil,
+  Play,
+  Plus,
+  Trash2,
+  Zap,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  JobsProvider,
+  JobListContent,
+  JobDetailPane,
+} from "@/components/app/jobs-pane";
+import { PathInput } from "@/components/app/path-input";
+import type { AgentType } from "@/lib/agent-types";
+import { type Agent } from "@/components/app/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  useTemplates,
+  useTemplateActions,
+  parseTemplateArgs,
+  type Template,
+  type TemplateArg,
+} from "@/hooks/use-templates";
+import {
+  AGENT_TYPE_LABELS,
+  type CliAgentType,
+  isCliAgentType,
+} from "@/lib/agent-types";
+import { agentRoute } from "@/lib/agent-routes";
+import { cn } from "@/lib/utils";
+
+type AutomationsTab = "templates" | "jobs";
+
+function resolveTab(pathname: string): AutomationsTab {
+  if (
+    pathname.startsWith("/automations/jobs") ||
+    pathname === "/automations/jobs"
+  ) {
+    return "jobs";
+  }
+  return "templates";
+}
+
+// ---------------------------------------------------------------------------
+// Automations sidebar (tabs + list)
+// ---------------------------------------------------------------------------
+
+function AutomationsSidebar({
+  activeTab,
+  onTabChange,
+  onItemSelect,
+}: {
+  activeTab: AutomationsTab;
+  onTabChange: (tab: AutomationsTab) => void;
+  onItemSelect?: () => void;
+}): JSX.Element {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="mt-2 flex h-14 items-center border-b border-border px-3">
+        <div className="flex w-full gap-1 rounded-lg bg-white/[0.04] p-0.5">
+          <TabButton
+            active={activeTab === "templates"}
+            onClick={() => onTabChange("templates")}
+            icon={<Zap className="h-3.5 w-3.5" />}
+            label="Templates"
+          />
+          <TabButton
+            active={activeTab === "jobs"}
+            onClick={() => onTabChange("jobs")}
+            icon={<AlarmClock className="h-3.5 w-3.5" />}
+            label="Jobs"
+          />
+        </div>
+      </div>
+      {activeTab === "templates" ? (
+        <TemplateListContent onItemSelect={onItemSelect} />
+      ) : (
+        <JobListContent onItemSelect={onItemSelect} />
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-primary/15 text-primary"
+          : "text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template list
+// ---------------------------------------------------------------------------
+
+function TemplateListContent({
+  onItemSelect,
+}: {
+  onItemSelect?: () => void;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const { templateId } = useParams<{ templateId?: string }>();
+  const { data: templates = [] } = useTemplates();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const callableTemplates = useMemo(
+    () => templates.filter((t) => t.callable),
+    [templates]
+  );
+
+  return (
+    <>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-2">
+        <div className="mb-2 flex items-center justify-between px-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Templates
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1 px-2 text-xs"
+            onClick={() => setShowCreate(true)}
+          >
+            <Plus className="h-3 w-3" />
+            Create
+          </Button>
+        </div>
+        {callableTemplates.length === 0 ? (
+          <div className="px-2 py-8 text-center text-xs text-muted-foreground">
+            No templates yet. Create one to get started.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {callableTemplates.map((template) => (
+              <TemplateListItem
+                key={template.id}
+                template={template}
+                selected={templateId === template.id}
+                onSelect={() => {
+                  navigate(`/automations/templates/${template.id}`);
+                  onItemSelect?.();
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <CreateTemplateDialog open={showCreate} onOpenChange={setShowCreate} />
+    </>
+  );
+}
+
+function TemplateListItem({
+  template,
+  selected,
+  onSelect,
+}: {
+  template: Template;
+  selected: boolean;
+  onSelect: () => void;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { launchTemplate } = useTemplateActions();
+  const args = useMemo(
+    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
+    [template.prompt]
+  );
+
+  const handleLaunch = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (args.length > 0) {
+        navigate(`/automations/templates/${template.id}`);
+        return;
+      }
+      launchTemplate
+        .mutateAsync({ id: template.id })
+        .then(async (result) => {
+          await queryClient.invalidateQueries({ queryKey: ["agents"] });
+          navigate(agentRoute(result.agentId));
+        })
+        .catch((err: Error) => {
+          toast.error(`Failed to launch: ${err.message}`);
+        });
+    },
+    [args.length, launchTemplate, navigate, queryClient, template.id]
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
+        selected
+          ? "border border-primary/20 bg-primary/10 text-foreground"
+          : "border border-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground"
+      )}
+    >
+      <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate">{template.name}</span>
+      <button
+        type="button"
+        onClick={handleLaunch}
+        title="Launch template"
+        className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
+      >
+        <Play className="h-3 w-3 fill-current" />
+      </button>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template detail pane
+// ---------------------------------------------------------------------------
+
+export function TemplateDetailPane(): JSX.Element {
+  const { templateId } = useParams<{ templateId?: string }>();
+  const { data: templates = [] } = useTemplates();
+  const template = useMemo(
+    () => templates.find((t) => t.id === templateId) ?? null,
+    [templates, templateId]
+  );
+
+  if (!templateId || !template) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Select a template to view details
+      </div>
+    );
+  }
+
+  return <TemplateDetail template={template} />;
+}
+
+function TemplateDetail({ template }: { template: Template }): JSX.Element {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { launchTemplate, removeTemplate } = useTemplateActions();
+  const [showEdit, setShowEdit] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+
+  const args = useMemo(
+    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
+    [template.prompt]
+  );
+  const [argValues, setArgValues] = useState<Record<string, string>>({});
+
+  const handleLaunch = useCallback(() => {
+    const launchArgs = args.length > 0 ? argValues : undefined;
+    launchTemplate
+      .mutateAsync({ id: template.id, args: launchArgs })
+      .then(async (result) => {
+        await queryClient.invalidateQueries({ queryKey: ["agents"] });
+        navigate(agentRoute(result.agentId));
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to launch: ${err.message}`);
+      });
+  }, [args, argValues, launchTemplate, navigate, queryClient, template.id]);
+
+  const handleDelete = useCallback(() => {
+    removeTemplate
+      .mutateAsync(template.id)
+      .then(() => {
+        navigate("/automations");
+        toast.success(`Template "${template.name}" deleted.`);
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to delete: ${err.message}`);
+      });
+    setShowDelete(false);
+  }, [removeTemplate, template, navigate]);
+
+  const allArgsFilled =
+    args.length === 0 || args.every((a) => argValues[a.key]?.trim());
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="border-b border-border px-6 py-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">
+              {template.name}
+            </h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {shortPath(template.directory)}
+            </p>
+          </div>
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1"
+              onClick={() => setShowEdit(true)}
+            >
+              <Pencil className="h-3 w-3" />
+              Edit
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1 text-destructive hover:text-destructive"
+              onClick={() => setShowDelete(true)}
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Launch form */}
+      <div className="flex-1 px-6 py-5">
+        {args.length > 0 ? (
+          <div className="mb-5">
+            <h3 className="mb-3 text-sm font-medium text-foreground">
+              Arguments
+            </h3>
+            <div className="flex flex-col gap-3">
+              {args.map((arg) => (
+                <ArgInput
+                  key={arg.key}
+                  arg={arg}
+                  value={argValues[arg.key] ?? ""}
+                  onChange={(value) =>
+                    setArgValues((prev) => ({ ...prev, [arg.key]: value }))
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <Button
+          className="gap-1.5"
+          onClick={handleLaunch}
+          disabled={!allArgsFilled || launchTemplate.isPending}
+        >
+          <Play className="h-3.5 w-3.5 fill-current" />
+          Launch
+        </Button>
+
+        {/* Config summary */}
+        <div className="mt-8 space-y-2 text-xs text-muted-foreground">
+          <div>
+            Agent type:{" "}
+            <span className="text-foreground">
+              {AGENT_TYPE_LABELS[template.agentType] ?? template.agentType}
+            </span>
+          </div>
+          {template.useWorktree ? (
+            <div>
+              Worktree:{" "}
+              <span className="text-foreground">
+                {template.baseBranch ?? "default branch"}
+              </span>
+            </div>
+          ) : null}
+          {template.fullAccess ? (
+            <div className="text-amber-500/80">Full access enabled</div>
+          ) : null}
+        </div>
+
+        {template.prompt ? (
+          <div className="mt-6">
+            <h3 className="mb-2 text-sm font-medium text-foreground">Prompt</h3>
+            <pre className="max-h-60 overflow-y-auto whitespace-pre-wrap rounded-md bg-white/[0.04] p-3 text-xs text-muted-foreground">
+              {template.prompt}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+
+      <EditTemplateDialog
+        template={template}
+        open={showEdit}
+        onOpenChange={setShowEdit}
+      />
+
+      <Dialog open={showDelete} onOpenChange={setShowDelete}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete template</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &ldquo;{template.name}&rdquo;?
+              This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setShowDelete(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              Delete
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ArgInput({
+  arg,
+  value,
+  onChange,
+}: {
+  arg: TemplateArg;
+  value: string;
+  onChange: (value: string) => void;
+}): JSX.Element {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-medium text-foreground">
+        {arg.name}
+      </label>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={`Enter ${arg.name}`}
+        className="h-8 text-sm"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create / Edit template dialogs
+// ---------------------------------------------------------------------------
+
+function CreateTemplateDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  const { addTemplate } = useTemplateActions();
+  const [name, setName] = useState("");
+  const [directory, setDirectory] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [agentType, setAgentType] = useState<CliAgentType>("claude");
+  const [useWorktree, setUseWorktree] = useState(false);
+  const [baseBranch, setBaseBranch] = useState("");
+  const [fullAccess, setFullAccess] = useState(false);
+
+  const detectedArgs = useMemo(
+    () => (prompt ? parseTemplateArgs(prompt) : []),
+    [prompt]
+  );
+
+  const handleCreate = useCallback(() => {
+    addTemplate
+      .mutateAsync({
+        name,
+        directory,
+        prompt: prompt || null,
+        agentType,
+        useWorktree,
+        baseBranch: baseBranch || null,
+        fullAccess,
+        callable: true,
+      })
+      .then(() => {
+        onOpenChange(false);
+        setName("");
+        setDirectory("");
+        setPrompt("");
+        setAgentType("claude");
+        setUseWorktree(false);
+        setBaseBranch("");
+        setFullAccess(false);
+        toast.success("Template created.");
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to create template: ${err.message}`);
+      });
+  }, [
+    addTemplate,
+    name,
+    directory,
+    prompt,
+    agentType,
+    useWorktree,
+    baseBranch,
+    fullAccess,
+    onOpenChange,
+  ]);
+
+  const canCreate = name.trim() && directory.trim();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create template</DialogTitle>
+          <DialogDescription>
+            A reusable agent launch configuration. Use{" "}
+            <code className="rounded bg-white/[0.08] px-1 text-xs">
+              {"{{D:Arg Name}}"}
+            </code>{" "}
+            in the prompt for runtime arguments.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My template"
+              className="h-8"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium">Directory</label>
+            <PathInput
+              value={directory}
+              onChange={setDirectory}
+              placeholder="/path/to/repo"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium">Prompt</label>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe what the agent should do..."
+              className="min-h-[100px] w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
+            />
+            {detectedArgs.length > 0 ? (
+              <div className="mt-1.5 text-xs text-muted-foreground">
+                Detected arguments:{" "}
+                {detectedArgs.map((a) => (
+                  <span
+                    key={a.key}
+                    className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+                  >
+                    {a.name}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium">Agent type</label>
+            <select
+              value={agentType}
+              onChange={(e) => {
+                if (isCliAgentType(e.target.value))
+                  setAgentType(e.target.value);
+              }}
+              className="h-8 w-full rounded-md border border-border bg-transparent px-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
+            >
+              {Object.entries(AGENT_TYPE_LABELS)
+                .filter(([key]) => isCliAgentType(key))
+                .map(([key, label]) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={useWorktree}
+              onCheckedChange={(checked) => setUseWorktree(checked === true)}
+              id="create-template-worktree"
+            />
+            <label
+              htmlFor="create-template-worktree"
+              className="text-sm text-foreground"
+            >
+              Use worktree
+            </label>
+          </div>
+          {useWorktree ? (
+            <div>
+              <label className="mb-1 block text-xs font-medium">
+                Base branch
+              </label>
+              <Input
+                value={baseBranch}
+                onChange={(e) => setBaseBranch(e.target.value)}
+                placeholder="main"
+                className="h-8"
+              />
+            </div>
+          ) : null}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={fullAccess}
+              onCheckedChange={(checked) => setFullAccess(checked === true)}
+              id="create-template-full-access"
+            />
+            <label
+              htmlFor="create-template-full-access"
+              className="text-sm text-foreground"
+            >
+              Full access
+            </label>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!canCreate}>
+              Create
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditTemplateDialog({
+  template,
+  open,
+  onOpenChange,
+}: {
+  template: Template;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  const { updateTemplate } = useTemplateActions();
+  const [name, setName] = useState(template.name);
+  const [prompt, setPrompt] = useState(template.prompt ?? "");
+  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
+  const [useWorktree, setUseWorktree] = useState(template.useWorktree);
+  const [baseBranch, setBaseBranch] = useState(template.baseBranch ?? "");
+  const [fullAccess, setFullAccess] = useState(template.fullAccess);
+  const [callable, setCallable] = useState(template.callable);
+
+  const detectedArgs = useMemo(
+    () => (prompt ? parseTemplateArgs(prompt) : []),
+    [prompt]
+  );
+
+  const handleSave = useCallback(() => {
+    updateTemplate
+      .mutateAsync({
+        id: template.id,
+        name,
+        prompt: prompt || null,
+        agentType,
+        useWorktree,
+        baseBranch: baseBranch || null,
+        fullAccess,
+        callable,
+      })
+      .then(() => {
+        onOpenChange(false);
+        toast.success("Template updated.");
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to update: ${err.message}`);
+      });
+  }, [
+    updateTemplate,
+    template.id,
+    name,
+    prompt,
+    agentType,
+    useWorktree,
+    baseBranch,
+    fullAccess,
+    callable,
+    onOpenChange,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit template</DialogTitle>
+          <DialogDescription>
+            Modify the template configuration.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="h-8"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium">Prompt</label>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              className="min-h-[100px] w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
+            />
+            {detectedArgs.length > 0 ? (
+              <div className="mt-1.5 text-xs text-muted-foreground">
+                Detected arguments:{" "}
+                {detectedArgs.map((a) => (
+                  <span
+                    key={a.key}
+                    className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+                  >
+                    {a.name}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium">Agent type</label>
+            <select
+              value={agentType}
+              onChange={(e) => {
+                if (isCliAgentType(e.target.value))
+                  setAgentType(e.target.value);
+              }}
+              className="h-8 w-full rounded-md border border-border bg-transparent px-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
+            >
+              {Object.entries(AGENT_TYPE_LABELS)
+                .filter(([key]) => isCliAgentType(key))
+                .map(([key, label]) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={useWorktree}
+              onCheckedChange={(checked) => setUseWorktree(checked === true)}
+              id="edit-template-worktree"
+            />
+            <label
+              htmlFor="edit-template-worktree"
+              className="text-sm text-foreground"
+            >
+              Use worktree
+            </label>
+          </div>
+          {useWorktree ? (
+            <div>
+              <label className="mb-1 block text-xs font-medium">
+                Base branch
+              </label>
+              <Input
+                value={baseBranch}
+                onChange={(e) => setBaseBranch(e.target.value)}
+                placeholder="main"
+                className="h-8"
+              />
+            </div>
+          ) : null}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={fullAccess}
+              onCheckedChange={(checked) => setFullAccess(checked === true)}
+              id="edit-template-full-access"
+            />
+            <label
+              htmlFor="edit-template-full-access"
+              className="text-sm text-foreground"
+            >
+              Full access
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={callable}
+              onCheckedChange={(checked) => setCallable(checked === true)}
+              id="edit-template-callable"
+            />
+            <label
+              htmlFor="edit-template-callable"
+              className="text-sm text-foreground"
+            >
+              Show in Cmd+K
+            </label>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function shortPath(value: string): string {
+  const home = "/Users/";
+  if (value.startsWith(home)) {
+    const afterHome = value.slice(home.length);
+    const slash = afterHome.indexOf("/");
+    return slash === -1 ? `~` : `~${afterHome.slice(slash)}`;
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Main automations pane (exported)
+// ---------------------------------------------------------------------------
+
+export function AutomationsSidebarContent({
+  agents,
+  enabledAgentTypes,
+  isMobile,
+  closeSidebar,
+}: {
+  agents: Agent[];
+  enabledAgentTypes: AgentType[];
+  isMobile: boolean;
+  closeSidebar?: () => void;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const activeTab = resolveTab(location.pathname);
+
+  const handleTabChange = useCallback(
+    (tab: AutomationsTab) => {
+      if (tab === "jobs") {
+        navigate("/automations/jobs");
+      } else {
+        navigate("/automations");
+      }
+    },
+    [navigate]
+  );
+
+  const openAgent = useCallback(
+    async (agent: Agent) => {
+      navigate(agentRoute(agent.id));
+    },
+    [navigate]
+  );
+
+  if (activeTab === "jobs") {
+    return (
+      <JobsProvider
+        open={true}
+        agents={agents}
+        onOpenAgent={openAgent}
+        enabledAgentTypes={enabledAgentTypes}
+      >
+        <AutomationsSidebar
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          onItemSelect={isMobile ? closeSidebar : undefined}
+        />
+      </JobsProvider>
+    );
+  }
+
+  return (
+    <AutomationsSidebar
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+      onItemSelect={isMobile ? closeSidebar : undefined}
+    />
+  );
+}
+
+export function AutomationsDetailContent({
+  agents,
+  enabledAgentTypes,
+}: {
+  agents: Agent[];
+  enabledAgentTypes: AgentType[];
+}): JSX.Element {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const activeTab = resolveTab(location.pathname);
+
+  const openAgent = useCallback(
+    async (agent: Agent) => {
+      navigate(agentRoute(agent.id));
+    },
+    [navigate]
+  );
+
+  if (activeTab === "templates") {
+    return <TemplateDetailPane />;
+  }
+
+  return (
+    <JobsProvider
+      open={true}
+      agents={agents}
+      onOpenAgent={openAgent}
+      enabledAgentTypes={enabledAgentTypes}
+    >
+      <JobDetailPane />
+    </JobsProvider>
+  );
+}

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -349,7 +349,8 @@ function TemplateDetail({
   enabledAgentTypes: AgentType[];
 }): JSX.Element {
   const navigate = useNavigate();
-  const { updateTemplate, removeTemplate } = useTemplateActions();
+  const { updateTemplate, removeTemplate, launchTemplate } =
+    useTemplateActions();
 
   // Editable form state — reset when template changes
   const [displayName, setDisplayName] = useState(template.name);
@@ -364,7 +365,9 @@ function TemplateDetail({
   const [callable, setCallable] = useState(template.callable);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
-  const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
+  const [launchArgValues, setLaunchArgValues] = useState<
+    Record<string, string>
+  >({});
 
   useEffect(() => {
     setDisplayName(template.name);
@@ -379,7 +382,7 @@ function TemplateDetail({
     setCallable(template.callable);
     setSaveError(null);
     setRemoveDialogOpen(false);
-    setLaunchDialogOpen(false);
+    setLaunchArgValues({});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template.id]);
 
@@ -387,6 +390,27 @@ function TemplateDetail({
     () => (prompt ? parseTemplateArgs(prompt) : []),
     [prompt]
   );
+
+  const savedArgs = useMemo(
+    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
+    [template.prompt]
+  );
+
+  const allLaunchArgsFilled =
+    savedArgs.length === 0 ||
+    savedArgs.every((a) => launchArgValues[a.key]?.trim());
+
+  const handleInlineLaunch = useCallback(() => {
+    const args = savedArgs.length > 0 ? launchArgValues : undefined;
+    launchTemplate
+      .mutateAsync({ id: template.id, args })
+      .then((result) => {
+        navigate(agentRoute(result.agent.id));
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to launch: ${err.message}`);
+      });
+  }, [savedArgs, launchArgValues, launchTemplate, template.id, navigate]);
 
   const canSave = !!displayName.trim() && !!directory.trim();
 
@@ -458,13 +482,52 @@ function TemplateDetail({
           {shortPath(template.directory)}
         </p>
 
-        <Button
-          className="mt-4 gap-1.5"
-          onClick={() => setLaunchDialogOpen(true)}
-        >
-          <Play className="h-3.5 w-3.5 fill-current" />
-          Launch
-        </Button>
+        {savedArgs.length > 0 ? (
+          <div className="mt-4 space-y-2">
+            {savedArgs.map((arg) => (
+              <div key={arg.key} className="space-y-1">
+                <label className="text-xs text-muted-foreground">
+                  {arg.name}
+                </label>
+                <Input
+                  placeholder={arg.name}
+                  value={launchArgValues[arg.key] ?? ""}
+                  onChange={(e) =>
+                    setLaunchArgValues((prev) => ({
+                      ...prev,
+                      [arg.key]: e.target.value,
+                    }))
+                  }
+                />
+              </div>
+            ))}
+            <Button
+              className="gap-1.5"
+              disabled={!allLaunchArgsFilled || launchTemplate.isPending}
+              onClick={handleInlineLaunch}
+            >
+              {launchTemplate.isPending ? (
+                <ActivityBars size={16} className="mr-1" />
+              ) : (
+                <Play className="h-3.5 w-3.5 fill-current" />
+              )}
+              Launch
+            </Button>
+          </div>
+        ) : (
+          <Button
+            className="mt-4 gap-1.5"
+            disabled={launchTemplate.isPending}
+            onClick={handleInlineLaunch}
+          >
+            {launchTemplate.isPending ? (
+              <ActivityBars size={16} className="mr-1" />
+            ) : (
+              <Play className="h-3.5 w-3.5 fill-current" />
+            )}
+            Launch
+          </Button>
+        )}
       </div>
 
       {/* Inline-editable config form */}
@@ -642,12 +705,6 @@ function TemplateDetail({
           </div>
         </DialogContent>
       </Dialog>
-
-      <LaunchTemplateDialog
-        template={template}
-        open={launchDialogOpen}
-        onOpenChange={setLaunchDialogOpen}
-      />
     </div>
   );
 }
@@ -822,6 +879,7 @@ function CreateTemplateDialogContent({
   const [baseBranch, setBaseBranch] = useState("main");
   const [branchName, setBranchName] = useState("");
   const [fullAccess, setFullAccess] = useState(false);
+  const [callable, setCallable] = useState(true);
   const [creating, setCreating] = useState(false);
 
   const cliAgentTypes = useMemo(
@@ -847,7 +905,7 @@ function CreateTemplateDialogContent({
         baseBranch: useWorktree ? baseBranch : null,
         branchName: useWorktree ? branchName || null : null,
         fullAccess,
-        callable: true,
+        callable,
       })
       .then(() => {
         onOpenChange(false);
@@ -868,6 +926,7 @@ function CreateTemplateDialogContent({
     baseBranch,
     branchName,
     fullAccess,
+    callable,
     onOpenChange,
   ]);
 
@@ -941,6 +1000,22 @@ function CreateTemplateDialogContent({
             checked={fullAccess}
             onCheckedChange={setFullAccess}
           />
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+            <Checkbox
+              checked={callable}
+              onCheckedChange={() => setCallable((c) => !c)}
+              className="mt-0.5"
+            />
+            <span className="space-y-1">
+              <span className="block text-sm font-medium text-foreground">
+                Show in command palette
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                Launch this template from the {"⌘"}K palette.
+              </span>
+            </span>
+          </label>
 
           <div className="space-y-1">
             <label className="text-sm text-muted-foreground">Prompt</label>

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -1160,13 +1160,9 @@ function TemplateFullAccessOption({
 // ---------------------------------------------------------------------------
 
 function shortPath(value: string): string {
-  const home = "/Users/";
-  if (value.startsWith(home)) {
-    const afterHome = value.slice(home.length);
-    const slash = afterHome.indexOf("/");
-    return slash === -1 ? `~` : `~${afterHome.slice(slash)}`;
-  }
-  return value;
+  const parts = value.split("/").filter(Boolean);
+  if (parts.length <= 3) return value;
+  return `.../${parts.slice(-3).join("/")}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -365,9 +365,7 @@ function TemplateDetail({
   const [callable, setCallable] = useState(template.callable);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
-  const [launchArgValues, setLaunchArgValues] = useState<
-    Record<string, string>
-  >({});
+  const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
 
   useEffect(() => {
     setDisplayName(template.name);
@@ -382,7 +380,7 @@ function TemplateDetail({
     setCallable(template.callable);
     setSaveError(null);
     setRemoveDialogOpen(false);
-    setLaunchArgValues({});
+    setLaunchDialogOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template.id]);
 
@@ -396,21 +394,20 @@ function TemplateDetail({
     [template.prompt]
   );
 
-  const allLaunchArgsFilled =
-    savedArgs.length === 0 ||
-    savedArgs.every((a) => launchArgValues[a.key]?.trim());
-
-  const handleInlineLaunch = useCallback(() => {
-    const args = savedArgs.length > 0 ? launchArgValues : undefined;
+  const handleLaunch = useCallback(() => {
+    if (savedArgs.length > 0) {
+      setLaunchDialogOpen(true);
+      return;
+    }
     launchTemplate
-      .mutateAsync({ id: template.id, args })
+      .mutateAsync({ id: template.id })
       .then((result) => {
         navigate(agentRoute(result.agent.id));
       })
       .catch((err: Error) => {
         toast.error(`Failed to launch: ${err.message}`);
       });
-  }, [savedArgs, launchArgValues, launchTemplate, template.id, navigate]);
+  }, [savedArgs.length, launchTemplate, template.id, navigate]);
 
   const canSave = !!displayName.trim() && !!directory.trim();
 
@@ -483,51 +480,32 @@ function TemplateDetail({
         </p>
 
         {savedArgs.length > 0 ? (
-          <div className="mt-4 space-y-2">
-            {savedArgs.map((arg) => (
-              <div key={arg.key} className="space-y-1">
-                <label className="text-xs text-muted-foreground">
-                  {arg.name}
-                </label>
-                <Input
-                  placeholder={arg.name}
-                  value={launchArgValues[arg.key] ?? ""}
-                  onChange={(e) =>
-                    setLaunchArgValues((prev) => ({
-                      ...prev,
-                      [arg.key]: e.target.value,
-                    }))
-                  }
-                />
-              </div>
+          <div className="mt-3 rounded-md border border-border/60 bg-muted/15 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">
+              Required arguments:
+            </span>{" "}
+            {savedArgs.map((a, i) => (
+              <span key={a.key}>
+                {i > 0 ? ", " : ""}
+                <span className="rounded bg-primary/10 px-1.5 py-0.5 text-primary">
+                  {a.name}
+                </span>
+              </span>
             ))}
-            <Button
-              className="gap-1.5"
-              disabled={!allLaunchArgsFilled || launchTemplate.isPending}
-              onClick={handleInlineLaunch}
-            >
-              {launchTemplate.isPending ? (
-                <ActivityBars size={16} className="mr-1" />
-              ) : (
-                <Play className="h-3.5 w-3.5 fill-current" />
-              )}
-              Launch
-            </Button>
           </div>
-        ) : (
-          <Button
-            className="mt-4 gap-1.5"
-            disabled={launchTemplate.isPending}
-            onClick={handleInlineLaunch}
-          >
-            {launchTemplate.isPending ? (
-              <ActivityBars size={16} className="mr-1" />
-            ) : (
-              <Play className="h-3.5 w-3.5 fill-current" />
-            )}
-            Launch
-          </Button>
-        )}
+        ) : null}
+        <Button
+          className="mt-4 gap-1.5"
+          disabled={launchTemplate.isPending}
+          onClick={handleLaunch}
+        >
+          {launchTemplate.isPending ? (
+            <ActivityBars size={16} className="mr-1" />
+          ) : (
+            <Play className="h-3.5 w-3.5 fill-current" />
+          )}
+          Launch
+        </Button>
       </div>
 
       {/* Inline-editable config form */}
@@ -705,6 +683,11 @@ function TemplateDetail({
           </div>
         </DialogContent>
       </Dialog>
+      <LaunchTemplateDialog
+        template={template}
+        open={launchDialogOpen}
+        onOpenChange={setLaunchDialogOpen}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -4,15 +4,13 @@ import {
   AlarmClock,
   Check,
   ChevronDown,
-  FileText,
   GitBranch,
   Play,
-  Plus,
   Trash2,
   Zap,
 } from "lucide-react";
+import { motion } from "framer-motion";
 import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
 
 import {
   JobsProvider,
@@ -108,7 +106,7 @@ function AutomationsSidebar({
           onItemSelect={onItemSelect}
         />
       ) : (
-        <JobListContent onItemSelect={onItemSelect} />
+        <JobListContent onItemSelect={onItemSelect} hideHeader />
       )}
     </div>
   );
@@ -130,14 +128,21 @@ function TabButton({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
-        active
-          ? "bg-primary/15 text-primary"
-          : "text-muted-foreground hover:text-foreground"
+        "relative flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+        active ? "text-primary" : "text-muted-foreground hover:text-foreground"
       )}
     >
-      {icon}
-      {label}
+      {active ? (
+        <motion.div
+          layoutId="automations-tab-indicator"
+          className="absolute inset-0 rounded-md bg-primary/15"
+          transition={{ type: "spring", bounce: 0.15, duration: 0.4 }}
+        />
+      ) : null}
+      <span className="relative z-10 flex items-center gap-1.5">
+        {icon}
+        {label}
+      </span>
     </button>
   );
 }
@@ -164,28 +169,32 @@ function TemplateListContent({
   );
 
   return (
-    <>
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-2">
-        <div className="mb-2 flex items-center justify-between px-1">
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Templates
-          </span>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 gap-1 px-2 text-xs"
-            onClick={() => setShowCreate(true)}
-          >
-            <Plus className="h-3 w-3" />
-            Create
-          </Button>
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-end px-3 py-2">
+        <Button
+          size="sm"
+          variant="default"
+          className="bg-muted/35 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
+          onClick={() => setShowCreate(true)}
+        >
+          <Zap className="mr-1 h-4 w-4" />
+          Create
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {callableTemplates.length === 0 ? (
-          <div className="px-2 py-8 text-center text-xs text-muted-foreground">
-            No templates yet. Create one to get started.
+          <div className="p-4 text-sm text-muted-foreground">
+            <div className="rounded-md border border-dashed border-border p-4">
+              <div className="font-medium text-foreground">
+                No templates yet.
+              </div>
+              <div className="mt-1 text-xs">
+                Create a template to launch agents from the command palette.
+              </div>
+            </div>
           </div>
         ) : (
-          <div className="flex flex-col gap-0.5">
+          <div>
             {callableTemplates.map((template) => (
               <TemplateListItem
                 key={template.id}
@@ -205,7 +214,7 @@ function TemplateListContent({
         onOpenChange={setShowCreate}
         enabledAgentTypes={enabledAgentTypes}
       />
-    </>
+    </div>
   );
 }
 
@@ -219,8 +228,8 @@ function TemplateListItem({
   onSelect: () => void;
 }): JSX.Element {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const { launchTemplate } = useTemplateActions();
+  const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
   const args = useMemo(
     () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
     [template.prompt]
@@ -230,51 +239,72 @@ function TemplateListItem({
     (e: React.MouseEvent) => {
       e.stopPropagation();
       if (args.length > 0) {
-        navigate(`/automations/templates/${template.id}`);
+        setLaunchDialogOpen(true);
         return;
       }
       launchTemplate
         .mutateAsync({ id: template.id })
-        .then(async (result) => {
-          await queryClient.invalidateQueries({ queryKey: ["agents"] });
-          navigate(agentRoute(result.agentId));
+        .then((result) => {
+          navigate(agentRoute(result.agent.id));
         })
         .catch((err: Error) => {
           toast.error(`Failed to launch: ${err.message}`);
         });
     },
-    [args.length, launchTemplate, navigate, queryClient, template.id]
+    [args.length, launchTemplate, navigate, template.id]
   );
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
-      className={cn(
-        "group flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
-        selected
-          ? "border border-primary/20 bg-primary/10 text-foreground"
-          : "border border-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground"
-      )}
-    >
-      <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      <span className="min-w-0 flex-1 truncate">{template.name}</span>
-      <button
-        type="button"
-        onClick={handleLaunch}
-        title="Launch template"
-        className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+        className={cn(
+          "group w-full cursor-pointer border-b border-r-4 border-border border-r-transparent px-3 py-2 text-left transition-colors hover:bg-muted/40",
+          selected && "border-r-primary bg-muted/60"
+        )}
       >
-        <Play className="h-3 w-3 fill-current" />
-      </button>
-    </div>
+        <div className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold leading-5">
+              {template.name}
+            </div>
+            {template.description ? (
+              <div className="truncate text-xs text-muted-foreground">
+                {template.description}
+              </div>
+            ) : (
+              <div
+                className="truncate font-mono text-[11px] text-muted-foreground"
+                title={template.directory}
+              >
+                {shortPath(template.directory)}
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleLaunch}
+            title="Launch template"
+            className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
+          >
+            <Play className="h-3 w-3 fill-current" />
+          </button>
+        </div>
+      </div>
+      <LaunchTemplateDialog
+        template={template}
+        open={launchDialogOpen}
+        onOpenChange={setLaunchDialogOpen}
+      />
+    </>
   );
 }
 
@@ -315,19 +345,11 @@ function TemplateDetail({
   enabledAgentTypes: AgentType[];
 }): JSX.Element {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { launchTemplate, updateTemplate, removeTemplate } =
-    useTemplateActions();
-
-  // Launch arg values
-  const launchArgs = useMemo(
-    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
-    [template.prompt]
-  );
-  const [argValues, setArgValues] = useState<Record<string, string>>({});
+  const { updateTemplate, removeTemplate } = useTemplateActions();
 
   // Editable form state — reset when template changes
   const [displayName, setDisplayName] = useState(template.name);
+  const [description, setDescription] = useState(template.description ?? "");
   const [directory, setDirectory] = useState(template.directory);
   const [prompt, setPrompt] = useState(template.prompt ?? "");
   const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
@@ -339,9 +361,11 @@ function TemplateDetail({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
 
   useEffect(() => {
     setDisplayName(template.name);
+    setDescription(template.description ?? "");
     setDirectory(template.directory);
     setPrompt(template.prompt ?? "");
     setAgentType(template.agentType);
@@ -353,7 +377,7 @@ function TemplateDetail({
     setSaveError(null);
     setSaved(false);
     setRemoveDialogOpen(false);
-    setArgValues({});
+    setLaunchDialogOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template.id]);
 
@@ -371,6 +395,7 @@ function TemplateDetail({
       .mutateAsync({
         id: template.id,
         name: displayName.trim(),
+        description: description.trim() || null,
         directory: directory.trim(),
         prompt: prompt || null,
         agentType,
@@ -386,6 +411,7 @@ function TemplateDetail({
     updateTemplate,
     template.id,
     displayName,
+    description,
     directory,
     prompt,
     agentType,
@@ -394,26 +420,6 @@ function TemplateDetail({
     branchName,
     fullAccess,
     callable,
-  ]);
-
-  const handleLaunch = useCallback(() => {
-    const args = launchArgs.length > 0 ? argValues : undefined;
-    launchTemplate
-      .mutateAsync({ id: template.id, args })
-      .then(async (result) => {
-        await queryClient.invalidateQueries({ queryKey: ["agents"] });
-        navigate(agentRoute(result.agentId));
-      })
-      .catch((err: Error) => {
-        toast.error(`Failed to launch: ${err.message}`);
-      });
-  }, [
-    launchArgs,
-    argValues,
-    launchTemplate,
-    navigate,
-    queryClient,
-    template.id,
   ]);
 
   const handleDelete = useCallback(() => {
@@ -429,10 +435,6 @@ function TemplateDetail({
     setRemoveDialogOpen(false);
   }, [removeTemplate, template, navigate]);
 
-  const allArgsFilled =
-    launchArgs.length === 0 ||
-    launchArgs.every((a) => argValues[a.key]?.trim());
-
   const cliAgentTypes = useMemo(
     () => enabledAgentTypes.filter(isCliAgentType),
     [enabledAgentTypes]
@@ -445,40 +447,20 @@ function TemplateDetail({
         <h2 className="text-lg font-semibold text-foreground">
           {template.name}
         </h2>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        {template.description ? (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {template.description}
+          </p>
+        ) : null}
+        <p className="mt-0.5 text-xs text-muted-foreground/70">
           {shortPath(template.directory)}
         </p>
 
-        {launchArgs.length > 0 ? (
-          <div className="mt-4">
-            <div className="mb-3 text-sm font-medium text-foreground">
-              Arguments
-            </div>
-            <div className="flex flex-col gap-3">
-              {launchArgs.map((arg) => (
-                <ArgInput
-                  key={arg.key}
-                  arg={arg}
-                  value={argValues[arg.key] ?? ""}
-                  onChange={(value) =>
-                    setArgValues((prev) => ({ ...prev, [arg.key]: value }))
-                  }
-                />
-              ))}
-            </div>
-          </div>
-        ) : null}
-
         <Button
           className="mt-4 gap-1.5"
-          onClick={handleLaunch}
-          disabled={!allArgsFilled || launchTemplate.isPending}
+          onClick={() => setLaunchDialogOpen(true)}
         >
-          {launchTemplate.isPending ? (
-            <ActivityBars size={16} className="mr-1" />
-          ) : (
-            <Play className="h-3.5 w-3.5 fill-current" />
-          )}
+          <Play className="h-3.5 w-3.5 fill-current" />
           Launch
         </Button>
       </div>
@@ -493,10 +475,30 @@ function TemplateDetail({
             </p>
             <div className="mt-4 grid gap-3 md:grid-cols-2">
               <div className="space-y-1 md:col-span-2">
+                <label className="text-sm text-muted-foreground">
+                  Agent type
+                </label>
+                <AgentTypeCombobox
+                  value={agentType}
+                  onChange={setAgentType}
+                  agentTypes={cliAgentTypes}
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
                 <label className="text-sm text-muted-foreground">Name</label>
                 <Input
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <label className="text-sm text-muted-foreground">
+                  Description
+                </label>
+                <Input
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Optional short description"
                 />
               </div>
               <div className="space-y-1 md:col-span-2">
@@ -507,16 +509,6 @@ function TemplateDetail({
                   value={directory}
                   onChange={setDirectory}
                   placeholder="/path/to/repo"
-                />
-              </div>
-              <div className="space-y-1 md:col-span-2">
-                <label className="text-sm text-muted-foreground">
-                  Agent type
-                </label>
-                <AgentTypeCombobox
-                  value={agentType}
-                  onChange={setAgentType}
-                  agentTypes={cliAgentTypes}
                 />
               </div>
             </div>
@@ -645,6 +637,12 @@ function TemplateDetail({
           </div>
         </DialogContent>
       </Dialog>
+
+      <LaunchTemplateDialog
+        template={template}
+        open={launchDialogOpen}
+        onOpenChange={setLaunchDialogOpen}
+      />
     </div>
   );
 }
@@ -670,6 +668,110 @@ function ArgInput({
         className="h-8 text-sm"
       />
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Launch template dialog (modal with args + launch)
+// ---------------------------------------------------------------------------
+
+export function LaunchTemplateDialog({
+  template,
+  open,
+  onOpenChange,
+}: {
+  template: Template;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const { launchTemplate } = useTemplateActions();
+
+  const args = useMemo(
+    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
+    [template.prompt]
+  );
+  const [argValues, setArgValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (open) setArgValues({});
+  }, [open]);
+
+  const allArgsFilled =
+    args.length === 0 || args.every((a) => argValues[a.key]?.trim());
+
+  const handleLaunch = useCallback(() => {
+    const launchArgs = args.length > 0 ? argValues : undefined;
+    launchTemplate
+      .mutateAsync({ id: template.id, args: launchArgs })
+      .then((result) => {
+        onOpenChange(false);
+        navigate(agentRoute(result.agent.id));
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to launch: ${err.message}`);
+      });
+  }, [args, argValues, launchTemplate, navigate, onOpenChange, template.id]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{template.name}</DialogTitle>
+          {template.description ? (
+            <DialogDescription>{template.description}</DialogDescription>
+          ) : (
+            <DialogDescription>
+              This will create a new agent from this template.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (allArgsFilled && !launchTemplate.isPending) handleLaunch();
+          }}
+        >
+          {args.length > 0 ? (
+            <div className="flex flex-col gap-3">
+              {args.map((arg) => (
+                <ArgInput
+                  key={arg.key}
+                  arg={arg}
+                  value={argValues[arg.key] ?? ""}
+                  onChange={(value) =>
+                    setArgValues((prev) => ({ ...prev, [arg.key]: value }))
+                  }
+                />
+              ))}
+            </div>
+          ) : null}
+
+          <div className="flex flex-row-reverse justify-start gap-2 pt-3">
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!allArgsFilled || launchTemplate.isPending}
+            >
+              {launchTemplate.isPending ? (
+                <ActivityBars size={16} className="mr-1.5" />
+              ) : (
+                <Play className="h-3.5 w-3.5 mr-1.5 fill-current" />
+              )}
+              Launch
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -707,6 +809,7 @@ function CreateTemplateDialogContent({
 }): JSX.Element {
   const { addTemplate } = useTemplateActions();
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [directory, setDirectory] = useState("");
   const [prompt, setPrompt] = useState("");
   const [agentType, setAgentType] = useState<CliAgentType>("claude");
@@ -731,6 +834,7 @@ function CreateTemplateDialogContent({
     addTemplate
       .mutateAsync({
         name,
+        description: description.trim() || null,
         directory,
         prompt: prompt || null,
         agentType,
@@ -751,6 +855,7 @@ function CreateTemplateDialogContent({
   }, [
     addTemplate,
     name,
+    description,
     directory,
     prompt,
     agentType,
@@ -798,6 +903,15 @@ function CreateTemplateDialogContent({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="template name"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm text-muted-foreground">Description</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional short description"
             />
           </div>
 

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -224,11 +224,18 @@ function TemplateListItem({
   );
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       className={cn(
-        "group flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
+        "group flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
         selected
           ? "border border-primary/20 bg-primary/10 text-foreground"
           : "border border-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground"
@@ -244,7 +251,7 @@ function TemplateListItem({
       >
         <Play className="h-3 w-3 fill-current" />
       </button>
-    </button>
+    </div>
   );
 }
 

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   AlarmClock,
+  Check,
+  ChevronDown,
   FileText,
-  Pencil,
+  GitBranch,
   Play,
   Plus,
   Trash2,
@@ -17,10 +19,19 @@ import {
   JobListContent,
   JobDetailPane,
 } from "@/components/app/jobs-pane";
+import { BranchSelect } from "@/components/app/branch-select";
 import { PathInput } from "@/components/app/path-input";
 import type { AgentType } from "@/lib/agent-types";
 import { type Agent } from "@/components/app/types";
+import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -29,7 +40,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   useTemplates,
   useTemplateActions,
@@ -42,6 +52,8 @@ import {
   type CliAgentType,
   isCliAgentType,
 } from "@/lib/agent-types";
+import { useClickOutside } from "@/hooks/use-click-outside";
+import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { agentRoute } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
 
@@ -64,10 +76,12 @@ function resolveTab(pathname: string): AutomationsTab {
 function AutomationsSidebar({
   activeTab,
   onTabChange,
+  enabledAgentTypes,
   onItemSelect,
 }: {
   activeTab: AutomationsTab;
   onTabChange: (tab: AutomationsTab) => void;
+  enabledAgentTypes: AgentType[];
   onItemSelect?: () => void;
 }): JSX.Element {
   return (
@@ -89,7 +103,10 @@ function AutomationsSidebar({
         </div>
       </div>
       {activeTab === "templates" ? (
-        <TemplateListContent onItemSelect={onItemSelect} />
+        <TemplateListContent
+          enabledAgentTypes={enabledAgentTypes}
+          onItemSelect={onItemSelect}
+        />
       ) : (
         <JobListContent onItemSelect={onItemSelect} />
       )}
@@ -130,8 +147,10 @@ function TabButton({
 // ---------------------------------------------------------------------------
 
 function TemplateListContent({
+  enabledAgentTypes,
   onItemSelect,
 }: {
+  enabledAgentTypes: AgentType[];
   onItemSelect?: () => void;
 }): JSX.Element {
   const navigate = useNavigate();
@@ -181,7 +200,11 @@ function TemplateListContent({
           </div>
         )}
       </div>
-      <CreateTemplateDialog open={showCreate} onOpenChange={setShowCreate} />
+      <CreateTemplateDialog
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        enabledAgentTypes={enabledAgentTypes}
+      />
     </>
   );
 }
@@ -259,7 +282,11 @@ function TemplateListItem({
 // Template detail pane
 // ---------------------------------------------------------------------------
 
-export function TemplateDetailPane(): JSX.Element {
+export function TemplateDetailPane({
+  enabledAgentTypes,
+}: {
+  enabledAgentTypes: AgentType[];
+}): JSX.Element {
   const { templateId } = useParams<{ templateId?: string }>();
   const { data: templates = [] } = useTemplates();
   const template = useMemo(
@@ -275,26 +302,104 @@ export function TemplateDetailPane(): JSX.Element {
     );
   }
 
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template} enabledAgentTypes={enabledAgentTypes} />
+  );
 }
 
-function TemplateDetail({ template }: { template: Template }): JSX.Element {
+function TemplateDetail({
+  template,
+  enabledAgentTypes,
+}: {
+  template: Template;
+  enabledAgentTypes: AgentType[];
+}): JSX.Element {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { launchTemplate, removeTemplate } = useTemplateActions();
-  const [showEdit, setShowEdit] = useState(false);
-  const [showDelete, setShowDelete] = useState(false);
+  const { launchTemplate, updateTemplate, removeTemplate } =
+    useTemplateActions();
 
-  const args = useMemo(
+  // Launch arg values
+  const launchArgs = useMemo(
     () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
     [template.prompt]
   );
   const [argValues, setArgValues] = useState<Record<string, string>>({});
 
+  // Editable form state — reset when template changes
+  const [displayName, setDisplayName] = useState(template.name);
+  const [directory, setDirectory] = useState(template.directory);
+  const [prompt, setPrompt] = useState(template.prompt ?? "");
+  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
+  const [useWorktree, setUseWorktree] = useState(template.useWorktree);
+  const [baseBranch, setBaseBranch] = useState(template.baseBranch ?? "main");
+  const [branchName, setBranchName] = useState(template.branchName ?? "");
+  const [fullAccess, setFullAccess] = useState(template.fullAccess);
+  const [callable, setCallable] = useState(template.callable);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+
+  useEffect(() => {
+    setDisplayName(template.name);
+    setDirectory(template.directory);
+    setPrompt(template.prompt ?? "");
+    setAgentType(template.agentType);
+    setUseWorktree(template.useWorktree);
+    setBaseBranch(template.baseBranch ?? "main");
+    setBranchName(template.branchName ?? "");
+    setFullAccess(template.fullAccess);
+    setCallable(template.callable);
+    setSaveError(null);
+    setSaved(false);
+    setRemoveDialogOpen(false);
+    setArgValues({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [template.id]);
+
+  const detectedArgs = useMemo(
+    () => (prompt ? parseTemplateArgs(prompt) : []),
+    [prompt]
+  );
+
+  const canSave = !!displayName.trim() && !!directory.trim();
+
+  const handleSave = useCallback(() => {
+    setSaveError(null);
+    setSaved(false);
+    updateTemplate
+      .mutateAsync({
+        id: template.id,
+        name: displayName.trim(),
+        directory: directory.trim(),
+        prompt: prompt || null,
+        agentType,
+        useWorktree,
+        baseBranch: useWorktree ? baseBranch : null,
+        branchName: useWorktree ? branchName || null : null,
+        fullAccess,
+        callable,
+      })
+      .then(() => setSaved(true))
+      .catch((err: Error) => setSaveError(err.message));
+  }, [
+    updateTemplate,
+    template.id,
+    displayName,
+    directory,
+    prompt,
+    agentType,
+    useWorktree,
+    baseBranch,
+    branchName,
+    fullAccess,
+    callable,
+  ]);
+
   const handleLaunch = useCallback(() => {
-    const launchArgs = args.length > 0 ? argValues : undefined;
+    const args = launchArgs.length > 0 ? argValues : undefined;
     launchTemplate
-      .mutateAsync({ id: template.id, args: launchArgs })
+      .mutateAsync({ id: template.id, args })
       .then(async (result) => {
         await queryClient.invalidateQueries({ queryKey: ["agents"] });
         navigate(agentRoute(result.agentId));
@@ -302,7 +407,14 @@ function TemplateDetail({ template }: { template: Template }): JSX.Element {
       .catch((err: Error) => {
         toast.error(`Failed to launch: ${err.message}`);
       });
-  }, [args, argValues, launchTemplate, navigate, queryClient, template.id]);
+  }, [
+    launchArgs,
+    argValues,
+    launchTemplate,
+    navigate,
+    queryClient,
+    template.id,
+  ]);
 
   const handleDelete = useCallback(() => {
     removeTemplate
@@ -314,55 +426,36 @@ function TemplateDetail({ template }: { template: Template }): JSX.Element {
       .catch((err: Error) => {
         toast.error(`Failed to delete: ${err.message}`);
       });
-    setShowDelete(false);
+    setRemoveDialogOpen(false);
   }, [removeTemplate, template, navigate]);
 
   const allArgsFilled =
-    args.length === 0 || args.every((a) => argValues[a.key]?.trim());
+    launchArgs.length === 0 ||
+    launchArgs.every((a) => argValues[a.key]?.trim());
+
+  const cliAgentTypes = useMemo(
+    () => enabledAgentTypes.filter(isCliAgentType),
+    [enabledAgentTypes]
+  );
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
+      {/* Header with launch */}
       <div className="border-b border-border px-6 py-5">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">
-              {template.name}
-            </h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {shortPath(template.directory)}
-            </p>
-          </div>
-          <div className="flex gap-1.5">
-            <Button
-              size="sm"
-              variant="ghost"
-              className="gap-1"
-              onClick={() => setShowEdit(true)}
-            >
-              <Pencil className="h-3 w-3" />
-              Edit
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="gap-1 text-destructive hover:text-destructive"
-              onClick={() => setShowDelete(true)}
-            >
-              <Trash2 className="h-3 w-3" />
-            </Button>
-          </div>
-        </div>
-      </div>
+        <h2 className="text-lg font-semibold text-foreground">
+          {template.name}
+        </h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {shortPath(template.directory)}
+        </p>
 
-      {/* Launch form */}
-      <div className="flex-1 px-6 py-5">
-        {args.length > 0 ? (
-          <div className="mb-5">
-            <h3 className="mb-3 text-sm font-medium text-foreground">
+        {launchArgs.length > 0 ? (
+          <div className="mt-4">
+            <div className="mb-3 text-sm font-medium text-foreground">
               Arguments
-            </h3>
+            </div>
             <div className="flex flex-col gap-3">
-              {args.map((arg) => (
+              {launchArgs.map((arg) => (
                 <ArgInput
                   key={arg.key}
                   arg={arg}
@@ -377,52 +470,163 @@ function TemplateDetail({ template }: { template: Template }): JSX.Element {
         ) : null}
 
         <Button
-          className="gap-1.5"
+          className="mt-4 gap-1.5"
           onClick={handleLaunch}
           disabled={!allArgsFilled || launchTemplate.isPending}
         >
-          <Play className="h-3.5 w-3.5 fill-current" />
+          {launchTemplate.isPending ? (
+            <ActivityBars size={16} className="mr-1" />
+          ) : (
+            <Play className="h-3.5 w-3.5 fill-current" />
+          )}
           Launch
         </Button>
-
-        {/* Config summary */}
-        <div className="mt-8 space-y-2 text-xs text-muted-foreground">
-          <div>
-            Agent type:{" "}
-            <span className="text-foreground">
-              {AGENT_TYPE_LABELS[template.agentType] ?? template.agentType}
-            </span>
-          </div>
-          {template.useWorktree ? (
-            <div>
-              Worktree:{" "}
-              <span className="text-foreground">
-                {template.baseBranch ?? "default branch"}
-              </span>
-            </div>
-          ) : null}
-          {template.fullAccess ? (
-            <div className="text-amber-500/80">Full access enabled</div>
-          ) : null}
-        </div>
-
-        {template.prompt ? (
-          <div className="mt-6">
-            <h3 className="mb-2 text-sm font-medium text-foreground">Prompt</h3>
-            <pre className="max-h-60 overflow-y-auto whitespace-pre-wrap rounded-md bg-white/[0.04] p-3 text-xs text-muted-foreground">
-              {template.prompt}
-            </pre>
-          </div>
-        ) : null}
       </div>
 
-      <EditTemplateDialog
-        template={template}
-        open={showEdit}
-        onOpenChange={setShowEdit}
-      />
+      {/* Inline-editable config form */}
+      <div className="flex-1 px-6 py-5">
+        <div className="grid gap-4">
+          <div className="rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
+            <div className="text-sm font-medium">Template configuration</div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Agent launch settings for this template.
+            </p>
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div className="space-y-1 md:col-span-2">
+                <label className="text-sm text-muted-foreground">Name</label>
+                <Input
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <label className="text-sm text-muted-foreground">
+                  Working directory
+                </label>
+                <PathInput
+                  value={directory}
+                  onChange={setDirectory}
+                  placeholder="/path/to/repo"
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <label className="text-sm text-muted-foreground">
+                  Agent type
+                </label>
+                <AgentTypeCombobox
+                  value={agentType}
+                  onChange={setAgentType}
+                  agentTypes={cliAgentTypes}
+                />
+              </div>
+            </div>
 
-      <Dialog open={showDelete} onOpenChange={setShowDelete}>
+            <div className="mt-4 grid gap-3">
+              <TemplateWorktreeOption
+                checked={useWorktree}
+                cwd={directory}
+                baseBranch={baseBranch}
+                branchName={branchName}
+                onCheckedChange={setUseWorktree}
+                onBaseBranchChange={setBaseBranch}
+                onBranchNameChange={setBranchName}
+              />
+              <TemplateFullAccessOption
+                checked={fullAccess}
+                onCheckedChange={setFullAccess}
+              />
+              <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+                <Checkbox
+                  checked={callable}
+                  onCheckedChange={() => setCallable((c) => !c)}
+                  className="mt-0.5"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">
+                    Show in command palette
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Launch this template from the {"⌘"}K palette.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div className="mt-4 space-y-1 md:col-span-2">
+              <label className="text-sm text-muted-foreground">Prompt</label>
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder="Describe what the agent should do..."
+                className={cn(
+                  "flex min-h-[120px] w-full resize-y rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+                  "ring-offset-background placeholder:text-muted-foreground",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                )}
+              />
+              {detectedArgs.length > 0 ? (
+                <div className="mt-1.5 text-xs text-muted-foreground">
+                  Detected arguments:{" "}
+                  {detectedArgs.map((a) => (
+                    <span
+                      key={a.key}
+                      className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+                    >
+                      {a.name}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            {saveError ? (
+              <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+                {saveError}
+              </div>
+            ) : null}
+            {saved ? (
+              <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">
+                Settings saved.
+              </div>
+            ) : null}
+            <div className="mt-4 flex justify-end">
+              <Button
+                variant="primary"
+                disabled={!canSave || updateTemplate.isPending}
+                onClick={handleSave}
+              >
+                {updateTemplate.isPending ? (
+                  <ActivityBars size={16} className="mr-2" />
+                ) : null}
+                Save
+              </Button>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-status-blocked/30 bg-status-blocked/5 p-4">
+            <div className="text-sm font-medium text-status-blocked">
+              Delete template
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Permanently remove this template. Jobs that reference it will lose
+              their backing template.
+            </p>
+            <div className="mt-3 flex justify-end">
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={removeTemplate.isPending}
+                onClick={() => setRemoveDialogOpen(true)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Dialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Delete template</DialogTitle>
@@ -432,7 +636,7 @@ function TemplateDetail({ template }: { template: Template }): JSX.Element {
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => setShowDelete(false)}>
+            <Button variant="ghost" onClick={() => setRemoveDialogOpen(false)}>
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleDelete}>
@@ -470,15 +674,36 @@ function ArgInput({
 }
 
 // ---------------------------------------------------------------------------
-// Create / Edit template dialogs
+// Create template dialog (mirrors create-agent-dialog components)
 // ---------------------------------------------------------------------------
 
 function CreateTemplateDialog({
   open,
   onOpenChange,
+  enabledAgentTypes,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  enabledAgentTypes: AgentType[];
+}): JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <CreateTemplateDialogContent
+          onOpenChange={onOpenChange}
+          enabledAgentTypes={enabledAgentTypes}
+        />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function CreateTemplateDialogContent({
+  onOpenChange,
+  enabledAgentTypes,
+}: {
+  onOpenChange: (open: boolean) => void;
+  enabledAgentTypes: AgentType[];
 }): JSX.Element {
   const { addTemplate } = useTemplateActions();
   const [name, setName] = useState("");
@@ -486,8 +711,15 @@ function CreateTemplateDialog({
   const [prompt, setPrompt] = useState("");
   const [agentType, setAgentType] = useState<CliAgentType>("claude");
   const [useWorktree, setUseWorktree] = useState(false);
-  const [baseBranch, setBaseBranch] = useState("");
+  const [baseBranch, setBaseBranch] = useState("main");
+  const [branchName, setBranchName] = useState("");
   const [fullAccess, setFullAccess] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  const cliAgentTypes = useMemo(
+    () => enabledAgentTypes.filter(isCliAgentType),
+    [enabledAgentTypes]
+  );
 
   const detectedArgs = useMemo(
     () => (prompt ? parseTemplateArgs(prompt) : []),
@@ -495,6 +727,7 @@ function CreateTemplateDialog({
   );
 
   const handleCreate = useCallback(() => {
+    setCreating(true);
     addTemplate
       .mutateAsync({
         name,
@@ -502,24 +735,19 @@ function CreateTemplateDialog({
         prompt: prompt || null,
         agentType,
         useWorktree,
-        baseBranch: baseBranch || null,
+        baseBranch: useWorktree ? baseBranch : null,
+        branchName: useWorktree ? branchName || null : null,
         fullAccess,
         callable: true,
       })
       .then(() => {
         onOpenChange(false);
-        setName("");
-        setDirectory("");
-        setPrompt("");
-        setAgentType("claude");
-        setUseWorktree(false);
-        setBaseBranch("");
-        setFullAccess(false);
         toast.success("Template created.");
       })
       .catch((err: Error) => {
         toast.error(`Failed to create template: ${err.message}`);
-      });
+      })
+      .finally(() => setCreating(false));
   }, [
     addTemplate,
     name,
@@ -528,6 +756,7 @@ function CreateTemplateDialog({
     agentType,
     useWorktree,
     baseBranch,
+    branchName,
     fullAccess,
     onOpenChange,
   ]);
@@ -535,43 +764,76 @@ function CreateTemplateDialog({
   const canCreate = name.trim() && directory.trim();
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Create template</DialogTitle>
-          <DialogDescription>
-            A reusable agent launch configuration. Use{" "}
-            <code className="rounded bg-white/[0.08] px-1 text-xs">
-              {"{{D:Arg Name}}"}
-            </code>{" "}
-            in the prompt for runtime arguments.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div>
-            <label className="mb-1 block text-xs font-medium">Name</label>
+    <DialogContent
+      onEscapeKeyDown={(e) => {
+        swallowEscapeFromCombobox(e);
+      }}
+    >
+      <DialogHeader>
+        <DialogTitle>Create Template</DialogTitle>
+        <DialogDescription>
+          A reusable agent launch configuration. Use{" "}
+          <code className="rounded bg-white/[0.08] px-1 text-xs">
+            {"{{D:Arg Name}}"}
+          </code>{" "}
+          in the prompt for runtime arguments.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-1">
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm text-muted-foreground">Agent type</label>
+            <AgentTypeCombobox
+              value={agentType}
+              onChange={setAgentType}
+              agentTypes={cliAgentTypes}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm text-muted-foreground">Name</label>
             <Input
+              autoFocus
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="My template"
-              className="h-8"
+              placeholder="template name"
             />
           </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium">Directory</label>
-            <PathInput
-              value={directory}
-              onChange={setDirectory}
-              placeholder="/path/to/repo"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium">Prompt</label>
+
+          <PathInput
+            value={directory}
+            onChange={setDirectory}
+            label="Working directory"
+            placeholder="/path/to/repo"
+          />
+
+          <TemplateWorktreeOption
+            checked={useWorktree}
+            cwd={directory}
+            baseBranch={baseBranch}
+            branchName={branchName}
+            onCheckedChange={setUseWorktree}
+            onBaseBranchChange={setBaseBranch}
+            onBranchNameChange={setBranchName}
+          />
+
+          <TemplateFullAccessOption
+            checked={fullAccess}
+            onCheckedChange={setFullAccess}
+          />
+
+          <div className="space-y-1">
+            <label className="text-sm text-muted-foreground">Prompt</label>
             <textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="Describe what the agent should do..."
-              className="min-h-[100px] w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
+              className={cn(
+                "flex min-h-[120px] w-full resize-y rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+                "ring-offset-background placeholder:text-muted-foreground",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              )}
             />
             {detectedArgs.length > 0 ? (
               <div className="mt-1.5 text-xs text-muted-foreground">
@@ -587,252 +849,195 @@ function CreateTemplateDialog({
               </div>
             ) : null}
           </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium">Agent type</label>
-            <select
-              value={agentType}
-              onChange={(e) => {
-                if (isCliAgentType(e.target.value))
-                  setAgentType(e.target.value);
-              }}
-              className="h-8 w-full rounded-md border border-border bg-transparent px-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
-            >
-              {Object.entries(AGENT_TYPE_LABELS)
-                .filter(([key]) => isCliAgentType(key))
-                .map(([key, label]) => (
-                  <option key={key} value={key}>
-                    {label}
-                  </option>
-                ))}
-            </select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Checkbox
-              checked={useWorktree}
-              onCheckedChange={(checked) => setUseWorktree(checked === true)}
-              id="create-template-worktree"
-            />
-            <label
-              htmlFor="create-template-worktree"
-              className="text-sm text-foreground"
-            >
-              Use worktree
-            </label>
-          </div>
-          {useWorktree ? (
-            <div>
-              <label className="mb-1 block text-xs font-medium">
-                Base branch
-              </label>
-              <Input
-                value={baseBranch}
-                onChange={(e) => setBaseBranch(e.target.value)}
-                placeholder="main"
-                className="h-8"
-              />
-            </div>
-          ) : null}
-          <div className="flex items-center gap-2">
-            <Checkbox
-              checked={fullAccess}
-              onCheckedChange={(checked) => setFullAccess(checked === true)}
-              id="create-template-full-access"
-            />
-            <label
-              htmlFor="create-template-full-access"
-              className="text-sm text-foreground"
-            >
-              Full access
-            </label>
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleCreate} disabled={!canCreate}>
-              Create
-            </Button>
-          </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-3">
+        <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleCreate}
+          disabled={!canCreate || creating}
+        >
+          {creating ? <ActivityBars size={16} className="mr-1.5" /> : null}
+          Create
+        </Button>
+      </div>
+    </DialogContent>
   );
 }
 
-function EditTemplateDialog({
-  template,
-  open,
-  onOpenChange,
+// ---------------------------------------------------------------------------
+// Shared form components for create & edit
+// ---------------------------------------------------------------------------
+
+function AgentTypeCombobox({
+  value,
+  onChange,
+  agentTypes,
 }: {
-  template: Template;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  value: CliAgentType;
+  onChange: (value: CliAgentType) => void;
+  agentTypes: CliAgentType[];
 }): JSX.Element {
-  const { updateTemplate } = useTemplateActions();
-  const [name, setName] = useState(template.name);
-  const [prompt, setPrompt] = useState(template.prompt ?? "");
-  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
-  const [useWorktree, setUseWorktree] = useState(template.useWorktree);
-  const [baseBranch, setBaseBranch] = useState(template.baseBranch ?? "");
-  const [fullAccess, setFullAccess] = useState(template.fullAccess);
-  const [callable, setCallable] = useState(template.callable);
-
-  const detectedArgs = useMemo(
-    () => (prompt ? parseTemplateArgs(prompt) : []),
-    [prompt]
-  );
-
-  const handleSave = useCallback(() => {
-    updateTemplate
-      .mutateAsync({
-        id: template.id,
-        name,
-        prompt: prompt || null,
-        agentType,
-        useWorktree,
-        baseBranch: baseBranch || null,
-        fullAccess,
-        callable,
-      })
-      .then(() => {
-        onOpenChange(false);
-        toast.success("Template updated.");
-      })
-      .catch((err: Error) => {
-        toast.error(`Failed to update: ${err.message}`);
-      });
-  }, [
-    updateTemplate,
-    template.id,
-    name,
-    prompt,
-    agentType,
-    useWorktree,
-    baseBranch,
-    fullAccess,
-    callable,
-    onOpenChange,
-  ]);
+  const [open, setOpen] = useState(false);
+  const cmdRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useClickOutside(cmdRef, open, close);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Edit template</DialogTitle>
-          <DialogDescription>
-            Modify the template configuration.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div>
-            <label className="mb-1 block text-xs font-medium">Name</label>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="h-8"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium">Prompt</label>
-            <textarea
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              className="min-h-[100px] w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
-            />
-            {detectedArgs.length > 0 ? (
-              <div className="mt-1.5 text-xs text-muted-foreground">
-                Detected arguments:{" "}
-                {detectedArgs.map((a) => (
-                  <span
-                    key={a.key}
-                    className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+    <div className="relative" ref={cmdRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            if (!open) setOpen(true);
+          }
+        }}
+        className={cn(
+          "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+          "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+        )}
+      >
+        {AGENT_TYPE_LABELS[value]}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
+          <Command
+            shouldFilter={false}
+            ref={(el) => {
+              if (el) requestAnimationFrame(() => el.focus());
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setOpen(false);
+                requestAnimationFrame(() => triggerRef.current?.focus());
+              }
+            }}
+          >
+            <CommandList>
+              <CommandGroup>
+                {agentTypes.map((t) => (
+                  <CommandItem
+                    key={t}
+                    value={t}
+                    onSelect={() => {
+                      onChange(t);
+                      setOpen(false);
+                      requestAnimationFrame(() => triggerRef.current?.focus());
+                    }}
                   >
-                    {a.name}
-                  </span>
+                    <Check
+                      className={cn(
+                        "mr-2 h-3 w-3 shrink-0",
+                        t === value ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    {AGENT_TYPE_LABELS[t]}
+                  </CommandItem>
                 ))}
-              </div>
-            ) : null}
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium">Agent type</label>
-            <select
-              value={agentType}
-              onChange={(e) => {
-                if (isCliAgentType(e.target.value))
-                  setAgentType(e.target.value);
-              }}
-              className="h-8 w-full rounded-md border border-border bg-transparent px-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
-            >
-              {Object.entries(AGENT_TYPE_LABELS)
-                .filter(([key]) => isCliAgentType(key))
-                .map(([key, label]) => (
-                  <option key={key} value={key}>
-                    {label}
-                  </option>
-                ))}
-            </select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Checkbox
-              checked={useWorktree}
-              onCheckedChange={(checked) => setUseWorktree(checked === true)}
-              id="edit-template-worktree"
-            />
-            <label
-              htmlFor="edit-template-worktree"
-              className="text-sm text-foreground"
-            >
-              Use worktree
-            </label>
-          </div>
-          {useWorktree ? (
-            <div>
-              <label className="mb-1 block text-xs font-medium">
-                Base branch
-              </label>
-              <Input
-                value={baseBranch}
-                onChange={(e) => setBaseBranch(e.target.value)}
-                placeholder="main"
-                className="h-8"
-              />
-            </div>
-          ) : null}
-          <div className="flex items-center gap-2">
-            <Checkbox
-              checked={fullAccess}
-              onCheckedChange={(checked) => setFullAccess(checked === true)}
-              id="edit-template-full-access"
-            />
-            <label
-              htmlFor="edit-template-full-access"
-              className="text-sm text-foreground"
-            >
-              Full access
-            </label>
-          </div>
-          <div className="flex items-center gap-2">
-            <Checkbox
-              checked={callable}
-              onCheckedChange={(checked) => setCallable(checked === true)}
-              id="edit-template-callable"
-            />
-            <label
-              htmlFor="edit-template-callable"
-              className="text-sm text-foreground"
-            >
-              Show in Cmd+K
-            </label>
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave}>Save</Button>
-          </div>
+              </CommandGroup>
+            </CommandList>
+          </Command>
         </div>
-      </DialogContent>
-    </Dialog>
+      ) : null}
+    </div>
+  );
+}
+
+function TemplateWorktreeOption({
+  checked,
+  cwd,
+  baseBranch,
+  branchName,
+  onCheckedChange,
+  onBaseBranchChange,
+  onBranchNameChange,
+}: {
+  checked: boolean;
+  cwd: string;
+  baseBranch: string;
+  branchName: string;
+  onCheckedChange: (checked: boolean) => void;
+  onBaseBranchChange: (value: string) => void;
+  onBranchNameChange: (value: string) => void;
+}): JSX.Element {
+  return (
+    <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+      <label className="flex cursor-pointer items-start gap-3">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={() => onCheckedChange(!checked)}
+          className="mt-0.5"
+          title="Toggle git worktree"
+        />
+        <span className="space-y-1">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <GitBranch className="h-3.5 w-3.5" />
+            Run in a git worktree
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            Creates an isolated worktree when this template is launched.
+          </span>
+        </span>
+      </label>
+      {checked ? (
+        <div className="ml-8 w-[calc(100%-2rem)]">
+          <BranchSelect
+            cwd={cwd}
+            baseBranch={baseBranch}
+            onBaseBranchChange={onBaseBranchChange}
+            worktreeBranch={branchName}
+            onWorktreeBranchChange={onBranchNameChange}
+            testIdPrefix="template-worktree"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function TemplateFullAccessOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}): JSX.Element {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Toggle full access"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Start in full access mode
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          Starts the selected agent with its most permissive supported execution
+          mode.
+        </span>
+      </span>
+    </label>
   );
 }
 
@@ -898,6 +1103,7 @@ export function AutomationsSidebarContent({
         <AutomationsSidebar
           activeTab={activeTab}
           onTabChange={handleTabChange}
+          enabledAgentTypes={enabledAgentTypes}
           onItemSelect={isMobile ? closeSidebar : undefined}
         />
       </JobsProvider>
@@ -908,6 +1114,7 @@ export function AutomationsSidebarContent({
     <AutomationsSidebar
       activeTab={activeTab}
       onTabChange={handleTabChange}
+      enabledAgentTypes={enabledAgentTypes}
       onItemSelect={isMobile ? closeSidebar : undefined}
     />
   );
@@ -932,7 +1139,7 @@ export function AutomationsDetailContent({
   );
 
   if (activeTab === "templates") {
-    return <TemplateDetailPane />;
+    return <TemplateDetailPane enabledAgentTypes={enabledAgentTypes} />;
   }
 
   return (

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -160,13 +160,8 @@ function TemplateListContent({
 }): JSX.Element {
   const navigate = useNavigate();
   const { templateId } = useParams<{ templateId?: string }>();
-  const { data: templates = [] } = useTemplates();
+  const { data: templates = [], isLoading } = useTemplates();
   const [showCreate, setShowCreate] = useState(false);
-
-  const callableTemplates = useMemo(
-    () => templates.filter((t) => t.callable),
-    [templates]
-  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -182,20 +177,29 @@ function TemplateListContent({
         </Button>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {callableTemplates.length === 0 ? (
+        {isLoading ? (
+          <div className="space-y-3 p-4">
+            {Array.from({ length: 3 }, (_, i) => (
+              <div
+                key={i}
+                className="h-10 animate-pulse rounded-md bg-muted/40"
+              />
+            ))}
+          </div>
+        ) : templates.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground">
             <div className="rounded-md border border-dashed border-border p-4">
               <div className="font-medium text-foreground">
                 No templates yet.
               </div>
               <div className="mt-1 text-xs">
-                Create a template to launch agents from the command palette.
+                Create a template to launch agents with saved configurations.
               </div>
             </div>
           </div>
         ) : (
           <div>
-            {callableTemplates.map((template) => (
+            {templates.map((template) => (
               <TemplateListItem
                 key={template.id}
                 template={template}
@@ -293,7 +297,7 @@ function TemplateListItem({
             type="button"
             onClick={handleLaunch}
             title="Launch template"
-            className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
+            className="shrink-0 rounded p-2 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
           >
             <Play className="h-3 w-3 fill-current" />
           </button>
@@ -359,7 +363,6 @@ function TemplateDetail({
   const [fullAccess, setFullAccess] = useState(template.fullAccess);
   const [callable, setCallable] = useState(template.callable);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
 
@@ -375,7 +378,6 @@ function TemplateDetail({
     setFullAccess(template.fullAccess);
     setCallable(template.callable);
     setSaveError(null);
-    setSaved(false);
     setRemoveDialogOpen(false);
     setLaunchDialogOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -390,7 +392,6 @@ function TemplateDetail({
 
   const handleSave = useCallback(() => {
     setSaveError(null);
-    setSaved(false);
     updateTemplate
       .mutateAsync({
         id: template.id,
@@ -405,7 +406,7 @@ function TemplateDetail({
         fullAccess,
         callable,
       })
-      .then(() => setSaved(true))
+      .then(() => toast.success("Settings saved."))
       .catch((err: Error) => setSaveError(err.message));
   }, [
     updateTemplate,
@@ -426,13 +427,14 @@ function TemplateDetail({
     removeTemplate
       .mutateAsync(template.id)
       .then(() => {
+        setRemoveDialogOpen(false);
         navigate("/automations");
         toast.success(`Template "${template.name}" deleted.`);
       })
       .catch((err: Error) => {
+        setRemoveDialogOpen(false);
         toast.error(`Failed to delete: ${err.message}`);
       });
-    setRemoveDialogOpen(false);
   }, [removeTemplate, template, navigate]);
 
   const cliAgentTypes = useMemo(
@@ -576,11 +578,6 @@ function TemplateDetail({
                 {saveError}
               </div>
             ) : null}
-            {saved ? (
-              <div className="mt-4 rounded-md border border-status-done/40 bg-status-done/10 p-3 text-sm text-status-done">
-                Settings saved.
-              </div>
-            ) : null}
             <div className="mt-4 flex justify-end">
               <Button
                 variant="primary"
@@ -628,11 +625,19 @@ function TemplateDetail({
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => setRemoveDialogOpen(false)}>
+            <Button
+              variant="ghost"
+              onClick={() => setRemoveDialogOpen(false)}
+              disabled={removeTemplate.isPending}
+            >
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleDelete}>
-              Delete
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={removeTemplate.isPending}
+            >
+              {removeTemplate.isPending ? "Deleting…" : "Delete"}
             </Button>
           </div>
         </DialogContent>

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -22,7 +22,7 @@ export type DocsSection =
   | "shortcuts"
   | "personalities"
   | "tools"
-  | "jobs"
+  | "automations"
   | "worktrees"
   | "personas"
   | "events"
@@ -323,11 +323,11 @@ const SECTIONS: SectionDef[] = [
             </li>
           </ul>
           <P>
-            Jobs with <strong>Show in command palette</strong> enabled appear in
-            a separate <em>Jobs</em> group below the built-in commands.
-            Selecting a job shows a confirmation step with{" "}
-            <strong>Launch</strong> / <strong>Cancel</strong> — press Enter
-            twice to launch immediately.
+            Templates with <strong>Show in command palette</strong> enabled
+            appear in a separate <em>Templates</em> group below the built-in
+            commands. Templates without arguments show a confirmation step —
+            press Enter twice to launch immediately. Templates with arguments
+            open a launch dialog where you fill in each value before launching.
           </P>
           <P>
             Each action shows its hotkey badge inline so you can learn the
@@ -655,23 +655,131 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
     ),
   },
   {
-    id: "jobs",
-    label: "Jobs",
+    id: "automations",
+    label: "Automations",
     icon: Briefcase,
-    title: "Jobs",
+    title: "Automations: Templates & Jobs",
     content: (
       <>
         <P>
-          Jobs are saved agent prompts that you can run on a cron schedule or on
-          demand. Each run spawns a fresh agent that works in its own worktree
-          and reports progress through a small set of lifecycle tools.
+          The Automations system has two layers: <strong>templates</strong> are
+          reusable agent launch configurations, and <strong>jobs</strong> add
+          scheduling, timeouts, monitoring, and structured reporting on top of a
+          template. Both live under the <strong>Automations</strong> page,
+          accessible from the sidebar.
         </P>
+
+        <Section>
+          <H3>Templates</H3>
+          <P>
+            A template captures a prompt, agent type, directory, worktree
+            settings, and an optional set of runtime arguments. Launching a
+            template creates a normal agent session with no supervision — ideal
+            for quick-launch workflows like code review, feature scaffolding, or
+            ad-hoc tasks.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Creating a template</H3>
+          <P>
+            Open the <strong>Automations</strong> page and select the{" "}
+            <strong>Templates</strong> tab. Click <strong>Create</strong> and
+            fill in:
+          </P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li>
+              <strong>Name</strong> — display name, unique within its directory.
+            </li>
+            <li>
+              <strong>Working directory</strong> — the repo the template runs
+              against.
+            </li>
+            <li>
+              <strong>Prompt</strong> — instructions sent as the agent's first
+              message. Supports <Code>{"{{D:Arg Name}}"}</Code> placeholders for
+              runtime arguments (see below).
+            </li>
+            <li>
+              <strong>Agent type</strong> — <Code>claude</Code>,{" "}
+              <Code>codex</Code>, or <Code>opencode</Code>.
+            </li>
+            <li>
+              <strong>Use worktree</strong> — give each launch its own git
+              worktree. Optionally set a base branch and custom branch name.
+            </li>
+            <li>
+              <strong>Full access</strong> — launch the CLI in its most
+              permissive mode.
+            </li>
+            <li>
+              <strong>Show in command palette</strong> — when on, the template
+              appears in the <Code>Mod+K</Code> palette for quick access.
+            </li>
+          </ul>
+        </Section>
+
+        <Section>
+          <H3>Runtime arguments</H3>
+          <P>
+            Templates support <Code>{"{{D:Arg Name}}"}</Code> placeholders in
+            their prompt. At launch time, each placeholder becomes a required
+            input field. Argument values are also pinned to the spawned agent's
+            sidebar for reference.
+          </P>
+          <P>
+            For example, a prompt like{" "}
+            <Code>
+              {"Review the PR at {{D:PR URL}} focusing on {{D:Review Focus}}"}
+            </Code>{" "}
+            creates two input fields: "PR URL" and "Review Focus".
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Launching templates</H3>
+          <P>There are three ways to launch a template:</P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li>
+              <strong>Template detail pane</strong> — select a template in the
+              sidebar, fill in any arguments, and click <strong>Launch</strong>.
+            </li>
+            <li>
+              <strong>Inline play button</strong> — each template in the list
+              has a play icon for quick launch. Templates without arguments
+              launch directly; those with arguments open a launch dialog.
+            </li>
+            <li>
+              <strong>Command palette</strong> (<Code>Mod+K</Code>) — callable
+              templates appear under a "Templates" group. Templates without
+              arguments show a confirmation step (press Enter twice). Templates
+              with arguments open a launch dialog where you fill in values
+              before launching.
+            </li>
+          </ul>
+          <P>
+            After launch, the new agent appears in the sidebar immediately and
+            the view navigates to it.
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Jobs</H3>
+          <P>
+            A job references a backing template and adds automation on top: cron
+            scheduling, run timeouts, singleton enforcement, structured
+            reporting via MCP tools, auto-archive, and notifications. Jobs are
+            the right choice for recurring or monitored work — nightly triage,
+            release babysitting, janitorial cleanup — where you want a
+            machine-readable outcome.
+          </P>
+        </Section>
 
         <Section>
           <H3>Creating a job</H3>
           <P>
-            Open the <strong>Jobs</strong> page from the sidebar and click{" "}
-            <strong>Add job</strong>. The basic fields are:
+            Switch to the <strong>Jobs</strong> tab and click{" "}
+            <strong>Create</strong>. The basic fields are:
           </P>
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
             <li>
@@ -695,9 +803,11 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             </li>
             <li>
               <strong>Prompt</strong> — the instructions sent as the agent's
-              first message. Dispatch prepends a short preamble that names the
-              job, includes the run ID, and reminds the agent to drive the run
-              to a terminal state. Required before a run can start.
+              first message. Supports <Code>{"{{D:Arg Name}}"}</Code>{" "}
+              placeholders just like templates. Dispatch prepends a short
+              preamble that names the job, includes the run ID, and reminds the
+              agent to drive the run to a terminal state. Required before a run
+              can start.
             </li>
           </ul>
           <P>
@@ -728,11 +838,6 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               <strong>Keep agent after run completes</strong> — by default the
               agent is auto-archived once a run reaches a terminal state. Check
               this to leave the agent (and its worktree) around for inspection.
-            </li>
-            <li>
-              <strong>Show in command palette</strong> — makes the job
-              launchable from the <Code>Mod+K</Code> palette. See{" "}
-              <strong>Keyboard Shortcuts → Command palette</strong> for details.
             </li>
             <li>
               <strong>Single instance</strong> — when on (the default), only one
@@ -870,6 +975,17 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             next scheduled fire time. Open the <strong>History</strong> tab on a
             job to browse past runs with their reports, durations, and trigger
             source (manual vs. scheduled).
+          </P>
+        </Section>
+
+        <Section>
+          <H3>Automations UI</H3>
+          <P>
+            The Automations page has a tabbed sidebar with{" "}
+            <strong>Templates</strong> and <strong>Jobs</strong> tabs. Both tabs
+            use the same flat-list layout with a sliding indicator that animates
+            between them. Select an item to see its detail view, or use the
+            inline play button on a template for quick launch.
           </P>
         </Section>
       </>

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -344,8 +344,10 @@ export function JobsProvider({
 /** Job list content for the unified sidebar. */
 export function JobListContent({
   onItemSelect,
+  hideHeader,
 }: {
   onItemSelect?: () => void;
+  hideHeader?: boolean;
 }): JSX.Element {
   const {
     jobs,
@@ -360,12 +362,9 @@ export function JobListContent({
   } = useJobsContext();
 
   return (
-    <div data-testid="jobs-sidebar" className="flex h-full min-h-0 flex-col">
-      <div className="mt-2 flex h-14 items-center border-b border-border px-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          Jobs
-        </h2>
-        <div className="ml-auto flex items-center">
+    <div data-testid="jobs-sidebar" className="flex min-h-0 flex-1 flex-col">
+      {hideHeader ? (
+        <div className="flex items-center justify-end px-3 py-2">
           <Button
             size="sm"
             variant="default"
@@ -377,7 +376,25 @@ export function JobListContent({
             Create
           </Button>
         </div>
-      </div>
+      ) : (
+        <div className="mt-2 flex h-14 items-center border-b border-border px-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Jobs
+          </h2>
+          <div className="ml-auto flex items-center">
+            <Button
+              size="sm"
+              variant="default"
+              className="bg-muted/35 text-muted-foreground hover:bg-muted/65 hover:text-foreground"
+              onClick={openAddJob}
+              data-testid="add-job-button"
+            >
+              <AlarmClock className="mr-1 h-4 w-4" />
+              Create
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div
         data-testid="jobs-sidebar-scroll"

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -282,7 +282,7 @@ export function JobsProvider({
   const selectJob = (job: Job) => {
     setIsAddingJob(false);
     setJustAddedJobId(null);
-    navigate(`/jobs/${job.id}`);
+    navigate(`/automations/jobs/${job.id}`);
   };
 
   const openAddJob = () => {
@@ -331,7 +331,7 @@ export function JobsProvider({
             const added = await addJob.mutateAsync(job);
             setIsAddingJob(false);
             setJustAddedJobId(added.id);
-            navigate(`/jobs/${added.id}`);
+            navigate(`/automations/jobs/${added.id}`);
           }}
           isAdding={addJob.isPending}
           enabledAgentTypes={enabledAgentTypes}
@@ -411,7 +411,7 @@ export function JobListContent({
                 showOverview && "border-r-primary bg-muted/60"
               )}
               onClick={() => {
-                navigate("/jobs/overview");
+                navigate("/automations/jobs/overview");
                 onItemSelect?.();
               }}
             >
@@ -533,7 +533,7 @@ export function JobDetailPane(): JSX.Element {
               tab={tab}
               onTabChange={(nextTab) => {
                 navigate(
-                  `/jobs/${selectedJob.id}${nextTab === "configure" ? "" : `/${nextTab}`}`
+                  `/automations/jobs/${selectedJob.id}${nextTab === "configure" ? "" : `/${nextTab}`}`
                 );
               }}
               history={history.data?.runs ?? []}
@@ -542,8 +542,8 @@ export function JobDetailPane(): JSX.Element {
               onSelectRun={(runId) => {
                 navigate(
                   runId
-                    ? `/jobs/${selectedJob.id}/history/${runId}`
-                    : `/jobs/${selectedJob.id}/history`
+                    ? `/automations/jobs/${selectedJob.id}/history/${runId}`
+                    : `/automations/jobs/${selectedJob.id}/history`
                 );
               }}
               attachedAgent={attachedAgent}
@@ -560,7 +560,7 @@ export function JobDetailPane(): JSX.Element {
               }}
               onRemoveJob={async (job) => {
                 await removeJob.mutateAsync(job);
-                navigate("/jobs");
+                navigate("/automations/jobs");
               }}
               isUpdating={updateJob.isPending}
               isRemoving={removeJob.isPending}
@@ -576,7 +576,7 @@ export function JobDetailPane(): JSX.Element {
               statsLoading={jobStats.isLoading}
               onSelectJob={selectJob}
               onSelectRun={(jobId, runId) =>
-                navigate(`/jobs/${jobId}/history/${runId}`)
+                navigate(`/automations/jobs/${jobId}/history/${runId}`)
               }
             />
           </div>

--- a/apps/web/src/components/app/sidebar-shell.tsx
+++ b/apps/web/src/components/app/sidebar-shell.tsx
@@ -19,7 +19,7 @@ import { useIconColor } from "@/hooks/use-icon-color";
 import { useInstanceName } from "@/hooks/use-instance-name";
 import { cn } from "@/lib/utils";
 
-export type NavSection = "agents" | "jobs" | "activity" | "settings";
+export type NavSection = "agents" | "automations" | "activity" | "settings";
 
 type SidebarNavBarProps = {
   activeSection?: NavSection;
@@ -51,7 +51,7 @@ export function SidebarNavBar({
 
   const items: Array<{ id: NavSection; icon: typeof Bot; label: string }> = [
     { id: "agents", icon: Bot, label: "Agents" },
-    { id: "jobs", icon: AlarmClock, label: "Jobs" },
+    { id: "automations", icon: AlarmClock, label: "Automations" },
     { id: "activity", icon: Activity, label: "Activity" },
     { id: "settings", icon: Settings, label: "Settings" },
   ];

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -19,7 +19,11 @@ import {
 import { type Agent } from "@/components/app/types";
 import { agentRoute } from "@/lib/agent-routes";
 import { useHotkey } from "@/lib/hotkeys/use-hotkey";
-import { useJobs, useJobActions } from "@/hooks/use-jobs";
+import {
+  useTemplates,
+  useTemplateActions,
+  parseTemplateArgs,
+} from "@/hooks/use-templates";
 import { useQueryClient } from "@tanstack/react-query";
 
 type UseAgentHotkeysArgs = {
@@ -60,8 +64,8 @@ export function useAgentHotkeys({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const { data: jobs = [] } = useJobs();
-  const { runNow } = useJobActions();
+  const { data: templates = [] } = useTemplates();
+  const { launchTemplate } = useTemplateActions();
 
   useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
 
@@ -154,36 +158,47 @@ export function useAgentHotkeys({
   );
 
   const paletteGroups = useMemo<CommandGroup[]>(() => {
-    const callableJobs = jobs.filter((j) => j.callable);
-    if (callableJobs.length === 0) return [];
+    const callableTemplates = templates.filter((t) => t.callable);
+    if (callableTemplates.length === 0) return [];
     return [
       {
-        label: "Jobs",
-        actions: callableJobs.map((job) => ({
-          id: `job-${job.id}`,
-          title: job.name,
-          keywords: ["job", "run", "launch"],
-          icon: Play,
-          confirm: {
-            description: "This will create a new agent and run this job.",
-          },
-          run: () => {
-            runNow
-              .mutateAsync(job)
-              .then(async (result) => {
-                await queryClient.invalidateQueries({ queryKey: ["agents"] });
-                if (result.agentId) {
+        label: "Templates",
+        actions: callableTemplates.map((template) => {
+          const args = parseTemplateArgs(template.prompt ?? "");
+          const hasArgs = args.length > 0;
+          return {
+            id: `template-${template.id}`,
+            title: template.name,
+            keywords: ["template", "launch", "run"],
+            icon: Play,
+            confirm: hasArgs
+              ? undefined
+              : {
+                  description:
+                    "This will create a new agent from this template.",
+                },
+            run: () => {
+              if (hasArgs) {
+                navigate(`/automations/templates/${template.id}`);
+                return;
+              }
+              launchTemplate
+                .mutateAsync({ id: template.id })
+                .then(async (result) => {
+                  await queryClient.invalidateQueries({
+                    queryKey: ["agents"],
+                  });
                   navigate(agentRoute(result.agentId));
-                }
-              })
-              .catch((err: Error) => {
-                toast.error(`Failed to launch job: ${err.message}`);
-              });
-          },
-        })),
+                })
+                .catch((err: Error) => {
+                  toast.error(`Failed to launch template: ${err.message}`);
+                });
+            },
+          };
+        }),
       },
     ];
-  }, [jobs, runNow, navigate, queryClient]);
+  }, [templates, launchTemplate, navigate, queryClient]);
 
   return { paletteOpen, setPaletteOpen, paletteActions, paletteGroups };
 }

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -23,6 +23,7 @@ import {
   useTemplates,
   useTemplateActions,
   parseTemplateArgs,
+  type Template,
 } from "@/hooks/use-templates";
 
 type UseAgentHotkeysArgs = {
@@ -42,7 +43,7 @@ export type UseAgentHotkeysResult = {
   setPaletteOpen: (open: boolean) => void;
   paletteActions: CommandAction[];
   paletteGroups: CommandGroup[];
-  launchTemplateId: string | null;
+  launchTemplate: Template | null;
   setLaunchTemplateId: (id: string | null) => void;
 };
 
@@ -200,12 +201,17 @@ export function useAgentHotkeys({
     ];
   }, [templates, launchTemplate, navigate, setPaletteOpen]);
 
+  const resolvedLaunchTemplate = useMemo(
+    () => templates.find((t) => t.id === launchTemplateId) ?? null,
+    [templates, launchTemplateId]
+  );
+
   return {
     paletteOpen,
     setPaletteOpen,
     paletteActions,
     paletteGroups,
-    launchTemplateId,
+    launchTemplate: resolvedLaunchTemplate,
     setLaunchTemplateId,
   };
 }

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -24,7 +24,6 @@ import {
   useTemplateActions,
   parseTemplateArgs,
 } from "@/hooks/use-templates";
-import { useQueryClient } from "@tanstack/react-query";
 
 type UseAgentHotkeysArgs = {
   agents: Agent[];
@@ -43,6 +42,8 @@ export type UseAgentHotkeysResult = {
   setPaletteOpen: (open: boolean) => void;
   paletteActions: CommandAction[];
   paletteGroups: CommandGroup[];
+  launchTemplateId: string | null;
+  setLaunchTemplateId: (id: string | null) => void;
 };
 
 /**
@@ -62,8 +63,8 @@ export function useAgentHotkeys({
   openCreateDialog,
 }: UseAgentHotkeysArgs): UseAgentHotkeysResult {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [launchTemplateId, setLaunchTemplateId] = useState<string | null>(null);
   const { data: templates = [] } = useTemplates();
   const { launchTemplate } = useTemplateActions();
 
@@ -175,20 +176,19 @@ export function useAgentHotkeys({
               ? undefined
               : {
                   description:
+                    template.description ||
                     "This will create a new agent from this template.",
                 },
             run: () => {
               if (hasArgs) {
-                navigate(`/automations/templates/${template.id}`);
+                setPaletteOpen(false);
+                setLaunchTemplateId(template.id);
                 return;
               }
               launchTemplate
                 .mutateAsync({ id: template.id })
-                .then(async (result) => {
-                  await queryClient.invalidateQueries({
-                    queryKey: ["agents"],
-                  });
-                  navigate(agentRoute(result.agentId));
+                .then((result) => {
+                  navigate(agentRoute(result.agent.id));
                 })
                 .catch((err: Error) => {
                   toast.error(`Failed to launch template: ${err.message}`);
@@ -198,7 +198,14 @@ export function useAgentHotkeys({
         }),
       },
     ];
-  }, [templates, launchTemplate, navigate, queryClient]);
+  }, [templates, launchTemplate, navigate, setPaletteOpen]);
 
-  return { paletteOpen, setPaletteOpen, paletteActions, paletteGroups };
+  return {
+    paletteOpen,
+    setPaletteOpen,
+    paletteActions,
+    paletteGroups,
+    launchTemplateId,
+    setLaunchTemplateId,
+  };
 }

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -53,6 +53,8 @@ export type Job = {
   autoArchive: boolean;
   callable: boolean;
   singleton: boolean;
+  templateId: string | null;
+  defaultArgs: Record<string, string>;
   createdAt: string;
   updatedAt: string;
   lastRunId: string | null;

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -38,6 +38,7 @@ type UiEvent =
   | { type: "feedback.created"; agentId: string }
   | { type: "feedback.updated"; agentId: string }
   | { type: "job.changed" }
+  | { type: "template.changed" }
   | {
       type: "notification";
       notificationId: string;
@@ -85,6 +86,7 @@ export function useSSE(authState: AuthState): void {
           // `release.cached_info_changed` event would keep stale release
           // state forever (the query has staleTime: Infinity).
           void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+          void queryClient.invalidateQueries({ queryKey: ["templates"] });
           void queryClient.invalidateQueries({
             queryKey: CACHED_RELEASE_INFO_QUERY_KEY,
           });
@@ -176,6 +178,11 @@ export function useSSE(authState: AuthState): void {
 
         if (payload.type === "job.changed") {
           void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+          return;
+        }
+
+        if (payload.type === "template.changed") {
+          void queryClient.invalidateQueries({ queryKey: ["templates"] });
           return;
         }
 

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -1,0 +1,116 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import type { CliAgentType } from "@/lib/agent-types";
+
+export type Template = {
+  id: string;
+  directory: string;
+  name: string;
+  prompt: string | null;
+  agentType: CliAgentType;
+  useWorktree: boolean;
+  baseBranch: string | null;
+  branchName: string | null;
+  fullAccess: boolean;
+  callable: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TemplateArg = {
+  name: string;
+  key: string;
+  placeholder: string;
+};
+
+export type AddTemplateConfig = {
+  name: string;
+  directory: string;
+  prompt?: string | null;
+  agentType?: CliAgentType;
+  useWorktree?: boolean;
+  baseBranch?: string | null;
+  branchName?: string | null;
+  fullAccess?: boolean;
+  callable?: boolean;
+};
+
+export type LaunchResult = {
+  agentId: string;
+  templateId: string;
+  templateName: string;
+};
+
+const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
+
+export function parseTemplateArgs(prompt: string): TemplateArg[] {
+  const seen = new Set<string>();
+  const args: TemplateArg[] = [];
+  let match;
+  while ((match = ARG_REGEX.exec(prompt)) !== null) {
+    const name = match[1].trim();
+    const key = name.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      args.push({ name, key, placeholder: match[0] });
+    }
+  }
+  return args;
+}
+
+export function useTemplates(enabled = true) {
+  return useQuery<Template[]>({
+    queryKey: ["templates"],
+    queryFn: () => api<Template[]>("/api/v1/templates"),
+    enabled,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useTemplateActions() {
+  const queryClient = useQueryClient();
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({ queryKey: ["templates"] });
+  };
+
+  const addTemplate = useMutation({
+    mutationFn: (template: AddTemplateConfig) =>
+      api<Template>("/api/v1/templates", {
+        method: "POST",
+        body: JSON.stringify(template),
+      }),
+    onSuccess: invalidate,
+  });
+
+  const updateTemplate = useMutation({
+    mutationFn: ({
+      id,
+      ...updates
+    }: Partial<AddTemplateConfig> & { id: string }) =>
+      api<Template>(`/api/v1/templates/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(updates),
+      }),
+    onSuccess: invalidate,
+  });
+
+  const removeTemplate = useMutation({
+    mutationFn: (id: string) =>
+      api<Template>(`/api/v1/templates/${id}`, {
+        method: "DELETE",
+      }),
+    onSuccess: invalidate,
+  });
+
+  const launchTemplate = useMutation({
+    mutationFn: ({ id, args }: { id: string; args?: Record<string, string> }) =>
+      api<LaunchResult>(`/api/v1/templates/${id}/launch`, {
+        method: "POST",
+        body: JSON.stringify({ args }),
+      }),
+    onSuccess: invalidate,
+  });
+
+  return { addTemplate, updateTemplate, removeTemplate, launchTemplate };
+}

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -44,6 +44,7 @@ export type LaunchResult = {
   agent: Agent;
 };
 
+// Mirrored in apps/server/src/templates/store.ts — keep in sync
 const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
 
 export function parseTemplateArgs(prompt: string): TemplateArg[] {

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -2,11 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import type { CliAgentType } from "@/lib/agent-types";
+import type { Agent } from "@/components/app/types";
+import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 
 export type Template = {
   id: string;
   directory: string;
   name: string;
+  description: string | null;
   prompt: string | null;
   agentType: CliAgentType;
   useWorktree: boolean;
@@ -27,6 +30,7 @@ export type TemplateArg = {
 export type AddTemplateConfig = {
   name: string;
   directory: string;
+  description?: string | null;
   prompt?: string | null;
   agentType?: CliAgentType;
   useWorktree?: boolean;
@@ -37,9 +41,7 @@ export type AddTemplateConfig = {
 };
 
 export type LaunchResult = {
-  agentId: string;
-  templateId: string;
-  templateName: string;
+  agent: Agent;
 };
 
 const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
@@ -109,7 +111,11 @@ export function useTemplateActions() {
         method: "POST",
         body: JSON.stringify({ args }),
       }),
-    onSuccess: invalidate,
+    onSuccess: (result) => {
+      queryClient.setQueryData<Agent[]>(["agents"], (old) =>
+        sortAgentsByCreatedAtDesc([...(old ?? []), result.agent])
+      );
+    },
   });
 
   return { addTemplate, updateTemplate, removeTemplate, launchTemplate };

--- a/apps/web/src/layouts/dashboard-sections.tsx
+++ b/apps/web/src/layouts/dashboard-sections.tsx
@@ -5,10 +5,9 @@ import { BarChart3, History, PanelRightOpen } from "lucide-react";
 import { AgentsView } from "@/components/app/agents-view";
 import { ActivityPane } from "@/components/app/activity-pane";
 import {
-  JobsProvider,
-  JobListContent,
-  JobDetailPane,
-} from "@/components/app/jobs-pane";
+  AutomationsSidebarContent,
+  AutomationsDetailContent,
+} from "@/components/app/automations-pane";
 import {
   SettingsContent,
   SettingsNavContent,
@@ -21,7 +20,6 @@ import { GlassSidebar } from "@/components/ui/glass-sidebar";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useDashboardContext } from "@/App";
-import { agentRoute } from "@/lib/agent-routes";
 
 function serviceDotClass(state: ServiceState): string {
   if (state === "ok") return "bg-status-working";
@@ -137,35 +135,27 @@ export function AgentsRoute(): JSX.Element {
   );
 }
 
-export function JobsRoute(): JSX.Element {
-  const navigate = useNavigate();
+export function AutomationsRoute(): JSX.Element {
   const { agents, enabledAgentTypes, isMobile, setMobileLeftOpen } =
     useDashboardContext();
-  const openAgent = useCallback(
-    async (agent: (typeof agents)[number]) => {
-      navigate(agentRoute(agent.id));
-    },
-    [navigate]
-  );
 
   return (
-    <JobsProvider
-      open={true}
-      agents={agents}
-      onOpenAgent={openAgent}
-      enabledAgentTypes={enabledAgentTypes}
+    <SectionShell
+      activeSection="automations"
+      sidebar={
+        <AutomationsSidebarContent
+          agents={agents}
+          enabledAgentTypes={enabledAgentTypes}
+          isMobile={isMobile}
+          closeSidebar={() => setMobileLeftOpen(false)}
+        />
+      }
     >
-      <SectionShell
-        activeSection="jobs"
-        sidebar={
-          <JobListContent
-            onItemSelect={isMobile ? () => setMobileLeftOpen(false) : undefined}
-          />
-        }
-      >
-        <JobDetailPane />
-      </SectionShell>
-    </JobsProvider>
+      <AutomationsDetailContent
+        agents={agents}
+        enabledAgentTypes={enabledAgentTypes}
+      />
+    </SectionShell>
   );
 }
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -11,8 +11,8 @@ import { DashboardLayout } from "@/App";
 import {
   ActivityRoute,
   AgentsRoute,
+  AutomationsRoute,
   DesignLabRoute,
-  JobsRoute,
   SettingsRoute,
 } from "@/layouts/dashboard-sections";
 import { LoginRoute } from "@/components/app/login-page";
@@ -95,24 +95,42 @@ export const router = createBrowserRouter([
                 handle: { navSection: "activity" },
               },
               {
+                path: "automations",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/templates/:templateId",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/jobs",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/jobs/:jobId",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/jobs/:jobId/:section",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/jobs/:jobId/:section/:runId",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
                 path: "jobs",
-                element: <JobsRoute />,
-                handle: { navSection: "jobs" },
+                element: <Navigate to="/automations/jobs" replace />,
               },
               {
-                path: "jobs/:jobId",
-                element: <JobsRoute />,
-                handle: { navSection: "jobs" },
-              },
-              {
-                path: "jobs/:jobId/:section",
-                element: <JobsRoute />,
-                handle: { navSection: "jobs" },
-              },
-              {
-                path: "jobs/:jobId/:section/:runId",
-                element: <JobsRoute />,
-                handle: { navSection: "jobs" },
+                path: "jobs/*",
+                element: <LegacyJobsRedirect />,
               },
               {
                 path: "design-lab",
@@ -138,4 +156,9 @@ function LegacyDocsRedirect(): JSX.Element {
       replace
     />
   );
+}
+
+function LegacyJobsRedirect(): JSX.Element {
+  const { "*": rest } = useParams();
+  return <Navigate to={`/automations/jobs/${rest ?? ""}`} replace />;
 }

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -1,33 +1,87 @@
-# Jobs
+# Automations: Templates & Jobs
 
 ## Overview
 
-A **job** is a named, repo-scoped agent task that can run on a schedule or on demand. Each invocation is a **run**, which spawns a fresh agent with the job's prompt, posts structured progress via MCP, and returns a terminal `JobReport`.
+The Automations system has two layers:
 
-Jobs are the right mechanism for recurring work (nightly PR triage, release babysitting, janitorial cleanup) and for one-shot tasks where you want a machine-readable outcome instead of a free-form chat transcript.
+- **Templates** — reusable agent launch configurations. A template captures a prompt, agent type, directory, worktree settings, and an optional set of runtime arguments (`{{D:Arg Name}}` syntax). Templates can be launched from the Cmd+K command palette or the Automations UI to spin up a normal agent session with no supervision.
 
-## Data Model
+- **Jobs** — automation on top of a template. A job references a backing template and adds scheduling (cron), timeouts, singleton enforcement, structured reporting via MCP, auto-archive, and notifications. Each job invocation is a **run**.
 
-Jobs are uniquely identified by (`directory`, `name`). Each job has:
+Templates are the right choice for quick-launch workflows (code review, feature scaffolding, ad-hoc tasks). Jobs are for recurring or monitored work (nightly triage, release babysitting, janitorial cleanup) where you want a machine-readable outcome.
+
+## Templates
+
+### Data Model
+
+Templates are uniquely identified by (`directory`, `name`). Each template has:
+
+| Field         | Description                                                |
+| ------------- | ---------------------------------------------------------- |
+| `name`        | Display name, unique within its `directory`                |
+| `directory`   | Absolute path of the repo the template runs against        |
+| `prompt`      | User-supplied prompt used as the agent's first turn        |
+| `agentType`   | One of `claude`, `codex`, `opencode`                       |
+| `useWorktree` | If true, the agent gets its own git worktree               |
+| `baseBranch`  | Base branch for the worktree (optional)                    |
+| `branchName`  | Branch for the worktree (optional)                         |
+| `fullAccess`  | Pass the agent CLI's full-access/bypass-approvals flag     |
+| `callable`    | If true, the template appears in the Cmd+K command palette |
+
+### Runtime Arguments
+
+Templates support `{{D:Arg Name}}` placeholders in their prompt. At launch time, each placeholder becomes a required input field. Arguments are also pinned to the spawned agent's sidebar for reference.
+
+Example prompt:
+
+```
+Review the PR at {{D:PR URL}} and focus on {{D:Review Focus}}.
+```
+
+This creates two input fields: "PR URL" and "Review Focus".
+
+### Command Palette (Cmd+K)
+
+Templates with `callable: true` appear in the Cmd+K command palette under a "Templates" group.
+
+- Templates **without** arguments show a confirmation step — pressing Enter twice (select → confirm) launches immediately.
+- Templates **with** arguments navigate to the template detail page (`/automations/templates/:id`) where you fill in the argument values before launching.
+
+After launch, the new agent appears in the sidebar via SSE and the URL navigates to it automatically.
+
+### API
+
+| Method | Path                           | Description         |
+| ------ | ------------------------------ | ------------------- |
+| GET    | `/api/v1/templates`            | List all templates  |
+| GET    | `/api/v1/templates/:id`        | Get single template |
+| POST   | `/api/v1/templates`            | Create template     |
+| PATCH  | `/api/v1/templates/:id`        | Update template     |
+| DELETE | `/api/v1/templates/:id`        | Delete template     |
+| POST   | `/api/v1/templates/:id/launch` | Launch template     |
+
+The launch endpoint accepts `{ args?: Record<string, string> }` for runtime arguments.
+
+## Jobs
+
+### Data Model
+
+Jobs are uniquely identified by (`directory`, `name`). Each job references a backing template and adds:
 
 | Field                 | Description                                                                          |
 | --------------------- | ------------------------------------------------------------------------------------ |
-| `name`                | Display/slug name, unique within its `directory`                                     |
-| `directory`           | Absolute path of the repo the job runs against                                       |
-| `prompt`              | User-supplied prompt used as the agent's first turn                                  |
+| `templateId`          | References the backing template for agent config                                     |
+| `defaultArgs`         | Default argument values for scheduled runs                                           |
 | `schedule`            | Cron expression (optional). Jobs without a schedule can still be triggered manually. |
-| `agentType`           | One of `claude`, `codex`, `opencode`                                                 |
-| `useWorktree`         | If true, the run gets its own git worktree (default)                                 |
-| `branchName`          | Branch for the worktree (optional)                                                   |
-| `fullAccess`          | Pass the agent CLI's full-access/bypass-approvals flag                               |
 | `timeoutMs`           | Max wall-clock for a run (default 30 min)                                            |
 | `needsInputTimeoutMs` | Max time a run may sit in `needs_input` (default 24 h)                               |
-| `callable`            | If true, the job appears in the Cmd+K command palette for quick launch               |
 | `singleton`           | If true (default), only one run can be active at a time                              |
 | `autoArchive`         | If true, the spawned agent is auto-archived when the run completes                   |
 | `enabled`             | If false, the cron schedule is skipped but manual runs still work                    |
 
-## Run Lifecycle
+Agent configuration (prompt, agentType, useWorktree, etc.) is read from the backing template at run time.
+
+### Run Lifecycle
 
 States: `started` → `running` → (`completed` | `failed` | `needs_input` | `timed_out` | `crashed`).
 
@@ -35,7 +89,7 @@ States: `started` → `running` → (`completed` | `failed` | `needs_input` | `t
 - A run that calls `job_needs_input` transitions to `needs_input` and pauses. Answering it (via the UI or deleting the run) resumes or ends it; an unanswered `needs_input` times out per `needsInputTimeoutMs`.
 - Singleton jobs (the default) only allow one active run at a time. Attempting to launch a second run while one is active returns an error.
 
-## Report Shape
+### Report Shape
 
 The MCP tools `job_complete` / `job_failed` require a report:
 
@@ -65,7 +119,7 @@ The MCP tools `job_complete` / `job_failed` require a report:
 
 Report size limits: 1 MB total, 100 tasks, 500 logs per task, 10 KB summary and error-message strings, 5 KB log-message strings.
 
-## Notifications
+### Notifications
 
 Jobs emit their own Slack messages (distinct from the per-agent notifications in [docs/16-notifications.md](16-notifications.md)) on the following events, each with an independent webhook URL list:
 
@@ -75,7 +129,7 @@ Jobs emit their own Slack messages (distinct from the per-agent notifications in
 
 The job agent's `latest-event` notifications are suppressed so you do not double-notify on completion.
 
-## API
+### API
 
 See [docs/03-api-spec.md](03-api-spec.md#jobs) for the full endpoint reference. The relevant endpoints are:
 
@@ -84,7 +138,7 @@ See [docs/03-api-spec.md](03-api-spec.md#jobs) for the full endpoint reference. 
 - `POST /api/v1/jobs/run` — trigger manually (`{ name, directory, wait? }`)
 - `GET /api/v1/jobs/stats` / `GET /api/v1/jobs/history`
 
-## MCP Tools (job-scope only)
+### MCP Tools (job-scope only)
 
 Job agents are given a narrowed MCP toolset (see `JOB_TOOLS` in `apps/server/src/shared/mcp/server.ts`). The job-lifecycle tools are:
 
@@ -97,16 +151,11 @@ Job agents are given a narrowed MCP toolset (see `JOB_TOOLS` in `apps/server/src
 
 Job agents may also call analytics tools (`get_activity_summary`, `get_agent_history`, `get_feedback_summary`), lister tools (`list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`), and `create_pr` / `get_pr_status` / `dispatch_event` / `dispatch_rename_session` / `dispatch_notify`.
 
-## Command Palette (Cmd+K)
-
-Jobs with `callable: true` appear in the Cmd+K command palette under a "Jobs" group, separate from the built-in commands. This lets users launch jobs with a few keystrokes without navigating to the jobs pane.
-
-The launch flow includes a confirmation step — selecting a callable job shows the job name with Launch/Cancel options. Launch is pre-selected, so pressing Enter twice (once to select, once to confirm) triggers the job immediately.
-
-After launch, the new agent appears in the sidebar via SSE and the URL navigates to it automatically. If the job is a singleton and already has an active run, the launch fails with an error toast.
-
-To make a job callable, toggle "Show in command palette" in the job's create or settings form, or set `callable: true` in the API.
-
 ## UI
 
-The jobs pane (`/jobs`) lists every configured job with its latest run status. Drill-down views show run history, per-run reports, and the MCP log stream. A run blocked on `needs_input` exposes an answer box that resumes the agent.
+The Automations pane (`/automations`) has a tabbed sidebar with **Templates** and **Jobs** tabs.
+
+- The Templates tab lists callable templates with inline launch buttons. Selecting a template shows its detail view with argument inputs and a Launch button.
+- The Jobs tab lists configured jobs with their latest run status. Drill-down views show run history, per-run reports, and the MCP log stream. A run blocked on `needs_input` exposes an answer box that resumes the agent.
+
+Legacy `/jobs` URLs redirect to `/automations/jobs`.

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -19,6 +19,7 @@ Templates are uniquely identified by (`directory`, `name`). Each template has:
 | Field         | Description                                                |
 | ------------- | ---------------------------------------------------------- |
 | `name`        | Display name, unique within its `directory`                |
+| `description` | Optional short description shown in Cmd+K and launch views |
 | `directory`   | Absolute path of the repo the template runs against        |
 | `prompt`      | User-supplied prompt used as the agent's first turn        |
 | `agentType`   | One of `claude`, `codex`, `opencode`                       |
@@ -45,9 +46,9 @@ This creates two input fields: "PR URL" and "Review Focus".
 Templates with `callable: true` appear in the Cmd+K command palette under a "Templates" group.
 
 - Templates **without** arguments show a confirmation step — pressing Enter twice (select → confirm) launches immediately.
-- Templates **with** arguments navigate to the template detail page (`/automations/templates/:id`) where you fill in the argument values before launching.
+- Templates **with** arguments open a launch dialog where you fill in the argument values before launching.
 
-After launch, the new agent appears in the sidebar via SSE and the URL navigates to it automatically.
+After launch, the agent record is optimistically added to the sidebar cache and the URL navigates to it immediately. The launch endpoint returns the full agent record (matching the create-agent response shape).
 
 ### API
 
@@ -60,7 +61,7 @@ After launch, the new agent appears in the sidebar via SSE and the URL navigates
 | DELETE | `/api/v1/templates/:id`        | Delete template     |
 | POST   | `/api/v1/templates/:id/launch` | Launch template     |
 
-The launch endpoint accepts `{ args?: Record<string, string> }` for runtime arguments.
+The launch endpoint accepts `{ args?: Record<string, string> }` for runtime arguments and returns `{ agent }` with the full agent record.
 
 ## Jobs
 
@@ -155,7 +156,9 @@ Job agents may also call analytics tools (`get_activity_summary`, `get_agent_his
 
 The Automations pane (`/automations`) has a tabbed sidebar with **Templates** and **Jobs** tabs.
 
-- The Templates tab lists callable templates with inline launch buttons. Selecting a template shows its detail view with argument inputs and a Launch button.
-- The Jobs tab lists configured jobs with their latest run status. Drill-down views show run history, per-run reports, and the MCP log stream. A run blocked on `needs_input` exposes an answer box that resumes the agent.
+The sidebar has a tabbed layout with a sliding indicator that animates between tabs. Both tabs use consistent flat-list styling with border separators and a right-aligned Create button.
+
+- The **Templates** tab lists callable templates with inline play buttons for quick launch. Templates with arguments open a launch dialog; templates without arguments launch directly. Selecting a template shows its detail view with a Launch button and an editable configuration form.
+- The **Jobs** tab lists configured jobs with their latest run status and an Overview dashboard with stats and charts. Drill-down views show run history, per-run reports, and the MCP log stream. A run blocked on `needs_input` exposes an answer box that resumes the agent.
 
 Legacy `/jobs` URLs redirect to `/automations/jobs`.

--- a/e2e/callable-jobs.spec.ts
+++ b/e2e/callable-jobs.spec.ts
@@ -20,13 +20,13 @@ function initGitRepo(dir: string): void {
   );
 }
 
-test.describe("Callable jobs — Cmd+K launch lifecycle", () => {
-  const jobDir = join(tmpdir(), `dispatch-e2e-callable-${Date.now()}`);
-  initGitRepo(jobDir);
-  const jobName = `e2e-callable-${Date.now()}`;
+test.describe("Callable templates — Cmd+K launch lifecycle", () => {
+  const templateDir = join(tmpdir(), `dispatch-e2e-callable-${Date.now()}`);
+  initGitRepo(templateDir);
+  const templateName = `e2e-callable-${Date.now()}`;
+  let templateId: string | null = null;
 
   test.afterEach(async ({ request }) => {
-    // Clean up any agents spawned by the job
     const listRes = await request.get("/api/v1/agents", {
       headers: AUTH_HEADER,
     });
@@ -34,7 +34,7 @@ test.describe("Callable jobs — Cmd+K launch lifecycle", () => {
       agents: Array<{ id: string; name: string; status: string }>;
     };
     for (const agent of agents) {
-      if (agent.name.startsWith("job-e2e-callable-")) {
+      if (agent.name.startsWith("e2e-callable-")) {
         if (agent.status !== "stopped") {
           await request.post(`/api/v1/agents/${agent.id}/stop`, {
             headers: AUTH_HEADER,
@@ -47,33 +47,35 @@ test.describe("Callable jobs — Cmd+K launch lifecycle", () => {
       }
     }
 
-    // Clean up the job (need to clear active runs first)
-    await request.delete("/api/v1/jobs", {
-      headers: HEADERS,
-      data: { name: jobName, directory: jobDir },
-    });
+    if (templateId) {
+      await request.delete(`/api/v1/templates/${templateId}`, {
+        headers: AUTH_HEADER,
+      });
+      templateId = null;
+    }
 
     await cleanupE2EAgents(request);
   });
 
-  test("launching a callable job from Cmd+K shows agent in sidebar and navigates to it", async ({
+  test("launching a callable template from Cmd+K shows agent in sidebar and navigates to it", async ({
     page,
     request,
   }) => {
-    // 1. Create a callable job via API
-    const createRes = await request.post("/api/v1/jobs", {
+    // 1. Create a callable template via API
+    const createRes = await request.post("/api/v1/templates", {
       headers: HEADERS,
       data: {
-        name: jobName,
-        directory: jobDir,
-        prompt: "Say hello and call job_complete.",
+        name: templateName,
+        directory: templateDir,
+        prompt: "Say hello and stop.",
         callable: true,
         agentType: "claude",
-        autoArchive: true,
         useWorktree: true,
       },
     });
     expect(createRes.ok()).toBeTruthy();
+    const created = (await createRes.json()) as { id: string };
+    templateId = created.id;
 
     // 2. Load the app
     await loadApp(page);
@@ -83,22 +85,20 @@ test.describe("Callable jobs — Cmd+K launch lifecycle", () => {
     const palette = page.getByRole("dialog", { name: "Command palette" });
     await expect(palette).toBeVisible({ timeout: 3_000 });
 
-    // 4. Type the job name to filter
+    // 4. Type the template name to filter
     const input = palette.getByRole("combobox");
     await input.pressSequentially("e2e-callable", { delay: 30 });
 
-    // 5. Verify only the job shows (Commands group hidden)
-    await expect(palette.getByText(jobName)).toBeVisible();
+    // 5. Verify only the template shows (Commands group hidden)
+    await expect(palette.getByText(templateName)).toBeVisible();
     await expect(palette.getByText("Commands")).not.toBeVisible();
 
-    // 6. Press Enter to select the job
+    // 6. Press Enter to select the template
     await page.keyboard.press("Enter");
 
-    // 7. Confirmation step appears — verify it shows the job name and launch button
+    // 7. Confirmation step appears
     await expect(palette.getByText("This will create a new agent")).toBeVisible(
-      {
-        timeout: 3_000,
-      }
+      { timeout: 3_000 }
     );
     const launchOption = palette.getByRole("option", { name: "Launch" });
     await expect(launchOption).toBeVisible();
@@ -111,9 +111,9 @@ test.describe("Callable jobs — Cmd+K launch lifecycle", () => {
 
     // 10. Wait for the agent to appear in the sidebar (via SSE, no refresh)
     const sidebar = page.getByTestId("agent-sidebar");
-    await expect(
-      sidebar.getByText(new RegExp(`job-e2e-callable-`))
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(sidebar.getByText(new RegExp(`e2e-callable-`))).toBeVisible({
+      timeout: 10_000,
+    });
 
     // 11. Verify URL navigated to the new agent (worktree setup adds latency)
     await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -214,14 +214,16 @@ test.describe("Overflow layout", () => {
 
     await loadApp(page);
     await page.getByTestId("automations-button").click();
-    await page.getByRole("button", { name: "Jobs" }).click();
+    await page.getByRole("button", { name: "Jobs", exact: true }).click();
 
     const jobsSidebar = page.getByTestId("jobs-sidebar");
     const jobsSidebarScroll = page.getByTestId("jobs-sidebar-scroll");
 
     await expect(jobsSidebar).toBeVisible();
     await expect(jobsSidebarScroll).toBeVisible();
-    await expect(page.getByRole("button", { name: "Jobs" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jobs", exact: true })
+    ).toBeVisible();
     await expect(page.getByTestId("agents-button")).toBeVisible();
     await expect(page.getByTestId("settings-button")).toBeVisible();
 

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -148,7 +148,7 @@ test.describe("Overflow layout", () => {
     await expect(agentSidebarScroll).toBeVisible();
     await expect(pinsPanelScroll).toBeVisible();
     await expect(terminalPane).toBeVisible();
-    await expect(page.getByTestId("jobs-button")).toBeVisible();
+    await expect(page.getByTestId("automations-button")).toBeVisible();
 
     await expectOverflow(agentSidebarScroll);
     await expectOverflow(pinsPanelScroll);
@@ -213,7 +213,8 @@ test.describe("Overflow layout", () => {
     );
 
     await loadApp(page);
-    await page.getByTestId("jobs-button").click();
+    await page.getByTestId("automations-button").click();
+    await page.getByRole("button", { name: "Jobs" }).click();
 
     const jobsSidebar = page.getByTestId("jobs-sidebar");
     const jobsSidebarScroll = page.getByTestId("jobs-sidebar-scroll");

--- a/e2e/overflow-layout.spec.ts
+++ b/e2e/overflow-layout.spec.ts
@@ -221,7 +221,7 @@ test.describe("Overflow layout", () => {
 
     await expect(jobsSidebar).toBeVisible();
     await expect(jobsSidebarScroll).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Jobs" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Jobs" })).toBeVisible();
     await expect(page.getByTestId("agents-button")).toBeVisible();
     await expect(page.getByTestId("settings-button")).toBeVisible();
 

--- a/e2e/sidebar-interactions.spec.ts
+++ b/e2e/sidebar-interactions.spec.ts
@@ -67,8 +67,8 @@ test.describe("Sidebar interactions", () => {
 
     await page.getByTitle("Open sidebar").click();
     await expectMobileSidebarOpen(page);
-    await page.getByTestId("jobs-button").click();
-    await expect(page).toHaveURL(/\/jobs$/);
+    await page.getByTestId("automations-button").click();
+    await expect(page).toHaveURL(/\/automations$/);
 
     // Sidebar auto-opens on mobile when switching sections — wait for it
     await expect(page.getByTestId("agents-button")).toBeVisible({

--- a/update-migrations/0005-templates-table.yaml
+++ b/update-migrations/0005-templates-table.yaml
@@ -1,0 +1,40 @@
+id: templates-table
+title: Verify templates table migration
+summary: >
+  Adds a `templates` table for the new agent templates feature and adds
+  `template_id` and `default_args` columns to the existing `jobs` table.
+  Existing jobs are migrated to backing templates via a DO block in the
+  migration. The migration runs automatically on server boot. Route this
+  update through assisted-update so the operator can confirm the migration
+  applied cleanly, existing jobs still function, and the service is healthy.
+
+alreadySatisfied:
+  description: >
+    The install is already on the target tag, the local health endpoint
+    returns status=ok, and release.json reports the target tag. Server boot
+    runs migrations idempotently and the templates table plus job column
+    additions are additive, so any healthy install at the target tag has
+    already taken the migration — no operator action is required.
+
+instructions:
+  - Confirm the service has been restarted to the target release tag.
+  - Confirm $DISPATCH_API_URL/api/v1/health returns status=ok.
+  - Confirm release.json under the install directory reports the target tag.
+  - Since alreadySatisfied is true on every healthy install at the target tag,
+    do not perform any change steps — proceed straight to the validate phase.
+    The framework re-runs the checks below server-side and marks the migration
+    applied.
+
+validation:
+  requiredChecks:
+    - service_restarted
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - If the new release does not return healthy, roll back to the previous
+    release tag using the normal release rollback path for this host. The
+    templates table and new job columns are additive — leaving them in place
+    after rollback is harmless and is safer than dropping them manually.
+  - Restart the service and confirm $DISPATCH_API_URL/api/v1/health returns
+    status=ok and release.json reports the prior tag.


### PR DESCRIPTION
## Summary

- **Templates** are now first-class entities — reusable agent launch configs with prompt, agent type, worktree settings, and optional runtime arguments (`{{D:Arg Name}}` syntax). Callable templates appear in Cmd+K for quick launch.
- **Jobs** now reference a backing template for agent config, keeping automation concerns (schedule, timeout, singleton, structured reporting, auto-archive) separate from launch config.
- **Automations pane** replaces the Jobs pane with a tabbed sidebar (Templates | Jobs). Legacy `/jobs` URLs redirect to `/automations/jobs`.

### Backend
- New `templates` table, store, service, and API routes (CRUD + launch)
- Migration creates backing templates for all existing jobs
- `JobService.runJob` reads agent config from backing template; job CRUD auto-syncs the backing template
- `template.changed` SSE event for real-time UI updates

### Frontend
- Automations pane with Templates and Jobs tabs
- Template create/edit dialogs with live `{{D:...}}` argument detection
- Template detail view with argument inputs and launch button
- Cmd+K palette shows callable templates (replaces callable jobs)
- Nav item renamed from "Jobs" to "Automations"

### Other
- Updated in-app docs (`docs/17-jobs.md`)
- Updated E2E tests for new nav structure and callable templates

Closes DIS-140

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — web build succeeds
- [x] `pnpm run test` — all 926 unit tests pass
- [x] `pnpm run test:e2e` — all 140 E2E tests pass (10 skipped)
- [x] Playwright UI validation — Templates tab, Jobs tab, `/jobs` redirect all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)