### PR TITLE
Fix terminal hotkey review follow-ups

### DIFF
--- a/apps/web/src/components/app/command-palette.tsx
+++ b/apps/web/src/components/app/command-palette.tsx
@@ -111,6 +111,7 @@ export function CommandPalette({
         <Dialog.Overlay className="fixed inset-0 z-[65] bg-black/60" />
         <Dialog.Content
           aria-label="Command palette"
+          data-hotkey-disable="true"
           onEscapeKeyDown={(e) => {
             if (pages.length > 0) {
               e.preventDefault();

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -74,7 +74,7 @@ export function useAgentHotkeys({
       if (!canFocusTerminal) return;
       focusTerminal();
     },
-    { enabled: !isMobile }
+    { enabled: !isMobile && canFocusTerminal }
   );
 
   useHotkey("toggle-media-sidebar", () => {

--- a/e2e/callable-jobs.spec.ts
+++ b/e2e/callable-jobs.spec.ts
@@ -172,4 +172,23 @@ test.describe("Callable templates — Cmd+K launch lifecycle", () => {
     await launchDialog.getByRole("button", { name: "Launch" }).click();
     await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });
   });
+
+  test("command palette disables global terminal-focus hotkey", async ({
+    page,
+  }) => {
+    await loadApp(page);
+
+    await page.keyboard.press(`${MOD_KEY}+k`);
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible({ timeout: 3_000 });
+
+    const input = palette.getByRole("combobox");
+    await expect(input).toBeFocused();
+
+    await page.keyboard.press(`${MOD_KEY}+Shift+Space`);
+
+    await expect(palette).toBeVisible();
+    await expect(input).toBeFocused();
+    await expect(page.locator(".xterm-helper-textarea")).not.toBeFocused();
+  });
 });


### PR DESCRIPTION
## Summary
- disable document-level global hotkeys inside the command palette modal
- only register the terminal-focus hotkey when a live tmux terminal can actually be focused
- add a regression test covering the command palette focus-trap case

## Background
PR #556 merged the initial terminal focus hotkey, but these reviewer-driven follow-up fixes were completed afterward and were not included in the merged branch.

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e`
- `bash scripts/e2e-isolated.sh e2e/callable-jobs.spec.ts --project=parallel`