### PR TITLE
Extract utils and worktree section from create-agent-dialog

### DIFF
--- a/.dispatch/job-state/componentizer.md
+++ b/.dispatch/job-state/componentizer.md
@@ -1,6 +1,6 @@
 ---
 job: componentizer
-updated_at: 2026-05-18
+updated_at: 2026-05-21
 ---
 
 # componentizer — state handoff
@@ -9,36 +9,33 @@ Each run of the componentizer job reads this file at Phase 0 and overwrites it a
 
 ## last_audited_sha
 
-`5ae57c34374a5336800553e43a78d437cfe8c6ee`
+`90e37bdf1c9626e72514a68c0f28592dc810c652`
 
 ## next_focus
 
-**File:** `apps/web/src/components/app/create-agent-dialog.tsx` (1446 lines)
-**Strategy:** Extract form sections + custom hook. This dialog has complex multi-step form state (agent type selection, context handling, clipboard detection, worktree config). Recommended extractions:
+**File:** `apps/web/src/components/app/activity-pane.tsx` (1142 lines)
+**Strategy:** Extract chart subcomponents + utility functions. This pane has many inlined chart components (Heatmap, ActiveHoursGrid, DailyStackedBarChart, DailyTokenChart, ModelBreakdown, ProjectBreakdown) plus data transformation utilities. Recommended extractions:
 
-1. Extract form state management into `use-create-agent-form.ts` — the hook owns all useState/useEffect for the dialog's form lifecycle (~200 lines of hooks and handlers)
-2. Extract the "context" section (clipboard reading, link tiles, file tiles, drag-and-drop) into `create-agent-context.tsx` (~300 lines)
-3. Extract agent-type-specific field groups into `create-agent-type-fields.tsx` if they're large enough to justify a separate file
+1. Extract chart components into `activity-charts.tsx` (~500 lines) — each chart is a self-contained visualization with its own data shaping and Recharts config
+2. Extract utility/formatter functions (date formatting, number formatting, color helpers) into `activity-utils.ts` (~80 lines)
 
-This is the second-highest line count after docs-pane, and unlike docs-pane (static content), it has genuinely mixed concerns: form state, clipboard APIs, context handling, and agent creation logic.
+This is the highest-impact remaining candidate: many independent chart subcomponents that are logically separate from the pane's tab/layout orchestration.
 
 ## backlog
 
-1. **`apps/web/src/components/app/docs-pane.tsx`** — 1880 lines. Mostly static content organized as `SECTIONS` array. Large by nature (documentation), but the section content blocks could be moved to individual files under a `docs/` directory. Lower priority since it's relatively cohesive and rarely edited for logic changes.
+1. **`apps/web/src/components/app/docs-pane.tsx`** — 1970 lines. Mostly static content organized as `SECTIONS` array. Large by nature (documentation), but the section content blocks could be moved to individual files under a `docs/` directory. Lower priority since it's relatively cohesive and rarely edited for logic changes.
 
-2. **`apps/web/src/components/app/activity-pane.tsx`** — 1142 lines. Many chart subcomponents (Heatmap, ActiveHoursGrid, DailyStackedBarChart, DailyTokenChart, ModelBreakdown, ProjectBreakdown). Extract chart components into `activity-charts.tsx` (~500 lines). Extract utility functions into `activity-utils.ts`.
+2. **`apps/web/src/components/app/release-manager.tsx`** — 1142 lines. Mixed concerns: release UI, update checking, version comparison. Extract subcomponents by release lifecycle phase.
 
-3. **`apps/web/src/components/app/release-manager.tsx`** — 1142 lines. Mixed concerns: release UI, update checking, version comparison. Extract subcomponents by release lifecycle phase.
+3. **`apps/web/src/components/app/agent-history-tab.tsx`** — 1141 lines. Multiple subcomponents (AgentHistoryList, EventTimeline, FeedbackTimeline, DetailTabs, AgentHistoryDetail). Extract `AgentHistoryDetail` + `DetailTabs` into `agent-history-detail.tsx` (~340 lines). Extract timeline components into `agent-history-timeline.tsx`.
 
