### PR TITLE
test: add unit tests for format, active-hours, pins, error-message, and worktree-slug

### DIFF
--- a/apps/server/test/error-message.test.ts
+++ b/apps/server/test/error-message.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { errorMessage } from "../src/shared/lib/error-message.js";
+
+describe("errorMessage", () => {
+  it("extracts message from Error instances", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("extracts message from Error subclasses", () => {
+    expect(errorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(errorMessage("string error")).toBe("string error");
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+});

--- a/apps/server/test/worktree-slug.test.ts
+++ b/apps/server/test/worktree-slug.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  worktreePathSlug,
+  assertSafeRefName,
+  GitWorktreeError,
+} from "../src/shared/git/worktree.js";
+
+describe("worktreePathSlug", () => {
+  it("slugifies branch name for new branches", () => {
+    expect(
+      worktreePathSlug("feature/auth-flow", { createNewBranch: true })
+    ).toBe("feature-auth-flow");
+  });
+
+  it("appends hash for existing branches", () => {
+    const slug = worktreePathSlug("feature/auth-flow", {
+      createNewBranch: false,
+    });
+    expect(slug).toMatch(/^feature-auth-flow-[a-f0-9]{6}$/);
+  });
+
+  it("produces stable hashes for the same input", () => {
+    const a = worktreePathSlug("main", { createNewBranch: false });
+    const b = worktreePathSlug("main", { createNewBranch: false });
+    expect(a).toBe(b);
+  });
+
+  it("differentiates similar branch names via hash", () => {
+    const a = worktreePathSlug("feature/x", { createNewBranch: false });
+    const b = worktreePathSlug("feature-x", { createNewBranch: false });
+    expect(a).not.toBe(b);
+  });
+
+  it("lowercases the slug", () => {
+    expect(worktreePathSlug("Feature/Auth", { createNewBranch: true })).toBe(
+      "feature-auth"
+    );
+  });
+
+  it("throws for empty input after slugification", () => {
+    expect(() => worktreePathSlug("///", { createNewBranch: true })).toThrow(
+      GitWorktreeError
+    );
+  });
+});
+
+describe("assertSafeRefName", () => {
+  it("accepts valid ref names", () => {
+    expect(assertSafeRefName("main", "branch")).toBe("main");
+    expect(assertSafeRefName("feature/login", "branch")).toBe("feature/login");
+    expect(assertSafeRefName("release-2026.04", "branch")).toBe(
+      "release-2026.04"
+    );
+    expect(assertSafeRefName("my_branch", "branch")).toBe("my_branch");
+  });
+
+  it("trims whitespace", () => {
+    expect(assertSafeRefName("  main  ", "branch")).toBe("main");
+  });
+
+  it("rejects empty string", () => {
+    expect(() => assertSafeRefName("", "branch")).toThrow(GitWorktreeError);
+    expect(() => assertSafeRefName("   ", "branch")).toThrow(GitWorktreeError);
+  });
+
+  it("rejects shell metacharacters", () => {
+    expect(() => assertSafeRefName("branch;rm -rf", "branch")).toThrow(
+      GitWorktreeError
+    );
+    expect(() => assertSafeRefName("branch$(cmd)", "branch")).toThrow(
+      GitWorktreeError
+    );
+    expect(() => assertSafeRefName("branch`cmd`", "branch")).toThrow(
+      GitWorktreeError
+    );
+    expect(() => assertSafeRefName("branch name", "branch")).toThrow(
+      GitWorktreeError
+    );
+  });
+});

--- a/apps/web/src/lib/active-hours.test.ts
+++ b/apps/web/src/lib/active-hours.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildActiveHours, type ActiveHourEvent } from "./active-hours";
+
+describe("buildActiveHours", () => {
+  const now = new Date("2026-01-15T12:00:00Z");
+
+  it("returns 168 cells (7 days x 24 hours) for empty input", () => {
+    const cells = buildActiveHours([], now);
+    expect(cells).toHaveLength(168);
+    expect(cells.every((c) => c.count === 0 && c.avgPerWeek === 0)).toBe(true);
+  });
+
+  it("counts events in the correct day/hour bucket", () => {
+    const d = new Date(2026, 0, 14, 10, 0, 0);
+    const expectedDay = d.getDay();
+    const expectedHour = d.getHours();
+
+    const events: ActiveHourEvent[] = [
+      { created_at: d.toISOString() },
+      { created_at: d.toISOString() },
+    ];
+
+    const cells = buildActiveHours(events, now);
+    const cell = cells.find(
+      (c) => c.dayOfWeek === expectedDay && c.hour === expectedHour
+    );
+    expect(cell?.count).toBe(2);
+  });
+
+  it("skips events with invalid timestamps", () => {
+    const events: ActiveHourEvent[] = [
+      { created_at: "not-a-date" },
+      { created_at: new Date("2026-01-14T10:00:00Z").toISOString() },
+    ];
+
+    const cells = buildActiveHours(events, now);
+    const totalCount = cells.reduce((sum, c) => sum + c.count, 0);
+    expect(totalCount).toBe(1);
+  });
+
+  it("computes avgPerWeek based on the event span", () => {
+    const twoWeeksAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+    const events: ActiveHourEvent[] = [
+      { created_at: twoWeeksAgo.toISOString() },
+      { created_at: now.toISOString() },
+    ];
+
+    const cells = buildActiveHours(events, now);
+    const nonZero = cells.filter((c) => c.count > 0);
+    for (const cell of nonZero) {
+      expect(cell.avgPerWeek).toBeLessThanOrEqual(cell.count);
+    }
+  });
+
+  it("clamps span to at least 1 week", () => {
+    const events: ActiveHourEvent[] = [{ created_at: now.toISOString() }];
+
+    const cells = buildActiveHours(events, now);
+    const cell = cells.find((c) => c.count === 1);
+    expect(cell?.avgPerWeek).toBe(1);
+  });
+});

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import {
+  formatDuration,
+  formatTokenCount,
+  shortProjectName,
+  formatRelativeTime,
+} from "./format";
+
+describe("formatDuration", () => {
+  it("returns 0s for sub-second values", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(999)).toBe("0s");
+  });
+
+  it("returns seconds for < 60s", () => {
+    expect(formatDuration(1000)).toBe("1s");
+    expect(formatDuration(59_000)).toBe("59s");
+  });
+
+  it("returns minutes for < 60m", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+    expect(formatDuration(3_540_000)).toBe("59m");
+  });
+
+  it("returns hours with remainder minutes", () => {
+    expect(formatDuration(3_600_000)).toBe("1h");
+    expect(formatDuration(5_400_000)).toBe("1h 30m");
+  });
+
+  it("returns days with remainder hours", () => {
+    expect(formatDuration(86_400_000)).toBe("1d");
+    expect(formatDuration(90_000_000)).toBe("1d 1h");
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("returns raw number below 1K", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+
+  it("returns K notation for thousands", () => {
+    expect(formatTokenCount(1_000)).toBe("1.0K");
+    expect(formatTokenCount(1_500)).toBe("1.5K");
+    expect(formatTokenCount(999_999)).toBe("1000.0K");
+  });
+
+  it("returns M notation for millions", () => {
+    expect(formatTokenCount(1_000_000)).toBe("1.0M");
+    expect(formatTokenCount(2_500_000)).toBe("2.5M");
+  });
+});
+
+describe("shortProjectName", () => {
+  it("returns short paths unchanged", () => {
+    expect(shortProjectName("myproject")).toBe("myproject");
+    expect(shortProjectName("a/b")).toBe("a/b");
+  });
+
+  it("returns last two segments for long paths", () => {
+    expect(shortProjectName("/Users/brad/dev/dispatch")).toBe("dev/dispatch");
+  });
+
+  it("strips trailing slash before splitting", () => {
+    expect(shortProjectName("/Users/brad/dev/dispatch/")).toBe("dev/dispatch");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty string for invalid ISO", () => {
+    expect(formatRelativeTime("not-a-date")).toBe("");
+  });
+
+  it("returns 'just now' for recent timestamps", () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:30Z") });
+    expect(formatRelativeTime("2026-01-01T00:00:00Z")).toBe("just now");
+  });
+
+  it("returns minutes ago", () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:05:00Z") });
+    expect(formatRelativeTime("2026-01-01T00:00:00Z")).toBe("5m ago");
+  });
+
+  it("returns hours ago", () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T03:00:00Z") });
+    expect(formatRelativeTime("2026-01-01T00:00:00Z")).toBe("3h ago");
+  });
+
+  it("returns days ago", () => {
+    vi.useFakeTimers({ now: new Date("2026-01-05T00:00:00Z") });
+    expect(formatRelativeTime("2026-01-01T00:00:00Z")).toBe("4d ago");
+  });
+
+  it("returns formatted date for 30+ days", () => {
+    vi.useFakeTimers({ now: new Date(2026, 2, 1) });
+    const iso = new Date(2026, 0, 15).toISOString();
+    const result = formatRelativeTime(iso);
+    expect(result).toContain("Jan");
+  });
+});

