### PR TITLE
Refine Cursor agent: deliver guidance via CLI prompt, pre-trust workspace

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -40,7 +40,6 @@ import { type Reconciler, createReconciler } from "./reconciler.js";
 import { type AgentRuntime, createAgentRuntime } from "./runtime.js";
 import {
   buildAgentCommand,
-  buildCursorRulesFile,
   buildLaunchGuidance,
   buildStartupPrompt,
 } from "./tmux/command-builder.js";
@@ -594,26 +593,6 @@ export class AgentManager {
           startupPrompt,
           personality?.prompt ?? null
         );
-        // For cursor agents, build the rules file content that the setup
-        // script writes to .cursor/rules/dispatch.mdc. This carries the same
-        // launch guidance + personality that other agent types receive via CLI flags.
-        let cursorRulesContent: string | undefined;
-        if (type === "cursor") {
-          const guidance = buildLaunchGuidance(id, {
-            jobRunId: input.jobRunId,
-            suggestSessionRename: shouldSuggestSessionRename(name, id, {
-              persona: input.persona,
-              jobRunId: input.jobRunId,
-            }),
-            autoReview:
-              !input.persona && !input.jobRunId && (input.autoReview ?? false),
-          });
-          cursorRulesContent = buildCursorRulesFile(
-            guidance,
-            personality?.prompt ?? null
-          );
-        }
-
         // Generate a setup script that handles worktree creation, env copy,
         // dep install, and then exec's into the agent CLI — all visible in the terminal.
         // Stderr/exit-capture wrapping is applied by the runtime, not the script.
