### PR TITLE
refactor: extract resolveTilde to shared utility

### DIFF
--- a/.dispatch/job-state/tech-debt.md
+++ b/.dispatch/job-state/tech-debt.md
@@ -2,36 +2,33 @@
 
 ## last_audited_sha
 
-47160c61539438532327e5bdac30e86814e8686d
+e9e43bc1755434a18eae24cf47fff1d927268df1
 
 ## next_focus
 
-**Duplicate `resolveTilde` functions in route files**
+**`as unknown as WebSocket` cast in `apps/server/src/stream-manager.ts:52`**
 
-- `apps/server/src/routes/jobs.ts` and `apps/server/src/routes/templates.ts` both have byte-identical `resolveTilde` implementations that expand `~` to `os.homedir()`.
-- **Action**: Extract `resolveTilde` to `apps/server/src/shared/lib/resolve-tilde.ts`, export it, and replace the local definitions in both route files with imports. Run `pnpm run check`, `pnpm run test`, and `pnpm run test:e2e`.
+- There's an unsafe `as unknown as WebSocket` cast around line 52 in `stream-manager.ts`.
+- **Action**: Investigate whether the underlying Fastify WebSocket type can be used directly or if a narrower interface type would eliminate the double cast. Check what methods/properties are actually used and define a minimal interface if the full WebSocket type doesn't align. Run `pnpm run check` and `pnpm run test:e2e` after any change.
 
 ## backlog
 
-1. **Large file: `apps/web/src/components/app/jobs-pane.tsx` (2489 lines)**. Largest component file. Look for extractable sub-components (job detail panels, form sections, list items).
+1. **Large file: `apps/server/src/shared/mcp/server.ts` (2101 lines)**. MCP server implementation. Check if tool handler registration can be split into separate modules.
 
-2. **Large file: `apps/server/src/shared/mcp/server.ts` (2101 lines)**. MCP server implementation. Check if tool handler registration can be split into separate modules.
+2. **Large file: `apps/server/src/agents/manager.ts` (1733 lines)**. Agent manager — check for functions that can be extracted to dedicated files.
 