-4. **`apps/web/src/components/app/agent-history-tab.tsx`** — 1141 lines. Multiple subcomponents (AgentHistoryList, EventTimeline, FeedbackTimeline, DetailTabs, AgentHistoryDetail). Extract `AgentHistoryDetail` + `DetailTabs` into `agent-history-detail.tsx` (~340 lines). Extract timeline components into `agent-history-timeline.tsx`.
+4. **`apps/web/src/components/app/jobs-pane.tsx`** — 1609 lines. Further extraction possible: SettingsTab + RemoveJobDialog + PromptTab (~500 lines) into `jobs-settings-tab.tsx`, HistoryTab + RunReport (~150 lines) into `jobs-history-tab.tsx`. Deferred since it recently went through a split.
 
-5. **`apps/web/src/components/app/jobs-pane.tsx`** — 1609 lines. Further extraction possible: SettingsTab + RemoveJobDialog + PromptTab (~500 lines) into `jobs-settings-tab.tsx`, HistoryTab + RunReport (~150 lines) into `jobs-history-tab.tsx`. Deferred since it recently went through a split.
+5. **`apps/web/src/components/app/agents-view.tsx`** — 1028 lines. Single exported component but likely has distinct UI sections. Assess on future run.
 
-6. **`apps/web/src/components/app/agents-view.tsx`** — 1026 lines. Single exported component but likely has distinct UI sections. Assess on future run.
+6. **`apps/web/src/components/app/settings-pane.tsx`** — 840 lines. Already delegates to sub-settings components but still large. Lower priority since it's already partially extracted.
 
-7. **`apps/web/src/components/app/settings-pane.tsx`** — 840 lines. Already delegates to sub-settings components but still large. Lower priority since it's already partially extracted.
-
-8. **`apps/web/src/components/app/agent-card.tsx`** — 727 lines. Moderate size, single cohesive component. Lower priority.
+7. **`apps/web/src/components/app/agent-card.tsx`** — 758 lines. Moderate size, single cohesive component. Lower priority.
 
 ## patterns
 
