### PR TITLE
Extract parent-side persona interaction tools from MCP server.ts

### DIFF
--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -1,0 +1,312 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import type { McpRequestContext } from "./server.js";
+import { toToolError } from "./tool-error.js";
+
+const LAUNCH_PERSONA_AGENT_TYPES = [
+  "claude",
+  "codex",
+  "cursor",
+  "opencode",
+] as const;
+
+export type PersonaInteractionCallbacks = {
+  agentId: string;
+  worktreeRoot?: string | null;
+  repoRoot?: string | null;
+  listPersonas?: McpRequestContext["listPersonas"];
+  launchPersona?: McpRequestContext["launchPersona"];
+  getFeedback?: McpRequestContext["getFeedback"];
+  resolveFeedback?: McpRequestContext["resolveFeedback"];
+  submitResolution?: McpRequestContext["submitResolution"];
+};
+
+export function registerPersonaInteractionTools(
+  server: McpServer,
+  allowed: Set<string>,
+  callbacks: PersonaInteractionCallbacks
+): void {
+  const { agentId } = callbacks;
+
+  // ── list_personas ────────────────────────────────────────────────
+  if (allowed.has("list_personas") && callbacks.listPersonas) {
+    const personaRoot = callbacks.worktreeRoot ?? callbacks.repoRoot;
+    const listPersonas = callbacks.listPersonas;
+
+    server.registerTool(
+      "list_personas",
+      {
+        description:
+          "List the persona reviewers available for this project. Returns each persona's slug, name, and description. Use this to decide which personas to launch via dispatch_launch_persona.",
+        inputSchema: {},
+      },
+      async () => {
+        if (!personaRoot) {
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ personas: [] }, null, 2) },
+            ],
+            structuredContent: { personas: [] },
+          };
+        }
+        try {
+          const personas = await listPersonas(personaRoot);
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ personas }, null, 2) },
+            ],
+            structuredContent: { personas },
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_launch_persona ───────────────────────────────────────
+  if (allowed.has("dispatch_launch_persona") && callbacks.launchPersona) {
+    const launchPersona = callbacks.launchPersona;
+
+    server.registerTool(
+      "dispatch_launch_persona",
+      {
+        description:
+          "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files. Pass `allowRecheck: true` to opt into a single round-trip — the reviewer will stay alive after its initial verdict and perform a second pass after you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters.",
+        inputSchema: {
+          persona: z
+            .string()
+            .describe(
+              "Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."
+            ),
+          context: z
+            .string()
+            .max(100_000)
+            .describe(
+              "Briefing for the persona — describe what you built, key files changed, and areas that need attention."
+            ),
+          agentType: z
+            .enum(LAUNCH_PERSONA_AGENT_TYPES)
+            .optional()
+            .describe(
+              "Optional agent runtime override for the persona launch."
+            ),
+          allowRecheck: z
+            .boolean()
+            .default(false)
+            .describe(
+              "Opt into a single round-trip review: the reviewer stays alive after its initial verdict and performs a second pass once you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters."
+            ),
+          includeDiff: z
+            .boolean()
+            .default(true)
+            .describe(
+              "Whether to include the git diff in the persona prompt. Set to false for non-code reviews (PRDs, docs, media) where the diff is not the review target."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await launchPersona(agentId, {
+            persona: args.persona,
+            context: args.context,
+            agentType: args.agentType,
+            allowRecheck: args.allowRecheck,
+            includeDiff: args.includeDiff,
+          });
+          const text = buildLaunchPersonaResponseText(
+            result.persona,
+            result.agentId,
+            args.allowRecheck ?? false
+          );
+          return {
+            content: [{ type: "text", text }],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_get_feedback ───────────────────────────────────────────
+  if (allowed.has("dispatch_get_feedback") && callbacks.getFeedback) {
+    const getFeedback = callbacks.getFeedback;
+
+    server.registerTool(
+      "dispatch_get_feedback",
+      {
+        description:
+          "Retrieve structured feedback submitted by persona agents you launched. Returns feedback grouped by persona. Only returns feedback from your direct child persona agents.",
+        inputSchema: {
+          persona: z
+            .string()
+            .optional()
+            .describe(
+              "Filter to a specific persona by name. If omitted, returns feedback from all child personas."
+            ),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(100)
+            .default(100)
+            .describe(
+              "Maximum number of feedback items to return. Defaults and caps at 100."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await getFeedback(agentId, {
+            persona: args.persona,
+            limit: args.limit,
+          });
+          const totalItems = result.personas.reduce(
+            (sum, p) => sum + p.feedback.length,
+            0
+          );
+          const summary =
+            result.personas.length === 0
+              ? "No persona feedback found."
+              : `Found ${totalItems} feedback item(s) from ${result.personas.length} persona(s).`;
+          return {
+            content: [{ type: "text", text: summary }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_resolve_feedback ───────────────────────────────────────
+  if (allowed.has("dispatch_resolve_feedback") && callbacks.resolveFeedback) {
+    const resolveFeedback = callbacks.resolveFeedback;
+
+    server.registerTool(
+      "dispatch_resolve_feedback",
+      {
+        description:
+          "Mark a feedback item as fixed or ignored. If status is 'ignored', you must include a `reason` explaining why — when the review was launched with allowRecheck: true, the reviewer sees the reason in their recheck pass. If status is 'fixed', `reason` is optional but encouraged when the fix is non-obvious. The server records the current HEAD commit at the time of the call as the resolution commit.",
+        inputSchema: {
+          feedbackId: z
+            .number()
+            .int()
+            .positive()
+            .describe("The ID of the feedback item to resolve."),
+          status: z
+            .enum(["fixed", "ignored"])
+            .describe(
+              "Resolution status: 'fixed' if addressed, 'ignored' if not applicable."
+            ),
+          reason: z
+            .string()
+            .max(10_000)
+            .optional()
+            .describe(
+              "Why you chose this resolution. REQUIRED when status is 'ignored'. Optional but encouraged for 'fixed'. Max 10,000 characters."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await resolveFeedback(
+            agentId,
+            args.feedbackId,
+            args.status,
+            { reason: args.reason ?? null }
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Feedback #${result.id} marked as ${result.status}.`,
+              },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_submit_resolution ────────────────────────────────────
+  if (allowed.has("dispatch_submit_resolution") && callbacks.submitResolution) {
+    const submitResolution = callbacks.submitResolution;
+
+    server.registerTool(
+      "dispatch_submit_resolution",
+      {
+        description:
+          "Call this after you have resolved every feedback item from a review and are ready for the reviewer to verify your work. `summary` is required — 1–3 sentences explaining what you addressed and what you chose to leave alone. IMPORTANT: commit your fixes before calling this. The server captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit — if you submit with uncommitted changes, the reviewer sees an empty diff and will re-flag the same issues. When the review was launched with allowRecheck: true, submitting the resolution triggers the reviewer's single recheck pass. Rejected if any feedback item is still 'open' or if any 'ignored' item is missing a reason.",
+        inputSchema: {
+          personaAgentId: z
+            .string()
+            .describe(
+              "The persona agent ID whose review you are resolving (the agent you launched via dispatch_launch_persona)."
+            ),
+          summary: z
+            .string()
+            .min(1)
+            .max(10_000)
+            .describe(
+              "1–3 sentence narrative summary of what you addressed and what you left alone."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await submitResolution(agentId, {
+            personaAgentId: args.personaAgentId,
+            summary: args.summary,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Resolution submitted for review #${result.review.id} (round ${result.resolution.roundNumber}).`,
+              },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+}
+
+export function buildLaunchPersonaResponseText(
+  persona: string,
+  agentId: string,
+  allowRecheck: boolean
+): string {
+  const base = `Launched persona "${persona}" as agent ${agentId}.`;
+  if (!allowRecheck) {
+    return `${base}
+
+This review is push-based. Do not emit a terminal dispatch_event yet. Keep this turn alive and wait for the server to inject a completion prompt into this terminal when the reviewer finishes.
+
+There is no tool to poll while waiting. When the completion prompt arrives, call dispatch_get_feedback (personaAgentId="${agentId}") only if that prompt says feedback items were recorded, then wrap up.
+
+If no prompt has arrived after a clearly unreasonable delay (the reviewer crashed, was archived, or got stuck), bail out on your own with a non-done dispatch_event explaining what happened — there is no parent-side cancel tool for single-pass reviews today.`;
+  }
+  return `${base}
+
+Review was launched with recheck enabled. This is a multi-step round-trip — do not emit a terminal dispatch_event yet. The reviewer will stay alive waiting for your resolution, and the server will push a new prompt into this terminal when each round transitions.
+
+1. Wait for round 1. The server will inject a new prompt here when the reviewer submits their round-1 verdict. There is no tool to poll — keep this turn alive however your agent runtime allows, then act on the prompt when it arrives.
+
+2. When the round-1 prompt arrives, call dispatch_get_feedback (personaAgentId="${agentId}") to read the items. For each one, decide if you'll fix it or ignore it. Apply the fix, then call dispatch_resolve_feedback (status 'fixed' or 'ignored' — include a 'reason' for any you ignore).
+
+3. Commit your fixes before submitting the resolution. dispatch_submit_resolution captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit. If you submit while your fixes are uncommitted, the reviewer sees an empty diff and will re-flag the same issues.
+
+4. Call dispatch_submit_resolution with a 1–3 sentence summary of what you addressed. This triggers the reviewer's round-2 pass.
+
+5. Wait for round 2. The server will inject another prompt here when the reviewer submits their round-2 verdict. Read any new findings (filter dispatch_get_feedback for items where respondsToFeedbackId points at one of your round-1 items), then wrap up and emit a terminal dispatch_event.`;
+}

--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -4,12 +4,14 @@ import * as z from "zod/v4";
 import type { McpRequestContext } from "./server.js";
 import { toToolError } from "./tool-error.js";
 
-const LAUNCH_PERSONA_AGENT_TYPES = [
+export const LAUNCH_PERSONA_AGENT_TYPES = [
   "claude",
   "codex",
   "cursor",
   "opencode",
 ] as const;
+export type LaunchPersonaAgentType =
+  (typeof LAUNCH_PERSONA_AGENT_TYPES)[number];
 
 export type PersonaInteractionCallbacks = {
   agentId: string;

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -9,7 +9,10 @@ import { createPr, getPrStatus } from "../github/pr.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
 import { registerJobTools, type JobTools } from "./job-tools.js";
-import { registerPersonaInteractionTools } from "./persona-interaction-tools.js";
+import {
+  registerPersonaInteractionTools,
+  type LaunchPersonaAgentType,
+} from "./persona-interaction-tools.js";
 import { registerPersonaTools } from "./persona-tools.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 import { toToolError } from "./tool-error.js";
@@ -264,7 +267,7 @@ export type McpRequestContext = {
     opts: {
       persona: string;
       context: string;
-      agentType?: "claude" | "codex" | "cursor" | "opencode";
+      agentType?: LaunchPersonaAgentType;
       allowRecheck?: boolean;
       includeDiff?: boolean;
     }

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -9,6 +9,7 @@ import { createPr, getPrStatus } from "../github/pr.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
 import { registerJobTools, type JobTools } from "./job-tools.js";
+import { registerPersonaInteractionTools } from "./persona-interaction-tools.js";
 import { registerPersonaTools } from "./persona-tools.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 import { toToolError } from "./tool-error.js";
@@ -66,14 +67,6 @@ export type PersonaFeedbackGroup = {
 export type GetFeedbackResult = {
   personas: PersonaFeedbackGroup[];
 };
-
-const LAUNCH_PERSONA_AGENT_TYPES = [
-  "claude",
-  "codex",
-  "cursor",
-  "opencode",
-] as const;
-type LaunchPersonaAgentType = (typeof LAUNCH_PERSONA_AGENT_TYPES)[number];
 
 // ── Tool sets per agent type ──────────────────────────────────────────
 // Each list defines which MCP tools are exposed to that agent type.
@@ -271,7 +264,7 @@ export type McpRequestContext = {
     opts: {
       persona: string;
       context: string;
-      agentType?: LaunchPersonaAgentType;
+      agentType?: "claude" | "codex" | "cursor" | "opencode";
       allowRecheck?: boolean;
       includeDiff?: boolean;
     }
@@ -350,46 +343,6 @@ export type McpRequestContext = {
   toolScope?: "agent" | "reviewer" | "job";
   brainStore?: BrainStore;
 };
-
-/**
- * Builds the text body returned by dispatch_launch_persona. The parent-facing
- * guidance is push-based in both modes: for single-pass reviews the parent
- * waits for one completion prompt; for recheck reviews the parent waits for a
- * round-1 prompt and, after submitting a resolution, a round-2 prompt.
- *
- * The recheck round-trip is driven by server-side prompt injection: the
- * parent receives a fresh prompt in this terminal when the reviewer reports
- * back, and again after round 2. The parent does NOT poll any tool to wait.
- */
-export function buildLaunchPersonaResponseText(
-  persona: string,
-  agentId: string,
-  allowRecheck: boolean
-): string {
-  const base = `Launched persona "${persona}" as agent ${agentId}.`;
-  if (!allowRecheck) {
-    return `${base}
-
-This review is push-based. Do not emit a terminal dispatch_event yet. Keep this turn alive and wait for the server to inject a completion prompt into this terminal when the reviewer finishes.
-
-There is no tool to poll while waiting. When the completion prompt arrives, call dispatch_get_feedback (personaAgentId="${agentId}") only if that prompt says feedback items were recorded, then wrap up.
-
-If no prompt has arrived after a clearly unreasonable delay (the reviewer crashed, was archived, or got stuck), bail out on your own with a non-done dispatch_event explaining what happened — there is no parent-side cancel tool for single-pass reviews today.`;
-  }
-  return `${base}
-
-Review was launched with recheck enabled. This is a multi-step round-trip — do not emit a terminal dispatch_event yet. The reviewer will stay alive waiting for your resolution, and the server will push a new prompt into this terminal when each round transitions.
-
-1. Wait for round 1. The server will inject a new prompt here when the reviewer submits their round-1 verdict. There is no tool to poll — keep this turn alive however your agent runtime allows, then act on the prompt when it arrives.
-
-2. When the round-1 prompt arrives, call dispatch_get_feedback (personaAgentId="${agentId}") to read the items. For each one, decide if you'll fix it or ignore it. Apply the fix, then call dispatch_resolve_feedback (status 'fixed' or 'ignored' — include a 'reason' for any you ignore).
-
-3. Commit your fixes before submitting the resolution. dispatch_submit_resolution captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit. If you submit while your fixes are uncommitted, the reviewer sees an empty diff and will re-flag the same issues.
-
-4. Call dispatch_submit_resolution with a 1–3 sentence summary of what you addressed. This triggers the reviewer's round-2 pass.
-
-5. Wait for round 2. The server will inject another prompt here when the reviewer submits their round-2 verdict. Read any new findings (filter dispatch_get_feedback for items where respondsToFeedbackId points at one of your round-1 items), then wrap up and emit a terminal dispatch_event.`;
-}
 
 export async function handleMcpRequest(
   req: IncomingMessage,
@@ -730,275 +683,18 @@ async function createDispatchMcpServer(
 
   if (allowed.has("dispatch_feedback")) registerFeedbackTool(server, context);
 
-  // ── list_personas ────────────────────────────────────────────────
-  if (allowed.has("list_personas") && context.agent && context.listPersonas) {
-    const personaRoot = context.worktreeRoot ?? context.repoRoot;
-    const listPersonas = context.listPersonas;
-
-    server.registerTool(
-      "list_personas",
-      {
-        description:
-          "List the persona reviewers available for this project. Returns each persona's slug, name, and description. Use this to decide which personas to launch via dispatch_launch_persona.",
-        inputSchema: {},
-      },
-      async () => {
-        if (!personaRoot) {
-          return {
-            content: [
-              { type: "text", text: JSON.stringify({ personas: [] }, null, 2) },
-            ],
-            structuredContent: { personas: [] },
-          };
-        }
-        try {
-          const personas = await listPersonas(personaRoot);
-          return {
-            content: [
-              { type: "text", text: JSON.stringify({ personas }, null, 2) },
-            ],
-            structuredContent: { personas },
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_launch_persona ───────────────────────────────────────
-  if (
-    allowed.has("dispatch_launch_persona") &&
-    context.agent &&
-    context.launchPersona
-  ) {
-    const agentId = context.agent.id;
-    const launchPersona = context.launchPersona;
-
-    server.registerTool(
-      "dispatch_launch_persona",
-      {
-        description:
-          "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files. Pass `allowRecheck: true` to opt into a single round-trip — the reviewer will stay alive after its initial verdict and perform a second pass after you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters.",
-        inputSchema: {
-          persona: z
-            .string()
-            .describe(
-              "Name of the persona to launch (matches filename without .md extension, e.g. 'security-review')."
-            ),
-          context: z
-            .string()
-            .max(100_000)
-            .describe(
-              "Briefing for the persona — describe what you built, key files changed, and areas that need attention."
-            ),
-          agentType: z
-            .enum(LAUNCH_PERSONA_AGENT_TYPES)
-            .optional()
-            .describe(
-              "Optional agent runtime override for the persona launch."
-            ),
-          allowRecheck: z
-            .boolean()
-            .default(false)
-            .describe(
-              "Opt into a single round-trip review: the reviewer stays alive after its initial verdict and performs a second pass once you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters."
-            ),
-          includeDiff: z
-            .boolean()
-            .default(true)
-            .describe(
-              "Whether to include the git diff in the persona prompt. Set to false for non-code reviews (PRDs, docs, media) where the diff is not the review target."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await launchPersona(agentId, {
-            persona: args.persona,
-            context: args.context,
-            agentType: args.agentType,
-            allowRecheck: args.allowRecheck,
-            includeDiff: args.includeDiff,
-          });
-          const text = buildLaunchPersonaResponseText(
-            result.persona,
-            result.agentId,
-            args.allowRecheck ?? false
-          );
-          return {
-            content: [{ type: "text", text }],
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_get_feedback ───────────────────────────────────────────
-  if (
-    allowed.has("dispatch_get_feedback") &&
-    context.agent &&
-    context.getFeedback
-  ) {
-    const agentId = context.agent.id;
-    const getFeedback = context.getFeedback;
-
-    server.registerTool(
-      "dispatch_get_feedback",
-      {
-        description:
-          "Retrieve structured feedback submitted by persona agents you launched. Returns feedback grouped by persona. Only returns feedback from your direct child persona agents.",
-        inputSchema: {
-          persona: z
-            .string()
-            .optional()
-            .describe(
-              "Filter to a specific persona by name. If omitted, returns feedback from all child personas."
-            ),
-          limit: z
-            .number()
-            .int()
-            .positive()
-            .max(100)
-            .default(100)
-            .describe(
-              "Maximum number of feedback items to return. Defaults and caps at 100."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await getFeedback(agentId, {
-            persona: args.persona,
-            limit: args.limit,
-          });
-          const totalItems = result.personas.reduce(
-            (sum, p) => sum + p.feedback.length,
-            0
-          );
-          const summary =
-            result.personas.length === 0
-              ? "No persona feedback found."
-              : `Found ${totalItems} feedback item(s) from ${result.personas.length} persona(s).`;
-          return {
-            content: [{ type: "text", text: summary }],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_resolve_feedback ───────────────────────────────────────
-  if (
-    allowed.has("dispatch_resolve_feedback") &&
-    context.agent &&
-    context.resolveFeedback
-  ) {
-    const agentId = context.agent.id;
-    const resolveFeedback = context.resolveFeedback;
-
-    server.registerTool(
-      "dispatch_resolve_feedback",
-      {
-        description:
-          "Mark a feedback item as fixed or ignored. If status is 'ignored', you must include a `reason` explaining why — when the review was launched with allowRecheck: true, the reviewer sees the reason in their recheck pass. If status is 'fixed', `reason` is optional but encouraged when the fix is non-obvious. The server records the current HEAD commit at the time of the call as the resolution commit.",
-        inputSchema: {
-          feedbackId: z
-            .number()
-            .int()
-            .positive()
-            .describe("The ID of the feedback item to resolve."),
-          status: z
-            .enum(["fixed", "ignored"])
-            .describe(
-              "Resolution status: 'fixed' if addressed, 'ignored' if not applicable."
-            ),
-          reason: z
-            .string()
-            .max(10_000)
-            .optional()
-            .describe(
-              "Why you chose this resolution. REQUIRED when status is 'ignored'. Optional but encouraged for 'fixed'. Max 10,000 characters."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await resolveFeedback(
-            agentId,
-            args.feedbackId,
-            args.status,
-            { reason: args.reason ?? null }
-          );
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Feedback #${result.id} marked as ${result.status}.`,
-              },
-            ],
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_submit_resolution ────────────────────────────────────
-  if (
-    allowed.has("dispatch_submit_resolution") &&
-    context.agent &&
-    context.submitResolution
-  ) {
-    const agentId = context.agent.id;
-    const submitResolution = context.submitResolution;
-
-    server.registerTool(
-      "dispatch_submit_resolution",
-      {
-        description:
-          "Call this after you have resolved every feedback item from a review and are ready for the reviewer to verify your work. `summary` is required — 1–3 sentences explaining what you addressed and what you chose to leave alone. IMPORTANT: commit your fixes before calling this. The server captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit — if you submit with uncommitted changes, the reviewer sees an empty diff and will re-flag the same issues. When the review was launched with allowRecheck: true, submitting the resolution triggers the reviewer's single recheck pass. Rejected if any feedback item is still 'open' or if any 'ignored' item is missing a reason.",
-        inputSchema: {
-          personaAgentId: z
-            .string()
-            .describe(
-              "The persona agent ID whose review you are resolving (the agent you launched via dispatch_launch_persona)."
-            ),
-          summary: z
-            .string()
-            .min(1)
-            .max(10_000)
-            .describe(
-              "1–3 sentence narrative summary of what you addressed and what you left alone."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await submitResolution(agentId, {
-            personaAgentId: args.personaAgentId,
-            summary: args.summary,
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Resolution submitted for review #${result.review.id} (round ${result.resolution.roundNumber}).`,
-              },
-            ],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
+  // ── Parent-side persona interaction tools ─────────────────────────
+  if (context.agent) {
+    registerPersonaInteractionTools(server, allowed, {
+      agentId: context.agent.id,
+      worktreeRoot: context.worktreeRoot,
+      repoRoot: context.repoRoot,
+      listPersonas: context.listPersonas,
+      launchPersona: context.launchPersona,
+      getFeedback: context.getFeedback,
+      resolveFeedback: context.resolveFeedback,
+      submitResolution: context.submitResolution,
+    });
   }
 
   // ── Brain tools (shared memory for agents) ────────────────────────

--- a/apps/server/test/mcp-launch-persona-response.test.ts
+++ b/apps/server/test/mcp-launch-persona-response.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { buildLaunchPersonaResponseText } from "../src/shared/mcp/server.js";
+import { buildLaunchPersonaResponseText } from "../src/shared/mcp/persona-interaction-tools.js";
 
 describe("buildLaunchPersonaResponseText", () => {
   const persona = "backend-security-review";


### PR DESCRIPTION
## Summary

- Extracted 5 parent-side persona tools (`list_personas`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`) and `buildLaunchPersonaResponseText` from `server.ts` into a new `persona-interaction-tools.ts` module
- Follows the same extraction pattern as `persona-tools.ts` (PR #572), `job-tools.ts`, and `analytics-tools.ts`
- `server.ts` reduced from 1377 to 1073 lines (-304 lines)

## Why this is tech debt

The MCP `server.ts` file accumulated all tool registrations inline, making it hard to navigate and maintain. This is the continuation of a multi-run extraction effort (see pattern in Brain). The parent-side persona tools formed a cohesive group that was identified in the previous run as the next candidate.

## What's next

Top backlog items for future runs:
1. Large file: `apps/server/src/agents/manager.ts` (1733 lines) — check for extractable functions
2. `ide-settings.ts` / `agent-type-settings.ts` shared pattern — monitor for a third instance
3. Re-scan route files for new utility duplication

## Test plan

- [x] `pnpm run check` — TypeScript clean
- [x] `pnpm run test` — all unit tests pass (including `mcp-launch-persona-response.test.ts` with updated import)
- [x] `pnpm run test:e2e` — 144/144 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)