### PR TITLE
Fix dev migrations leaking to production database

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -31,7 +31,7 @@ function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
     throw new Error(
-      `${name} is not set. Production: set it in .env. Development: use dispatch-dev to start an isolated environment.`
+      `${name} is not set or is empty. Production: set it in .env. Development: use dispatch-dev to start an isolated environment.`
     );
   }
   return value;

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -27,6 +27,16 @@ export type AppConfig = {
   tls: TlsConfig | null;
 };
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Production: set it in .env. Development: use dispatch-dev to start an isolated environment.`
+    );
+  }
+  return value;
+}
+
 function expandHome(p: string): string {
   return p.startsWith("~/")
     ? path.join(process.env.HOME ?? "/tmp", p.slice(2))
@@ -72,9 +82,7 @@ export function loadConfig(): AppConfig {
   const config: AppConfig = {
     host: process.env.DISPATCH_HOST ?? process.env.HOST ?? "127.0.0.1",
     port: Number(process.env.DISPATCH_PORT ?? process.env.PORT ?? 6767),
-    databaseUrl:
-      process.env.DATABASE_URL ??
-      "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch",
+    databaseUrl: requireEnv("DATABASE_URL"),
     authToken: "", // resolved from DB in start() via getOrCreateAuthToken()
     mediaRoot:
       process.env.MEDIA_ROOT ??

--- a/apps/server/src/db/migrations/0022_templates-description.sql
+++ b/apps/server/src/db/migrations/0022_templates-description.sql
@@ -1,0 +1,2 @@
+-- Add description column missed during initial templates migration
+ALTER TABLE templates ADD COLUMN IF NOT EXISTS description TEXT;

--- a/apps/server/src/db/migrations/0022_templates-description.sql
+++ b/apps/server/src/db/migrations/0022_templates-description.sql
@@ -1,2 +1,0 @@
--- Add description column missed during initial templates migration
-ALTER TABLE templates ADD COLUMN IF NOT EXISTS description TEXT;

--- a/apps/server/test/db/setup.ts
+++ b/apps/server/test/db/setup.ts
@@ -10,7 +10,7 @@ import { runMigrations } from "../../src/db/migrate.js";
 
 const ADMIN_DATABASE_URL =
   process.env.TEST_DATABASE_URL ??
-  "postgres://dispatch:dispatch@127.0.0.1:5432/postgres";
+  "postgres://dispatch:dispatch@127.0.0.1:5433/postgres";
 
 let testDbName: string;
 let adminPool: Pool;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ const protocol = process.env.TLS_CERT ? "https" : "http";
 const baseURL = `${protocol}://127.0.0.1:${devPort}`;
 const databaseUrl =
   process.env.DATABASE_URL ??
-  "postgres://dispatch:dispatch@127.0.0.1:5432/dispatch_dev";
+  "postgres://dispatch:dispatch@127.0.0.1:5433/dispatch_dev";
 const mediaRoot =
   process.env.MEDIA_ROOT ?? `${process.env.HOME}/.dispatch/media-dev`;
 const agentRuntime =


### PR DESCRIPTION
## Summary
- Migration 0021 (templates) ran against production during development because pg_hba.conf used `trust` auth and all dev defaults pointed at the production database
- Adds migration 0022 to backfill the missing `description` column that was added to 0021 after it had already been applied
- Removes the hardcoded production `DATABASE_URL` default from `config.ts` — now throws if not explicitly set
- Changes test/Playwright fallback ports from 5432 → 5433 so they can't accidentally connect to the production postgres

### Manual fixes applied outside this PR
- `pg_hba.conf`: changed from `trust` to `scram-sha-256` for all localhost connections
- Root `.env`: removed `DATABASE_URL` (was being copied into agent worktrees)

## Test plan
- [ ] `pnpm run check` passes
- [ ] Production server stays healthy after pg_hba change (verified live)
- [ ] `dispatch:dispatch` credentials rejected by production postgres (verified)
- [ ] Correct production credentials still work (verified)
- [ ] CI uses explicit `TEST_DATABASE_URL` so port change doesn't affect it
- [ ] New agent worktrees no longer get `DATABASE_URL` in their `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)