### PR TITLE
docs: add Cursor agent type to all docs surfaces

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -1,6 +1,6 @@
 ---
 job: docs-audit
-updated_at: 2026-05-09
+updated_at: 2026-05-10
 ---
 
 # docs-audit — state handoff
@@ -9,7 +9,7 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`e7838799ed00b95583bbf4575c38eef47b4407e4` — HEAD at the start of the 2026-05-09 run. v0.20.0 release tag.
+`168cdfc702fe89352c0471563deb82d19f4183ee` — HEAD at the start of the 2026-05-10 run. v0.20.1 release tag.
 
 ## next_focus
 
@@ -29,7 +29,9 @@ Items noticed during prior passes but left for later runs. Pick the most relevan
 - **`release-notes/AUTHORING.md` — migration manifest authoring is undocumented.** CRU-146 added `update-migrations/*.yaml` manifests with their own evaluator but AUTHORING.md does not cover them yet.
 - **`docs/10-operations-runbook.md` — handed-off concerns.** (a) diagnostics jq examples worth re-checking if response shape is rev'd; (b) runbook does not mention `bin/preflight` / `bin/dispatch-stream` / `bin/pack-release`.
 - **`docs/03-api-spec.md` — Jobs POST/PATCH body schema.** The spec has the endpoint table but doesn't document the body fields for `POST /jobs` or `PATCH /jobs`. The `callable` and `singleton` fields added in PR #510 are not in the spec; neither are any of the other body fields. Consider adding a body schema subsection next time the api-spec is touched.
+- **`docs/03-api-spec.md` — Templates CRUD.** PR #515 added `apps/server/src/routes/templates.ts` but the api-spec has no Templates section. Add when next auditing the spec.
 - **`unknown` AgentStatus is dead code.** Worth a separate cleanup PR (not docs work).
+- **README install table — Cursor CLI install instructions are approximate.** The binary defaults to `agent`; the exact npm package / install path should be verified once the CLI is publicly documented by Anysphere.
 
 ## drift_patterns
 
@@ -47,7 +49,7 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **Settings defaults flip without the docs noticing.** Trace default claims to both the component's `useState(...)` initial value and the server-side fallback.
 - **The built-in MCP tool list sprawls without touching the docs.** Grep for `AGENT_TOOLS = new Set` and diff against the `Built-in tools` list in `docs-pane.tsx`.
 - **The create-agent dialog accretes options silently.** When `create-agent-dialog.tsx` gains a field, the "Creating an agent" bullet list needs a matching entry.
-- **Agent types list accretes silently.** `AGENT_TYPES` in `apps/web/src/lib/agent-types.ts` started as `claude/codex/opencode` and now includes `terminal`.
+- **Agent types list accretes silently.** `AGENT_TYPES` in `apps/web/src/lib/agent-types.ts` started as `claude/codex/opencode` and now includes `terminal` and `cursor`. All five need to appear in every type-list in docs-pane.
 - **MCP tool sets change by agent type.** The AGENT / JOB / PERSONA tool lists evolve independently.
 - **System-prompt injection has a per-flow allowlist.** Personalities are appended only for "regular" launches.
 - **Repo tool prefix is `repo_`, not `repo.`.** MCP clients don't support dots in tool names.
@@ -59,6 +61,8 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **API-spec endpoint tables go stale when new route files are added.** Personalities CRUD was added without an api-spec section. When a new route file appears in `apps/server/src/routes/`, check whether its endpoints are in the spec.
 - **History endpoint query params change without docs updates.** The `sort` values changed from `recent|oldest` to `created_at|name|updated_at` and an `order` param was added, but the api-spec wasn't updated. Grep the actual query parsing in the route handler.
 - **Job form accretes advanced settings without docs updates.** PR #510 added callable/singleton toggles to both the create and settings forms. The in-app docs Jobs section needs to mirror these whenever the form gains a new field.
