### PR TITLE
Remove allowRecheck option — make recheck always-on

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -1113,7 +1113,6 @@ export class AgentManager {
     parentAgentId: string;
     persona: string;
     lastReviewedCommit?: string | null;
-    allowRecheck?: boolean;
   }): Promise<PersonaReviewRecord> {
     return personaReviews.createPersonaReview(this.pool, input);
   }
@@ -1377,7 +1376,6 @@ export class AgentManager {
            'summary', pr.summary,
            'filesReviewed', pr.files_reviewed,
            'roundNumber', pr.round_number,
-           'allowRecheck', pr.allow_recheck,
            'updatedAt', pr.updated_at,
            'resolution', (
              SELECT json_build_object(

--- a/apps/server/src/agents/persona-reviews.ts
+++ b/apps/server/src/agents/persona-reviews.ts
@@ -14,7 +14,6 @@ export type PersonaReviewRecord = {
   filesReviewed: string[] | null;
   lastReviewedCommit: string | null;
   roundNumber: number;
-  allowRecheck: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -54,7 +53,6 @@ const PERSONA_REVIEW_SELECT = `
          files_reviewed AS "filesReviewed",
          last_reviewed_commit AS "lastReviewedCommit",
          round_number AS "roundNumber",
-         allow_recheck AS "allowRecheck",
          created_at AS "createdAt", updated_at AS "updatedAt"
   FROM persona_reviews
 `;
@@ -65,7 +63,6 @@ const PERSONA_REVIEW_RETURNING = `
             files_reviewed AS "filesReviewed",
             last_reviewed_commit AS "lastReviewedCommit",
             round_number AS "roundNumber",
-            allow_recheck AS "allowRecheck",
             created_at AS "createdAt", updated_at AS "updatedAt"
 `;
 
@@ -120,19 +117,17 @@ export async function createPersonaReview(
     parentAgentId: string;
     persona: string;
     lastReviewedCommit?: string | null;
-    allowRecheck?: boolean;
   }
 ): Promise<PersonaReviewRecord> {
   const result = await pool.query<PersonaReviewRecord>(
     `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, last_reviewed_commit, allow_recheck)
-     VALUES ($1, $2, $3, $4, COALESCE($5, false))
+     VALUES ($1, $2, $3, $4, true)
      ${PERSONA_REVIEW_RETURNING}`,
     [
       input.agentId,
       input.parentAgentId,
       input.persona,
       input.lastReviewedCommit ?? null,
-      input.allowRecheck ?? null,
     ]
   );
   return result.rows[0]!;
@@ -465,7 +460,7 @@ export async function submitReviewResolution(
       [review.id, roundNumber, summary, input.resolutionCommit ?? null]
     );
 
-    const nextStatus = review.allowRecheck ? "awaiting_recheck" : "complete";
+    const nextStatus = "awaiting_recheck";
     const updatedReviewResult = await client.query<PersonaReviewRecord>(
       `UPDATE persona_reviews
          SET status = $2, updated_at = NOW()
@@ -588,12 +583,11 @@ export async function cancelReviewRecheck(
       await client.query("COMMIT");
       return { review, transitioned: false };
     }
-    if (
-      review.status !== "awaiting_recheck" &&
-      !(review.status === "complete" && review.allowRecheck)
-    ) {
+    const isAwaitingResolution =
+      review.status === "complete" && review.roundNumber < 2;
+    if (review.status !== "awaiting_recheck" && !isAwaitingResolution) {
       throw new AgentError(
-        `Recheck can only be cancelled while awaiting round 2 or while the reviewer is polling after round 1 (current: ${review.status}).`,
+        `Recheck can only be cancelled while awaiting resolution or round 2 (current: ${review.status}, round: ${review.roundNumber}).`,
         409
       );
     }

--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -109,7 +109,6 @@ export type AgentRecord = {
     summary: string | null;
     filesReviewed: string[] | null;
     roundNumber: number;
-    allowRecheck: boolean;
     updatedAt: string;
     resolution: {
       summary: string;

--- a/apps/server/src/db/seed/persona-reviews.ts
+++ b/apps/server/src/db/seed/persona-reviews.ts
@@ -23,7 +23,6 @@ type ReviewerSeed = {
     message: string | null;
     summary: string | null;
     roundNumber: number;
-    allowRecheck: boolean;
     minutesAgo: number;
     resolution: Resolution | null;
   } | null;
@@ -47,7 +46,6 @@ const REVIEWERS: ReviewerSeed[] = [
       message: "Scanning hook dependencies",
       summary: null,
       roundNumber: 1,
-      allowRecheck: false,
       minutesAgo: 1,
       resolution: null,
     },
@@ -67,7 +65,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Timezone drift and legend reset need to be resolved before merge. Keyboard focus regression on the day picker is also open.",
       roundNumber: 1,
-      allowRecheck: true,
       minutesAgo: 30,
       resolution: null,
     },
@@ -82,7 +79,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "The loading-state polish looks better, but I need to verify the final retry flow after your fixes land.",
       roundNumber: 1,
-      allowRecheck: true,
       minutesAgo: 20,
       resolution: {
         summary:
@@ -103,7 +99,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Missing JSDoc on the public hooks export and the README example no longer compiles.",
       roundNumber: 1,
-      allowRecheck: false,
       minutesAgo: 90,
       resolution: {
         summary:
@@ -124,7 +119,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Round 2: the retry loop now handles the cache miss, but still bypasses the circuit breaker.",
       roundNumber: 2,
-      allowRecheck: true,
       minutesAgo: 60,
       resolution: {
         summary:
@@ -145,7 +139,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "No regressions on the hot path; p95 render time unchanged at 12ms.",
       roundNumber: 1,
-      allowRecheck: false,
       minutesAgo: 45,
       resolution: null,
     },
@@ -160,7 +153,6 @@ const REVIEWERS: ReviewerSeed[] = [
       summary:
         "Focus order and ARIA labels look correct after the latest pass.",
       roundNumber: 1,
-      allowRecheck: false,
       minutesAgo: 120,
       resolution: {
         summary:
@@ -197,7 +189,7 @@ export async function seedPersonaReviews(client: PoolClient): Promise<void> {
       INSERT INTO persona_reviews (
         agent_id, parent_agent_id, persona, status, verdict, message, summary,
         files_reviewed, round_number, allow_recheck, created_at, updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$11)
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,true,$10,$10)
       RETURNING id
       `,
       [
@@ -210,7 +202,6 @@ export async function seedPersonaReviews(client: PoolClient): Promise<void> {
         r.summary,
         JSON.stringify([]),
         r.roundNumber,
-        r.allowRecheck,
         createdAt,
       ]
     );

--- a/apps/server/src/personas/loader.ts
+++ b/apps/server/src/personas/loader.ts
@@ -147,13 +147,8 @@ Do NOT submit positive affirmations, praise, or "good job" feedback. Feedback li
 `.trim();
 }
 
-/**
- * Round-trip guidance appended when the review was launched with
- * allowRecheck: true. Tells the reviewer to stay alive after round 1,
- * wait for a server-injected round-2 prompt, and deliver a second verdict.
- */
 const RECHECK_ROUND_TRIP_GUIDANCE = `
-## Recheck round-trip (this review has \`allowRecheck: true\`)
+## Recheck round-trip
 
 This is a two-round review. You have a round-1 obligation (already described above) AND a round-2 obligation described below. Do not emit a terminal \`dispatch_event\` until BOTH rounds are complete or the recheck has been explicitly cancelled.
 
@@ -165,8 +160,6 @@ This is a two-round review. You have a round-1 obligation (already described abo
 `.trim();
 
 export type AssemblePersonaPromptOptions = {
-  /** When true, appends the recheck round-trip guidance block. */
-  allowRecheck?: boolean;
   /** When false, omits the git diff section from the prompt. Defaults to true. */
   includeDiff?: boolean;
 };
@@ -249,9 +242,7 @@ export function assemblePersonaPrompt(
     personaBody.trimEnd(),
     buildStandardFeedbackGuidance(includeDiff),
   ];
-  if (options.allowRecheck) {
-    sections.push(RECHECK_ROUND_TRIP_GUIDANCE);
-  }
+  sections.push(RECHECK_ROUND_TRIP_GUIDANCE);
   sections.push(`## Context from parent agent\n${context}`);
   if (includeDiff && diffResult) {
     if (diffResult.diffByteSize <= INLINE_DIFF_THRESHOLD_BYTES) {

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -267,9 +267,7 @@ export async function registerMcpRoutes(
         persona: agent.persona,
         parentAgentId: agent.parentAgentId,
         baseBranch: agent.baseBranch,
-        review: review
-          ? { allowRecheck: review.allowRecheck, status: review.status }
-          : null,
+        review: review ? { status: review.status } : null,
       },
       repoRoot,
       worktreeRoot,

--- a/apps/server/src/routes/persona-reviews.ts
+++ b/apps/server/src/routes/persona-reviews.ts
@@ -22,7 +22,6 @@ type PersonaReviewRouteDeps = {
       persona: string;
       context: string;
       agentType?: (typeof CLI_AGENT_TYPES)[number];
-      allowRecheck?: boolean;
       includeDiff?: boolean;
     }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
@@ -67,7 +66,6 @@ export async function registerPersonaReviewRoutes(
     const body = request.body as {
       persona?: unknown;
       agentType?: unknown;
-      allowRecheck?: unknown;
       includeDiff?: unknown;
     } | null;
     const agentId = params.id ?? "";
@@ -93,11 +91,6 @@ export async function registerPersonaReviewRoutes(
         error: `agentType must be one of: ${CLI_AGENT_TYPES.join(", ")}`,
       });
     }
-    if (typeof body.allowRecheck !== "boolean") {
-      return reply
-        .code(400)
-        .send({ error: "allowRecheck is required and must be a boolean." });
-    }
     if (
       body.includeDiff !== undefined &&
       typeof body.includeDiff !== "boolean"
@@ -118,9 +111,9 @@ export async function registerPersonaReviewRoutes(
       const includeDiff = body.includeDiff !== false;
       const prompt = [
         `Use the dispatch_launch_persona MCP tool to launch the "${body.persona}" persona on your current work.`,
-        `Use agentType: "${body.agentType}", allowRecheck: ${body.allowRecheck ? "true" : "false"}, and includeDiff: ${includeDiff ? "true" : "false"}.`,
+        `Use agentType: "${body.agentType}" and includeDiff: ${includeDiff ? "true" : "false"}.`,
         "Treat this as an author-requested review for the current worktree/branch.",
-        "After launch, if recheck is enabled, do not emit a terminal dispatch_event yet — you will receive a terminal prompt here when the reviewer reports back, and again after round 2.",
+        "Do not emit a terminal dispatch_event yet — you will receive a terminal prompt here when the reviewer reports back, and again after round 2.",
         "Provide a detailed context briefing covering what you built, key files changed, and any areas that need extra attention.",
       ].join(" ");
 
@@ -136,7 +129,6 @@ export async function registerPersonaReviewRoutes(
     const body = request.body as {
       persona?: unknown;
       agentType?: unknown;
-      allowRecheck?: unknown;
       includeDiff?: unknown;
       context?: unknown;
     } | null;
@@ -163,14 +155,6 @@ export async function registerPersonaReviewRoutes(
       return reply.code(400).send({
         error: `agentType must be one of: ${CLI_AGENT_TYPES.join(", ")}`,
       });
-    }
-    if (
-      body.allowRecheck !== undefined &&
-      typeof body.allowRecheck !== "boolean"
-    ) {
-      return reply
-        .code(400)
-        .send({ error: "allowRecheck must be a boolean when provided." });
     }
     if (
       body.includeDiff !== undefined &&
@@ -226,7 +210,6 @@ export async function registerPersonaReviewRoutes(
         persona: body.persona.trim(),
         context,
         agentType: requestedAgentType,
-        allowRecheck: body.allowRecheck === true,
         includeDiff: includeDiffVal,
       });
       const agent = await deps.agentManager.getAgent(result.agentId);

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -362,7 +362,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       }
 
       const feedbackCount = await agentManager.countFeedbackForAgent(agentId);
-      const isMidRoundTrip = review.allowRecheck && review.roundNumber < 2;
+      const isMidRoundTrip = review.roundNumber < 2;
       const parentPrompt = isMidRoundTrip
         ? buildParentRound1FeedbackPrompt({
             persona: review.persona,
@@ -411,7 +411,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       agentId: string
     ): Promise<RecheckContextResult | null> {
       const review = await agentManager.getPersonaReview(agentId);
-      if (!review || !review.allowRecheck) {
+      if (!review) {
         return null;
       }
 
@@ -524,7 +524,6 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         persona: string;
         context: string;
         agentType?: (typeof CLI_AGENT_TYPES)[number];
-        allowRecheck?: boolean;
         includeDiff?: boolean;
       }
     ): Promise<{ agentId: string; persona: string; parentAgentId: string }> {
@@ -613,7 +612,6 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         );
       }
       const prompt = assemblePersonaPrompt(persona, opts.context, diffResult, {
-        allowRecheck: opts.allowRecheck,
         includeDiff,
       });
 
@@ -653,7 +651,6 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         parentAgentId: agentId,
         persona: opts.persona,
         lastReviewedCommit: launchCommit,
-        allowRecheck: opts.allowRecheck,
       });
 
       const agentWithReview = await agentManager.getAgent(agent.id);

--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -75,7 +75,7 @@ export function registerPersonaInteractionTools(
       "dispatch_launch_persona",
       {
         description:
-          "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files. Pass `allowRecheck: true` to opt into a single round-trip — the reviewer will stay alive after its initial verdict and perform a second pass after you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters.",
+          "Launch a persona agent to review or test your current work. The persona runs in your working directory with specialized instructions. Available personas are defined in .dispatch/personas/ as markdown files. Reviews always include a recheck pass — the reviewer stays alive after its initial verdict and performs a second pass after you call dispatch_submit_resolution.",
         inputSchema: {
           persona: z
             .string()
@@ -94,12 +94,6 @@ export function registerPersonaInteractionTools(
             .describe(
               "Optional agent runtime override for the persona launch."
             ),
-          allowRecheck: z
-            .boolean()
-            .default(false)
-            .describe(
-              "Opt into a single round-trip review: the reviewer stays alive after its initial verdict and performs a second pass once you call dispatch_submit_resolution. Adds latency (~several minutes); use when verification matters."
-            ),
           includeDiff: z
             .boolean()
             .default(true)
@@ -114,13 +108,11 @@ export function registerPersonaInteractionTools(
             persona: args.persona,
             context: args.context,
             agentType: args.agentType,
-            allowRecheck: args.allowRecheck,
             includeDiff: args.includeDiff,
           });
           const text = buildLaunchPersonaResponseText(
             result.persona,
-            result.agentId,
-            args.allowRecheck ?? false
+            result.agentId
           );
           return {
             content: [{ type: "text", text }],
@@ -192,7 +184,7 @@ export function registerPersonaInteractionTools(
       "dispatch_resolve_feedback",
       {
         description:
-          "Mark a feedback item as fixed or ignored. If status is 'ignored', you must include a `reason` explaining why — when the review was launched with allowRecheck: true, the reviewer sees the reason in their recheck pass. If status is 'fixed', `reason` is optional but encouraged when the fix is non-obvious. The server records the current HEAD commit at the time of the call as the resolution commit.",
+          "Mark a feedback item as fixed or ignored. If status is 'ignored', you must include a `reason` explaining why — the reviewer sees the reason in their recheck pass. If status is 'fixed', `reason` is optional but encouraged when the fix is non-obvious. The server records the current HEAD commit at the time of the call as the resolution commit.",
         inputSchema: {
           feedbackId: z
             .number()
@@ -244,7 +236,7 @@ export function registerPersonaInteractionTools(
       "dispatch_submit_resolution",
       {
         description:
-          "Call this after you have resolved every feedback item from a review and are ready for the reviewer to verify your work. `summary` is required — 1–3 sentences explaining what you addressed and what you chose to leave alone. IMPORTANT: commit your fixes before calling this. The server captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit — if you submit with uncommitted changes, the reviewer sees an empty diff and will re-flag the same issues. When the review was launched with allowRecheck: true, submitting the resolution triggers the reviewer's single recheck pass. Rejected if any feedback item is still 'open' or if any 'ignored' item is missing a reason.",
+          "Call this after you have resolved every feedback item from a review and are ready for the reviewer to verify your work. `summary` is required — 1–3 sentences explaining what you addressed and what you chose to leave alone. IMPORTANT: commit your fixes before calling this. The server captures the current HEAD as the resolution commit, and the reviewer's round-2 diff is computed from that commit — if you submit with uncommitted changes, the reviewer sees an empty diff and will re-flag the same issues. Submitting the resolution triggers the reviewer's recheck pass. Rejected if any feedback item is still 'open' or if any 'ignored' item is missing a reason.",
         inputSchema: {
           personaAgentId: z
             .string()
@@ -285,22 +277,11 @@ export function registerPersonaInteractionTools(
 
 export function buildLaunchPersonaResponseText(
   persona: string,
-  agentId: string,
-  allowRecheck: boolean
+  agentId: string
 ): string {
-  const base = `Launched persona "${persona}" as agent ${agentId}.`;
-  if (!allowRecheck) {
-    return `${base}
+  return `Launched persona "${persona}" as agent ${agentId}.
 
-This review is push-based. Do not emit a terminal dispatch_event yet. Keep this turn alive and wait for the server to inject a completion prompt into this terminal when the reviewer finishes.
-
-There is no tool to poll while waiting. When the completion prompt arrives, call dispatch_get_feedback (personaAgentId="${agentId}") only if that prompt says feedback items were recorded, then wrap up.
-
-If no prompt has arrived after a clearly unreasonable delay (the reviewer crashed, was archived, or got stuck), bail out on your own with a non-done dispatch_event explaining what happened — there is no parent-side cancel tool for single-pass reviews today.`;
-  }
-  return `${base}
-
-Review was launched with recheck enabled. This is a multi-step round-trip — do not emit a terminal dispatch_event yet. The reviewer will stay alive waiting for your resolution, and the server will push a new prompt into this terminal when each round transitions.
+This is a multi-step round-trip review — do not emit a terminal dispatch_event yet. The reviewer will stay alive waiting for your resolution, and the server will push a new prompt into this terminal when each round transitions.
 
 1. Wait for round 1. The server will inject a new prompt here when the reviewer submits their round-1 verdict. There is no tool to poll — keep this turn alive however your agent runtime allows, then act on the prompt when it arrives.
 

--- a/apps/server/src/shared/mcp/persona-tools.ts
+++ b/apps/server/src/shared/mcp/persona-tools.ts
@@ -7,7 +7,6 @@ import { toToolError } from "./tool-error.js";
 export type PersonaToolCallbacks = {
   agentId: string;
   parentAgentId?: string | null;
-  allowRecheck?: boolean;
   updateReviewStatus?: McpRequestContext["updateReviewStatus"];
   completeReview?: McpRequestContext["completeReview"];
   getParentContext?: McpRequestContext["getParentContext"];
@@ -154,7 +153,6 @@ export function registerPersonaTools(
   // ── dispatch_get_recheck_context (persona) ────────────────────────
   if (
     allowed.has("dispatch_get_recheck_context") &&
-    callbacks.allowRecheck === true &&
     callbacks.getRecheckContext
   ) {
     const getRecheckContext = callbacks.getRecheckContext;
@@ -163,7 +161,7 @@ export function registerPersonaTools(
       "dispatch_get_recheck_context",
       {
         description:
-          "Reviewer-only for recheck-enabled sessions. Returns whether round-2 context is ready yet and, once it is, the parent's resolution summary, per-item resolutions, and the exact commit range to inspect locally with git diff.",
+          "Reviewer-only. Returns whether round-2 context is ready yet and, once it is, the parent's resolution summary, per-item resolutions, and the exact commit range to inspect locally with git diff.",
         inputSchema: {},
       },
       async () => {

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -25,7 +25,6 @@ export type McpAgent = {
   parentAgentId?: string | null;
   baseBranch?: string | null;
   review?: {
-    allowRecheck?: boolean;
     status?: string | null;
   } | null;
 };
@@ -301,7 +300,6 @@ export type McpRequestContext = {
       persona: string;
       context: string;
       agentType?: LaunchPersonaAgentType;
-      allowRecheck?: boolean;
       includeDiff?: boolean;
     }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
@@ -425,7 +423,6 @@ async function createDispatchMcpServer(
     registerPersonaTools(server, allowed, {
       agentId: context.agent.id,
       parentAgentId: context.agent.parentAgentId,
-      allowRecheck: context.agent.review?.allowRecheck,
       updateReviewStatus: context.updateReviewStatus,
       completeReview: context.completeReview,
       getParentContext: context.getParentContext,

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -1832,7 +1832,6 @@ describe("AgentManager", () => {
           parentAgentId: parent.id,
           persona: "security-review",
           lastReviewedCommit: "launchsha",
-          allowRecheck: true,
         });
         await manager.completePersonaReview(child.id, {
           verdict: "approve",
@@ -2001,18 +2000,17 @@ describe("AgentManager", () => {
         expect(resolutions[0].resolutionCommit).toBe("headsha1");
       });
 
-      it("keeps non-recheck reviews in complete after resolution submission", async () => {
+      it("transitions reviews to awaiting_recheck after resolution submission", async () => {
         const { parent, child } = await seedCompletedReview();
 
         const result = await manager.submitReviewResolution({
           parentAgentId: parent.id,
           personaAgentId: child.id,
-          summary: "Recorded the resolution without a recheck.",
+          summary: "Recorded the resolution for recheck.",
           resolutionCommit: "headsha1",
         });
 
-        expect(result.review.status).toBe("complete");
-        expect(result.review.allowRecheck).toBe(false);
+        expect(result.review.status).toBe("awaiting_recheck");
       });
 
       it("rejects repeat submit once the review is awaiting_recheck", async () => {
@@ -2159,7 +2157,6 @@ describe("AgentManager", () => {
           parentAgentId: parent.id,
           persona: "security-review",
           lastReviewedCommit: "launchsha",
-          allowRecheck: true,
         });
         await manager.completePersonaReview(child.id, {
           verdict: "approve",
@@ -2308,7 +2305,6 @@ describe("AgentManager", () => {
           parentAgentId: parent.id,
           persona: "security-review",
           lastReviewedCommit: "launchsha",
-          allowRecheck: true,
         });
 
         await expect(
@@ -2316,7 +2312,7 @@ describe("AgentManager", () => {
             parentAgentId: parent.id,
             personaAgentId: child.id,
           })
-        ).rejects.toThrow(/can only be cancelled while awaiting round 2/i);
+        ).rejects.toThrow(/can only be cancelled while awaiting/i);
       });
 
       it("records round 2 findings with round_number = 2", async () => {
@@ -2978,7 +2974,6 @@ describe("AgentManager", () => {
         parentAgentId: parent.id,
         persona: "architecture-review",
         lastReviewedCommit: "abc123",
-        allowRecheck: true,
       });
       await manager.completePersonaReview(reviewer.id, {
         verdict: "request_changes",

--- a/apps/server/test/launch-review-route.test.ts
+++ b/apps/server/test/launch-review-route.test.ts
@@ -118,7 +118,6 @@ describe("POST /api/v1/agents/:id/launch-review — input validation", () => {
       payload: {
         persona: malicious,
         agentType: "claude",
-        allowRecheck: true,
       },
     });
 
@@ -137,7 +136,6 @@ describe("POST /api/v1/agents/:id/launch-review — input validation", () => {
       payload: {
         persona: "../../etc/passwd",
         agentType: "claude",
-        allowRecheck: false,
       },
     });
 
@@ -156,7 +154,7 @@ describe("POST /api/v1/agents/:id/launch-review — input validation", () => {
         method: "POST",
         url: `/api/v1/agents/${agentId}/launch-review`,
         headers: { cookie: sessionCookie, "content-type": "application/json" },
-        payload: { persona, agentType: "claude", allowRecheck: false },
+        payload: { persona, agentType: "claude" },
       });
       expect(response.statusCode).toBe(400);
     }
@@ -171,7 +169,6 @@ describe("POST /api/v1/agents/:id/launch-review — input validation", () => {
       payload: {
         persona: "backend-security-review",
         agentType: "claude",
-        allowRecheck: true,
       },
     });
 

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -184,7 +184,7 @@ describe("MCP auth integration", () => {
     expect(jobResponse.json()).toEqual({ error: "Agent not found." });
   });
 
-  it("never exposes removed await tools and exposes recheck context for recheck-enabled sessions", async () => {
+  it("never exposes removed await tools and exposes recheck context for all persona sessions", async () => {
     await pool.query(
       `INSERT INTO agents (id, name, type, status, cwd, persona, parent_agent_id, full_access)
        VALUES
@@ -198,7 +198,7 @@ describe("MCP auth integration", () => {
           agent_id, parent_agent_id, persona, status, round_number, allow_recheck
         )
         VALUES
-        ('agt_persona_plain', 'agt_parentreview', 'backend-security-review', 'reviewing', 1, false),
+        ('agt_persona_plain', 'agt_parentreview', 'backend-security-review', 'reviewing', 1, true),
         ('agt_persona_recheck', 'agt_parentreview', 'backend-security-review', 'reviewing', 1, true),
         ('agt_persona_round2', 'agt_parentreview', 'backend-security-review', 'awaiting_recheck', 1, true)`
     );
@@ -236,11 +236,7 @@ describe("MCP auth integration", () => {
       expect(response.statusCode).toBe(200);
       expect(response.body).not.toContain("dispatch_await_recheck");
       expect(response.body).not.toContain("dispatch_await_review");
-      if (personaAgentId === "agt_persona_plain") {
-        expect(response.body).not.toContain("dispatch_get_recheck_context");
-      } else {
-        expect(response.body).toContain("dispatch_get_recheck_context");
-      }
+      expect(response.body).toContain("dispatch_get_recheck_context");
     }
 
     const round2Response = await app.inject({

--- a/apps/server/test/mcp-crud-tools.test.ts
+++ b/apps/server/test/mcp-crud-tools.test.ts
@@ -241,7 +241,7 @@ describe("MCP CRUD tools", () => {
       );
       await pool.query(
         `INSERT INTO persona_reviews (agent_id, parent_agent_id, persona, status, round_number, allow_recheck)
-         VALUES ('agt_crud_persona', 'agt_crud_parent', 'security-review', 'reviewing', 1, false)`
+         VALUES ('agt_crud_persona', 'agt_crud_parent', 'security-review', 'reviewing', 1, true)`
       );
 
       const response = await mcpToolsList(

--- a/apps/server/test/mcp-launch-persona-response.test.ts
+++ b/apps/server/test/mcp-launch-persona-response.test.ts
@@ -7,19 +7,14 @@ describe("buildLaunchPersonaResponseText", () => {
   const agentId = "agt_test123";
   const base = `Launched persona "${persona}" as agent ${agentId}.`;
 
-  it("adds single-pass wait guidance when allowRecheck is false", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, false);
+  it("starts with the launch confirmation", () => {
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text.startsWith(base)).toBe(true);
-    expect(text).toContain("This review is push-based");
-    expect(text).toContain("There is no tool to poll");
-    expect(text).toContain(`personaAgentId="${agentId}"`);
   });
 
-  it("appends round-trip guidance when allowRecheck is true", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
-
-    expect(text.startsWith(base)).toBe(true);
-    expect(text).toContain("Review was launched with recheck enabled");
+  it("includes round-trip guidance", () => {
+    const text = buildLaunchPersonaResponseText(persona, agentId);
+    expect(text).toContain("multi-step round-trip review");
     expect(text).toContain("dispatch_get_feedback");
     expect(text).toContain("dispatch_resolve_feedback");
     expect(text).toContain("dispatch_submit_resolution");
@@ -27,51 +22,36 @@ describe("buildLaunchPersonaResponseText", () => {
   });
 
   it("tells the parent not to emit a terminal event yet (stay alive)", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).toContain("do not emit a terminal dispatch_event yet");
   });
 
   it("references the specific reviewer agent id in the guidance", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).toContain(`personaAgentId="${agentId}"`);
   });
 
   it("describes waiting in agent-runtime-neutral terms (no Claude-specific tool names)", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).not.toContain("ScheduleWakeup");
     expect(text).toMatch(/keep this turn alive/i);
   });
 
   it("does not instruct the parent to call any await/poll tool", () => {
-    // Round-trip transitions are now pushed via terminal injection, not
-    // surfaced through a polling MCP tool.
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).not.toContain("dispatch_await_review");
     expect(text).not.toContain("dispatch_await_recheck");
     expect(text).not.toMatch(/pollAgainInSeconds/i);
-  });
-
-  it("uses the same non-polling guidance for single-pass reviews", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, false);
-    expect(text).not.toContain("dispatch_await_review");
-    expect(text).not.toContain("dispatch_await_recheck");
-    expect(text).not.toMatch(/pollAgainInSeconds/i);
-  });
-
-  it("acknowledges that single-pass parents must bail out manually if no prompt arrives", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, false);
-    expect(text).toMatch(/bail out/i);
-    expect(text).toMatch(/no parent-side cancel tool/i);
   });
 
   it("explains that the next-round signal arrives via terminal injection", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).toMatch(/inject .* prompt/i);
     expect(text).toMatch(/this terminal/i);
   });
 
   it("tells the parent to commit fixes before submitting resolution", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
     expect(text).toContain(
       "Commit your fixes before submitting the resolution"
     );
@@ -79,7 +59,7 @@ describe("buildLaunchPersonaResponseText", () => {
   });
 
   it("places the guidance block after a blank line separator", () => {
-    const text = buildLaunchPersonaResponseText(persona, agentId, true);
-    expect(text).toContain(`${base}\n\nReview was launched with recheck`);
+    const text = buildLaunchPersonaResponseText(persona, agentId);
+    expect(text).toContain(`${base}\n\nThis is a multi-step round-trip`);
   });
 });

--- a/apps/server/test/persona-loader.test.ts
+++ b/apps/server/test/persona-loader.test.ts
@@ -250,19 +250,8 @@ describe("assemblePersonaPrompt", () => {
     expect(result).toContain("Do NOT submit positive affirmations");
   });
 
-  it("omits the recheck round-trip block by default", () => {
+  it("always includes the recheck round-trip block", () => {
     const result = assemblePersonaPrompt(basePersona, "", null);
-    expect(result).not.toContain("Recheck round-trip");
-  });
-
-  it("appends the recheck round-trip block when allowRecheck is true", () => {
-    const result = assemblePersonaPrompt(
-      basePersona,
-      "ctx",
-      makeDiffResult("diff"),
-      { allowRecheck: true }
-    );
-
     expect(result).toContain("Recheck round-trip");
     expect(result).toContain("dispatch_complete_review");
     expect(result).toContain("respondsToFeedbackId");
@@ -271,22 +260,20 @@ describe("assemblePersonaPrompt", () => {
     expect(result).not.toContain("pollAgainInSeconds");
     expect(result).toMatch(/push a short prompt/i);
     expect(result).toMatch(/exact commit range/i);
+  });
+
+  it("places the recheck block before context and diff sections", () => {
+    const result = assemblePersonaPrompt(
+      basePersona,
+      "ctx",
+      makeDiffResult("diff")
+    );
 
     const guidanceIdx = result.indexOf("Recheck round-trip");
     const contextIdx = result.indexOf("## Context from parent agent");
     const diffIdx = result.indexOf("## Changes to review");
     expect(guidanceIdx).toBeLessThan(contextIdx);
     expect(contextIdx).toBeLessThan(diffIdx);
-  });
-
-  it("omits the recheck round-trip block when allowRecheck is false", () => {
-    const result = assemblePersonaPrompt(
-      basePersona,
-      "ctx",
-      makeDiffResult("diff"),
-      { allowRecheck: false }
-    );
-    expect(result).not.toContain("Recheck round-trip");
   });
 
   it("includes the diff section by default (includeDiff unset)", () => {

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -1076,9 +1076,8 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
             Because job agents can launch personas and act on their findings, a
             recurring job can self-review its own work without a human in the
             loop: open a PR with <Code>create_pr</Code>, launch a persona with{" "}
-            <Code>dispatch_launch_persona</Code> (pass{" "}
-            <Code>allowRecheck: true</Code> for a round-2 pass), read findings
-            with <Code>dispatch_get_feedback</Code>, fix and commit them, then{" "}
+            <Code>dispatch_launch_persona</Code>, read findings with{" "}
+            <Code>dispatch_get_feedback</Code>, fix and commit them, then{" "}
             <Code>dispatch_submit_resolution</Code> — the reviewer rechecks
             against the new HEAD and emits a final verdict. The mechanics are
             documented under <strong>Reviewers → Round-trip reviews</strong> and
@@ -1349,9 +1348,7 @@ issues caused or worsened by this diff.`}</CodeBlock>
         <Section>
           <H3>Round-trip reviews</H3>
           <P>
-            Parent agents can opt into a single recheck pass by passing{" "}
-            <Code>allowRecheck: true</Code> to{" "}
-            <Code>dispatch_launch_persona</Code>. The reviewer stays alive after
+            Every review includes a recheck pass. The reviewer stays alive after
             its round-1 verdict, waiting for the parent to resolve feedback and
             submit a resolution — then performs a second pass and emits a final
             verdict.

--- a/apps/web/src/components/app/feedback-utils.ts
+++ b/apps/web/src/components/app/feedback-utils.ts
@@ -63,9 +63,7 @@ export function shortSha(sha: string | null | undefined): string | null {
 }
 
 export function canCancelRecheck(agent: Agent): boolean {
-  const review = agent.review;
-  if (!review?.allowRecheck) return false;
-  return review.status === "awaiting_recheck";
+  return agent.review?.status === "awaiting_recheck";
 }
 
 export function formatFeedbackText(item: FeedbackItem): string {

--- a/apps/web/src/components/app/feedback-utils.ts
+++ b/apps/web/src/components/app/feedback-utils.ts
@@ -63,7 +63,10 @@ export function shortSha(sha: string | null | undefined): string | null {
 }
 
 export function canCancelRecheck(agent: Agent): boolean {
-  return agent.review?.status === "awaiting_recheck";
+  const review = agent.review;
+  if (!review) return false;
+  if (review.status === "awaiting_recheck") return true;
+  return review.status === "complete" && review.roundNumber < 2;
 }
 
 export function formatFeedbackText(item: FeedbackItem): string {

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -258,7 +258,6 @@ function stepsFromReview(
 ): { step1: StepDef; step2: StepDef } {
   const hasResolution = !!child.review?.resolution?.summary;
   const roundNumber = child.review?.roundNumber ?? 1;
-  const allowRecheck = child.review?.allowRecheck ?? false;
   const reviewStatus = child.review?.status ?? null;
   const step1: StepDef = {
     label:
@@ -271,7 +270,7 @@ function stepsFromReview(
   let step2: StepDef;
   if (reviewStatus === "awaiting_recheck") {
     step2 = { label: "Rechecking", color: "orange", filled: false };
-  } else if (allowRecheck && roundNumber < 2) {
+  } else if (roundNumber < 2) {
     step2 = hasResolution
       ? { label: "Awaiting recheck", color: "muted", filled: false }
       : { label: "Awaiting resolution", color: "muted", filled: false };

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -1,12 +1,10 @@
 import { Check, ChevronDown } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
-import { useAtom } from "jotai";
+import { useCallback, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { type Agent } from "@/components/app/types";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Command,
   CommandGroup,
@@ -39,7 +37,6 @@ import {
   type AgentType,
   isCliAgentType,
 } from "@/lib/agent-types";
-import { reviewAllowRecheckPrefAtom } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
 type PersonaSummary = {
@@ -72,10 +69,6 @@ export function PersonaLauncher({
 }): JSX.Element {
   const queryClient = useQueryClient();
   const cwd = agent.worktreePath ?? agent.cwd;
-  const allowRecheckAtom = useMemo(
-    () => reviewAllowRecheckPrefAtom(cwd.trim()),
-    [cwd]
-  );
   const reviewerTypes = enabledAgentTypes.filter(isCliAgentType);
   const showReviewAgentTypePicker = reviewerTypes.length > 1;
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -83,7 +76,6 @@ export function PersonaLauncher({
   const [selectedAgentType, setSelectedAgentType] = useState<AgentType>(
     defaultReviewAgentType(agent)
   );
-  const [allowRecheck, setAllowRecheck] = useAtom(allowRecheckAtom);
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
   const typeCmdRef = useRef<HTMLDivElement>(null);
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
@@ -109,7 +101,6 @@ export function PersonaLauncher({
         body: JSON.stringify({
           persona,
           agentType: selectedAgentType,
-          allowRecheck,
         }),
       });
     },
@@ -348,27 +339,6 @@ export function PersonaLauncher({
                       </div>
                     ) : null}
                   </div>
-
-                  <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
-                    <Checkbox
-                      checked={allowRecheck}
-                      onCheckedChange={() => {
-                        launchMutation.reset();
-                        setAllowRecheck((current) => !current);
-                      }}
-                      className="mt-0.5"
-                      data-testid="launch-reviewer-allow-recheck"
-                    />
-                    <span className="space-y-1">
-                      <span className="block text-sm font-medium text-foreground">
-                        Re-review after feedback is addressed
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        Adds a second pass once the first round of feedback is
-                        resolved.
-                      </span>
-                    </span>
-                  </label>
 
                   <div className="space-y-2">
                     <label className="text-sm text-muted-foreground">

--- a/apps/web/src/components/app/persona-launcher.tsx
+++ b/apps/web/src/components/app/persona-launcher.tsx
@@ -242,8 +242,9 @@ export function PersonaLauncher({
             <DialogHeader>
               <DialogTitle>Launch Review</DialogTitle>
               <DialogDescription>
-                Pick a reviewer persona, review agent type, and whether to ask
-                for a follow-up verification pass.
+                Pick a reviewer persona and review agent type. The reviewer will
+                automatically do a follow-up verification pass after you resolve
+                its feedback.
               </DialogDescription>
             </DialogHeader>
 

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -60,7 +60,6 @@ export type Agent = {
     summary: string | null;
     filesReviewed: string[] | null;
     roundNumber: number;
-    allowRecheck: boolean;
     updatedAt: string;
     resolution: {
       summary: string;

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -75,10 +75,6 @@ export const createNewBranchPrefAtom = atomFamily((cwd: string) =>
   atomWithLocalStorage<boolean>(`dispatch:createNewBranch:${cwd}`, true)
 );
 
-export const reviewAllowRecheckPrefAtom = atomFamily((cwd: string) =>
-  atomWithLocalStorage<boolean>(`dispatch:reviewAllowRecheck:${cwd}`, false)
-);
-
 // Per-tag dismissal flag for the "release available" toast. Dismissing
 // vX.Y.Z prevents that toast from re-showing for the same tag, but a
 // newer tag still triggers a fresh toast on its own atom.

--- a/e2e/persona-recheck-ui.spec.ts
+++ b/e2e/persona-recheck-ui.spec.ts
@@ -90,7 +90,7 @@ test.describe("Persona recheck UI", () => {
     await expect(cancelButton).not.toBeVisible();
   });
 
-  test("launcher opt-in sends allowRecheck through the launch route", async ({
+  test("launcher does not show allowRecheck toggle (recheck is always on)", async ({
     page,
     request,
   }) => {
@@ -98,21 +98,6 @@ test.describe("Persona recheck UI", () => {
       name: `e2e-agent-${Date.now()}`,
       cwd: process.cwd(),
       useWorktree: false,
-    });
-    let launchRouteCalls = 0;
-    let lastLaunchPayload: unknown = null;
-    page.on("request", (req) => {
-      if (
-        req.method() === "POST" &&
-        req.url().includes(`/api/v1/agents/${agent.id}/launch-review`)
-      ) {
-        launchRouteCalls += 1;
-        try {
-          lastLaunchPayload = req.postDataJSON();
-        } catch {
-          lastLaunchPayload = null;
-        }
-      }
     });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
@@ -122,29 +107,10 @@ test.describe("Persona recheck UI", () => {
     await expect(
       page.getByRole("heading", { name: "Launch Review" })
     ).toBeVisible();
-    const recheckToggle = page.getByTestId("launch-reviewer-allow-recheck");
-    await recheckToggle.click();
-    await expect(recheckToggle).toHaveAttribute("data-state", "checked");
-    await page.getByRole("button", { name: "Cancel" }).click();
+
     await expect(
-      page.getByRole("heading", { name: "Launch Review" })
+      page.getByTestId("launch-reviewer-allow-recheck")
     ).not.toBeVisible();
-
-    await page.getByTestId("launch-reviewer-button").click();
-    await expect(
-      page.getByRole("heading", { name: "Launch Review" })
-    ).toBeVisible();
-    await expect(recheckToggle).toHaveAttribute("data-state", "checked");
-    await page
-      .getByTestId("launch-reviewer-persona-architecture-review")
-      .click();
-    await page.getByTestId("launch-reviewer-submit").click();
-
-    await expect.poll(() => launchRouteCalls).toBeGreaterThanOrEqual(1);
-    expect(lastLaunchPayload).toMatchObject({
-      persona: "architecture-review",
-      allowRecheck: true,
-    });
   });
 
   test("launcher shows an error when review launch fails", async ({


### PR DESCRIPTION
## Summary
- Removes the `allowRecheck` parameter from persona reviews — recheck (round-trip review) is now the default and only behavior
- Every review automatically includes a verification pass: reviewer completes round 1 → parent resolves feedback → reviewer does round 2
- DB column `allow_recheck` is kept but always written as `true` (no migration needed)
- Updates frontend: removes the recheck checkbox from the Launch Review dialog, updates dialog description and docs, fixes `canCancelRecheck` guard to match backend

24 files changed, 67 insertions, 256 deletions.

## Test plan
- [x] `pnpm run finalize:web` — type check + production build passes
- [x] `pnpm run test` — all 1356 unit tests pass
- [x] `pnpm run test:e2e` — all 160 E2E tests pass (including updated `persona-recheck-ui.spec.ts`)
- [x] backend-security-review persona — approved round 2
- [x] architecture-review persona — approved round 2
- [x] frontend-ux-review persona — approved round 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)