### PR TITLE
Add inter-agent messaging (dispatch_send_message)

### DIFF
--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -61,6 +61,8 @@ type McpRouteDeps = {
   mcpJobFailed: unknown;
   mcpJobNeedsInput: unknown;
   mcpJobLog: unknown;
+  mcpSendMessage: unknown;
+  mcpListAgentsForAgent: unknown;
   mcpMethodNotAllowed: () => unknown;
 };
 
@@ -204,6 +206,8 @@ export async function registerMcpRoutes(
       resolveFeedback: deps.mcpResolveFeedback,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
+      sendMessage: deps.mcpSendMessage,
+      listAgentsForAgent: deps.mcpListAgentsForAgent,
       getActivitySummary: (params: Record<string, unknown>) =>
         deps.agentManager.getActivitySummary(params as never) as Promise<
           Record<string, unknown>
@@ -283,6 +287,8 @@ export async function registerMcpRoutes(
       resolveFeedback: deps.mcpResolveFeedback,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
+      sendMessage: deps.mcpSendMessage,
+      listAgentsForAgent: deps.mcpListAgentsForAgent,
       upsertPin: deps.mcpUpsertPin,
       deletePin: deps.mcpDeletePin,
       getParentContext: deps.mcpGetParentContext,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -461,6 +461,8 @@ async function registerRoutes() {
     mcpResolveFeedback: mcpHandlers.resolveFeedback,
     mcpSubmitResolution: mcpHandlers.submitResolution,
     mcpCancelRecheck: mcpHandlers.cancelRecheck,
+    mcpSendMessage: mcpHandlers.sendMessage,
+    mcpListAgentsForAgent: mcpHandlers.listAgentsForAgent,
     mcpUpsertPin: mcpHandlers.upsertPin,
     mcpDeletePin: mcpHandlers.deletePin,
     mcpGetParentContext: mcpHandlers.getParentContext,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -299,6 +299,7 @@ const mcpHandlers = createMcpHandlers({
   publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
   withStreamFlag,
   sendAgentPrompt: injectAgentPrompt,
+  appLog: app.log,
 });
 const jobTerminalStatuses = new Set([
   "completed",

--- a/apps/server/src/server/agent-prompts.ts
+++ b/apps/server/src/server/agent-prompts.ts
@@ -15,6 +15,12 @@ export function createPromptInjector(
     try {
       const access = await agentManager.getTerminalAccess(agentId);
       if (access.mode !== "tmux") {
+        const err = new Error(
+          "Agent has no active terminal session — prompt cannot be delivered."
+        );
+        if (opts.swallowFailure === false) {
+          throw err;
+        }
         appLog.debug(
           { agentId, mode: access.mode },
           "Skipping tmux injection — agent has no tmux session"

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 
+import type { FastifyBaseLogger } from "fastify";
 import type { Pool } from "pg";
 
 import type {
@@ -84,6 +85,7 @@ type CreateMcpHandlersDeps = {
     agent: T
   ) => T & { hasStream: boolean };
   sendAgentPrompt: SendAgentPrompt;
+  appLog: FastifyBaseLogger;
 };
 
 function isAgentLatestEventType(value: unknown): value is AgentLatestEventType {
@@ -118,6 +120,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
     publishUiEvent,
     withStreamFlag,
     sendAgentPrompt,
+    appLog,
   } = deps;
 
   return {
@@ -844,23 +847,28 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         );
       }
 
-      const senderName = sender.name;
       const envelope = JSON.stringify({
-        from: senderName,
+        from: sender.name,
         senderId: agentId,
         message: input.message,
+        replyTarget: agentId,
       });
-      const prompt = [
-        `--- DISPATCH MESSAGE ---`,
-        envelope,
-        `--- END MESSAGE ---`,
-        "",
-        `You received a message from another agent. The sender name and ID are in the JSON envelope above.`,
-        `To reply, use the dispatch_send_message tool with target "${agentId}".`,
-      ].join("\n");
+      const prompt = `--- DISPATCH MESSAGE ---\n${envelope}\n--- END MESSAGE ---\nReply with dispatch_send_message using the replyTarget above.`;
 
-      await sendAgentPrompt(target.id, prompt, { swallowFailure: false });
+      try {
+        await sendAgentPrompt(target.id, prompt, { swallowFailure: false });
+      } catch (err) {
+        appLog.error(
+          { err, senderId: agentId, targetId: target.id },
+          "dispatch_send_message: tmux delivery failed"
+        );
+        throw err;
+      }
 
+      appLog.info(
+        { senderId: agentId, targetId: target.id },
+        "dispatch_send_message: delivered"
+      );
       return {
         delivered: true,
         targetAgentId: target.id,

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -855,7 +855,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         envelope,
         `--- END MESSAGE ---`,
         "",
-        `You received a message from agent "${senderName}" (${agentId}).`,
+        `You received a message from another agent. The sender name and ID are in the JSON envelope above.`,
         `To reply, use the dispatch_send_message tool with target "${agentId}".`,
       ].join("\n");
 

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -771,6 +771,137 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       };
     },
 
+    async sendMessage(
+      agentId: string,
+      input: { target: string; message: string; senderRepoRoot: string | null }
+    ): Promise<{
+      delivered: boolean;
+      targetAgentId: string;
+      targetAgentName: string;
+    }> {
+      const sender = await agentManager.getAgent(agentId);
+      if (!sender) throw new Error("Sender agent not found.");
+
+      const senderRepoRoot = input.senderRepoRoot;
+      const allAgentsRaw = await agentManager.listAgents();
+
+      const allAgents: typeof allAgentsRaw = [];
+      for (const a of allAgentsRaw) {
+        if (a.id === agentId) continue;
+        if (!senderRepoRoot) {
+          allAgents.push(a);
+          continue;
+        }
+        try {
+          const aRoot = await resolveRepoRoot(a.cwd);
+          if (aRoot === senderRepoRoot) allAgents.push(a);
+        } catch {
+          // agent cwd not in a git repo — skip
+        }
+      }
+
+      const isAgentId = input.target.startsWith("agt_");
+
+      let target: (typeof allAgents)[number] | undefined;
+      if (isAgentId) {
+        target = allAgents.find((a) => a.id === input.target);
+      } else {
+        const lowerTarget = input.target.toLowerCase();
+        const matches = allAgents.filter(
+          (a) =>
+            a.id !== agentId &&
+            a.status === "running" &&
+            a.name.toLowerCase().includes(lowerTarget)
+        );
+        if (matches.length === 1) {
+          target = matches[0];
+        } else if (matches.length > 1) {
+          const list = matches.map((a) => `  ${a.id} "${a.name}"`).join("\n");
+          throw new Error(
+            `Multiple agents match "${input.target}". Use the agent ID:\n${list}`
+          );
+        }
+      }
+
+      if (!target) {
+        const running = allAgents
+          .filter((a) => a.id !== agentId && a.status === "running")
+          .map((a) => `  ${a.id} "${a.name}"`)
+          .join("\n");
+        throw new Error(
+          `No agent found matching "${input.target}".${running ? ` Running agents:\n${running}` : " No other agents are running."}`
+        );
+      }
+
+      if (target.id === agentId) {
+        throw new Error("Cannot send a message to yourself.");
+      }
+
+      if (target.status !== "running") {
+        throw new Error(
+          `Agent "${target.name}" (${target.id}) is ${target.status}, not running.`
+        );
+      }
+
+      const senderName = sender.name;
+      const prompt = [
+        `<agent-message from="${senderName}" sender-id="${agentId}">`,
+        input.message,
+        `</agent-message>`,
+        "",
+        `You received a message from agent "${senderName}" (${agentId}).`,
+        `To reply, use the dispatch_send_message tool with target "${agentId}".`,
+      ].join("\n");
+
+      await sendAgentPrompt(target.id, prompt, { swallowFailure: false });
+
+      return {
+        delivered: true,
+        targetAgentId: target.id,
+        targetAgentName: target.name,
+      };
+    },
+
+    async listAgentsForAgent(
+      agentId: string,
+      senderRepoRoot: string | null
+    ): Promise<
+      Array<{
+        id: string;
+        name: string;
+        status: string;
+        latestEvent: { type: string; message: string } | null;
+      }>
+    > {
+      const agents = await agentManager.listAgents();
+      const result: Array<{
+        id: string;
+        name: string;
+        status: string;
+        latestEvent: { type: string; message: string } | null;
+      }> = [];
+      for (const a of agents) {
+        if (a.id === agentId) continue;
+        if (senderRepoRoot) {
+          try {
+            const aRoot = await resolveRepoRoot(a.cwd);
+            if (aRoot !== senderRepoRoot) continue;
+          } catch {
+            continue;
+          }
+        }
+        result.push({
+          id: a.id,
+          name: a.name,
+          status: a.status,
+          latestEvent: a.latestEvent
+            ? { type: a.latestEvent.type, message: a.latestEvent.message }
+            : null,
+        });
+      }
+      return result;
+    },
+
     async listMedia(
       agentId: string,
       opts: { source?: string }

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -783,15 +783,16 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       if (!sender) throw new Error("Sender agent not found.");
 
       const senderRepoRoot = input.senderRepoRoot;
-      const allAgentsRaw = await agentManager.listAgents();
+      if (!senderRepoRoot) {
+        throw new Error(
+          "Cannot send messages: unable to determine your project's repository root."
+        );
+      }
 
+      const allAgentsRaw = await agentManager.listAgents();
       const allAgents: typeof allAgentsRaw = [];
       for (const a of allAgentsRaw) {
         if (a.id === agentId) continue;
-        if (!senderRepoRoot) {
-          allAgents.push(a);
-          continue;
-        }
         try {
           const aRoot = await resolveRepoRoot(a.cwd);
           if (aRoot === senderRepoRoot) allAgents.push(a);
@@ -844,10 +845,15 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       }
 
       const senderName = sender.name;
+      const envelope = JSON.stringify({
+        from: senderName,
+        senderId: agentId,
+        message: input.message,
+      });
       const prompt = [
-        `<agent-message from="${senderName}" sender-id="${agentId}">`,
-        input.message,
-        `</agent-message>`,
+        `--- DISPATCH MESSAGE ---`,
+        envelope,
+        `--- END MESSAGE ---`,
         "",
         `You received a message from agent "${senderName}" (${agentId}).`,
         `To reply, use the dispatch_send_message tool with target "${agentId}".`,
@@ -873,6 +879,12 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         latestEvent: { type: string; message: string } | null;
       }>
     > {
+      if (!senderRepoRoot) {
+        throw new Error(
+          "Cannot list agents: unable to determine your project's repository root."
+        );
+      }
+
       const agents = await agentManager.listAgents();
       const result: Array<{
         id: string;
@@ -882,13 +894,11 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       }> = [];
       for (const a of agents) {
         if (a.id === agentId) continue;
-        if (senderRepoRoot) {
-          try {
-            const aRoot = await resolveRepoRoot(a.cwd);
-            if (aRoot !== senderRepoRoot) continue;
-          } catch {
-            continue;
-          }
+        try {
+          const aRoot = await resolveRepoRoot(a.cwd);
+          if (aRoot !== senderRepoRoot) continue;
+        } catch {
+          continue;
         }
         result.push({
           id: a.id,

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -90,6 +90,8 @@ const AGENT_TOOLS = new Set([
   "dispatch_resolve_feedback",
   "dispatch_submit_resolution",
   "dispatch_cancel_recheck",
+  "list_agents",
+  "dispatch_send_message",
   "get_activity_summary",
   "get_agent_history",
   "get_feedback_summary",
@@ -136,6 +138,7 @@ const JOB_TOOLS = new Set([
   "job_needs_input",
   "job_log",
   "list_agents",
+  "dispatch_send_message",
   "list_personas",
   "list_recent_persona_reviews",
   "list_recent_feedback",
@@ -351,6 +354,25 @@ export type McpRequestContext = {
     agentId: string,
     input: { personaAgentId: string; reason?: string }
   ) => Promise<void>;
+  sendMessage?: (
+    agentId: string,
+    input: { target: string; message: string; senderRepoRoot: string | null }
+  ) => Promise<{
+    delivered: boolean;
+    targetAgentId: string;
+    targetAgentName: string;
+  }>;
+  listAgentsForAgent?: (
+    agentId: string,
+    senderRepoRoot: string | null
+  ) => Promise<
+    Array<{
+      id: string;
+      name: string;
+      status: string;
+      latestEvent: { type: string; message: string } | null;
+    }>
+  >;
   getActivitySummary?: (params: {
     start: Date;
     end: Date;
@@ -730,6 +752,94 @@ async function createDispatchMcpServer(
       resolveFeedback: context.resolveFeedback,
       submitResolution: context.submitResolution,
     });
+  }
+
+  // ── Inter-agent messaging tools ───────────────────────────────────
+  // list_agents for standard agents (job agents get it via registerJobTools)
+  if (
+    allowed.has("list_agents") &&
+    context.agent &&
+    context.listAgentsForAgent &&
+    !context.jobTools
+  ) {
+    const agentId = context.agent.id;
+    const listAgentsForAgent = context.listAgentsForAgent;
+
+    server.registerTool(
+      "list_agents",
+      {
+        description:
+          "List other agents on this Dispatch server with their IDs, names, statuses, and latest activity. " +
+          "Use this to discover agents you can communicate with via dispatch_send_message.",
+        inputSchema: {},
+      },
+      async () => {
+        try {
+          const agents = await listAgentsForAgent(agentId, context.repoRoot);
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ agents }, null, 2) },
+            ],
+            structuredContent: { agents },
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (
+    allowed.has("dispatch_send_message") &&
+    context.agent &&
+    context.sendMessage
+  ) {
+    const agentId = context.agent.id;
+    const sendMessage = context.sendMessage;
+
+    server.registerTool(
+      "dispatch_send_message",
+      {
+        description:
+          "Send a message to another running agent. The message is injected into the target agent's session. " +
+          "The target agent can reply using the same tool. Use list_agents to discover available agents. " +
+          "Target can be an agent ID (agt_xxx) or a name (partial match). " +
+          "Only works for agents that are currently running.",
+        inputSchema: {
+          target: z
+            .string()
+            .min(1)
+            .describe(
+              "Agent ID (agt_xxx) or name to send the message to. Names are fuzzy-matched against running agents."
+            ),
+          message: z
+            .string()
+            .min(1)
+            .max(10000)
+            .describe("The message content to send."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await sendMessage(agentId, {
+            target: args.target,
+            message: args.message,
+            senderRepoRoot: context.repoRoot,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message delivered to "${result.targetAgentName}" (${result.targetAgentId}).`,
+              },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
   }
 
   // ── Brain tools (shared memory for agents) ────────────────────────

--- a/apps/server/src/terminal/tmux-terminal.ts
+++ b/apps/server/src/terminal/tmux-terminal.ts
@@ -156,7 +156,7 @@ export class TmuxTerminal {
     // the program until copy mode is cancelled. Exit it first so injections
     // land on the live prompt.
     await this.exitCopyMode().catch(() => undefined);
-    await runCommand("tmux", ["set-buffer", "-b", bufferName, sanitized]);
+    await runCommand("tmux", ["set-buffer", "-b", bufferName, "--", sanitized]);
     try {
       await runCommand("tmux", [
         "paste-buffer",

--- a/apps/server/test/tmux-terminal.test.ts
+++ b/apps/server/test/tmux-terminal.test.ts
@@ -25,7 +25,13 @@ describe("TmuxTerminal.sendCommand", () => {
   function setBufferCalls(): string[] {
     return runCommandMock.mock.calls
       .filter(([, args]) => Array.isArray(args) && args[0] === "set-buffer")
-      .map(([, args]) => (args as string[])[3] ?? "");
+      .map(([, args]) => (args as string[])[4] ?? "");
+  }
+
+  function setBufferArgs(): string[][] {
+    return runCommandMock.mock.calls
+      .filter(([, args]) => Array.isArray(args) && args[0] === "set-buffer")
+      .map(([, args]) => args as string[]);
   }
 
   it("strips bracketed-paste end markers before passing to set-buffer", async () => {
@@ -52,6 +58,27 @@ describe("TmuxTerminal.sendCommand", () => {
     await terminal.sendCommand(text);
 
     expect(setBufferCalls()[0]).toBe(text);
+  });
+
+  it("passes -- end-of-options before buffer content in set-buffer", async () => {
+    const terminal = new TmuxTerminal("session-x");
+    await terminal.sendCommand("hello world");
+
+    const args = setBufferArgs();
+    expect(args).toHaveLength(1);
+    expect(args[0][3]).toBe("--");
+    expect(args[0][4]).toBe("hello world");
+  });
+
+  it("delivers content starting with dashes without flag parsing", async () => {
+    const terminal = new TmuxTerminal("session-x");
+    const dashContent = '--- DISPATCH MESSAGE ---\n{"from":"test"}';
+    await terminal.sendCommand(dashContent);
+
+    const args = setBufferArgs();
+    expect(args).toHaveLength(1);
+    expect(args[0][3]).toBe("--");
+    expect(args[0][4]).toBe(dashContent);
   });
 
   it("cancels tmux copy mode before injecting", async () => {


### PR DESCRIPTION
## Summary

- Adds `dispatch_send_message` MCP tool that lets agents send messages to other running agents in the same project
- Promotes `list_agents` from job-only to all standard agents, so agents can discover who to message
- Messages are delivered via tmux prompt injection with reply instructions, enabling bidirectional agent-to-agent conversations
- Both tools are scoped by repo root — agents can only see and message agents in the same git repository

## How it works

1. Agent calls `list_agents` to discover other running agents (returns ID, name, status, latest event)
2. Agent calls `dispatch_send_message` with a target (name or ID) and message
3. Server resolves the target, validates it's running and in the same repo, then injects a formatted prompt into the target's tmux session
4. The injected prompt includes the sender's ID and instructions for replying via `dispatch_send_message`
5. Target agent processes the message and can reply — same tool in reverse

## Test plan

- [x] Type check passes (`pnpm run check`)
- [x] Unit tests pass (`pnpm run test`)
- [x] E2E tests pass (`pnpm run test:e2e` — 160 passed)
- [x] Validated with real agents on a live dev instance:
  - Sending messages by name (fuzzy match) and by agent ID
  - Bidirectional replies
  - Self-message blocked
  - Non-existent agent returns helpful error with list of running agents
  - Agents in different repos cannot see or message each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)