### PR TITLE
Show repo favicon/logo in agent sidebar

### DIFF
--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -55,6 +55,7 @@ export type AgentGitContext = {
   worktreePath: string;
   worktreeName: string;
   isWorktree: boolean;
+  repoIconPath?: string | null;
 };
 
 export type WorktreeCleanupMode = "auto" | "keep" | "force";

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -288,6 +288,12 @@ export async function registerAgentRoutes(
       return reply.code(400).send({ error: "Invalid icon path." });
     }
 
+    try {
+      await access(realIconPath, constants.R_OK);
+    } catch {
+      return reply.code(404).send({ error: "Icon file not readable." });
+    }
+
     const contentType =
       ext === ".svg"
         ? "image/svg+xml"

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -268,7 +268,8 @@ export async function registerAgentRoutes(
       return reply.code(400).send({ error: "Invalid icon extension." });
     }
 
-    const baseDir = agent.worktreePath ?? agent.cwd;
+    const baseDir =
+      agent.gitContext?.worktreePath ?? agent.worktreePath ?? agent.cwd;
     const iconAbsPath = path.join(baseDir, iconRelPath);
 
     let realIconPath: string;

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1,3 +1,5 @@
+import { createReadStream } from "node:fs";
+import { access, constants, realpath } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -244,6 +246,63 @@ export async function registerAgentRoutes(
       return reply.code(404).send({ error: "Agent not found." });
     }
     return { agent: deps.withStreamFlag(agent) };
