### PR TITLE
Add terminal focus hotkey

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -486,6 +486,8 @@ export function AgentsView({
     isMobile,
     sidebarAgentId,
     validatedSelectedAgentId,
+    canFocusTerminal: terminalMode === "tmux" && !!focusedAgentId,
+    focusTerminal,
     mediaOpen,
     setMediaOpen,
     leftPanelOpen,

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -305,6 +305,9 @@ const SECTIONS: SectionDef[] = [
               <Code>Mod+K</Code> — Open the command palette.
             </li>
             <li>
+              <Code>Mod+Shift+Space</Code> — Focus the terminal input.
+            </li>
+            <li>
               <Code>Mod+Shift+&gt;</Code> — Toggle the media sidebar.
             </li>
             <li>
@@ -330,6 +333,11 @@ const SECTIONS: SectionDef[] = [
           <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
             <li>
               <strong>New agent</strong> — opens the Create dialog.
+            </li>
+            <li>
+              <strong>Focus terminal input</strong> — same as{" "}
+              <Code>Mod+Shift+Space</Code>. Disabled when no tmux terminal is
+              attached.
             </li>
             <li>
               <strong>Toggle media sidebar</strong> — same as{" "}

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import {
   ArrowDown,
   ArrowUp,
+  BetweenHorizonalStart,
   PanelLeft,
   PanelLeftOpen,
   PanelRight,
@@ -25,6 +26,8 @@ type UseAgentHotkeysArgs = {
   isMobile: boolean;
   sidebarAgentId: string | null;
   validatedSelectedAgentId: string | null;
+  canFocusTerminal: boolean;
+  focusTerminal: () => void;
   mediaOpen: boolean;
   setMediaOpen: (open: boolean) => void;
   leftPanelOpen: boolean;
@@ -51,6 +54,8 @@ export function useAgentHotkeys({
   isMobile,
   sidebarAgentId,
   validatedSelectedAgentId,
+  canFocusTerminal,
+  focusTerminal,
   mediaOpen,
   setMediaOpen,
   leftPanelOpen,
@@ -63,6 +68,14 @@ export function useAgentHotkeys({
   const { data: templates = [] } = useTemplates();
 
   useHotkey("open-command-palette", () => setPaletteOpen((v) => !v));
+  useHotkey(
+    "focus-terminal-input",
+    () => {
+      if (!canFocusTerminal) return;
+      focusTerminal();
+    },
+    { enabled: !isMobile }
+  );
 
   useHotkey("toggle-media-sidebar", () => {
     if (!isMobile && !sidebarAgentId) return;
@@ -104,6 +117,18 @@ export function useAgentHotkeys({
         run: () => openCreateDialog(),
       },
       {
+        id: "focus-terminal-input",
+        title: "Focus terminal input",
+        keywords: ["terminal", "input", "cursor", "shell"],
+        hotkey: "focus-terminal-input",
+        icon: BetweenHorizonalStart,
+        disabled: !canFocusTerminal,
+        run: () => {
+          if (!canFocusTerminal) return;
+          focusTerminal();
+        },
+      },
+      {
         id: "toggle-media-sidebar",
         title: "Toggle media sidebar",
         keywords: ["pins", "media", "right"],
@@ -141,7 +166,9 @@ export function useAgentHotkeys({
       },
     ],
     [
+      canFocusTerminal,
       cycleAgent,
+      focusTerminal,
       handleSetLeftPanelOpen,
       isMobile,
       leftPanelOpen,

--- a/apps/web/src/lib/hotkeys/keymap.ts
+++ b/apps/web/src/lib/hotkeys/keymap.ts
@@ -24,6 +24,10 @@ export type HotkeyDef = {
 };
 
 export const HOTKEYS = {
+  "focus-terminal-input": {
+    combo: "mod+shift+space",
+    description: "Focus terminal input",
+  },
   "toggle-media-sidebar": {
     combo: "mod+shift+>",
     description: "Toggle media sidebar",

--- a/e2e/terminal-live.spec.ts
+++ b/e2e/terminal-live.spec.ts
@@ -351,6 +351,31 @@ test.describe("Terminal live connection", () => {
     });
   });
 
+  test("focuses terminal input with the global shortcut", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!IS_LIVE, "Requires --live agent runtime");
+
+    const agent = await createAndStartAgent(request, `e2e-agent-${Date.now()}`);
+    await loadApp(page);
+
+    const agentCard = page.getByTestId(`agent-card-${agent.id}`);
+    await agentCard.waitFor({ state: "visible", timeout: 5_000 });
+    await page.getByTestId(`agent-row-${agent.id}`).click();
+    await waitForTerminalConnected(page, agent.name, 5_000);
+
+    const pinsButton = page.getByRole("button", { name: "Pins" });
+    await pinsButton.focus();
+    await expect(pinsButton).toBeFocused();
+
+    await page.keyboard.press("Meta+Shift+Space");
+
+    await expect(page.locator(".xterm-helper-textarea")).toBeFocused({
+      timeout: 1_000,
+    });
+  });
+
   test("does not steal focus from another input on foreground", async ({
     page,
     request,


### PR DESCRIPTION
## Summary
- add a global `Cmd/Ctrl+Shift+Space` hotkey to focus the terminal input
- surface the action in the command palette and shortcut docs
- add live terminal coverage for the new shortcut in Playwright

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- manual live-stack validation on a tmux-backed terminal: `Cmd+Shift+Space` moved focus from `Pins` to xterm's `Terminal input` textarea