### PR TITLE
Add CRUD tools to docs and document Brains tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `brain_list_delete`          | Delete a shared Brain list and all of its items                            |
 | `brain_append_event`         | Append a structured event to the Brain's immutable event log               |
 | `brain_query_events`         | Query Brain events by collection, kind, subject, tags, and time range      |
+| `list_jobs`                  | List jobs scoped to a directory                                            |
+| `get_job`                    | Get a single job by ID or name                                             |
+| `create_job`                 | Create a new job                                                           |
+| `update_job`                 | Update an existing job's configuration                                     |
+| `delete_job`                 | Delete a job                                                               |
+| `run_job`                    | Trigger an immediate run of a job                                          |
+| `list_templates`             | List templates scoped to a directory                                       |
+| `get_template`               | Get a single template by ID or name                                        |
+| `create_template`            | Create a new reusable agent launch template                                |
+| `update_template`            | Update an existing template                                                |
+| `delete_template`            | Delete a template                                                          |
 
 ### Persona agents
 
@@ -190,7 +201,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, and `brain_query_events`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
 
 ### Repo-specific tools
 

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -658,6 +658,18 @@ const SECTIONS: SectionDef[] = [
               <Code>brain_append_event</Code>, <Code>brain_query_events</Code> —
               append to and query the Brain's immutable event log
             </li>
+            <li>
+              <Code>list_jobs</Code>, <Code>get_job</Code>,{" "}
+              <Code>create_job</Code>, <Code>update_job</Code>,{" "}
+              <Code>delete_job</Code>, <Code>run_job</Code> — manage and trigger
+              Dispatch jobs programmatically
+            </li>
+            <li>
+              <Code>list_templates</Code>, <Code>get_template</Code>,{" "}
+              <Code>create_template</Code>, <Code>update_template</Code>,{" "}
+              <Code>delete_template</Code> — manage reusable agent launch
+              templates
+            </li>
           </ul>
         </Section>
 
@@ -1067,6 +1079,15 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               and <Code>brain_query_events</Code>. Same tools as standard
               agents.
             </li>
+            <li>
+              <strong>Automation CRUD</strong> — <Code>list_jobs</Code>,{" "}
+              <Code>get_job</Code>, <Code>create_job</Code>,{" "}
+              <Code>update_job</Code>, <Code>delete_job</Code>,{" "}
+              <Code>run_job</Code>, <Code>list_templates</Code>,{" "}
+              <Code>get_template</Code>, <Code>create_template</Code>,{" "}
+              <Code>update_template</Code>, and <Code>delete_template</Code>.
+              Same tools as standard agents.
+            </li>
           </ul>
         </Section>
 
@@ -1128,10 +1149,13 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <H3>Automations UI</H3>
           <P>
             The Automations page has a tabbed sidebar with{" "}
-            <strong>Templates</strong> and <strong>Jobs</strong> tabs. Both tabs
-            use the same flat-list layout with a sliding indicator that animates
-            between them. Select an item to see its detail view, or use the
-            inline play button on a template for quick launch.
+            <strong>Templates</strong>, <strong>Jobs</strong>, and{" "}
+            <strong>Brains</strong> tabs. The first two use the same flat-list
+            layout with a sliding indicator that animates between them. Select
+            an item to see its detail view, or use the inline play button on a
+            template for quick launch. The <strong>Brains</strong> tab shows a
+            collection-first browser for the repo-scoped Brain — select a
+            project to browse its collections, objects, lists, and events.
           </P>
         </Section>
       </>


### PR DESCRIPTION
## Summary
- Added the 11 job/template CRUD tools (`list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, `delete_template`) to docs-pane Built-in tools list, job agent tools list, and README MCP tools tables
- Updated Automations UI section to document the new **Brains** tab added in #595

## What was audited
- MCP tool sets in `apps/server/src/shared/mcp/server.ts` (`AGENT_TOOLS`, `JOB_TOOLS`, `PERSONA_TOOLS`) against all tool documentation surfaces
- Automations page tabs against docs-pane Automations UI section
- 6 commits since last audit (41175500..HEAD): #595 Brains page, #596 MCP CRUD tests, #597 brains-pane fixes, #598 parseBody refactor, #599 agent-types tests

## Deferred to next run
- Audit the Reviewers (personas) section against current persona tool implementations
- Verify `docs/03-api-spec.md` covers the Brain and CRUD endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)