### PR TITLE
Adopt shared errorMessage() in agents.ts and templates.ts

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -35,6 +35,7 @@ import {
   parseOptionalBooleanField,
   parseOptionalStringArrayField,
 } from "./agent-startup.js";
+import { errorMessage } from "../shared/lib/error-message.js";
 const AGENT_INITIAL_PROMPT_MAX_CHARS = 16_000;
 const COPY_MODE_ASSIST_DISABLED_ERROR = "Copy mode assist is disabled.";
 const AGENT_LATEST_EVENT_TYPES = [
@@ -442,9 +443,7 @@ export async function registerAgentRoutes(
       try {
         await deps.startStream(id, body.port);
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Failed to start stream.";
-        return reply.code(502).send({ error: message });
+        return reply.code(502).send({ error: errorMessage(error) });
       }
       return { ok: true };
     }
@@ -526,7 +525,7 @@ export async function registerAgentRoutes(
       parsedRequest = await parseCreateAgentRequest(request);
     } catch (error) {
       return reply.code(400).send({
-        error: error instanceof Error ? error.message : "Invalid request body.",
+        error: errorMessage(error),
       });
     }
     const { body, startupFiles } = parsedRequest;
@@ -577,7 +576,7 @@ export async function registerAgentRoutes(
       );
     } catch (error) {
       return reply.code(400).send({
-        error: error instanceof Error ? error.message : "Invalid request body.",
+        error: errorMessage(error),
       });
     }
 
@@ -651,7 +650,7 @@ export async function registerAgentRoutes(
       startupPins = createStartupPins(startupLinks ?? []);
     } catch (error) {
       return reply.code(400).send({
-        error: error instanceof Error ? error.message : "Invalid startupLinks.",
+        error: errorMessage(error),
       });
     }
 
@@ -1130,9 +1129,9 @@ export async function registerAgentRoutes(
           assistState.connectionId = assistConnection.connectionId;
         }
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Terminal attach failed.";
-        socket.send(JSON.stringify({ type: "error", message }));
+        socket.send(
+          JSON.stringify({ type: "error", message: errorMessage(error) })
+        );
         socket.close(1011, "attach failed");
         return;
       }

--- a/apps/server/src/routes/templates.ts
+++ b/apps/server/src/routes/templates.ts
@@ -225,8 +225,7 @@ export async function registerTemplateRoutes(
         );
       } catch (error) {
         return reply.code(400).send({
-          error:
-            error instanceof Error ? error.message : "Invalid startupLinks.",
+          error: errorMessage(error),
         });
       }
 
@@ -236,8 +235,7 @@ export async function registerTemplateRoutes(
           startupPins = createStartupPins(startupLinks);
         } catch (error) {
           return reply.code(400).send({
-            error:
-              error instanceof Error ? error.message : "Invalid startupLinks.",
+            error: errorMessage(error),
           });
         }
       }


### PR DESCRIPTION
## Summary
- Replaced 5 inline `error instanceof Error ? error.message : "..."` patterns in `agents.ts` with the shared `errorMessage()` helper from `shared/lib/error-message.ts`
- Replaced 2 remaining inline patterns in `templates.ts` (which already imported the helper but wasn't using it everywhere)
- This is a continuation of the tech-debt effort from PR #602 which adopted `errorMessage()` in `personalities.ts`

## Why this is tech debt
The shared `errorMessage()` helper was introduced specifically to eliminate this boilerplate. These 7 remaining inline instances were the last holdouts — using them inconsistently defeats the purpose of the shared helper and makes future changes (e.g., adding logging or changing the fallback behavior) require touching every file instead of one.

## What's next
Next tech-debt run will tackle the top backlog item: monitoring the `ide-settings.ts` / `agent-type-settings.ts` pattern similarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)