### PR TITLE
Prune stale release binaries during updates

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -124,6 +124,7 @@ import { createAuthRuntime } from "./server/auth-runtime.js";
 import { getBearerToken, handleAgentError } from "./server/http-helpers.js";
 import {
   createReleaseRuntime,
+  pruneReleaseBinaries,
   type ReleaseJob,
   RELEASE_VERSION_TYPES,
 } from "./server/release-runtime.js";
@@ -680,6 +681,13 @@ export async function start() {
   app.log.info(
     `Dispatch listening on ${protocol}://${config.host}:${config.port}`
   );
+
+  const removed = pruneReleaseBinaries(serverDir, `v${packageVersion}`);
+  if (removed > 0) {
+    app.log.info(
+      `Pruned ${removed} old release binary file${removed === 1 ? "" : "s"} from dist/bun`
+    );
+  }
 }
 
 export { app, shutdown };

--- a/apps/server/src/server/release-runtime.ts
+++ b/apps/server/src/server/release-runtime.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { readdirSync, unlinkSync } from "node:fs";
+import path from "node:path";
 
 import type { Pool } from "pg";
 
@@ -121,6 +123,28 @@ type CreateReleaseRuntimeDeps = {
     onLine?: (line: string) => void
   ) => ReleaseLogStreamProcessor;
 };
+
+export function pruneReleaseBinaries(
+  serverDir: string,
+  keepTag: string
+): number {
+  const bunDir = path.join(serverDir, "dist/bun");
+  const version = keepTag.replace(/^v/, "");
+  let removed = 0;
+
+  try {
+    for (const entry of readdirSync(bunDir)) {
+      if (!entry.startsWith("dispatch-")) continue;
+      if (entry.startsWith(`dispatch-${version}-bun-`)) continue;
+      try {
+        unlinkSync(path.join(bunDir, entry));
+        removed += 1;
+      } catch {}
+    }
+  } catch {}
+
+  return removed;
+}
 
 export function createReleaseRuntime(deps: CreateReleaseRuntimeDeps) {
   let activeReleaseJob: ReleaseJob | null = null;

--- a/apps/server/test/release-runtime.test.ts
+++ b/apps/server/test/release-runtime.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { createReleaseRuntime } from "../src/server/release-runtime.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createReleaseRuntime,
+  pruneReleaseBinaries,
+} from "../src/server/release-runtime.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("release runtime stream targeting", () => {
   it("sends targeted release events only to the matching stream client", () => {
@@ -43,5 +64,37 @@ describe("release runtime stream targeting", () => {
     expect(writeA).not.toHaveBeenCalled();
     expect(writeB).toHaveBeenCalledTimes(1);
     expect(writeB.mock.calls[0]?.[0]).toContain('"type":"info-progress"');
+  });
+});
+
+describe("pruneReleaseBinaries", () => {
+  it("removes stale release binaries while keeping the deployed version", () => {
+    const serverDir = mkdtempSync(path.join(tmpdir(), "dispatch-release-"));
+    tempDirs.push(serverDir);
+    const bunDir = path.join(serverDir, "dist/bun");
+    mkdirSync(bunDir, { recursive: true });
+
+    writeFileSync(
+      path.join(bunDir, "dispatch-0.21.1-bun-darwin-arm64"),
+      "current"
+    );
+    writeFileSync(
+      path.join(bunDir, "dispatch-0.21.0-bun-darwin-arm64"),
+      "old-a"
+    );
+    writeFileSync(path.join(bunDir, "dispatch-0.20.9-bun-linux-x64"), "old-b");
+    writeFileSync(
+      path.join(bunDir, "dispatch-0.21.10-bun-darwin-arm64"),
+      "old-c"
+    );
+    writeFileSync(path.join(bunDir, "README.txt"), "keep");
+
+    const removed = pruneReleaseBinaries(serverDir, "v0.21.1");
+
+    expect(removed).toBe(3);
+    expect(readdirSync(bunDir).sort()).toEqual([
+      "README.txt",
+      "dispatch-0.21.1-bun-darwin-arm64",
+    ]);
   });
 });

--- a/update-migrations/0007-prune-old-release-binaries.yaml
+++ b/update-migrations/0007-prune-old-release-binaries.yaml
@@ -1,0 +1,48 @@
+id: prune-old-release-binaries
+title: Prune stale release binaries from dist/bun
+summary: >
+  Older installs may have accumulated stale Dispatch Bun binaries under
+  dist/bun/ because previous update flows extracted each release's artifacts
+  without removing prior versions. This migration routes the release through
+  assisted update once so the operator can reclaim that disk usage on existing
+  installs while confirming the current release binary remains intact and the
+  service stays healthy.
+
+alreadySatisfied:
+  description: >
+    The install is already on the target tag, the active Dispatch runtime
+    artifact for the host platform still exists, the health endpoint returns
+    status=ok, and every dispatch-* file in dist/bun/ already starts with
+    dispatch-<target-version>-bun- for the exact deployed release version.
+    If those conditions are true, the migration is a no-op and the agent
+    should proceed straight to validation.
+
+instructions:
+  - Confirm the install directory is on the target tag and inspect dist/bun/
+    for files whose names start with dispatch-.
+  - Determine the deployed release version string from the target tag by
+    removing the leading v, for example v0.21.1 -> 0.21.1.
+  - If every dispatch-* file in dist/bun/ already starts with
+    dispatch-<target-version>-bun- for that exact target version, treat the
+    migration as already satisfied and skip the cleanup steps.
+  - Otherwise remove only the dispatch-* files in dist/bun/ whose filenames do
+    not start with dispatch-<target-version>-bun-. Leave non-dispatch files in
+    place.
+  - Confirm the platform-matched Dispatch Bun runtime artifact for the target
+    release still exists after cleanup.
+  - Confirm $DISPATCH_API_URL/api/v1/health returns status=ok before reporting
+    validate.
+
+validation:
+  requiredChecks:
+    - expected_runtime_artifact
+    - health_endpoint
+    - version_converged
+
+rollback:
+  - If cleanup removed the wrong runtime artifact or the service no longer
+    reports healthy, roll back to the previous healthy release tag using the
+    normal release rollback path for this host.
+  - Restore the missing runtime artifact from the previous healthy release if
+    rollback requires it, then confirm the health endpoint returns status=ok
+    and release.json reports the prior tag.


### PR DESCRIPTION
## Summary
- prune stale `dist/bun/dispatch-*` binaries using exact `dispatch-<version>-bun-` matching
- run pruning on successful server startup instead of the pre-restart deploy path
- add an assisted-update migration manifest for existing installs and cover the `0.21.1` vs `0.21.10` regression

## Testing
- `pnpm vitest apps/server/test/release-runtime.test.ts`
- `pnpm vitest apps/server/test/update-migrations.test.ts`
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e`

## Context
- Implements `DIS-161`
- Infra review approved on recheck