### PR TITLE
test: add unit tests for activity-query, auto-rename-prompter, and UiEventBroker

### DIFF
--- a/apps/server/test/activity-query.test.ts
+++ b/apps/server/test/activity-query.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseActivityQuery,
+  timeRangeClause,
+  dateTruncTz,
+  escapeLike,
+} from "../src/server/activity-query.js";
+
+describe("parseActivityQuery", () => {
+  it("returns defaults for empty input", () => {
+    const result = parseActivityQuery({});
+    expect(result.start).toBeNull();
+    expect(result.end).toBeNull();
+    expect(result.granularity).toBe("day");
+    expect(result.tz).toBeTruthy();
+  });
+
+  it("parses valid start and end dates", () => {
+    const result = parseActivityQuery({
+      start: "2026-01-01T00:00:00Z",
+      end: "2026-01-31T23:59:59Z",
+    });
+    expect(result.start).toBeInstanceOf(Date);
+    expect(result.end).toBeInstanceOf(Date);
+    expect(result.start!.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.end!.toISOString()).toBe("2026-01-31T23:59:59.000Z");
+  });
+
+  it("returns null for invalid date strings", () => {
+    const result = parseActivityQuery({
+      start: "not-a-date",
+      end: "also-not-a-date",
+    });
+    expect(result.start).toBeNull();
+    expect(result.end).toBeNull();
+  });
+
+  it("accepts all valid granularities", () => {
+    for (const granularity of ["hour", "day", "week", "month"]) {
+      const result = parseActivityQuery({ granularity });
+      expect(result.granularity).toBe(granularity);
+    }
+  });
+
+  it("defaults invalid granularity to day", () => {
+    const result = parseActivityQuery({ granularity: "year" });
+    expect(result.granularity).toBe("day");
+  });
+
+  it("accepts a valid timezone", () => {
+    const result = parseActivityQuery({ tz: "America/New_York" });
+    expect(result.tz).toBe("America/New_York");
+  });
+
+  it("falls back to system timezone for invalid tz", () => {
+    const fallback = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const result = parseActivityQuery({ tz: "Invalid/Timezone" });
+    expect(result.tz).toBe(fallback);
+  });
+
+  it("falls back to system timezone for empty tz", () => {
+    const fallback = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const result = parseActivityQuery({ tz: "" });
+    expect(result.tz).toBe(fallback);
+  });
+
+  it("ignores non-string query values", () => {
+    const result = parseActivityQuery({
+      start: 12345,
+      end: null,
+      tz: 42,
+      granularity: true,
+    });
+    expect(result.start).toBeNull();
+    expect(result.end).toBeNull();
+    expect(result.granularity).toBe("day");
+  });
+});
+
+describe("timeRangeClause", () => {
+  it("returns empty clause when no start or end", () => {
+    const aq = parseActivityQuery({});
+    const { clause, params } = timeRangeClause(aq, "created_at");
+    expect(clause).toBe("");
+    expect(params).toEqual([]);
+  });
+
+  it("returns start-only clause", () => {
+    const aq = parseActivityQuery({ start: "2026-01-01T00:00:00Z" });
+    const { clause, params } = timeRangeClause(aq, "created_at");
+    expect(clause).toBe("WHERE created_at >= $1");
+    expect(params).toHaveLength(1);
+  });
+
+  it("returns end-only clause", () => {
+    const aq = parseActivityQuery({ end: "2026-01-31T23:59:59Z" });
+    const { clause, params } = timeRangeClause(aq, "created_at");
+    expect(clause).toBe("WHERE created_at <= $1");
+    expect(params).toHaveLength(1);
+  });
+
+  it("returns both start and end clause", () => {
+    const aq = parseActivityQuery({
+      start: "2026-01-01T00:00:00Z",
+      end: "2026-01-31T23:59:59Z",
+    });
+    const { clause, params } = timeRangeClause(aq, "created_at");
+    expect(clause).toBe("WHERE created_at >= $1 AND created_at <= $2");
+    expect(params).toHaveLength(2);
+  });
+
+  it("applies paramOffset correctly", () => {
+    const aq = parseActivityQuery({
+      start: "2026-01-01T00:00:00Z",
+      end: "2026-01-31T23:59:59Z",
+    });
+    const { clause } = timeRangeClause(aq, "ts", 3);
+    expect(clause).toBe("WHERE ts >= $4 AND ts <= $5");
+  });
+});
+
+describe("dateTruncTz", () => {
+  it("produces hour format with to_char for hourly granularity", () => {
+    const sql = dateTruncTz("hour", "created_at", "America/New_York");
+    expect(sql).toContain("to_char");
+    expect(sql).toContain("HH24:00");
+    expect(sql).toContain("America/New_York");
+  });
+
+  it("produces date::text for non-hour granularity", () => {
+    const sql = dateTruncTz("day", "created_at", "UTC");
+    expect(sql).toContain("::date::text");
+    expect(sql).not.toContain("to_char");
+  });
+
+  it("escapes single quotes in timezone", () => {
+    const sql = dateTruncTz("day", "created_at", "O'Clock/Zone");
+    expect(sql).toContain("O''Clock/Zone");
+  });
+
+  it("includes date_trunc with the given granularity", () => {
+    for (const g of ["day", "week", "month"] as const) {
+      const sql = dateTruncTz(g, "created_at", "UTC");
+      expect(sql).toContain(`date_trunc('${g}'`);
+    }
+  });
+});
+
+describe("escapeLike", () => {
+  it("returns unmodified string with no special characters", () => {
+    expect(escapeLike("hello world")).toBe("hello world");
+  });
+
+  it("escapes percent sign", () => {
+    expect(escapeLike("100%")).toBe("100\\%");
+  });
+
+  it("escapes underscore", () => {
+    expect(escapeLike("a_b")).toBe("a\\_b");
+  });
+
+  it("escapes backslash", () => {
+    expect(escapeLike("path\\file")).toBe("path\\\\file");
+  });
+
+  it("escapes all special characters in combination", () => {
+    expect(escapeLike("%_\\")).toBe("\\%\\_\\\\");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeLike("")).toBe("");
+  });
+});

