### PR TITLE
docs: add sidebar badges + fix template launch behavior

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -1,6 +1,6 @@
 ---
 job: docs-audit
-updated_at: 2026-05-10
+updated_at: 2026-05-11
 ---
 
 # docs-audit — state handoff
@@ -9,17 +9,16 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`168cdfc702fe89352c0471563deb82d19f4183ee` — HEAD at the start of the 2026-05-10 run. v0.20.1 release tag.
+`8770fb11273e1dbf05ac7fc0788bb7097dd43337` — HEAD at the start of the 2026-05-11 run. v0.20.5 release tag.
 
 ## next_focus
 
-**Audit docs-pane "Agents" section sidebar badges enumeration.** The backlog item from prior runs notes that `agent-card.tsx` renders several conditional badges (Job, Update, Attention, full-access) that aren't enumerated in the docs. Check `agent-card.tsx` for the full badge list and compare against the "Agent details" subsection in docs-pane. A single "Sidebar badges" subsection would close the gap.
+**Audit docs-pane "Reviewers" section — resolution capture UI surfaces.** The backlog item from prior runs notes that PR #374 (`8ad64b9`) added resolution reasons + parent summary rendering in `feedback-panel.tsx` (`ResolutionInfoBlock` at line 735, resolution `summary` at lines 1179 / 1570). The docs don't describe what the human sees in the Feedback panel for resolved items; could be a one-paragraph addition to "Submitting findings" or "Round-trip reviews".
 
 ## backlog
 
 Items noticed during prior passes but left for later runs. Pick the most relevant one when `next_focus` is empty or already done.
 
-- **docs-pane "Reviewers" section — resolution capture UI surfaces.** PR #374 (`8ad64b9`) added resolution reasons + parent summary rendering in `feedback-panel.tsx` (`ResolutionInfoBlock` at line 735, resolution `summary` at lines 1179 / 1570). The docs don't describe what the human sees in the Feedback panel for resolved items; could be a one-paragraph addition to "Submitting findings" or "Round-trip reviews".
 - **docs-pane "Updates" section — `ASSISTED_UPDATE_METADATA_INVALID`.** Low-impact but worth a sentence if the section gets revisited.
 - **docs-pane "Updates" section — release-channel deep mechanics.** PR #487 (2026-05-03) may have introduced new user-visible release-detection state — spot-check `release-manager.tsx` next time the Updates section is touched.
 - **docs-pane "Status Events" section — `metadata` parameter** — `dispatch_event` accepts an optional `metadata` (Record<string, unknown>) param. Currently undocumented in docs-pane. Revisit only if a feature starts using metadata in a user-visible way.
@@ -30,6 +29,7 @@ Items noticed during prior passes but left for later runs. Pick the most relevan
 - **`docs/10-operations-runbook.md` — handed-off concerns.** (a) diagnostics jq examples worth re-checking if response shape is rev'd; (b) runbook does not mention `bin/preflight` / `bin/dispatch-stream` / `bin/pack-release`.
 - **`docs/03-api-spec.md` — Jobs POST/PATCH body schema.** The spec has the endpoint table but doesn't document the body fields for `POST /jobs` or `PATCH /jobs`. The `callable` and `singleton` fields added in PR #510 are not in the spec; neither are any of the other body fields. Consider adding a body schema subsection next time the api-spec is touched.
 - **`docs/03-api-spec.md` — Templates CRUD.** PR #515 added `apps/server/src/routes/templates.ts` but the api-spec has no Templates section. Add when next auditing the spec.
+- **`docs/03-api-spec.md` — Template launch `agentType` override.** PR #523 added an optional `agentType` field to `POST /templates/:id/launch`. Add to the Templates CRUD section when that section is created.
 - **`unknown` AgentStatus is dead code.** Worth a separate cleanup PR (not docs work).
 - **README install table — Cursor CLI install instructions are approximate.** The binary defaults to `agent`; the exact npm package / install path should be verified once the CLI is publicly documented by Anysphere.
 
@@ -63,6 +63,7 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **Job form accretes advanced settings without docs updates.** PR #510 added callable/singleton toggles to both the create and settings forms. The in-app docs Jobs section needs to mirror these whenever the form gains a new field.
 - **New agent types land without docs updates.** Cursor was added in PR #513 without updating any docs surfaces. Every location that enumerates agent types needs checking when a new type is added.
 - **README CLI install table drifts from agent-type-settings.** The README CLI table should match the agent types that can be enabled in the UI; when a new type is added to `AGENT_TYPES`, add a row.