+  });
+
+  app.get("/api/v1/agents/:id/repo-icon", async (request, reply) => {
+    const ALLOWED_ICON_EXTENSIONS = new Set([".svg", ".png", ".ico"]);
+
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const iconRelPath = agent.gitContext?.repoIconPath;
+    if (!iconRelPath) {
+      return reply.code(404).send({ error: "No repo icon." });
+    }
+
+    const ext = path.extname(iconRelPath).toLowerCase();
+    if (!ALLOWED_ICON_EXTENSIONS.has(ext)) {
+      return reply.code(400).send({ error: "Invalid icon extension." });
+    }
+
+    const baseDir = agent.worktreePath ?? agent.cwd;
+    const iconAbsPath = path.join(baseDir, iconRelPath);
+
+    let realIconPath: string;
+    let realBaseDir: string;
+    try {
+      realBaseDir = await realpath(baseDir);
+      realIconPath = await realpath(iconAbsPath);
+    } catch {
+      return reply.code(404).send({ error: "Icon file not found." });
+    }
+
+    if (
+      !realIconPath.startsWith(realBaseDir + path.sep) &&
+      realIconPath !== realBaseDir
+    ) {
+      return reply.code(400).send({ error: "Invalid icon path." });
+    }
+
+    const contentType =
+      ext === ".svg"
+        ? "image/svg+xml"
+        : ext === ".png"
+          ? "image/png"
+          : "image/x-icon";
+
+    return reply
+      .type(contentType)
+      .header("Cache-Control", "private, max-age=30")
+      .header(
+        "Content-Security-Policy",
+        "default-src 'none'; style-src 'unsafe-inline'"
+      )
+      .header("X-Content-Type-Options", "nosniff")
+      .send(createReadStream(realIconPath));
   });
 
   app.patch("/api/v1/agents/:id/review-agent-type", async (request, reply) => {

--- a/apps/server/src/shared/git/git-context.ts
+++ b/apps/server/src/shared/git/git-context.ts
@@ -1,98 +1,10 @@
-import { readdir } from "node:fs/promises";
 import path from "node:path";
 
 import type { AgentGitContext } from "../../agents/types.js";
 import { runCommand } from "../lib/run-command.js";
+import { detectRepoIcon } from "../repo-icon.js";
 
 const DEFAULT_PROBE_TIMEOUT_MS = 800;
-
-const ICON_EXTENSIONS = new Set([".svg", ".png", ".ico"]);
-
-const ICON_NAME_PATTERNS = [
-  /^favicon\b/i,
-  /^icon\b/i,
-  /\bicon\b/i,
-  /^brand-icon\b/i,
-  /^logo\b/i,
-  /\blogo\b/i,
-  /^brand\b/i,
-];
-
-const EXT_PRIORITY: Record<string, number> = {
-  ".svg": 0,
-  ".png": 1,
-  ".ico": 2,
-};
-const MAX_SCAN_DEPTH = 4;
-const MAX_DIR_ENTRIES = 200;
-
-function iconScore(relPath: string): number {
-  const name = path.basename(relPath, path.extname(relPath)).toLowerCase();
-  const ext = path.extname(relPath).toLowerCase();
-  const extRank = EXT_PRIORITY[ext] ?? 3;
-
-  let nameRank = ICON_NAME_PATTERNS.length;
-  for (let i = 0; i < ICON_NAME_PATTERNS.length; i++) {
-    if (ICON_NAME_PATTERNS[i].test(name)) {
-      nameRank = i;
-      break;
-    }
-  }
-
-  const depth = relPath.split(path.sep).length - 1;
-  return nameRank * 100 + extRank * 10 + depth;
-}
-
-async function scanForIcons(
-  base: string,
-  rel: string,
-  depth: number,
-  results: string[]
-): Promise<void> {
-  if (depth > MAX_SCAN_DEPTH) return;
-  let entries;
-  try {
-    entries = await readdir(path.join(base, rel), { withFileTypes: true });
-  } catch {
-    return;
-  }
-  if (entries.length > MAX_DIR_ENTRIES) return;
-
-  for (const entry of entries) {
-    const childRel = rel ? `${rel}/${entry.name}` : entry.name;
-    if (
-      entry.name.startsWith(".") ||
-      entry.name === "node_modules" ||
-      entry.name === "dist" ||
-      entry.name === "build"
-    )
-      continue;
-
-    if (
-      entry.isFile() &&
-      ICON_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
-    ) {
-      const nameLower = entry.name.toLowerCase();
-      if (
-        ICON_NAME_PATTERNS.some((p) =>
-          p.test(path.basename(nameLower, path.extname(nameLower)))
-        )
-      ) {
-        results.push(childRel);
-      }
-    } else if (entry.isDirectory()) {
-      await scanForIcons(base, childRel, depth + 1, results);
-    }
-  }
-}
-
-async function detectRepoIcon(dir: string): Promise<string | null> {
-  const candidates: string[] = [];
-  await scanForIcons(dir, "", 0, candidates);
-  if (candidates.length === 0) return null;
-  candidates.sort((a, b) => iconScore(a) - iconScore(b));
-  return candidates[0];
-}
 
 export type ProbeOptions = { timeoutMs?: number };
 

--- a/apps/server/src/shared/git/git-context.ts
+++ b/apps/server/src/shared/git/git-context.ts
@@ -1,9 +1,98 @@
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 
 import type { AgentGitContext } from "../../agents/types.js";
 import { runCommand } from "../lib/run-command.js";
 
 const DEFAULT_PROBE_TIMEOUT_MS = 800;
+
+const ICON_EXTENSIONS = new Set([".svg", ".png", ".ico"]);
+
+const ICON_NAME_PATTERNS = [
+  /^favicon\b/i,
+  /^icon\b/i,
+  /\bicon\b/i,
+  /^brand-icon\b/i,
+  /^logo\b/i,
+  /\blogo\b/i,
+  /^brand\b/i,
+];
+
+const EXT_PRIORITY: Record<string, number> = {
+  ".svg": 0,
+  ".png": 1,
+  ".ico": 2,
+};
+const MAX_SCAN_DEPTH = 4;
+const MAX_DIR_ENTRIES = 200;
+
+function iconScore(relPath: string): number {
+  const name = path.basename(relPath, path.extname(relPath)).toLowerCase();
+  const ext = path.extname(relPath).toLowerCase();
+  const extRank = EXT_PRIORITY[ext] ?? 3;
+
+  let nameRank = ICON_NAME_PATTERNS.length;
+  for (let i = 0; i < ICON_NAME_PATTERNS.length; i++) {
+    if (ICON_NAME_PATTERNS[i].test(name)) {
+      nameRank = i;
+      break;
+    }
+  }
+
+  const depth = relPath.split(path.sep).length - 1;
+  return nameRank * 100 + extRank * 10 + depth;
+}
+
+async function scanForIcons(
+  base: string,
+  rel: string,
+  depth: number,
+  results: string[]
+): Promise<void> {
+  if (depth > MAX_SCAN_DEPTH) return;
+  let entries;
+  try {
+    entries = await readdir(path.join(base, rel), { withFileTypes: true });
+  } catch {
+    return;
+  }
+  if (entries.length > MAX_DIR_ENTRIES) return;
+
+  for (const entry of entries) {
+    const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+    if (
+      entry.name.startsWith(".") ||
+      entry.name === "node_modules" ||
+      entry.name === "dist" ||
+      entry.name === "build"
+    )
+      continue;
+
+    if (
+      entry.isFile() &&
+      ICON_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    ) {
+      const nameLower = entry.name.toLowerCase();
+      if (
+        ICON_NAME_PATTERNS.some((p) =>
+          p.test(path.basename(nameLower, path.extname(nameLower)))
+        )
+      ) {
+        results.push(childRel);
+      }
+    } else if (entry.isDirectory()) {
+      await scanForIcons(base, childRel, depth + 1, results);
+    }
+  }
+}
+
+async function detectRepoIcon(dir: string): Promise<string | null> {
+  const candidates: string[] = [];
+  await scanForIcons(dir, "", 0, candidates);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => iconScore(a) - iconScore(b));
+  return candidates[0];
+}
 
 export type ProbeOptions = { timeoutMs?: number };
 
@@ -127,6 +216,8 @@ export async function probeGitContext(
       ).stdout;
     }
 