+- **New agent types land without docs updates.** Cursor was added in PR #513 without updating any docs surfaces. Every location that enumerates agent types needs checking when a new type is added.
+- **README CLI install table drifts from agent-type-settings.** The README CLI table should match the agent types that can be enabled in the UI; when a new type is added to `AGENT_TYPES`, add a row.
 
 ## Notes for the next run
 
@@ -94,3 +98,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-05-06** (Size-adaptive review diffs + README audit) — Updated Reviewers "How personas work" to document size-adaptive diff behavior (PR #501: diffs >15KB get file-level summaries + git commands instead of inline). Updated README.md: added "shortcuts" and "personalities" to docs section list, added personalities and keyboard shortcuts to features list, fixed JOB_TOOLS list (added 6 missing review round-trip tools).
 - **2026-05-07** (API spec v2) — Closed the api-spec `next_focus`. Added: release auto-check endpoints (auto-update-mode, cached-info), SSE event type enumeration (15 types), Personalities CRUD section, diff-stats and prompt-rename agent endpoints. Fixed: History query params (sort values, added search/order, archived-only behavior), Media POST source field, Settings endpoint description.
 - **2026-05-09** (Jobs — callable + singleton) — Pivoted from next_focus (Agents history/base-ref) to diff-driven update for PR #510. Added "Show in command palette" and "Single instance" to Jobs advanced settings list. Updated "On-demand runs" to reflect singleton-gated concurrency. Added callable-jobs paragraph to Keyboard Shortcuts command palette section.
+- **2026-05-10** (Cursor agent type + templates) — Pivoted from next_focus (sidebar badges) to diff-driven update for PRs #513/#517. Added `cursor` to all agent-type lists in docs-pane (Agents, Personalities, Automations Templates, Automations Jobs, Reviewers). Updated README features list and CLI install table with Cursor. Templates section already existed from PR #515 — no additional docs needed.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 >    - **macOS**: Run `bin/install-launchd` to create a launchd plist that starts on boot.
 >    - **Linux**: Create a systemd user service for Xvfb (`~/.config/systemd/user/xvfb.service`) that runs `Xvfb :99 -screen 0 1024x768x24`. Enable with `systemctl --user enable --now xvfb`. Then create the Dispatch service (`~/.config/systemd/user/dispatch.service`) that runs the compiled `dist/bun/dispatch-<version>-bun-linux-x64` or `dist/bun/dispatch-<version>-bun-linux-arm64` binary with `EnvironmentFile=~/.dispatch/server/.env`. Add `DISPATCH_COPY_DISPLAY=:99` to the `.env` file for clipboard image support. Enable with `systemctl --user enable --now dispatch`.
 > 6. Verify: `curl http://127.0.0.1:6767/api/v1/health`
-> 7. Check which agent CLIs are installed (`claude --version`, `codex --version`, `opencode --version`). In the Dispatch UI under Settings, disable any agent types whose CLI is not installed.
+> 7. Check which agent CLIs are installed (`claude --version`, `codex --version`, `agent --version`, `opencode --version`). In the Dispatch UI under Settings, disable any agent types whose CLI is not installed.
 
 <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/efb154d9-7d4c-411a-861b-d460cb0816d6" />
 
 ## Features
 
-- Start, monitor, and stop multiple long-running agents (Claude, Codex, OpenCode, or a plain tmux terminal) remotely.
+- Start, monitor, and stop multiple long-running agents (Claude, Codex, Cursor, OpenCode, or a plain tmux terminal) remotely.
 - Persist each agent in `tmux` so browser disconnects do not kill work.
 - Git worktree isolation for parallel agent work on separate branches.
 - MCP-based tooling with repo-specific custom tools (`.dispatch/tools.json`).
@@ -73,6 +73,7 @@ Dispatch spawns agents via their CLI tools. Install at least one:
 | ------------ | ------------------------------------------ | --------------------------------------------- |
 | **Claude**   | `npm install -g @anthropic-ai/claude-code` | `claude` (follow login prompts)               |
 | **Codex**    | `npm install -g codex`                     | Set `OPENAI_API_KEY` in your shell profile    |
+| **Cursor**   | Install [Cursor](https://www.cursor.com/)  | Configure in Cursor settings                  |
 | **OpenCode** | `npm install -g opencode`                  | Set `ANTHROPIC_API_KEY` in your shell profile |
 
 The agent CLI must be authenticated before Dispatch can spawn agents of that type. Dispatch invokes the CLI directly, so any API keys or login state in your shell environment are inherited automatically.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -94,7 +94,7 @@ const SECTIONS: SectionDef[] = [
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
             <li>
               <strong>Type</strong> — pick a CLI assistant (<Code>claude</Code>,{" "}
-              <Code>codex</Code>, <Code>opencode</Code>) or{" "}
+              <Code>codex</Code>, <Code>cursor</Code>, <Code>opencode</Code>) or{" "}
               <Code>terminal</Code> for a plain tmux shell with no CLI attached.
               Disabled types can be enabled in Settings.
             </li>
@@ -398,8 +398,8 @@ const SECTIONS: SectionDef[] = [
             The active personality is appended at launch and on resume for every
             standard agent regardless of CLI: it goes into Claude's{" "}
             <Code>--append-system-prompt</Code> flag and into the launch prompt
-            for Codex and OpenCode. Terminal agents have no CLI to inject into,
-            so the personality is silently skipped.
+            for Codex, Cursor, and OpenCode. Terminal agents have no CLI to
+            inject into, so the personality is silently skipped.
           </P>
           <P>
             Three flows intentionally <em>don't</em> get the personality, since
@@ -702,7 +702,7 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             </li>
             <li>
               <strong>Agent type</strong> — <Code>claude</Code>,{" "}
-              <Code>codex</Code>, or <Code>opencode</Code>.
+              <Code>codex</Code>, <Code>cursor</Code>, or <Code>opencode</Code>.
             </li>
             <li>
               <strong>Use worktree</strong> — give each launch its own git
@@ -798,8 +798,8 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             </li>
             <li>
               <strong>Agent type</strong> — <Code>claude</Code>,{" "}
-              <Code>codex</Code>, or <Code>opencode</Code>. Terminal-type agents
-              can't run jobs.
+              <Code>codex</Code>, <Code>cursor</Code>, or <Code>opencode</Code>.
+              Terminal-type agents can't run jobs.
             </li>
             <li>
               <strong>Prompt</strong> — the instructions sent as the agent's
@@ -1121,7 +1121,7 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             media) where the git diff is not the review target.
           </P>
           <P>
-            Reviewers always run as a CLI-type agent (claude / codex /
+            Reviewers always run as a CLI-type agent (claude / codex / cursor /
             opencode); the launcher only offers types that have a CLI assistant,
             so terminal-type agents are not selectable as reviewers.
           </P>


### PR DESCRIPTION
## Summary

- Added `cursor` to every agent-type enumeration in in-app docs (`docs-pane.tsx`): Agents, Personalities, Automations Templates, Automations Jobs, and Reviewers sections.
- Added Cursor to README: features list, CLI install table, and quick-install version check.
- Updated docs-audit state file: advanced `last_audited_sha`, added `Templates CRUD` and `Cursor install instructions` to backlog, added two new drift patterns about agent-type and README CLI table accrual.

**Audited:** PRs #513 (Cursor agent type) and #517 (Cursor refinement). Templates feature (PR #515) already had matching docs from the same PR.

**Deferred to next run:** Sidebar badges enumeration (original `next_focus`, deferred because diff-driven Cursor update took priority).

## Test plan

- [ ] Open in-app docs, verify Cursor appears in all agent-type lists
- [ ] Verify README renders correctly with new Cursor row in CLI table
- [ ] No code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)