### PR TITLE
Add template launch agent type override

### DIFF
--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -42,6 +42,7 @@ const UpdateTemplateBodySchema = z.object({
 const LaunchBodySchema = z.object({
   args: z.record(z.string(), z.string()).optional(),
   directory: directoryField.optional(),
+  agentType: z.enum(CLI_AGENT_TYPES).optional(),
 });
 
 function resolveTilde(value: string): string {

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -29,6 +29,7 @@ export type LaunchTemplateInput = {
   templateId: string;
   args?: Record<string, string>;
   directory?: string;
+  agentType?: JobAgentType;
 };
 
 export type LaunchResult = {
@@ -151,7 +152,7 @@ export class TemplateService {
     const cwd = input.directory ?? template.directory;
     const agent = await this.agentManager.createAgent({
       name: sanitizeAgentName(template.name),
-      type: template.agentType,
+      type: input.agentType ?? template.agentType,
       cwd,
       initialPrompt: finalPrompt,
       fullAccess: template.fullAccess,

--- a/apps/server/test/templates/service.test.ts
+++ b/apps/server/test/templates/service.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentRecord } from "../../src/agents/types.js";
+import { TemplateService } from "../../src/templates/service.js";
+import type { TemplateRecord } from "../../src/templates/store.js";
+
+function buildTemplate(
+  overrides: Partial<TemplateRecord> = {}
+): TemplateRecord {
+  return {
+    id: "tmpl_123",
+    directory: "/tmp/repo",
+    name: "Template Launch",
+    description: null,
+    prompt: "Review {{D:Target}}",
+    agentType: "claude",
+    useWorktree: false,
+    baseBranch: null,
+    branchName: null,
+    fullAccess: false,
+    callable: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function buildAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  const timestamp = new Date().toISOString();
+  return {
+    id: "agt_123",
+    name: "template-launch",
+    type: "codex",
+    role: "standard",
+    status: "running",
+    cwd: "/tmp/repo",
+    worktreePath: null,
+    worktreeBranch: null,
+    tmuxSession: null,
+    simulatorUdid: null,
+    mediaDir: null,
+    agentArgs: [],
+    fullAccess: false,
+    setupPhase: null,
+    archivePhase: null,
+    archiveCleanupMode: null,
+    lastError: null,
+    latestEvent: null,
+    pins: [],
+    gitContext: null,
+    gitContextStale: false,
+    gitContextUpdatedAt: null,
+    persona: null,
+    parentAgentId: null,
+    personaContext: null,
+    reviewAgentType: null,
+    review: null,
+    baseBranch: null,
+    templateId: "tmpl_123",
+    autoReview: false,
+    cliSessionId: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  };
+}
+
+describe("TemplateService.launchTemplate", () => {
+  it("uses the requested agent type override when launching", async () => {
+    const createAgent = vi.fn(async () => buildAgent());
+    const service = new TemplateService(
+      {} as never,
+      { createAgent } as never,
+      { info: vi.fn() } as never
+    );
+
+    vi.spyOn(service.store, "getTemplate").mockResolvedValue(buildTemplate());
+
+    await service.launchTemplate({
+      templateId: "tmpl_123",
+      agentType: "codex",
+      args: { target: "src/app.tsx" },
+    });
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "codex",
+        initialPrompt: "Review src/app.tsx",
+      })
+    );
+  });
+});

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -33,7 +33,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { GlassSidebar } from "@/components/ui/glass-sidebar";
 import { api } from "@/lib/api";
-import { type AgentType, isAgentType } from "@/lib/agent-types";
+import { type AgentType, isAgentType, isCliAgentType } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
 import {
   agentFeedbackRoute,
@@ -982,6 +982,7 @@ export function AgentsView({
           onOpenChange={(open) => {
             if (!open) setLaunchTemplateId(null);
           }}
+          agentTypes={enabledAgentTypes.filter(isCliAgentType)}
         />
       ) : null}
 

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -203,6 +203,7 @@ function TemplateListContent({
               <TemplateListItem
                 key={template.id}
                 template={template}
+                enabledAgentTypes={enabledAgentTypes}
                 selected={templateId === template.id}
                 onSelect={() => {
                   navigate(`/automations/templates/${template.id}`);
@@ -224,39 +225,25 @@ function TemplateListContent({
 
 function TemplateListItem({
   template,
+  enabledAgentTypes,
   selected,
   onSelect,
 }: {
   template: Template;
+  enabledAgentTypes: AgentType[];
   selected: boolean;
   onSelect: () => void;
 }): JSX.Element {
-  const navigate = useNavigate();
-  const { launchTemplate } = useTemplateActions();
   const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
-  const args = useMemo(
-    () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
-    [template.prompt]
+  const cliAgentTypes = useMemo(
+    () => enabledAgentTypes.filter(isCliAgentType),
+    [enabledAgentTypes]
   );
 
-  const handleLaunch = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (args.length > 0) {
-        setLaunchDialogOpen(true);
-        return;
-      }
-      launchTemplate
-        .mutateAsync({ id: template.id })
-        .then((result) => {
-          navigate(agentRoute(result.agent.id));
-        })
-        .catch((err: Error) => {
-          toast.error(`Failed to launch: ${err.message}`);
-        });
-    },
-    [args.length, launchTemplate, navigate, template.id]
-  );
+  const handleLaunch = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setLaunchDialogOpen(true);
+  }, []);
 
   return (
     <>
@@ -307,6 +294,7 @@ function TemplateListItem({
         template={template}
         open={launchDialogOpen}
         onOpenChange={setLaunchDialogOpen}
+        agentTypes={cliAgentTypes}
       />
     </>
   );
@@ -395,19 +383,8 @@ function TemplateDetail({
   );
 
   const handleLaunch = useCallback(() => {
-    if (savedArgs.length > 0) {
-      setLaunchDialogOpen(true);
-      return;
-    }
-    launchTemplate
-      .mutateAsync({ id: template.id })
-      .then((result) => {
-        navigate(agentRoute(result.agent.id));
-      })
-      .catch((err: Error) => {
-        toast.error(`Failed to launch: ${err.message}`);
-      });
-  }, [savedArgs.length, launchTemplate, template.id, navigate]);
+    setLaunchDialogOpen(true);
+  }, []);
 
   const canSave = !!displayName.trim() && !!directory.trim();
 
@@ -687,6 +664,7 @@ function TemplateDetail({
         template={template}
         open={launchDialogOpen}
         onOpenChange={setLaunchDialogOpen}
+        agentTypes={cliAgentTypes}
       />
     </div>
   );
@@ -702,10 +680,8 @@ function ArgInput({
   onChange: (value: string) => void;
 }): JSX.Element {
   return (
-    <div>
-      <label className="mb-1 block text-xs font-medium text-foreground">
-        {arg.name}
-      </label>
+    <div className="space-y-2">
+      <label className="text-sm text-muted-foreground">{arg.name}</label>
       <Input
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -724,23 +700,34 @@ export function LaunchTemplateDialog({
   template,
   open,
   onOpenChange,
+  agentTypes,
 }: {
   template: Template;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  agentTypes: CliAgentType[];
 }): JSX.Element {
   const navigate = useNavigate();
   const { launchTemplate } = useTemplateActions();
+  const launchButtonRef = useRef<HTMLButtonElement>(null);
 
   const args = useMemo(
     () => (template.prompt ? parseTemplateArgs(template.prompt) : []),
     [template.prompt]
   );
   const [argValues, setArgValues] = useState<Record<string, string>>({});
+  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
 
   useEffect(() => {
-    if (open) setArgValues({});
-  }, [open]);
+    if (!open) return;
+    setArgValues({});
+    setAgentType(template.agentType);
+  }, [open, template.agentType]);
+
+  useEffect(() => {
+    if (!open || args.length > 0) return;
+    requestAnimationFrame(() => launchButtonRef.current?.focus());
+  }, [args.length, open]);
 
   const allArgsFilled =
     args.length === 0 || args.every((a) => argValues[a.key]?.trim());
@@ -748,7 +735,7 @@ export function LaunchTemplateDialog({
   const handleLaunch = useCallback(() => {
     const launchArgs = args.length > 0 ? argValues : undefined;
     launchTemplate
-      .mutateAsync({ id: template.id, args: launchArgs })
+      .mutateAsync({ id: template.id, args: launchArgs, agentType })
       .then((result) => {
         onOpenChange(false);
         navigate(agentRoute(result.agent.id));
@@ -756,12 +743,25 @@ export function LaunchTemplateDialog({
       .catch((err: Error) => {
         toast.error(`Failed to launch: ${err.message}`);
       });
-  }, [args, argValues, launchTemplate, navigate, onOpenChange, template.id]);
+  }, [
+    agentType,
+    args.length,
+    argValues,
+    launchTemplate,
+    navigate,
+    onOpenChange,
+    template.id,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
+      <DialogContent
+        className="max-w-md"
+        onEscapeKeyDown={(e) => {
+          swallowEscapeFromCombobox(e);
+        }}
+      >
+        <DialogHeader className="space-y-2">
           <DialogTitle>{template.name}</DialogTitle>
           {template.description ? (
             <DialogDescription>{template.description}</DialogDescription>
@@ -777,9 +777,19 @@ export function LaunchTemplateDialog({
             e.preventDefault();
             if (allArgsFilled && !launchTemplate.isPending) handleLaunch();
           }}
+          className="space-y-5"
         >
+          <div className="space-y-2">
+            <label className="text-sm text-muted-foreground">Agent type</label>
+            <AgentTypeCombobox
+              value={agentType}
+              onChange={setAgentType}
+              agentTypes={agentTypes}
+            />
+          </div>
+
           {args.length > 0 ? (
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-4">
               {args.map((arg) => (
                 <ArgInput
                   key={arg.key}
@@ -793,8 +803,9 @@ export function LaunchTemplateDialog({
             </div>
           ) : null}
 
-          <div className="flex flex-row-reverse justify-start gap-2 pt-3">
+          <div className="flex flex-row-reverse justify-start gap-2 pt-2">
             <Button
+              ref={launchButtonRef}
               type="submit"
               variant="primary"
               disabled={!allArgsFilled || launchTemplate.isPending}

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -10,7 +10,6 @@ import {
   Play,
   Plus,
 } from "lucide-react";
-import { toast } from "sonner";
 
 import {
   type CommandAction,
@@ -19,12 +18,7 @@ import {
 import { type Agent } from "@/components/app/types";
 import { agentRoute } from "@/lib/agent-routes";
 import { useHotkey } from "@/lib/hotkeys/use-hotkey";
-import {
-  useTemplates,
-  useTemplateActions,
-  parseTemplateArgs,
-  type Template,
-} from "@/hooks/use-templates";
+import { useTemplates, type Template } from "@/hooks/use-templates";
 
 type UseAgentHotkeysArgs = {
   agents: Agent[];
@@ -67,7 +61,6 @@ export function useAgentHotkeys({
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [launchTemplateId, setLaunchTemplateId] = useState<string | null>(null);
   const { data: templates = [] } = useTemplates();
-  const { launchTemplate } = useTemplateActions();
 
   useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
 
@@ -166,40 +159,20 @@ export function useAgentHotkeys({
       {
         label: "Templates",
         actions: callableTemplates.map((template) => {
-          const args = parseTemplateArgs(template.prompt ?? "");
-          const hasArgs = args.length > 0;
           return {
             id: `template-${template.id}`,
             title: template.name,
             keywords: ["template", "launch", "run"],
             icon: Play,
-            confirm: hasArgs
-              ? undefined
-              : {
-                  description:
-                    template.description ||
-                    "This will create a new agent from this template.",
-                },
             run: () => {
-              if (hasArgs) {
-                setPaletteOpen(false);
-                setLaunchTemplateId(template.id);
-                return;
-              }
-              launchTemplate
-                .mutateAsync({ id: template.id })
-                .then((result) => {
-                  navigate(agentRoute(result.agent.id));
-                })
-                .catch((err: Error) => {
-                  toast.error(`Failed to launch template: ${err.message}`);
-                });
+              setPaletteOpen(false);
+              setLaunchTemplateId(template.id);
             },
           };
         }),
       },
     ];
-  }, [templates, launchTemplate, navigate, setPaletteOpen]);
+  }, [templates, setPaletteOpen]);
 
   const resolvedLaunchTemplate = useMemo(
     () => templates.find((t) => t.id === launchTemplateId) ?? null,

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -107,10 +107,18 @@ export function useTemplateActions() {
   });
 
   const launchTemplate = useMutation({
-    mutationFn: ({ id, args }: { id: string; args?: Record<string, string> }) =>
+    mutationFn: ({
+      id,
+      args,
+      agentType,
+    }: {
+      id: string;
+      args?: Record<string, string>;
+      agentType?: CliAgentType;
+    }) =>
       api<LaunchResult>(`/api/v1/templates/${id}/launch`, {
         method: "POST",
-        body: JSON.stringify({ args }),
+        body: JSON.stringify({ args, agentType }),
       }),
     onSuccess: (result) => {
       queryClient.setQueryData<Agent[]>(["agents"], (old) => {

--- a/e2e/callable-jobs.spec.ts
+++ b/e2e/callable-jobs.spec.ts
@@ -93,26 +93,27 @@ test.describe("Callable templates — Cmd+K launch lifecycle", () => {
     await expect(palette.getByText(templateName)).toBeVisible();
     await expect(palette.getByText("Commands")).not.toBeVisible();
 
-    // 6. Press Enter to select the template
+    // 6. Press Enter to open the launch form
     await page.keyboard.press("Enter");
 
-    // 7. Confirmation step appears
-    await expect(palette.getByText("This will create a new agent")).toBeVisible(
-      { timeout: 3_000 }
-    );
-    const launchOption = palette.getByRole("option", { name: "Launch" });
-    await expect(launchOption).toBeVisible();
-
-    // 8. Press Enter to confirm launch
-    await page.keyboard.press("Enter");
-
-    // 9. Palette should close
+    // 7. Launch dialog appears with agent type override controls
     await expect(palette).not.toBeVisible({ timeout: 3_000 });
+    const launchDialog = page.getByRole("dialog", { name: templateName });
+    await expect(launchDialog).toBeVisible({ timeout: 3_000 });
+    const agentTypeField = launchDialog.getByRole("combobox");
+    await expect(agentTypeField).toContainText("Claude");
+    await agentTypeField.click();
+    await page.getByRole("option", { name: "Codex" }).click();
+    await expect(agentTypeField).toContainText("Codex");
+    const launchButton = launchDialog.getByRole("button", { name: "Launch" });
 
-    // 10. Verify URL navigated to the new agent (worktree setup adds latency)
+    // 8. Launch the template with the override applied
+    await launchButton.click();
+
+    // 9. Verify URL navigated to the new agent (worktree setup adds latency)
     await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });
 
-    // 11. Wait for the specific launched agent card to appear as a top-level
+    // 10. Wait for the specific launched agent card to appear as a top-level
     // sidebar entry. Scope to the scroll region so we don't match duplicated
     // descendant markup outside the owning list item.
     const agentId = page.url().match(/\/agents\/(agt_[a-f0-9]{12})/)?.[1];
@@ -125,5 +126,48 @@ test.describe("Callable templates — Cmd+K launch lifecycle", () => {
     await expect(launchedAgentCard).toBeVisible({
       timeout: 10_000,
     });
+
+    // 11. Verify the launch respected the selected override.
+    const listRes = await request.get("/api/v1/agents", {
+      headers: AUTH_HEADER,
+    });
+    const { agents } = (await listRes.json()) as {
+      agents: Array<{ id: string; type: string }>;
+    };
+    expect(agents.find((agent) => agent.id === agentId)?.type).toBe("codex");
+  });
+
+  test("no-arg callable template still supports fast Enter-to-launch from Cmd+K", async ({
+    page,
+  }) => {
+    const createRes = await page.request.post("/api/v1/templates", {
+      headers: HEADERS,
+      data: {
+        name: templateName,
+        directory: templateDir,
+        prompt: "Say hello and stop.",
+        callable: true,
+        agentType: "claude",
+        useWorktree: false,
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = (await createRes.json()) as { id: string };
+    templateId = created.id;
+
+    await loadApp(page);
+    await page.keyboard.press(`${MOD_KEY}+k`);
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible({ timeout: 3_000 });
+    await palette.getByRole("combobox").pressSequentially("e2e-callable", {
+      delay: 30,
+    });
+
+    await page.keyboard.press("Enter");
+    const launchDialog = page.getByRole("dialog", { name: templateName });
+    await expect(launchDialog).toBeVisible({ timeout: 3_000 });
+
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });
   });
 });


### PR DESCRIPTION
## Summary
- add a launch-time agent type override for templates in both the Templates page modal and the Cmd+K launch flow
- route callable template launches through the shared launch dialog and restore the fast zero-arg keyboard path
- align runtime arg label styling and add backend plus E2E coverage for the new launch behavior