### PR TITLE
Add unit tests for template args, cron validation, and agent startup

### DIFF
--- a/apps/server/test/agent-startup.test.ts
+++ b/apps/server/test/agent-startup.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  parseOptionalBooleanField,
+  parseOptionalStringArrayField,
+  createStartupPins,
+  parseCreateAgentRequest,
+  MAX_STARTUP_FILE_COUNT,
+} from "../src/routes/agent-startup.js";
+
+describe("parseOptionalBooleanField", () => {
+  it("returns undefined for undefined input", () => {
+    expect(parseOptionalBooleanField(undefined, "f", false)).toBeUndefined();
+  });
+
+  it("passes through boolean values", () => {
+    expect(parseOptionalBooleanField(true, "f", false)).toBe(true);
+    expect(parseOptionalBooleanField(false, "f", false)).toBe(false);
+  });
+
+  it("coerces string booleans when allowed", () => {
+    expect(parseOptionalBooleanField("true", "f", true)).toBe(true);
+    expect(parseOptionalBooleanField("false", "f", true)).toBe(false);
+  });
+
+  it("rejects string booleans when coercion is disabled", () => {
+    expect(() => parseOptionalBooleanField("true", "myField", false)).toThrow(
+      "myField must be a boolean"
+    );
+  });
+
+  it("rejects non-boolean types", () => {
+    expect(() => parseOptionalBooleanField(42, "field", true)).toThrow(
+      "field must be a boolean"
+    );
+    expect(() => parseOptionalBooleanField("yes", "field", true)).toThrow(
+      "field must be a boolean"
+    );
+  });
+});
+
+describe("parseOptionalStringArrayField", () => {
+  it("returns undefined for undefined input", () => {
+    expect(
+      parseOptionalStringArrayField(undefined, "f", false)
+    ).toBeUndefined();
+  });
+
+  it("passes through string arrays", () => {
+    expect(parseOptionalStringArrayField(["a", "b"], "f", false)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("parses JSON string when coercion is allowed", () => {
+    expect(parseOptionalStringArrayField('["x","y"]', "f", true)).toEqual([
+      "x",
+      "y",
+    ]);
+  });
+
+  it("rejects non-string-array JSON", () => {
+    expect(() => parseOptionalStringArrayField("[1,2]", "f", true)).toThrow(
+      "must be an array of strings"
+    );
+  });
+
+  it("rejects plain string when coercion is disabled", () => {
+    expect(() => parseOptionalStringArrayField("hello", "f", false)).toThrow(
+      "must be an array of strings"
+    );
+  });
+
+  it("rejects mixed arrays", () => {
+    expect(() => parseOptionalStringArrayField(["a", 1], "f", false)).toThrow(
+      "must be an array of strings"
+    );
+  });
+});
+
+describe("createStartupPins", () => {
+  it("creates pins from URLs with hostname labels", () => {
+    const pins = createStartupPins(["https://github.com/foo/bar"]);
+    expect(pins).toEqual([
+      { label: "github.com", value: "https://github.com/foo/bar", type: "url" },
+    ]);
+  });
+
+  it("strips www. from hostnames", () => {
+    const pins = createStartupPins(["https://www.example.com/page"]);
+    expect(pins[0].label).toBe("example.com");
+  });
+
+  it("numbers duplicate hostnames", () => {
+    const pins = createStartupPins([
+      "https://github.com/a",
+      "https://github.com/b",
+      "https://github.com/c",
+    ]);
+    expect(pins.map((p) => p.label)).toEqual([
+      "github.com",
+      "github.com 2",
+      "github.com 3",
+    ]);
+  });
+
+  it("handles mixed hostnames", () => {
+    const pins = createStartupPins([
+      "https://github.com/a",
+      "https://linear.app/b",
+      "https://github.com/c",
+    ]);
+    expect(pins.map((p) => p.label)).toEqual([
+      "github.com",
+      "linear.app",
+      "github.com 2",
+    ]);
+  });
+
+  it("returns empty array for no URLs", () => {
+    expect(createStartupPins([])).toEqual([]);
+  });
+});
+
+describe("parseCreateAgentRequest", () => {
+  it("handles non-multipart request", async () => {
+    const result = await parseCreateAgentRequest({
+      body: { name: "test" },
+      isMultipart: () => false,
+      parts: async function* () {},
+    });
+    expect(result.body).toEqual({ name: "test" });
+    expect(result.startupFiles).toEqual([]);
+    expect(result.isMultipart).toBe(false);
+  });
+
+  it("handles non-multipart request with no body", async () => {
+    const result = await parseCreateAgentRequest({
+      body: undefined,
+      isMultipart: () => false,
+      parts: async function* () {},
+    });
+    expect(result.body).toEqual({});
+  });
+
+  it("parses multipart fields and files", async () => {
+    const result = await parseCreateAgentRequest({
+      body: undefined,
+      isMultipart: () => true,
+      parts: async function* () {
+        yield { type: "field", fieldname: "name", value: "my-agent" };
+        yield {
+          type: "file",
+          fieldname: "startupFiles",
+          filename: "notes.md",
+          toBuffer: async () => Buffer.from("# Notes"),
+        };
+      },
+    });
+    expect(result.isMultipart).toBe(true);
+    expect(result.body.name).toBe("my-agent");
+    expect(result.startupFiles).toHaveLength(1);
+    expect(result.startupFiles[0].fileName).toBe("notes.md");
+    expect(result.startupFiles[0].source).toBe("text");
+  });
+
+  it("classifies image files as user source", async () => {
+    const result = await parseCreateAgentRequest({
+      body: undefined,
+      isMultipart: () => true,
+      parts: async function* () {
+        yield {
+          type: "file",
+          fieldname: "startupFiles",
+          filename: "screenshot.png",
+          toBuffer: async () => Buffer.from("fake-png"),
+        };
+      },
+    });
+    expect(result.startupFiles[0].source).toBe("user");
+  });
+
+  it("rejects unexpected file fields", async () => {
+    await expect(
+      parseCreateAgentRequest({
+        body: undefined,
+        isMultipart: () => true,
+        parts: async function* () {
+          yield {
+            type: "file",
+            fieldname: "avatar",
+            filename: "pic.png",
+            toBuffer: async () => Buffer.from(""),
+          };
+        },
+      })
+    ).rejects.toThrow("Unexpected file field");
+  });
+
+  it("rejects unsupported file types", async () => {
+    await expect(
+      parseCreateAgentRequest({
+        body: undefined,
+        isMultipart: () => true,
+        parts: async function* () {
+          yield {
+            type: "file",
+            fieldname: "startupFiles",
+            filename: "script.exe",
+            toBuffer: async () => Buffer.from(""),
+          };
+        },
+      })
+    ).rejects.toThrow("Unsupported file type");
+  });
+
+  it("enforces maximum file count", async () => {
+    await expect(
+      parseCreateAgentRequest({
+        body: undefined,
+        isMultipart: () => true,
+        parts: async function* () {
+          for (let i = 0; i <= MAX_STARTUP_FILE_COUNT; i++) {
+            yield {
+              type: "file",
+              fieldname: "startupFiles",
+              filename: `file${i}.txt`,
+              toBuffer: async () => Buffer.from("content"),
+            };
+          }
+        },
+      })
+    ).rejects.toThrow(`A maximum of ${MAX_STARTUP_FILE_COUNT}`);
+  });
+});

--- a/apps/server/test/cron.test.ts
+++ b/apps/server/test/cron.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getNextRun,
+  validateCronExpression,
+  validateCronInterval,
+} from "../src/jobs/cron.js";
+
+describe("validateCronExpression", () => {
+  it("accepts standard five-field expressions", () => {
+    expect(validateCronExpression("0 * * * *")).toBe(true);
+    expect(validateCronExpression("*/5 * * * *")).toBe(true);
+    expect(validateCronExpression("0 9 * * 1-5")).toBe(true);
+  });
+
+  it("rejects empty or garbage strings", () => {
+    expect(validateCronExpression("")).toBe(false);
+    expect(validateCronExpression("not a cron")).toBe(false);
+    expect(validateCronExpression("* * * *")).toBe(false);
+  });
+});
+
+describe("validateCronInterval", () => {
+  it("allows hourly schedule", () => {
+    expect(validateCronInterval("0 * * * *")).toBeNull();
+  });
+
+  it("allows every-5-minutes schedule", () => {
+    expect(validateCronInterval("*/5 * * * *")).toBeNull();
+  });
+
+  it("rejects every-minute schedule as too frequent", () => {
+    const result = validateCronInterval("* * * * *");
+    expect(result).toContain("too frequently");
+    expect(result).toContain("60s");
+  });
+
+  it("rejects every-2-minutes as too frequent", () => {
+    const result = validateCronInterval("*/2 * * * *");
+    expect(result).toContain("too frequently");
+    expect(result).toContain("120s");
+  });
+
+  it("rejects every-4-minutes as too frequent", () => {
+    const result = validateCronInterval("*/4 * * * *");
+    expect(result).toContain("too frequently");
+    expect(result).toContain("240s");
+  });
+
+  it("returns error for invalid expression", () => {
+    expect(validateCronInterval("garbage")).toBe("Invalid cron expression.");
+  });
+});
+
+describe("getNextRun", () => {
+  it("returns a Date for valid expression", () => {
+    const next = getNextRun("0 * * * *");
+    expect(next).toBeInstanceOf(Date);
+    expect(next!.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null for invalid expression", () => {
+    expect(getNextRun("not valid")).toBeNull();
+  });
+});

--- a/apps/server/test/template-args.test.ts
+++ b/apps/server/test/template-args.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import { parseTemplateArgs, substituteArgs } from "../src/templates/store.js";
+
+describe("parseTemplateArgs", () => {
+  it("extracts a single argument", () => {
+    const args = parseTemplateArgs("Hello {{D:Name}}!");
+    expect(args).toEqual([
+      { name: "Name", key: "name", placeholder: "{{D:Name}}" },
+    ]);
+  });
+
+  it("extracts multiple distinct arguments", () => {
+    const args = parseTemplateArgs("{{D:Repo}} on {{D:Branch}}");
+    expect(args).toHaveLength(2);
+    expect(args[0].name).toBe("Repo");
+    expect(args[1].name).toBe("Branch");
+  });
+
+  it("deduplicates case-insensitively", () => {
+    const args = parseTemplateArgs("{{D:Name}} and {{D:name}} and {{D:NAME}}");
+    expect(args).toHaveLength(1);
+    expect(args[0].name).toBe("Name");
+  });
+
+  it("trims whitespace from argument names", () => {
+    const args = parseTemplateArgs("{{D:  Spaced  }}");
+    expect(args).toEqual([
+      { name: "Spaced", key: "spaced", placeholder: "{{D:  Spaced  }}" },
+    ]);
+  });
+
+  it("returns empty array when no arguments present", () => {
+    expect(parseTemplateArgs("no args here")).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseTemplateArgs("")).toEqual([]);
+  });
+
+  it("ignores incomplete patterns", () => {
+    expect(parseTemplateArgs("{{D:Unclosed")).toEqual([]);
+    expect(parseTemplateArgs("{{D:}}")).toEqual([]);
+  });
+
+  it("handles adjacent arguments", () => {
+    const args = parseTemplateArgs("{{D:A}}{{D:B}}");
+    expect(args).toHaveLength(2);
+    expect(args[0].name).toBe("A");
+    expect(args[1].name).toBe("B");
+  });
+});
+
+describe("substituteArgs", () => {
+  it("replaces a single argument", () => {
+    expect(substituteArgs("Hello {{D:Name}}!", { name: "World" })).toBe(
+      "Hello World!"
+    );
+  });
+
+  it("replaces multiple arguments", () => {
+    expect(
+      substituteArgs("{{D:Repo}} on {{D:Branch}}", {
+        repo: "dispatch",
+        branch: "main",
+      })
+    ).toBe("dispatch on main");
+  });
+
+  it("matches args by lowercased key first, then original name", () => {
+    expect(substituteArgs("{{D:Name}}", { name: "lower" })).toBe("lower");
+    expect(substituteArgs("{{D:Name}}", { Name: "original" })).toBe("original");
+  });
+
+  it("throws when required argument is missing", () => {
+    expect(() => substituteArgs("{{D:Missing}}", {})).toThrow(
+      "Missing required template arguments: Missing"
+    );
+  });
+
+  it("lists all missing arguments in the error", () => {
+    expect(() => substituteArgs("{{D:A}} {{D:B}}", {})).toThrow(
+      "Missing required template arguments: A, B"
+    );
+  });
+
+  it("replaces deduplicated arguments consistently", () => {
+    expect(substituteArgs("{{D:X}} and {{D:x}}", { x: "val" })).toBe(
+      "val and val"
+    );
+  });
+
+  it("returns prompt unchanged when there are no placeholders", () => {
+    expect(substituteArgs("plain text", {})).toBe("plain text");
+  });
+
+  it("handles empty replacement value", () => {
+    expect(substituteArgs("before{{D:Gap}}after", { gap: "" })).toBe(
+      "beforeafter"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add 49 unit tests covering previously untested pure-logic functions
- **template-args** (16 tests): `parseTemplateArgs` and `substituteArgs` — argument extraction, deduplication, case handling, substitution, and missing-arg errors
- **cron** (9 tests): `validateCronExpression`, `validateCronInterval`, and `getNextRun` — valid/invalid expressions, interval boundary enforcement
- **agent-startup** (24 tests): `parseOptionalBooleanField`, `parseOptionalStringArrayField`, `createStartupPins`, and `parseCreateAgentRequest` — type coercion, pin hostname labeling, multipart parsing, file type gating, file count limits

## Test plan

- [x] All 49 new tests pass locally
- [x] Full `pnpm run check` passes
- [x] Full `pnpm run test` passes (1175 tests)
- [x] Full `pnpm run test:e2e` passes (141 tests)
- [x] No product code changes — test-only additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)