### PR TITLE
Show repo name in collapsed agent sidebar items

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -8,7 +8,6 @@ import {
   ArrowDownToLine,
   Copy,
   Folder,
-  FolderGit2,
   FolderTree,
   GitBranch,
   Play,
@@ -191,6 +190,9 @@ export function AgentCard({
     }
   }, [agent.id, renamePromptPending]);
   const sidebarBaseBranch = agent.baseBranch ?? "main";
+  const collapsedRepoName = agent.gitContext
+    ? (agent.gitContext.repoRoot.split("/").pop() ?? null)
+    : (agent.cwd.split("/").pop() ?? null);
   const { diffStats, refresh: refreshDiffStats } = useAgentDiffStats(
     agent.id,
     isExpanded
@@ -423,6 +425,11 @@ export function AgentCard({
                 <span className="shrink-0">
                   {formatRelativeTime(agent.latestEvent.updatedAt)}
                 </span>
+                {collapsedRepoName ? (
+                  <span className="ml-auto shrink-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                    {collapsedRepoName}
+                  </span>
+                ) : null}
               </div>
               <div className="mt-0.5 leading-relaxed text-muted-foreground">
                 {agent.latestEvent.message}
@@ -444,12 +451,11 @@ export function AgentCard({
               <span className="shrink-0">
                 {formatRelativeTime(agent.latestEvent.updatedAt)}
               </span>
-              <span className="mx-1.5 shrink-0 text-muted-foreground/70">
-                •
-              </span>
-              <span className="min-w-0 truncate">
-                {agent.latestEvent.message}
-              </span>
+              {collapsedRepoName ? (
+                <span className="ml-auto shrink-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                  {collapsedRepoName}
+                </span>
+              ) : null}
             </div>
           )
         ) : null}
@@ -475,14 +481,6 @@ export function AgentCard({
                     </div>
                     {agent.gitContext?.isWorktree ? (
                       <>
-                        <CompactMetaRow
-                          label="Repo"
-                          icon={<FolderGit2 className="h-3.5 w-3.5" />}
-                          value={
-                            agent.gitContext.repoRoot.split("/").pop() ??
-                            agent.gitContext.repoRoot
-                          }
-                        />
                         <div className="flex items-start justify-between gap-3">
                           <span
                             className="shrink-0 text-muted-foreground/75"

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -426,7 +426,7 @@ export function AgentCard({
                   {formatRelativeTime(agent.latestEvent.updatedAt)}
                 </span>
                 {collapsedRepoName ? (
-                  <span className="ml-auto max-w-[40%] truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                  <span className="ml-auto min-w-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
                     {collapsedRepoName}
                   </span>
                 ) : null}
@@ -452,7 +452,7 @@ export function AgentCard({
                 {formatRelativeTime(agent.latestEvent.updatedAt)}
               </span>
               {collapsedRepoName ? (
-                <span className="ml-auto max-w-[40%] truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                <span className="ml-auto min-w-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
                   {collapsedRepoName}
                 </span>
               ) : null}

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -426,7 +426,7 @@ export function AgentCard({
                   {formatRelativeTime(agent.latestEvent.updatedAt)}
                 </span>
                 {collapsedRepoName ? (
-                  <span className="ml-auto shrink-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                  <span className="ml-auto max-w-[40%] truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
                     {collapsedRepoName}
                   </span>
                 ) : null}
@@ -452,7 +452,7 @@ export function AgentCard({
                 {formatRelativeTime(agent.latestEvent.updatedAt)}
               </span>
               {collapsedRepoName ? (
-                <span className="ml-auto shrink-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
+                <span className="ml-auto max-w-[40%] truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
                   {collapsedRepoName}
                 </span>
               ) : null}

--- a/e2e/agent-crud.spec.ts
+++ b/e2e/agent-crud.spec.ts
@@ -349,9 +349,9 @@ test.describe("Agent CRUD", () => {
       message: "refreshing sidebar state",
     });
 
-    await expect(
-      attachedCard.getByText("refreshing sidebar state")
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(attachedCard.getByText("Working")).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(peekCard.getByText("/tmp")).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Replace the truncated event description in collapsed agent cards with the repo/folder name, right-aligned in mono text
- Show the repo name in the same position when expanded (on the status/time row) for visual consistency
- Remove the now-redundant repo name row from the expanded info box (worktree agents)
- Event description is preserved in the expanded view on its own line

## Test plan
- [ ] Verify collapsed agent cards show repo name right-aligned after status + time
- [ ] Verify expanded cards show repo name in the same position, with full event message below
- [ ] Verify worktree agents no longer show duplicate repo name in the expanded info box
- [ ] Verify non-worktree agents show cwd folder name as fallback
- [ ] Verify terminal agents still skip the status line entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)