+- **Template launch dialogs now always open.** PR #523 changed inline play and command palette to always open a launch dialog (agent type override + args). If the dialog gains more fields, the "Launching templates" section needs updating.
 
 ## Notes for the next run
 
@@ -99,3 +100,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-05-07** (API spec v2) — Closed the api-spec `next_focus`. Added: release auto-check endpoints (auto-update-mode, cached-info), SSE event type enumeration (15 types), Personalities CRUD section, diff-stats and prompt-rename agent endpoints. Fixed: History query params (sort values, added search/order, archived-only behavior), Media POST source field, Settings endpoint description.
 - **2026-05-09** (Jobs — callable + singleton) — Pivoted from next_focus (Agents history/base-ref) to diff-driven update for PR #510. Added "Show in command palette" and "Single instance" to Jobs advanced settings list. Updated "On-demand runs" to reflect singleton-gated concurrency. Added callable-jobs paragraph to Keyboard Shortcuts command palette section.
 - **2026-05-10** (Cursor agent type + templates) — Pivoted from next_focus (sidebar badges) to diff-driven update for PRs #513/#517. Added `cursor` to all agent-type lists in docs-pane (Agents, Personalities, Automations Templates, Automations Jobs, Reviewers). Updated README features list and CLI install table with Cursor. Templates section already existed from PR #515 — no additional docs needed.
+- **2026-05-11** (Sidebar badges + template launch override) — Closed the sidebar badges next_focus: added "Sidebar badges" subsection to Agents documenting Attention, Job, and Update badges. Fixed "Launching templates" section: inline play button and command palette now always open a launch dialog (PR #523), and the dialog includes an agent type override selector.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -162,6 +162,29 @@ const SECTIONS: SectionDef[] = [
         </Section>
 
         <Section>
+          <H3>Sidebar badges</H3>
+          <P>
+            Three contextual badges can appear next to an agent's name in the
+            sidebar:
+          </P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li>
+              <strong>Attention</strong> — the agent entered an error state and
+              may need manual intervention. Hover the badge to see the specific
+              error.
+            </li>
+            <li>
+              <strong>Job</strong> — the agent was spawned by a scheduled or
+              on-demand job run.
+            </li>
+            <li>
+              <strong>Update</strong> — the agent is performing an assisted
+              Dispatch update.
+            </li>
+          </ul>
+        </Section>
+
+        <Section>
           <H3>Starting and stopping</H3>
           <P>
             Press the play button to resume a stopped agent. Press the stop
@@ -746,17 +769,22 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             </li>
             <li>
               <strong>Inline play button</strong> — each template in the list
-              has a play icon for quick launch. Templates without arguments
-              launch directly; those with arguments open a launch dialog.
+              has a play icon that opens a launch dialog where you can override
+              the agent type and fill in any arguments before launching.
             </li>
             <li>
               <strong>Command palette</strong> (<Code>Mod+K</Code>) — callable
-              templates appear under a "Templates" group. Templates without
-              arguments show a confirmation step (press Enter twice). Templates
-              with arguments open a launch dialog where you fill in values
-              before launching.
+              templates appear under a "Templates" group. Selecting one opens a
+              launch dialog where you can override the agent type and fill in
+              arguments.
             </li>
           </ul>
+          <P>
+            Every launch dialog includes an <strong>Agent type</strong> selector
+            that defaults to the template's configured type. This lets you run
+            the same template with a different CLI without editing the template
+            itself.
+          </P>
           <P>
             After launch, the new agent appears in the sidebar immediately and
             the view navigates to it.


### PR DESCRIPTION
## Summary

- Added "Sidebar badges" subsection to Agents docs enumerating the three contextual badges (Attention, Job, Update) that appear on agent cards in the sidebar.
- Fixed "Launching templates" section: inline play button and command palette now always open a launch dialog with an agent type override selector (PR #523), rather than launching directly for arg-less templates.
- Updated state file for next run — next focus is Reviewers resolution capture UI surfaces.

## Deferred to next run

- Reviewers section: resolution capture UI surfaces (promoted to next_focus)
- API spec: Templates CRUD section + `agentType` launch override field
- Several lower-priority backlog items (see state file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)