### PR TITLE
docs: add Jobs body schemas to API spec

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -1,6 +1,6 @@
 ---
 job: docs-audit
-updated_at: 2026-05-16
+updated_at: 2026-05-17
 ---
 
 # docs-audit — state handoff
@@ -9,11 +9,11 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`ad155782a47faf48c9e7bd0971f06d34241943a9` — HEAD at the start of the 2026-05-16 run.
+`128842f33d67d0502752b8c6c26cbbbb386753b8` — HEAD at the start of the 2026-05-17 run.
 
 ## next_focus
 
-**Audit `docs/03-api-spec.md` — Jobs POST/PATCH body schema.** The spec has the endpoint table but doesn't document the body fields for `POST /jobs` or `PATCH /jobs`. The `callable` and `singleton` fields added in PR #510 are not in the spec; neither are any of the other body fields (`name`, `directory`, `schedule`, `prompt`, `agentType`, `useWorktree`, `baseBranch`). Cross-check against `apps/server/src/routes/jobs.ts` for the actual Zod schemas and add body documentation matching the style of the Templates section added this run.
+**Audit `docs/10-operations-runbook.md` — missing bin scripts and diagnostics jq examples.** The backlog notes that the runbook does not mention `bin/preflight`, `bin/dispatch-stream`, or `bin/pack-release`. Check whether these scripts still exist and what they do, then add entries if warranted. Also re-check the diagnostics jq examples against the current API response shapes.
 
 ## backlog
 
