### PR TITLE
Fix job-backed templates leaking into Templates list + click bug

### DIFF
--- a/apps/server/src/db/migrations/0023_index-jobs-template-id.sql
+++ b/apps/server/src/db/migrations/0023_index-jobs-template-id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_jobs_template_id ON jobs(template_id);

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -69,7 +69,7 @@ export async function registerTemplateRoutes(
   deps: TemplateRouteDeps
 ): Promise<void> {
   app.get("/api/v1/templates", async () => {
-    return await deps.templateService.listTemplates();
+    return await deps.templateService.listTemplates({ excludeJobBacked: true });
   });
 
   app.get<{ Params: { id: string } }>(

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -111,6 +111,7 @@ export class TemplateService {
 
   async listTemplates(filter?: {
     callable?: boolean;
+    excludeJobBacked?: boolean;
   }): Promise<TemplateRecord[]> {
     return await this.store.listTemplates(filter);
   }

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -149,12 +149,22 @@ export class TemplateStore {
 
   async listTemplates(filter?: {
     callable?: boolean;
+    excludeJobBacked?: boolean;
   }): Promise<TemplateRecord[]> {
     let query = `SELECT ${this.columns()} FROM templates`;
+    const conditions: string[] = [];
     const params: unknown[] = [];
     if (filter?.callable !== undefined) {
-      query += ` WHERE callable = $1`;
       params.push(filter.callable);
+      conditions.push(`callable = $${params.length}`);
+    }
+    if (filter?.excludeJobBacked) {
+      conditions.push(
+        `NOT EXISTS (SELECT 1 FROM jobs WHERE jobs.template_id = templates.id)`
+      );
+    }
+    if (conditions.length > 0) {
+      query += ` WHERE ${conditions.join(" AND ")}`;
     }
     query += ` ORDER BY name ASC, directory ASC`;
     const result = await this.pool.query(query, params);

--- a/apps/server/test/templates/store.test.ts
+++ b/apps/server/test/templates/store.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Pool } from "pg";
+
+import { TemplateStore } from "../../src/templates/store.js";
+import { setupTestDb, teardownTestDb, runTestMigrations } from "../db/setup.js";
+
+let pool: Pool;
+let store: TemplateStore;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+  await runTestMigrations();
+  store = new TemplateStore(pool);
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+describe("TemplateStore.listTemplates", () => {
+  const callableTemplate = {
+    name: "Callable Template",
+    directory: "/tmp/test",
+    description: null,
+    prompt: "do stuff",
+    agentType: "claude" as const,
+    useWorktree: false,
+    baseBranch: null,
+    branchName: null,
+    fullAccess: false,
+    callable: true,
+  };
+
+  const nonCallableTemplate = {
+    ...callableTemplate,
+    name: "Non-Callable Template",
+    callable: false,
+  };
+
+  const jobBackedTemplate = {
+    ...callableTemplate,
+    name: "Job-Backed Template",
+    callable: false,
+  };
+
+  let jobBackedId: string;
+
+  beforeAll(async () => {
+    const t1 = await store.createTemplate(callableTemplate);
+    await store.createTemplate(nonCallableTemplate);
+    const t3 = await store.createTemplate(jobBackedTemplate);
+    jobBackedId = t3.id;
+
+    // Create a job that references the job-backed template
+    await pool.query(
+      `INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms,
+        prompt, full_access, agent_type, use_worktree, auto_archive, callable, singleton, enabled, template_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+      [
+        "test-job-1",
+        "/tmp/test",
+        "test job",
+        "0 * * * *",
+        60000,
+        60000,
+        null,
+        false,
+        "claude",
+        false,
+        true,
+        false,
+        true,
+        true,
+        jobBackedId,
+      ]
+    );
+  });
+
+  it("returns all templates with no filter", async () => {
+    const templates = await store.listTemplates();
+    expect(templates).toHaveLength(3);
+  });
+
+  it("filters by callable", async () => {
+    const callable = await store.listTemplates({ callable: true });
+    expect(callable).toHaveLength(1);
+    expect(callable[0].name).toBe("Callable Template");
+
+    const nonCallable = await store.listTemplates({ callable: false });
+    expect(nonCallable).toHaveLength(2);
+  });
+
+  it("excludes job-backed templates", async () => {
+    const templates = await store.listTemplates({ excludeJobBacked: true });
+    expect(templates).toHaveLength(2);
+    expect(templates.map((t) => t.name).sort()).toEqual([
+      "Callable Template",
+      "Non-Callable Template",
+    ]);
+  });
+
+  it("combines callable and excludeJobBacked filters", async () => {
+    const templates = await store.listTemplates({
+      callable: true,
+      excludeJobBacked: true,
+    });
+    expect(templates).toHaveLength(1);
+    expect(templates[0].name).toBe("Callable Template");
+  });
+
+  it("returns results sorted by name", async () => {
+    const templates = await store.listTemplates();
+    const names = templates.map((t) => t.name);
+    expect(names).toEqual([...names].sort());
+  });
+});

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -297,7 +297,7 @@ function TemplateListItem({
             type="button"
             onClick={handleLaunch}
             title="Launch template"
-            className="shrink-0 rounded p-2 text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100"
+            className="shrink-0 rounded p-2 text-muted-foreground opacity-0 pointer-events-none transition-opacity hover:bg-white/[0.08] hover:text-primary group-hover:opacity-100 group-hover:pointer-events-auto"
           >
             <Play className="h-3 w-3 fill-current" />
           </button>


### PR DESCRIPTION
## Summary
- Filter job-backed templates from `GET /api/v1/templates` using a `NOT EXISTS` subquery against the jobs table, so templates tied to a job only appear in the Jobs UI — not the Templates list.
- Fix the invisible launch button (Play icon) on template rows swallowing clicks via `stopPropagation()` by adding `pointer-events-none` when hidden and `group-hover:pointer-events-auto` when visible.
- Add store-level unit tests covering all `listTemplates` filter combinations (`callable`, `excludeJobBacked`, both, neither).

## Test plan
- [x] Type checks pass (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (140/140)
- [x] New store unit tests pass (5/5)
- [x] Verified via Playwright: job-backed templates excluded from list, non-callable templates without jobs still shown, single-click selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)