### PR TITLE
refactor: extract jobs-pane.tsx into focused modules

### DIFF
--- a/.dispatch/job-state/componentizer.md
+++ b/.dispatch/job-state/componentizer.md
@@ -9,42 +9,40 @@ Each run of the componentizer job reads this file at Phase 0 and overwrites it a
 
 ## last_audited_sha
 
-`51570cae4d68767e21f6262264faa6738d05d2bb`
+`d64e0827d48e5a2b4362d0a9cea79dbada9a07de`
 
 ## next_focus
 
-**File:** `apps/web/src/components/app/jobs-pane.tsx` (2489 lines)
-**Strategy:** Extract subcomponents + split compound components. This file has 20+ internal functions covering wildly different concerns: job overview stats, daily runs chart, add-job dialog flow, job detail with settings/prompt/history tabs, and run reports. Recommended first extraction:
+**File:** `apps/web/src/components/app/automations-pane.tsx` (2029 lines)
+**Strategy:** Extract subcomponents + split compound components. This file contains multiple large dialog components that are self-contained. Recommended extractions:
 
-1. Extract `AddJobDialog` + `AddJobFlow` (~335 lines, 1097–1472) into `jobs-add-dialog.tsx`
-2. Extract `SettingsTab` (~320 lines, 1884–2206) into `jobs-settings-tab.tsx`
-3. Extract `HistoryTab` + `RunReport` (~150 lines, 2337–2489) into `jobs-history-tab.tsx`
-4. Extract chart components (`DailyRunsChart`, `JobAvgDuration`, `RunHistoryGrid`) (~260 lines) into `jobs-charts.tsx`
-5. Extract utility functions + constants (~120 lines, top of file) into `jobs-utils.ts`
+1. Extract `LaunchTemplateDialog` + `LaunchTemplateDialogContent` (~650 lines) into `automations-launch-dialog.tsx`
+2. Extract `CreateTemplateDialog` + `CreateTemplateDialogContent` (~250 lines) into `automations-create-dialog.tsx`
+3. Extract `TemplateDetail` / `TemplateDetailPane` (~360 lines) into `automations-template-detail.tsx`
 
-This is the worst offender at 2489 lines with many independent UI regions and clear extraction boundaries. It's also a frequently-edited route component.
+This is the second-worst offender by line count and follows the same "dialogs in parent file" pattern we just addressed in jobs-pane.
 
 ## backlog
 
-1. **`apps/web/src/components/app/automations-pane.tsx`** — 2029 lines. Multiple compound components (TemplateDetailPane, LaunchTemplateDialog, CreateTemplateDialog). Extract `LaunchTemplateDialog` + `LaunchTemplateDialogContent` into own file (~650 lines), `CreateTemplateDialog` + `CreateTemplateDialogContent` into own file (~250 lines), and `TemplateDetail` into own file (~360 lines).
+1. **`apps/web/src/components/app/docs-pane.tsx`** — 1880 lines. Mostly static content organized as `SECTIONS` array. Large by nature (documentation), but the section content blocks could be moved to individual files under a `docs/` directory. Lower priority since it's relatively cohesive and rarely edited for logic changes.
 
-2. **`apps/web/src/components/app/docs-pane.tsx`** — 1880 lines. Mostly static content organized as `SECTIONS` array. Large by nature (documentation), but the section content blocks could be moved to individual files under a `docs/` directory. Lower priority since it's relatively cohesive and rarely edited for logic changes.
+2. **`apps/web/src/components/app/feedback-panel.tsx`** — 1776 lines. Exports 5 distinct components (ParentFeedbackPanel, FeedbackDetailPanel, ReviewSummaryPanel, MobileFeedbackSheet, MobileReviewSummarySheet). Extract mobile sheets into `feedback-mobile.tsx` (~430 lines). Extract `ReviewSummaryPanel` into `review-summary-panel.tsx` (~240 lines). Extract `useFeedbackData` hook into `use-feedback-data.ts`.
 
-3. **`apps/web/src/components/app/feedback-panel.tsx`** — 1776 lines. Exports 5 distinct components (ParentFeedbackPanel, FeedbackDetailPanel, ReviewSummaryPanel, MobileFeedbackSheet, MobileReviewSummarySheet). Extract mobile sheets into `feedback-mobile.tsx` (~430 lines). Extract `ReviewSummaryPanel` into `review-summary-panel.tsx` (~240 lines). Extract `useFeedbackData` hook into `use-feedback-data.ts`.
+3. **`apps/web/src/components/app/create-agent-dialog.tsx`** — 1446 lines. Large dialog with complex form state. Extract form sections into subcomponents. Extract state management into a custom hook.
 
-4. **`apps/web/src/components/app/create-agent-dialog.tsx`** — 1446 lines. Large dialog with complex form state. Extract form sections into subcomponents. Extract state management into a custom hook.
+4. **`apps/web/src/components/app/activity-pane.tsx`** — 1142 lines. Many chart subcomponents (Heatmap, ActiveHoursGrid, DailyStackedBarChart, DailyTokenChart, ModelBreakdown, ProjectBreakdown). Extract chart components into `activity-charts.tsx` (~500 lines). Extract utility functions into `activity-utils.ts`.
 
-5. **`apps/web/src/components/app/activity-pane.tsx`** — 1142 lines. Many chart subcomponents (Heatmap, ActiveHoursGrid, DailyStackedBarChart, DailyTokenChart, ModelBreakdown, ProjectBreakdown). Extract chart components into `activity-charts.tsx` (~500 lines). Extract utility functions into `activity-utils.ts`.
+5. **`apps/web/src/components/app/release-manager.tsx`** — 1142 lines. Mixed concerns: release UI, update checking, version comparison. Extract subcomponents by release lifecycle phase.
 
-6. **`apps/web/src/components/app/release-manager.tsx`** — 1142 lines. Mixed concerns: release UI, update checking, version comparison. Extract subcomponents by release lifecycle phase.
+6. **`apps/web/src/components/app/agent-history-tab.tsx`** — 1141 lines. Multiple subcomponents (AgentHistoryList, EventTimeline, FeedbackTimeline, DetailTabs, AgentHistoryDetail). Extract `AgentHistoryDetail` + `DetailTabs` into `agent-history-detail.tsx` (~340 lines). Extract timeline components into `agent-history-timeline.tsx`.
 
-7. **`apps/web/src/components/app/agent-history-tab.tsx`** — 1141 lines. Multiple subcomponents (AgentHistoryList, EventTimeline, FeedbackTimeline, DetailTabs, AgentHistoryDetail). Extract `AgentHistoryDetail` + `DetailTabs` into `agent-history-detail.tsx` (~340 lines). Extract timeline components into `agent-history-timeline.tsx`.
+7. **`apps/web/src/components/app/agents-view.tsx`** — 1026 lines. Single exported component but likely has distinct UI sections. Assess on future run.
 
-8. **`apps/web/src/components/app/agents-view.tsx`** — 1026 lines. Single exported component but likely has distinct UI sections. Assess on future run.
+8. **`apps/web/src/components/app/settings-pane.tsx`** — 840 lines. Already delegates to sub-settings components but still large. Lower priority since it's already partially extracted.
 
-9. **`apps/web/src/components/app/settings-pane.tsx`** — 840 lines. Already delegates to sub-settings components but still large. Lower priority since it's already partially extracted.
+9. **`apps/web/src/components/app/agent-card.tsx`** — 727 lines. Moderate size, single cohesive component. Lower priority.
 
-10. **`apps/web/src/components/app/agent-card.tsx`** — 727 lines. Moderate size, single cohesive component. Lower priority.
+10. **`apps/web/src/components/app/jobs-pane.tsx`** — 1599 lines (reduced from 2489). Further extraction possible: SettingsTab + RemoveJobDialog + PromptTab (~500 lines) into `jobs-settings-tab.tsx`, HistoryTab + RunReport (~150 lines) into `jobs-history-tab.tsx`. Defer to a later run since it just went through a split.
 
 ## patterns
 
@@ -53,7 +51,9 @@ This is the worst offender at 2489 lines with many independent UI regions and cl
 - **Chart/visualization code is inlined.** Recharts components with config, data transformation, and formatting helpers are kept alongside the main component instead of being pulled into dedicated chart files.
 - **Mobile variants double component count.** feedback-panel has both desktop and mobile versions of the same panels, doubling the file size.
 - **Utility functions live at the top of component files.** Formatters, comparators, and helpers (formatDate, statusClasses, shortPath) could move to shared utils or colocated `*-utils.ts` files.
+- **Shared form components get inlined.** Toggle switches, checkbox options, and other reusable form primitives get copy-pasted rather than extracted (now addressed in jobs-utils.tsx as a model).
 
 ## history
 
 - 2026-05-17: Bootstrap scan completed. Identified 10 candidates, prioritized by impact and extraction clarity. No refactoring performed.
+- 2026-05-17: Refactored `jobs-pane.tsx` (2489→1599 lines). Extracted `jobs-utils.tsx` (295 lines, shared utilities + form components), `jobs-add-dialog.tsx` (409 lines, AddJobDialog + AddJobFlow), `jobs-charts.tsx` (247 lines, DailyRunsChart + JobAvgDuration + RunHistoryGrid). PR #TBD.