@@ -46,7 +43,7 @@ This is the second-highest line count after docs-pane, and unlike docs-pane (sta
 - **Dialogs stay in parent files.** Add/create/launch dialogs (AddJobDialog, CreateTemplateDialog, LaunchTemplateDialog) are defined inline rather than extracted, even when they're 300+ lines with their own state.
 - **Chart/visualization code is inlined.** Recharts components with config, data transformation, and formatting helpers are kept alongside the main component instead of being pulled into dedicated chart files.
 - **Mobile variants double component count.** feedback-panel had both desktop and mobile versions of the same panels, doubling the file size. Now addressed by extracting into feedback-mobile.tsx.
-- **Utility functions live at the top of component files.** Formatters, comparators, and helpers (formatDate, statusClasses, shortPath) could move to shared utils or colocated `*-utils.ts` files.
+- **Utility functions live at the top of component files.** Formatters, comparators, and helpers (formatDate, statusClasses, shortPath) could move to shared utils or colocated `*-utils.ts` files. Confirmed again in create-agent-dialog — localStorage helpers, cwd history management, and preferences hook were all inlined.
 - **Shared form components get inlined.** Toggle switches, checkbox options, and other reusable form primitives get copy-pasted rather than extracted (now addressed in jobs-utils.tsx and automations-form-fields.tsx as models).
 - **Shared data hooks inline in component files.** Data-fetching hooks (useFeedbackData) that serve multiple components stay in the first component file rather than being extracted. Now addressed in feedback-utils.ts as a model.
 
@@ -56,3 +53,4 @@ This is the second-highest line count after docs-pane, and unlike docs-pane (sta
 - 2026-05-17: Refactored `jobs-pane.tsx` (2489→1599 lines). Extracted `jobs-helpers.ts` (pure utilities), `jobs-form-fields.tsx` (shared form components), `jobs-add-dialog.tsx` (AddJobDialog + AddJobFlow), `jobs-charts.tsx` (chart components). PR #546.
 - 2026-05-17: Refactored `automations-pane.tsx` (2029→375 lines). Extracted `automations-form-fields.tsx`, `automations-launch-dialog.tsx`, `automations-create-dialog.tsx`, `automations-template-detail.tsx`. PR #547.
 - 2026-05-18: Refactored `feedback-panel.tsx` (1776→665 lines). Extracted `feedback-utils.ts` (types, constants), `use-feedback-data.ts` (useFeedbackData hook), `feedback-shared.tsx` (shared UI helpers), `feedback-mobile.tsx` (MobileFeedbackSheet, MobileReviewSummarySheet), `review-summary-panel.tsx` (ReviewSummaryPanel). PR #551.
+- 2026-05-21: Refactored `create-agent-dialog.tsx` (990→752 lines). Extracted `create-agent-dialog-utils.ts` (localStorage helpers, constants, useCreateAgentPrefs hook), `create-agent-worktree-section.tsx` (WorktreeSection component). PR #TBD.

--- a/apps/web/src/components/app/create-agent-dialog-utils.ts
+++ b/apps/web/src/components/app/create-agent-dialog-utils.ts
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAtom } from "jotai";
+
+import { type AgentType, isAgentType } from "@/lib/agent-types";
+import { createNewBranchPrefAtom } from "@/lib/store";
+
+export const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
+export const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
+export const CWD_HISTORY_KEY = "dispatch:cwdHistory";
+export const CWD_HISTORY_MAX = 20;
+export const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
+export const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
+export const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
+export const CONTEXT_PROMPT_ID = "create-agent-context-prompt";
+
+export function readStoredString(key: string): string {
+  if (typeof window === "undefined") return "";
+  return window.localStorage.getItem(key)?.trim() ?? "";
+}
+
+export function readStoredBoolean(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  const value = window.localStorage.getItem(key);
+  if (value === null) return fallback;
+  return value === "true";
+}
+
+export function readLastUsedCwd(): string {
+  return readStoredString(LAST_USED_CWD_KEY) || "~/";
+}
+
+export function readLastUsedAgentType(): AgentType | null {
+  const stored = readStoredString(LAST_USED_TYPE_KEY);
+  return stored && isAgentType(stored) ? stored : null;
+}
+
+export function readCwdHistory(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(CWD_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeCwdHistory(nextHistory: string[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(CWD_HISTORY_KEY, JSON.stringify(nextHistory));
+}
+
+export function addToCwdHistory(cwd: string): string[] {
+  const trimmed = cwd.trim();
+  if (!trimmed) return readCwdHistory();
+  const existing = readCwdHistory().filter((entry) => entry !== trimmed);
+  const updated = [trimmed, ...existing].slice(0, CWD_HISTORY_MAX);
+  writeCwdHistory(updated);
+  return updated;
+}
+
+export function removeCwdFromHistory(cwd: string): string[] {
+  const next = readCwdHistory().filter((entry) => entry !== cwd);
+  writeCwdHistory(next);
+  return next;
+}
+
+export function useCreateAgentPrefs(cwd: string) {
+  const trimmedCwd = cwd.trim();
+  const [fullAccess, setFullAccess] = useState(false);
+  const [autoReview, setAutoReview] = useState(false);
+  const [baseBranch, setBaseBranch] = useState("main");
+
+  const createNewBranchAtom = useMemo(
+    () => createNewBranchPrefAtom(trimmedCwd),
+    [trimmedCwd]
+  );
+  const [createNewBranch, setCreateNewBranch] = useAtom(createNewBranchAtom);
+
+  useEffect(() => {
+    if (!trimmedCwd) {
+      setFullAccess(false);
+      setAutoReview(false);
+      setBaseBranch("main");
+      return;
+    }
+    setFullAccess(
+      readStoredBoolean(`${FULL_ACCESS_PREFIX}${trimmedCwd}`, false)
+    );
+    setAutoReview(
+      readStoredBoolean(`${AUTO_REVIEW_PREFIX}${trimmedCwd}`, false)
+    );
+    setBaseBranch(
+      readStoredString(`${BASE_BRANCH_PREFIX}${trimmedCwd}`) || "main"
+    );
+  }, [trimmedCwd]);
+
+  useEffect(() => {
+    if (!trimmedCwd || typeof window === "undefined") return;
+    window.localStorage.setItem(
+      `${FULL_ACCESS_PREFIX}${trimmedCwd}`,
+      String(fullAccess)
+    );
+  }, [fullAccess, trimmedCwd]);
+
+  useEffect(() => {
+    if (!trimmedCwd || typeof window === "undefined") return;
+    window.localStorage.setItem(
+      `${AUTO_REVIEW_PREFIX}${trimmedCwd}`,
+      String(autoReview)
+    );
+  }, [autoReview, trimmedCwd]);
+
+  useEffect(() => {
+    if (!trimmedCwd || typeof window === "undefined") return;
+    window.localStorage.setItem(
+      `${BASE_BRANCH_PREFIX}${trimmedCwd}`,
+      baseBranch
+    );
+  }, [baseBranch, trimmedCwd]);
+
+  return {
+    fullAccess,
+    setFullAccess,
+    autoReview,
+    setAutoReview,
+    baseBranch,
+    setBaseBranch,
+    createNewBranch,
+    setCreateNewBranch,
+  };
+}

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -4,20 +4,29 @@ import {
   type FormEvent,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
-import { useAtom } from "jotai";
-import { Check, ChevronDown, ChevronLeft, GitBranch } from "lucide-react";
+import { Check, ChevronDown, ChevronLeft } from "lucide-react";
 
-import { BranchSelect } from "@/components/app/branch-select";
 import { ContextPicker } from "@/components/app/context-picker";
 import {
   createClipboardSuggestionFromText,
   getClipboardFilesFromEvent,
   startupFileKey,
 } from "@/components/app/create-agent-dialog-clipboard";
+import {
+  addToCwdHistory,
+  CONTEXT_PROMPT_ID,
+  LAST_USED_CWD_KEY,
+  LAST_USED_TYPE_KEY,
+  readCwdHistory,
+  readLastUsedAgentType,
+  readLastUsedCwd,
+  removeCwdFromHistory,
+  useCreateAgentPrefs,
+} from "@/components/app/create-agent-dialog-utils";
+import { WorktreeSection } from "@/components/app/create-agent-worktree-section";
 import { PathInput } from "@/components/app/path-input";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
@@ -39,148 +48,10 @@ import { Input } from "@/components/ui/input";
 import { type Agent } from "@/components/app/types";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import { useRadixPopoverZFix } from "@/hooks/use-radix-popover-z-fix";
-import {
-  AGENT_TYPE_LABELS,
-  type AgentType,
-  isAgentType,
-} from "@/lib/agent-types";
+import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
-import { createNewBranchPrefAtom } from "@/lib/store";
 import { cn } from "@/lib/utils";
-
-const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
-const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
-const CWD_HISTORY_KEY = "dispatch:cwdHistory";
-const CWD_HISTORY_MAX = 20;
-const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
-const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
-const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
-const CONTEXT_PROMPT_ID = "create-agent-context-prompt";
-
-function readStoredString(key: string): string {
-  if (typeof window === "undefined") return "";
-  return window.localStorage.getItem(key)?.trim() ?? "";
-}
-
-function readStoredBoolean(key: string, fallback: boolean): boolean {
-  if (typeof window === "undefined") return fallback;
-  const value = window.localStorage.getItem(key);
-  if (value === null) return fallback;
-  return value === "true";
-}
-
-function readLastUsedCwd(): string {
-  return readStoredString(LAST_USED_CWD_KEY) || "~/";
-}
-
-function readLastUsedAgentType(): AgentType | null {
-  const stored = readStoredString(LAST_USED_TYPE_KEY);
-  return stored && isAgentType(stored) ? stored : null;
-}
-
-function readCwdHistory(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(CWD_HISTORY_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0)
-      : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeCwdHistory(nextHistory: string[]): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(CWD_HISTORY_KEY, JSON.stringify(nextHistory));
-}
-
-function addToCwdHistory(cwd: string): string[] {
-  const trimmed = cwd.trim();
-  if (!trimmed) return readCwdHistory();
-  const existing = readCwdHistory().filter((entry) => entry !== trimmed);
-  const updated = [trimmed, ...existing].slice(0, CWD_HISTORY_MAX);
-  writeCwdHistory(updated);
-  return updated;
-}
-
-function removeCwdFromHistory(cwd: string): string[] {
-  const next = readCwdHistory().filter((entry) => entry !== cwd);
-  writeCwdHistory(next);
-  return next;
-}
-
-function useCreateAgentPrefs(cwd: string) {
-  const trimmedCwd = cwd.trim();
-  const [fullAccess, setFullAccess] = useState(false);
-  const [autoReview, setAutoReview] = useState(false);
-  const [baseBranch, setBaseBranch] = useState("main");
-
-  // createNewBranch is per-cwd persisted via a jotai atomFamily — the atom's
-  // identity changes with cwd, so reads/writes route to the correct
-  // localStorage entry without manual load/write effects.
-  const createNewBranchAtom = useMemo(
-    () => createNewBranchPrefAtom(trimmedCwd),
-    [trimmedCwd]
-  );
-  const [createNewBranch, setCreateNewBranch] = useAtom(createNewBranchAtom);
-
-  useEffect(() => {
-    if (!trimmedCwd) {
-      setFullAccess(false);
-      setAutoReview(false);
-      setBaseBranch("main");
-      return;
-    }
-    setFullAccess(
-      readStoredBoolean(`${FULL_ACCESS_PREFIX}${trimmedCwd}`, false)
-    );
-    setAutoReview(
-      readStoredBoolean(`${AUTO_REVIEW_PREFIX}${trimmedCwd}`, false)
-    );
-    setBaseBranch(
-      readStoredString(`${BASE_BRANCH_PREFIX}${trimmedCwd}`) || "main"
-    );
-  }, [trimmedCwd]);
-
-  useEffect(() => {
-    if (!trimmedCwd || typeof window === "undefined") return;
-    window.localStorage.setItem(
-      `${FULL_ACCESS_PREFIX}${trimmedCwd}`,
-      String(fullAccess)
-    );
-  }, [fullAccess, trimmedCwd]);
-
-  useEffect(() => {
-    if (!trimmedCwd || typeof window === "undefined") return;
-    window.localStorage.setItem(
-      `${AUTO_REVIEW_PREFIX}${trimmedCwd}`,
-      String(autoReview)
-    );
-  }, [autoReview, trimmedCwd]);
-
-  useEffect(() => {
-    if (!trimmedCwd || typeof window === "undefined") return;
-    window.localStorage.setItem(
-      `${BASE_BRANCH_PREFIX}${trimmedCwd}`,
-      baseBranch
-    );
-  }, [baseBranch, trimmedCwd]);
-
-  return {
-    fullAccess,
-    setFullAccess,
-    autoReview,
-    setAutoReview,
-    baseBranch,
-    setBaseBranch,
-    createNewBranch,
-    setCreateNewBranch,
-  };
-}
 
 type CreateAgentDialogProps = {
   open: boolean;
@@ -663,129 +534,19 @@ function CreateAgentDialogContent({
                   historyItemTestId="create-agent-cwd-history-option"
                 />
 
-                <div
-                  className={cn(
-                    "space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 transition-opacity duration-200",
-                    !worktreeAvailable && "opacity-60"
-                  )}
-                  data-testid="create-agent-worktree-section"
-                >
-                  <label
-                    className={cn(
-                      "flex items-start gap-3",
-                      worktreeAvailable
-                        ? "cursor-pointer"
-                        : "cursor-not-allowed"
-                    )}
-                  >
-                    <Checkbox
-                      checked={worktreeChecked}
-                      onCheckedChange={() =>
-                        setCreateUseWorktree((current) => !current)
-                      }
-                      disabled={!worktreeAvailable}
-                      className="mt-0.5"
-                      title={
-                        worktreeAvailable
-                          ? "Toggle managed git worktree"
-                          : "Not a git repository"
-                      }
-                      data-testid="create-agent-worktree"
-                    />
-                    <span className="space-y-1">
-                      <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                        <GitBranch className="h-3.5 w-3.5" />
-                        Create managed git worktree
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        {worktreeAvailable
-                          ? "Creates an isolated worktree for this agent. Dispatch tracks and cleans it up when the agent is archived."
-                          : "Working directory isn't a git repository, so a managed worktree isn't available here."}
-                      </span>
-                    </span>
-                  </label>
-                  <div
-                    className={cn(
-                      "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-                      worktreeChecked
-                        ? "grid-rows-[1fr] opacity-100"
-                        : "grid-rows-[0fr] opacity-0"
-                    )}
-                    aria-hidden={!worktreeChecked}
-                    // Keep collapsed controls out of focus and pointer
-                    // interaction. Cast for React 18 type defs.
-                    {...(!worktreeChecked
-                      ? ({ inert: "" } as Record<string, string>)
-                      : {})}
-                  >
-                    <div className="min-h-0 overflow-hidden">
-                      <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
-                        <BranchSelect
-                          cwd={createCwd}
-                          baseBranch={createBaseBranch}
-                          onBaseBranchChange={setCreateBaseBranch}
-                          worktreeBranch={createWorktreeBranch}
-                          onWorktreeBranchChange={setCreateWorktreeBranch}
-                          baseBranchLabel="Starting branch"
-                          baseBranchHelper="The branch to check out in the worktree."
-                          showNewBranchInput={false}
-                          testIdPrefix="create-agent"
-                        />
-                        <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
-                          <label className="flex cursor-pointer items-start gap-3">
-                            <Checkbox
-                              checked={createNewBranch}
-                              onCheckedChange={() =>
-                                setCreateNewBranch((current) => !current)
-                              }
-                              className="mt-0.5"
-                              title="Toggle new branch creation"
-                              data-testid="create-agent-new-branch"
-                            />
-                            <span className="space-y-1">
-                              <span className="block text-sm font-medium text-foreground">
-                                Create a new branch in this worktree
-                              </span>
-                              <span className="block text-xs text-muted-foreground">
-                                Creates a new working branch from the starting
-                                branch so the agent can make isolated changes
-                                for later submission.
-                              </span>
-                            </span>
-                          </label>
-                          <div
-                            className={cn(
-                              "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-                              createNewBranch
-                                ? "grid-rows-[1fr] opacity-100"
-                                : "grid-rows-[0fr] opacity-0"
-                            )}
-                            aria-hidden={!createNewBranch}
-                            {...(!createNewBranch
-                              ? ({ inert: "" } as Record<string, string>)
-                              : {})}
-                          >
-                            <div className="min-h-0 overflow-hidden">
-                              <div className="space-y-1 pt-2">
-                                <label className="block text-xs text-muted-foreground">
-                                  New branch name
-                                </label>
-                                <Input
-                                  value={createWorktreeBranch}
-                                  onChange={(event) =>
-                                    setCreateWorktreeBranch(event.target.value)
-                                  }
-                                  placeholder="auto-generated if empty"
-                                  data-testid="create-agent-worktree-branch"
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                <WorktreeSection
+                  cwd={createCwd}
+                  worktreeAvailable={worktreeAvailable}
+                  worktreeChecked={worktreeChecked}
+                  useWorktree={createUseWorktree}
+                  onUseWorktreeChange={setCreateUseWorktree}
+                  baseBranch={createBaseBranch}
+                  onBaseBranchChange={setCreateBaseBranch}
+                  worktreeBranch={createWorktreeBranch}
+                  onWorktreeBranchChange={setCreateWorktreeBranch}
+                  createNewBranch={createNewBranch}
+                  onCreateNewBranchChange={setCreateNewBranch}
+                />
 
                 {createType !== "terminal" ? (
                   <>

--- a/apps/web/src/components/app/create-agent-worktree-section.tsx
+++ b/apps/web/src/components/app/create-agent-worktree-section.tsx
@@ -1,0 +1,151 @@
+import { GitBranch } from "lucide-react";
+
+import { BranchSelect } from "@/components/app/branch-select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+type WorktreeSectionProps = {
+  cwd: string;
+  worktreeAvailable: boolean;
+  worktreeChecked: boolean;
+  useWorktree: boolean;
+  onUseWorktreeChange: (value: boolean) => void;
+  baseBranch: string;
+  onBaseBranchChange: (value: string) => void;
+  worktreeBranch: string;
+  onWorktreeBranchChange: (value: string) => void;
+  createNewBranch: boolean;
+  onCreateNewBranchChange: (value: boolean) => void;
+};
+
+export function WorktreeSection({
+  cwd,
+  worktreeAvailable,
+  worktreeChecked,
+  useWorktree,
+  onUseWorktreeChange,
+  baseBranch,
+  onBaseBranchChange,
+  worktreeBranch,
+  onWorktreeBranchChange,
+  createNewBranch,
+  onCreateNewBranchChange,
+}: WorktreeSectionProps): JSX.Element {
+  return (
+    <div
+      className={cn(
+        "space-y-2 rounded-md border border-border/70 bg-muted/20 px-3 py-3 transition-opacity duration-200",
+        !worktreeAvailable && "opacity-60"
+      )}
+      data-testid="create-agent-worktree-section"
+    >
+      <label
+        className={cn(
+          "flex items-start gap-3",
+          worktreeAvailable ? "cursor-pointer" : "cursor-not-allowed"
+        )}
+      >
+        <Checkbox
+          checked={worktreeChecked}
+          onCheckedChange={() => onUseWorktreeChange(!useWorktree)}
+          disabled={!worktreeAvailable}
+          className="mt-0.5"
+          title={
+            worktreeAvailable
+              ? "Toggle managed git worktree"
+              : "Not a git repository"
+          }
+          data-testid="create-agent-worktree"
+        />
+        <span className="space-y-1">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <GitBranch className="h-3.5 w-3.5" />
+            Create managed git worktree
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            {worktreeAvailable
+              ? "Creates an isolated worktree for this agent. Dispatch tracks and cleans it up when the agent is archived."
+              : "Working directory isn't a git repository, so a managed worktree isn't available here."}
+          </span>
+        </span>
+      </label>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+          worktreeChecked
+            ? "grid-rows-[1fr] opacity-100"
+            : "grid-rows-[0fr] opacity-0"
+        )}
+        aria-hidden={!worktreeChecked}
+        {...(!worktreeChecked ? ({ inert: "" } as Record<string, string>) : {})}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
+            <BranchSelect
+              cwd={cwd}
+              baseBranch={baseBranch}
+              onBaseBranchChange={onBaseBranchChange}
+              worktreeBranch={worktreeBranch}
+              onWorktreeBranchChange={onWorktreeBranchChange}
+              baseBranchLabel="Starting branch"
+              baseBranchHelper="The branch to check out in the worktree."
+              showNewBranchInput={false}
+              testIdPrefix="create-agent"
+            />
+            <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={createNewBranch}
+                  onCheckedChange={() =>
+                    onCreateNewBranchChange(!createNewBranch)
+                  }
+                  className="mt-0.5"
+                  title="Toggle new branch creation"
+                  data-testid="create-agent-new-branch"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">
+                    Create a new branch in this worktree
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Creates a new working branch from the starting branch so the
+                    agent can make isolated changes for later submission.
+                  </span>
+                </span>
+              </label>
+              <div
+                className={cn(
+                  "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                  createNewBranch
+                    ? "grid-rows-[1fr] opacity-100"
+                    : "grid-rows-[0fr] opacity-0"
+                )}
+                aria-hidden={!createNewBranch}
+                {...(!createNewBranch
+                  ? ({ inert: "" } as Record<string, string>)
+                  : {})}
+              >
+                <div className="min-h-0 overflow-hidden">
+                  <div className="space-y-1 pt-2">
+                    <label className="block text-xs text-muted-foreground">
+                      New branch name
+                    </label>
+                    <Input
+                      value={worktreeBranch}
+                      onChange={(event) =>
+                        onWorktreeBranchChange(event.target.value)
+                      }
+                      placeholder="auto-generated if empty"
+                      data-testid="create-agent-worktree-branch"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracted localStorage helpers, constants, and `useCreateAgentPrefs` hook into `create-agent-dialog-utils.ts` (135 lines)
- Extracted the worktree configuration section (checkbox, branch select, new-branch input) into `create-agent-worktree-section.tsx` (151 lines)
- Main dialog file drops from 990 → 752 lines with no behavior changes

## Why this was a candidate

`create-agent-dialog.tsx` was 990 lines with mixed concerns: localStorage utilities, a preferences hook with 4 persistence effects, and deeply nested worktree config JSX alongside the dialog's form rendering. The extractions separate pure logic (utils) and a self-contained UI region (worktree section) from the dialog orchestration.

## New file structure

```
create-agent-dialog.tsx              752 lines (was 990) — dialog shell + form rendering
create-agent-dialog-utils.ts         135 lines (new)     — localStorage helpers, constants, useCreateAgentPrefs
create-agent-dialog-clipboard.ts     (unchanged)         — clipboard detection helpers
create-agent-worktree-section.tsx    151 lines (new)     — WorktreeSection component
```

## Next up

`activity-pane.tsx` (1142 lines) — extract chart subcomponents into `activity-charts.tsx` and utility functions into `activity-utils.ts`.

## Test plan

- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — all 144 tests pass (12 terminal-live skipped as usual)
- [x] Pre-commit hooks (prettier, eslint, tsc) pass