### PR TITLE
Fix agent lifecycle doc: add missing cursor type

### DIFF
--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -19,7 +19,7 @@
 - `standard` — every agent created via the normal Create dialog or job/persona launch.
 - `assisted_update` — created exclusively by `POST /api/v1/release/assisted/launch`. Runs the assisted-update prompt and is wired to the assisted-update phase machine (see [Assisted-Update Phase Axis](#assisted-update-phase-axis)).
 
-Role is orthogonal to `AgentType` (`claude` / `codex` / `opencode` / `terminal`).
+Role is orthogonal to `AgentType` (`claude` / `codex` / `opencode` / `cursor` / `terminal`).
 
 ## Setup Phases
 


### PR DESCRIPTION
## Summary
- Added `cursor` to the `AgentType` list in `docs/04-agent-lifecycle.md` — it was omitted when the type was added to the codebase.

## Audit details
- **Scope**: Status Events docs-pane section + `docs/04-agent-lifecycle.md` state machine (per `next_focus` from previous run)
- **Verified accurate**: All 5 event types, sidebar display claims, Activity page features, notification events, reconciliation logic, setup/archive/assisted-update phases, persona review states
- **Single drift found**: `AgentType` list on line 22 omitted `cursor`
- **Deferred**: No new backlog items this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)