+    const repoIconPath = await detectRepoIcon(checkoutRoot);
+
     return {
       status: "ok",
       value: {
@@ -135,6 +226,7 @@ export async function probeGitContext(
         worktreePath: checkoutRoot,
         worktreeName: path.basename(checkoutRoot),
         isWorktree: checkoutRoot !== repoRoot,
+        repoIconPath,
       },
     };
   } catch {
@@ -157,6 +249,7 @@ export async function buildGitContextForWorktree(input: {
   try {
     const repoRoot = await resolveRepoRoot(worktreePath, opts);
     const normalizedWorktreePath = normalizePath(worktreePath);
+    const repoIconPath = await detectRepoIcon(normalizedWorktreePath);
     return {
       status: "ok",
       value: {
@@ -165,6 +258,7 @@ export async function buildGitContextForWorktree(input: {
         worktreePath: normalizedWorktreePath,
         worktreeName: path.basename(normalizedWorktreePath),
         isWorktree: normalizedWorktreePath !== repoRoot,
+        repoIconPath,
       },
     };
   } catch {

--- a/apps/server/src/shared/repo-icon.ts
+++ b/apps/server/src/shared/repo-icon.ts
@@ -54,7 +54,7 @@ async function scanForIcons(
   if (entries.length > MAX_DIR_ENTRIES) return;
 
   for (const entry of entries) {
-    const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+    const childRel = rel ? path.join(rel, entry.name) : entry.name;
     if (
       entry.name.startsWith(".") ||
       entry.name === "node_modules" ||

--- a/apps/server/src/shared/repo-icon.ts
+++ b/apps/server/src/shared/repo-icon.ts
@@ -1,0 +1,90 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ICON_EXTENSIONS = new Set([".svg", ".png", ".ico"]);
+
+const ICON_NAME_PATTERNS = [
+  /^favicon\b/i,
+  /^icon\b/i,
+  /\bicon\b/i,
+  /^brand-icon\b/i,
+  /^logo\b/i,
+  /\blogo\b/i,
+  /^brand\b/i,
+];
+
+const EXT_PRIORITY: Record<string, number> = {
+  ".svg": 0,
+  ".png": 1,
+  ".ico": 2,
+};
+const MAX_SCAN_DEPTH = 4;
+const MAX_DIR_ENTRIES = 200;
+
+function iconScore(relPath: string): number {
+  const name = path.basename(relPath, path.extname(relPath)).toLowerCase();
+  const ext = path.extname(relPath).toLowerCase();
+  const extRank = EXT_PRIORITY[ext] ?? 3;
+
+  let nameRank = ICON_NAME_PATTERNS.length;
+  for (let i = 0; i < ICON_NAME_PATTERNS.length; i++) {
+    if (ICON_NAME_PATTERNS[i].test(name)) {
+      nameRank = i;
+      break;
+    }
+  }
+
+  const depth = relPath.split(path.sep).length - 1;
+  return nameRank * 100 + extRank * 10 + depth;
+}
+
+async function scanForIcons(
+  base: string,
+  rel: string,
+  depth: number,
+  results: string[]
+): Promise<void> {
+  if (depth > MAX_SCAN_DEPTH) return;
+  let entries;
+  try {
+    entries = await readdir(path.join(base, rel), { withFileTypes: true });
+  } catch {
+    return;
+  }
+  if (entries.length > MAX_DIR_ENTRIES) return;
+
+  for (const entry of entries) {
+    const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+    if (
+      entry.name.startsWith(".") ||
+      entry.name === "node_modules" ||
+      entry.name === "dist" ||
+      entry.name === "build"
+    )
+      continue;
+
+    if (
+      entry.isFile() &&
+      ICON_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    ) {
+      const nameLower = entry.name.toLowerCase();
+      if (
+        ICON_NAME_PATTERNS.some((p) =>
+          p.test(path.basename(nameLower, path.extname(nameLower)))
+        )
+      ) {
+        results.push(childRel);
+      }
+    } else if (entry.isDirectory()) {
+      await scanForIcons(base, childRel, depth + 1, results);
+    }
+  }
+}
+
+export async function detectRepoIcon(dir: string): Promise<string | null> {
+  const candidates: string[] = [];
+  await scanForIcons(dir, "", 0, candidates);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => iconScore(a) - iconScore(b));
+  return candidates[0];
+}

--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -48,6 +48,35 @@ import { type AgentType } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
 import { cn } from "@/lib/utils";
 
+function RepoLabel({
+  agentId,
+  repoIconPath,
+  name,
+}: {
+  agentId: string;
+  repoIconPath?: string | null;
+  name: string;
+}) {
+  const [iconError, setIconError] = React.useState(false);
+  const showIcon = !!repoIconPath && !iconError;
+
+  return (
+    <span className="ml-auto flex min-w-0 items-center gap-1 pl-2">
+      {showIcon ? (
+        <img
+          src={`/api/v1/agents/${agentId}/repo-icon`}
+          alt=""
+          className="h-3.5 w-3.5 shrink-0 object-contain"
+          onError={() => setIconError(true)}
+        />
+      ) : null}
+      <span className="min-w-0 truncate font-mono text-[10px] text-muted-foreground/60">
+        {name}
+      </span>
+    </span>
+  );
+}
+
 function hasDefaultSessionName(agent: Agent): boolean {
   if (agent.persona) return false;
   if (agent.type === "terminal") return false;
@@ -426,9 +455,11 @@ export function AgentCard({
                   {formatRelativeTime(agent.latestEvent.updatedAt)}
                 </span>
                 {collapsedRepoName ? (
-                  <span className="ml-auto min-w-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
-                    {collapsedRepoName}
-                  </span>
+                  <RepoLabel
+                    agentId={agent.id}
+                    repoIconPath={agent.gitContext?.repoIconPath}
+                    name={collapsedRepoName}
+                  />
                 ) : null}
               </div>
               <div className="mt-0.5 leading-relaxed text-muted-foreground">
@@ -452,9 +483,11 @@ export function AgentCard({
                 {formatRelativeTime(agent.latestEvent.updatedAt)}
               </span>
               {collapsedRepoName ? (
-                <span className="ml-auto min-w-0 truncate pl-2 font-mono text-[10px] text-muted-foreground/60">
-                  {collapsedRepoName}
-                </span>
+                <RepoLabel
+                  agentId={agent.id}
+                  repoIconPath={agent.gitContext?.repoIconPath}
+                  name={collapsedRepoName}
+                />
               ) : null}
             </div>
           )

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -47,6 +47,7 @@ export type Agent = {
     worktreePath: string;
     worktreeName: string;
     isWorktree: boolean;
+    repoIconPath?: string | null;
   } | null;
   persona?: string | null;
   parentAgentId?: string | null;


### PR DESCRIPTION
## Summary
- Automatically detect favicon/logo/icon image files in a project repo and display them inline next to the repo name in the agent sidebar
- New `GET /api/v1/agents/:id/repo-icon` endpoint serves the detected icon from the agent's working directory (worktree-aware, so live edits are reflected)
- Flexible filesystem scan (depth 4, scored by name pattern + extension + depth) finds icons in common locations — tested against this repo where it discovers `apps/web/public/brand-icon.svg`
- Security hardened: `realpath()` containment check, extension allowlist, readability preflight, CSP `default-src 'none'` + `X-Content-Type-Options: nosniff` for SVG XSS prevention
- Icon detection extracted into dedicated `shared/repo-icon.ts` module to keep git-context probing focused

## Changed files
- `apps/server/src/shared/repo-icon.ts` — New module: icon detection scanner
- `apps/server/src/shared/git/git-context.ts` — Wire icon detection into git context probing
- `apps/server/src/agents/types.ts` — Add `repoIconPath` to `AgentGitContext`
- `apps/server/src/routes/agents.ts` — New repo-icon serving endpoint
- `apps/web/src/components/app/agent-card.tsx` — `RepoLabel` component with inline icon
- `apps/web/src/components/app/types.ts` — Frontend type update

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Web finalization passes (`pnpm run finalize:web`)
- [x] All 1175 unit tests pass (`pnpm run test`)
- [x] All 141 E2E tests pass (`pnpm run test:e2e`)
- [x] Playwright validation — icon renders correctly in sidebar
- [x] Backend security review: approved (realpath traversal, SVG XSS)
- [x] Architecture review: approved (module separation, base dir resolution)
- [x] Infra review: approved (readability preflight, cross-platform path.join)

🤖 Generated with [Claude Code](https://claude.com/claude-code)