### PR TITLE
Add unit tests for repo-icon, resolve-tilde, http-helpers, and static-theme

### DIFF
--- a/apps/server/test/http-helpers.test.ts
+++ b/apps/server/test/http-helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { getBearerToken } from "../src/server/http-helpers.js";
+
+describe("getBearerToken", () => {
+  it("extracts token from a valid Bearer header", () => {
+    expect(
+      getBearerToken({ headers: { authorization: "Bearer abc123" } })
+    ).toBe("abc123");
+  });
+
+  it("returns null when no authorization header exists", () => {
+    expect(getBearerToken({ headers: {} })).toBeNull();
+  });
+
+  it("returns null when authorization is not a string", () => {
+    expect(getBearerToken({ headers: { authorization: 42 } })).toBeNull();
+  });
+
+  it("returns null for non-Bearer schemes", () => {
+    expect(
+      getBearerToken({ headers: { authorization: "Basic dXNlcjpwYXNz" } })
+    ).toBeNull();
+  });
+
+  it("handles tokens with special characters", () => {
+    expect(
+      getBearerToken({
+        headers: { authorization: "Bearer eyJ0eXAiOi.eyJzdWIiOi.sig" },
+      })
+    ).toBe("eyJ0eXAiOi.eyJzdWIiOi.sig");
+  });
+
+  it("returns empty string for 'Bearer ' with no token", () => {
+    expect(getBearerToken({ headers: { authorization: "Bearer " } })).toBe("");
+  });
+
+  it("is case-sensitive for the Bearer prefix", () => {
+    expect(
+      getBearerToken({ headers: { authorization: "bearer abc123" } })
+    ).toBeNull();
+  });
+});