@@ -27,8 +27,6 @@ Items noticed during prior passes but left for later runs. Pick the most relevan
 - **docs-pane "Worktrees" — failure surfaces (PR #409).** Worktree-create failures now mark the agent `stopped` with `last_error` and a blocked latest_event. The docs-pane Worktrees section didn't get the failure UX paragraph — add if the failure path becomes surprising.
 - **`docs/04-agent-lifecycle.md` — round-trip back from in-app docs.** If the in-app docs-pane gains a "Lifecycle" or "Architecture" section, link to this doc rather than re-explaining the state machine.
 - **`release-notes/AUTHORING.md` — migration manifest authoring is undocumented.** CRU-146 added `update-migrations/*.yaml` manifests with their own evaluator but AUTHORING.md does not cover them yet.
-- **`docs/10-operations-runbook.md` — handed-off concerns.** (a) diagnostics jq examples worth re-checking if response shape is rev'd; (b) runbook does not mention `bin/preflight` / `bin/dispatch-stream` / `bin/pack-release`.
-- **`docs/03-api-spec.md` — Template launch `agentType` override.** ✅ Addressed in the 2026-05-16 run — the new Templates section documents the `agentType` field on launch.
 - **`unknown` AgentStatus is dead code.** Worth a separate cleanup PR (not docs work).
 - **README install table — Cursor CLI install instructions are approximate.** The binary defaults to `agent`; the exact npm package / install path should be verified once the CLI is publicly documented by Anysphere.
 
@@ -68,6 +66,7 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **Create-agent nested controls hide behind the worktree checkbox.** The "Starting branch" picker and "Create a new branch" checkbox are only visible when worktree mode is checked. Docs describing these controls should mention the conditional visibility.
 - **CLAUDE.md project structure tree drifts as new feature directories are added.** Check `ls -d apps/server/src/*/` against the tree whenever new packages or route-adjacent dirs appear.
 - **API-spec agent-types enum lists go stale.** The Settings section listed only four types; `cursor` was missing. Always check `AGENT_TYPES` array when touching the agent-types endpoint docs.
+- **API-spec body schemas lag behind Zod schemas in route handlers.** When a new field is added to a route's Zod schema, the spec often doesn't get updated. Cross-check route handlers directly rather than relying on PRs to flag it.
 
 ## Notes for the next run
 
@@ -109,3 +108,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-05-13** (Agents — history/base-ref) — Closed the Agents history/base-ref next_focus. Fixed "Agent details" paragraph: replaced inaccurate "agent type" claim with correct description of repo name + base/working branch display for worktree agents vs. working directory for non-worktree agents. Added "Starting branch" picker to "Creating an agent" bullet list — was missing from the worktree controls description. Noted history type-filter UI bug (missing Cursor/Terminal) in backlog.
 - **2026-05-14** (CLAUDE.md structure tree + Reviewers resolution verification) — Verified next_focus (Reviewers resolution UI paragraph): Fixed/Ignored statuses, resolution reasons, and commit SHA all confirmed accurate against feedback-panel.tsx and MCP tool definitions. Fixed CLAUDE.md project structure tree: added 5 missing server/src directories (media, reviews, routes, server, templates), replaced stale `.dispatch/worktrees/` with actual `job-prompts/` and `job-state/` entries. Verified MCP tool lists (AGENT_TOOLS, JOB_TOOLS, PERSONA_TOOLS) and create-agent dialog fields — all in sync.
 - **2026-05-16** (API spec — Templates CRUD) — Added new Templates section to `docs/03-api-spec.md` covering all 6 endpoints (list, get, create, update, delete, launch) with body schemas and multipart launch documentation. Fixed Settings agent-types list (added missing `cursor`). Added `template.changed` SSE event to the events table.
+- **2026-05-17** (API spec — Jobs body schemas) — Closed the Jobs POST/PATCH body schema next_focus. Added `POST /jobs` body schema with all 16 fields from `AddJobBodySchema`, field-by-field descriptions, and `PATCH /jobs` note. Added `DELETE /jobs` and `POST /jobs/enable` / `POST /jobs/disable` bodies. Fixed `GET /jobs/history` params from stale `jobId, status, limit, offset` to actual `name, directory, limit`. Added new drift pattern for Zod schema/spec lag.

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -454,17 +454,75 @@ Returns `{ "state": <AssistedUpdateState> | null }`.
 
 ## Jobs
 
-| Method | Path            | Description                                                              |
-| ------ | --------------- | ------------------------------------------------------------------------ |
-| GET    | `/jobs`         | List all configured jobs                                                 |
-| POST   | `/jobs`         | Create a job                                                             |
-| PATCH  | `/jobs`         | Update a job configuration                                               |
-| DELETE | `/jobs`         | Delete a job configuration                                               |
-| POST   | `/jobs/enable`  | Enable a job (registers cron schedule)                                   |
-| POST   | `/jobs/disable` | Disable a job (removes cron schedule)                                    |
-| POST   | `/jobs/run`     | Manually trigger a job run                                               |
-| GET    | `/jobs/stats`   | Get job run statistics                                                   |
-| GET    | `/jobs/history` | Get job run history (filterable by `jobId`, `status`, `limit`, `offset`) |
+| Method | Path            | Description                                                      |
+| ------ | --------------- | ---------------------------------------------------------------- |
+| GET    | `/jobs`         | List all configured jobs                                         |
+| POST   | `/jobs`         | Create a job                                                     |
+| PATCH  | `/jobs`         | Update a job configuration                                       |
+| DELETE | `/jobs`         | Delete a job configuration                                       |
+| POST   | `/jobs/enable`  | Enable a job (registers cron schedule)                           |
+| POST   | `/jobs/disable` | Disable a job (removes cron schedule)                            |
+| POST   | `/jobs/run`     | Manually trigger a job run                                       |
+| GET    | `/jobs/stats`   | Get job run statistics                                           |
+| GET    | `/jobs/history` | Get job run history (filterable by `name`, `directory`, `limit`) |
+
+### `POST /jobs`
+
+```json
+{
+  "name": "docs-audit",
+  "directory": "~/dev/apps/dispatch",
+  "displayName": "Documentation Audit",
+  "prompt": "Audit the docs and fix drift.",
+  "schedule": "0 3 * * *",
+  "timeoutMs": 1800000,
+  "needsInputTimeoutMs": 600000,
+  "agentType": "claude",
+  "useWorktree": true,
+  "baseBranch": "main",
+  "branchName": "job/docs-audit-{{run_id}}",
+  "fullAccess": true,
+  "autoArchive": true,
+  "callable": false,
+  "singleton": true,
+  "defaultArgs": { "scope": "primary" },
+  "enabled": true
+}
+```
+
+`name` and `directory` are required (they form the composite key). `~` in `directory` is expanded to the user's home directory. All other fields are optional:
+
+- `displayName` — human-readable label shown in the UI.
+- `prompt` — the job prompt (nullable; when null, falls back to a prompt file in `.dispatch/job-prompts/`).
+- `schedule` — cron expression for automatic runs (nullable; null means manual-only).
+- `timeoutMs` — maximum run duration in milliseconds.
+- `needsInputTimeoutMs` — how long a run can stay in `needs_input` before timing out.
+- `agentType` — one of `claude`, `codex`, `cursor`, `opencode`.
+- `useWorktree` — run in a managed git worktree.
+- `baseBranch` — branch to fork worktrees from (nullable).
+- `branchName` — branch name for the worktree (nullable).
+- `fullAccess` — grant full filesystem access to the agent.
+- `autoArchive` — automatically archive the agent when the run completes.
+- `callable` — expose in the command palette for on-demand runs.
+- `singleton` — prevent concurrent runs of this job.
+- `defaultArgs` — key-value pairs passed to the job prompt as default arguments.
+- `enabled` — whether the cron schedule is active on creation.
+
+### `PATCH /jobs`
+
+Same schema as `POST /jobs`. `name` and `directory` are required to identify the job; all other fields are optional and only provided fields are updated.
+
+### `DELETE /jobs`
+
+```json
+{ "name": "docs-audit", "directory": "~/dev/apps/dispatch" }
+```
+
+### `POST /jobs/enable` / `POST /jobs/disable`
+
+```json
+{ "name": "docs-audit", "directory": "~/dev/apps/dispatch" }
+```
 
 ### `POST /jobs/run`
 
@@ -473,6 +531,10 @@ Returns `{ "state": <AssistedUpdateState> | null }`.
 ```
 
 `name` + `directory` together identify the job. `wait: true` blocks the response until the run reaches a terminal state; otherwise the response returns as soon as the run is queued. Manual runs are tagged with `triggerSource: "manual"` internally.
+
+### `GET /jobs/history`
+
+Query params: `name` (required), `directory` (required), `limit` (1–100, optional).
 
 ## Templates
 


### PR DESCRIPTION
## Summary

- Added `POST /jobs` body schema with all 16 fields from `AddJobBodySchema` and field-by-field descriptions
- Added `PATCH /jobs`, `DELETE /jobs`, and `POST /jobs/enable` / `POST /jobs/disable` body documentation
- Fixed `GET /jobs/history` query params from stale `jobId, status, limit, offset` to actual `name, directory, limit`
- Updated docs-audit state file with new next_focus (ops runbook bin scripts)

## What was audited

Closed the `next_focus` from the 2026-05-16 run: "Audit `docs/03-api-spec.md` — Jobs POST/PATCH body schema." Cross-checked `AddJobBodySchema`, `JobEnableDisableBodySchema`, `RunJobBodySchema`, and `JobHistoryParamsSchema` in `apps/server/src/routes/jobs.ts` against the spec.

## Deferred to next run

- Audit `docs/10-operations-runbook.md` for missing bin scripts (`preflight`, `dispatch-stream`, `pack-release`) and diagnostics jq examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)