### PR TITLE
Add per-project Brain viewer in Automations (#DIS-160)

### DIFF
--- a/apps/web/src/components/app/automations-pane.tsx
+++ b/apps/web/src/components/app/automations-pane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { AlarmClock, FormInput, Play } from "lucide-react";
+import { AlarmClock, Brain, FormInput, Play } from "lucide-react";
 import { motion } from "framer-motion";
 
 import {
@@ -8,6 +8,10 @@ import {
   JobListContent,
   JobDetailPane,
 } from "@/components/app/jobs-pane";
+import {
+  BrainsListContent,
+  BrainsDetailPane,
+} from "@/components/app/brains-pane";
 import { CreateTemplateDialog } from "@/components/app/automations-create-dialog";
 import { LaunchTemplateDialog } from "@/components/app/automations-launch-dialog";
 import { TemplateDetailPane } from "@/components/app/automations-template-detail";
@@ -18,14 +22,14 @@ import { useTemplates, type Template } from "@/hooks/use-templates";
 import { agentRoute } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
 
-type AutomationsTab = "templates" | "jobs";
+type AutomationsTab = "templates" | "jobs" | "brains";
 
 function resolveTab(pathname: string): AutomationsTab {
-  if (
-    pathname.startsWith("/automations/jobs") ||
-    pathname === "/automations/jobs"
-  ) {
+  if (pathname.startsWith("/automations/jobs")) {
     return "jobs";
+  }
+  if (pathname.startsWith("/automations/brains")) {
+    return "brains";
   }
   return "templates";
 }
@@ -61,6 +65,12 @@ function AutomationsSidebar({
             icon={<AlarmClock className="h-3.5 w-3.5" />}
             label="Jobs"
           />
+          <TabButton
+            active={activeTab === "brains"}
+            onClick={() => onTabChange("brains")}
+            icon={<Brain className="h-3.5 w-3.5" />}
+            label="Brains"
+          />
         </div>
       </div>
       {activeTab === "templates" ? (
@@ -68,8 +78,10 @@ function AutomationsSidebar({
           enabledAgentTypes={enabledAgentTypes}
           onItemSelect={onItemSelect}
         />
-      ) : (
+      ) : activeTab === "jobs" ? (
         <JobListContent onItemSelect={onItemSelect} hideHeader />
+      ) : (
+        <BrainsListContent onItemSelect={onItemSelect} />
       )}
     </div>
   );
@@ -292,6 +304,8 @@ export function AutomationsSidebarContent({
     (tab: AutomationsTab) => {
       if (tab === "jobs") {
         navigate("/automations/jobs");
+      } else if (tab === "brains") {
+        navigate("/automations/brains");
       } else {
         navigate("/automations");
       }
@@ -306,6 +320,15 @@ export function AutomationsSidebarContent({
     [navigate]
   );
 
+  const sidebar = (
+    <AutomationsSidebar
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+      enabledAgentTypes={enabledAgentTypes}
+      onItemSelect={isMobile ? closeSidebar : undefined}
+    />
+  );
+
   if (activeTab === "jobs") {
     return (
       <JobsProvider
@@ -314,24 +337,12 @@ export function AutomationsSidebarContent({
         onOpenAgent={openAgent}
         enabledAgentTypes={enabledAgentTypes}
       >
-        <AutomationsSidebar
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-          enabledAgentTypes={enabledAgentTypes}
-          onItemSelect={isMobile ? closeSidebar : undefined}
-        />
+        {sidebar}
       </JobsProvider>
     );
   }
 
-  return (
-    <AutomationsSidebar
-      activeTab={activeTab}
-      onTabChange={handleTabChange}
-      enabledAgentTypes={enabledAgentTypes}
-      onItemSelect={isMobile ? closeSidebar : undefined}
-    />
-  );
+  return sidebar;
 }
 
 export function AutomationsDetailContent({
@@ -354,6 +365,10 @@ export function AutomationsDetailContent({
 
   if (activeTab === "templates") {
     return <TemplateDetailPane enabledAgentTypes={enabledAgentTypes} />;
+  }
+
+  if (activeTab === "brains") {
+    return <BrainsDetailPane />;
   }
 
   return (

--- a/apps/web/src/components/app/brain-tab-content.tsx
+++ b/apps/web/src/components/app/brain-tab-content.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import {
+  ArrowRight,
   Brain,
   Check,
   ChevronDown,
@@ -20,12 +22,25 @@ import {
 import { useCopyText } from "@/hooks/use-copy";
 import { cn } from "@/lib/utils";
 
+export function encodeRepoRoot(repoRoot: string): string {
+  return btoa(repoRoot)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function decodeRepoRoot(encoded: string): string {
+  let base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  while (base64.length % 4) base64 += "=";
+  return atob(base64);
+}
+
 type BrainTabContentProps = {
   agentId: string | null;
   repoRoot: string | null;
 };
 
-function formatRelative(date: Date): string {
+export function formatRelative(date: Date): string {
   const diffMs = Date.now() - date.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
   const diffHr = Math.floor(diffMin / 60);
@@ -37,7 +52,7 @@ function formatRelative(date: Date): string {
   return `${diffDay}d ago`;
 }
 
-function RelativeTime({ iso }: { iso: string }): JSX.Element {
+export function RelativeTime({ iso }: { iso: string }): JSX.Element {
   const date = new Date(iso);
   return (
     <time
@@ -50,7 +65,7 @@ function RelativeTime({ iso }: { iso: string }): JSX.Element {
   );
 }
 
-function CopyButton({
+export function CopyButton({
   value,
   className,
 }: {
@@ -83,7 +98,7 @@ function CopyButton({
   );
 }
 
-function CollapsibleSection({
+export function CollapsibleSection({
   title,
   icon: Icon,
   count,
@@ -124,7 +139,10 @@ function CollapsibleSection({
 
 // ── Value renderers ─────────────────────────────────────────────
 
-function formatPrimitive(v: unknown): { text: string; className: string } {
+export function formatPrimitive(v: unknown): {
+  text: string;
+  className: string;
+} {
   if (v === undefined)
     return { text: "undefined", className: "text-violet-400" };
   if (v === null) return { text: "null", className: "text-violet-400" };
@@ -156,7 +174,7 @@ function formatPrimitive(v: unknown): { text: string; className: string } {
   };
 }
 
-function KeyValueTable({ value }: { value: unknown }): JSX.Element {
+export function KeyValueTable({ value }: { value: unknown }): JSX.Element {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     const fmt = formatPrimitive(value);
     return (
@@ -327,7 +345,7 @@ function ListCard({
 
 // ── Event card ──────────────────────────────────────────────────
 
-const KIND_STYLES: Record<
+export const KIND_STYLES: Record<
   string,
   { dot: string; text: string; badge: string }
 > = {
@@ -348,7 +366,7 @@ const KIND_STYLES: Record<
   },
 };
 
-function getKindStyle(kind: string) {
+export function getKindStyle(kind: string) {
   return (
     KIND_STYLES[kind] ?? {
       dot: "bg-muted-foreground",
@@ -461,10 +479,19 @@ export function BrainTabContent({
 
   return (
     <div className={cn("flex flex-col overflow-y-auto")}>
-      <div className="px-3 py-3 border-b border-border">
+      <div className="px-3 py-3 border-b border-border flex items-center justify-between">
         <p className="text-xs text-muted-foreground">
           Shared memory this agent has written.
         </p>
+        {repoRoot ? (
+          <Link
+            to={`/automations/brains/${encodeRepoRoot(repoRoot)}`}
+            className="flex items-center gap-1 text-[11px] text-primary/70 hover:text-primary transition-colors shrink-0"
+          >
+            View full brain
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        ) : null}
       </div>
       <CollapsibleSection
         title="Objects"

--- a/apps/web/src/components/app/brains-pane.tsx
+++ b/apps/web/src/components/app/brains-pane.tsx
@@ -1,0 +1,593 @@
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  Activity,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Database,
+  List,
+  Radio,
+  Search,
+} from "lucide-react";
+
+import {
+  useBrainProjects,
+  useBrainCollections,
+  useBrainObjects,
+  useBrainLists,
+  useBrainEvents,
+  useBrainListItems,
+  type BrainObject,
+  type BrainList,
+  type BrainEvent,
+} from "@/hooks/use-brain";
+import {
+  CollapsibleSection,
+  CopyButton,
+  KeyValueTable,
+  RelativeTime,
+  decodeRepoRoot,
+  encodeRepoRoot,
+  getKindStyle,
+} from "@/components/app/brain-tab-content";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+function repoBasename(repoRoot: string): string {
+  return repoRoot.split("/").filter(Boolean).pop() ?? repoRoot;
+}
+
+function shortPath(value: string): string {
+  const parts = value.split("/").filter(Boolean);
+  if (parts.length <= 3) return value;
+  return `.../${parts.slice(-3).join("/")}`;
+}
+
+// ── Sidebar ─────────────────────────────────────────────────────
+
+export function BrainsListContent({
+  onItemSelect,
+}: {
+  onItemSelect?: () => void;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const { encodedRepoRoot } = useParams<{ encodedRepoRoot?: string }>();
+  const { data: projects = [], isLoading } = useBrainProjects();
+  const showOverview = !encodedRepoRoot;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="space-y-3 p-4">
+            {Array.from({ length: 3 }, (_, i) => (
+              <div
+                key={i}
+                className="h-10 animate-pulse rounded-md bg-muted/40"
+              />
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="p-4 text-sm text-muted-foreground">
+            <div className="rounded-md border border-dashed border-border p-4">
+              <div className="font-medium text-foreground">
+                No brain data yet.
+              </div>
+              <div className="mt-1 text-xs">
+                Brain data will appear here when agents write shared memory.
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <button
+              className={cn(
+                "flex w-full items-center gap-2 border-b border-r-4 border-border border-r-transparent px-3 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/40",
+                showOverview && "border-r-primary bg-muted/60"
+              )}
+              onClick={() => {
+                navigate("/automations/brains");
+                onItemSelect?.();
+              }}
+            >
+              <Activity className="h-3.5 w-3.5" />
+              <span>Overview</span>
+            </button>
+            {projects.map((project) => {
+              const encoded = encodeRepoRoot(project.repoRoot);
+              const selected = encodedRepoRoot === encoded;
+              return (
+                <div
+                  key={project.repoRoot}
+                  role="button"
+                  tabIndex={0}
+                  className={cn(
+                    "w-full cursor-pointer border-b border-r-4 border-border border-r-transparent px-3 py-2 text-left transition-colors hover:bg-muted/40",
+                    selected && "border-r-primary bg-muted/60"
+                  )}
+                  onClick={() => {
+                    navigate(`/automations/brains/${encoded}`);
+                    onItemSelect?.();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      navigate(`/automations/brains/${encoded}`);
+                      onItemSelect?.();
+                    }
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold leading-5">
+                        {repoBasename(project.repoRoot)}
+                      </div>
+                      <div
+                        className="truncate font-mono text-[11px] text-muted-foreground"
+                        title={project.repoRoot}
+                      >
+                        {shortPath(project.repoRoot)}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground shrink-0">
+                      {project.objectCount > 0 ? (
+                        <span className="flex items-center gap-0.5">
+                          <Database className="h-2.5 w-2.5" />
+                          {project.objectCount}
+                        </span>
+                      ) : null}
+                      {project.listCount > 0 ? (
+                        <span className="flex items-center gap-0.5">
+                          <List className="h-2.5 w-2.5" />
+                          {project.listCount}
+                        </span>
+                      ) : null}
+                      {project.eventCount > 0 ? (
+                        <span className="flex items-center gap-0.5">
+                          <Radio className="h-2.5 w-2.5" />
+                          {project.eventCount}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Detail Pane ──────────────────────────────────────────────────
+
+export function BrainsDetailPane(): JSX.Element {
+  const { encodedRepoRoot, collection } = useParams<{
+    encodedRepoRoot?: string;
+    collection?: string;
+  }>();
+
+  if (!encodedRepoRoot) {
+    return <BrainsOverview />;
+  }
+
+  const repoRoot = decodeRepoRoot(encodedRepoRoot);
+  return (
+    <BrainProjectDetail
+      repoRoot={repoRoot}
+      encodedRepoRoot={encodedRepoRoot}
+      selectedCollection={collection ? decodeURIComponent(collection) : null}
+    />
+  );
+}
+
+function BrainsOverview(): JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground">
+      <div>
+        <Brain className="mx-auto mb-3 h-8 w-8" />
+        <div className="font-medium text-foreground">Brain Explorer</div>
+        <div className="mt-1 max-w-sm text-sm">
+          Select a project to inspect its shared brain memory — objects, lists,
+          and events organized by collection.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Project Detail ───────────────────────────────────────────────
+
+function BrainProjectDetail({
+  repoRoot,
+  encodedRepoRoot,
+  selectedCollection,
+}: {
+  repoRoot: string;
+  encodedRepoRoot: string;
+  selectedCollection: string | null;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const { data: collections = [], isLoading: collectionsLoading } =
+    useBrainCollections(repoRoot);
+  const [search, setSearch] = useState("");
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="border-b border-border px-4 py-3 md:px-6">
+        <h2 className="truncate text-xl font-semibold">
+          {repoBasename(repoRoot)}
+        </h2>
+        <div
+          className="mt-0.5 truncate font-mono text-xs text-muted-foreground"
+          title={repoRoot}
+        >
+          {repoRoot}
+        </div>
+      </div>
+
+      <div className="border-b border-border px-4 md:px-6">
+        <div className="flex items-center gap-3 py-2">
+          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto scrollbar-none">
+            <CollectionPill
+              label="All"
+              active={selectedCollection === null}
+              onClick={() => navigate(`/automations/brains/${encodedRepoRoot}`)}
+            />
+            {collectionsLoading
+              ? null
+              : collections.map((col) => (
+                  <CollectionPill
+                    key={col.collection}
+                    label={col.collection}
+                    count={col.objectCount + col.listCount + col.eventCount}
+                    active={selectedCollection === col.collection}
+                    onClick={() =>
+                      navigate(
+                        `/automations/brains/${encodedRepoRoot}/${encodeURIComponent(col.collection)}`
+                      )
+                    }
+                  />
+                ))}
+          </div>
+          <div className="relative shrink-0">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Filter..."
+              className="h-8 w-40 pl-8 text-xs"
+            />
+          </div>
+        </div>
+      </div>
+
+      <BrainCollectionView
+        repoRoot={repoRoot}
+        collection={selectedCollection}
+        search={search}
+      />
+    </div>
+  );
+}
+
+function CollectionPill({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+        active
+          ? "bg-primary/15 text-primary"
+          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+      )}
+    >
+      {label}
+      {count !== undefined ? (
+        <span
+          className={cn(
+            "rounded-full px-1.5 py-0.5 text-[10px]",
+            active ? "bg-primary/20" : "bg-muted"
+          )}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+// ── Collection View ──────────────────────────────────────────────
+
+function BrainCollectionView({
+  repoRoot,
+  collection,
+  search,
+}: {
+  repoRoot: string;
+  collection: string | null;
+  search: string;
+}): JSX.Element {
+  const objectFilters = collection ? { collection } : undefined;
+  const listFilters = collection ? { collection } : undefined;
+  const eventFilters = collection ? { collection, limit: 100 } : { limit: 100 };
+
+  const { data: objects = [], isLoading: objectsLoading } = useBrainObjects(
+    repoRoot,
+    objectFilters
+  );
+  const { data: lists = [], isLoading: listsLoading } = useBrainLists(
+    repoRoot,
+    listFilters
+  );
+  const { data: events = [], isLoading: eventsLoading } = useBrainEvents(
+    repoRoot,
+    eventFilters
+  );
+
+  const isLoading = objectsLoading || listsLoading || eventsLoading;
+
+  const lowerSearch = search.toLowerCase();
+  const filteredObjects = search
+    ? objects.filter(
+        (o) =>
+          o.name.toLowerCase().includes(lowerSearch) ||
+          o.collection.toLowerCase().includes(lowerSearch)
+      )
+    : objects;
+  const filteredLists = search
+    ? lists.filter(
+        (l) =>
+          l.name.toLowerCase().includes(lowerSearch) ||
+          l.collection.toLowerCase().includes(lowerSearch)
+      )
+    : lists;
+  const filteredEvents = search
+    ? events.filter(
+        (e) =>
+          e.kind.toLowerCase().includes(lowerSearch) ||
+          (e.subject?.toLowerCase().includes(lowerSearch) ?? false) ||
+          e.collection.toLowerCase().includes(lowerSearch)
+      )
+    : events;
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (
+    filteredObjects.length === 0 &&
+    filteredLists.length === 0 &&
+    filteredEvents.length === 0
+  ) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        <div className="flex flex-col items-center gap-2">
+          <Brain className="h-8 w-8" />
+          <div className="mt-4">
+            {search
+              ? "No brain data matches your filter."
+              : "No brain data in this collection yet."}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="min-h-0 flex-1">
+      <div className="mx-auto max-w-5xl space-y-1 px-3 pt-4 pb-12 sm:px-5 md:px-8">
+        <CollapsibleSection
+          title="Objects"
+          icon={Database}
+          count={filteredObjects.length}
+        >
+          {filteredObjects.map((obj) => (
+            <ProjectObjectCard
+              key={`${obj.collection}/${obj.name}`}
+              obj={obj}
+            />
+          ))}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Lists"
+          icon={List}
+          count={filteredLists.length}
+        >
+          {filteredLists.map((list) => (
+            <ProjectListCard
+              key={`${list.collection}/${list.name}`}
+              list={list}
+              repoRoot={repoRoot}
+            />
+          ))}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Events"
+          icon={Radio}
+          count={filteredEvents.length}
+        >
+          {filteredEvents.map((event) => (
+            <ProjectEventCard key={event.id} event={event} />
+          ))}
+        </CollapsibleSection>
+      </div>
+    </ScrollArea>
+  );
+}
+
+// ── Cards ────────────────────────────────────────────────────────
+
+function AgentLink({ agentId }: { agentId: string }): JSX.Element {
+  return (
+    <Link
+      to={`/agents/${agentId}`}
+      className="font-mono text-[10px] text-primary/70 hover:text-primary transition-colors"
+      title={agentId}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {agentId.slice(0, 12)}
+    </Link>
+  );
+}
+
+function ProjectObjectCard({ obj }: { obj: BrainObject }): JSX.Element {
+  return (
+    <div className="mx-3 mb-2 rounded-md border border-border bg-muted/20 p-2.5">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-1.5 text-xs min-w-0">
+          <span className="rounded bg-sky-950/50 px-1.5 py-0.5 font-mono text-sky-400 text-[10px] shrink-0">
+            {obj.collection}
+          </span>
+          <span className="font-medium truncate">{obj.name}</span>
+          <span className="text-[10px] text-muted-foreground shrink-0">
+            rev {obj.revision}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground shrink-0">
+          <AgentLink agentId={obj.updatedByAgentId} />
+          <CopyButton value={obj.value} />
+          <RelativeTime iso={obj.updatedAt} />
+        </div>
+      </div>
+      <div className="rounded bg-muted/30 px-2.5 py-2 overflow-x-auto">
+        <KeyValueTable value={obj.value} />
+      </div>
+    </div>
+  );
+}
+
+function ProjectListCard({
+  list,
+  repoRoot,
+}: {
+  list: BrainList;
+  repoRoot: string;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const { data } = useBrainListItems(
+    expanded ? repoRoot : null,
+    list.collection,
+    list.name,
+    { limit: 50, order: "asc" }
+  );
+
+  const items = data?.items ?? [];
+
+  return (
+    <div className="mx-3 mb-2 rounded-md border border-border bg-muted/20 p-2.5">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-2 mb-2 text-left"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <div className="flex items-center gap-1.5 text-xs min-w-0">
+          {expanded ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )}
+          <span className="rounded bg-violet-950/50 px-1.5 py-0.5 font-mono text-violet-400 text-[10px] shrink-0">
+            {list.collection}
+          </span>
+          <span className="font-medium truncate">{list.name}</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground shrink-0">
+          <AgentLink agentId={list.updatedByAgentId} />
+          <span>{list.itemCount} items</span>
+          <RelativeTime iso={list.updatedAt} />
+        </div>
+      </button>
+      {expanded && items.length > 0 ? (
+        <div className="rounded bg-muted/30 overflow-hidden">
+          {items.map((item) => (
+            <div
+              key={item.index}
+              className="flex gap-2 px-2.5 py-1.5 text-xs font-mono border-b border-border/50 last:border-b-0 min-w-0"
+            >
+              <span className="text-muted-foreground shrink-0 w-4 text-right pt-px">
+                {item.index}
+              </span>
+              <div className="flex-1 overflow-x-auto">
+                <KeyValueTable value={item.value} />
+              </div>
+              <CopyButton value={item.value} className="shrink-0 mt-px" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ProjectEventCard({ event }: { event: BrainEvent }): JSX.Element {
+  const style = getKindStyle(event.kind);
+
+  return (
+    <div className="mx-3 mb-2 rounded-md border border-border bg-muted/20 p-2.5">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-1.5 text-xs min-w-0">
+          <span className={cn("h-2 w-2 rounded-full shrink-0", style.dot)} />
+          <span
+            className={cn(
+              "rounded px-1.5 py-0.5 font-mono text-[10px] shrink-0",
+              style.badge
+            )}
+          >
+            {event.kind}
+          </span>
+          <span className="rounded bg-sky-950/50 px-1.5 py-0.5 font-mono text-sky-400 text-[10px] shrink-0">
+            {event.collection}
+          </span>
+          {event.subject ? (
+            <span className="truncate text-muted-foreground">
+              {event.subject}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground shrink-0">
+          <AgentLink agentId={event.agentId} />
+          <CopyButton value={event.value} />
+          <RelativeTime iso={event.createdAt} />
+        </div>
+      </div>
+      {event.tags.length > 0 ? (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {event.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {event.value != null ? (
+        <div className="rounded bg-muted/30 px-2.5 py-2 overflow-x-auto">
+          <KeyValueTable value={event.value} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -125,6 +125,21 @@ export const router = createBrowserRouter([
                 handle: { navSection: "automations" },
               },
               {
+                path: "automations/brains",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/brains/:encodedRepoRoot",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
+                path: "automations/brains/:encodedRepoRoot/:collection",
+                element: <AutomationsRoute />,
+                handle: { navSection: "automations" },
+              },
+              {
                 path: "jobs",
                 element: <Navigate to="/automations/jobs" replace />,
               },


### PR DESCRIPTION
## Summary

- Adds **Brains** as the 3rd tab in the Automations section — a full project-level brain viewer with collection-first organization
- Sidebar lists all projects with brain data, showing object/list/event count badges
- Project detail view includes collection picker pills, search filter, and collapsible Objects/Lists/Events sections
- Agent attribution links on all brain entries navigate back to the agent session
- "View full brain →" link added to the per-agent Brain sidebar tab (from DIS-159)
- Live updates via existing `brain.changed` SSE event invalidation

## Routing

```
/automations/brains                              → overview
/automations/brains/:encodedRepoRoot             → project brain (all collections)
/automations/brains/:encodedRepoRoot/:collection → project brain, specific collection
```

## Test plan

- [x] Type check passes (`pnpm run check`)
- [x] Production build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (113/114 — 1 pre-existing flaky failure in agent-routing)
- [x] Unit tests pass
- [x] Playwright validation: tab switching, project selection, collection filtering, search, list expansion, agent links

Closes DIS-160

🤖 Generated with [Claude Code](https://claude.com/claude-code)