### PR TITLE
Extract duplicate constraint-error handler in personalities.ts

### DIFF
--- a/apps/server/src/routes/personalities.ts
+++ b/apps/server/src/routes/personalities.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply } from "fastify";
 import type { Pool } from "pg";
 
 import {
@@ -10,9 +10,19 @@ import {
   setActivePersonalityId,
   updatePersonality,
 } from "../db/personalities.js";
+import { errorMessage } from "../shared/lib/error-message.js";
 
 const NAME_MAX = 80;
 const PROMPT_MAX = 1000;
+
+function throwUnlessDuplicateName(error: unknown, reply: FastifyReply) {
+  if (errorMessage(error).includes("personalities_name_key")) {
+    return reply
+      .code(409)
+      .send({ error: "A personality with that name already exists." });
+  }
+  throw error;
+}
 
 type PersonalityRouteDeps = {
   pool: Pool;
@@ -58,13 +68,7 @@ export async function registerPersonalityRoutes(
       const personality = await createPersonality(pool, { name, prompt });
       return reply.code(201).send({ personality });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "";
-      if (message.includes("personalities_name_key")) {
-        return reply
-          .code(409)
-          .send({ error: "A personality with that name already exists." });
-      }
-      throw error;
+      return throwUnlessDuplicateName(error, reply);
     }
   });
 
@@ -118,13 +122,7 @@ export async function registerPersonalityRoutes(
       }
       return { personality: updated };
     } catch (error) {
-      const message = error instanceof Error ? error.message : "";
-      if (message.includes("personalities_name_key")) {
-        return reply
-          .code(409)
-          .send({ error: "A personality with that name already exists." });
-      }
-      throw error;
+      return throwUnlessDuplicateName(error, reply);
     }
   });
 


### PR DESCRIPTION
## Summary

- Extracted a `throwUnlessDuplicateName` helper in `personalities.ts` to deduplicate identical catch blocks in the POST and PATCH routes for handling the `personalities_name_key` unique constraint violation
- Adopted the shared `errorMessage()` utility from `shared/lib/error-message.ts` instead of inline `error instanceof Error ? error.message : ""` checks
- Net: 2 fewer lines, one source of truth for constraint-error handling in this file

## Why this is tech debt

Both catch blocks were byte-for-byte identical — any change to the error message or status code had to be made in two places. The inline `instanceof` check also bypassed the shared `errorMessage()` helper that prior tech-debt runs established as the project convention.

## Next up

The next tech-debt run will address incomplete adoption of the shared `errorMessage()` helper in `agents.ts` and `templates.ts` (backlog item #3).

## Test plan

- [x] `pnpm run check` — TypeScript type checking passes
- [x] `pnpm run test` — All 95 unit tests pass
- [x] `pnpm run test:e2e` — All 160 E2E tests pass (12 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)