### PR TITLE
Run E2E tests in parallel with Playwright projects

### DIFF
--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -16,7 +16,7 @@ function pathnameTerminalTokenMatch(pathname: string): boolean {
 
 test.describe("Agent CRUD", () => {
   test.afterEach(async ({ request }) => {
-    await cleanupE2EAgents(request);
+    await cleanupE2EAgents(request, "all");
   });
 
   test("displays 'No agents yet' when the list is empty", async ({

--- a/e2e/base-branch.spec.ts
+++ b/e2e/base-branch.spec.ts
@@ -1,7 +1,12 @@
 import { execSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { test, expect } from "@playwright/test";
-import { cleanupE2EAgents, createAgentViaAPI, loadApp } from "./helpers";
+import {
+  cleanupE2EAgents,
+  createAgentViaAPI,
+  loadApp,
+  trackAgent,
+} from "./helpers";
 
 const authHeader = {
   Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
@@ -112,7 +117,10 @@ test.describe("Agent base branch", () => {
       headers: authHeader,
       data: { cwd: "/tmp", baseBranch: "feature/foo", useWorktree: false },
     });
-    const body = (await res.json()) as { agent: { baseBranch: string | null } };
+    const body = (await res.json()) as {
+      agent: { id: string; baseBranch: string | null };
+    };
+    trackAgent(body.agent.id);
     expect(body.agent.baseBranch).toBe("feature/foo");
   });
 
@@ -123,7 +131,10 @@ test.describe("Agent base branch", () => {
       headers: authHeader,
       data: { cwd: "/tmp", useWorktree: false },
     });
-    const body = (await res.json()) as { agent: { baseBranch: string | null } };
+    const body = (await res.json()) as {
+      agent: { id: string; baseBranch: string | null };
+    };
+    trackAgent(body.agent.id);
     expect(body.agent.baseBranch).toBeNull();
   });
 
@@ -142,6 +153,7 @@ test.describe("Agent base branch", () => {
     const body = (await res.json()) as {
       agent: { id: string; baseBranch: string | null };
     };
+    trackAgent(body.agent.id);
     expect(body.agent.baseBranch).toBe("develop");
 
     const baseBranchDefault = await getCreatePrBaseBranchDefault(

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -4,6 +4,13 @@ import { type Page, type APIRequestContext } from "@playwright/test";
 const API = "/api/v1";
 const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "dev-token";
 
+const trackedAgentIds = new Set<string>();
+
+/** Register an agent ID for cleanup — use when creating agents outside createAgentViaAPI. */
+export function trackAgent(id: string): void {
+  trackedAgentIds.add(id);
+}
+
 /** Return Authorization header for API requests. */
 function authHeaders(): Record<string, string> {
   return { Authorization: `Bearer ${AUTH_TOKEN}` };
@@ -51,6 +58,7 @@ export async function createAgentViaAPI(
   });
   const body = (await res.json()) as { agent: AgentResult };
   let agent = body.agent;
+  trackedAgentIds.add(agent.id);
 
   // When using worktrees, the setup runs asynchronously in tmux.
   // Poll until the agent transitions to 'running' (setup complete).
@@ -412,11 +420,47 @@ export async function deleteAgentViaAPI(
 }
 
 /**
- * Delete all agents whose name starts with `e2e-agent-` to keep the dev DB clean.
+ * Clean up agents created during tests.
+ *
+ * Default ("tracked") mode only deletes agents created by `createAgentViaAPI`
+ * in this worker process — safe to call from parallel workers.
+ *
+ * Pass "all" to delete every `e2e-agent-*` agent and its children.
+ * Only use "all" from tests that run with a single worker (serial suite).
  */
 export async function cleanupE2EAgents(
-  request: APIRequestContext
+  request: APIRequestContext,
+  mode: "tracked" | "all" = "tracked"
 ): Promise<void> {
+  if (mode === "tracked") {
+    const ids = [...trackedAgentIds];
+    trackedAgentIds.clear();
+    // Also delete child agents (e.g. persona reviewers)
+    if (ids.length > 0) {
+      const res = await request.get(`${API}/agents`, {
+        headers: authHeaders(),
+      });
+      const body = (await res.json()) as {
+        agents?: Array<{
+          id: string;
+          name: string;
+          parentAgentId?: string | null;
+        }>;
+      };
+      const parentSet = new Set(ids);
+      const toDelete = new Set(ids);
+      for (const agent of body.agents ?? []) {
+        if (agent.parentAgentId && parentSet.has(agent.parentAgentId)) {
+          toDelete.add(agent.id);
+        }
+      }
+      await Promise.all(
+        [...toDelete].map((id) => deleteAgentViaAPI(request, id))
+      );
+    }
+    return;
+  }
+
   const res = await request.get(`${API}/agents`, { headers: authHeaders() });
   const body = (await res.json()) as {
     agents?: Array<{ id: string; name: string; parentAgentId?: string | null }>;
@@ -427,14 +471,15 @@ export async function cleanupE2EAgents(
       .filter((agent) => agent.name.startsWith("e2e-agent-"))
       .map((agent) => agent.id)
   );
-  for (const agent of body.agents) {
-    if (
+  const toDelete = body.agents.filter(
+    (agent) =>
       agent.name.startsWith("e2e-agent-") ||
       (agent.parentAgentId && parentIds.has(agent.parentAgentId))
-    ) {
-      await deleteAgentViaAPI(request, agent.id);
-    }
-  }
+  );
+  await Promise.all(
+    toDelete.map((agent) => deleteAgentViaAPI(request, agent.id))
+  );
+  trackedAgentIds.clear();
 }
 
 function mulberry32(seed: number): () => number {

--- a/e2e/terminal-agent-type.spec.ts
+++ b/e2e/terminal-agent-type.spec.ts
@@ -1,8 +1,10 @@
 import { test, expect } from "@playwright/test";
 import {
   cleanupE2EAgents,
+  createAgentViaAPI,
   loadApp,
   setEnabledAgentTypesViaAPI,
+  trackAgent,
 } from "./helpers";
 
 const authHeader = {
@@ -137,6 +139,7 @@ test.describe("Terminal agent type", () => {
     expect(res.status()).toBe(201);
 
     const { agent } = (await res.json()) as { agent: AgentRecord };
+    trackAgent(agent.id);
     expect(agent.type).toBe("terminal");
     // Created via the inert test runtime — initial event should be idle,
     // not "working" like the CLI types.
@@ -161,6 +164,7 @@ test.describe("Terminal agent type", () => {
     expect(res.status()).toBe(201);
 
     const { agent } = (await res.json()) as { agent: AgentRecord };
+    trackAgent(agent.id);
     expect(agent.fullAccess).toBe(false);
     expect(agent.autoReview).toBe(false);
     // No full-access flag should be injected for terminal.
@@ -178,6 +182,7 @@ test.describe("Terminal agent type", () => {
       },
     });
     const { agent } = (await create.json()) as { agent: { id: string } };
+    trackAgent(agent.id);
 
     const patch = await request.patch(
       `/api/v1/agents/${agent.id}/review-agent-type`,

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -173,7 +173,7 @@ test.describe("Terminal live connection", () => {
 
   test.afterEach(async ({ request }) => {
     await setCopyModeAssistEnabled(request, false);
-    await cleanupE2EAgents(request);
+    await cleanupE2EAgents(request, "all");
   });
 
   test("connects to terminal within 3 seconds", async ({ page, request }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,12 +17,21 @@ const mediaRoot =
 const agentRuntime =
   process.env.DISPATCH_AGENT_RUNTIME === "tmux" ? "tmux" : "inert";
 
+// Tests that mutate global settings, create agents via UI, or have explicit
+// serial constraints. These run after the parallel suite with a single worker.
+const serialTests = [
+  "e2e/settings.spec.ts",
+  "e2e/jobs-api.spec.ts",
+  "e2e/agent-crud.spec.ts",
+  "e2e/terminal-live.spec.ts",
+  "e2e/persona-recheck-ui.spec.ts",
+  "e2e/mobile-layout.spec.ts",
+];
+
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: 1,
   reporter: "list",
   use: {
     baseURL,
@@ -46,4 +55,19 @@ export default defineConfig({
     reuseExistingServer: false,
     timeout: 60_000,
   },
+  projects: [
+    {
+      name: "parallel",
+      testIgnore: serialTests,
+      fullyParallel: false,
+      workers: 4,
+    },
+    {
+      name: "serial",
+      testMatch: serialTests,
+      fullyParallel: false,
+      workers: 1,
+      dependencies: ["parallel"],
+    },
+  ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,7 @@ const serialTests = [
   "e2e/terminal-live.spec.ts",
   "e2e/persona-recheck-ui.spec.ts",
   "e2e/mobile-layout.spec.ts",
+  "e2e/media-sidebar.spec.ts",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Split E2E tests into parallel (4 workers) and serial (1 worker) suites using Playwright projects
- Add per-worker agent tracking so cleanup only deletes agents created by the current worker process, preventing cross-worker interference
- Switch cleanup to `Promise.all` for concurrent agent deletion
- Move timing-sensitive UI tests (`persona-recheck-ui`, `mobile-layout`) to serial to avoid load-induced flakes

## Test plan
- [x] `pnpm run check` passes
- [x] Full E2E suite passes locally (139 passed, 11 skipped)
- [ ] CI E2E passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)