--- a/apps/server/test/repo-icon.test.ts
+++ b/apps/server/test/repo-icon.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectRepoIcon } from "../src/shared/repo-icon.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "repo-icon-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function touch(relPath: string): Promise<void> {
+  const full = path.join(tmpDir, relPath);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, "");
+}
+
+describe("detectRepoIcon", () => {
+  it("returns null for an empty directory", async () => {
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("returns null when no icon-like files exist", async () => {
+    await touch("README.md");
+    await touch("src/index.ts");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("finds a root-level favicon.svg", async () => {
+    await touch("favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe("favicon.svg");
+  });
+
+  it("finds a favicon.png in a subdirectory", async () => {
+    await touch("public/favicon.png");
+    expect(await detectRepoIcon(tmpDir)).toBe(
+      path.join("public", "favicon.png")
+    );
+  });
+
+  it("prefers svg over png", async () => {
+    await touch("icon.svg");
+    await touch("icon.png");
+    expect(await detectRepoIcon(tmpDir)).toBe("icon.svg");
+  });
+
+  it("prefers png over ico", async () => {
+    await touch("favicon.png");
+    await touch("favicon.ico");
+    expect(await detectRepoIcon(tmpDir)).toBe("favicon.png");
+  });
+
+  it("prefers favicon over logo", async () => {
+    await touch("logo.svg");
+    await touch("favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe("favicon.svg");
+  });
+
+  it("prefers shallower files over deeper ones", async () => {
+    await touch("favicon.svg");
+    await touch("assets/deep/favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe("favicon.svg");
+  });
+
+  it("finds logo files", async () => {
+    await touch("assets/logo.png");
+    expect(await detectRepoIcon(tmpDir)).toBe(path.join("assets", "logo.png"));
+  });
+
+  it("finds brand-icon files", async () => {
+    await touch("brand-icon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe("brand-icon.svg");
+  });
+
+  it("is case-insensitive for icon names", async () => {
+    await touch("FAVICON.SVG");
+    expect(await detectRepoIcon(tmpDir)).toBe("FAVICON.SVG");
+  });
+
+  it("skips node_modules", async () => {
+    await touch("node_modules/pkg/favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("skips dotfiles and dot directories", async () => {
+    await touch(".hidden/favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("skips dist and build directories", async () => {
+    await touch("dist/favicon.svg");
+    await touch("build/logo.png");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("does not match non-icon image files", async () => {
+    await touch("screenshot.png");
+    await touch("photo.svg");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("returns null for a missing directory", async () => {
+    expect(await detectRepoIcon(path.join(tmpDir, "nonexistent"))).toBeNull();
+  });
+
+  it("handles icon pattern in the middle of a name", async () => {
+    await touch("my-icon-file.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe("my-icon-file.svg");
+  });
+
+  it("handles logo pattern in the middle of a name", async () => {
+    await touch("project-logo-dark.png");
+    expect(await detectRepoIcon(tmpDir)).toBe("project-logo-dark.png");
+  });
+
+  it("ignores icons deeper than MAX_SCAN_DEPTH (4)", async () => {
+    await touch("a/b/c/d/e/favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBeNull();
+  });
+
+  it("finds icons at exactly MAX_SCAN_DEPTH", async () => {
+    await touch("a/b/c/d/favicon.svg");
+    expect(await detectRepoIcon(tmpDir)).toBe(
+      path.join("a", "b", "c", "d", "favicon.svg")
+    );
+  });
+});

--- a/apps/server/test/resolve-tilde.test.ts
+++ b/apps/server/test/resolve-tilde.test.ts
@@ -1,0 +1,42 @@
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveTilde } from "../src/shared/lib/resolve-tilde.js";
+
+describe("resolveTilde", () => {
+  const home = os.homedir();
+
+  it("expands ~/path to the home directory", () => {
+    expect(resolveTilde("~/Documents")).toBe(path.join(home, "Documents"));
+  });
+
+  it("expands ~/nested/path", () => {
+    expect(resolveTilde("~/a/b/c")).toBe(path.join(home, "a", "b", "c"));
+  });
+
+  it("expands bare ~ to the home directory", () => {
+    expect(resolveTilde("~")).toBe(home);
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    expect(resolveTilde("/usr/local/bin")).toBe("/usr/local/bin");
+  });
+
+  it("leaves relative paths unchanged", () => {
+    expect(resolveTilde("relative/path")).toBe("relative/path");
+  });
+
+  it("does not expand ~user-style paths", () => {
+    expect(resolveTilde("~otheruser/dir")).toBe("~otheruser/dir");
+  });
+
+  it("leaves empty string unchanged", () => {
+    expect(resolveTilde("")).toBe("");
+  });
+
+  it("handles ~/. (trailing dot)", () => {
+    expect(resolveTilde("~/.config")).toBe(path.join(home, ".config"));
+  });
+});

--- a/apps/server/test/static-theme.test.ts
+++ b/apps/server/test/static-theme.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createStaticThemeRuntime,
+  VALID_ICON_COLORS,
+} from "../src/server/static-theme.js";
+
+function fakeAsset(routePath: string, content: string) {
+  return {
+    routePath,
+    contentType: "text/html",
+    base64: Buffer.from(content).toString("base64"),
+  };
+}
+
+describe("createStaticThemeRuntime", () => {
+  it("defaults to teal icon color", () => {
+    const runtime = createStaticThemeRuntime([]);
+    expect(runtime.getCachedIconColor()).toBe("teal");
+  });
+
+  it("returns unmodified HTML when color is teal", () => {
+    const html = '<link rel="icon" href="/icons/teal/favicon.svg">';
+    const runtime = createStaticThemeRuntime([fakeAsset("/index.html", html)]);
+    expect(runtime.getCachedIndexHtml()).toBe(html);
+  });
+
+  it("rewrites icon paths for non-teal colors", () => {
+    const html = '<link rel="icon" href="/icons/teal/favicon.svg">';
+    const runtime = createStaticThemeRuntime([fakeAsset("/index.html", html)]);
+    runtime.rewriteForColor("purple");
+    expect(runtime.getCachedIconColor()).toBe("purple");
+    expect(runtime.getCachedIndexHtml()).toBe(
+      '<link rel="icon" href="/icons/purple/favicon.svg">'
+    );
+  });
+
+  it("rewrites manifest icon paths", () => {
+    const manifest = '{"icons":[{"src":"/icons/teal/icon-192.png"}]}';
+    const runtime = createStaticThemeRuntime([
+      fakeAsset("/manifest.webmanifest", manifest),
+    ]);
+    runtime.rewriteForColor("blue");
+    expect(runtime.getCachedManifest()).toContain("/icons/blue/icon-192.png");
+  });
+
+  it("reverts to original templates when switching back to teal", () => {
+    const html = '<link href="/icons/teal/icon.svg">';
+    const runtime = createStaticThemeRuntime([fakeAsset("/index.html", html)]);
+    runtime.rewriteForColor("red");
+    expect(runtime.getCachedIndexHtml()).toContain("/icons/red/");
+    runtime.rewriteForColor("teal");
+    expect(runtime.getCachedIndexHtml()).toBe(html);
+  });
+
+  it("replaces all teal references in a single rewrite", () => {
+    const html =
+      '<link href="/icons/teal/a.svg"><link href="/icons/teal/b.png">';
+    const runtime = createStaticThemeRuntime([fakeAsset("/index.html", html)]);
+    runtime.rewriteForColor("orange");
+    expect(runtime.getCachedIndexHtml()).not.toContain("/icons/teal/");
+    expect(runtime.getCachedIndexHtml()).toContain("/icons/orange/a.svg");
+    expect(runtime.getCachedIndexHtml()).toContain("/icons/orange/b.png");
+  });
+
+  it("stores decoded static assets in the map", () => {
+    const runtime = createStaticThemeRuntime([
+      fakeAsset("/index.html", "<html>"),
+      fakeAsset("/manifest.webmanifest", "{}"),
+    ]);
+    expect(runtime.staticAssets.size).toBe(2);
+    expect(runtime.staticAssets.get("/index.html")?.body.toString()).toBe(
+      "<html>"
+    );
+  });
+
+  it("VALID_ICON_COLORS contains the expected palette", () => {
+    expect(VALID_ICON_COLORS).toContain("teal");
+    expect(VALID_ICON_COLORS).toContain("blue");
+    expect(VALID_ICON_COLORS).toContain("purple");
+    expect(VALID_ICON_COLORS.length).toBeGreaterThanOrEqual(8);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 43 focused unit tests covering four previously untested server modules
- **repo-icon** (20 tests): icon detection scoring, filesystem scanning, skip rules (`node_modules`, `dist`, dotfiles), depth limits, extension/name priority
- **resolve-tilde** (8 tests): tilde expansion for `~/path`, bare `~`, passthrough for absolute/relative paths
- **http-helpers** (7 tests): Bearer token extraction including missing headers, wrong schemes, case sensitivity
- **static-theme** (8 tests): icon color rewriting, template caching, revert-to-default behavior, asset map population

## Test plan
- [x] All 43 new tests pass locally
- [x] Full unit suite green (1160+ tests)
- [x] Full E2E suite green (142 passed)
- [x] Type checking passes (`pnpm run check`)
- [x] Pre-commit hooks pass (prettier + tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)