--- a/apps/server/test/auto-rename-prompter.test.ts
+++ b/apps/server/test/auto-rename-prompter.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createAutoRenamePrompter,
+  RENAME_PROMPT,
+} from "../src/agents/auto-rename-prompter.js";
+import type { AgentRecord } from "../src/agents/types.js";
+
+const fakeLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: () => fakeLogger,
+  level: "info",
+  silent: vi.fn(),
+} as unknown as import("fastify").FastifyBaseLogger;
+
+function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  const id = overrides.id ?? "agt_aabbccddeeff";
+  return {
+    id,
+    name: `agent-${id.slice(-6)}`,
+    type: "claude",
+    role: "primary",
+    status: "running",
+    cwd: "/tmp/repo",
+    worktreePath: null,
+    worktreeBranch: null,
+    tmuxSession: null,
+    simulatorUdid: null,
+    mediaDir: null,
+    agentArgs: [],
+    fullAccess: false,
+    setupPhase: "done",
+    archivePhase: "none",
+    archiveCleanupMode: null,
+    lastError: null,
+    latestEvent: {
+      type: "working",
+      message: "doing work",
+      updatedAt: new Date().toISOString(),
+    },
+    pins: [],
+    gitContext: null,
+    gitContextStale: false,
+    gitContextUpdatedAt: null,
+    persona: null,
+    parentAgentId: null,
+    personaContext: null,
+    reviewAgentType: null,
+    review: null,
+    baseBranch: null,
+    templateId: null,
+    autoReview: false,
+    cliSessionId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as AgentRecord;
+}
+
+describe("createAutoRenamePrompter", () => {
+  it("injects the rename prompt on first working event with default name", async () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(makeAgent());
+
+    await vi.waitFor(() => expect(inject).toHaveBeenCalledOnce());
+    expect(inject).toHaveBeenCalledWith("agt_aabbccddeeff", RENAME_PROMPT);
+  });
+
+  it("does not inject when event type is not working", () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(
+      makeAgent({
+        latestEvent: {
+          type: "idle",
+          message: "idle",
+          updatedAt: new Date().toISOString(),
+        },
+      })
+    );
+
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("does not inject for terminal-type agents", () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(makeAgent({ type: "terminal" }));
+
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("does not inject for persona agents", () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(makeAgent({ persona: "security-review" }));
+
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("does not inject when agent already has a custom name", () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(makeAgent({ name: "my-custom-agent" }));
+
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("only injects once per agent (one-shot)", async () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    const agent = makeAgent();
+    handler(agent);
+    handler(agent);
+    handler(agent);
+
+    await vi.waitFor(() => expect(inject).toHaveBeenCalledOnce());
+  });
+
+  it("injects for agents with template IDs and working event", async () => {
+    const inject = vi.fn().mockResolvedValue(undefined);
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: fakeLogger,
+    });
+
+    handler(makeAgent({ name: "some-template-name", templateId: "tmpl_123" }));
+
+    await vi.waitFor(() => expect(inject).toHaveBeenCalledOnce());
+  });
+
+  it("logs warning when injection fails", async () => {
+    const warnSpy = vi.fn();
+    const failLogger = {
+      ...fakeLogger,
+      warn: warnSpy,
+    } as unknown as import("fastify").FastifyBaseLogger;
+    const inject = vi.fn().mockRejectedValue(new Error("tmux down"));
+    const handler = createAutoRenamePrompter({
+      injectAgentPrompt: inject,
+      log: failLogger,
+    });
+
+    handler(makeAgent());
+
+    await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(warnSpy.mock.calls[0][1]).toContain(
+      "Auto rename-prompt injection failed"
+    );
+  });
+});

