### PR TITLE
Fix mobile scrollback regression from PR #519

### DIFF
--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -954,12 +954,6 @@ export function useTerminal(args: {
     }
 
     const disposable = term.onData((data) => {
-      if (copyModeRef.current === "copy" || copyModeRef.current === "exiting") {
-        if (copyModeRef.current === "copy" && data === "\x1b") {
-          void exitCopyModeRef.current();
-        }
-        return;
-      }
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
       if (ctrlPendingRef.current && data.length === 1) {


### PR DESCRIPTION
## Summary
- PR #519 added a client-side `onData` gate that swallowed all terminal input during copy/exiting state to stabilize E2E tests
- This blocked SGR mouse reports that carry scroll events to tmux, killing scrollback on mobile once the first touch-scroll entered copy mode
- The gate was unnecessary — tmux natively handles copy mode input (Escape/q exits, other keys exit and pass through)
- Fix: remove the gate entirely and let all input flow straight to tmux. The copy mode assist banner still works for display and tap-to-exit.

## Test plan
- [x] Verified scrollback works after wheel-scroll enters tmux copy mode (Playwright + live dev instance)
- [ ] On mobile (iOS Safari), touch-scroll up through terminal output history
- [ ] Verify continued scrolling works after entering copy mode
- [ ] Verify Escape still exits copy mode natively via tmux
- [ ] Verify copy mode assist banner still displays and tap-to-exit works