### PR TITLE
chore: remove unused @formkit/auto-animate dependency

### DIFF
--- a/.dispatch/job-state/tech-debt.md
+++ b/.dispatch/job-state/tech-debt.md
@@ -2,39 +2,41 @@
 
 ## last_audited_sha
 
-e043da3d614c4c5731a0e8635e20857343ab1c6e
+aae60d5f774176d0e594956a5995f8ace5fb1ba8
 
 ## next_focus
 
-**Unused dependency: `@formkit/auto-animate`**
+**Repeated error-handling boilerplate in route files**
 
-- `apps/web/package.json` lists `@formkit/auto-animate` as a dependency, but it has zero imports anywhere in `apps/web/src/`.
-- **Action**: Remove it from `apps/web/package.json` via `pnpm --filter @dispatch/web remove @formkit/auto-animate`. Run `pnpm run check` and `pnpm run finalize:web` to confirm nothing breaks.
+- `apps/server/src/routes/jobs.ts` repeats the pattern `const message = error instanceof Error ? error.message : String(error); return reply.code(500).send({ error: message });` 8 times across ~176 lines.
+- The same pattern appears 2x in `routes/personalities.ts` and 4x in `routes/templates.ts`.
+- **Action**: Extract a small `sendError(reply, error, code?)` helper local to the routes directory (e.g., `routes/helpers.ts` or inline in each file). Replace all instances. Run `pnpm run check` and `pnpm run test` to verify.
 
 ## backlog
 
-1. **Repeated error-handling boilerplate in `apps/server/src/routes/jobs.ts`**. The pattern `const message = error instanceof Error ? error.message : String(error); return reply.code(500).send({ error: message });` appears 8 times in 176 lines. Extract a small `sendError(reply, error)` helper local to the file. Also appears 2x in `routes/personalities.ts` and 4x in `routes/templates.ts`.
+1. **Large file: `apps/web/src/components/app/jobs-pane.tsx` (2489 lines)**. Largest component file. Look for extractable sub-components (job detail panels, form sections, list items).
 
-2. **Large file: `apps/web/src/components/app/jobs-pane.tsx` (2489 lines)**. Largest component file. Look for extractable sub-components (job detail panels, form sections, list items).
+2. **Large file: `apps/server/src/shared/mcp/server.ts` (2101 lines)**. MCP server implementation. Check if tool handler registration can be split into separate modules.
 
-3. **Large file: `apps/server/src/shared/mcp/server.ts` (2101 lines)**. MCP server implementation. Check if tool handler registration can be split into separate modules.
+3. **Large file: `apps/web/src/components/app/automations-pane.tsx` (2029 lines)**. Similar to jobs-pane — likely has extractable sub-components.
 
-4. **Large file: `apps/web/src/components/app/automations-pane.tsx` (2029 lines)**. Similar to jobs-pane — likely has extractable sub-components.
+4. **Large file: `apps/server/src/agents/manager.ts` (1736 lines)**. Agent manager — check for functions that can be extracted to dedicated files.
 
-5. **Large file: `apps/server/src/agents/manager.ts` (1736 lines)**. Agent manager — check for functions that can be extracted to dedicated files.
+5. **`as unknown as WebSocket` cast in `apps/server/src/stream-manager.ts:52`**. Investigate whether proper typing is feasible.
 