-3. **Large file: `apps/web/src/components/app/automations-pane.tsx` (2029 lines)**. Similar to jobs-pane — likely has extractable sub-components.
+3. **`ide-settings.ts` and `agent-type-settings.ts` share a near-identical pattern**: type guard, sanitize function, get/set with JSON parse. Consider a generic settings-value helper if a third instance appears (monitor, don't act yet).
 
-4. **Large file: `apps/server/src/agents/manager.ts` (1733 lines)**. Agent manager — check for functions that can be extracted to dedicated files.
-
-5. **`as unknown as WebSocket` cast in `apps/server/src/stream-manager.ts:52`**. Investigate whether proper typing is feasible.
-
-6. **`ide-settings.ts` and `agent-type-settings.ts` share a near-identical pattern**: type guard, sanitize function, get/set with JSON parse. Consider a generic settings-value helper if a third instance appears (monitor, don't act yet).
+4. **Re-scan route files for new utility duplication**. The `resolveTilde`, `sanitizeUploadedFileName`, and `errorMessage` patterns were all found in routes. Worth a fresh grep for other copy-pasted helpers, especially in newer route files.
 
 ## patterns
 
-- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (fixed in run 2), the `resolveTilde` duplication (backlog), and now the `errorMessage` duplication (fixed in runs 4+5) confirm that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes and large classes.
-- **Private method duplication in large classes**: `manager.ts` had `private errorMessage()` duplicating shared logic (fixed this run). Large classes are prone to re-implementing utilities as private methods instead of importing shared helpers. Worth scanning other large classes for similar patterns.
+- **Copy-paste between `shared/` and `routes/`**: The `sanitizeUploadedFileName` duplication (fixed in run 2), the `resolveTilde` duplication (fixed this run), and the `errorMessage` duplication (fixed in runs 4+5) confirm that utilities sometimes get re-implemented locally instead of imported from `shared/`. Watch for this pattern when auditing routes and large classes.
+- **Private method duplication in large classes**: `manager.ts` had `private errorMessage()` duplicating shared logic (fixed in run 5). Large classes are prone to re-implementing utilities as private methods instead of importing shared helpers. Worth scanning other large classes for similar patterns.
 - **Route files accumulate boilerplate**: Routes that use Zod validation + try/catch tend to grow identical error-handling blocks. The `errorMessage` helper (added in run 4) now exists to prevent this from recurring.
-- **Large component files**: The top 5 web components are all 1100-2500 lines. These are feature-dense panes (jobs, automations, docs, feedback, create-agent). Extraction is valuable but moderate-risk since they may have tightly coupled state.
+- **Large component files**: The top web components were 1100-2500 lines. The componentizer job has been extracting these (jobs-pane in PR #546, automations-pane in PR #547). Monitor whether more are needed.
 - **Unused dependencies can linger**: `@formkit/auto-animate` was listed in `package.json` for an indeterminate period with zero imports. Worth periodically re-scanning with `pnpm why` or import grep.
+- **Three-way duplication across route files**: `resolveTilde` appeared in jobs.ts, templates.ts, AND system.ts (under the name `resolveTildePath`). When hunting duplicates, check all route files — not just the obvious pair.
 
 ## history
 
@@ -40,3 +37,4 @@
 - 2026-05-14: Removed unused `@formkit/auto-animate` dependency from `apps/web/package.json`. Zero imports existed anywhere in `apps/web/src/`. PR #535.
 - 2026-05-15: Extracted shared `errorMessage()` utility to `shared/lib/error-message.ts`. Replaced 12 inline `error instanceof Error ? error.message : String(error)` expressions across `routes/jobs.ts` (8) and `routes/templates.ts` (4). PR #538.
 - 2026-05-16: Consolidated duplicate `errorMessage` in `diagnostics.ts` (local arrow fn) and `agents/manager.ts` (private method) — replaced both with imports from `shared/lib/error-message.ts`. Updated 3 call sites in manager.ts and 1 in diagnostics.ts.
+- 2026-05-17: Extracted `resolveTilde` to `shared/lib/resolve-tilde.ts`. Replaced 3 identical implementations: `routes/jobs.ts`, `routes/templates.ts`, and `routes/system.ts` (was named `resolveTildePath`).

--- a/apps/server/src/routes/jobs.ts
+++ b/apps/server/src/routes/jobs.ts
@@ -1,12 +1,10 @@
-import os from "node:os";
-import path from "node:path";
-
 import type { FastifyInstance } from "fastify";
 import * as z from "zod/v4";
 
 import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
 import type { JobService } from "../jobs/service.js";
 import { errorMessage } from "../shared/lib/error-message.js";
+import { resolveTilde } from "../shared/lib/resolve-tilde.js";
 
 const directoryField = z
   .string()
@@ -43,12 +41,6 @@ const JobHistoryParamsSchema = z.object({
   directory: directoryField,
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
-
-function resolveTilde(value: string): string {
-  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
-  if (value === "~") return os.homedir();
-  return value;
-}
 
 type JobsRouteDeps = {
   jobService: JobService;

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import os from "node:os";
+import path from "node:path";
 import { spawn } from "node:child_process";
 import { readdir, stat, unlink, writeFile } from "node:fs/promises";
 
@@ -24,17 +24,12 @@ import {
   isValidSlackWebhookUrl,
 } from "../notifications/slack.js";
 import { runCommand } from "../shared/lib/run-command.js";
+import { resolveTilde } from "../shared/lib/resolve-tilde.js";
 import { shouldSkipAutomaticMacPathProbe } from "../shared/mac-path-privacy.js";
 
 const WORKTREE_LOCATION_KEY = "worktree_location";
 const INSTANCE_NAME_KEY = "instance_name";
 const VALID_WORKTREE_LOCATIONS = ["sibling", "nested"] as const;
-
-function resolveTildePath(raw: string): string {
-  if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
-  if (raw === "~") return os.homedir();
-  return raw;
-}
 
 type SystemRouteDeps = {
   pool: Pool;
@@ -146,7 +141,7 @@ export async function registerSystemRoutes(
         .code(400)
         .send({ error: "path query parameter is required." });
     }
-    const resolved = resolveTildePath(query.path.trim());
+    const resolved = resolveTilde(query.path.trim());
     if (!path.isAbsolute(resolved)) {
       return {
         exists: false,
@@ -204,7 +199,7 @@ export async function registerSystemRoutes(
         .send({ error: "prefix query parameter is required." });
     }
     const raw = query.prefix.trim();
-    const resolved = resolveTildePath(raw);
+    const resolved = resolveTilde(raw);
     if (!path.isAbsolute(resolved)) {
       return { completions: [] };
     }
@@ -253,7 +248,7 @@ export async function registerSystemRoutes(
         .send({ error: "cwd query parameter is required." });
     }
     try {
-      const cwd = resolveTildePath(query.cwd.trim());
+      const cwd = resolveTilde(query.cwd.trim());
       const result = await runCommand(
         "git",
         ["-C", cwd, "ls-remote", "--heads", "origin"],

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -1,4 +1,3 @@
-import os from "node:os";
 import path from "node:path";
 
 import type { FastifyInstance } from "fastify";
@@ -6,6 +5,7 @@ import * as z from "zod/v4";
 
 import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
 import { errorMessage } from "../shared/lib/error-message.js";
+import { resolveTilde } from "../shared/lib/resolve-tilde.js";
 import {
   type StartupFileUpload,
   MAX_STARTUP_FILE_COUNT,
@@ -58,12 +58,6 @@ const LaunchBodySchema = z.object({
   directory: directoryField.optional(),
   agentType: z.enum(CLI_AGENT_TYPES).optional(),
 });
-
-function resolveTilde(value: string): string {
-  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
-  if (value === "~") return os.homedir();
-  return value;
-}
 
 function classifyErrorCode(message: string): number {
   if (message.includes("not found")) return 404;

--- a/apps/server/src/shared/lib/resolve-tilde.ts
+++ b/apps/server/src/shared/lib/resolve-tilde.ts
@@ -1,0 +1,8 @@
+import os from "node:os";
+import path from "node:path";
+
+export function resolveTilde(value: string): string {
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  if (value === "~") return os.homedir();
+  return value;
+}


### PR DESCRIPTION
## Summary

- Extracted `resolveTilde` into `apps/server/src/shared/lib/resolve-tilde.ts` — a shared utility that expands `~` and `~/…` to `os.homedir()`.
- Removed three identical local implementations from `routes/jobs.ts`, `routes/templates.ts`, and `routes/system.ts` (where it was named `resolveTildePath`), replacing them with imports from the shared module.
- This continues the pattern of prior tech debt runs that consolidated `sanitizeUploadedFileName` (PR #534) and `errorMessage` (PRs #538, #541).

## Why this qualifies as tech debt

The same 4-line function was copy-pasted into three route files. Any future behavior change (e.g., handling `~user` syntax) would need to be applied in three places. Now there's a single source of truth.

## What's next

The next tech debt run will investigate the `as unknown as WebSocket` cast in `stream-manager.ts` to see if proper typing can eliminate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)