### PR TITLE
docs: add Brain V1 shared memory tools to docs

### DIFF
--- a/.dispatch/job-state/docs-audit.md
+++ b/.dispatch/job-state/docs-audit.md
@@ -1,6 +1,6 @@
 ---
 job: docs-audit
-updated_at: 2026-05-19
+updated_at: 2026-05-20
 ---
 
 # docs-audit — state handoff
@@ -9,11 +9,11 @@ Each run of the docs-audit job reads this file at Phase 0 and overwrites it at P
 
 ## last_audited_sha
 
-`68f80fa5c0bd96bbd15a4550acbdabd69623c861` — HEAD at the start of the 2026-05-19 run.
+`17056a78c2d49d93deb72daa9cfcf8c6ea638c0c` — HEAD at the start of the 2026-05-20 run.
 
 ## next_focus
 
-**Audit docs-pane "Repo Tools" section against `server.ts` built-in tool list and `repo-tools.ts`.** The AGENT_TOOLS set currently has 18 tools; verify the "Built-in tools" list in docs-pane matches. Also check whether the newly extracted `job-tools.ts` (PR #555) introduced any new tool names or changed tool availability per flow.
+**Audit docs-pane "Automations: Templates & Jobs" section against the template create/edit form fields in `automations-form-fields.tsx` and `automations-create-dialog.tsx`.** PR #563 improved template variable templating (optional args, `|required`, `|multiline` modifiers) and the previous run updated the docs for this. However, the context picker unification (PR #562) changed how directories and worktree settings are shared between template launch and create-agent dialogs — verify the "Creating a template" and "Launching templates" subsections still accurately describe the UI flow and field set.
 
 ## backlog
 
@@ -30,6 +30,8 @@ Items noticed during prior passes but left for later runs. Pick the most relevan
 - **`unknown` AgentStatus is dead code.** Worth a separate cleanup PR (not docs work).
 - **README install table — Cursor CLI install instructions are approximate.** The binary defaults to `agent`; the exact npm package / install path should be verified once the CLI is publicly documented by Anysphere.
 - **`docs/18-subagent-orchestration.md` — add to README docs index when implemented.** Currently a design doc for a forward-looking feature. Add once the feature ships and has user-facing surface.
+- **docs-pane "Repo Tools" Brain subsection — expand when Brain gains a UI.** The current Brain docs describe the MCP tool interface only. If/when a Brain explorer UI is added (e.g. in Settings or Activity), add a subsection describing the UI surface.
+- **`docs/03-api-spec.md` — add Brain API endpoints.** The Brain tools work through MCP, but the underlying store routes (`/brain/objects`, `/brain/events`) may gain a direct HTTP API. When they do, add them to the API spec.
 
 ## drift_patterns
 
@@ -70,6 +72,7 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **API-spec body schemas lag behind Zod schemas in route handlers.** When a new field is added to a route's Zod schema, the spec often doesn't get updated. Cross-check route handlers directly rather than relying on PRs to flag it.
 - **Assisted-update check descriptions drift from implementation.** The check names in `release-metadata.ts` are stable but the check logic in `release-checks.ts` evolves (e.g. `version_converged` reads `release.json`, not the health endpoint). Re-verify descriptions against the actual functions when touching this section.
 - **Collapsed sidebar card claims drift from agent-card.tsx layout changes.** PR #558 moved the repo name from the expanded detail card to the collapsed status line and removed the event message from collapsed view. Any future sidebar layout change needs a docs-pane cross-check.
+- **New MCP tool categories (e.g. Brain) land without docs section.** PR #569 added 6 brain tools to AGENT_TOOLS and JOB_TOOLS. When a new tool category is added, the "Built-in tools" list AND the README MCP tools section both need updates, plus a conceptual subsection if the feature is new.
 
 ## Notes for the next run
 
@@ -114,3 +117,4 @@ Observations about where docs tend to go stale. Each run should add new observat
 - **2026-05-17** (API spec — Jobs body schemas) — Closed the Jobs POST/PATCH body schema next_focus. Added `POST /jobs` body schema with all 16 fields from `AddJobBodySchema`, field-by-field descriptions, and `PATCH /jobs` note. Added `DELETE /jobs` and `POST /jobs/enable` / `POST /jobs/disable` bodies. Fixed `GET /jobs/history` params from stale `jobId, status, limit, offset` to actual `name, directory, limit`. Added new drift pattern for Zod schema/spec lag.
 - **2026-05-18** (Ops runbook — bin scripts + check descriptions) — Closed the ops-runbook bin scripts next_focus. Added `bin/preflight` to Installation section. Added `bin/pack-release` mention to Release Pipeline. Added comprehensive Bin Scripts table (all 9 scripts). Fixed 3 inaccurate assisted-update check descriptions: `version_converged` reads `release.json` not health endpoint, `service_entrypoint` checks `package.json` not launchd plist, `expected_runtime_artifact` also checks `apps/web/dist/index.html`. Added drift pattern for check-description staleness.
 - **2026-05-19** (Agents — sidebar collapsed view + create-agent audit) — Diff-driven: PR #558 moved repo name from expanded detail card to collapsed sidebar status line and removed event message from collapsed view. Fixed "Status indicators" section (collapsed card now shows status + time + repo name, not event message). Fixed "Agent details" section (worktree agents no longer show repo name row — just base + working branch). Audited create-agent dialog fields (next_focus): all 6 form fields match docs, no drift found.
+- **2026-05-20** (Brain V1 — built-in tools + shared memory) — Diff-driven: PR #569 added Dispatch Brain V1 with 6 new MCP tools (`brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_append_event`, `brain_query_events`) to both AGENT_TOOLS and JOB_TOOLS. Added brain tools to docs-pane "Built-in tools" list and "Tools available to job agents" list. Added "Brain (shared memory)" subsection to Repo Tools explaining the concept. Updated "State across runs" to mention Brain as an alternative to filesystem handoff. Added brain tools to README Interactive agents table and Job agents list. Fixed CLAUDE.md project structure tree (added missing `brain/` directory).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ dispatch/
 │   ├── server/                # Fastify API server (@dispatch/server)
 │   │   ├── src/               # backend source
 │   │   │   ├── agents/        # agent manager, lifecycle, token harvesting
+│   │   │   ├── brain/         # repo-scoped shared memory (objects + event log)
 │   │   │   ├── db/            # PostgreSQL migrations and queries
 │   │   │   ├── jobs/          # job scheduler, runner, reporting
 │   │   │   ├── media/         # media file storage

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `get_activity_summary`       | Summarize agent activity over a time range                                 |
 | `get_agent_history`          | Get detailed agent session history                                         |
 | `get_feedback_summary`       | Aggregate persona review feedback for pattern detection                    |
+| `brain_get_object`           | Read a shared object from the repo-scoped Brain                            |
+| `brain_store_object`         | Create or update a shared Brain object (optimistic concurrency)            |
+| `brain_list_objects`         | List Brain objects, optionally filtered by collection or prefix            |
+| `brain_delete_object`        | Delete a shared Brain object                                               |
+| `brain_append_event`         | Append a structured event to the Brain's immutable event log               |
+| `brain_query_events`         | Query Brain events by collection, kind, subject, tags, and time range      |
 
 ### Persona agents
 
@@ -179,7 +185,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, and `get_feedback_summary`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_append_event`, and `brain_query_events`.
 
 ### Repo-specific tools
 

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -642,7 +642,37 @@ const SECTIONS: SectionDef[] = [
               <Code>get_feedback_summary</Code> — analytics queries over recent
               Dispatch activity
             </li>
+            <li>
+              <Code>brain_get_object</Code>, <Code>brain_store_object</Code>,{" "}
+              <Code>brain_list_objects</Code>, <Code>brain_delete_object</Code>{" "}
+              — read and write shared objects in the repo-scoped Brain (see
+              below)
+            </li>
+            <li>
+              <Code>brain_append_event</Code>, <Code>brain_query_events</Code> —
+              append to and query the Brain's immutable event log
+            </li>
           </ul>
+        </Section>
+
+        <Section>
+          <H3>Brain (shared memory)</H3>
+          <P>
+            The Brain is a repo-scoped key-value store and event log that lets
+            agents share structured state. Objects are organized into
+            collections, identified by name, and tracked with an integer
+            revision for optimistic concurrency — updates require passing the
+            expected revision so concurrent writes don't silently overwrite each
+            other. Events are append-only and can be filtered by collection,
+            kind, subject, tags, and time range.
+          </P>
+          <P>
+            Brain tools are available to both standard agents and job agents.
+            Persona reviewers do not have access. Common use cases include
+            passing findings or assessments between recurring job runs, sharing
+            configuration between agents working in the same repo, and recording
+            structured observations that other agents can query.
+          </P>
         </Section>
 
         <Section>
@@ -1006,6 +1036,13 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               <Code>dispatch_submit_resolution</Code>, and{" "}
               <Code>dispatch_cancel_recheck</Code>. See below.
             </li>
+            <li>
+              <strong>Brain (shared memory)</strong> —{" "}
+              <Code>brain_get_object</Code>, <Code>brain_store_object</Code>,{" "}
+              <Code>brain_list_objects</Code>, <Code>brain_delete_object</Code>,{" "}
+              <Code>brain_append_event</Code>, and{" "}
+              <Code>brain_query_events</Code>. Same tools as standard agents.
+            </li>
           </ul>
         </Section>
 
@@ -1029,14 +1066,27 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <H3>State across runs</H3>
           <P>
             Recurring jobs often need to pass context from one run to the next
-            without re-inventorying the repo every time. The convention is a
-            small markdown handoff file at{" "}
-            <Code>.dispatch/job-state/{"<job>"}.md</Code> that the prompt tells
-            the agent to read at the start of a run and overwrite at the end.
-            It's not a server feature — just a pattern that keeps the work
-            focused. Treat it as a note to the next run, not an append-only log;
-            prune what's no longer relevant.
+            without re-inventorying the repo every time. Two approaches work
+            well:
           </P>
+          <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+            <li>
+              <strong>Filesystem handoff</strong> — a small markdown file at{" "}
+              <Code>.dispatch/job-state/{"<job>"}.md</Code> that the prompt
+              tells the agent to read at the start and overwrite at the end.
+              Treat it as a note to the next run, not an append-only log; prune
+              what's no longer relevant. This pattern is simple and
+              version-controlled.
+            </li>
+            <li>
+              <strong>Brain shared memory</strong> — use the{" "}
+              <Code>brain_store_object</Code> and <Code>brain_get_object</Code>{" "}
+              tools to persist structured state across runs without committing
+              files. Brain objects support optimistic concurrency and can be
+              queried by collection, making them a good fit for state that
+              multiple jobs or agents need to coordinate on.
+            </li>
+          </ul>
         </Section>
 
         <Section>


### PR DESCRIPTION
## Summary
- Added 6 Brain MCP tools (`brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_append_event`, `brain_query_events`) to docs-pane "Built-in tools" list and "Tools available to job agents" list
- Added "Brain (shared memory)" subsection to Repo Tools explaining the concept (objects, collections, optimistic concurrency, event log)
- Updated "State across runs" in Jobs to mention Brain as an alternative to filesystem handoff
- Added brain tools to README Interactive agents table and Job agents list
- Added missing `brain/` directory to CLAUDE.md project structure tree

Deferred to next run: audit Automations Templates/Jobs section against context-picker unification (PR #562).

## Test plan
- [ ] `pnpm run check` passes (type checking)
- [ ] `pnpm run format:write` clean (prettier)
- [ ] Verify docs-pane renders correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)