### PR TITLE
chore: extract shared errorMessage utility to reduce route boilerplate

### DIFF
--- a/.dispatch/job-state/tech-debt.md
+++ b/.dispatch/job-state/tech-debt.md
@@ -2,15 +2,15 @@
 
 ## last_audited_sha
 
-aae60d5f774176d0e594956a5995f8ace5fb1ba8
+a89adf2118e76d05df41c04329862cf1a6477665
 
 ## next_focus
 
-**Repeated error-handling boilerplate in route files**
+**Consolidate `errorMessage` usage in `diagnostics.ts` and `agents/manager.ts`**
 
-- `apps/server/src/routes/jobs.ts` repeats the pattern `const message = error instanceof Error ? error.message : String(error); return reply.code(500).send({ error: message });` 8 times across ~176 lines.
-- The same pattern appears 2x in `routes/personalities.ts` and 4x in `routes/templates.ts`.
-- **Action**: Extract a small `sendError(reply, error, code?)` helper local to the routes directory (e.g., `routes/helpers.ts` or inline in each file). Replace all instances. Run `pnpm run check` and `pnpm run test` to verify.
+- `apps/server/src/diagnostics.ts:31` has a local `const errorMessage` arrow function that duplicates the shared `errorMessage` in `shared/lib/error-message.ts`.
+- `apps/server/src/agents/manager.ts:1697` has a `private errorMessage()` method that does the same thing.
+- **Action**: Import `errorMessage` from `../shared/lib/error-message.js` in both files, remove the local definitions, and update all call sites (1 in diagnostics, 3 in manager — the manager ones use `this.errorMessage()` so the call sites need the `this.` prefix removed). Run `pnpm run check` and `pnpm run test:e2e`.
 
 ## backlog
 