-6. **`as unknown as WebSocket` cast in `apps/server/src/stream-manager.ts:52`**. Investigate whether proper typing is feasible.
+6. **`ide-settings.ts` and `agent-type-settings.ts` share a near-identical pattern**: type guard, sanitize function, get/set with JSON parse. Consider a generic settings-value helper if a third instance appears (monitor, don't act yet).
 
-7. **`ide-settings.ts` and `agent-type-settings.ts` share a near-identical pattern**: type guard, sanitize function, get/set with JSON parse. Consider a generic settings-value helper if a third instance appears (monitor, don't act yet).
+7. **Flaky E2E test: `worktree.spec.ts:87` ("create dialog shows worktree checkbox defaulting to checked")**. Times out waiting for "Git repository" text after filling CWD. May need a longer timeout or a more stable selector. Observed on 2026-05-14.
 
 ## patterns
 
-- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (now fixed) confirmed that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes.
+- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (fixed in run 2) confirmed that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes.
 - **Route files accumulate boilerplate**: `routes/jobs.ts` has 8 identical try/catch blocks. Routes that use Zod validation + try/catch tend to grow this way because each endpoint handler is self-contained.
 - **Large component files**: The top 5 web components are all 1100-2500 lines. These are feature-dense panes (jobs, automations, docs, feedback, create-agent). Extraction is valuable but moderate-risk since they may have tightly coupled state.
-- **Unused shadcn scaffolding**: Several `ui/` components may have been scaffolded but never used. Worth auditing on a future run, but the grep was unreliable due to re-exports and aliasing — needs manual verification.
+- **Unused dependencies can linger**: `@formkit/auto-animate` was listed in `package.json` for an indeterminate period with zero imports. Worth periodically re-scanning with `pnpm why` or import grep.
 
 ## history
 
 - 2026-05-13: Bootstrap audit — scanned for dead code, type gaps, duplicated logic, complexity hotspots, unused dependencies, and inconsistent patterns. Created initial backlog with 8 items. No code changes.
-- 2026-05-14: Removed duplicated `sanitizeUploadedFileName` from `apps/server/src/routes/agent-startup.ts` — was byte-identical to the canonical copy in `apps/server/src/shared/media.ts`. Replaced with import.
+- 2026-05-14: Removed duplicated `sanitizeUploadedFileName` from `apps/server/src/routes/agent-startup.ts` — was byte-identical to the canonical copy in `apps/server/src/shared/media.ts`. Replaced with import. PR #534.
+- 2026-05-14: Removed unused `@formkit/auto-animate` dependency from `apps/web/package.json`. Zero imports existed anywhere in `apps/web/src/`.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@formkit/auto-animate": "^0.9.0",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
 
   apps/web:
     dependencies:
-      "@formkit/auto-animate":
-        specifier: ^0.9.0
-        version: 0.9.0
       "@radix-ui/react-checkbox":
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2017,12 +2014,6 @@ packages:
     resolution:
       {
         integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
-      }
-
-  "@formkit/auto-animate@0.9.0":
-    resolution:
-      {
-        integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==,
       }
 
   "@hono/node-server@1.19.12":
@@ -9977,8 +9968,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   "@floating-ui/utils@0.2.11": {}
-
-  "@formkit/auto-animate@0.9.0": {}
 
   "@hono/node-server@1.19.12(hono@4.12.9)":
     dependencies:


### PR DESCRIPTION
## Summary

- Removed `@formkit/auto-animate` from `apps/web/package.json` — it had zero imports anywhere in `apps/web/src/` and was dead weight in the dependency tree.
- Updated the tech debt state file: next run will tackle repeated error-handling boilerplate in route files (`jobs.ts`, `personalities.ts`, `templates.ts`).

## Why this is tech debt

Unused dependencies slow installs, bloat lockfiles, and create false signals during security audits. This one had no imports — safe to remove with no behavior change.

## What's next (queued for future runs)

1. Extract repeated `sendError` boilerplate in `routes/jobs.ts` (8x), `routes/personalities.ts` (2x), `routes/templates.ts` (4x)
2. Large file extraction: `jobs-pane.tsx` (2489 lines), `mcp/server.ts` (2101 lines)

## Test plan

- [x] `pnpm run check` — TypeScript passes
- [x] `pnpm run finalize:web` — production build succeeds
- [x] `pnpm run test:e2e` — 100/101 passed; 1 pre-existing flake (`worktree.spec.ts:87`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)