@@ -629,7 +608,6 @@ export class AgentManager {
           agentName: name,
           agentCommand,
           jobRunId: input.jobRunId,
-          cursorRulesContent,
         });
 
         await this.runtime.launch({

--- a/apps/server/src/agents/tmux/command-builder.ts
+++ b/apps/server/src/agents/tmux/command-builder.ts
@@ -191,28 +191,6 @@ export function buildLaunchGuidance(
 }
 
 /**
- * Build the `.cursor/rules/dispatch.mdc` content for Cursor agents.
- * Contains the same launch guidance and personality that other agent types
- * receive via CLI flags, formatted as a Cursor rules file.
- */
-export function buildCursorRulesFile(
-  launchGuidance: string,
-  personalityPrompt?: string | null
-): string {
-  const sections = [launchGuidance, personalityPrompt].filter(Boolean);
-  const body = sections.join("\n\n");
-  return [
-    "---",
-    "description: Dispatch agent guidance",
-    "alwaysApply: true",
-    "---",
-    "",
-    body,
-    "",
-  ].join("\n");
-}
-
-/**
  * Build the bash invocation that launches the agent CLI inside its tmux
  * session. Returns a shell-ready string.
  *
@@ -407,8 +385,8 @@ export function buildAgentCommand(
   }
 
   if (type === "cursor") {
-    // MCP + guidance are handled via files written in the setup script
-    // (.cursor/mcp.json and .cursor/rules/dispatch.mdc), not CLI flags.
+    // MCP config is written via .cursor/mcp.json in the setup script.
+    // Guidance + personality are delivered as the initial prompt (same as Codex).
     const flagParts: string[] = [];
     if (fullAccess) {
       flagParts.push("--force", "--approve-mcps");
@@ -416,9 +394,12 @@ export function buildAgentCommand(
     if (resume && cliSessionId) {
       flagParts.push("--resume", shellEscape(cliSessionId));
     }
-    const cursorPromptParts = [appendedSystemPrompt, initialPrompt].filter(
-      Boolean
-    );
+    const cursorPromptParts = [
+      launchGuidance,
+      appendedSystemPrompt,
+      personalityPrompt || null,
+      initialPrompt,
+    ].filter(Boolean);
     const startupPrompt = cursorPromptParts.join("\n\n");
     if (passthroughArgs.length > 0) {
       const escaped = passthroughArgs.map((arg) => shellEscape(arg)).join(" ");

--- a/apps/server/src/agents/tmux/setup-script.ts
+++ b/apps/server/src/agents/tmux/setup-script.ts
@@ -20,8 +20,6 @@ export type SetupScriptParams = {
   agentName: string;
   agentCommand: string;
   jobRunId?: string;
-  /** For cursor agents: the .cursor/rules/dispatch.mdc content. */
-  cursorRulesContent?: string;
 };
 
 /**
@@ -295,7 +293,7 @@ export function generateSetupScript(
     );
   }
 
-  // Cursor: write .cursor/mcp.json (MCP server) and .cursor/rules/dispatch.mdc (guidance).
+  // Cursor: write .cursor/mcp.json (MCP server) and pre-trust the workspace.
   if (agentType === "cursor") {
     const mcpUrl = dispatchMcpUrl(config, agentId, params.jobRunId);
     const dispatchMcpToken = params.jobRunId
@@ -313,7 +311,7 @@ export function generateSetupScript(
       `  echo "ERROR: $EFFECTIVE_CWD/.cursor is a symlink — refusing to write config outside the worktree" >&2`,
       `  exit 1`,
       `fi`,
-      `mkdir -p "$EFFECTIVE_CWD/.cursor/rules"`,
+      `mkdir -p "$EFFECTIVE_CWD/.cursor"`,
       `CURSOR_REAL=$(cd "$EFFECTIVE_CWD/.cursor" && pwd -P)`,
       `EFFECTIVE_REAL=$(cd "$EFFECTIVE_CWD" && pwd -P)`,
       `case "$CURSOR_REAL" in "$EFFECTIVE_REAL"/*) ;; *)`,
@@ -324,20 +322,18 @@ export function generateSetupScript(
       `MCP_ENTRY=${shellEscape(mcpEntry)}`,
       `node --input-type=module -e 'import { readFileSync, renameSync, writeFileSync } from "node:fs"; const [configPath, mcpEntryJson] = process.argv.slice(1); const mcpEntry = JSON.parse(mcpEntryJson); let cfg = {}; try { cfg = JSON.parse(readFileSync(configPath, "utf8")); } catch (error) { if (error?.code !== "ENOENT") throw error; } cfg.mcpServers = { ...(cfg.mcpServers ?? {}), dispatch: mcpEntry }; const tmpPath = \`\${configPath}.tmp-\${process.pid}\`; writeFileSync(tmpPath, JSON.stringify(cfg, null, 2) + "\\n"); renameSync(tmpPath, configPath);' "$CURSOR_MCP_CFG" "$MCP_ENTRY"`,
       `ok "Configured dispatch MCP in .cursor/mcp.json"`,
+      ``,
+      `# --- Pre-trust workspace for Cursor CLI ---`,
+      `# Cursor CLI prompts for workspace trust on first launch. Pre-create the`,
+      `# trust marker so the prompt is skipped automatically.`,
+      `CURSOR_PROJECTS_DIR="$HOME/.cursor/projects"`,
+      `TRUST_SLUG=$(echo "$EFFECTIVE_CWD" | sed 's|^/||; s|/|-|g')`,
+      `TRUST_DIR="$CURSOR_PROJECTS_DIR/$TRUST_SLUG"`,
+      `mkdir -p "$TRUST_DIR"`,
+      `printf '{"trustedAt":"%s","workspacePath":"%s"}\\n' "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" "$EFFECTIVE_CWD" > "$TRUST_DIR/.workspace-trusted"`,
+      `ok "Pre-trusted workspace for Cursor CLI"`,
       ``
     );
-
-    if (params.cursorRulesContent) {
-      const b64 = Buffer.from(params.cursorRulesContent, "utf-8").toString(
-        "base64"
-      );
-      lines.push(
-        `# --- Write Cursor rules file ---`,
-        `echo ${shellEscape(b64)} | base64 -d > "$EFFECTIVE_CWD/.cursor/rules/dispatch.mdc"`,
-        `ok "Wrote dispatch guidance to .cursor/rules/dispatch.mdc"`,
-        ``
-      );
-    }
   }
 
   lines.push(


### PR DESCRIPTION
## Summary

- **Guidance delivery**: Move launch guidance + personality from `.cursor/rules/dispatch.mdc` file to the CLI positional argument, matching the Codex pattern. Removes `buildCursorRulesFile()` and all `cursorRulesContent` plumbing.
- **Workspace trust**: Pre-create `~/.cursor/projects/<slug>/.workspace-trusted` so the Cursor CLI skips the interactive trust prompt on launch.
- **Cleanup**: Remove dead code paths in `manager.ts` (cursor rules building) and `setup-script.ts` (`.mdc` file writing, base64 encoding).

## Test plan

- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test:e2e` — 140 passed
- [x] Live tested: launched Cursor agent via dev UI, confirmed trust prompt skipped, guidance delivered in initial prompt, agent acknowledged all dispatch rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)