### PR TITLE
Allow Terminal agent type in templates

### DIFF
--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -124,6 +124,7 @@ export class JobService {
       ? await this.templateStore.getTemplate(job.templateId)
       : null;
     const agentConfig = template ?? job;
+    const agentType = agentConfig.agentType as JobAgentType;
 
     const rawPrompt = agentConfig.prompt;
     if (!rawPrompt) {
@@ -164,13 +165,9 @@ export class JobService {
     try {
       const agent = await this.agentManager.createAgent({
         name: `job-${sanitizeAgentName(job.name)}-${run.id.slice(0, 8)}`,
-        type: agentConfig.agentType,
+        type: agentType,
         cwd: job.directory,
-        agentArgs: buildAgentArgs(
-          agentConfig.agentType,
-          prompt,
-          agentConfig.fullAccess
-        ),
+        agentArgs: buildAgentArgs(agentType, prompt, agentConfig.fullAccess),
         fullAccess: agentConfig.fullAccess,
         useWorktree: agentConfig.useWorktree,
         baseBranch: agentConfig.baseBranch ?? undefined,

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { FastifyInstance } from "fastify";
 import * as z from "zod/v4";
 
-import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
+import { AGENT_TYPES } from "../agent-type-settings.js";
 import { errorMessage } from "../shared/lib/error-message.js";
 import { resolveTilde } from "../shared/lib/resolve-tilde.js";
 import {
@@ -30,7 +30,7 @@ const AddTemplateBodySchema = z.object({
   directory: directoryField,
   description: z.string().nullable().optional(),
   prompt: z.string().nullable().optional(),
-  agentType: z.enum(CLI_AGENT_TYPES).optional(),
+  agentType: z.enum(AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
   baseBranch: z.string().nullable().optional(),
   branchName: z.string().nullable().optional(),
@@ -44,7 +44,7 @@ const UpdateTemplateBodySchema = z.object({
   directory: directoryField.optional(),
   description: z.string().nullable().optional(),
   prompt: z.string().nullable().optional(),
-  agentType: z.enum(CLI_AGENT_TYPES).optional(),
+  agentType: z.enum(AGENT_TYPES).optional(),
   useWorktree: z.boolean().optional(),
   baseBranch: z.string().nullable().optional(),
   branchName: z.string().nullable().optional(),
@@ -56,7 +56,7 @@ const UpdateTemplateBodySchema = z.object({
 const LaunchBodySchema = z.object({
   args: z.record(z.string(), z.string()).optional(),
   directory: directoryField.optional(),
-  agentType: z.enum(CLI_AGENT_TYPES).optional(),
+  agentType: z.enum(AGENT_TYPES).optional(),
 });
 
 function classifyErrorCode(message: string): number {

--- a/apps/server/src/templates/service.ts
+++ b/apps/server/src/templates/service.ts
@@ -3,7 +3,7 @@ import type { Pool } from "pg";
 
 import type { AgentManager } from "../agents/manager.js";
 import type { AgentPin, AgentRecord } from "../agents/types.js";
-import type { JobAgentType } from "../jobs/store.js";
+import type { AgentType } from "../agent-type-settings.js";
 import { sanitizeAgentName } from "../shared/lib/agent-strings.js";
 import {
   TemplateStore,
@@ -17,7 +17,7 @@ export type AddTemplateInput = {
   directory: string;
   description?: string | null;
   prompt?: string | null;
-  agentType?: JobAgentType;
+  agentType?: AgentType;
   useWorktree?: boolean;
   baseBranch?: string | null;
   branchName?: string | null;
@@ -30,7 +30,7 @@ export type LaunchTemplateInput = {
   templateId: string;
   args?: Record<string, string>;
   directory?: string;
-  agentType?: JobAgentType;
+  agentType?: AgentType;
   startupFiles?: Array<{
     fileName: string;
     originalName?: string;
@@ -137,7 +137,11 @@ export class TemplateService {
     if (!template) {
       throw new Error(`Template ${input.templateId} not found.`);
     }
-    if (!template.prompt) {
+
+    const resolvedType = input.agentType ?? template.agentType;
+    const isTerminal = resolvedType === "terminal";
+
+    if (!isTerminal && !template.prompt) {
       throw new Error(
         `Template "${template.name}" has no prompt configured. Add a prompt before launching.`
       );
@@ -152,38 +156,43 @@ export class TemplateService {
       );
     }
 
-    const parsedArgs = parseTemplateArgs(template.prompt);
-    const args = input.args ?? {};
+    let finalPrompt: string | undefined;
+    let initialPins: AgentPin[] = [];
 
-    let finalPrompt: string;
-    if (parsedArgs.length > 0) {
-      finalPrompt = substituteArgs(template.prompt, args);
-    } else {
-      finalPrompt = template.prompt;
+    if (!isTerminal && template.prompt) {
+      const parsedArgs = parseTemplateArgs(template.prompt);
+      const args = input.args ?? {};
+
+      finalPrompt =
+        parsedArgs.length > 0
+          ? substituteArgs(template.prompt, args)
+          : template.prompt;
+
+      const argPins = parsedArgs
+        .filter((a) => args[a.key] != null || args[a.name] != null)
+        .map((a) => ({
+          label: a.name,
+          value: args[a.key] ?? args[a.name],
+          type: "string" as const,
+        }));
+
+      initialPins = [...argPins, ...(input.startupPins ?? [])];
     }
-
-    const argPins = parsedArgs
-      .filter((a) => args[a.key] != null || args[a.name] != null)
-      .map((a) => ({
-        label: a.name,
-        value: args[a.key] ?? args[a.name],
-        type: "string" as const,
-      }));
-
-    const initialPins = [...argPins, ...(input.startupPins ?? [])];
 
     const cwd = input.directory ?? template.directory;
     const agent = await this.agentManager.createAgent({
       name: sanitizeAgentName(template.name),
-      type: input.agentType ?? template.agentType,
+      type: resolvedType,
       cwd,
       initialPrompt: finalPrompt,
-      fullAccess: template.fullAccess,
-      useWorktree: template.useWorktree,
-      baseBranch: template.baseBranch ?? undefined,
-      worktreeBranch: template.branchName ?? undefined,
+      fullAccess: !isTerminal && template.fullAccess,
+      useWorktree: !isTerminal && template.useWorktree,
+      baseBranch: !isTerminal ? (template.baseBranch ?? undefined) : undefined,
+      worktreeBranch: !isTerminal
+        ? (template.branchName ?? undefined)
+        : undefined,
       initialPins,
-      initialFiles: input.startupFiles ?? [],
+      initialFiles: !isTerminal ? (input.startupFiles ?? []) : [],
       templateId: template.id,
     });
 

--- a/apps/server/src/templates/store.ts
+++ b/apps/server/src/templates/store.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import type { Pool } from "pg";
 
-import type { JobAgentType } from "../jobs/store.js";
+import type { AgentType } from "../agent-type-settings.js";
 import {
   parseTemplateArgs,
   substituteArgs,
@@ -19,7 +19,7 @@ export type TemplateRecord = {
   name: string;
   description: string | null;
   prompt: string | null;
-  agentType: JobAgentType;
+  agentType: AgentType;
   useWorktree: boolean;
   baseBranch: string | null;
   branchName: string | null;
@@ -35,7 +35,7 @@ export type TemplateConfigUpdate = {
   description?: string | null;
   directory?: string;
   prompt?: string | null;
-  agentType?: JobAgentType;
+  agentType?: AgentType;
   useWorktree?: boolean;
   baseBranch?: string | null;
   branchName?: string | null;
@@ -52,7 +52,7 @@ export class TemplateStore {
     directory: string;
     description: string | null;
     prompt: string | null;
-    agentType: JobAgentType;
+    agentType: AgentType;
     useWorktree: boolean;
     baseBranch: string | null;
     branchName: string | null;

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import React from "react";
+import React, { useMemo } from "react";
 import {
   AGENT_TYPE_LABELS,
   type AgentType,
@@ -81,6 +81,10 @@ export function AgentListContent({
   onRequestClose,
   closeOnSessionAction = false,
 }: AgentListContentProps): JSX.Element {
+  const sortedAgentTypes = useMemo(
+    () => sortAgentTypes(enabledAgentTypes),
+    [enabledAgentTypes]
+  );
   const defaultCreateType: AgentType =
     lastUsedAgentType && enabledAgentTypes.includes(lastUsedAgentType)
       ? lastUsedAgentType
@@ -124,7 +128,7 @@ export function AgentListContent({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {sortAgentTypes(enabledAgentTypes).map((agentType) => (
+                {sortedAgentTypes.map((agentType) => (
                   <DropdownMenuItem
                     key={agentType}
                     className="text-foreground"

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -13,7 +13,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import React from "react";
-import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  sortAgentTypes,
+} from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
 
 export type AgentListContentProps = {
@@ -120,7 +124,7 @@ export function AgentListContent({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {enabledAgentTypes.map((agentType) => (
+                {sortAgentTypes(enabledAgentTypes).map((agentType) => (
                   <DropdownMenuItem
                     key={agentType}
                     className="text-foreground"

--- a/apps/web/src/components/app/automations-create-dialog.tsx
+++ b/apps/web/src/components/app/automations-create-dialog.tsx
@@ -58,20 +58,21 @@ function CreateTemplateDialogContent({
   const [creating, setCreating] = useState(false);
 
   const handleCreate = useCallback(() => {
+    const isTerminal = agentType === "terminal";
     setCreating(true);
     addTemplate
       .mutateAsync({
         name,
         description: description.trim() || null,
         directory,
-        prompt: prompt || null,
+        prompt: isTerminal ? null : prompt || null,
         agentType,
-        useWorktree,
-        baseBranch: useWorktree ? baseBranch : null,
-        branchName: useWorktree ? branchName || null : null,
-        fullAccess,
+        useWorktree: isTerminal ? false : useWorktree,
+        baseBranch: isTerminal ? null : useWorktree ? baseBranch : null,
+        branchName: isTerminal ? null : useWorktree ? branchName || null : null,
+        fullAccess: isTerminal ? false : fullAccess,
         callable,
-        allowMedia,
+        allowMedia: isTerminal ? false : allowMedia,
       })
       .then(() => {
         onOpenChange(false);

--- a/apps/web/src/components/app/automations-create-dialog.tsx
+++ b/apps/web/src/components/app/automations-create-dialog.tsx
@@ -12,8 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useTemplateActions } from "@/hooks/use-templates";
-import type { AgentType } from "@/lib/agent-types";
-import { type CliAgentType } from "@/lib/agent-types";
+import { type AgentType } from "@/lib/agent-types";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 
 export function CreateTemplateDialog({
@@ -49,7 +48,7 @@ function CreateTemplateDialogContent({
   const [description, setDescription] = useState("");
   const [directory, setDirectory] = useState("");
   const [prompt, setPrompt] = useState("");
-  const [agentType, setAgentType] = useState<CliAgentType>("claude");
+  const [agentType, setAgentType] = useState<AgentType>("claude");
   const [useWorktree, setUseWorktree] = useState(false);
   const [baseBranch, setBaseBranch] = useState("main");
   const [branchName, setBranchName] = useState("");

--- a/apps/web/src/components/app/automations-form-fields.tsx
+++ b/apps/web/src/components/app/automations-form-fields.tsx
@@ -12,11 +12,10 @@ import {
 } from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import type { AgentType } from "@/lib/agent-types";
 import {
   AGENT_TYPE_LABELS,
-  type CliAgentType,
-  isCliAgentType,
+  type AgentType,
+  sortAgentTypes,
 } from "@/lib/agent-types";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import { parseTemplateArgs } from "@/hooks/use-templates";
@@ -27,10 +26,11 @@ export function AgentTypeCombobox({
   onChange,
   agentTypes,
 }: {
-  value: CliAgentType;
-  onChange: (value: CliAgentType) => void;
-  agentTypes: CliAgentType[];
+  value: AgentType;
+  onChange: (value: AgentType) => void;
+  agentTypes: AgentType[];
 }): JSX.Element {
+  const sorted = useMemo(() => sortAgentTypes(agentTypes), [agentTypes]);
   const [open, setOpen] = useState(false);
   const cmdRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -82,7 +82,7 @@ export function AgentTypeCombobox({
           >
             <CommandList>
               <CommandGroup>
-                {agentTypes.map((t) => (
+                {sorted.map((t) => (
                   <CommandItem
                     key={t}
                     value={t}
@@ -191,8 +191,8 @@ export function TemplateFullAccessOption({
 }
 
 export interface TemplateConfigFieldsProps {
-  agentType: CliAgentType;
-  onAgentTypeChange: (value: CliAgentType) => void;
+  agentType: AgentType;
+  onAgentTypeChange: (value: AgentType) => void;
   enabledAgentTypes: AgentType[];
   name: string;
   onNameChange: (value: string) => void;
@@ -243,10 +243,7 @@ export function TemplateConfigFields({
   onPromptChange,
   autoFocusName,
 }: TemplateConfigFieldsProps): JSX.Element {
-  const cliAgentTypes = useMemo(
-    () => enabledAgentTypes.filter(isCliAgentType),
-    [enabledAgentTypes]
-  );
+  const isTerminal = agentType === "terminal";
 
   const detectedArgs = useMemo(
     () => (prompt ? parseTemplateArgs(prompt) : []),
@@ -260,7 +257,7 @@ export function TemplateConfigFields({
         <AgentTypeCombobox
           value={agentType}
           onChange={onAgentTypeChange}
-          agentTypes={cliAgentTypes}
+          agentTypes={enabledAgentTypes}
         />
       </div>
 
@@ -294,20 +291,24 @@ export function TemplateConfigFields({
         />
       </div>
 
-      <TemplateWorktreeOption
-        checked={useWorktree}
-        cwd={directory}
-        baseBranch={baseBranch}
-        branchName={branchName}
-        onCheckedChange={onUseWorktreeChange}
-        onBaseBranchChange={onBaseBranchChange}
-        onBranchNameChange={onBranchNameChange}
-      />
+      {!isTerminal ? (
+        <>
+          <TemplateWorktreeOption
+            checked={useWorktree}
+            cwd={directory}
+            baseBranch={baseBranch}
+            branchName={branchName}
+            onCheckedChange={onUseWorktreeChange}
+            onBaseBranchChange={onBaseBranchChange}
+            onBranchNameChange={onBranchNameChange}
+          />
 
-      <TemplateFullAccessOption
-        checked={fullAccess}
-        onCheckedChange={onFullAccessChange}
-      />
+          <TemplateFullAccessOption
+            checked={fullAccess}
+            onCheckedChange={onFullAccessChange}
+          />
+        </>
+      ) : null}
 
       <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
         <Checkbox
@@ -325,52 +326,56 @@ export function TemplateConfigFields({
         </span>
       </label>
 
-      <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-        <Checkbox
-          checked={allowMedia}
-          onCheckedChange={() => onAllowMediaChange(!allowMedia)}
-          className="mt-0.5"
-        />
-        <span className="space-y-1">
-          <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            <Paperclip className="h-3.5 w-3.5" />
-            Allow media attachments on launch
-          </span>
-          <span className="block text-xs text-muted-foreground">
-            Show a context area for files and links when launching this
-            template.
-          </span>
-        </span>
-      </label>
-
-      <div className="space-y-1">
-        <label className="text-sm text-muted-foreground">Prompt</label>
-        <Textarea
-          value={prompt}
-          onChange={(e) => onPromptChange(e.target.value)}
-          placeholder="Describe what the agent should do..."
-          className={cn(
-            "min-h-[120px] resize-y",
-            "ring-offset-background placeholder:text-muted-foreground",
-            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          )}
-        />
-        {detectedArgs.length > 0 ? (
-          <div className="mt-1.5 text-xs text-muted-foreground">
-            Detected arguments:{" "}
-            {detectedArgs.map((a) => (
-              <span
-                key={a.key}
-                className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
-              >
-                {a.name}
-                {a.required ? " *" : ""}
-                {a.multiline ? " (multiline)" : ""}
+      {!isTerminal ? (
+        <>
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
+            <Checkbox
+              checked={allowMedia}
+              onCheckedChange={() => onAllowMediaChange(!allowMedia)}
+              className="mt-0.5"
+            />
+            <span className="space-y-1">
+              <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                <Paperclip className="h-3.5 w-3.5" />
+                Allow media attachments on launch
               </span>
-            ))}
+              <span className="block text-xs text-muted-foreground">
+                Show a context area for files and links when launching this
+                template.
+              </span>
+            </span>
+          </label>
+
+          <div className="space-y-1">
+            <label className="text-sm text-muted-foreground">Prompt</label>
+            <Textarea
+              value={prompt}
+              onChange={(e) => onPromptChange(e.target.value)}
+              placeholder="Describe what the agent should do..."
+              className={cn(
+                "min-h-[120px] resize-y",
+                "ring-offset-background placeholder:text-muted-foreground",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              )}
+            />
+            {detectedArgs.length > 0 ? (
+              <div className="mt-1.5 text-xs text-muted-foreground">
+                Detected arguments:{" "}
+                {detectedArgs.map((a) => (
+                  <span
+                    key={a.key}
+                    className="mr-1.5 inline-block rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+                  >
+                    {a.name}
+                    {a.required ? " *" : ""}
+                    {a.multiline ? " (multiline)" : ""}
+                  </span>
+                ))}
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/app/automations-launch-dialog.tsx
+++ b/apps/web/src/components/app/automations-launch-dialog.tsx
@@ -120,7 +120,8 @@ function LaunchTemplateDialogContent({
   const [argValues, setArgValues] = useState<Record<string, string>>({});
   const [agentType, setAgentType] = useState<AgentType>(template.agentType);
 
-  const showMedia = template.allowMedia;
+  const isTerminal = agentType === "terminal";
+  const showMedia = !isTerminal && template.allowMedia;
   const [startupFiles, setStartupFiles] = useState<File[]>([]);
   const [startupLinks, setStartupLinks] = useState<string[]>([]);
   const [draggingFiles, setDraggingFiles] = useState(false);

--- a/apps/web/src/components/app/automations-launch-dialog.tsx
+++ b/apps/web/src/components/app/automations-launch-dialog.tsx
@@ -31,7 +31,7 @@ import {
   type Template,
   type TemplateArg,
 } from "@/hooks/use-templates";
-import { type CliAgentType } from "@/lib/agent-types";
+import { type AgentType } from "@/lib/agent-types";
 import { useRadixPopoverZFix } from "@/hooks/use-radix-popover-z-fix";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { agentRoute } from "@/lib/agent-routes";
@@ -85,7 +85,7 @@ export function LaunchTemplateDialog({
   template: Template;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  agentTypes: CliAgentType[];
+  agentTypes: AgentType[];
 }): JSX.Element {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -107,7 +107,7 @@ function LaunchTemplateDialogContent({
 }: {
   template: Template;
   onOpenChange: (open: boolean) => void;
-  agentTypes: CliAgentType[];
+  agentTypes: AgentType[];
 }): JSX.Element {
   const navigate = useNavigate();
   const { launchTemplate } = useTemplateActions();
@@ -118,7 +118,7 @@ function LaunchTemplateDialogContent({
     [template.prompt]
   );
   const [argValues, setArgValues] = useState<Record<string, string>>({});
-  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
+  const [agentType, setAgentType] = useState<AgentType>(template.agentType);
 
   const showMedia = template.allowMedia;
   const [startupFiles, setStartupFiles] = useState<File[]>([]);

--- a/apps/web/src/components/app/automations-launch-dialog.tsx
+++ b/apps/web/src/components/app/automations-launch-dialog.tsx
@@ -251,7 +251,9 @@ function LaunchTemplateDialogContent({
           <DialogDescription>{template.description}</DialogDescription>
         ) : (
           <DialogDescription>
-            This will create a new agent from this template.
+            {isTerminal
+              ? `This will open a terminal session in ${template.directory}.`
+              : "This will create a new agent from this template."}
           </DialogDescription>
         )}
       </DialogHeader>
@@ -287,14 +289,16 @@ function LaunchTemplateDialogContent({
         }
         onDrop={showMedia ? handleDrop : undefined}
       >
-        <div className="space-y-2">
-          <label className="text-sm text-muted-foreground">Agent type</label>
-          <AgentTypeCombobox
-            value={agentType}
-            onChange={setAgentType}
-            agentTypes={agentTypes}
-          />
-        </div>
+        {!isTerminal ? (
+          <div className="space-y-2">
+            <label className="text-sm text-muted-foreground">Agent type</label>
+            <AgentTypeCombobox
+              value={agentType}
+              onChange={setAgentType}
+              agentTypes={agentTypes}
+            />
+          </div>
+        ) : null}
 
         {args.length > 0 ? (
           <div className="mt-3 flex flex-col gap-3">

--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { AlarmClock, FormInput, Play } from "lucide-react";
 import { motion } from "framer-motion";
@@ -15,7 +15,6 @@ import type { AgentType } from "@/lib/agent-types";
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
 import { useTemplates, type Template } from "@/hooks/use-templates";
-import { isCliAgentType } from "@/lib/agent-types";
 import { agentRoute } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
 
@@ -199,10 +198,6 @@ function TemplateListItem({
   onSelect: () => void;
 }): JSX.Element {
   const [launchDialogOpen, setLaunchDialogOpen] = useState(false);
-  const cliAgentTypes = useMemo(
-    () => enabledAgentTypes.filter(isCliAgentType),
-    [enabledAgentTypes]
-  );
 
   const handleLaunch = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -258,7 +253,7 @@ function TemplateListItem({
         template={template}
         open={launchDialogOpen}
         onOpenChange={setLaunchDialogOpen}
-        agentTypes={cliAgentTypes}
+        agentTypes={enabledAgentTypes}
       />
     </>
   );

--- a/apps/web/src/components/app/automations-template-detail.tsx
+++ b/apps/web/src/components/app/automations-template-detail.tsx
@@ -21,7 +21,6 @@ import {
   parseTemplateArgs,
   type Template,
 } from "@/hooks/use-templates";
-import { type CliAgentType, isCliAgentType } from "@/lib/agent-types";
 
 function shortPath(value: string): string {
   const parts = value.split("/").filter(Boolean);
@@ -69,7 +68,7 @@ function TemplateDetail({
   const [description, setDescription] = useState(template.description ?? "");
   const [directory, setDirectory] = useState(template.directory);
   const [prompt, setPrompt] = useState(template.prompt ?? "");
-  const [agentType, setAgentType] = useState<CliAgentType>(template.agentType);
+  const [agentType, setAgentType] = useState<AgentType>(template.agentType);
   const [useWorktree, setUseWorktree] = useState(template.useWorktree);
   const [baseBranch, setBaseBranch] = useState(template.baseBranch ?? "main");
   const [branchName, setBranchName] = useState(template.branchName ?? "");
@@ -157,11 +156,6 @@ function TemplateDetail({
         toast.error(`Failed to delete: ${err.message}`);
       });
   }, [removeTemplate, template, navigate]);
-
-  const cliAgentTypes = useMemo(
-    () => enabledAgentTypes.filter(isCliAgentType),
-    [enabledAgentTypes]
-  );
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -319,7 +313,7 @@ function TemplateDetail({
         template={template}
         open={launchDialogOpen}
         onOpenChange={setLaunchDialogOpen}
-        agentTypes={cliAgentTypes}
+        agentTypes={enabledAgentTypes}
       />
     </div>
   );

--- a/apps/web/src/components/app/automations-template-detail.tsx
+++ b/apps/web/src/components/app/automations-template-detail.tsx
@@ -109,6 +109,7 @@ function TemplateDetail({
   const canSave = !!displayName.trim() && !!directory.trim();
 
   const handleSave = useCallback(() => {
+    const isTerminal = agentType === "terminal";
     setSaveError(null);
     updateTemplate
       .mutateAsync({
@@ -116,14 +117,14 @@ function TemplateDetail({
         name: displayName.trim(),
         description: description.trim() || null,
         directory: directory.trim(),
-        prompt: prompt || null,
+        prompt: isTerminal ? null : prompt || null,
         agentType,
-        useWorktree,
-        baseBranch: useWorktree ? baseBranch : null,
-        branchName: useWorktree ? branchName || null : null,
-        fullAccess,
+        useWorktree: isTerminal ? false : useWorktree,
+        baseBranch: isTerminal ? null : useWorktree ? baseBranch : null,
+        branchName: isTerminal ? null : useWorktree ? branchName || null : null,
+        fullAccess: isTerminal ? false : fullAccess,
         callable,
-        allowMedia,
+        allowMedia: isTerminal ? false : allowMedia,
       })
       .then(() => toast.success("Settings saved."))
       .catch((err: Error) => setSaveError(err.message));

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -48,7 +48,11 @@ import { Input } from "@/components/ui/input";
 import { type Agent } from "@/components/app/types";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import { useRadixPopoverZFix } from "@/hooks/use-radix-popover-z-fix";
-import { AGENT_TYPE_LABELS, type AgentType } from "@/lib/agent-types";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  sortAgentTypes,
+} from "@/lib/agent-types";
 import { api } from "@/lib/api";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
@@ -478,29 +482,31 @@ function CreateAgentDialogContent({
                       >
                         <CommandList>
                           <CommandGroup>
-                            {enabledAgentTypes.map((agentType) => (
-                              <CommandItem
-                                key={agentType}
-                                value={agentType}
-                                onSelect={() => {
-                                  setCreateType(agentType);
-                                  setTypeDropdownOpen(false);
-                                  requestAnimationFrame(() =>
-                                    typeTriggerRef.current?.focus()
-                                  );
-                                }}
-                              >
-                                <Check
-                                  className={cn(
-                                    "mr-2 h-3 w-3 shrink-0",
-                                    agentType === createType
-                                      ? "opacity-100"
-                                      : "opacity-0"
-                                  )}
-                                />
-                                {AGENT_TYPE_LABELS[agentType]}
-                              </CommandItem>
-                            ))}
+                            {sortAgentTypes(enabledAgentTypes).map(
+                              (agentType) => (
+                                <CommandItem
+                                  key={agentType}
+                                  value={agentType}
+                                  onSelect={() => {
+                                    setCreateType(agentType);
+                                    setTypeDropdownOpen(false);
+                                    requestAnimationFrame(() =>
+                                      typeTriggerRef.current?.focus()
+                                    );
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-3 w-3 shrink-0",
+                                      agentType === createType
+                                        ? "opacity-100"
+                                        : "opacity-0"
+                                    )}
+                                  />
+                                  {AGENT_TYPE_LABELS[agentType]}
+                                </CommandItem>
+                              )
+                            )}
                           </CommandGroup>
                         </CommandList>
                       </Command>

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -4,6 +4,7 @@ import {
   type FormEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -180,6 +181,10 @@ function CreateAgentDialogContent({
     }
   }, [step]);
 
+  const sortedAgentTypes = useMemo(
+    () => sortAgentTypes(enabledAgentTypes),
+    [enabledAgentTypes]
+  );
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
@@ -482,31 +487,29 @@ function CreateAgentDialogContent({
                       >
                         <CommandList>
                           <CommandGroup>
-                            {sortAgentTypes(enabledAgentTypes).map(
-                              (agentType) => (
-                                <CommandItem
-                                  key={agentType}
-                                  value={agentType}
-                                  onSelect={() => {
-                                    setCreateType(agentType);
-                                    setTypeDropdownOpen(false);
-                                    requestAnimationFrame(() =>
-                                      typeTriggerRef.current?.focus()
-                                    );
-                                  }}
-                                >
-                                  <Check
-                                    className={cn(
-                                      "mr-2 h-3 w-3 shrink-0",
-                                      agentType === createType
-                                        ? "opacity-100"
-                                        : "opacity-0"
-                                    )}
-                                  />
-                                  {AGENT_TYPE_LABELS[agentType]}
-                                </CommandItem>
-                              )
-                            )}
+                            {sortedAgentTypes.map((agentType) => (
+                              <CommandItem
+                                key={agentType}
+                                value={agentType}
+                                onSelect={() => {
+                                  setCreateType(agentType);
+                                  setTypeDropdownOpen(false);
+                                  requestAnimationFrame(() =>
+                                    typeTriggerRef.current?.focus()
+                                  );
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-3 w-3 shrink-0",
+                                    agentType === createType
+                                      ? "opacity-100"
+                                      : "opacity-0"
+                                  )}
+                                />
+                                {AGENT_TYPE_LABELS[agentType]}
+                              </CommandItem>
+                            ))}
                           </CommandGroup>
                         </CommandList>
                       </Command>

--- a/apps/web/src/hooks/use-templates.ts
+++ b/apps/web/src/hooks/use-templates.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import type { CliAgentType } from "@/lib/agent-types";
+import type { AgentType } from "@/lib/agent-types";
 import type { Agent } from "@/components/app/types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import {
@@ -17,7 +17,7 @@ export type Template = {
   name: string;
   description: string | null;
   prompt: string | null;
-  agentType: CliAgentType;
+  agentType: AgentType;
   useWorktree: boolean;
   baseBranch: string | null;
   branchName: string | null;
@@ -33,7 +33,7 @@ export type AddTemplateConfig = {
   directory: string;
   description?: string | null;
   prompt?: string | null;
-  agentType?: CliAgentType;
+  agentType?: AgentType;
   useWorktree?: boolean;
   baseBranch?: string | null;
   branchName?: string | null;
@@ -104,7 +104,7 @@ export function useTemplateActions() {
     }: {
       id: string;
       args?: Record<string, string>;
-      agentType?: CliAgentType;
+      agentType?: AgentType;
       startupFiles?: File[];
       startupLinks?: string[];
     }) => {

--- a/apps/web/src/lib/agent-types.ts
+++ b/apps/web/src/lib/agent-types.ts
@@ -34,6 +34,14 @@ export function isAgentType(value: string): value is AgentType {
   return AGENT_TYPES.includes(value as AgentType);
 }
 
+export function sortAgentTypes<T extends AgentType>(types: T[]): T[] {
+  return [...types].sort((a, b) => {
+    if (a === "terminal") return 1;
+    if (b === "terminal") return -1;
+    return AGENT_TYPE_LABELS[a].localeCompare(AGENT_TYPE_LABELS[b]);
+  });
+}
+
 export function sanitizeEnabledAgentTypes(value: unknown): AgentType[] {
   if (!Array.isArray(value)) {
     return [...AGENT_TYPES];


### PR DESCRIPTION
## Summary
- Adds Terminal as a valid agent type for templates, enabling quick-launch terminal sessions in a specific directory
- Hides CLI-specific fields (prompt, worktree, full access, media) when Terminal is selected in create/edit forms
- Sorts all agent type dropdowns alphabetically with Terminal always last
- Nulls out irrelevant fields on save so DB state matches what the user saw
- Hides agent type picker in the launch dialog for terminal templates (switching to CLI would fail without a prompt)
- Updates launch dialog description for terminal: "This will open a terminal session in {directory}"

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Web build passes (`pnpm run finalize:web`)
- [x] Unit tests pass (`pnpm run test`)
- [x] E2E tests pass (143/143, 1 pre-existing flaky failure unrelated to changes)
- [x] Browser validated: create dialog, agent type dropdown ordering, terminal field hiding, detail pane, launch dialog
- [x] UX review persona passed (4/4 findings fixed and approved on recheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)