### PR TITLE
test: add unit tests for agent-strings, mcp-url, and parseBooleanSetting

### DIFF
--- a/apps/server/test/agent-strings.test.ts
+++ b/apps/server/test/agent-strings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MAX_NOTE_BYTES,
+  sanitizeAgentName,
+  sanitizeAgentString,
+} from "../src/shared/lib/agent-strings.js";
+
+describe("sanitizeAgentString", () => {
+  it("returns undefined for undefined input", () => {
+    expect(sanitizeAgentString(undefined)).toBeUndefined();
+  });
+
+  it("passes through a simple string unchanged", () => {
+    expect(sanitizeAgentString("hello world")).toBe("hello world");
+  });
+
+  it("replaces newlines with spaces", () => {
+    expect(sanitizeAgentString("line1\nline2")).toBe("line1 line2");
+  });
+
+  it("replaces carriage returns with spaces", () => {
+    expect(sanitizeAgentString("line1\rline2")).toBe("line1 line2");
+  });
+
+  it("collapses consecutive \\r\\n sequences into a single space", () => {
+    expect(sanitizeAgentString("a\r\n\r\nb")).toBe("a b");
+  });
+
+  it("truncates strings exceeding MAX_NOTE_BYTES", () => {
+    const long = "x".repeat(MAX_NOTE_BYTES + 100);
+    const result = sanitizeAgentString(long)!;
+    expect(result.length).toBe(MAX_NOTE_BYTES);
+  });
+
+  it("does not truncate strings at exactly MAX_NOTE_BYTES", () => {
+    const exact = "y".repeat(MAX_NOTE_BYTES);
+    expect(sanitizeAgentString(exact)).toBe(exact);
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeAgentString("")).toBe("");
+  });
+
+  it("strips newlines before checking length", () => {
+    const withNewlines = "a".repeat(MAX_NOTE_BYTES - 1) + "\n";
+    const result = sanitizeAgentString(withNewlines)!;
+    expect(result).toBe("a".repeat(MAX_NOTE_BYTES - 1) + " ");
+    expect(result.length).toBe(MAX_NOTE_BYTES);
+  });
+});
+
+describe("sanitizeAgentName", () => {
+  it("passes through valid names unchanged", () => {
+    expect(sanitizeAgentName("my-agent_01")).toBe("my-agent_01");
+  });
+
+  it("replaces invalid characters with underscores", () => {
+    expect(sanitizeAgentName("hello world!")).toBe("hello_world_");
+  });
+
+  it("replaces dots and slashes", () => {
+    expect(sanitizeAgentName("path/to.name")).toBe("path_to_name");
+  });
+
+  it("truncates to 60 characters", () => {
+    const long = "a".repeat(80);
+    expect(sanitizeAgentName(long).length).toBe(60);
+  });
+
+  it("does not truncate names at exactly 60 characters", () => {
+    const exact = "b".repeat(60);
+    expect(sanitizeAgentName(exact)).toBe(exact);
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeAgentName("")).toBe("");
+  });
+
+  it("replaces unicode characters but keeps hyphens", () => {
+    expect(sanitizeAgentName("café-résumé")).toBe("caf_-r_sum_");
+  });
+});

--- a/apps/server/test/mcp-url.test.ts
+++ b/apps/server/test/mcp-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { dispatchMcpUrl } from "../src/agents/tmux/mcp-url.js";
+import type { AppConfig } from "../src/config.js";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    host: "127.0.0.1",
+    port: 6767,
+    databaseUrl: "",
+    authToken: "",
+    mediaRoot: "",
+    dispatchBinDir: "",
+    codexBin: "",
+    claudeBin: "",
+    opencodeBin: "",
+    cursorBin: "",
+    agentRuntime: "tmux",
+    sessionPrefix: "dispatch",
+    tls: null,
+    ...overrides,
+  };
+}
+
+describe("dispatchMcpUrl", () => {
+  it("builds an HTTP URL for a standard agent", () => {
+    const config = makeConfig({ port: 6767, tls: null });
+    expect(dispatchMcpUrl(config, "agt_abc123")).toBe(
+      "http://127.0.0.1:6767/api/mcp/agt_abc123"
+    );
+  });
+
+  it("builds an HTTPS URL when TLS is configured", () => {
+    const config = makeConfig({
+      port: 8443,
+      tls: { cert: Buffer.from("c"), key: Buffer.from("k") },
+    });
+    expect(dispatchMcpUrl(config, "agt_xyz")).toBe(
+      "https://127.0.0.1:8443/api/mcp/agt_xyz"
+    );
+  });
+
+  it("builds a job-scoped URL when jobRunId is provided", () => {
+    const config = makeConfig({ port: 9000, tls: null });
+    expect(dispatchMcpUrl(config, "agt_001", "run_42")).toBe(
+      "http://127.0.0.1:9000/api/mcp/jobs/run_42/agt_001"
+    );
+  });
+
+  it("uses the standard path when jobRunId is undefined", () => {
+    const config = makeConfig();
+    expect(dispatchMcpUrl(config, "agt_test", undefined)).toBe(
+      "http://127.0.0.1:6767/api/mcp/agt_test"
+    );
+  });
+});

--- a/apps/server/test/parse-boolean-setting.test.ts
+++ b/apps/server/test/parse-boolean-setting.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+
+import { parseBooleanSetting } from "../src/copy-mode-assist-settings.js";
+
+describe("parseBooleanSetting", () => {
+  it("returns true for 'true'", () => {
+    expect(parseBooleanSetting("true", false)).toBe(true);
+  });
+
+  it("returns false for 'false'", () => {
+    expect(parseBooleanSetting("false", true)).toBe(false);
+  });
+
+  it("returns the default for null", () => {
+    expect(parseBooleanSetting(null, true)).toBe(true);
+    expect(parseBooleanSetting(null, false)).toBe(false);
+  });
+
+  it("returns the default for unrecognized strings", () => {
+    expect(parseBooleanSetting("yes", false)).toBe(false);
+    expect(parseBooleanSetting("1", true)).toBe(true);
+    expect(parseBooleanSetting("", false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add dedicated unit tests for `sanitizeAgentString` and `sanitizeAgentName` (boundary truncation, newline collapsing, special character replacement)
- Add unit tests for `dispatchMcpUrl` (HTTP/HTTPS selection, standard vs job-scoped routes)
- Add unit tests for `parseBooleanSetting` (true/false/null/unrecognized string handling)

## Test plan
- [x] All 24 new tests pass locally
- [x] Full unit suite passes (1052 tests, 0 failures)
- [x] E2E suite passes (140/140)
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)