--- a/apps/web/src/lib/pins.test.ts
+++ b/apps/web/src/lib/pins.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { splitPinValues } from "./pins";
+
+describe("splitPinValues", () => {
+  describe("filename type", () => {
+    it("splits comma-separated filenames", () => {
+      expect(splitPinValues("filename", "a.ts,b.ts")).toEqual(["a.ts", "b.ts"]);
+    });
+
+    it("splits newline-separated filenames", () => {
+      expect(splitPinValues("filename", "a.ts\nb.ts")).toEqual([
+        "a.ts",
+        "b.ts",
+      ]);
+    });
+
+    it("trims whitespace from parts", () => {
+      expect(splitPinValues("filename", " a.ts , b.ts ")).toEqual([
+        "a.ts",
+        "b.ts",
+      ]);
+    });
+
+    it("returns original value when splitting yields nothing", () => {
+      expect(splitPinValues("filename", "")).toEqual([""]);
+    });
+  });
+
+  describe("port type", () => {
+    it("splits space-separated ports", () => {
+      expect(splitPinValues("port", "3000 3001")).toEqual(["3000", "3001"]);
+    });
+
+    it("splits comma-separated ports", () => {
+      expect(splitPinValues("port", "3000,3001")).toEqual(["3000", "3001"]);
+    });
+
+    it("handles mixed delimiters", () => {
+      expect(splitPinValues("port", "3000, 3001 3002")).toEqual([
+        "3000",
+        "3001",
+        "3002",
+      ]);
+    });
+  });
+
+  describe("other types", () => {
+    it("returns value as single-element array for string type", () => {
+      expect(splitPinValues("string", "hello world")).toEqual(["hello world"]);
+    });
+
+    it("returns value as single-element array for url type", () => {
+      expect(splitPinValues("url", "http://example.com")).toEqual([
+        "http://example.com",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 5 previously untested pure-function modules covering formatting, data transformation, parsing, error handling, and path generation
- **format.ts**: `formatDuration`, `formatTokenCount`, `shortProjectName`, `formatRelativeTime` (17 tests)
- **active-hours.ts**: `buildActiveHours` heatmap grid calculation (5 tests)
- **pins.ts**: `splitPinValues` delimiter-based pin parsing (9 tests)
- **error-message.ts**: `errorMessage` extraction from unknown thrown values (4 tests)
- **worktree.ts**: `worktreePathSlug` and `assertSafeRefName` slug/validation logic (10 tests)

## Test plan
- [x] `pnpm run check` passes
- [x] `pnpm run test` passes (1062 server + 64 web tests)
- [x] `pnpm run test:e2e` passes (140 passed, 11 skipped)
- [x] `pnpm run finalize:web` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)