### PR TITLE
docs: fix sidebar collapsed view and agent detail claims

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -1,6 +1,6 @@
 ---
 job: docs-audit
-updated_at: 2026-05-18
+updated_at: 2026-05-19
 ---
 
 # docs-audit — state handoff
@@ -9,11 +9,11 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`52cebe25f4d2d29664c378bfb309e9b570e7fb59` — HEAD at the start of the 2026-05-18 run.
+`68f80fa5c0bd96bbd15a4550acbdabd69623c861` — HEAD at the start of the 2026-05-19 run.
 
 ## next_focus
 
-**Audit docs-pane "Agents" section against `create-agent-dialog.tsx` for new form fields.** The drift pattern "The create-agent dialog accretes options silently" has been flagged for a while. Re-read `create-agent-dialog.tsx` and verify every form field appears in the "Creating an agent" bullet list in `docs-pane.tsx`. Also check the agent type list — the Cursor/Terminal entries were added in previous runs but new types could appear at any time.
+**Audit docs-pane "Repo Tools" section against `server.ts` built-in tool list and `repo-tools.ts`.** The AGENT_TOOLS set currently has 18 tools; verify the "Built-in tools" list in docs-pane matches. Also check whether the newly extracted `job-tools.ts` (PR #555) introduced any new tool names or changed tool availability per flow.
 
 ## backlog
 
@@ -29,6 +29,7 @@ Items noticed during prior passes but left for later runs. Pick the most relevan
 - **`release-notes/AUTHORING.md` — migration manifest authoring is undocumented.** CRU-146 added `update-migrations/*.yaml` manifests with their own evaluator but AUTHORING.md does not cover them yet.
 - **`unknown` AgentStatus is dead code.** Worth a separate cleanup PR (not docs work).
 - **README install table — Cursor CLI install instructions are approximate.** The binary defaults to `agent`; the exact npm package / install path should be verified once the CLI is publicly documented by Anysphere.
+- **`docs/18-subagent-orchestration.md` — add to README docs index when implemented.** Currently a design doc for a forward-looking feature. Add once the feature ships and has user-facing surface.
 
 ## drift_patterns
 
@@ -68,6 +69,7 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **API-spec agent-types enum lists go stale.** The Settings section listed only four types; `cursor` was missing. Always check `AGENT_TYPES` array when touching the agent-types endpoint docs.
 - **API-spec body schemas lag behind Zod schemas in route handlers.** When a new field is added to a route's Zod schema, the spec often doesn't get updated. Cross-check route handlers directly rather than relying on PRs to flag it.
 - **Assisted-update check descriptions drift from implementation.** The check names in `release-metadata.ts` are stable but the check logic in `release-checks.ts` evolves (e.g. `version_converged` reads `release.json`, not the health endpoint). Re-verify descriptions against the actual functions when touching this section.
+- **Collapsed sidebar card claims drift from agent-card.tsx layout changes.** PR #558 moved the repo name from the expanded detail card to the collapsed status line and removed the event message from collapsed view. Any future sidebar layout change needs a docs-pane cross-check.
 
 ## Notes for the next run
 
@@ -111,3 +113,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-05-16** (API spec — Templates CRUD) — Added new Templates section to `docs/03-api-spec.md` covering all 6 endpoints (list, get, create, update, delete, launch) with body schemas and multipart launch documentation. Fixed Settings agent-types list (added missing `cursor`). Added `template.changed` SSE event to the events table.
 - **2026-05-17** (API spec — Jobs body schemas) — Closed the Jobs POST/PATCH body schema next_focus. Added `POST /jobs` body schema with all 16 fields from `AddJobBodySchema`, field-by-field descriptions, and `PATCH /jobs` note. Added `DELETE /jobs` and `POST /jobs/enable` / `POST /jobs/disable` bodies. Fixed `GET /jobs/history` params from stale `jobId, status, limit, offset` to actual `name, directory, limit`. Added new drift pattern for Zod schema/spec lag.
 - **2026-05-18** (Ops runbook — bin scripts + check descriptions) — Closed the ops-runbook bin scripts next_focus. Added `bin/preflight` to Installation section. Added `bin/pack-release` mention to Release Pipeline. Added comprehensive Bin Scripts table (all 9 scripts). Fixed 3 inaccurate assisted-update check descriptions: `version_converged` reads `release.json` not health endpoint, `service_entrypoint` checks `package.json` not launchd plist, `expected_runtime_artifact` also checks `apps/web/dist/index.html`. Added drift pattern for check-description staleness.
+- **2026-05-19** (Agents — sidebar collapsed view + create-agent audit) — Diff-driven: PR #558 moved repo name from expanded detail card to collapsed sidebar status line and removed event message from collapsed view. Fixed "Status indicators" section (collapsed card now shows status + time + repo name, not event message). Fixed "Agent details" section (worktree agents no longer show repo name row — just base + working branch). Audited create-agent dialog fields (next_focus): all 6 form fields match docs, no drift found.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -158,9 +158,10 @@ const SECTIONS: SectionDef[] = [
             CLI agents in the sidebar show a color-coded status from their
             latest event: green for <strong>working</strong>, red for{" "}
             <strong>blocked</strong>, yellow for <strong>waiting</strong>, and
-            blue for <strong>done</strong>. The sidebar also shows the event
-            message and how long ago it was reported. Terminal agents have no
-            CLI to emit events, so their card stays neutral.
+            blue for <strong>done</strong>. Collapsed cards show the status,
+            elapsed time, and the repo or directory name; expand the card to see
+            the full event message. Terminal agents have no CLI to emit events,
+            so their card stays neutral.
           </P>
         </Section>
 
@@ -210,14 +211,14 @@ const SECTIONS: SectionDef[] = [
           <H3>Agent details</H3>
           <P>
             Expand an agent card to see its metadata. Worktree agents show the
-            repo name, base branch, and working branch (indented below the
-            base); non-worktree agents show the working directory and current
-            branch. A <strong>diff-stats badge</strong> in the top-right
-            summarizes uncommitted changes against the base branch. CLI agents
-            also show whether they're running in full access or sandboxed mode,
-            plus a feedback panel and persona launcher; terminal agents skip
-            those since they have no CLI. Persona agents show their role and
-            link to their parent agent.
+            base branch and working branch (indented below the base);
+            non-worktree agents show the working directory and current branch. A{" "}
+            <strong>diff-stats badge</strong> in the top-right summarizes
+            uncommitted changes against the base branch. CLI agents also show
+            whether they're running in full access or sandboxed mode, plus a
+            feedback panel and persona launcher; terminal agents skip those
+            since they have no CLI. Persona agents show their role and link to
+            their parent agent.
           </P>
         </Section>
 


### PR DESCRIPTION
## Summary

- **Status indicators** section: updated to reflect that collapsed sidebar cards now show status + elapsed time + repo/directory name (PR #558 removed the event message from collapsed view)
- **Agent details** section: removed "repo name" from worktree card description — the Repo row was moved to the collapsed status line in PR #558
- Audited create-agent dialog fields against docs (next_focus) — all 6 fields match, no drift
- Updated `docs-audit.md` state file for next run

## Deferred to next run

- Audit docs-pane "Repo Tools" section against `server.ts` built-in tool list
- `docs/18-subagent-orchestration.md` — add to README docs index when feature ships

## Test plan

- [x] `pnpm run format:write` — clean
- [x] lint-staged hooks pass (prettier, eslint, tsc)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)