### PR TITLE
Add Dispatch Brain V1 — repo-scoped shared memory for agents

### DIFF
--- a/apps/server/src/brain/store.ts
+++ b/apps/server/src/brain/store.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from "node:crypto";
+
+import type { Pool } from "pg";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type BrainObject = {
+  collection: string;
+  name: string;
+  value: unknown;
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+  createdByAgentId: string;
+  updatedByAgentId: string;
+};
+
+export type BrainEvent = {
+  id: string;
+  collection: string;
+  kind: string;
+  subject: string | null;
+  tags: string[];
+  value: unknown;
+  createdAt: string;
+  agentId: string;
+};
+
+// ── Errors ───────────────────────────────────────────────────────────
+
+export class BrainNotFoundError extends Error {
+  readonly code = "not_found" as const;
+  constructor(collection: string, name: string) {
+    super(`Object "${collection}/${name}" not found.`);
+  }
+}
+
+export class BrainRevisionConflictError extends Error {
+  readonly code = "revision_conflict" as const;
+  readonly current: BrainObject;
+  constructor(current: BrainObject) {
+    super("Object revision does not match expectedRevision.");
+    this.current = current;
+  }
+}
+
+export class BrainValidationError extends Error {
+  readonly code = "validation_error" as const;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class BrainLimitExceededError extends Error {
+  readonly code = "limit_exceeded" as const;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function clampLimit(limit: number | undefined): number {
+  const n = limit ?? DEFAULT_LIMIT;
+  if (n < 1) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}
+
+// ── Store ────────────────────────────────────────────────────────────
+
+export class BrainStore {
+  constructor(private readonly pool: Pool) {}
+
+  // ── Objects ──────────────────────────────────────────────────────
+
+  async getObject(
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<BrainObject | null> {
+    const result = await this.pool.query(
+      `SELECT ${objectColumns()} FROM brain_objects
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return result.rows[0] ? mapObject(result.rows[0]) : null;
+  }
+
+  async storeObject(
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      name: string;
+      value: unknown;
+      expectedRevision?: number;
+    }
+  ): Promise<BrainObject> {
+    const { collection, name, value, expectedRevision } = input;
+
+    const existing = await this.getObject(repoRoot, collection, name);
+
+    if (!existing && expectedRevision !== undefined) {
+      throw new BrainNotFoundError(collection, name);
+    }
+
+    if (existing && expectedRevision === undefined) {
+      throw new BrainValidationError(
+        `Object "${collection}/${name}" already exists at revision ${existing.revision}. ` +
+          `Pass expectedRevision to update it.`
+      );
+    }
+
+    if (existing) {
+      if (existing.revision !== expectedRevision) {
+        throw new BrainRevisionConflictError(existing);
+      }
+      const result = await this.pool.query(
+        `UPDATE brain_objects
+         SET value = $1, revision = revision + 1, updated_at = now(), updated_by_agent_id = $2
+         WHERE repo_root = $3 AND collection = $4 AND name = $5 AND revision = $6
+         RETURNING ${objectColumns()}`,
+        [
+          JSON.stringify(value),
+          agentId,
+          repoRoot,
+          collection,
+          name,
+          expectedRevision,
+        ]
+      );
+      if (result.rows.length === 0) {
+        const current = await this.getObject(repoRoot, collection, name);
+        if (!current) throw new BrainNotFoundError(collection, name);
+        throw new BrainRevisionConflictError(current);
+      }
+      return mapObject(result.rows[0]);
+    }
+
+    try {
+      const result = await this.pool.query(
+        `INSERT INTO brain_objects (repo_root, collection, name, value, revision, created_by_agent_id, updated_by_agent_id)
+         VALUES ($1, $2, $3, $4, 1, $5, $5)
+         RETURNING ${objectColumns()}`,
+        [repoRoot, collection, name, JSON.stringify(value), agentId]
+      );
+      return mapObject(result.rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        const current = await this.getObject(repoRoot, collection, name);
+        if (current) {
+          throw new BrainValidationError(
+            `Object "${collection}/${name}" already exists at revision ${current.revision}. ` +
+              `Pass expectedRevision to update it.`
+          );
+        }
+      }
+      throw error;
+    }
+  }
+
+  async listObjects(
+    repoRoot: string,
+    filter?: {
+      collection?: string;
+      namePrefix?: string;
+      updatedAfter?: string;
+      limit?: number;
+    }
+  ): Promise<BrainObject[]> {
+    const conditions: string[] = ["repo_root = $1"];
+    const params: unknown[] = [repoRoot];
+
+    if (filter?.collection) {
+      params.push(filter.collection);
+      conditions.push(`collection = $${params.length}`);
+    }
+    if (filter?.namePrefix) {
+      params.push(escapeLike(filter.namePrefix) + "%");
+      conditions.push(`name LIKE $${params.length}`);
+    }
+    if (filter?.updatedAfter) {
+      params.push(filter.updatedAfter);
+      conditions.push(`updated_at > $${params.length}`);
+    }
+
+    const limit = clampLimit(filter?.limit);
+    params.push(limit);
+
+    const result = await this.pool.query(
+      `SELECT ${objectColumns()} FROM brain_objects
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY updated_at DESC
+       LIMIT $${params.length}`,
+      params
+    );
+    return result.rows.map(mapObject);
+  }
+
+  async deleteObject(
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM brain_objects
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  // ── Events ──────────────────────────────────────────────────────
+
+  async appendEvent(
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      kind: string;
+      value: unknown;
+      subject?: string;
+      tags?: string[];
+    }
+  ): Promise<BrainEvent> {
+    const id = randomUUID();
+    const { collection, kind, value, subject, tags } = input;
+
+    const result = await this.pool.query(
+      `INSERT INTO brain_events (id, repo_root, collection, kind, subject, tags, value, agent_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING ${eventColumns()}`,
+      [
+        id,
+        repoRoot,
+        collection,
+        kind,
+        subject ?? null,
+        tags ?? [],
+        JSON.stringify(value),
+        agentId,
+      ]
+    );
+    return mapEvent(result.rows[0]);
+  }
+
+  async queryEvents(
+    repoRoot: string,
+    filter?: {
+      collection?: string;
+      kind?: string;
+      subject?: string;
+      tags?: string[];
+      since?: string;
+      until?: string;
+      limit?: number;
+      order?: "asc" | "desc";
+    }
+  ): Promise<BrainEvent[]> {
+    const conditions: string[] = ["repo_root = $1"];
+    const params: unknown[] = [repoRoot];
+
+    if (filter?.collection) {
+      params.push(filter.collection);
+      conditions.push(`collection = $${params.length}`);
+    }
+    if (filter?.kind) {
+      params.push(filter.kind);
+      conditions.push(`kind = $${params.length}`);
+    }
+    if (filter?.subject) {
+      params.push(filter.subject);
+      conditions.push(`subject = $${params.length}`);
+    }
+    if (filter?.tags && filter.tags.length > 0) {
+      params.push(filter.tags);
+      conditions.push(`tags @> $${params.length}`);
+    }
+    if (filter?.since) {
+      params.push(filter.since);
+      conditions.push(`created_at >= $${params.length}`);
+    }
+    if (filter?.until) {
+      params.push(filter.until);
+      conditions.push(`created_at <= $${params.length}`);
+    }
+
+    const limit = clampLimit(filter?.limit);
+    params.push(limit);
+
+    const order = filter?.order === "asc" ? "ASC" : "DESC";
+
+    const result = await this.pool.query(
+      `SELECT ${eventColumns()} FROM brain_events
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY created_at ${order}
+       LIMIT $${params.length}`,
+      params
+    );
+    return result.rows.map(mapEvent);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function objectColumns(): string {
+  return `
+    collection,
+    name,
+    value,
+    revision,
+    created_at AS "createdAt",
+    updated_at AS "updatedAt",
+    created_by_agent_id AS "createdByAgentId",
+    updated_by_agent_id AS "updatedByAgentId"
+  `;
+}
+
+function mapObject(row: Record<string, unknown>): BrainObject {
+  return row as BrainObject;
+}
+
+function eventColumns(): string {
+  return `
+    id,
+    collection,
+    kind,
+    subject,
+    tags,
+    value,
+    created_at AS "createdAt",
+    agent_id AS "agentId"
+  `;
+}
+
+function mapEvent(row: Record<string, unknown>): BrainEvent {
+  return row as BrainEvent;
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "23505"
+  );
+}

--- a/apps/server/src/db/migrations/0025_brain.sql
+++ b/apps/server/src/db/migrations/0025_brain.sql
@@ -1,0 +1,41 @@
+-- Brain: repo-scoped shared memory for agents (objects + events)
+
+CREATE TABLE IF NOT EXISTS brain_objects (
+  repo_root text NOT NULL,
+  collection text NOT NULL,
+  name text NOT NULL,
+  value jsonb NOT NULL,
+  revision integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by_agent_id text NOT NULL,
+  updated_by_agent_id text NOT NULL,
+  PRIMARY KEY (repo_root, collection, name)
+);
+
+CREATE INDEX IF NOT EXISTS brain_objects_repo_collection_updated_idx
+  ON brain_objects (repo_root, collection, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_events (
+  id uuid PRIMARY KEY,
+  repo_root text NOT NULL,
+  collection text NOT NULL,
+  kind text NOT NULL,
+  subject text,
+  tags text[] NOT NULL DEFAULT '{}',
+  value jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  agent_id text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS brain_events_repo_collection_created_idx
+  ON brain_events (repo_root, collection, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS brain_events_repo_collection_kind_created_idx
+  ON brain_events (repo_root, collection, kind, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS brain_events_repo_collection_subject_created_idx
+  ON brain_events (repo_root, collection, subject, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS brain_events_tags_gin_idx
+  ON brain_events USING GIN (tags);

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 
 import type { AgentManager } from "../agents/manager.js";
+import type { BrainStore } from "../brain/store.js";
 import type { JobService } from "../jobs/service.js";
 import {
   resolveRepoRoot,
@@ -14,6 +15,7 @@ type McpRouteDeps = {
   };
   agentManager: AgentManager;
   jobService: JobService;
+  brainStore: BrainStore;
   getBearerToken: (request: {
     headers: { authorization?: string };
   }) => string | null;
@@ -168,6 +170,7 @@ export async function registerMcpRoutes(
         >,
       toolScope: run ? "job" : "agent",
       jobTools,
+      brainStore: deps.brainStore,
     } as Parameters<typeof handleMcpRequest>[3]);
   });
 
@@ -250,6 +253,7 @@ export async function registerMcpRoutes(
         deps.agentManager.getFeedbackSummary(params as never) as Promise<
           Record<string, unknown>
         >,
+      brainStore: deps.brainStore,
     } as Parameters<typeof handleMcpRequest>[3]);
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -95,6 +95,7 @@ import {
   packageVersion,
   staticFiles as embeddedStaticFiles,
 } from "./generated/runtime-assets.js";
+import { BrainStore } from "./brain/store.js";
 import { registerActivityRoutes } from "./routes/activity.js";
 import { registerAgentRoutes } from "./routes/agents.js";
 import { MAX_STARTUP_FILE_COUNT } from "./routes/agent-startup.js";
@@ -286,6 +287,7 @@ const authRuntime = createAuthRuntime({
   pool,
   sessionCleanupIntervalMs: 60 * 60 * 1000,
 });
+const brainStore = new BrainStore(pool);
 const mcpHandlers = createMcpHandlers({
   pool,
   mediaRoot: config.mediaRoot,
@@ -438,6 +440,7 @@ async function registerRoutes() {
     config,
     agentManager,
     jobService,
+    brainStore,
     getBearerToken,
     validateJobMcpToken,
     validateAgentMcpToken,

--- a/apps/server/src/shared/mcp/brain-tools.ts
+++ b/apps/server/src/shared/mcp/brain-tools.ts
@@ -1,0 +1,376 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import type { BrainStore } from "../../brain/store.js";
+import {
+  BrainNotFoundError,
+  BrainRevisionConflictError,
+  BrainValidationError,
+  BrainLimitExceededError,
+} from "../../brain/store.js";
+import { toToolError } from "./tool-error.js";
+
+type BrainToolContext = {
+  repoRoot: string;
+  agentId: string;
+  store: BrainStore;
+};
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: true;
+  structuredContent?: Record<string, unknown>;
+};
+
+function toBrainError(error: unknown): ToolResult {
+  if (error instanceof BrainRevisionConflictError) {
+    return {
+      content: [{ type: "text", text: error.message }],
+      isError: true,
+      structuredContent: {
+        error: {
+          code: error.code,
+          message: error.message,
+          current: {
+            collection: error.current.collection,
+            name: error.current.name,
+            value: error.current.value,
+            revision: error.current.revision,
+          },
+        },
+      } as Record<string, unknown>,
+    };
+  }
+  if (
+    error instanceof BrainNotFoundError ||
+    error instanceof BrainValidationError ||
+    error instanceof BrainLimitExceededError
+  ) {
+    return {
+      content: [{ type: "text", text: error.message }],
+      isError: true,
+      structuredContent: {
+        error: { code: error.code, message: error.message },
+      } as Record<string, unknown>,
+    };
+  }
+  return toToolError(error);
+}
+
+const collectionSchema = z.string().min(1).max(255);
+const nameSchema = z.string().min(1).max(255);
+const kindSchema = z.string().min(1).max(255);
+const subjectSchema = z.string().min(1).max(255);
+const tagSchema = z.string().min(1).max(255);
+const tagsSchema = z.array(tagSchema).max(50);
+
+export function registerBrainTools(
+  server: McpServer,
+  allowed: Set<string>,
+  ctx: BrainToolContext
+): void {
+  const { repoRoot, agentId, store } = ctx;
+
+  // ── brain_get_object ──────────────────────────────────────────────
+  if (allowed.has("brain_get_object")) {
+    server.registerTool(
+      "brain_get_object",
+      {
+        description:
+          "Get a single object from the shared brain by collection and name. " +
+          "Returns the object with its current value and revision, or an error if not found.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the object belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the object within the collection."
+          ),
+        },
+      },
+      async (args) => {
+        try {
+          const obj = await store.getObject(
+            repoRoot,
+            args.collection,
+            args.name
+          );
+          if (!obj) {
+            return toBrainError(
+              new BrainNotFoundError(args.collection, args.name)
+            );
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify(obj, null, 2) }],
+            structuredContent: obj as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_store_object ────────────────────────────────────────────
+  if (allowed.has("brain_store_object")) {
+    server.registerTool(
+      "brain_store_object",
+      {
+        description:
+          "Create or update an object in the shared brain. " +
+          "To create: omit expectedRevision. " +
+          "To update: pass expectedRevision matching the current revision (optimistic concurrency). " +
+          "Blind overwrites of existing objects are rejected — you must read first.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the object belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the object within the collection."
+          ),
+          value: z
+            .record(z.string(), z.unknown())
+            .describe("The JSON value to store."),
+          expectedRevision: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "The revision you expect the object to be at. Required for updates. " +
+                "Omit when creating a new object."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const obj = await store.storeObject(repoRoot, agentId, {
+            collection: args.collection,
+            name: args.name,
+            value: args.value,
+            expectedRevision: args.expectedRevision,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(obj, null, 2) }],
+            structuredContent: obj as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_objects ────────────────────────────────────────────
+  if (allowed.has("brain_list_objects")) {
+    server.registerTool(
+      "brain_list_objects",
+      {
+        description:
+          "List objects in the shared brain. Optionally filter by collection, name prefix, " +
+          "or updated-after timestamp. Returns up to `limit` objects ordered by most recently updated.",
+        inputSchema: {
+          collection: collectionSchema
+            .optional()
+            .describe("Filter to this collection."),
+          namePrefix: nameSchema
+            .optional()
+            .describe("Filter to objects whose name starts with this prefix."),
+          updatedAfter: z
+            .string()
+            .optional()
+            .describe(
+              "Only return objects updated after this ISO 8601 timestamp."
+            ),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(200)
+            .optional()
+            .describe("Max objects to return (default 50, max 200)."),
+        },
+      },
+      async (args) => {
+        try {
+          const objects = await store.listObjects(repoRoot, {
+            collection: args.collection,
+            namePrefix: args.namePrefix,
+            updatedAfter: args.updatedAfter,
+            limit: args.limit,
+          });
+          const result = { objects };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_delete_object ───────────────────────────────────────────
+  if (allowed.has("brain_delete_object")) {
+    server.registerTool(
+      "brain_delete_object",
+      {
+        description:
+          "Delete an object from the shared brain by collection and name.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the object belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the object within the collection."
+          ),
+        },
+      },
+      async (args) => {
+        try {
+          const deleted = await store.deleteObject(
+            repoRoot,
+            args.collection,
+            args.name
+          );
+          const result = { deleted };
+          return {
+            content: [
+              {
+                type: "text",
+                text: deleted
+                  ? `Deleted "${args.collection}/${args.name}".`
+                  : `Object "${args.collection}/${args.name}" not found.`,
+              },
+            ],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_append_event ────────────────────────────────────────────
+  if (allowed.has("brain_append_event")) {
+    server.registerTool(
+      "brain_append_event",
+      {
+        description:
+          "Append a structured event to the shared brain's event log. " +
+          "Events are immutable and append-only. Use events to record history, " +
+          "assessments, decisions, or any structured observation that other agents can query.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection this event belongs to."
+          ),
+          kind: kindSchema.describe(
+            "The event kind/type (e.g. 'assessment', 'decision', 'observation')."
+          ),
+          value: z
+            .record(z.string(), z.unknown())
+            .describe("The JSON payload of the event."),
+          subject: subjectSchema
+            .optional()
+            .describe(
+              "Optional subject identifier for filtering (e.g. a persona name, file path)."
+            ),
+          tags: tagsSchema
+            .optional()
+            .describe(
+              "Optional tags for filtering (e.g. ['noise', 'prompt-change']). Max 50 tags."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const event = await store.appendEvent(repoRoot, agentId, {
+            collection: args.collection,
+            kind: args.kind,
+            value: args.value,
+            subject: args.subject,
+            tags: args.tags,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(event, null, 2) }],
+            structuredContent: event as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_query_events ────────────────────────────────────────────
+  if (allowed.has("brain_query_events")) {
+    server.registerTool(
+      "brain_query_events",
+      {
+        description:
+          "Query the shared brain's event log. Filter by collection, kind, subject, " +
+          "tags, and time range. Returns up to `limit` events.",
+        inputSchema: {
+          collection: collectionSchema
+            .optional()
+            .describe("Filter to this collection."),
+          kind: kindSchema
+            .optional()
+            .describe("Filter to events of this kind."),
+          subject: subjectSchema
+            .optional()
+            .describe("Filter to events with this subject."),
+          tags: tagsSchema
+            .optional()
+            .describe("Filter to events containing all of these tags."),
+          since: z
+            .string()
+            .optional()
+            .describe(
+              "Only return events created at or after this ISO 8601 timestamp."
+            ),
+          until: z
+            .string()
+            .optional()
+            .describe(
+              "Only return events created at or before this ISO 8601 timestamp."
+            ),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(200)
+            .optional()
+            .describe("Max events to return (default 50, max 200)."),
+          order: z
+            .enum(["asc", "desc"])
+            .optional()
+            .describe("Sort order by creation time (default 'desc')."),
+        },
+      },
+      async (args) => {
+        try {
+          const events = await store.queryEvents(repoRoot, {
+            collection: args.collection,
+            kind: args.kind,
+            subject: args.subject,
+            tags: args.tags,
+            since: args.since,
+            until: args.until,
+            limit: args.limit,
+            order: args.order,
+          });
+          const result = { events };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+}

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -4,8 +4,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as z from "zod/v4";
 
+import type { BrainStore } from "../../brain/store.js";
 import { createPr, getPrStatus } from "../github/pr.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
+import { registerBrainTools } from "./brain-tools.js";
 import { registerJobTools, type JobTools } from "./job-tools.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 import { toToolError } from "./tool-error.js";
@@ -94,6 +96,12 @@ const AGENT_TOOLS = new Set([
   "get_activity_summary",
   "get_agent_history",
   "get_feedback_summary",
+  "brain_get_object",
+  "brain_store_object",
+  "brain_list_objects",
+  "brain_delete_object",
+  "brain_append_event",
+  "brain_query_events",
 ]);
 
 const JOB_TOOLS = new Set([
@@ -121,6 +129,12 @@ const JOB_TOOLS = new Set([
   "get_activity_summary",
   "get_agent_history",
   "get_feedback_summary",
+  "brain_get_object",
+  "brain_store_object",
+  "brain_list_objects",
+  "brain_delete_object",
+  "brain_append_event",
+  "brain_query_events",
 ]);
 
 const PERSONA_TOOLS = new Set([
@@ -333,6 +347,7 @@ export type McpRequestContext = {
   }) => Promise<Record<string, unknown>>;
   jobTools?: JobTools;
   toolScope?: "agent" | "reviewer" | "job";
+  brainStore?: BrainStore;
 };
 
 /**
@@ -1191,6 +1206,15 @@ async function createDispatchMcpServer(
         }
       }
     );
+  }
+
+  // ── Brain tools (shared memory for agents) ────────────────────────
+  if (context.agent && context.repoRoot && context.brainStore) {
+    registerBrainTools(server, allowed, {
+      repoRoot: context.repoRoot,
+      agentId: context.agent.id,
+      store: context.brainStore,
+    });
   }
 
   // ── Summary / analytics tools (available to both agents and jobs) ──

--- a/apps/server/test/brain-store.test.ts
+++ b/apps/server/test/brain-store.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Pool } from "pg";
+
+import {
+  BrainStore,
+  BrainNotFoundError,
+  BrainRevisionConflictError,
+  BrainValidationError,
+} from "../src/brain/store.js";
+import { setupTestDb, teardownTestDb, runTestMigrations } from "./db/setup.js";
+
+let pool: Pool;
+let store: BrainStore;
+
+beforeAll(async () => {
+  pool = await setupTestDb();
+  await runTestMigrations();
+  store = new BrainStore(pool);
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+const REPO = "/repo/test";
+const REPO_B = "/repo/other";
+const AGENT = "agt_test1";
+const AGENT_B = "agt_test2";
+
+// ── Objects ─────────────────────────────────────────────────────────
+
+describe("BrainStore objects", () => {
+  it("creates and gets an object", async () => {
+    const obj = await store.storeObject(REPO, AGENT, {
+      collection: "config",
+      name: "settings",
+      value: { theme: "dark" },
+    });
+
+    expect(obj.collection).toBe("config");
+    expect(obj.name).toBe("settings");
+    expect(obj.value).toEqual({ theme: "dark" });
+    expect(obj.revision).toBe(1);
+    expect(obj.createdByAgentId).toBe(AGENT);
+    expect(obj.updatedByAgentId).toBe(AGENT);
+
+    const fetched = await store.getObject(REPO, "config", "settings");
+    expect(fetched).not.toBeNull();
+    expect(fetched!.value).toEqual({ theme: "dark" });
+    expect(fetched!.revision).toBe(1);
+  });
+
+  it("updates an object with correct expectedRevision", async () => {
+    const updated = await store.storeObject(REPO, AGENT_B, {
+      collection: "config",
+      name: "settings",
+      value: { theme: "light" },
+      expectedRevision: 1,
+    });
+
+    expect(updated.revision).toBe(2);
+    expect(updated.value).toEqual({ theme: "light" });
+    expect(updated.createdByAgentId).toBe(AGENT);
+    expect(updated.updatedByAgentId).toBe(AGENT_B);
+  });
+
+  it("rejects blind overwrite of existing object", async () => {
+    await expect(
+      store.storeObject(REPO, AGENT, {
+        collection: "config",
+        name: "settings",
+        value: { theme: "blue" },
+      })
+    ).rejects.toThrow(BrainValidationError);
+  });
+
+  it("rejects stale expectedRevision", async () => {
+    await expect(
+      store.storeObject(REPO, AGENT, {
+        collection: "config",
+        name: "settings",
+        value: { theme: "red" },
+        expectedRevision: 1,
+      })
+    ).rejects.toThrow(BrainRevisionConflictError);
+  });
+
+  it("rejects expectedRevision on non-existent object", async () => {
+    await expect(
+      store.storeObject(REPO, AGENT, {
+        collection: "config",
+        name: "nonexistent",
+        value: {},
+        expectedRevision: 1,
+      })
+    ).rejects.toThrow(BrainNotFoundError);
+  });
+
+  it("lists objects with filters", async () => {
+    await store.storeObject(REPO, AGENT, {
+      collection: "config",
+      name: "frontend-flags",
+      value: { beta: true },
+    });
+
+    const all = await store.listObjects(REPO, { collection: "config" });
+    expect(all.length).toBeGreaterThanOrEqual(2);
+
+    const prefixed = await store.listObjects(REPO, {
+      collection: "config",
+      namePrefix: "front",
+    });
+    expect(prefixed).toHaveLength(1);
+    expect(prefixed[0].name).toBe("frontend-flags");
+  });
+
+  it("respects limit", async () => {
+    const limited = await store.listObjects(REPO, {
+      collection: "config",
+      limit: 1,
+    });
+    expect(limited).toHaveLength(1);
+  });
+
+  it("deletes an object", async () => {
+    const deleted = await store.deleteObject(REPO, "config", "frontend-flags");
+    expect(deleted).toBe(true);
+
+    const fetched = await store.getObject(REPO, "config", "frontend-flags");
+    expect(fetched).toBeNull();
+  });
+
+  it("returns false when deleting non-existent object", async () => {
+    const deleted = await store.deleteObject(REPO, "config", "nope");
+    expect(deleted).toBe(false);
+  });
+
+  it("isolates objects by repo", async () => {
+    await store.storeObject(REPO_B, AGENT, {
+      collection: "config",
+      name: "settings",
+      value: { isolated: true },
+    });
+
+    const fromA = await store.getObject(REPO, "config", "settings");
+    const fromB = await store.getObject(REPO_B, "config", "settings");
+
+    expect(fromA!.value).toEqual({ theme: "light" });
+    expect(fromB!.value).toEqual({ isolated: true });
+  });
+});
+
+// ── Events ──────────────────────────────────────────────────────────
+
+describe("BrainStore events", () => {
+  it("appends and queries events", async () => {
+    const event = await store.appendEvent(REPO, AGENT, {
+      collection: "reviews",
+      kind: "assessment",
+      value: { score: 0.8 },
+      subject: "ux-review",
+      tags: ["noise"],
+    });
+
+    expect(event.id).toBeDefined();
+    expect(event.collection).toBe("reviews");
+    expect(event.kind).toBe("assessment");
+    expect(event.subject).toBe("ux-review");
+    expect(event.tags).toEqual(["noise"]);
+    expect(event.value).toEqual({ score: 0.8 });
+    expect(event.agentId).toBe(AGENT);
+
+    const results = await store.queryEvents(REPO, {
+      collection: "reviews",
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(event.id);
+  });
+
+  it("queries by kind", async () => {
+    await store.appendEvent(REPO, AGENT, {
+      collection: "reviews",
+      kind: "decision",
+      value: { action: "approve" },
+    });
+
+    const assessments = await store.queryEvents(REPO, {
+      collection: "reviews",
+      kind: "assessment",
+    });
+    expect(assessments).toHaveLength(1);
+
+    const decisions = await store.queryEvents(REPO, {
+      collection: "reviews",
+      kind: "decision",
+    });
+    expect(decisions).toHaveLength(1);
+  });
+
+  it("queries by subject", async () => {
+    const results = await store.queryEvents(REPO, {
+      collection: "reviews",
+      subject: "ux-review",
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].subject).toBe("ux-review");
+  });
+
+  it("queries by tags", async () => {
+    await store.appendEvent(REPO, AGENT, {
+      collection: "reviews",
+      kind: "observation",
+      value: { note: "tagged" },
+      tags: ["noise", "prompt-change"],
+    });
+
+    const noiseEvents = await store.queryEvents(REPO, {
+      collection: "reviews",
+      tags: ["noise"],
+    });
+    expect(noiseEvents.length).toBeGreaterThanOrEqual(2);
+
+    const multiTag = await store.queryEvents(REPO, {
+      collection: "reviews",
+      tags: ["noise", "prompt-change"],
+    });
+    expect(multiTag).toHaveLength(1);
+  });
+
+  it("queries by time range", async () => {
+    const past = new Date(Date.now() - 60000).toISOString();
+    const future = new Date(Date.now() + 60000).toISOString();
+
+    const inRange = await store.queryEvents(REPO, {
+      collection: "reviews",
+      since: past,
+      until: future,
+    });
+    expect(inRange.length).toBeGreaterThan(0);
+
+    const outOfRange = await store.queryEvents(REPO, {
+      collection: "reviews",
+      since: future,
+    });
+    expect(outOfRange).toHaveLength(0);
+  });
+
+  it("orders ascending", async () => {
+    const desc = await store.queryEvents(REPO, {
+      collection: "reviews",
+      order: "desc",
+    });
+    const asc = await store.queryEvents(REPO, {
+      collection: "reviews",
+      order: "asc",
+    });
+
+    expect(desc.length).toBe(asc.length);
+    expect(desc[0].id).toBe(asc[asc.length - 1].id);
+  });
+
+  it("enforces default limit", async () => {
+    for (let i = 0; i < 55; i++) {
+      await store.appendEvent(REPO, AGENT, {
+        collection: "bulk",
+        kind: "tick",
+        value: { i },
+      });
+    }
+
+    const defaultResult = await store.queryEvents(REPO, {
+      collection: "bulk",
+    });
+    expect(defaultResult).toHaveLength(50);
+  });
+
+  it("enforces max limit", async () => {
+    const maxResult = await store.queryEvents(REPO, {
+      collection: "bulk",
+      limit: 999,
+    });
+    expect(maxResult.length).toBeLessThanOrEqual(200);
+  });
+
+  it("isolates events by repo", async () => {
+    await store.appendEvent(REPO_B, AGENT, {
+      collection: "reviews",
+      kind: "isolated",
+      value: { repo: "B" },
+    });
+
+    const repoA = await store.queryEvents(REPO, {
+      collection: "reviews",
+      kind: "isolated",
+    });
+    expect(repoA).toHaveLength(0);
+
+    const repoB = await store.queryEvents(REPO_B, {
+      collection: "reviews",
+      kind: "isolated",
+    });
+    expect(repoB).toHaveLength(1);
+  });
+});

--- a/update-migrations/0006-brain-tables.yaml
+++ b/update-migrations/0006-brain-tables.yaml
@@ -1,0 +1,40 @@
+id: brain-tables
+title: Verify brain tables migration
+summary: >
+  Adds `brain_objects` and `brain_events` tables for the new shared agent
+  memory (Brain) feature. brain_objects stores mutable key-value data with
+  optimistic concurrency; brain_events stores an append-only structured event
+  log. Both tables are repo-scoped. The migration runs automatically on
+  server boot. Route this update through assisted-update so the operator can
+  confirm the migration applied cleanly and the service is healthy.
+
+alreadySatisfied:
+  description: >
+    The install is already on the target tag, the local health endpoint
+    returns status=ok, and release.json reports the target tag. Server boot
+    runs migrations idempotently and both tables are additive, so any healthy
+    install at the target tag has already taken the migration — no operator
+    action is required.
+
+instructions:
+  - Confirm the service has been restarted to the target release tag.
+  - Confirm $DISPATCH_API_URL/api/v1/health returns status=ok.
+  - Confirm release.json under the install directory reports the target tag.
+  - Since alreadySatisfied is true on every healthy install at the target tag,
+    do not perform any change steps — proceed straight to the validate phase.
+    The framework re-runs the checks below server-side and marks the migration
+    applied.
+
+validation:
+  requiredChecks:
+    - service_restarted
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - If the new release does not return healthy, roll back to the previous
+    release tag using the normal release rollback path for this host. The
+    brain_objects and brain_events tables are additive — leaving them in place
+    after rollback is harmless and is safer than dropping them manually.
+  - Restart the service and confirm $DISPATCH_API_URL/api/v1/health returns
+    status=ok and release.json reports the prior tag.


### PR DESCRIPTION
## Summary

- Adds **Brain V1**: a repo-scoped shared memory surface for agents with two primitives — mutable **objects** (key-value with optimistic concurrency) and append-only **events** (structured history log).
- New database tables (`brain_objects`, `brain_events`) via migration `0025_brain.sql`, with appropriate indexes for collection/kind/subject/tags queries.
- Six new MCP tools (`brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_append_event`, `brain_query_events`) available to agent and job scopes.
- `BrainStore` class with optimistic concurrency (revision-based updates), TOCTOU race protection on concurrent creates, LIKE wildcard escaping, and clamped query limits (default 50, max 200).
- 19 unit tests covering CRUD, concurrency conflicts, filtering, repo isolation, and event queries.
- Assisted update migration manifest (`0006-brain-tables.yaml`) for the new tables.

## Test plan

- [x] TypeScript type checking passes (`pnpm run check`)
- [x] All 1243 unit tests pass (`pnpm run test`)
- [x] All 142 E2E tests pass (`pnpm run test:e2e`)
- [x] Live-tested with a real agent exercising all 6 brain tools through the UI
- [x] Architecture review persona approved (round 2, all 5 findings from round 1 fixed)
- [x] Assisted update migration manifest validates against runtime schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)