### PR TITLE
Add missing Description field to in-app template docs

### DIFF
--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -770,6 +770,10 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               <strong>Name</strong> — display name, unique within its directory.
             </li>
             <li>
+              <strong>Description</strong> — optional short summary shown in the
+              launch dialog and template list.
+            </li>
+            <li>
               <strong>Working directory</strong> — the repo the template runs
               against.
             </li>


### PR DESCRIPTION
## Summary
- The template create/edit form has a **Description** field (optional short summary) between Name and Working directory, but the docs-pane "Creating a template" section didn't mention it.
- This run also verified brain list tools in both the standard agent and job agent tool lists — all accurate after the previous run's additions.

## What was audited
- **Primary**: docs-pane Automations section ("Creating a template", "Launching templates", "Jobs") against `automations-form-fields.tsx`, `automations-create-dialog.tsx`, `automations-launch-dialog.tsx`
- **Secondary**: MCP tool lists (AGENT_TOOLS, JOB_TOOLS) in `server.ts` against docs-pane built-in tools and README tool table — all match
- **Diff-driven**: Brain list tools, persona tool extraction, create-agent dialog refactor — all code-only refactors with no docs impact

## Deferred to next run
- Audit the docs-pane Worktrees section against `packages/shared/src/git/worktree.ts` and worktree failure surfaces
- Template launch dialog field accuracy when new fields are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)