@@ -26,17 +26,19 @@ aae60d5f774176d0e594956a5995f8ace5fb1ba8
 
 6. **`ide-settings.ts` and `agent-type-settings.ts` share a near-identical pattern**: type guard, sanitize function, get/set with JSON parse. Consider a generic settings-value helper if a third instance appears (monitor, don't act yet).
 
-7. **Flaky E2E test: `worktree.spec.ts:87` ("create dialog shows worktree checkbox defaulting to checked")**. Times out waiting for "Git repository" text after filling CWD. May need a longer timeout or a more stable selector. Observed on 2026-05-14.
+7. **Duplicate `resolveTilde` functions in route files**. `apps/server/src/routes/jobs.ts:46` and `apps/server/src/routes/templates.ts:61` have byte-identical `resolveTilde` implementations. Extract to `shared/lib/` or a routes helper.
 
 ## patterns
 
-- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (fixed in run 2) confirmed that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes.
-- **Route files accumulate boilerplate**: `routes/jobs.ts` has 8 identical try/catch blocks. Routes that use Zod validation + try/catch tend to grow this way because each endpoint handler is self-contained.
+- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (fixed in run 2) and the `resolveTilde` duplication (discovered in run 4) confirm that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes.
+- **Route files accumulate boilerplate**: Routes that use Zod validation + try/catch tend to grow identical error-handling blocks. The `errorMessage` helper (added in run 4) now exists to prevent this from recurring.
 - **Large component files**: The top 5 web components are all 1100-2500 lines. These are feature-dense panes (jobs, automations, docs, feedback, create-agent). Extraction is valuable but moderate-risk since they may have tightly coupled state.
 - **Unused dependencies can linger**: `@formkit/auto-animate` was listed in `package.json` for an indeterminate period with zero imports. Worth periodically re-scanning with `pnpm why` or import grep.
+- **Private method duplication in large classes**: `manager.ts` has `private errorMessage()` that duplicates shared logic. Large classes are prone to re-implementing utilities as private methods instead of importing shared helpers.
 
 ## history
 
 - 2026-05-13: Bootstrap audit — scanned for dead code, type gaps, duplicated logic, complexity hotspots, unused dependencies, and inconsistent patterns. Created initial backlog with 8 items. No code changes.
 - 2026-05-14: Removed duplicated `sanitizeUploadedFileName` from `apps/server/src/routes/agent-startup.ts` — was byte-identical to the canonical copy in `apps/server/src/shared/media.ts`. Replaced with import. PR #534.
-- 2026-05-14: Removed unused `@formkit/auto-animate` dependency from `apps/web/package.json`. Zero imports existed anywhere in `apps/web/src/`.
+- 2026-05-14: Removed unused `@formkit/auto-animate` dependency from `apps/web/package.json`. Zero imports existed anywhere in `apps/web/src/`. PR #535.
+- 2026-05-15: Extracted shared `errorMessage()` utility to `shared/lib/error-message.ts`. Replaced 12 inline `error instanceof Error ? error.message : String(error)` expressions across `routes/jobs.ts` (8) and `routes/templates.ts` (4).

--- a/.dispatch/job-state/tech-debt.md
+++ b/.dispatch/job-state/tech-debt.md
@@ -10,7 +10,7 @@ a89adf2118e76d05df41c04329862cf1a6477665
 
 - `apps/server/src/diagnostics.ts:31` has a local `const errorMessage` arrow function that duplicates the shared `errorMessage` in `shared/lib/error-message.ts`.
 - `apps/server/src/agents/manager.ts:1697` has a `private errorMessage()` method that does the same thing.
-- **Action**: Import `errorMessage` from `../shared/lib/error-message.js` in both files, remove the local definitions, and update all call sites (1 in diagnostics, 3 in manager — the manager ones use `this.errorMessage()` so the call sites need the `this.` prefix removed). Run `pnpm run check` and `pnpm run test:e2e`.
+- **Action**: Import `errorMessage` from `./shared/lib/error-message.js` in `diagnostics.ts` and from `../shared/lib/error-message.js` in `agents/manager.ts`. Remove the local definitions and update all call sites (1 in diagnostics, 3 in manager — the manager ones use `this.errorMessage()` so the call sites need the `this.` prefix removed). Run `pnpm run check`, `pnpm run test`, and `pnpm run test:e2e`.
 
 ## backlog
 

--- a/apps/server/src/routes/jobs.ts
+++ b/apps/server/src/routes/jobs.ts
@@ -6,6 +6,7 @@ import * as z from "zod/v4";
 
 import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
 import type { JobService } from "../jobs/service.js";
+import { errorMessage } from "../shared/lib/error-message.js";
 
 const directoryField = z
   .string()
@@ -68,7 +69,7 @@ export async function registerJobRoutes(
       const result = await deps.jobService.runJob(parsed.data);
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -87,7 +88,7 @@ export async function registerJobRoutes(
       deps.publishUiEvent({ type: "job.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -102,7 +103,7 @@ export async function registerJobRoutes(
       deps.publishUiEvent({ type: "job.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -117,7 +118,7 @@ export async function registerJobRoutes(
       deps.publishUiEvent({ type: "job.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -132,7 +133,7 @@ export async function registerJobRoutes(
       deps.publishUiEvent({ type: "job.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -147,7 +148,7 @@ export async function registerJobRoutes(
       deps.publishUiEvent({ type: "job.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -156,7 +157,7 @@ export async function registerJobRoutes(
     try {
       return await deps.jobService.getStats();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(500).send({ error: message });
     }
   });
@@ -169,7 +170,7 @@ export async function registerJobRoutes(
     try {
       return await deps.jobService.listRunsForJob(parsed.data);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(404).send({ error: message });
     }
   });

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import * as z from "zod/v4";
 
 import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
+import { errorMessage } from "../shared/lib/error-message.js";
 import {
   type StartupFileUpload,
   MAX_STARTUP_FILE_COUNT,
@@ -110,7 +111,7 @@ export async function registerTemplateRoutes(
       deps.publishUiEvent({ type: "template.changed" });
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       return reply.code(classifyErrorCode(message)).send({ error: message });
     }
   });
@@ -130,7 +131,7 @@ export async function registerTemplateRoutes(
         deps.publishUiEvent({ type: "template.changed" });
         return result;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }
@@ -146,7 +147,7 @@ export async function registerTemplateRoutes(
         deps.publishUiEvent({ type: "template.changed" });
         return result;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }
@@ -265,7 +266,7 @@ export async function registerTemplateRoutes(
         });
         return { agent: result.agent };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return reply.code(classifyErrorCode(message)).send({ error: message });
       }
     }

--- a/apps/server/src/shared/lib/error-message.ts
+++ b/apps/server/src/shared/lib/error-message.ts
@@ -1,0 +1,3 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

- Extracted a shared `errorMessage(error: unknown): string` helper to `apps/server/src/shared/lib/error-message.ts`
- Replaced 12 inline `error instanceof Error ? error.message : String(error)` expressions across `routes/jobs.ts` (8 instances) and `routes/templates.ts` (4 instances)
- Left `routes/personalities.ts` untouched — its error handling has different semantics (checking for unique constraint violations)

## Why this is tech debt

The same 1-line expression was copy-pasted 12 times across route handlers. This makes the error-to-message coercion harder to update globally and clutters catch blocks with identical boilerplate. A shared utility reduces noise and establishes a single place to evolve the pattern.

## What's next

The next tech debt run will consolidate the remaining `errorMessage` duplicates in `diagnostics.ts` and `agents/manager.ts` to use the new shared utility.

## Test plan

- [x] `pnpm run check` — TypeScript types pass
- [x] `pnpm run test:e2e` — 140/140 Playwright tests pass
- [x] Unit tests pass (DB-dependent suites skipped — pre-existing, no local Postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)