### PR TITLE
Use per-job brain collections instead of shared job-state

### DIFF
--- a/.dispatch/job-prompts/componentizer.md
+++ b/.dispatch/job-prompts/componentizer.md
@@ -33,15 +33,15 @@ Prefer the smallest extraction that makes a meaningful difference. Don't over-sp
 
 State is spread across purpose-specific brain primitives to keep writes minimal:
 
-1. **Core state** (collection: `job-state`, name: `componentizer`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
+1. **Core state** (collection: `componentizer`, name: `state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
    - `last_audited_sha` — the HEAD SHA from the previous run
    - `next_focus` — the specific component + recommended extraction the last run queued up
 
-2. **Backlog** (collection: `job-state`, name: `componentizer-backlog`) — read with `brain_list_get`. Prioritized list of oversized components with line counts and suggested strategies. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
+2. **Backlog** (collection: `componentizer`, name: `backlog`) — read with `brain_list_get`. Prioritized list of oversized components with line counts and suggested strategies. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
 
-3. **Patterns** (collection: `job-state`, name: `componentizer-patterns`) — read with `brain_list_get`. Observations about where components tend to bloat in this codebase. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it.
+3. **Patterns** (collection: `componentizer`, name: `patterns`) — read with `brain_list_get`. Observations about where components tend to bloat in this codebase. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it.
 
-4. **Run history** — query with `brain_query_events(collection: "job-state", kind: "run", subject: "componentizer", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
+4. **Run history** — query with `brain_query_events(collection: "componentizer", kind: "run", subject: "componentizer", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
 
 If the core state object is not found (first run), fall through to the bootstrap scan in Phase 1.
 
@@ -61,7 +61,7 @@ Do a scan to seed the Brain. Do **not** refactor anything yet — the goal is to
 2. For each file over 300 lines, briefly assess which refactoring strategy would apply and how impactful the split would be.
 3. Prioritize by: (a) files that agents touch most often (route components, shared UI), (b) worst offenders by line count, (c) clearest extraction path (low-risk splits first).
 4. Skip files that are large by nature and don't benefit from splitting: generated code, test fixtures, single complex forms that are genuinely cohesive.
-5. Store core state using `brain_store_object` (collection: `job-state`, name: `componentizer`) with the top candidate as `next_focus`. Push all other items to the backlog list using `brain_list_push` (collection: `job-state`, name: `componentizer-backlog`). Open a PR with the scan summary and merge it.
+5. Store core state using `brain_store_object` (collection: `componentizer`, name: `state`) with the top candidate as `next_focus`. Push all other items to the backlog list using `brain_list_push` (collection: `componentizer`, name: `backlog`). Open a PR with the scan summary and merge it.
 
 ## Phase 2: Refactor the component
 
@@ -83,21 +83,21 @@ If a refactoring turns out to be riskier than expected (component is tightly cou
 
 ## Phase 4: Update the state in the Brain
 
-**Core state** — use `brain_store_object` (collection: `job-state`, name: `componentizer`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
+**Core state** — use `brain_store_object` (collection: `componentizer`, name: `state`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
 
 - `last_audited_sha` — current HEAD.
 - `next_focus` — the specific component the next run should tackle. Be concrete: include the file path, current line count, and the recommended extraction strategy. If the backlog is empty, describe what area to re-scan next.
 
-**Backlog** — use list operations (collection: `job-state`, name: `componentizer-backlog`). Do not rewrite the full list — use surgical mutations:
+**Backlog** — use list operations (collection: `componentizer`, name: `backlog`). Do not rewrite the full list — use surgical mutations:
 
 - `brain_list_remove` — remove the item you just refactored (index 0 if you took the top item).
 - `brain_list_push` — add any new candidates you noticed. Each item is a JSON object with a `description` field (e.g., `{"description": "..."}`). Each entry should have enough context that a future run can act on it without re-discovering the problem. Set `maxItems: 30` so the oldest items roll off if the list grows too large.
 
-**Patterns** — use list operations (collection: `job-state`, name: `componentizer-patterns`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new observations (with `maxItems: 50` so the oldest roll off) and `brain_list_remove` to prune stale ones. Skip if patterns didn't change.
+**Patterns** — use list operations (collection: `componentizer`, name: `patterns`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new observations (with `maxItems: 50` so the oldest roll off) and `brain_list_remove` to prune stale ones. Skip if patterns didn't change.
 
 **Run event** — log this run using `brain_append_event`:
 
-- collection: `job-state`
+- collection: `componentizer`
 - kind: `run`
 - subject: `componentizer`
 - value: `{ "date": "<today>", "summary": "<one-line summary of what was refactored>", "pr": "<PR number>" }`

--- a/.dispatch/job-prompts/docs-audit.md
+++ b/.dispatch/job-prompts/docs-audit.md
@@ -8,15 +8,15 @@ Dispatch is a local-first control plane for running and managing multiple AI cod
 
 State is spread across purpose-specific brain primitives to keep writes minimal:
 
-1. **Core state** (collection: `job-state`, name: `docs-audit`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
+1. **Core state** (collection: `docs-audit`, name: `state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
    - `last_audited_sha` — the HEAD SHA from the previous run
    - `next_focus` — the specific area the last run recommended you focus on this time
 
-2. **Backlog** (collection: `job-state`, name: `docs-audit-backlog`) — read with `brain_list_get`. Items noticed during prior passes but left for later runs. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
+2. **Backlog** (collection: `docs-audit`, name: `backlog`) — read with `brain_list_get`. Items noticed during prior passes but left for later runs. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
 
-3. **Patterns** (collection: `job-state`, name: `docs-audit-patterns`) — read with `brain_list_get`. Recurring observations about where docs tend to go stale. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it.
+3. **Patterns** (collection: `docs-audit`, name: `patterns`) — read with `brain_list_get`. Recurring observations about where docs tend to go stale. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it.
 
-4. **Run history** — query with `brain_query_events(collection: "job-state", kind: "run", subject: "docs-audit", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
+4. **Run history** — query with `brain_query_events(collection: "docs-audit", kind: "run", subject: "docs-audit", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
 
 If the core state object is not found (first run), fall through to a bootstrap full pass (see Phase 5 fallback), log what you found, and seed the Brain at the end.
 
@@ -72,21 +72,21 @@ Do not rewrite docs for style. Fix factual drift only.
 
 ## Phase 4: Update the state in the Brain
 
-**Core state** — use `brain_store_object` (collection: `job-state`, name: `docs-audit`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
+**Core state** — use `brain_store_object` (collection: `docs-audit`, name: `state`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
 
 - `last_audited_sha` — current HEAD (the commit you're about to create will supersede this when it lands).
 - `next_focus` — the specific area the next run should start with. Be concrete ("audit docs-pane Worktrees section against `packages/shared/src/git/worktree.ts`") rather than vague ("check worktrees").
 
-**Backlog** — use list operations (collection: `job-state`, name: `docs-audit-backlog`). Do not rewrite the full list — use surgical mutations:
+**Backlog** — use list operations (collection: `docs-audit`, name: `backlog`). Do not rewrite the full list — use surgical mutations:
 
 - `brain_list_remove` — remove items you addressed or that are no longer relevant.
 - `brain_list_push` — add any new issues you noticed but deferred. Each item is a JSON object with a `description` field (e.g., `{"description": "..."}`). Each entry should have enough context that a future run can act on it without re-discovering the problem. Set `maxItems: 30` so the oldest items roll off if the list grows too large.
 
-**Patterns** — use list operations (collection: `job-state`, name: `docs-audit-patterns`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new observations (with `maxItems: 50` so the oldest roll off) and `brain_list_remove` to prune stale ones. Skip if patterns didn't change.
+**Patterns** — use list operations (collection: `docs-audit`, name: `patterns`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new observations (with `maxItems: 50` so the oldest roll off) and `brain_list_remove` to prune stale ones. Skip if patterns didn't change.
 
 **Run event** — log this run using `brain_append_event`:
 
-- collection: `job-state`
+- collection: `docs-audit`
 - kind: `run`
 - subject: `docs-audit`
 - value: `{ "date": "<today>", "summary": "<one-line summary of what was audited and fixed>", "pr": "<PR number>" }`

--- a/.dispatch/job-prompts/persona-review.md
+++ b/.dispatch/job-prompts/persona-review.md
@@ -10,7 +10,7 @@ The goal is to keep the persona set effective: tune prompts that are producing n
 
 State is spread across purpose-specific brain primitives to keep writes minimal:
 
-1. **Core state** (collection: `job-state`, name: `persona-review`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 6.
+1. **Core state** (collection: `persona-review`, name: `state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 6.
    - `last_audited_sha` — the HEAD SHA from the previous run
    - `personas` — per-persona tracking keyed by persona name. Each value stores:
      - `prompt_sha`
@@ -20,11 +20,11 @@ State is spread across purpose-specific brain primitives to keep writes minimal:
      - `notes`
    - `next_focus` — the specific persona or issue the last run recommended you focus on this time
 
-2. **Backlog** (collection: `job-state`, name: `persona-review-backlog`) — read with `brain_list_get`. Prioritized deferred work items. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array. Each item is a JSON object with a `description` field.
+2. **Backlog** (collection: `persona-review`, name: `backlog`) — read with `brain_list_get`. Prioritized deferred work items. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array. Each item is a JSON object with a `description` field.
 
-3. **Patterns** (collection: `job-state`, name: `persona-review-patterns`) — read with `brain_list_get`. Recurring observations about persona effectiveness. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it. Each item is a JSON object with a `description` field.
+3. **Patterns** (collection: `persona-review`, name: `patterns`) — read with `brain_list_get`. Recurring observations about persona effectiveness. Managed via `brain_list_push` / `brain_list_remove` — most runs won't touch it. Each item is a JSON object with a `description` field.
 
-4. **Run history** — query with `brain_query_events(collection: "job-state", kind: "run", subject: "persona-review", limit: 5)`. Read-only context for recent decisions and PR summaries.
+4. **Run history** — query with `brain_query_events(collection: "persona-review", kind: "run", subject: "persona-review", limit: 5)`. Read-only context for recent decisions and PR summaries.
 
 If the core state object is not found (first run), fall through to the bootstrap pass in Phase 1.
 
@@ -117,7 +117,7 @@ If persona files were changed:
 
 Before committing, update Brain state instead of writing a file:
 
-**Core state** — use `brain_store_object` (collection: `job-state`, name: `persona-review`) with the `expectedRevision` from Phase 0. Updated every run. Store:
+**Core state** — use `brain_store_object` (collection: `persona-review`, name: `state`) with the `expectedRevision` from Phase 0. Updated every run. Store:
 
 - `last_audited_sha` — current HEAD.
 - `personas` — for each persona, update:
@@ -128,19 +128,19 @@ Before committing, update Brain state instead of writing a file:
   - `notes` — anything the next run should know (limited sample, recently changed, overlaps with another persona)
 - `next_focus` — the specific persona or issue the next run should tackle. Be concrete: name the persona, describe what to evaluate, and why.
 
-**Backlog** — use list operations (collection: `job-state`, name: `persona-review-backlog`). Do not rewrite the full list — use surgical mutations:
+**Backlog** — use list operations (collection: `persona-review`, name: `backlog`). Do not rewrite the full list — use surgical mutations:
 
 - `brain_list_remove` — remove items you addressed or that are no longer relevant.
 - `brain_list_push` — add new deferred items as `{"description": "..."}` with enough context for a future run to act on them. Set `maxItems: 30` so the oldest items roll off automatically.
 
-**Patterns** — use list operations (collection: `job-state`, name: `persona-review-patterns`).
+**Patterns** — use list operations (collection: `persona-review`, name: `patterns`).
 
 - `brain_list_remove` — prune stale observations when needed.
 - `brain_list_push` — add new observations as `{"description": "..."}`. Set `maxItems: 50` so the oldest items roll off automatically.
 
 **Run event** — log this run using `brain_append_event`:
 
-- collection: `job-state`
+- collection: `persona-review`
 - kind: `run`
 - subject: `persona-review`
 - value: `{ "date": "<today>", "summary": "<one-line summary of what was assessed or changed>", "pr": "<PR number or null>" }`

--- a/.dispatch/job-prompts/tech-debt.md
+++ b/.dispatch/job-prompts/tech-debt.md
@@ -10,17 +10,17 @@ Tech debt here means code that works but is unnecessarily hard to maintain, exte
 
 State is spread across purpose-specific brain primitives to keep writes minimal:
 
-1. **Core state** (collection: `job-state`, name: `tech-debt`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
+1. **Core state** (collection: `tech-debt`, name: `state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in Phase 4.
    - `last_audited_sha` — the HEAD SHA from the previous run
    - `next_focus` — the specific area/issue the last run recommended you tackle this time
 
-2. **Backlog** (collection: `job-state`, name: `tech-debt-backlog`) — read with `brain_list_get`. A prioritized list of deferred issues. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
+2. **Backlog** (collection: `tech-debt`, name: `backlog`) — read with `brain_list_get`. A prioritized list of deferred issues. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
 
-3. **Patterns** (collection: `job-state`, name: `tech-debt-patterns`) — read with `brain_get_object`. Save its `revision` too if you plan to update it.
+3. **Patterns** (collection: `tech-debt`, name: `patterns`) — read with `brain_get_object`. Save its `revision` too if you plan to update it.
    - `patterns` — recurring observations about where debt accumulates in this codebase
    - Only update this object when you have a new pattern to add or a stale one to prune. Most runs won't touch it.
 
-4. **Run history** — query with `brain_query_events(collection: "job-state", kind: "run", subject: "tech-debt", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
+4. **Run history** — query with `brain_query_events(collection: "tech-debt", kind: "run", subject: "tech-debt", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
 
 If the core state object is not found (first run), fall through to the bootstrap audit in Phase 1.
 
@@ -44,7 +44,7 @@ Do a broad audit to seed the state. Do **not** fix anything yet — the goal is 
 6. **Stale dependencies.** Check `package.json` files for dependencies that appear unused (not imported anywhere).
 7. **Inconsistent patterns.** Note places where the same concept is handled differently across the codebase (e.g., error handling, logging, config access).
 
-Organize findings into a prioritized backlog (highest-impact / lowest-risk items first). Store core state using `brain_store_object` (collection: `job-state`, name: `tech-debt`) with the top item as `next_focus`. Push all other items to the backlog list using `brain_list_push` (collection: `job-state`, name: `tech-debt-backlog`). Open a PR with the audit summary and merge it.
+Organize findings into a prioritized backlog (highest-impact / lowest-risk items first). Store core state using `brain_store_object` (collection: `tech-debt`, name: `state`) with the top item as `next_focus`. Push all other items to the backlog list using `brain_list_push` (collection: `tech-debt`, name: `backlog`). Open a PR with the audit summary and merge it.
 
 ## Phase 2: Fix the issue
 
@@ -65,21 +65,21 @@ For normal runs (not bootstrap), implement the fix:
 
 ## Phase 4: Update the state in the Brain
 
-**Core state** — use `brain_store_object` (collection: `job-state`, name: `tech-debt`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
+**Core state** — use `brain_store_object` (collection: `tech-debt`, name: `state`) with the `expectedRevision` from Phase 0. Updated every run. Only two fields:
 
 - `last_audited_sha` — current HEAD.
 - `next_focus` — the specific issue the next run should tackle. Be concrete: include file paths, line numbers, and a brief description of what to do. If the backlog is empty, describe what area to re-audit next.
 
-**Backlog** — use list operations (collection: `job-state`, name: `tech-debt-backlog`). Do not rewrite the full list — use surgical mutations:
+**Backlog** — use list operations (collection: `tech-debt`, name: `backlog`). Do not rewrite the full list — use surgical mutations:
 
 - `brain_list_remove` — remove the item you just fixed (index 0 if you took the top item).
 - `brain_list_push` — add any new issues you discovered. Each item is a JSON object with a `description` field (e.g., `{"description": "..."}`). Each entry should have enough context that a future run can act on it without re-discovering the problem.
 
-**Patterns** — use `brain_store_object` (collection: `job-state`, name: `tech-debt-patterns`) with its own `expectedRevision`. Only update when you have a new pattern to add or a stale one to prune. Skip this write if patterns didn't change.
+**Patterns** — use `brain_store_object` (collection: `tech-debt`, name: `patterns`) with its own `expectedRevision`. Only update when you have a new pattern to add or a stale one to prune. Skip this write if patterns didn't change.
 
 **Run event** — log this run using `brain_append_event`:
 
-- collection: `job-state`
+- collection: `tech-debt`
 - kind: `run`
 - subject: `tech-debt`
 - value: `{ "date": "<today>", "summary": "<one-line summary of what was fixed>", "pr": "<PR number>" }`

--- a/.dispatch/job-prompts/test-enforcer.md
+++ b/.dispatch/job-prompts/test-enforcer.md
@@ -12,16 +12,16 @@ Dispatch is a local-first control plane for running and managing multiple AI cod
 
 State is spread across purpose-specific brain primitives to keep writes minimal:
 
-1. **Core state** (collection: `job-state`, name: `test-enforcer`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in the state update phase.
+1. **Core state** (collection: `test-enforcer`, name: `state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` in the state update phase.
    - `last_audited_sha` — the HEAD SHA from the previous run
    - `next_focus` — the specific area the last run recommended you start with this time
    - `last_coverage_summary` — the most recent useful coverage snapshot and notable deltas
 
-2. **Backlog** (collection: `job-state`, name: `test-enforcer-backlog`) — read with `brain_list_get`. Worthwhile follow-up coverage or reliability work that prior runs deferred. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
+2. **Backlog** (collection: `test-enforcer`, name: `backlog`) — read with `brain_list_get`. Worthwhile follow-up coverage or reliability work that prior runs deferred. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
 
-3. **Flakes** (collection: `job-state`, name: `test-enforcer-flakes`) — read with `brain_list_get`. Flaky tests or local-only failure patterns worth remembering, with brief notes on fixes or hypotheses. Managed via `brain_list_push` / `brain_list_remove`.
+3. **Flakes** (collection: `test-enforcer`, name: `flakes`) — read with `brain_list_get`. Flaky tests or local-only failure patterns worth remembering, with brief notes on fixes or hypotheses. Managed via `brain_list_push` / `brain_list_remove`.
 
-4. **Run history** — query with `brain_query_events(collection: "job-state", kind: "run", subject: "test-enforcer", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
+4. **Run history** — query with `brain_query_events(collection: "test-enforcer", kind: "run", subject: "test-enforcer", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
 
 If the core state object is not found (first run), bootstrap it during this run and keep the scope modest.
 
@@ -109,22 +109,22 @@ If required tooling, credentials, or environment capabilities are missing, docum
 
 ## State update in the Brain
 
-**Core state** — use `brain_store_object` (collection: `job-state`, name: `test-enforcer`) with the `expectedRevision` from Phase 0. Updated every run. Three fields:
+**Core state** — use `brain_store_object` (collection: `test-enforcer`, name: `state`) with the `expectedRevision` from Phase 0. Updated every run. Three fields:
 
 - `last_audited_sha` — current HEAD.
 - `next_focus` — the specific area the next run should start with. Be concrete about file paths, tests, or workflows.
 - `last_coverage_summary` — concise snapshot of overall coverage and any meaningful movement observed this run.
 
-**Backlog** — use list operations (collection: `job-state`, name: `test-enforcer-backlog`). Do not rewrite the full list — use surgical mutations:
+**Backlog** — use list operations (collection: `test-enforcer`, name: `backlog`). Do not rewrite the full list — use surgical mutations:
 
 - `brain_list_remove` — remove items you addressed or that are no longer relevant.
 - `brain_list_push` — add any new deferred reliability or coverage work. Each item is a JSON object with a `description` field (e.g., `{"description": "..."}`). Each entry should have enough context that a future run can act on it without re-discovering the problem. Set `maxItems: 30` so the oldest items roll off if the list grows too large.
 
-**Flakes** — use list operations (collection: `job-state`, name: `test-enforcer-flakes`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new flake observations (with `maxItems: 30`) and `brain_list_remove` to prune resolved ones.
+**Flakes** — use list operations (collection: `test-enforcer`, name: `flakes`). Each item is a JSON object with a `description` field. Use `brain_list_push` to add new flake observations (with `maxItems: 30`) and `brain_list_remove` to prune resolved ones.
 
 **Run event** — log this run using `brain_append_event`:
 
-- collection: `job-state`
+- collection: `test-enforcer`
 - kind: `run`
 - subject: `test-enforcer`
 - value: `{ "date": "<today>", "summary": "<one-line summary of what was fixed and what coverage was added>", "pr": "<PR number>" }`


### PR DESCRIPTION
## Summary
- Updates all 5 job prompt files to use per-job brain collections instead of the shared `job-state` collection
- Each job now stores brain data in its own collection (`tech-debt`, `docs-audit`, `componentizer`, `persona-review`, `test-enforcer`)
- Object names simplified from prefixed (`tech-debt-backlog`) to generic (`backlog`) since the collection provides the namespace
- DB job prompts were also updated via MCP, and existing brain data was migrated to the new collections

## Changes
| Job | Collection | Objects |
|-----|-----------|---------|
| Debt Collector | `tech-debt` | `state`, `backlog`, `patterns` |
| Doc-ter | `docs-audit` | `state`, `backlog`, `patterns` |
| Componentizer | `componentizer` | `state`, `backlog`, `patterns` |
| Persona Review | `persona-review` | `state`, `backlog`, `patterns` |
| Test Enforcer | `test-enforcer` | `state`, `backlog`, `flakes` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)