### PR TITLE
Improve template variable templating

### DIFF
--- a/apps/server/src/templates/arg-parser.ts
+++ b/apps/server/src/templates/arg-parser.ts
@@ -1,0 +1,79 @@
+export type TemplatePromptArg = {
+  name: string;
+  key: string;
+  placeholder: string;
+  required: boolean;
+  multiline: boolean;
+};
+
+export const TEMPLATE_ARG_PATTERN = /\{\{D:([^}]+)\}\}/g;
+
+function parseArgSpec(
+  rawSpec: string
+): Omit<TemplatePromptArg, "placeholder"> | null {
+  const [rawName, ...rawModifiers] = rawSpec.split("|");
+  const name = rawName?.trim() ?? "";
+  if (!name) return null;
+
+  const modifiers = new Set(
+    rawModifiers.map((modifier) => modifier.trim().toLowerCase())
+  );
+
+  return {
+    name,
+    key: name.toLowerCase(),
+    required: modifiers.has("required"),
+    multiline: modifiers.has("multiline") || modifiers.has("textarea"),
+  };
+}
+
+export function parseTemplateArgs(prompt: string): TemplatePromptArg[] {
+  const regex = new RegExp(
+    TEMPLATE_ARG_PATTERN.source,
+    TEMPLATE_ARG_PATTERN.flags
+  );
+  const seen = new Map<string, number>();
+  const args: TemplatePromptArg[] = [];
+  let match;
+  while ((match = regex.exec(prompt)) !== null) {
+    const parsed = parseArgSpec(match[1]);
+    if (!parsed) continue;
+    const existingIndex = seen.get(parsed.key);
+    if (existingIndex === undefined) {
+      seen.set(parsed.key, args.length);
+      args.push({ ...parsed, placeholder: match[0] });
+      continue;
+    }
+
+    const existing = args[existingIndex];
+    args[existingIndex] = {
+      ...existing,
+      required: existing.required || parsed.required,
+      multiline: existing.multiline || parsed.multiline,
+    };
+  }
+  return args;
+}
+
+export function substituteArgs(
+  prompt: string,
+  args: Record<string, string>
+): string {
+  const parsed = parseTemplateArgs(prompt);
+  const missing = parsed.filter(
+    (a) => a.required && !(a.key in args) && !(a.name in args)
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required template arguments: ${missing.map((a) => a.name).join(", ")}`
+    );
+  }
+  return prompt.replace(
+    new RegExp(TEMPLATE_ARG_PATTERN.source, TEMPLATE_ARG_PATTERN.flags),
+    (_match, rawSpec: string) => {
+      const parsedArg = parseArgSpec(rawSpec);
+      if (!parsedArg) return "";
+      return args[parsedArg.key] ?? args[parsedArg.name] ?? "";
+    }
+  );
+}

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -4,6 +4,14 @@ import path from "node:path";
 import type { Pool } from "pg";
 
 import type { JobAgentType } from "../jobs/store.js";
+import {
+  parseTemplateArgs,
+  substituteArgs,
+  type TemplatePromptArg as ParsedArg,
+} from "./arg-parser.js";
+
+export { parseTemplateArgs, substituteArgs } from "./arg-parser.js";
+export type { TemplatePromptArg as ParsedArg } from "./arg-parser.js";
 
 export type TemplateRecord = {
   id: string;
@@ -35,52 +43,6 @@ export type TemplateConfigUpdate = {
   callable?: boolean;
   allowMedia?: boolean;
 };
-
-export type ParsedArg = {
-  name: string;
-  key: string;
-  placeholder: string;
-};
-
-// Mirrored in apps/web/src/hooks/use-templates.ts for client-side preview
-const ARG_PATTERN = /\{\{D:([^}]+)\}\}/g;
-
-export function parseTemplateArgs(prompt: string): ParsedArg[] {
-  const regex = new RegExp(ARG_PATTERN.source, ARG_PATTERN.flags);
-  const seen = new Set<string>();
-  const args: ParsedArg[] = [];
-  let match;
-  while ((match = regex.exec(prompt)) !== null) {
-    const name = match[1].trim();
-    const key = name.toLowerCase();
-    if (!seen.has(key)) {
-      seen.add(key);
-      args.push({ name, key, placeholder: match[0] });
-    }
-  }
-  return args;
-}
-
-export function substituteArgs(
-  prompt: string,
-  args: Record<string, string>
-): string {
-  const parsed = parseTemplateArgs(prompt);
-  const missing = parsed.filter((a) => !(a.key in args) && !(a.name in args));
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required template arguments: ${missing.map((a) => a.name).join(", ")}`
-    );
-  }
-  return prompt.replace(
-    new RegExp(ARG_PATTERN.source, ARG_PATTERN.flags),
-    (_match, rawName: string) => {
-      const name = rawName.trim();
-      const key = name.toLowerCase();
-      return args[key] ?? args[name] ?? "";
-    }
-  );
-}
 
 export class TemplateStore {
   constructor(private readonly pool: Pool) {}

--- a/apps/server/test/template-args.test.ts
+++ b/apps/server/test/template-args.test.ts
@@ -6,7 +6,13 @@ describe("parseTemplateArgs", () => {
   it("extracts a single argument", () => {
     const args = parseTemplateArgs("Hello {{D:Name}}!");
     expect(args).toEqual([
-      { name: "Name", key: "name", placeholder: "{{D:Name}}" },
+      {
+        name: "Name",
+        key: "name",
+        placeholder: "{{D:Name}}",
+        required: false,
+        multiline: false,
+      },
     ]);
   });
 
@@ -26,7 +32,51 @@ describe("parseTemplateArgs", () => {
   it("trims whitespace from argument names", () => {
     const args = parseTemplateArgs("{{D:  Spaced  }}");
     expect(args).toEqual([
-      { name: "Spaced", key: "spaced", placeholder: "{{D:  Spaced  }}" },
+      {
+        name: "Spaced",
+        key: "spaced",
+        placeholder: "{{D:  Spaced  }}",
+        required: false,
+        multiline: false,
+      },
+    ]);
+  });
+
+  it("parses required and multiline modifiers", () => {
+    expect(parseTemplateArgs("{{D:Summary|required|multiline}}")).toEqual([
+      {
+        name: "Summary",
+        key: "summary",
+        placeholder: "{{D:Summary|required|multiline}}",
+        required: true,
+        multiline: true,
+      },
+    ]);
+  });
+
+  it("supports textarea as an alias for multiline", () => {
+    expect(parseTemplateArgs("{{D:Notes|textarea}}")).toEqual([
+      {
+        name: "Notes",
+        key: "notes",
+        placeholder: "{{D:Notes|textarea}}",
+        required: false,
+        multiline: true,
+      },
+    ]);
+  });
+
+  it("merges repeated args to the strongest modifiers", () => {
+    expect(
+      parseTemplateArgs("{{D:Body}} {{D:body|required}} {{D:BODY|multiline}}")
+    ).toEqual([
+      {
+        name: "Body",
+        key: "body",
+        placeholder: "{{D:Body}}",
+        required: true,
+        multiline: true,
+      },
     ]);
   });
 
@@ -72,16 +122,20 @@ describe("substituteArgs", () => {
     expect(substituteArgs("{{D:Name}}", { Name: "original" })).toBe("original");
   });
 
-  it("throws when required argument is missing", () => {
-    expect(() => substituteArgs("{{D:Missing}}", {})).toThrow(
+  it("throws when a required argument is missing", () => {
+    expect(() => substituteArgs("{{D:Missing|required}}", {})).toThrow(
       "Missing required template arguments: Missing"
     );
   });
 
   it("lists all missing arguments in the error", () => {
-    expect(() => substituteArgs("{{D:A}} {{D:B}}", {})).toThrow(
-      "Missing required template arguments: A, B"
-    );
+    expect(() =>
+      substituteArgs("{{D:A|required}} {{D:B|required}}", {})
+    ).toThrow("Missing required template arguments: A, B");
+  });
+
+  it("treats arguments as optional by default", () => {
+    expect(substituteArgs("{{D:Optional}}", {})).toBe("");
   });
 
   it("replaces deduplicated arguments consistently", () => {
@@ -98,5 +152,13 @@ describe("substituteArgs", () => {
     expect(substituteArgs("before{{D:Gap}}after", { gap: "" })).toBe(
       "beforeafter"
     );
+  });
+
+  it("substitutes arguments with modifiers", () => {
+    expect(
+      substituteArgs("{{D:Prompt|required|multiline}}", {
+        prompt: "Line 1\nLine 2",
+      })
+    ).toBe("Line 1\nLine 2");
   });
 });

--- a/apps/server/test/templates/service.test.ts
+++ b/apps/server/test/templates/service.test.ts
@@ -89,4 +89,31 @@ describe("TemplateService.launchTemplate", () => {
       })
     );
   });
+
+  it("allows optional template arguments to be omitted", async () => {
+    const createAgent = vi.fn(async () => buildAgent());
+    const service = new TemplateService(
+      {} as never,
+      { createAgent } as never,
+      { info: vi.fn() } as never
+    );
+
+    vi.spyOn(service.store, "getTemplate").mockResolvedValue(
+      buildTemplate({
+        prompt: "Review {{D:Target}} with {{D:Notes|multiline}}",
+      })
+    );
+
+    await service.launchTemplate({
+      templateId: "tmpl_123",
+      agentType: "codex",
+      args: {},
+    });
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialPrompt: "Review  with ",
+      })
+    );
+  });
 });