--- a/apps/web/src/components/app/jobs-add-dialog.tsx
+++ b/apps/web/src/components/app/jobs-add-dialog.tsx
@@ -4,15 +4,17 @@ import { useState } from "react";
 
 import { PathInput } from "@/components/app/path-input";
 import {
-  cronError,
-  errorMessage,
-  humanSchedule,
   JobFullAccessOption,
   JobKeepAgentOption,
   JobWorktreeOption,
-  msFromMinutes,
   SwitchToggle,
-} from "@/components/app/jobs-utils";
+} from "@/components/app/jobs-form-fields";
+import {
+  cronError,
+  errorMessage,
+  humanSchedule,
+  msFromMinutes,
+} from "@/components/app/jobs-helpers";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/apps/web/src/components/app/jobs-add-dialog.tsx
+++ b/apps/web/src/components/app/jobs-add-dialog.tsx
@@ -1,0 +1,409 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ChevronDown, X } from "lucide-react";
+import { useState } from "react";
+
+import { PathInput } from "@/components/app/path-input";
+import {
+  cronError,
+  errorMessage,
+  humanSchedule,
+  JobFullAccessOption,
+  JobKeepAgentOption,
+  JobWorktreeOption,
+  msFromMinutes,
+  SwitchToggle,
+} from "@/components/app/jobs-utils";
+import { ActivityBars } from "@/components/ui/activity-bars";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { type AddJobConfig } from "@/hooks/use-jobs";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  type CliAgentType,
+  isCliAgentType,
+} from "@/lib/agent-types";
+import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
+import { cn } from "@/lib/utils";
+
+export function AddJobDialog({
+  open,
+  onOpenChange,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md" />
+        <DialogPrimitive.Content
+          onEscapeKeyDown={swallowEscapeFromCombobox}
+          className="fixed inset-x-2 bottom-2 top-2 z-50 flex max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-lg border border-white/[0.2] bg-[hsl(var(--card))] backdrop-blur-2xl shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] outline-none md:left-1/2 md:top-1/2 md:h-[min(760px,88vh)] md:w-[min(760px,calc(100vw-2rem))] md:-translate-x-1/2 md:-translate-y-1/2"
+        >
+          <DialogPrimitive.Title className="sr-only">
+            Add job
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Create a new recurring Dispatch job.
+          </DialogPrimitive.Description>
+          <DialogPrimitive.Close asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-3 top-3 z-10"
+              aria-label="Close add job"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </DialogPrimitive.Close>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export function AddJobFlow({
+  onAddJob,
+  isAdding,
+  enabledAgentTypes,
+}: {
+  onAddJob: (job: AddJobConfig) => Promise<void>;
+  isAdding: boolean;
+  enabledAgentTypes: AgentType[];
+}) {
+  const [displayName, setDisplayName] = useState("");
+  const [directory, setDirectory] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [schedule, setSchedule] = useState("");
+  const [timeoutMinutes, setTimeoutMinutes] = useState("30");
+  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] =
+    useState("1440");
+  const jobAgentTypes = enabledAgentTypes.filter(isCliAgentType);
+  const [agentType, setAgentType] = useState<CliAgentType>(
+    jobAgentTypes[0] ?? "codex"
+  );
+  const [fullAccess, setFullAccess] = useState(false);
+  const [useWorktree, setUseWorktree] = useState(false);
+  const [baseBranch, setBaseBranch] = useState("main");
+  const [branchName, setBranchName] = useState("");
+  const [keepAgent, setKeepAgent] = useState(false);
+  const [callable, setCallable] = useState(false);
+  const [singleton, setSingleton] = useState(true);
+  const [enableImmediately, setEnableImmediately] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const effectiveEnabled = schedule.trim() ? enableImmediately : false;
+  const scheduleError = cronError(schedule, effectiveEnabled);
+  const canAdd =
+    !!displayName.trim() &&
+    !!directory.trim() &&
+    !!prompt.trim() &&
+    !scheduleError &&
+    !!msFromMinutes(timeoutMinutes) &&
+    !!msFromMinutes(needsInputTimeoutMinutes);
+
+  return (
+    <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col overflow-hidden p-4 md:p-8">
+      <div className="text-lg font-semibold">Create a new job</div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Define an automation with a prompt — on a schedule or on demand.
+      </p>
+
+      <ScrollArea className="mt-6 min-h-0 flex-1 pr-1">
+        <div className="grid min-w-0 gap-4">
+          <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
+            <div className="grid min-w-0 gap-3 md:grid-cols-2">
+              <div className="min-w-0 space-y-1 md:col-span-2">
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-display-name"
+                >
+                  Name
+                </label>
+                <Input
+                  id="job-display-name"
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="e.g. Daily cleanup"
+                />
+              </div>
+              <div className="min-w-0 space-y-1 md:col-span-2">
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-directory"
+                >
+                  Working directory
+                </label>
+                <PathInput
+                  value={directory}
+                  onChange={setDirectory}
+                  label=""
+                  placeholder="~/code/project"
+                  id="job-directory"
+                  data-testid="job-directory-input"
+                />
+              </div>
+              <div className="min-w-0 space-y-1">
+                <label
+                  className="text-sm text-muted-foreground"
+                  htmlFor="job-schedule"
+                >
+                  Cron schedule{" "}
+                  <span className="text-muted-foreground/70">(optional)</span>
+                </label>
+                <Input
+                  id="job-schedule"
+                  value={schedule}
+                  onChange={(event) => setSchedule(event.target.value)}
+                  placeholder="*/30 * * * *"
+                  className="font-mono text-xs"
+                />
+                {scheduleError ? (
+                  <div className="text-xs text-status-blocked">
+                    {scheduleError}
+                  </div>
+                ) : null}
+                {!scheduleError && schedule.trim() ? (
+                  <div className="text-xs text-muted-foreground">
+                    {humanSchedule(schedule)}
+                  </div>
+                ) : null}
+                {!schedule.trim() ? (
+                  <div className="text-xs text-muted-foreground">
+                    Leave blank for an on-demand job.
+                  </div>
+                ) : null}
+                {schedule.trim() ? (
+                  <label className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+                    <span>
+                      <span className="block font-medium text-foreground">
+                        Enabled
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        Run this job on its schedule after creating it.
+                      </span>
+                    </span>
+                    <SwitchToggle
+                      checked={enableImmediately}
+                      onCheckedChange={setEnableImmediately}
+                      ariaLabel="Enable job"
+                    />
+                  </label>
+                ) : null}
+              </div>
+              <div className="min-w-0 space-y-1">
+                <label className="text-sm text-muted-foreground">
+                  Agent type
+                </label>
+                <Select
+                  value={agentType}
+                  onValueChange={(value) => setAgentType(value as CliAgentType)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {jobAgentTypes.map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {AGENT_TYPE_LABELS[type]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
+                <span>
+                  <span className="block font-medium text-foreground">
+                    Show in command palette
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Launch this job from the {"⌘"}K palette.
+                  </span>
+                </span>
+                <SwitchToggle
+                  checked={callable}
+                  onCheckedChange={setCallable}
+                  ariaLabel="Show in command palette"
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
+                <span>
+                  <span className="block font-medium text-foreground">
+                    Single instance
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Only allow one active run at a time.
+                  </span>
+                </span>
+                <SwitchToggle
+                  checked={singleton}
+                  onCheckedChange={setSingleton}
+                  ariaLabel="Single instance"
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="min-w-0 rounded-md border border-border bg-muted/20 p-4">
+            <div className="space-y-1">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="job-prompt"
+              >
+                Prompt
+              </label>
+              <p className="text-xs text-muted-foreground">
+                The instructions the agent will follow when this job runs.
+              </p>
+            </div>
+            <textarea
+              id="job-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Describe what the agent should do..."
+              className="mt-2 min-h-64 w-full rounded-md border border-white/[0.12] bg-white/[0.04] backdrop-blur-md shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+
+          <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-3 text-left"
+              onClick={() => setAdvancedOpen((current) => !current)}
+            >
+              <div>
+                <div className="text-sm font-medium">Advanced settings</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Timeouts, worktree, permissions, and whether the agent is kept
+                  after running.
+                </div>
+              </div>
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 text-muted-foreground transition-transform",
+                  advancedOpen && "rotate-180"
+                )}
+              />
+            </button>
+            <div
+              className={cn(
+                "grid min-w-0 overflow-hidden transition-all duration-200 ease-out",
+                advancedOpen
+                  ? "mt-4 grid-rows-[1fr] opacity-100"
+                  : "mt-0 grid-rows-[0fr] opacity-0"
+              )}
+              aria-hidden={!advancedOpen}
+            >
+              <div className="min-h-0">
+                <div className="grid min-w-0 gap-3 md:grid-cols-2">
+                  <div className="min-w-0 space-y-1">
+                    <label
+                      className="text-sm text-muted-foreground"
+                      htmlFor="job-timeout"
+                    >
+                      Run timeout, minutes
+                    </label>
+                    <Input
+                      id="job-timeout"
+                      value={timeoutMinutes}
+                      onChange={(event) =>
+                        setTimeoutMinutes(event.target.value)
+                      }
+                      inputMode="numeric"
+                    />
+                  </div>
+                  <div className="min-w-0 space-y-1">
+                    <label
+                      className="text-sm text-muted-foreground"
+                      htmlFor="job-needs-input-timeout"
+                    >
+                      Wait for input, minutes
+                    </label>
+                    <Input
+                      id="job-needs-input-timeout"
+                      value={needsInputTimeoutMinutes}
+                      onChange={(event) =>
+                        setNeedsInputTimeoutMinutes(event.target.value)
+                      }
+                      inputMode="numeric"
+                    />
+                  </div>
+                  <JobWorktreeOption
+                    checked={useWorktree}
+                    cwd={directory}
+                    baseBranch={baseBranch}
+                    branchName={branchName}
+                    onCheckedChange={setUseWorktree}
+                    onBaseBranchChange={setBaseBranch}
+                    onBranchNameChange={setBranchName}
+                    testIdPrefix="job-create"
+                  />
+                  <JobFullAccessOption
+                    checked={fullAccess}
+                    onCheckedChange={setFullAccess}
+                  />
+                  <JobKeepAgentOption
+                    checked={keepAgent}
+                    onCheckedChange={setKeepAgent}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {submitError ? (
+            <div className="rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
+              {submitError}
+            </div>
+          ) : null}
+        </div>
+      </ScrollArea>
+
+      <div className="mt-4 flex shrink-0 justify-end gap-2 border-t border-border/70 pt-4">
+        <DialogPrimitive.Close asChild>
+          <Button variant="ghost">Cancel</Button>
+        </DialogPrimitive.Close>
+        <Button
+          variant="primary"
+          disabled={!canAdd || isAdding}
+          onClick={() => {
+            setSubmitError(null);
+            void onAddJob({
+              name: displayName.trim(),
+              directory: directory.trim(),
+              displayName: displayName.trim(),
+              prompt: prompt.trim(),
+              schedule: schedule.trim() || null,
+              timeoutMs: msFromMinutes(timeoutMinutes),
+              needsInputTimeoutMs: msFromMinutes(needsInputTimeoutMinutes),
+              agentType,
+              useWorktree,
+              baseBranch: useWorktree ? baseBranch : null,
+              branchName: useWorktree ? branchName : null,
+              fullAccess,
+              autoArchive: !keepAgent,
+              callable,
+              singleton,
+              enabled: effectiveEnabled,
+            }).catch((error) => setSubmitError(errorMessage(error)));
+          }}
+        >
+          {isAdding ? <ActivityBars size={16} className="mr-2" /> : null}
+          Add job
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/jobs-charts.tsx
+++ b/apps/web/src/components/app/jobs-charts.tsx
@@ -1,0 +1,247 @@
+import { useMemo } from "react";
+import { Bar, BarChart, XAxis } from "recharts";
+
+import { formatDuration } from "@/components/app/jobs-utils";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { type JobRunStatus } from "@/hooks/use-jobs";
+import { formatRelativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+const dailyRunsChartConfig = {
+  completed: { label: "Completed", color: "hsl(var(--chart-1))" },
+  failed: { label: "Failed", color: "hsl(var(--status-blocked))" },
+} satisfies ChartConfig;
+
+export function DailyRunsChart({
+  data,
+}: {
+  data: Array<{
+    day: string;
+    label: string;
+    completed: number;
+    failed: number;
+  }>;
+}) {
+  return (
+    <ChartContainer config={dailyRunsChartConfig} className="h-full w-full">
+      <BarChart data={data} barCategoryGap="20%">
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tick={{ fontSize: 11 }}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              formatter={(value, name, item) => (
+                <>
+                  <div
+                    className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                    style={{ backgroundColor: item.color }}
+                  />
+                  <div className="flex flex-1 items-center justify-between gap-4">
+                    <span className="text-muted-foreground">
+                      {dailyRunsChartConfig[
+                        name as keyof typeof dailyRunsChartConfig
+                      ]?.label ?? name}
+                    </span>
+                    <span className="font-mono font-medium tabular-nums text-foreground">
+                      {value as number}
+                    </span>
+                  </div>
+                </>
+              )}
+              labelFormatter={(label) => label as string}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent className="gap-2" />} />
+        <Bar
+          dataKey="completed"
+          stackId="runs"
+          fill="var(--color-completed)"
+          radius={0}
+        />
+        <Bar
+          dataKey="failed"
+          stackId="runs"
+          fill="var(--color-failed)"
+          radius={[2, 2, 0, 0]}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+export function JobAvgDuration({
+  runs,
+}: {
+  runs: Array<{ jobName: string; durationMs: number | null }>;
+}) {
+  const perJob = useMemo(() => {
+    const map = new Map<string, number[]>();
+    for (const run of runs) {
+      if (run.durationMs == null) continue;
+      if (!map.has(run.jobName)) map.set(run.jobName, []);
+      map.get(run.jobName)!.push(run.durationMs);
+    }
+    const result = [...map.entries()].map(([name, durations]) => ({
+      name,
+      avg: Math.round(durations.reduce((a, b) => a + b, 0) / durations.length),
+      runs: durations.length,
+    }));
+    const maxAvg = Math.max(...result.map((j) => j.avg), 1);
+    return { jobs: result, maxAvg };
+  }, [runs]);
+
+  if (perJob.jobs.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Avg Duration
+      </h3>
+      <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-center">
+        <div className="flex flex-col gap-3 overflow-y-auto min-h-0">
+          {perJob.jobs.map((job) => (
+            <div key={job.name}>
+              <div className="mb-1 flex items-center justify-between">
+                <span className="truncate text-xs text-muted-foreground">
+                  {job.name}
+                </span>
+                <span className="text-xs font-medium tabular-nums text-foreground">
+                  {formatDuration(job.avg)}
+                </span>
+              </div>
+              <div className="flex h-2 overflow-hidden rounded-sm bg-muted/60">
+                <div
+                  className="bg-chart-1/70 transition-all rounded-sm"
+                  style={{ width: `${(job.avg / perJob.maxAvg) * 100}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const MAX_RUN_CELLS = 16;
+
+export function RunHistoryGrid({
+  runs,
+}: {
+  runs: Array<{
+    jobId: string;
+    jobName: string;
+    status: JobRunStatus;
+    startedAt: string;
+  }>;
+}) {
+  const perJob = useMemo(() => {
+    const grouped = new Map<
+      string,
+      Array<{ status: JobRunStatus; startedAt: string }>
+    >();
+    for (const run of runs) {
+      if (!grouped.has(run.jobName)) grouped.set(run.jobName, []);
+      grouped
+        .get(run.jobName)!
+        .push({ status: run.status, startedAt: run.startedAt });
+    }
+    const result: Array<{
+      name: string;
+      runs: Array<{ status: JobRunStatus; startedAt: string }>;
+    }> = [];
+    for (const [name, jobRuns] of grouped) {
+      result.push({ name, runs: jobRuns.slice(0, MAX_RUN_CELLS).reverse() });
+    }
+    return result;
+  }, [runs]);
+
+  if (perJob.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Run History
+      </h3>
+      <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-between">
+        <TooltipProvider delayDuration={80}>
+          <div className="space-y-2 overflow-y-auto min-h-0 flex-1">
+            {perJob.map(({ name, runs: jobRuns }) => (
+              <div key={name}>
+                <div className="mb-1 truncate text-[10px] text-muted-foreground">
+                  {name}
+                </div>
+                <div
+                  className="grid gap-[1px]"
+                  style={{
+                    gridTemplateColumns: `repeat(${MAX_RUN_CELLS}, 1fr)`,
+                  }}
+                >
+                  {Array.from({ length: MAX_RUN_CELLS }, (_, i) => {
+                    const run = i < jobRuns.length ? jobRuns[i] : null;
+                    if (!run)
+                      return <div key={i} className="h-4 sm:h-3 bg-muted/30" />;
+                    return (
+                      <Tooltip key={i}>
+                        <TooltipTrigger asChild>
+                          <div
+                            className={cn(
+                              "h-4 sm:h-3",
+                              run.status === "completed" && "bg-status-done/70",
+                              (run.status === "failed" ||
+                                run.status === "timed_out" ||
+                                run.status === "crashed") &&
+                                "bg-status-blocked/70",
+                              (run.status === "running" ||
+                                run.status === "started") &&
+                                "bg-status-working/70",
+                              run.status === "needs_input" &&
+                                "bg-status-waiting/70"
+                            )}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="text-xs">
+                          {run.status} — {formatRelativeTime(run.startedAt)}
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </TooltipProvider>
+        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-3 bg-status-done/70" />
+            Completed
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-3 bg-status-blocked/70" />
+            Failed
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/jobs-charts.tsx
+++ b/apps/web/src/components/app/jobs-charts.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Bar, BarChart, XAxis } from "recharts";
 
-import { formatDuration } from "@/components/app/jobs-utils";
+import { formatDuration } from "@/components/app/jobs-helpers";
 import {
   ChartContainer,
   ChartLegend,

--- a/apps/web/src/components/app/jobs-form-fields.tsx
+++ b/apps/web/src/components/app/jobs-form-fields.tsx
@@ -1,0 +1,146 @@
+import { GitBranch } from "lucide-react";
+
+import { BranchSelect } from "@/components/app/branch-select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+
+export function SwitchToggle({
+  checked,
+  onCheckedChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent p-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+        checked ? "bg-primary" : "bg-muted"
+      )}
+    >
+      <span
+        className={cn(
+          "h-5 w-5 rounded-full bg-background shadow-sm transition-transform",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  );
+}
+
+export function JobWorktreeOption({
+  checked,
+  cwd,
+  baseBranch,
+  branchName,
+  onCheckedChange,
+  onBaseBranchChange,
+  onBranchNameChange,
+  testIdPrefix,
+}: {
+  checked: boolean;
+  cwd: string;
+  baseBranch: string;
+  branchName: string;
+  onCheckedChange: (checked: boolean) => void;
+  onBaseBranchChange: (value: string) => void;
+  onBranchNameChange: (value: string) => void;
+  testIdPrefix?: string;
+}) {
+  return (
+    <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <label className="flex cursor-pointer items-start gap-3">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={() => onCheckedChange(!checked)}
+          className="mt-0.5"
+          title="Toggle git worktree"
+        />
+        <span className="space-y-1">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <GitBranch className="h-3.5 w-3.5" />
+            Run in a git worktree
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            Creates an isolated worktree and branch when this job runs.
+          </span>
+        </span>
+      </label>
+      {checked ? (
+        <div className="ml-8 w-[calc(100%-2rem)]">
+          <BranchSelect
+            cwd={cwd}
+            baseBranch={baseBranch}
+            onBaseBranchChange={onBaseBranchChange}
+            worktreeBranch={branchName}
+            onWorktreeBranchChange={onBranchNameChange}
+            testIdPrefix={testIdPrefix ?? "job-worktree"}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function JobKeepAgentOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Keep agent after run completes"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Keep agent after run completes
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          The agent stays in your Agents list so you can continue the session
+          after the job finishes.
+        </span>
+      </span>
+    </label>
+  );
+}
+
+export function JobFullAccessOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Toggle full access"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Run in full access mode
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          Starts the selected agent with its most permissive supported execution
+          mode.
+        </span>
+      </span>
+    </label>
+  );
+}

--- a/apps/web/src/components/app/jobs-helpers.ts
+++ b/apps/web/src/components/app/jobs-helpers.ts
@@ -1,11 +1,6 @@
 import cronstrue from "cronstrue";
-import { CheckCircle2, GitBranch, XCircle } from "lucide-react";
 
-import { BranchSelect } from "@/components/app/branch-select";
 import { type JobRun, type JobRunStatus } from "@/hooks/use-jobs";
-import { ActivityBars } from "@/components/ui/activity-bars";
-import { Checkbox } from "@/components/ui/checkbox";
-import { cn } from "@/lib/utils";
 
 export const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
   "started",
@@ -33,15 +28,6 @@ export function statusTextColor(status: JobRunStatus | null): string {
   if (status === "started" || status === "running")
     return "text-status-working";
   return "text-muted-foreground";
-}
-
-export function statusIcon(status: JobRunStatus | null): JSX.Element | null {
-  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" />;
-  if (status === "failed" || status === "timed_out" || status === "crashed")
-    return <XCircle className="h-3.5 w-3.5" />;
-  if (status === "started" || status === "running" || status === "needs_input")
-    return <ActivityBars size={14} className="shrink-0" />;
-  return null;
 }
 
 export function statusDotColor(status: JobRunStatus | null): string {
@@ -151,145 +137,4 @@ export function formatTimeUntilDate(iso: string): string {
     hour: "numeric",
     minute: "2-digit",
   });
-}
-
-export function SwitchToggle({
-  checked,
-  onCheckedChange,
-  ariaLabel,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onCheckedChange(!checked)}
-      className={cn(
-        "inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent p-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
-        checked ? "bg-primary" : "bg-muted"
-      )}
-    >
-      <span
-        className={cn(
-          "h-5 w-5 rounded-full bg-background shadow-sm transition-transform",
-          checked ? "translate-x-5" : "translate-x-0"
-        )}
-      />
-    </button>
-  );
-}
-
-export function JobWorktreeOption({
-  checked,
-  cwd,
-  baseBranch,
-  branchName,
-  onCheckedChange,
-  onBaseBranchChange,
-  onBranchNameChange,
-  testIdPrefix,
-}: {
-  checked: boolean;
-  cwd: string;
-  baseBranch: string;
-  branchName: string;
-  onCheckedChange: (checked: boolean) => void;
-  onBaseBranchChange: (value: string) => void;
-  onBranchNameChange: (value: string) => void;
-  testIdPrefix?: string;
-}) {
-  return (
-    <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <label className="flex cursor-pointer items-start gap-3">
-        <Checkbox
-          checked={checked}
-          onCheckedChange={() => onCheckedChange(!checked)}
-          className="mt-0.5"
-          title="Toggle git worktree"
-        />
-        <span className="space-y-1">
-          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            <GitBranch className="h-3.5 w-3.5" />
-            Run in a git worktree
-          </span>
-          <span className="block text-xs text-muted-foreground">
-            Creates an isolated worktree and branch when this job runs.
-          </span>
-        </span>
-      </label>
-      {checked ? (
-        <div className="ml-8 w-[calc(100%-2rem)]">
-          <BranchSelect
-            cwd={cwd}
-            baseBranch={baseBranch}
-            onBaseBranchChange={onBaseBranchChange}
-            worktreeBranch={branchName}
-            onWorktreeBranchChange={onBranchNameChange}
-            testIdPrefix={testIdPrefix ?? "job-worktree"}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-export function JobKeepAgentOption({
-  checked,
-  onCheckedChange,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={() => onCheckedChange(!checked)}
-        className="mt-0.5"
-        title="Keep agent after run completes"
-      />
-      <span className="space-y-1">
-        <span className="block text-sm font-medium text-foreground">
-          Keep agent after run completes
-        </span>
-        <span className="block text-xs text-muted-foreground">
-          The agent stays in your Agents list so you can continue the session
-          after the job finishes.
-        </span>
-      </span>
-    </label>
-  );
-}
-
-export function JobFullAccessOption({
-  checked,
-  onCheckedChange,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={() => onCheckedChange(!checked)}
-        className="mt-0.5"
-        title="Toggle full access"
-      />
-      <span className="space-y-1">
-        <span className="block text-sm font-medium text-foreground">
-          Run in full access mode
-        </span>
-        <span className="block text-xs text-muted-foreground">
-          Starts the selected agent with its most permissive supported execution
-          mode.
-        </span>
-      </span>
-    </label>
-  );
 }

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -1,30 +1,49 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import cronstrue from "cronstrue";
 import {
   Activity,
   AlarmClock,
-  CheckCircle2,
-  ChevronDown,
   Clock,
-  GitBranch,
   History,
   MessageSquareText,
   Play,
   Settings,
   Terminal,
   Trash2,
-  X,
-  XCircle,
 } from "lucide-react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { BranchSelect } from "@/components/app/branch-select";
-import { PathInput } from "@/components/app/path-input";
 import { type Agent } from "@/components/app/types";
+import { AddJobDialog, AddJobFlow } from "@/components/app/jobs-add-dialog";
+import {
+  DailyRunsChart,
+  JobAvgDuration,
+  RunHistoryGrid,
+} from "@/components/app/jobs-charts";
+import {
+  ACTIVE_RUN_STATUSES,
+  cronError,
+  errorMessage,
+  formatDate,
+  formatDuration,
+  formatTimeUntil,
+  formatTimeUntilDate,
+  humanSchedule,
+  JobFullAccessOption,
+  JobKeepAgentOption,
+  JobWorktreeOption,
+  minutesFromMs,
+  msFromMinutes,
+  shortPath,
+  statusClasses,
+  statusDotColor,
+  statusIcon,
+  statusTextColor,
+  SwitchToggle,
+  triggerSourceLabel,
+} from "@/components/app/jobs-utils";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -36,30 +55,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Bar, BarChart, XAxis } from "recharts";
-import {
   type AddJobConfig,
   type Job,
   type JobRun,
-  type JobRunStatus,
   useJobActions,
   useJobHistory,
   useJobs,
   useJobStats,
 } from "@/hooks/use-jobs";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  ChartLegend,
-  ChartLegendContent,
-  type ChartConfig,
-} from "@/components/ui/chart";
 import { StatCard } from "@/components/app/stat-card";
 import { formatRelativeTime } from "@/lib/format";
 import {
@@ -68,7 +71,6 @@ import {
   type CliAgentType,
   isCliAgentType,
 } from "@/lib/agent-types";
-import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
 
 type JobsPaneProps = {
@@ -121,120 +123,9 @@ function useJobsContext(): JobsContextValue {
 
 type DetailTab = "configure" | "prompt" | "history";
 
-const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
-  "started",
-  "running",
-  "needs_input",
-];
-
-function statusClasses(status: JobRunStatus | null): string {
-  if (status === "completed")
-    return "border-status-done/45 bg-status-done/15 text-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed")
-    return "border-status-blocked/45 bg-status-blocked/15 text-status-blocked";
-  if (status === "needs_input")
-    return "border-status-waiting/45 bg-status-waiting/15 text-status-waiting";
-  if (status === "started" || status === "running")
-    return "border-status-working/45 bg-status-working/15 text-status-working";
-  return "border-border bg-muted/35 text-muted-foreground";
-}
-
-function statusTextColor(status: JobRunStatus | null): string {
-  if (status === "completed") return "text-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed")
-    return "text-status-blocked";
-  if (status === "needs_input") return "text-status-waiting";
-  if (status === "started" || status === "running")
-    return "text-status-working";
-  return "text-muted-foreground";
-}
-
-function statusIcon(status: JobRunStatus | null): JSX.Element | null {
-  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" />;
-  if (status === "failed" || status === "timed_out" || status === "crashed")
-    return <XCircle className="h-3.5 w-3.5" />;
-  if (status === "started" || status === "running" || status === "needs_input")
-    return <ActivityBars size={14} className="shrink-0" />;
-  return null;
-}
-
-function statusDotColor(status: JobRunStatus | null): string {
-  if (status === "completed") return "bg-status-done";
-  if (status === "failed" || status === "timed_out" || status === "crashed")
-    return "bg-status-blocked";
-  if (status === "needs_input") return "bg-status-waiting";
-  if (status === "started" || status === "running") return "bg-status-working";
-  return "bg-muted-foreground";
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return "Not scheduled";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "Unknown";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
-}
-
-function formatDuration(ms: number | null | undefined): string {
-  if (!ms) return "n/a";
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remaining = seconds % 60;
-  return `${minutes}m ${remaining}s`;
-}
-
-function minutesFromMs(ms: number | null | undefined): string {
-  if (!ms) return "";
-  return String(Math.max(1, Math.round(ms / 60_000)));
-}
-
-function msFromMinutes(value: string): number | undefined {
-  const minutes = Number.parseInt(value, 10);
-  if (!Number.isFinite(minutes) || minutes <= 0) return undefined;
-  return minutes * 60_000;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function cronError(schedule: string, enabled: boolean): string | null {
-  const trimmed = schedule.trim();
-  if (!trimmed)
-    return enabled ? "Add a cron schedule before enabling this job." : null;
-  const fields = trimmed.split(/\s+/);
-  if (fields.length !== 5)
-    return "Use a 5-field cron expression like */30 * * * *.";
-  return null;
-}
-
-function shortPath(value: string): string {
-  const parts = value.split("/").filter(Boolean);
-  if (parts.length <= 3) return value;
-  return `.../${parts.slice(-3).join("/")}`;
-}
-
-function humanSchedule(schedule: string | null): string {
-  if (!schedule) return "On demand";
-  try {
-    return cronstrue.toString(schedule, { use24HourTimeFormat: false });
-  } catch {
-    return `Cron: ${schedule.trim()}`;
-  }
-}
-
-function triggerSourceLabel(run: JobRun): string {
-  return run.config.triggerSource === "scheduled" ? "Scheduled" : "Manual";
-}
-
 function useAttachedJobAgent(job: Job | null, agents: Agent[]) {
   return useMemo(() => {
     if (!job?.lastRunId || !job.lastRunStatus) return null;
-    // Active statuses always resolve; terminal statuses only resolve when the
-    // job opted out of auto-archive so the agent should still exist.
     const isActive = ACTIVE_RUN_STATUSES.includes(job.lastRunStatus);
     const keepsAgent = !job.autoArchive;
     if (!isActive && !keepsAgent) return null;
@@ -603,43 +494,6 @@ export function JobDetailPane(): JSX.Element {
   );
 }
 
-function formatTimeUntil(iso: string): string {
-  const ms = new Date(iso).getTime() - Date.now();
-  if (Number.isNaN(ms) || ms < 0) return "now";
-  const mins = Math.floor(ms / 60_000);
-  if (mins < 1) return "< 1m";
-  if (mins < 60) return `in ${mins}m`;
-  const hours = Math.floor(mins / 60);
-  const remMins = mins % 60;
-  if (hours < 24)
-    return remMins > 0 ? `in ${hours}h ${remMins}m` : `in ${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `in ${days}d`;
-}
-
-function formatTimeUntilDate(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "";
-  const now = new Date();
-  const isToday = date.toDateString() === now.toDateString();
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const isTomorrow = date.toDateString() === tomorrow.toDateString();
-  const time = date.toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  if (isToday) return `Today at ${time}`;
-  if (isTomorrow) return `Tomorrow at ${time}`;
-  return date.toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
 function JobsOverview({
   jobs,
   stats,
@@ -860,612 +714,6 @@ function JobsOverview({
         )}
       </div>
     </ScrollArea>
-  );
-}
-
-const dailyRunsChartConfig = {
-  completed: { label: "Completed", color: "hsl(var(--chart-1))" },
-  failed: { label: "Failed", color: "hsl(var(--status-blocked))" },
-} satisfies ChartConfig;
-
-function DailyRunsChart({
-  data,
-}: {
-  data: Array<{
-    day: string;
-    label: string;
-    completed: number;
-    failed: number;
-  }>;
-}) {
-  return (
-    <ChartContainer config={dailyRunsChartConfig} className="h-full w-full">
-      <BarChart data={data} barCategoryGap="20%">
-        <XAxis
-          dataKey="label"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={6}
-          tick={{ fontSize: 11 }}
-        />
-        <ChartTooltip
-          content={
-            <ChartTooltipContent
-              indicator="dot"
-              formatter={(value, name, item) => (
-                <>
-                  <div
-                    className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-                    style={{ backgroundColor: item.color }}
-                  />
-                  <div className="flex flex-1 items-center justify-between gap-4">
-                    <span className="text-muted-foreground">
-                      {dailyRunsChartConfig[
-                        name as keyof typeof dailyRunsChartConfig
-                      ]?.label ?? name}
-                    </span>
-                    <span className="font-mono font-medium tabular-nums text-foreground">
-                      {value as number}
-                    </span>
-                  </div>
-                </>
-              )}
-              labelFormatter={(label) => label as string}
-            />
-          }
-        />
-        <ChartLegend content={<ChartLegendContent className="gap-2" />} />
-        <Bar
-          dataKey="completed"
-          stackId="runs"
-          fill="var(--color-completed)"
-          radius={0}
-        />
-        <Bar
-          dataKey="failed"
-          stackId="runs"
-          fill="var(--color-failed)"
-          radius={[2, 2, 0, 0]}
-        />
-      </BarChart>
-    </ChartContainer>
-  );
-}
-
-// ─── Avg Duration Per Job ─────────────────────────────────────────────
-
-function JobAvgDuration({
-  runs,
-}: {
-  runs: Array<{ jobName: string; durationMs: number | null }>;
-}) {
-  const perJob = useMemo(() => {
-    const map = new Map<string, number[]>();
-    for (const run of runs) {
-      if (run.durationMs == null) continue;
-      if (!map.has(run.jobName)) map.set(run.jobName, []);
-      map.get(run.jobName)!.push(run.durationMs);
-    }
-    const result = [...map.entries()].map(([name, durations]) => ({
-      name,
-      avg: Math.round(durations.reduce((a, b) => a + b, 0) / durations.length),
-      runs: durations.length,
-    }));
-    const maxAvg = Math.max(...result.map((j) => j.avg), 1);
-    return { jobs: result, maxAvg };
-  }, [runs]);
-
-  if (perJob.jobs.length === 0) return null;
-
-  return (
-    <div>
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        Avg Duration
-      </h3>
-      <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-center">
-        <div className="flex flex-col gap-3 overflow-y-auto min-h-0">
-          {perJob.jobs.map((job) => (
-            <div key={job.name}>
-              <div className="mb-1 flex items-center justify-between">
-                <span className="truncate text-xs text-muted-foreground">
-                  {job.name}
-                </span>
-                <span className="text-xs font-medium tabular-nums text-foreground">
-                  {formatDuration(job.avg)}
-                </span>
-              </div>
-              <div className="flex h-2 overflow-hidden rounded-sm bg-muted/60">
-                <div
-                  className="bg-chart-1/70 transition-all rounded-sm"
-                  style={{ width: `${(job.avg / perJob.maxAvg) * 100}%` }}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Run History Grid ────────────────────────────────────────────────
-
-const MAX_RUN_CELLS = 16;
-
-function RunHistoryGrid({
-  runs,
-}: {
-  runs: Array<{
-    jobId: string;
-    jobName: string;
-    status: JobRunStatus;
-    startedAt: string;
-  }>;
-}) {
-  const perJob = useMemo(() => {
-    const grouped = new Map<
-      string,
-      Array<{ status: JobRunStatus; startedAt: string }>
-    >();
-    for (const run of runs) {
-      if (!grouped.has(run.jobName)) grouped.set(run.jobName, []);
-      grouped
-        .get(run.jobName)!
-        .push({ status: run.status, startedAt: run.startedAt });
-    }
-    // Each job's runs are newest-first from the API; take last N then reverse to oldest→newest
-    const result: Array<{
-      name: string;
-      runs: Array<{ status: JobRunStatus; startedAt: string }>;
-    }> = [];
-    for (const [name, jobRuns] of grouped) {
-      result.push({ name, runs: jobRuns.slice(0, MAX_RUN_CELLS).reverse() });
-    }
-    return result;
-  }, [runs]);
-
-  if (perJob.length === 0) return null;
-
-  return (
-    <div>
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        Run History
-      </h3>
-      <div className="h-[180px] sm:h-[220px] rounded-md border border-border bg-muted/40 p-3 flex flex-col justify-between">
-        <TooltipProvider delayDuration={80}>
-          <div className="space-y-2 overflow-y-auto min-h-0 flex-1">
-            {perJob.map(({ name, runs: jobRuns }) => (
-              <div key={name}>
-                <div className="mb-1 truncate text-[10px] text-muted-foreground">
-                  {name}
-                </div>
-                <div
-                  className="grid gap-[1px]"
-                  style={{
-                    gridTemplateColumns: `repeat(${MAX_RUN_CELLS}, 1fr)`,
-                  }}
-                >
-                  {Array.from({ length: MAX_RUN_CELLS }, (_, i) => {
-                    const run = i < jobRuns.length ? jobRuns[i] : null;
-                    if (!run)
-                      return <div key={i} className="h-4 sm:h-3 bg-muted/30" />;
-                    return (
-                      <Tooltip key={i}>
-                        <TooltipTrigger asChild>
-                          <div
-                            className={cn(
-                              "h-4 sm:h-3",
-                              run.status === "completed" && "bg-status-done/70",
-                              (run.status === "failed" ||
-                                run.status === "timed_out" ||
-                                run.status === "crashed") &&
-                                "bg-status-blocked/70",
-                              (run.status === "running" ||
-                                run.status === "started") &&
-                                "bg-status-working/70",
-                              run.status === "needs_input" &&
-                                "bg-status-waiting/70"
-                            )}
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent side="top" className="text-xs">
-                          {run.status} — {formatRelativeTime(run.startedAt)}
-                        </TooltipContent>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
-        </TooltipProvider>
-        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-3 bg-status-done/70" />
-            Completed
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-3 bg-status-blocked/70" />
-            Failed
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AddJobDialog({
-  open,
-  onOpenChange,
-  children,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md" />
-        <DialogPrimitive.Content
-          onEscapeKeyDown={swallowEscapeFromCombobox}
-          className="fixed inset-x-2 bottom-2 top-2 z-50 flex max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-lg border border-white/[0.2] bg-[hsl(var(--card))] backdrop-blur-2xl shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] outline-none md:left-1/2 md:top-1/2 md:h-[min(760px,88vh)] md:w-[min(760px,calc(100vw-2rem))] md:-translate-x-1/2 md:-translate-y-1/2"
-        >
-          <DialogPrimitive.Title className="sr-only">
-            Add job
-          </DialogPrimitive.Title>
-          <DialogPrimitive.Description className="sr-only">
-            Create a new recurring Dispatch job.
-          </DialogPrimitive.Description>
-          <DialogPrimitive.Close asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="absolute right-3 top-3 z-10"
-              aria-label="Close add job"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </DialogPrimitive.Close>
-          {children}
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
-  );
-}
-
-function AddJobFlow({
-  onAddJob,
-  isAdding,
-  enabledAgentTypes,
-}: {
-  onAddJob: (job: AddJobConfig) => Promise<void>;
-  isAdding: boolean;
-  enabledAgentTypes: AgentType[];
-}) {
-  const [displayName, setDisplayName] = useState("");
-  const [directory, setDirectory] = useState("");
-  const [prompt, setPrompt] = useState("");
-  const [schedule, setSchedule] = useState("");
-  const [timeoutMinutes, setTimeoutMinutes] = useState("30");
-  const [needsInputTimeoutMinutes, setNeedsInputTimeoutMinutes] =
-    useState("1440");
-  const jobAgentTypes = enabledAgentTypes.filter(isCliAgentType);
-  const [agentType, setAgentType] = useState<CliAgentType>(
-    jobAgentTypes[0] ?? "codex"
-  );
-  const [fullAccess, setFullAccess] = useState(false);
-  const [useWorktree, setUseWorktree] = useState(false);
-  const [baseBranch, setBaseBranch] = useState("main");
-  const [branchName, setBranchName] = useState("");
-  const [keepAgent, setKeepAgent] = useState(false);
-  const [callable, setCallable] = useState(false);
-  const [singleton, setSingleton] = useState(true);
-  const [enableImmediately, setEnableImmediately] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  // Enabled is only meaningful when there's a schedule — derive rather than reset.
-  const effectiveEnabled = schedule.trim() ? enableImmediately : false;
-  const scheduleError = cronError(schedule, effectiveEnabled);
-  const canAdd =
-    !!displayName.trim() &&
-    !!directory.trim() &&
-    !!prompt.trim() &&
-    !scheduleError &&
-    !!msFromMinutes(timeoutMinutes) &&
-    !!msFromMinutes(needsInputTimeoutMinutes);
-
-  return (
-    <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col overflow-hidden p-4 md:p-8">
-      <div className="text-lg font-semibold">Create a new job</div>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Define an automation with a prompt — on a schedule or on demand.
-      </p>
-
-      <ScrollArea className="mt-6 min-h-0 flex-1 pr-1">
-        <div className="grid min-w-0 gap-4">
-          <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
-            <div className="grid min-w-0 gap-3 md:grid-cols-2">
-              <div className="min-w-0 space-y-1 md:col-span-2">
-                <label
-                  className="text-sm text-muted-foreground"
-                  htmlFor="job-display-name"
-                >
-                  Name
-                </label>
-                <Input
-                  id="job-display-name"
-                  value={displayName}
-                  onChange={(event) => setDisplayName(event.target.value)}
-                  placeholder="e.g. Daily cleanup"
-                />
-              </div>
-              <div className="min-w-0 space-y-1 md:col-span-2">
-                <label
-                  className="text-sm text-muted-foreground"
-                  htmlFor="job-directory"
-                >
-                  Working directory
-                </label>
-                <PathInput
-                  value={directory}
-                  onChange={setDirectory}
-                  label=""
-                  placeholder="~/code/project"
-                  id="job-directory"
-                  data-testid="job-directory-input"
-                />
-              </div>
-              <div className="min-w-0 space-y-1">
-                <label
-                  className="text-sm text-muted-foreground"
-                  htmlFor="job-schedule"
-                >
-                  Cron schedule{" "}
-                  <span className="text-muted-foreground/70">(optional)</span>
-                </label>
-                <Input
-                  id="job-schedule"
-                  value={schedule}
-                  onChange={(event) => setSchedule(event.target.value)}
-                  placeholder="*/30 * * * *"
-                  className="font-mono text-xs"
-                />
-                {scheduleError ? (
-                  <div className="text-xs text-status-blocked">
-                    {scheduleError}
-                  </div>
-                ) : null}
-                {!scheduleError && schedule.trim() ? (
-                  <div className="text-xs text-muted-foreground">
-                    {humanSchedule(schedule)}
-                  </div>
-                ) : null}
-                {!schedule.trim() ? (
-                  <div className="text-xs text-muted-foreground">
-                    Leave blank for an on-demand job.
-                  </div>
-                ) : null}
-                {schedule.trim() ? (
-                  <label className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
-                    <span>
-                      <span className="block font-medium text-foreground">
-                        Enabled
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        Run this job on its schedule after creating it.
-                      </span>
-                    </span>
-                    <SwitchToggle
-                      checked={enableImmediately}
-                      onCheckedChange={setEnableImmediately}
-                      ariaLabel="Enable job"
-                    />
-                  </label>
-                ) : null}
-              </div>
-              <div className="min-w-0 space-y-1">
-                <label className="text-sm text-muted-foreground">
-                  Agent type
-                </label>
-                <Select
-                  value={agentType}
-                  onValueChange={(value) => setAgentType(value as CliAgentType)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {jobAgentTypes.map((type) => (
-                      <SelectItem key={type} value={type}>
-                        {AGENT_TYPE_LABELS[type]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
-                <span>
-                  <span className="block font-medium text-foreground">
-                    Show in command palette
-                  </span>
-                  <span className="block text-xs text-muted-foreground">
-                    Launch this job from the {"⌘"}K palette.
-                  </span>
-                </span>
-                <SwitchToggle
-                  checked={callable}
-                  onCheckedChange={setCallable}
-                  ariaLabel="Show in command palette"
-                />
-              </label>
-              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm md:col-span-2">
-                <span>
-                  <span className="block font-medium text-foreground">
-                    Single instance
-                  </span>
-                  <span className="block text-xs text-muted-foreground">
-                    Only allow one active run at a time.
-                  </span>
-                </span>
-                <SwitchToggle
-                  checked={singleton}
-                  onCheckedChange={setSingleton}
-                  ariaLabel="Single instance"
-                />
-              </label>
-            </div>
-          </div>
-
-          <div className="min-w-0 rounded-md border border-border bg-muted/20 p-4">
-            <div className="space-y-1">
-              <label
-                className="text-sm font-medium text-foreground"
-                htmlFor="job-prompt"
-              >
-                Prompt
-              </label>
-              <p className="text-xs text-muted-foreground">
-                The instructions the agent will follow when this job runs.
-              </p>
-            </div>
-            <textarea
-              id="job-prompt"
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              placeholder="Describe what the agent should do..."
-              className="mt-2 min-h-64 w-full rounded-md border border-white/[0.12] bg-white/[0.04] backdrop-blur-md shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
-
-          <div className="min-w-0 rounded-md border border-white/[0.12] bg-white/[0.04] p-4">
-            <button
-              type="button"
-              className="flex w-full items-center justify-between gap-3 text-left"
-              onClick={() => setAdvancedOpen((current) => !current)}
-            >
-              <div>
-                <div className="text-sm font-medium">Advanced settings</div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  Timeouts, worktree, permissions, and whether the agent is kept
-                  after running.
-                </div>
-              </div>
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 text-muted-foreground transition-transform",
-                  advancedOpen && "rotate-180"
-                )}
-              />
-            </button>
-            <div
-              className={cn(
-                "grid min-w-0 overflow-hidden transition-all duration-200 ease-out",
-                advancedOpen
-                  ? "mt-4 grid-rows-[1fr] opacity-100"
-                  : "mt-0 grid-rows-[0fr] opacity-0"
-              )}
-              aria-hidden={!advancedOpen}
-            >
-              <div className="min-h-0">
-                <div className="grid min-w-0 gap-3 md:grid-cols-2">
-                  <div className="min-w-0 space-y-1">
-                    <label
-                      className="text-sm text-muted-foreground"
-                      htmlFor="job-timeout"
-                    >
-                      Run timeout, minutes
-                    </label>
-                    <Input
-                      id="job-timeout"
-                      value={timeoutMinutes}
-                      onChange={(event) =>
-                        setTimeoutMinutes(event.target.value)
-                      }
-                      inputMode="numeric"
-                    />
-                  </div>
-                  <div className="min-w-0 space-y-1">
-                    <label
-                      className="text-sm text-muted-foreground"
-                      htmlFor="job-needs-input-timeout"
-                    >
-                      Wait for input, minutes
-                    </label>
-                    <Input
-                      id="job-needs-input-timeout"
-                      value={needsInputTimeoutMinutes}
-                      onChange={(event) =>
-                        setNeedsInputTimeoutMinutes(event.target.value)
-                      }
-                      inputMode="numeric"
-                    />
-                  </div>
-                  <JobWorktreeOption
-                    checked={useWorktree}
-                    cwd={directory}
-                    baseBranch={baseBranch}
-                    branchName={branchName}
-                    onCheckedChange={setUseWorktree}
-                    onBaseBranchChange={setBaseBranch}
-                    onBranchNameChange={setBranchName}
-                    testIdPrefix="job-create"
-                  />
-                  <JobFullAccessOption
-                    checked={fullAccess}
-                    onCheckedChange={setFullAccess}
-                  />
-                  <JobKeepAgentOption
-                    checked={keepAgent}
-                    onCheckedChange={setKeepAgent}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {submitError ? (
-            <div className="rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
-              {submitError}
-            </div>
-          ) : null}
-        </div>
-      </ScrollArea>
-
-      <div className="mt-4 flex shrink-0 justify-end gap-2 border-t border-border/70 pt-4">
-        <DialogPrimitive.Close asChild>
-          <Button variant="ghost">Cancel</Button>
-        </DialogPrimitive.Close>
-        <Button
-          variant="primary"
-          disabled={!canAdd || isAdding}
-          onClick={() => {
-            setSubmitError(null);
-            void onAddJob({
-              name: displayName.trim(),
-              directory: directory.trim(),
-              displayName: displayName.trim(),
-              prompt: prompt.trim(),
-              schedule: schedule.trim() || null,
-              timeoutMs: msFromMinutes(timeoutMinutes),
-              needsInputTimeoutMs: msFromMinutes(needsInputTimeoutMinutes),
-              agentType,
-              useWorktree,
-              baseBranch: useWorktree ? baseBranch : null,
-              branchName: useWorktree ? branchName : null,
-              fullAccess,
-              autoArchive: !keepAgent,
-              callable,
-              singleton,
-              enabled: effectiveEnabled,
-            }).catch((error) => setSubmitError(errorMessage(error)));
-          }}
-        >
-          {isAdding ? <ActivityBars size={16} className="mr-2" /> : null}
-          Add job
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -1740,147 +988,6 @@ function TabButton({
   );
 }
 
-function JobWorktreeOption({
-  checked,
-  cwd,
-  baseBranch,
-  branchName,
-  onCheckedChange,
-  onBaseBranchChange,
-  onBranchNameChange,
-  testIdPrefix,
-}: {
-  checked: boolean;
-  cwd: string;
-  baseBranch: string;
-  branchName: string;
-  onCheckedChange: (checked: boolean) => void;
-  onBaseBranchChange: (value: string) => void;
-  onBranchNameChange: (value: string) => void;
-  testIdPrefix?: string;
-}) {
-  return (
-    <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <label className="flex cursor-pointer items-start gap-3">
-        <Checkbox
-          checked={checked}
-          onCheckedChange={() => onCheckedChange(!checked)}
-          className="mt-0.5"
-          title="Toggle git worktree"
-        />
-        <span className="space-y-1">
-          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            <GitBranch className="h-3.5 w-3.5" />
-            Run in a git worktree
-          </span>
-          <span className="block text-xs text-muted-foreground">
-            Creates an isolated worktree and branch when this job runs.
-          </span>
-        </span>
-      </label>
-      {checked ? (
-        <div className="ml-8 w-[calc(100%-2rem)]">
-          <BranchSelect
-            cwd={cwd}
-            baseBranch={baseBranch}
-            onBaseBranchChange={onBaseBranchChange}
-            worktreeBranch={branchName}
-            onWorktreeBranchChange={onBranchNameChange}
-            testIdPrefix={testIdPrefix ?? "job-worktree"}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function JobKeepAgentOption({
-  checked,
-  onCheckedChange,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={() => onCheckedChange(!checked)}
-        className="mt-0.5"
-        title="Keep agent after run completes"
-      />
-      <span className="space-y-1">
-        <span className="block text-sm font-medium text-foreground">
-          Keep agent after run completes
-        </span>
-        <span className="block text-xs text-muted-foreground">
-          The agent stays in your Agents list so you can continue the session
-          after the job finishes.
-        </span>
-      </span>
-    </label>
-  );
-}
-
-function JobFullAccessOption({
-  checked,
-  onCheckedChange,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={() => onCheckedChange(!checked)}
-        className="mt-0.5"
-        title="Toggle full access"
-      />
-      <span className="space-y-1">
-        <span className="block text-sm font-medium text-foreground">
-          Run in full access mode
-        </span>
-        <span className="block text-xs text-muted-foreground">
-          Starts the selected agent with its most permissive supported execution
-          mode.
-        </span>
-      </span>
-    </label>
-  );
-}
-
-function SwitchToggle({
-  checked,
-  onCheckedChange,
-  ariaLabel,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onCheckedChange(!checked)}
-      className={cn(
-        "inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent p-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
-        checked ? "bg-primary" : "bg-muted"
-      )}
-    >
-      <span
-        className={cn(
-          "h-5 w-5 rounded-full bg-background shadow-sm transition-transform",
-          checked ? "translate-x-5" : "translate-x-0"
-        )}
-      />
-    </button>
-  );
-}
-
 function SettingsTab({
   job,
   enabledAgentTypes,
@@ -1917,7 +1024,6 @@ function SettingsTab({
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [saved, setSaved] = useState(false);
-  // Enabled is only meaningful when there's a schedule — derive rather than reset.
   const effectiveEnabled = schedule.trim() ? enabled : false;
   const scheduleError = cronError(schedule, effectiveEnabled);
   const canSave =

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -2,6 +2,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   Activity,
   AlarmClock,
+  CheckCircle2,
   Clock,
   History,
   MessageSquareText,
@@ -9,6 +10,7 @@ import {
   Settings,
   Terminal,
   Trash2,
+  XCircle,
 } from "lucide-react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -21,6 +23,12 @@ import {
   RunHistoryGrid,
 } from "@/components/app/jobs-charts";
 import {
+  JobFullAccessOption,
+  JobKeepAgentOption,
+  JobWorktreeOption,
+  SwitchToggle,
+} from "@/components/app/jobs-form-fields";
+import {
   ACTIVE_RUN_STATUSES,
   cronError,
   errorMessage,
@@ -29,19 +37,14 @@ import {
   formatTimeUntil,
   formatTimeUntilDate,
   humanSchedule,
-  JobFullAccessOption,
-  JobKeepAgentOption,
-  JobWorktreeOption,
   minutesFromMs,
   msFromMinutes,
   shortPath,
   statusClasses,
   statusDotColor,
-  statusIcon,
   statusTextColor,
-  SwitchToggle,
   triggerSourceLabel,
-} from "@/components/app/jobs-utils";
+} from "@/components/app/jobs-helpers";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -122,6 +125,17 @@ function useJobsContext(): JobsContextValue {
 }
 
 type DetailTab = "configure" | "prompt" | "history";
+
+function statusIcon(
+  status: import("@/hooks/use-jobs").JobRunStatus | null
+): JSX.Element | null {
+  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" />;
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return <XCircle className="h-3.5 w-3.5" />;
+  if (status === "started" || status === "running" || status === "needs_input")
+    return <ActivityBars size={14} className="shrink-0" />;
+  return null;
+}
 
 function useAttachedJobAgent(job: Job | null, agents: Agent[]) {
   return useMemo(() => {

--- a/apps/web/src/components/app/jobs-utils.tsx
+++ b/apps/web/src/components/app/jobs-utils.tsx
@@ -1,0 +1,295 @@
+import cronstrue from "cronstrue";
+import { CheckCircle2, GitBranch, XCircle } from "lucide-react";
+
+import { BranchSelect } from "@/components/app/branch-select";
+import { type JobRun, type JobRunStatus } from "@/hooks/use-jobs";
+import { ActivityBars } from "@/components/ui/activity-bars";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+
+export const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
+  "started",
+  "running",
+  "needs_input",
+];
+
+export function statusClasses(status: JobRunStatus | null): string {
+  if (status === "completed")
+    return "border-status-done/45 bg-status-done/15 text-status-done";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "border-status-blocked/45 bg-status-blocked/15 text-status-blocked";
+  if (status === "needs_input")
+    return "border-status-waiting/45 bg-status-waiting/15 text-status-waiting";
+  if (status === "started" || status === "running")
+    return "border-status-working/45 bg-status-working/15 text-status-working";
+  return "border-border bg-muted/35 text-muted-foreground";
+}
+
+export function statusTextColor(status: JobRunStatus | null): string {
+  if (status === "completed") return "text-status-done";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "text-status-blocked";
+  if (status === "needs_input") return "text-status-waiting";
+  if (status === "started" || status === "running")
+    return "text-status-working";
+  return "text-muted-foreground";
+}
+
+export function statusIcon(status: JobRunStatus | null): JSX.Element | null {
+  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" />;
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return <XCircle className="h-3.5 w-3.5" />;
+  if (status === "started" || status === "running" || status === "needs_input")
+    return <ActivityBars size={14} className="shrink-0" />;
+  return null;
+}
+
+export function statusDotColor(status: JobRunStatus | null): string {
+  if (status === "completed") return "bg-status-done";
+  if (status === "failed" || status === "timed_out" || status === "crashed")
+    return "bg-status-blocked";
+  if (status === "needs_input") return "bg-status-waiting";
+  if (status === "started" || status === "running") return "bg-status-working";
+  return "bg-muted-foreground";
+}
+
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "Not scheduled";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function formatDuration(ms: number | null | undefined): string {
+  if (!ms) return "n/a";
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+export function minutesFromMs(ms: number | null | undefined): string {
+  if (!ms) return "";
+  return String(Math.max(1, Math.round(ms / 60_000)));
+}
+
+export function msFromMinutes(value: string): number | undefined {
+  const minutes = Number.parseInt(value, 10);
+  if (!Number.isFinite(minutes) || minutes <= 0) return undefined;
+  return minutes * 60_000;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function cronError(schedule: string, enabled: boolean): string | null {
+  const trimmed = schedule.trim();
+  if (!trimmed)
+    return enabled ? "Add a cron schedule before enabling this job." : null;
+  const fields = trimmed.split(/\s+/);
+  if (fields.length !== 5)
+    return "Use a 5-field cron expression like */30 * * * *.";
+  return null;
+}
+
+export function shortPath(value: string): string {
+  const parts = value.split("/").filter(Boolean);
+  if (parts.length <= 3) return value;
+  return `.../${parts.slice(-3).join("/")}`;
+}
+
+export function humanSchedule(schedule: string | null): string {
+  if (!schedule) return "On demand";
+  try {
+    return cronstrue.toString(schedule, { use24HourTimeFormat: false });
+  } catch {
+    return `Cron: ${schedule.trim()}`;
+  }
+}
+
+export function triggerSourceLabel(run: JobRun): string {
+  return run.config.triggerSource === "scheduled" ? "Scheduled" : "Manual";
+}
+
+export function formatTimeUntil(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (Number.isNaN(ms) || ms < 0) return "now";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "< 1m";
+  if (mins < 60) return `in ${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  if (hours < 24)
+    return remMins > 0 ? `in ${hours}h ${remMins}m` : `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+}
+
+export function formatTimeUntilDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const isTomorrow = date.toDateString() === tomorrow.toDateString();
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (isToday) return `Today at ${time}`;
+  if (isTomorrow) return `Tomorrow at ${time}`;
+  return date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function SwitchToggle({
+  checked,
+  onCheckedChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent p-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+        checked ? "bg-primary" : "bg-muted"
+      )}
+    >
+      <span
+        className={cn(
+          "h-5 w-5 rounded-full bg-background shadow-sm transition-transform",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  );
+}
+
+export function JobWorktreeOption({
+  checked,
+  cwd,
+  baseBranch,
+  branchName,
+  onCheckedChange,
+  onBaseBranchChange,
+  onBranchNameChange,
+  testIdPrefix,
+}: {
+  checked: boolean;
+  cwd: string;
+  baseBranch: string;
+  branchName: string;
+  onCheckedChange: (checked: boolean) => void;
+  onBaseBranchChange: (value: string) => void;
+  onBranchNameChange: (value: string) => void;
+  testIdPrefix?: string;
+}) {
+  return (
+    <div className="space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <label className="flex cursor-pointer items-start gap-3">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={() => onCheckedChange(!checked)}
+          className="mt-0.5"
+          title="Toggle git worktree"
+        />
+        <span className="space-y-1">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <GitBranch className="h-3.5 w-3.5" />
+            Run in a git worktree
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            Creates an isolated worktree and branch when this job runs.
+          </span>
+        </span>
+      </label>
+      {checked ? (
+        <div className="ml-8 w-[calc(100%-2rem)]">
+          <BranchSelect
+            cwd={cwd}
+            baseBranch={baseBranch}
+            onBaseBranchChange={onBaseBranchChange}
+            worktreeBranch={branchName}
+            onWorktreeBranchChange={onBranchNameChange}
+            testIdPrefix={testIdPrefix ?? "job-worktree"}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function JobKeepAgentOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Keep agent after run completes"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Keep agent after run completes
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          The agent stays in your Agents list so you can continue the session
+          after the job finishes.
+        </span>
+      </span>
+    </label>
+  );
+}
+
+export function JobFullAccessOption({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3 md:col-span-2">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onCheckedChange(!checked)}
+        className="mt-0.5"
+        title="Toggle full access"
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          Run in full access mode
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          Starts the selected agent with its most permissive supported execution
+          mode.
+        </span>
+      </span>
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary

- Split the oversized `jobs-pane.tsx` (2489 lines) into focused modules, reducing it to 1599 lines
- Extracted `jobs-utils.tsx` (295 lines) — shared utilities, status helpers, and form components used across job UI
- Extracted `jobs-add-dialog.tsx` (409 lines) — the AddJobDialog and AddJobFlow components
- Extracted `jobs-charts.tsx` (247 lines) — DailyRunsChart, JobAvgDuration, and RunHistoryGrid

This is a purely structural refactoring — no behavior changes. The rendered UI and all interactions remain identical.

## New file structure

```
apps/web/src/components/app/
├── jobs-pane.tsx          (1599 lines, was 2489 — orchestrator, context, detail views)
├── jobs-utils.tsx         (295 lines — statusClasses, formatDate, SwitchToggle, etc.)
├── jobs-add-dialog.tsx    (409 lines — AddJobDialog + AddJobFlow)
└── jobs-charts.tsx        (247 lines — chart components for the overview)
```

## Why this was a candidate

- 2489 lines with 20+ internal functions covering wildly different concerns
- Multiple logically independent UI regions (overview charts, add-job dialog, settings tabs, history)
- Mixed concerns: utility functions, form components, chart visualizations, and orchestration all in one file

## What's queued for next run

The componentizer will tackle `automations-pane.tsx` (2029 lines) next — extracting LaunchTemplateDialog, CreateTemplateDialog, and TemplateDetailPane.

## Test plan

- [x] `pnpm run check` passes (TypeScript)
- [x] `pnpm run finalize:web` passes (type check + production build)
- [x] `pnpm run test:e2e` passes (140/140 passed, 11 skipped terminal-live tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)