### PR TITLE
Add Brain list support for ordered shared state

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `brain_store_object`         | Create or update a shared Brain object (optimistic concurrency)            |
 | `brain_list_objects`         | List Brain objects, optionally filtered by collection or prefix            |
 | `brain_delete_object`        | Delete a shared Brain object                                               |
+| `brain_list_push`            | Append one or more items to a shared Brain list                            |
+| `brain_list_remove`          | Remove one item from a shared Brain list by index or field match           |
+| `brain_list_get`             | Read items from a shared Brain list with paging and ordering               |
+| `brain_list_set`             | Replace one item in a shared Brain list by index                           |
+| `brain_list_delete`          | Delete a shared Brain list and all of its items                            |
 | `brain_append_event`         | Append a structured event to the Brain's immutable event log               |
 | `brain_query_events`         | Query Brain events by collection, kind, subject, tags, and time range      |
 
@@ -185,7 +190,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_append_event`, and `brain_query_events`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, and `brain_query_events`.
 
 ### Repo-specific tools
 

--- a/apps/server/src/brain/store.ts
+++ b/apps/server/src/brain/store.ts
@@ -676,36 +676,34 @@ export class BrainStore {
       throw new BrainListNotFoundError(collection, name);
     }
 
-    try {
-      const insertResult = await client.query(
-        `INSERT INTO brain_lists (repo_root, collection, name, revision, created_by_agent_id, updated_by_agent_id)
-         VALUES ($1, $2, $3, 0, $4, $4)
-         RETURNING ${listColumns()}`,
-        [repoRoot, collection, name, agentId]
-      );
+    const insertResult = await client.query(
+      `INSERT INTO brain_lists (repo_root, collection, name, revision, created_by_agent_id, updated_by_agent_id)
+       VALUES ($1, $2, $3, 0, $4, $4)
+       ON CONFLICT (repo_root, collection, name) DO NOTHING
+       RETURNING ${listColumns()}`,
+      [repoRoot, collection, name, agentId]
+    );
+    if (insertResult.rows[0]) {
       return mapList(insertResult.rows[0]);
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        const retryResult = await client.query(
-          `SELECT ${listColumns()} FROM brain_lists
-           WHERE repo_root = $1 AND collection = $2 AND name = $3
-           FOR UPDATE`,
-          [repoRoot, collection, name]
-        );
-        if (!retryResult.rows[0]) {
-          throw error;
-        }
-        const existing = mapList(retryResult.rows[0]);
-        if (
-          expectedRevision !== undefined &&
-          existing.revision !== expectedRevision
-        ) {
-          throw new BrainRevisionConflictError(existing);
-        }
-        return existing;
-      }
-      throw error;
     }
+
+    const retryResult = await client.query(
+      `SELECT ${listColumns()} FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3
+       FOR UPDATE`,
+      [repoRoot, collection, name]
+    );
+    if (!retryResult.rows[0]) {
+      throw new BrainListNotFoundError(collection, name);
+    }
+    const existing = mapList(retryResult.rows[0]);
+    if (
+      expectedRevision !== undefined &&
+      existing.revision !== expectedRevision
+    ) {
+      throw new BrainRevisionConflictError(existing);
+    }
+    return existing;
   }
 
   private async getListForUpdate(

--- a/apps/server/src/brain/store.ts
+++ b/apps/server/src/brain/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Pool } from "pg";
+import type { Pool, PoolClient } from "pg";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -26,6 +26,23 @@ export type BrainEvent = {
   agentId: string;
 };
 
+export type BrainList = {
+  collection: string;
+  name: string;
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+  createdByAgentId: string;
+  updatedByAgentId: string;
+};
+
+export type BrainListItem = {
+  index: number;
+  value: unknown;
+  createdAt: string;
+  updatedAt: string;
+};
+
 // ── Errors ───────────────────────────────────────────────────────────
 
 export class BrainNotFoundError extends Error {
@@ -35,11 +52,38 @@ export class BrainNotFoundError extends Error {
   }
 }
 
+export class BrainListNotFoundError extends Error {
+  readonly code = "not_found" as const;
+  constructor(collection: string, name: string) {
+    super(`List "${collection}/${name}" not found.`);
+  }
+}
+
+export class BrainListItemNotFoundError extends Error {
+  readonly code = "not_found" as const;
+  constructor(
+    collection: string,
+    name: string,
+    details: { index?: number; field?: string; equals?: string }
+  ) {
+    if (details.index !== undefined) {
+      super(
+        `List item "${collection}/${name}" at index ${details.index} not found.`
+      );
+      return;
+    }
+    super(
+      `List item "${collection}/${name}" matching ${details.field}="${details.equals}" not found.`
+    );
+  }
+}
+
 export class BrainRevisionConflictError extends Error {
   readonly code = "revision_conflict" as const;
-  readonly current: BrainObject;
-  constructor(current: BrainObject) {
-    super("Object revision does not match expectedRevision.");
+  readonly current: BrainObject | BrainList;
+  constructor(current: BrainObject | BrainList) {
+    const kind = "value" in current ? "Object" : "List";
+    super(`${kind} revision does not match expectedRevision.`);
     this.current = current;
   }
 }
@@ -213,6 +257,280 @@ export class BrainStore {
     return (result.rowCount ?? 0) > 0;
   }
 
+  // ── Lists ────────────────────────────────────────────────────────
+
+  async getList(
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<BrainList | null> {
+    const result = await this.pool.query(
+      `SELECT ${listColumns()} FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return result.rows[0] ? mapList(result.rows[0]) : null;
+  }
+
+  async getListItems(
+    repoRoot: string,
+    input: {
+      collection: string;
+      name: string;
+      limit?: number;
+      offset?: number;
+      order?: "asc" | "desc";
+    }
+  ): Promise<{ items: BrainListItem[]; totalCount: number; revision: number }> {
+    const { collection, name } = input;
+    return await this.withTransaction(
+      async (client) => {
+        const list = await this.getListForUpdate(
+          client,
+          repoRoot,
+          collection,
+          name
+        );
+        if (!list) {
+          return { items: [], totalCount: 0, revision: 0 };
+        }
+
+        const offset = Math.max(0, input.offset ?? 0);
+        const limit = clampLimit(input.limit);
+        const order = input.order === "desc" ? "DESC" : "ASC";
+        const result = await client.query(
+          `SELECT ${listItemColumns()},
+                  COUNT(*) OVER()::int AS total_count
+           FROM brain_list_items
+           WHERE repo_root = $1 AND collection = $2 AND name = $3
+           ORDER BY item_index ${order}
+           OFFSET $4
+           LIMIT $5`,
+          [repoRoot, collection, name, offset, limit]
+        );
+
+        return {
+          items: result.rows.map(mapListItem),
+          totalCount: result.rows[0]?.total_count ?? 0,
+          revision: list.revision,
+        };
+      },
+      { isolationLevel: "REPEATABLE READ" }
+    );
+  }
+
+  async pushListItems(
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      name: string;
+      items: unknown[];
+      maxItems?: number;
+      expectedRevision?: number;
+    }
+  ): Promise<{ length: number; revision: number }> {
+    const { collection, name, items, maxItems, expectedRevision } = input;
+    if (items.length === 0) {
+      throw new BrainValidationError("List push requires at least one item.");
+    }
+    if (maxItems !== undefined && maxItems < 1) {
+      throw new BrainValidationError("maxItems must be at least 1.");
+    }
+
+    return await this.withTransaction(async (client) => {
+      const list = await this.lockOrCreateList(client, repoRoot, agentId, {
+        collection,
+        name,
+        expectedRevision,
+      });
+      const nextIndex = await this.getNextListIndex(
+        client,
+        repoRoot,
+        collection,
+        name
+      );
+
+      for (const [offset, item] of items.entries()) {
+        await client.query(
+          `INSERT INTO brain_list_items (repo_root, collection, name, item_index, value)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [repoRoot, collection, name, nextIndex + offset, JSON.stringify(item)]
+        );
+      }
+
+      if (maxItems !== undefined) {
+        await this.trimListToMaxItems(
+          client,
+          repoRoot,
+          collection,
+          name,
+          maxItems
+        );
+      }
+
+      const updated = await this.bumpListRevision(
+        client,
+        repoRoot,
+        collection,
+        name,
+        agentId,
+        list.revision
+      );
+      const length = await this.getListLength(
+        client,
+        repoRoot,
+        collection,
+        name
+      );
+      return { length, revision: updated.revision };
+    });
+  }
+
+  async removeListItem(
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      name: string;
+      index?: number;
+      where?: { field: string; equals: string };
+      expectedRevision?: number;
+    }
+  ): Promise<{ removed: unknown; length: number; revision: number }> {
+    const { collection, name, index, where, expectedRevision } = input;
+    if ((index === undefined) === (where === undefined)) {
+      throw new BrainValidationError(
+        "Provide exactly one of index or where when removing a list item."
+      );
+    }
+
+    return await this.withTransaction(async (client) => {
+      const list = await this.lockExistingList(
+        client,
+        repoRoot,
+        collection,
+        name,
+        expectedRevision
+      );
+      const target = await this.findListItemForRemoval(
+        client,
+        repoRoot,
+        collection,
+        name,
+        {
+          index,
+          where,
+        }
+      );
+      if (!target) {
+        if (index !== undefined) {
+          throw new BrainListItemNotFoundError(collection, name, { index });
+        }
+        throw new BrainListItemNotFoundError(collection, name, {
+          field: where?.field,
+          equals: where?.equals,
+        });
+      }
+
+      await client.query(
+        `DELETE FROM brain_list_items
+         WHERE repo_root = $1 AND collection = $2 AND name = $3 AND item_index = $4`,
+        [repoRoot, collection, name, target.index]
+      );
+      await this.reindexListItems(client, repoRoot, collection, name);
+      const updated = await this.bumpListRevision(
+        client,
+        repoRoot,
+        collection,
+        name,
+        agentId,
+        list.revision
+      );
+      const length = await this.getListLength(
+        client,
+        repoRoot,
+        collection,
+        name
+      );
+      return { removed: target.value, length, revision: updated.revision };
+    });
+  }
+
+  async setListItem(
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      name: string;
+      index: number;
+      value: unknown;
+      expectedRevision?: number;
+    }
+  ): Promise<{ item: BrainListItem; length: number; revision: number }> {
+    const { collection, name, index, value, expectedRevision } = input;
+    if (index < 0) {
+      throw new BrainValidationError("List item index must be 0 or greater.");
+    }
+    if (expectedRevision === undefined) {
+      throw new BrainValidationError(
+        "List item updates require expectedRevision because item positions can shift after removals."
+      );
+    }
+
+    return await this.withTransaction(async (client) => {
+      const list = await this.lockExistingList(
+        client,
+        repoRoot,
+        collection,
+        name,
+        expectedRevision
+      );
+      const result = await client.query(
+        `UPDATE brain_list_items
+         SET value = $1, updated_at = now()
+         WHERE repo_root = $2 AND collection = $3 AND name = $4 AND item_index = $5
+         RETURNING ${listItemColumns()}`,
+        [JSON.stringify(value), repoRoot, collection, name, index]
+      );
+      if (result.rows.length === 0) {
+        throw new BrainListItemNotFoundError(collection, name, { index });
+      }
+      const updated = await this.bumpListRevision(
+        client,
+        repoRoot,
+        collection,
+        name,
+        agentId,
+        list.revision
+      );
+      const length = await this.getListLength(
+        client,
+        repoRoot,
+        collection,
+        name
+      );
+      return {
+        item: mapListItem(result.rows[0]),
+        length,
+        revision: updated.revision,
+      };
+    });
+  }
+
+  async deleteList(
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
   // ── Events ──────────────────────────────────────────────────────
 
   async appendEvent(
@@ -302,6 +620,287 @@ export class BrainStore {
     );
     return result.rows.map(mapEvent);
   }
+
+  private async withTransaction<T>(
+    fn: (client: PoolClient) => Promise<T>,
+    options?: { isolationLevel?: "REPEATABLE READ" | "SERIALIZABLE" }
+  ): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      if (options?.isolationLevel) {
+        await client.query(
+          `SET TRANSACTION ISOLATION LEVEL ${options.isolationLevel}`
+        );
+      }
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async lockOrCreateList(
+    client: PoolClient,
+    repoRoot: string,
+    agentId: string,
+    input: {
+      collection: string;
+      name: string;
+      expectedRevision?: number;
+    }
+  ): Promise<BrainList> {
+    const { collection, name, expectedRevision } = input;
+    const existingResult = await client.query(
+      `SELECT ${listColumns()} FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3
+       FOR UPDATE`,
+      [repoRoot, collection, name]
+    );
+    if (existingResult.rows[0]) {
+      const existing = mapList(existingResult.rows[0]);
+      if (
+        expectedRevision !== undefined &&
+        existing.revision !== expectedRevision
+      ) {
+        throw new BrainRevisionConflictError(existing);
+      }
+      return existing;
+    }
+
+    if (expectedRevision !== undefined) {
+      throw new BrainListNotFoundError(collection, name);
+    }
+
+    try {
+      const insertResult = await client.query(
+        `INSERT INTO brain_lists (repo_root, collection, name, revision, created_by_agent_id, updated_by_agent_id)
+         VALUES ($1, $2, $3, 0, $4, $4)
+         RETURNING ${listColumns()}`,
+        [repoRoot, collection, name, agentId]
+      );
+      return mapList(insertResult.rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        const retryResult = await client.query(
+          `SELECT ${listColumns()} FROM brain_lists
+           WHERE repo_root = $1 AND collection = $2 AND name = $3
+           FOR UPDATE`,
+          [repoRoot, collection, name]
+        );
+        if (!retryResult.rows[0]) {
+          throw error;
+        }
+        const existing = mapList(retryResult.rows[0]);
+        if (
+          expectedRevision !== undefined &&
+          existing.revision !== expectedRevision
+        ) {
+          throw new BrainRevisionConflictError(existing);
+        }
+        return existing;
+      }
+      throw error;
+    }
+  }
+
+  private async getListForUpdate(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<BrainList | null> {
+    const result = await client.query(
+      `SELECT ${listColumns()} FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return result.rows[0] ? mapList(result.rows[0]) : null;
+  }
+
+  private async lockExistingList(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string,
+    expectedRevision?: number
+  ): Promise<BrainList> {
+    const result = await client.query(
+      `SELECT ${listColumns()} FROM brain_lists
+       WHERE repo_root = $1 AND collection = $2 AND name = $3
+       FOR UPDATE`,
+      [repoRoot, collection, name]
+    );
+    if (!result.rows[0]) {
+      throw new BrainListNotFoundError(collection, name);
+    }
+    const list = mapList(result.rows[0]);
+    if (expectedRevision !== undefined && list.revision !== expectedRevision) {
+      throw new BrainRevisionConflictError(list);
+    }
+    return list;
+  }
+
+  private async getNextListIndex(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<number> {
+    const result = await client.query(
+      `SELECT COALESCE(MAX(item_index) + 1, 0)::int AS next_index
+       FROM brain_list_items
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return result.rows[0]?.next_index ?? 0;
+  }
+
+  private async trimListToMaxItems(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string,
+    maxItems: number
+  ): Promise<void> {
+    await client.query(
+      `WITH overflow AS (
+         SELECT GREATEST(COUNT(*)::int - $4, 0) AS remove_count
+         FROM brain_list_items
+         WHERE repo_root = $1 AND collection = $2 AND name = $3
+       ), ranked AS (
+         SELECT items.repo_root,
+                items.collection,
+                items.name,
+                items.item_index,
+                ROW_NUMBER() OVER (ORDER BY items.item_index ASC) AS row_num,
+                overflow.remove_count
+         FROM brain_list_items AS items
+         CROSS JOIN overflow
+         WHERE items.repo_root = $1 AND items.collection = $2 AND items.name = $3
+       )
+       DELETE FROM brain_list_items
+       WHERE (repo_root, collection, name, item_index) IN (
+         SELECT repo_root, collection, name, item_index
+         FROM ranked
+         WHERE row_num <= remove_count
+       )`,
+      [repoRoot, collection, name, maxItems]
+    );
+    await this.reindexListItems(client, repoRoot, collection, name);
+  }
+
+  private async findListItemForRemoval(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string,
+    selector: {
+      index?: number;
+      where?: { field: string; equals: string };
+    }
+  ): Promise<BrainListItem | null> {
+    if (selector.index !== undefined) {
+      const result = await client.query(
+        `SELECT ${listItemColumns()} FROM brain_list_items
+         WHERE repo_root = $1 AND collection = $2 AND name = $3 AND item_index = $4`,
+        [repoRoot, collection, name, selector.index]
+      );
+      return result.rows[0] ? mapListItem(result.rows[0]) : null;
+    }
+
+    const result = await client.query(
+      `SELECT ${listItemColumns()} FROM brain_list_items
+       WHERE repo_root = $1 AND collection = $2 AND name = $3
+         AND value ->> $4 = $5
+       ORDER BY item_index ASC
+       LIMIT 1`,
+      [
+        repoRoot,
+        collection,
+        name,
+        selector.where?.field,
+        selector.where?.equals,
+      ]
+    );
+    return result.rows[0] ? mapListItem(result.rows[0]) : null;
+  }
+
+  private async reindexListItems(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<void> {
+    await client.query(
+      `WITH ordered AS (
+         SELECT ctid,
+                ROW_NUMBER() OVER (ORDER BY item_index) - 1 AS next_index,
+                ROW_NUMBER() OVER (ORDER BY item_index) + 1000000 AS temp_index
+         FROM brain_list_items
+         WHERE repo_root = $1 AND collection = $2 AND name = $3
+       )
+       UPDATE brain_list_items AS items
+       SET item_index = ordered.temp_index
+       FROM ordered
+       WHERE items.ctid = ordered.ctid`,
+      [repoRoot, collection, name]
+    );
+    await client.query(
+      `WITH ordered AS (
+         SELECT ctid, ROW_NUMBER() OVER (ORDER BY item_index) - 1 AS next_index
+         FROM brain_list_items
+         WHERE repo_root = $1 AND collection = $2 AND name = $3
+       )
+       UPDATE brain_list_items AS items
+       SET item_index = ordered.next_index
+       FROM ordered
+       WHERE items.ctid = ordered.ctid`,
+      [repoRoot, collection, name]
+    );
+  }
+
+  private async bumpListRevision(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string,
+    agentId: string,
+    revision: number
+  ): Promise<BrainList> {
+    const result = await client.query(
+      `UPDATE brain_lists
+       SET revision = revision + 1, updated_at = now(), updated_by_agent_id = $1
+       WHERE repo_root = $2 AND collection = $3 AND name = $4 AND revision = $5
+       RETURNING ${listColumns()}`,
+      [agentId, repoRoot, collection, name, revision]
+    );
+    if (!result.rows[0]) {
+      const current = await this.getList(repoRoot, collection, name);
+      if (!current) throw new BrainListNotFoundError(collection, name);
+      throw new BrainRevisionConflictError(current);
+    }
+    return mapList(result.rows[0]);
+  }
+
+  private async getListLength(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string
+  ): Promise<number> {
+    const result = await client.query(
+      `SELECT COUNT(*)::int AS total
+       FROM brain_list_items
+       WHERE repo_root = $1 AND collection = $2 AND name = $3`,
+      [repoRoot, collection, name]
+    );
+    return result.rows[0]?.total ?? 0;
+  }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -338,6 +937,35 @@ function eventColumns(): string {
 
 function mapEvent(row: Record<string, unknown>): BrainEvent {
   return row as BrainEvent;
+}
+
+function listColumns(): string {
+  return `
+    collection,
+    name,
+    revision,
+    created_at AS "createdAt",
+    updated_at AS "updatedAt",
+    created_by_agent_id AS "createdByAgentId",
+    updated_by_agent_id AS "updatedByAgentId"
+  `;
+}
+
+function mapList(row: Record<string, unknown>): BrainList {
+  return row as BrainList;
+}
+
+function listItemColumns(): string {
+  return `
+    item_index AS "index",
+    value,
+    created_at AS "createdAt",
+    updated_at AS "updatedAt"
+  `;
+}
+
+function mapListItem(row: Record<string, unknown>): BrainListItem {
+  return row as BrainListItem;
 }
 
 function escapeLike(value: string): string {

--- a/apps/server/src/brain/store.ts
+++ b/apps/server/src/brain/store.ts
@@ -106,6 +106,7 @@ export class BrainLimitExceededError extends Error {
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+export const MAX_LIST_ITEMS_PER_PUSH = 200;
 
 function clampLimit(limit: number | undefined): number {
   const n = limit ?? DEFAULT_LIMIT;
@@ -334,8 +335,16 @@ export class BrainStore {
     if (items.length === 0) {
       throw new BrainValidationError("List push requires at least one item.");
     }
+    if (items.length > MAX_LIST_ITEMS_PER_PUSH) {
+      throw new BrainValidationError(
+        `List push accepts at most ${MAX_LIST_ITEMS_PER_PUSH} items per call.`
+      );
+    }
     if (maxItems !== undefined && maxItems < 1) {
       throw new BrainValidationError("maxItems must be at least 1.");
+    }
+    if (maxItems !== undefined && maxItems > MAX_LIMIT) {
+      throw new BrainValidationError(`maxItems cannot exceed ${MAX_LIMIT}.`);
     }
 
     return await this.withTransaction(async (client) => {
@@ -351,13 +360,14 @@ export class BrainStore {
         name
       );
 
-      for (const [offset, item] of items.entries()) {
-        await client.query(
-          `INSERT INTO brain_list_items (repo_root, collection, name, item_index, value)
-           VALUES ($1, $2, $3, $4, $5)`,
-          [repoRoot, collection, name, nextIndex + offset, JSON.stringify(item)]
-        );
-      }
+      await this.insertListItems(
+        client,
+        repoRoot,
+        collection,
+        name,
+        nextIndex,
+        items
+      );
 
       if (maxItems !== undefined) {
         await this.trimListToMaxItems(
@@ -898,6 +908,34 @@ export class BrainStore {
       [repoRoot, collection, name]
     );
     return result.rows[0]?.total ?? 0;
+  }
+
+  private async insertListItems(
+    client: PoolClient,
+    repoRoot: string,
+    collection: string,
+    name: string,
+    startIndex: number,
+    items: unknown[]
+  ): Promise<void> {
+    const values: unknown[] = [];
+    const placeholders = items.map((item, offset) => {
+      const base = values.length;
+      values.push(
+        repoRoot,
+        collection,
+        name,
+        startIndex + offset,
+        JSON.stringify(item)
+      );
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5})`;
+    });
+
+    await client.query(
+      `INSERT INTO brain_list_items (repo_root, collection, name, item_index, value)
+       VALUES ${placeholders.join(", ")}`,
+      values
+    );
   }
 }
 

--- a/apps/server/src/db/migrations/0026_brain-lists.sql
+++ b/apps/server/src/db/migrations/0026_brain-lists.sql
@@ -1,0 +1,33 @@
+-- Brain lists: ordered mutable collections with push/remove/set semantics
+
+CREATE TABLE IF NOT EXISTS brain_lists (
+  repo_root text NOT NULL,
+  collection text NOT NULL,
+  name text NOT NULL,
+  revision integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by_agent_id text NOT NULL,
+  updated_by_agent_id text NOT NULL,
+  PRIMARY KEY (repo_root, collection, name)
+);
+
+CREATE INDEX IF NOT EXISTS brain_lists_repo_collection_updated_idx
+  ON brain_lists (repo_root, collection, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_list_items (
+  repo_root text NOT NULL,
+  collection text NOT NULL,
+  name text NOT NULL,
+  item_index integer NOT NULL,
+  value jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (repo_root, collection, name, item_index),
+  FOREIGN KEY (repo_root, collection, name)
+    REFERENCES brain_lists (repo_root, collection, name)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS brain_list_items_repo_collection_name_idx
+  ON brain_list_items (repo_root, collection, name, item_index);

--- a/apps/server/src/shared/mcp/brain-tools.ts
+++ b/apps/server/src/shared/mcp/brain-tools.ts
@@ -9,6 +9,7 @@ import {
   BrainRevisionConflictError,
   BrainValidationError,
   BrainLimitExceededError,
+  MAX_LIST_ITEMS_PER_PUSH,
 } from "../../brain/store.js";
 import { toToolError } from "./tool-error.js";
 
@@ -185,11 +186,13 @@ export function registerBrainTools(
           items: z
             .array(jsonObjectSchema)
             .min(1)
+            .max(MAX_LIST_ITEMS_PER_PUSH)
             .describe("One or more JSON objects to append."),
           maxItems: z
             .number()
             .int()
             .positive()
+            .max(200)
             .optional()
             .describe(
               "If set, trim oldest items after the push so the list stays within this size."

--- a/apps/server/src/shared/mcp/brain-tools.ts
+++ b/apps/server/src/shared/mcp/brain-tools.ts
@@ -4,6 +4,8 @@ import * as z from "zod/v4";
 import type { BrainStore } from "../../brain/store.js";
 import {
   BrainNotFoundError,
+  BrainListNotFoundError,
+  BrainListItemNotFoundError,
   BrainRevisionConflictError,
   BrainValidationError,
   BrainLimitExceededError,
@@ -34,8 +36,8 @@ function toBrainError(error: unknown): ToolResult {
           current: {
             collection: error.current.collection,
             name: error.current.name,
-            value: error.current.value,
             revision: error.current.revision,
+            ...("value" in error.current ? { value: error.current.value } : {}),
           },
         },
       } as Record<string, unknown>,
@@ -43,6 +45,8 @@ function toBrainError(error: unknown): ToolResult {
   }
   if (
     error instanceof BrainNotFoundError ||
+    error instanceof BrainListNotFoundError ||
+    error instanceof BrainListItemNotFoundError ||
     error instanceof BrainValidationError ||
     error instanceof BrainLimitExceededError
   ) {
@@ -63,6 +67,8 @@ const kindSchema = z.string().min(1).max(255);
 const subjectSchema = z.string().min(1).max(255);
 const tagSchema = z.string().min(1).max(255);
 const tagsSchema = z.array(tagSchema).max(50);
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+const listOrderSchema = z.enum(["asc", "desc"]);
 
 export function registerBrainTools(
   server: McpServer,
@@ -153,6 +159,267 @@ export function registerBrainTools(
           return {
             content: [{ type: "text", text: JSON.stringify(obj, null, 2) }],
             structuredContent: obj as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_push ──────────────────────────────────────────────
+  if (allowed.has("brain_list_push")) {
+    server.registerTool(
+      "brain_list_push",
+      {
+        description:
+          "Push one or more items to a shared brain list. " +
+          "Optionally cap the list size with maxItems so the oldest items roll off automatically.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the list belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the list within the collection."
+          ),
+          items: z
+            .array(jsonObjectSchema)
+            .min(1)
+            .describe("One or more JSON objects to append."),
+          maxItems: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "If set, trim oldest items after the push so the list stays within this size."
+            ),
+          expectedRevision: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Optional optimistic concurrency check for coordinated multi-step updates."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await store.pushListItems(repoRoot, agentId, {
+            collection: args.collection,
+            name: args.name,
+            items: args.items,
+            maxItems: args.maxItems,
+            expectedRevision: args.expectedRevision,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_remove ────────────────────────────────────────────
+  if (allowed.has("brain_list_remove")) {
+    server.registerTool(
+      "brain_list_remove",
+      {
+        description:
+          "Remove a single item from a shared brain list by index or by matching a field value.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the list belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the list within the collection."
+          ),
+          index: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("Remove the item at this 0-based position."),
+          where: z
+            .object({
+              field: z.string().min(1).max(255),
+              equals: z.string(),
+            })
+            .optional()
+            .describe(
+              "Remove the first item whose top-level field matches this string value."
+            ),
+          expectedRevision: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Optional optimistic concurrency check for coordinated multi-step updates."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await store.removeListItem(repoRoot, agentId, {
+            collection: args.collection,
+            name: args.name,
+            index: args.index,
+            where: args.where,
+            expectedRevision: args.expectedRevision,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_get ───────────────────────────────────────────────
+  if (allowed.has("brain_list_get")) {
+    server.registerTool(
+      "brain_list_get",
+      {
+        description:
+          "Read items from a shared brain list. Returns the selected items, total count, and current revision.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the list belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the list within the collection."
+          ),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(200)
+            .optional()
+            .describe("Max items to return (default 50, max 200)."),
+          offset: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("Skip this many items from the start of the list."),
+          order: listOrderSchema
+            .optional()
+            .describe("Return oldest-first ('asc') or newest-first ('desc')."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await store.getListItems(repoRoot, {
+            collection: args.collection,
+            name: args.name,
+            limit: args.limit,
+            offset: args.offset,
+            order: args.order,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_set ───────────────────────────────────────────────
+  if (allowed.has("brain_list_set")) {
+    server.registerTool(
+      "brain_list_set",
+      {
+        description:
+          "Replace a single item at a specific index in a shared brain list without rewriting the rest.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the list belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the list within the collection."
+          ),
+          index: z
+            .number()
+            .int()
+            .min(0)
+            .describe("The 0-based index to replace."),
+          value: jsonObjectSchema.describe(
+            "The JSON object to store at that index."
+          ),
+          expectedRevision: z
+            .number()
+            .int()
+            .positive()
+            .describe(
+              "Required optimistic concurrency check. Pass the revision returned by brain_list_get."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await store.setListItem(repoRoot, agentId, {
+            collection: args.collection,
+            name: args.name,
+            index: args.index,
+            value: args.value,
+            expectedRevision: args.expectedRevision,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (error) {
+          return toBrainError(error);
+        }
+      }
+    );
+  }
+
+  // ── brain_list_delete ────────────────────────────────────────────
+  if (allowed.has("brain_list_delete")) {
+    server.registerTool(
+      "brain_list_delete",
+      {
+        description:
+          "Delete a shared brain list by collection and name. Deletes all items in the list as well.",
+        inputSchema: {
+          collection: collectionSchema.describe(
+            "The collection the list belongs to."
+          ),
+          name: nameSchema.describe(
+            "The unique name of the list within the collection."
+          ),
+        },
+      },
+      async (args) => {
+        try {
+          const deleted = await store.deleteList(
+            repoRoot,
+            args.collection,
+            args.name
+          );
+          const result = { deleted };
+          return {
+            content: [
+              {
+                type: "text",
+                text: deleted
+                  ? `Deleted list "${args.collection}/${args.name}".`
+                  : `List "${args.collection}/${args.name}" not found.`,
+              },
+            ],
+            structuredContent: result as unknown as Record<string, unknown>,
           };
         } catch (error) {
           return toBrainError(error);

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -101,6 +101,11 @@ const AGENT_TOOLS = new Set([
   "brain_store_object",
   "brain_list_objects",
   "brain_delete_object",
+  "brain_list_push",
+  "brain_list_remove",
+  "brain_list_get",
+  "brain_list_set",
+  "brain_list_delete",
   "brain_append_event",
   "brain_query_events",
 ]);
@@ -134,6 +139,11 @@ const JOB_TOOLS = new Set([
   "brain_store_object",
   "brain_list_objects",
   "brain_delete_object",
+  "brain_list_push",
+  "brain_list_remove",
+  "brain_list_get",
+  "brain_list_set",
+  "brain_list_delete",
   "brain_append_event",
   "brain_query_events",
 ]);

--- a/apps/server/test/brain-store.test.ts
+++ b/apps/server/test/brain-store.test.ts
@@ -8,6 +8,7 @@ import {
   BrainListItemNotFoundError,
   BrainRevisionConflictError,
   BrainValidationError,
+  MAX_LIST_ITEMS_PER_PUSH,
 } from "../src/brain/store.js";
 import { setupTestDb, teardownTestDb, runTestMigrations } from "./db/setup.js";
 
@@ -465,6 +466,32 @@ describe("BrainStore lists", () => {
         expectedRevision: 1,
       })
     ).rejects.toThrow(BrainListNotFoundError);
+  });
+
+  it("rejects pushes that exceed the per-call item cap", async () => {
+    await expect(
+      store.pushListItems(REPO, AGENT, {
+        collection: "job-state",
+        name: "oversized",
+        items: Array.from(
+          { length: MAX_LIST_ITEMS_PER_PUSH + 1 },
+          (_, index) => ({
+            id: `item-${index}`,
+          })
+        ),
+      })
+    ).rejects.toThrow(BrainValidationError);
+  });
+
+  it("rejects maxItems values above the bounded list size", async () => {
+    await expect(
+      store.pushListItems(REPO, AGENT, {
+        collection: "job-state",
+        name: "oversized-cap",
+        items: [{ id: "x" }],
+        maxItems: 201,
+      })
+    ).rejects.toThrow(BrainValidationError);
   });
 
   it("errors when removing or setting a missing item", async () => {

--- a/apps/server/test/brain-store.test.ts
+++ b/apps/server/test/brain-store.test.ts
@@ -4,6 +4,8 @@ import type { Pool } from "pg";
 import {
   BrainStore,
   BrainNotFoundError,
+  BrainListNotFoundError,
+  BrainListItemNotFoundError,
   BrainRevisionConflictError,
   BrainValidationError,
 } from "../src/brain/store.js";
@@ -300,5 +302,243 @@ describe("BrainStore events", () => {
       kind: "isolated",
     });
     expect(repoB).toHaveLength(1);
+  });
+});
+
+// ── Lists ───────────────────────────────────────────────────────────
+
+describe("BrainStore lists", () => {
+  it("pushes and gets list items", async () => {
+    const pushed = await store.pushListItems(REPO, AGENT, {
+      collection: "job-state",
+      name: "backlog",
+      items: [{ id: "a" }, { id: "b" }],
+    });
+
+    expect(pushed.length).toBe(2);
+    expect(pushed.revision).toBe(1);
+
+    const list = await store.getList(REPO, "job-state", "backlog");
+    expect(list).not.toBeNull();
+    expect(list!.revision).toBe(1);
+
+    const fetched = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    expect(fetched.totalCount).toBe(2);
+    expect(fetched.revision).toBe(1);
+    expect(fetched.items.map((item) => item.value)).toEqual([
+      { id: "a" },
+      { id: "b" },
+    ]);
+  });
+
+  it("supports pagination and descending order", async () => {
+    const paged = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+      order: "desc",
+      limit: 1,
+      offset: 0,
+    });
+
+    expect(paged.totalCount).toBe(2);
+    expect(paged.items).toHaveLength(1);
+    expect(paged.items[0].index).toBe(1);
+    expect(paged.items[0].value).toEqual({ id: "b" });
+  });
+
+  it("trims from the front when maxItems is set", async () => {
+    const pushed = await store.pushListItems(REPO, AGENT_B, {
+      collection: "job-state",
+      name: "backlog",
+      items: [{ id: "c" }, { id: "d" }],
+      maxItems: 3,
+    });
+
+    expect(pushed.length).toBe(3);
+
+    const fetched = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    expect(fetched.items.map((item) => item.value)).toEqual([
+      { id: "b" },
+      { id: "c" },
+      { id: "d" },
+    ]);
+    expect(fetched.items.map((item) => item.index)).toEqual([0, 1, 2]);
+  });
+
+  it("removes by index and reindexes remaining items", async () => {
+    const removed = await store.removeListItem(REPO, AGENT, {
+      collection: "job-state",
+      name: "backlog",
+      index: 1,
+    });
+
+    expect(removed.removed).toEqual({ id: "c" });
+    expect(removed.length).toBe(2);
+
+    const fetched = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    expect(fetched.items.map((item) => item.value)).toEqual([
+      { id: "b" },
+      { id: "d" },
+    ]);
+    expect(fetched.items.map((item) => item.index)).toEqual([0, 1]);
+  });
+
+  it("removes by field match", async () => {
+    const removed = await store.removeListItem(REPO, AGENT, {
+      collection: "job-state",
+      name: "backlog",
+      where: { field: "id", equals: "b" },
+    });
+
+    expect(removed.removed).toEqual({ id: "b" });
+
+    const fetched = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    expect(fetched.items.map((item) => item.value)).toEqual([{ id: "d" }]);
+    expect(fetched.items[0].index).toBe(0);
+  });
+
+  it("sets a single list item", async () => {
+    const list = await store.getList(REPO, "job-state", "backlog");
+    expect(list).not.toBeNull();
+
+    const updated = await store.setListItem(REPO, AGENT_B, {
+      collection: "job-state",
+      name: "backlog",
+      index: 0,
+      value: { id: "d", status: "fixed" },
+      expectedRevision: list!.revision,
+    });
+
+    expect(updated.item.value).toEqual({ id: "d", status: "fixed" });
+
+    const fetched = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    expect(fetched.items[0].value).toEqual({ id: "d", status: "fixed" });
+  });
+
+  it("returns an empty result for a missing list", async () => {
+    const missing = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "missing",
+    });
+
+    expect(missing).toEqual({ items: [], totalCount: 0, revision: 0 });
+  });
+
+  it("enforces list revision checks when provided", async () => {
+    const list = await store.getList(REPO, "job-state", "backlog");
+    expect(list).not.toBeNull();
+
+    await expect(
+      store.pushListItems(REPO, AGENT, {
+        collection: "job-state",
+        name: "backlog",
+        items: [{ id: "e" }],
+        expectedRevision: 1,
+      })
+    ).rejects.toThrow(BrainRevisionConflictError);
+
+    const refreshed = await store.getList(REPO, "job-state", "backlog");
+    expect(refreshed!.revision).toBeGreaterThan(1);
+  });
+
+  it("rejects expectedRevision on non-existent list", async () => {
+    await expect(
+      store.pushListItems(REPO, AGENT, {
+        collection: "job-state",
+        name: "missing",
+        items: [{ id: "x" }],
+        expectedRevision: 1,
+      })
+    ).rejects.toThrow(BrainListNotFoundError);
+  });
+
+  it("errors when removing or setting a missing item", async () => {
+    await expect(
+      store.removeListItem(REPO, AGENT, {
+        collection: "job-state",
+        name: "backlog",
+        index: 8,
+      })
+    ).rejects.toThrow(BrainListItemNotFoundError);
+
+    await expect(
+      store.setListItem(REPO, AGENT, {
+        collection: "job-state",
+        name: "backlog",
+        index: 8,
+        value: { nope: true },
+        expectedRevision: (await store.getList(REPO, "job-state", "backlog"))!
+          .revision,
+      })
+    ).rejects.toThrow(BrainListItemNotFoundError);
+  });
+
+  it("requires expectedRevision for list item updates", async () => {
+    await expect(
+      store.setListItem(REPO, AGENT, {
+        collection: "job-state",
+        name: "backlog",
+        index: 0,
+        value: { nope: true },
+      })
+    ).rejects.toThrow(BrainValidationError);
+  });
+
+  it("deletes a list and its items", async () => {
+    const deleted = await store.deleteList(REPO, "job-state", "backlog");
+    expect(deleted).toBe(true);
+
+    expect(await store.getList(REPO, "job-state", "backlog")).toBeNull();
+    expect(
+      await store.getListItems(REPO, {
+        collection: "job-state",
+        name: "backlog",
+      })
+    ).toEqual({ items: [], totalCount: 0, revision: 0 });
+  });
+
+  it("returns false when deleting a missing list", async () => {
+    const deleted = await store.deleteList(REPO, "job-state", "backlog");
+    expect(deleted).toBe(false);
+  });
+
+  it("isolates lists by repo", async () => {
+    await store.pushListItems(REPO, AGENT, {
+      collection: "job-state",
+      name: "backlog",
+      items: [{ id: "local" }],
+    });
+    await store.pushListItems(REPO_B, AGENT, {
+      collection: "job-state",
+      name: "backlog",
+      items: [{ id: "other" }],
+    });
+
+    const fromA = await store.getListItems(REPO, {
+      collection: "job-state",
+      name: "backlog",
+    });
+    const fromB = await store.getListItems(REPO_B, {
+      collection: "job-state",
+      name: "backlog",
+    });
+
+    expect(fromA.items.map((item) => item.value)).toEqual([{ id: "local" }]);
+    expect(fromB.items.map((item) => item.value)).toEqual([{ id: "other" }]);
   });
 });

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -673,8 +673,10 @@ const SECTIONS: SectionDef[] = [
             set, and delete operations, which makes them a better fit for
             queues, backlogs, and rolling history than stuffing arrays into
             objects. Positional list updates require the current revision
-            because removals reindex later items. Events are append-only and can
-            be filtered by collection, kind, subject, tags, and time range.
+            because removals reindex later items. List pushes are capped per
+            call, and bounded list sizes keep remove/reindex work predictable.
+            Events are append-only and can be filtered by collection, kind,
+            subject, tags, and time range.
           </P>
           <P>
             Brain tools are available to both standard agents and job agents.

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -649,6 +649,12 @@ const SECTIONS: SectionDef[] = [
               below)
             </li>
             <li>
+              <Code>brain_list_push</Code>, <Code>brain_list_remove</Code>,{" "}
+              <Code>brain_list_get</Code>, <Code>brain_list_set</Code>,{" "}
+              <Code>brain_list_delete</Code> — manage ordered Brain lists
+              without rewriting whole arrays
+            </li>
+            <li>
               <Code>brain_append_event</Code>, <Code>brain_query_events</Code> —
               append to and query the Brain's immutable event log
             </li>
@@ -663,8 +669,12 @@ const SECTIONS: SectionDef[] = [
             collections, identified by name, and tracked with an integer
             revision for optimistic concurrency — updates require passing the
             expected revision so concurrent writes don't silently overwrite each
-            other. Events are append-only and can be filtered by collection,
-            kind, subject, tags, and time range.
+            other. Lists are ordered mutable collections with push, remove, get,
+            set, and delete operations, which makes them a better fit for
+            queues, backlogs, and rolling history than stuffing arrays into
+            objects. Positional list updates require the current revision
+            because removals reindex later items. Events are append-only and can
+            be filtered by collection, kind, subject, tags, and time range.
           </P>
           <P>
             Brain tools are available to both standard agents and job agents.
@@ -1040,8 +1050,11 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               <strong>Brain (shared memory)</strong> —{" "}
               <Code>brain_get_object</Code>, <Code>brain_store_object</Code>,{" "}
               <Code>brain_list_objects</Code>, <Code>brain_delete_object</Code>,{" "}
-              <Code>brain_append_event</Code>, and{" "}
-              <Code>brain_query_events</Code>. Same tools as standard agents.
+              <Code>brain_list_push</Code>, <Code>brain_list_remove</Code>,{" "}
+              <Code>brain_list_get</Code>, <Code>brain_list_set</Code>,{" "}
+              <Code>brain_list_delete</Code>, <Code>brain_append_event</Code>,
+              and <Code>brain_query_events</Code>. Same tools as standard
+              agents.
             </li>
           </ul>
         </Section>
@@ -1080,11 +1093,12 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             </li>
             <li>
               <strong>Brain shared memory</strong> — use the{" "}
-              <Code>brain_store_object</Code> and <Code>brain_get_object</Code>{" "}
-              tools to persist structured state across runs without committing
-              files. Brain objects support optimistic concurrency and can be
-              queried by collection, making them a good fit for state that
-              multiple jobs or agents need to coordinate on.
+              <Code>brain_store_object</Code>, <Code>brain_get_object</Code>,{" "}
+              and Brain list tools to persist structured state across runs
+              without committing files. Brain objects support optimistic
+              concurrency, while Brain lists support surgical queue-style
+              updates, making them a good fit for state that multiple jobs or
+              agents need to coordinate on.
             </li>
           </ul>
         </Section>


### PR DESCRIPTION
## Summary
- add Brain lists as a first-class primitive with dedicated storage, MCP tools, and docs
- implement transactional list push/remove/get/set/delete semantics with revision-aware concurrency handling
- harden the mutation path with snapshot-consistent reads, safe concurrent creation, bounded push/list sizes, and batched inserts

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test`
- `pnpm run test:e2e` (passed previously; one rerun hit an unrelated flaky callable-jobs test)
- `bun x vitest run test/brain-store.test.ts`
- `pnpm --filter @dispatch/server check`

## Notes
- architecture review completed after two rounds
- backend security review completed after two rounds