--- a/apps/web/src/components/app/automations-create-dialog.tsx
+++ b/apps/web/src/components/app/automations-create-dialog.tsx
@@ -113,7 +113,11 @@ function CreateTemplateDialogContent({
           <code className="rounded bg-white/[0.08] px-1 text-xs">
             {"{{D:Arg Name}}"}
           </code>{" "}
-          in the prompt for runtime arguments.
+          in the prompt for optional runtime arguments, with modifiers like{" "}
+          <code className="rounded bg-white/[0.08] px-1 text-xs">
+            {"{{D:Arg Name|required|multiline}}"}
+          </code>
+          .
         </DialogDescription>
       </DialogHeader>
 

--- a/apps/web/src/components/app/automations-form-fields.tsx
+++ b/apps/web/src/components/app/automations-form-fields.tsx
@@ -11,6 +11,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import type { AgentType } from "@/lib/agent-types";
 import {
   AGENT_TYPE_LABELS,
@@ -344,12 +345,12 @@ export function TemplateConfigFields({
 
       <div className="space-y-1">
         <label className="text-sm text-muted-foreground">Prompt</label>
-        <textarea
+        <Textarea
           value={prompt}
           onChange={(e) => onPromptChange(e.target.value)}
           placeholder="Describe what the agent should do..."
           className={cn(
-            "flex min-h-[120px] w-full resize-y rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+            "min-h-[120px] resize-y",
             "ring-offset-background placeholder:text-muted-foreground",
             "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           )}
@@ -363,6 +364,8 @@ export function TemplateConfigFields({
                 className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
               >
                 {a.name}
+                {a.required ? " *" : ""}
+                {a.multiline ? " (multiline)" : ""}
               </span>
             ))}
           </div>

--- a/apps/web/src/components/app/automations-launch-dialog.tsx
+++ b/apps/web/src/components/app/automations-launch-dialog.tsx
@@ -4,6 +4,7 @@ import {
   type DragEvent,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -44,6 +45,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Popover,
   PopoverContent,
@@ -70,15 +72,33 @@ function ArgInput({
   value: string;
   onChange: (value: string) => void;
 }): JSX.Element {
+  const inputId = useId();
+
   return (
     <div className="space-y-2">
-      <label className="text-sm text-muted-foreground">{arg.name}</label>
-      <Input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={`Enter ${arg.name}`}
-        className="h-8 text-sm"
-      />
+      <label htmlFor={inputId} className="text-sm text-muted-foreground">
+        {arg.name}
+        {arg.required ? (
+          <span className="ml-1 text-status-blocked">*</span>
+        ) : null}
+      </label>
+      {arg.multiline ? (
+        <Textarea
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={`Enter ${arg.name}`}
+          className="min-h-24 resize-y text-sm"
+        />
+      ) : (
+        <Input
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={`Enter ${arg.name}`}
+          className="h-8 text-sm"
+        />
+      )}
     </div>
   );
 }
@@ -464,7 +484,8 @@ function LaunchTemplateDialogContent({
   }, [addStartupLink]);
 
   const allArgsFilled =
-    args.length === 0 || args.every((a) => argValues[a.key]?.trim());
+    args.length === 0 ||
+    args.every((a) => !a.required || argValues[a.key]?.trim());
 
   const handleLaunch = useCallback(() => {
     const launchArgs = args.length > 0 ? argValues : undefined;

--- a/apps/web/src/components/app/automations-template-detail.tsx
+++ b/apps/web/src/components/app/automations-template-detail.tsx
@@ -182,13 +182,15 @@ function TemplateDetail({
         {savedArgs.length > 0 ? (
           <div className="mt-3 rounded-md border border-border/60 bg-muted/15 px-3 py-2 text-xs text-muted-foreground">
             <span className="font-medium text-foreground">
-              Required arguments:
+              Launch arguments:
             </span>{" "}
             {savedArgs.map((a, i) => (
               <span key={a.key}>
                 {i > 0 ? ", " : ""}
                 <span className="rounded bg-primary/10 px-1.5 py-0.5 text-primary">
                   {a.name}
+                  {a.required ? " *" : ""}
+                  {a.multiline ? " (multiline)" : ""}
                 </span>
               </span>
             ))}

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -734,7 +734,8 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             <li>
               <strong>Prompt</strong> — instructions sent as the agent's first
               message. Supports <Code>{"{{D:Arg Name}}"}</Code> placeholders for
-              runtime arguments (see below).
+              optional runtime arguments, plus filter-style modifiers like{" "}
+              <Code>{"{{D:Arg Name|required|multiline}}"}</Code> (see below).
             </li>
             <li>
               <strong>Agent type</strong> — <Code>claude</Code>,{" "}
@@ -765,16 +766,30 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <H3>Runtime arguments</H3>
           <P>
             Templates support <Code>{"{{D:Arg Name}}"}</Code> placeholders in
-            their prompt. At launch time, each placeholder becomes a required
-            input field. Argument values are also pinned to the spawned agent's
-            sidebar for reference.
+            their prompt. Arguments are optional by default. Add{" "}
+            <Code>|required</Code> to enforce input at launch, and{" "}
+            <Code>|multiline</Code> for a textarea-style field. Argument values
+            are also pinned to the spawned agent's sidebar for reference.
+          </P>
+          <P>
+            If you leave an optional argument blank, Dispatch removes that
+            placeholder and leaves the surrounding text as-is. Write prompts so
+            they still read naturally when optional values are omitted.
           </P>
           <P>
             For example, a prompt like{" "}
             <Code>
-              {"Review the PR at {{D:PR URL}} focusing on {{D:Review Focus}}"}
+              {
+                "Review the PR at {{D:PR URL|required}} focusing on {{D:Review Focus|multiline}}"
+              }
             </Code>{" "}
-            creates two input fields: "PR URL" and "Review Focus".
+            creates one required single-line field ("PR URL") and one optional
+            multiline field ("Review Focus").
+          </P>
+          <P>
+            If the same argument appears more than once, modifiers are merged.
+            That means the argument is treated as required or multiline if any
+            occurrence uses that modifier.
           </P>
         </Section>
 

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { glassInset } from "@/lib/glass";
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      data-slot="textarea"
+      ref={ref}
+      className={cn(
+        "flex min-h-20 w-full rounded-md px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        glassInset,
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -4,6 +4,12 @@ import { api } from "@/lib/api";
 import type { CliAgentType } from "@/lib/agent-types";
 import type { Agent } from "@/components/app/types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
+import {
+  parseTemplateArgs as parseSharedTemplateArgs,
+  type TemplatePromptArg as TemplateArg,
+} from "../../../server/src/templates/arg-parser";
+
+export type { TemplateArg };
 
 export type Template = {
   id: string;
@@ -20,12 +26,6 @@ export type Template = {
   allowMedia: boolean;
   createdAt: string;
   updatedAt: string;
-};
-
-export type TemplateArg = {
-  name: string;
-  key: string;
-  placeholder: string;
 };
 
 export type AddTemplateConfig = {
@@ -46,22 +46,8 @@ export type LaunchResult = {
   agent: Agent;
 };
 
-// Mirrored in apps/server/src/templates/store.ts — keep in sync
-const ARG_REGEX = /\{\{D:([^}]+)\}\}/g;
-
 export function parseTemplateArgs(prompt: string): TemplateArg[] {
-  const seen = new Set<string>();
-  const args: TemplateArg[] = [];
-  let match;
-  while ((match = ARG_REGEX.exec(prompt)) !== null) {
-    const name = match[1].trim();
-    const key = name.toLowerCase();
-    if (!seen.has(key)) {
-      seen.add(key);
-      args.push({ name, key, placeholder: match[0] });
-    }
-  }
-  return args;
+  return parseSharedTemplateArgs(prompt);
 }
 
 export function useTemplates(enabled = true) {

--- a/docs/17-jobs.md
+++ b/docs/17-jobs.md
@@ -4,7 +4,7 @@
 
 The Automations system has two layers:
 
-- **Templates** — reusable agent launch configurations. A template captures a prompt, agent type, directory, worktree settings, and an optional set of runtime arguments (`{{D:Arg Name}}` syntax). Templates can be launched from the Cmd+K command palette or the Automations UI to spin up a normal agent session with no supervision.
+- **Templates** — reusable agent launch configurations. A template captures a prompt, agent type, directory, worktree settings, and an optional set of runtime arguments (`{{D:Arg Name}}` with optional filter-style modifiers like `|required|multiline`). Templates can be launched from the Cmd+K command palette or the Automations UI to spin up a normal agent session with no supervision.
 
 - **Jobs** — automation on top of a template. A job references a backing template and adds scheduling (cron), timeouts, singleton enforcement, structured reporting via MCP, auto-archive, and notifications. Each job invocation is a **run**.
 
@@ -31,15 +31,19 @@ Templates are uniquely identified by (`directory`, `name`). Each template has:
 
 ### Runtime Arguments
 
-Templates support `{{D:Arg Name}}` placeholders in their prompt. At launch time, each placeholder becomes a required input field. Arguments are also pinned to the spawned agent's sidebar for reference.
+Templates support `{{D:Arg Name}}` placeholders in their prompt. Arguments are optional by default. Add `|required` to make one mandatory at launch, and `|multiline` (or `|textarea`) to render a textarea instead of a single-line input. Arguments are also pinned to the spawned agent's sidebar for reference.
+
+If you leave an optional argument blank, Dispatch removes that placeholder and leaves the surrounding text as-is. Write prompts so they still read naturally when optional values are omitted.
 
 Example prompt:
 
 ```
-Review the PR at {{D:PR URL}} and focus on {{D:Review Focus}}.
+Review the PR at {{D:PR URL|required}} and focus on {{D:Review Focus|multiline}}.
 ```
 
-This creates two input fields: "PR URL" and "Review Focus".
+This creates a required single-line field ("PR URL") and an optional multiline field ("Review Focus").
+
+If the same argument appears more than once, modifiers are merged. An argument is treated as `required` or `multiline` if any occurrence uses that modifier.
 
 ### Command Palette (Cmd+K)
 

--- a/e2e/callable-jobs.spec.ts
+++ b/e2e/callable-jobs.spec.ts
@@ -173,6 +173,59 @@ test.describe("Callable templates — Cmd+K launch lifecycle", () => {
     await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });
   });
 
+  test("launch dialog renders required and multiline template args", async ({
+    page,
+  }) => {
+    const multilineTemplateName = `e2e-callable-multiline-${Date.now()}`;
+    const createRes = await page.request.post("/api/v1/templates", {
+      headers: HEADERS,
+      data: {
+        name: multilineTemplateName,
+        directory: templateDir,
+        prompt:
+          "Summarize {{D:Summary|required|multiline}} for {{D:Audience}}.",
+        callable: true,
+        allowMedia: false,
+        agentType: "claude",
+        useWorktree: false,
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = (await createRes.json()) as { id: string };
+    templateId = created.id;
+
+    await loadApp(page);
+    await page.keyboard.press(`${MOD_KEY}+k`);
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible({ timeout: 3_000 });
+    await palette
+      .getByRole("combobox")
+      .pressSequentially(multilineTemplateName, { delay: 30 });
+    await expect(palette.getByText(multilineTemplateName)).toBeVisible();
+
+    await page.keyboard.press("Enter");
+    const launchDialog = page.getByRole("dialog", {
+      name: multilineTemplateName,
+    });
+    await expect(launchDialog).toBeVisible({ timeout: 3_000 });
+
+    const launchButton = launchDialog.getByRole("button", { name: "Launch" });
+    await expect(launchButton).toBeDisabled();
+
+    const summaryField = launchDialog.getByLabel("Summary", { exact: false });
+    await expect(summaryField).toHaveAttribute("placeholder", "Enter Summary");
+    await expect(summaryField).toHaveAttribute("data-slot", "textarea");
+
+    const audienceField = launchDialog.getByLabel("Audience", { exact: false });
+    await expect(audienceField).not.toHaveAttribute("data-slot", "textarea");
+
+    await summaryField.fill("Line 1\nLine 2");
+    await expect(launchButton).toBeEnabled();
+    await launchButton.click();
+
+    await expect(page).toHaveURL(/\/agents\/agt_/, { timeout: 30_000 });
+  });
+
   test("command palette disables global terminal-focus hotkey", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- add filter-style template arg modifiers so args are optional by default and can opt into `required` and `multiline`
- render multiline launch variables with a shared textarea primitive and update template authoring/detail docs
- extract template arg parsing into a shared module used by both server and web, plus add test coverage for the new behavior

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test
- pnpm run test:e2e