--- a/apps/server/test/ui-events.test.ts
+++ b/apps/server/test/ui-events.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { PassThrough } from "node:stream";
+
+import { UiEventBroker } from "../src/server/ui-events.js";
+
+function createWritableStream() {
+  const stream = new PassThrough();
+  const chunks: string[] = [];
+  stream.on("data", (chunk) => chunks.push(chunk.toString()));
+  return { stream, chunks };
+}
+
+describe("UiEventBroker", () => {
+  it("has no connected clients initially", () => {
+    const broker = new UiEventBroker();
+    expect(broker.hasConnectedClient()).toBe(false);
+  });
+
+  it("tracks connected clients after subscribe", () => {
+    const broker = new UiEventBroker();
+    const { stream } = createWritableStream();
+    broker.subscribe(stream);
+    expect(broker.hasConnectedClient()).toBe(true);
+  });
+
+  it("unsubscribe removes the client", () => {
+    const broker = new UiEventBroker();
+    const { stream } = createWritableStream();
+    const unsub = broker.subscribe(stream);
+    expect(broker.hasConnectedClient()).toBe(true);
+    unsub();
+    expect(broker.hasConnectedClient()).toBe(false);
+  });
+
+  it("publishes events to all subscribed clients", () => {
+    const broker = new UiEventBroker();
+    const c1 = createWritableStream();
+    const c2 = createWritableStream();
+    broker.subscribe(c1.stream);
+    broker.subscribe(c2.stream);
+
+    broker.publish({ type: "job.changed" });
+
+    expect(c1.chunks).toHaveLength(1);
+    expect(c2.chunks).toHaveLength(1);
+    expect(c1.chunks[0]).toContain('"type":"job.changed"');
+    expect(c2.chunks[0]).toContain('"type":"job.changed"');
+  });
+
+  it("formats events as SSE with id and data fields", () => {
+    const broker = new UiEventBroker();
+    const { stream, chunks } = createWritableStream();
+    broker.subscribe(stream);
+
+    broker.publish({ type: "template.changed" });
+
+    const message = chunks[0];
+    expect(message).toMatch(/^id: \d+\n/);
+    expect(message).toContain("data: ");
+    expect(message).toMatch(/\n\n$/);
+  });
+
+  it("increments the event id across publishes", () => {
+    const broker = new UiEventBroker();
+    const { stream, chunks } = createWritableStream();
+    broker.subscribe(stream);
+
+    broker.publish({ type: "job.changed" });
+    broker.publish({ type: "template.changed" });
+
+    const id1 = chunks[0].match(/^id: (\d+)/)?.[1];
+    const id2 = chunks[1].match(/^id: (\d+)/)?.[1];
+    expect(Number(id2)).toBeGreaterThan(Number(id1));
+  });
+
+  it("does not send to unsubscribed clients", () => {
+    const broker = new UiEventBroker();
+    const { stream, chunks } = createWritableStream();
+    const unsub = broker.subscribe(stream);
+    unsub();
+
+    broker.publish({ type: "job.changed" });
+
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("removes clients that throw on write", () => {
+    const broker = new UiEventBroker();
+    const badStream = {
+      write: vi.fn().mockImplementation(() => {
+        throw new Error("broken pipe");
+      }),
+    } as unknown as NodeJS.WritableStream;
+    const good = createWritableStream();
+
+    broker.subscribe(badStream);
+    broker.subscribe(good.stream);
+
+    broker.publish({ type: "job.changed" });
+
+    expect(good.chunks).toHaveLength(1);
+    expect(broker.hasConnectedClient()).toBe(true);
+
+    broker.publish({ type: "template.changed" });
+    expect(good.chunks).toHaveLength(2);
+  });
+
+  it("sendSnapshot writes only to the target stream", () => {
+    const broker = new UiEventBroker();
+    const c1 = createWritableStream();
+    const c2 = createWritableStream();
+    broker.subscribe(c1.stream);
+    broker.subscribe(c2.stream);
+
+    broker.sendSnapshot(c1.stream, []);
+
+    expect(c1.chunks).toHaveLength(1);
+    expect(c1.chunks[0]).toContain('"type":"snapshot"');
+    expect(c2.chunks).toHaveLength(0);
+  });
+
+  it("sendSnapshot includes agents in the payload", () => {
+    const broker = new UiEventBroker();
+    const { stream, chunks } = createWritableStream();
+    broker.subscribe(stream);
+
+    const fakeAgent = { id: "agt_test123", name: "test" } as any;
+    broker.sendSnapshot(stream, [fakeAgent]);
+
+    const data = chunks[0].split("data: ")[1].replace(/\n\n$/, "");
+    const parsed = JSON.parse(data);
+    expect(parsed.type).toBe("snapshot");
+    expect(parsed.agents).toHaveLength(1);
+    expect(parsed.agents[0].id).toBe("agt_test123");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 42 new unit tests covering three previously untested server modules
- **activity-query**: `parseActivityQuery`, `timeRangeClause`, `dateTruncTz`, `escapeLike` — validates user input parsing, SQL clause generation, and special character escaping
- **auto-rename-prompter**: one-shot injection logic, skip conditions (terminal, persona, custom name), failure handling
- **UiEventBroker**: SSE fan-out pub/sub, subscribe/unsubscribe lifecycle, error resilience, snapshot targeting

## Test plan
- [x] All 42 new tests pass locally
- [x] `pnpm run check` passes
- [x] `pnpm run test` passes (995 tests, up from 953)
- [x] `pnpm run test:e2e` passes (140 passed, 11 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)