### PR TITLE
Add deferred-work intake tools and triage job

### DIFF
--- a/.dispatch/job-prompts/deferred-work-triage.md
+++ b/.dispatch/job-prompts/deferred-work-triage.md
@@ -1,0 +1,110 @@
+Triage the deferred-work intake queue: deduplicate items, route them into the correct recurring job's Brain backlog, and clean up processed entries. This job runs on a recurring schedule.
+
+## Important context
+
+Dispatch is a local-first control plane for running and managing multiple AI coding agents. Agents report deferred work via the `dispatch_report_deferred_work` MCP tool, which places items into a shared intake queue. This triage job reads that queue and routes items into job-specific Brain collections so the right recurring job picks them up.
+
+## Brain layout
+
+### Intake queue (source — read and drain)
+
+- **Intake list** (collection: `deferred-work`, name: `intake`) — read with `brain_list_get`. Each item is a JSON object with fields:
+  - `kind` — one of: `flake`, `coverage_gap`, `tech_debt`, `componentization`, `docs_gap`, `bug`, `refactor`, `other`
+  - `summary` — short description
+  - `details` — longer context (may be null)
+  - `files` — array of file paths
+  - `evidence` — structured supporting data
+  - `priority` — `low`, `medium`, or `high`
+  - `suggestedJob` — optional hint for routing
+  - `reportedBy` — agent ID that reported the item
+  - `reportedAt` — ISO timestamp
+  - `status` — always `pending` when in the intake queue
+
+### Routing targets (destination — push into)
+
+Each recurring job owns a Brain collection with a `backlog` list. Route items by pushing into the appropriate list:
+
+| Kind               | Target collection | Target list | Notes                        |
+| ------------------ | ----------------- | ----------- | ---------------------------- |
+| `flake`            | `test-enforcer`   | `flakes`    | Flaky test observations      |
+| `coverage_gap`     | `test-enforcer`   | `backlog`   | Missing test coverage        |
+| `bug`              | `test-enforcer`   | `backlog`   | Bugs exposed by tests        |
+| `componentization` | `componentizer`   | `backlog`   | Oversized components         |
+| `tech_debt`        | `tech-debt`       | `backlog`   | Code quality issues          |
+| `refactor`         | `tech-debt`       | `backlog`   | Structural improvements      |
+| `docs_gap`         | `docs-audit`      | `backlog`   | Missing/stale documentation  |
+| `other`            | `deferred-work`   | `unrouted`  | Items that don't match a job |
+
+If `suggestedJob` is set and maps to a known job, prefer that routing over the default kind-based routing. Known job names: `test-enforcer`, `componentizer`, `tech-debt`, `docs-audit`.
+
+### Triage state (own state)
+
+1. **Core state** (collection: `deferred-work`, name: `triage-state`) — read with `brain_get_object`. **Save the `revision`** for `expectedRevision` when updating.
+   - `last_run_at` — ISO timestamp of the last triage run
+   - `items_processed` — total items processed across all runs
+   - `items_routed` — breakdown by target job
+
+2. **Run history** — log each run with `brain_append_event`:
+   - collection: `deferred-work`
+   - kind: `triage-run`
+   - subject: `deferred-work-triage`
+   - value: `{ "date": "<today>", "processed": <count>, "routed": { "<job>": <count>, ... }, "duplicates_skipped": <count> }`
+
+## Phase 1: Read the intake queue
+
+1. Read the intake list: `brain_list_get(collection: "deferred-work", name: "intake", limit: 200, order: "asc")`. Save the `revision`.
+2. If the list is empty, log a triage run with `processed: 0` and call `job_complete` with a summary saying nothing to triage.
+3. Read the triage state object if it exists: `brain_get_object(collection: "deferred-work", name: "triage-state")`.
+
+## Phase 2: Deduplicate
+
+For each intake item, check whether a substantially similar item already exists in the target backlog:
+
+1. Read the target list (e.g., `brain_list_get(collection: "test-enforcer", name: "backlog")`).
+2. An item is a duplicate if an existing backlog entry has essentially the same summary or covers the same files with the same kind of work. Use judgment — exact string matching is too strict, but "same area, same problem" is a duplicate.
+3. Mark duplicates for skipping. Do not route them.
+
+Keep deduplication lightweight. Reading each target list once per run is enough — don't re-read after each push.
+
+## Phase 3: Route items
+
+For each non-duplicate intake item:
+
+1. Determine the target collection and list using the routing table above. If `suggestedJob` overrides the default, use it.
+2. Transform the item into the target job's backlog format. Each backlog item should be a JSON object with at minimum:
+   - `description` — the summary, optionally enriched with details
+   - `files` — relevant file paths (if any)
+   - `source` — `"deferred-work-triage"` to mark provenance
+   - `reportedBy` — original agent ID
+   - `reportedAt` — original timestamp
+   - `priority` — preserved from the intake item
+3. Push the transformed item: `brain_list_push(collection: "<target>", name: "<list>", items: [<item>], maxItems: 30)`.
+4. For flake items routed to `test-enforcer/flakes`, format as `{ "description": "<summary + details>", "source": "deferred-work-triage", "reportedBy": "<agentId>", "reportedAt": "<timestamp>" }`.
+
+## Phase 4: Clean up the intake queue
+
+After all items have been routed (or marked as duplicates), remove all processed items from the intake list.
+
+Use `brain_list_remove` with the `where` filter to remove items by their `reportedAt` timestamp, working from the oldest items first. Alternatively, remove by index starting from the highest index to avoid reindexing issues.
+
+## Phase 5: Update state
+
+1. Update triage state: `brain_store_object(collection: "deferred-work", name: "triage-state", value: { last_run_at, items_processed, items_routed }, expectedRevision: <saved revision or omit if first run>)`.
+2. Log the run event: `brain_append_event(collection: "deferred-work", kind: "triage-run", subject: "deferred-work-triage", value: { date, processed, routed, duplicates_skipped })`.
+
+## Dispatch behavior
+
+- Rename the session to "Deferred Work Triage".
+- Emit `dispatch_event` status updates as work progresses.
+- Use `job_log` for task-level progress.
+- End with exactly one terminal tool call: `job_complete`, `job_failed`, or `job_needs_input`.
+
+## Terminal report
+
+The report should include:
+
+1. How many items were in the intake queue.
+2. How many were routed, broken down by target job.
+3. How many were skipped as duplicates.
+4. How many ended up in the unrouted list.
+5. Any items that could not be processed and why.

--- a/.dispatch/job-prompts/test-enforcer.md
+++ b/.dispatch/job-prompts/test-enforcer.md
@@ -17,9 +17,9 @@ State is spread across purpose-specific brain primitives to keep writes minimal:
    - `next_focus` — the specific area the last run recommended you start with this time
    - `last_coverage_summary` — the most recent useful coverage snapshot and notable deltas
 
-2. **Backlog** (collection: `test-enforcer`, name: `backlog`) — read with `brain_list_get`. Worthwhile follow-up coverage or reliability work that prior runs deferred. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array.
+2. **Backlog** (collection: `test-enforcer`, name: `backlog`) — read with `brain_list_get`. Worthwhile follow-up coverage or reliability work that prior runs deferred. Managed via `brain_list_push` / `brain_list_remove` — never regenerate the full array. Items with `source: "deferred-work-triage"` were reported by other agents and routed here automatically — treat them like any other backlog item.
 
-3. **Flakes** (collection: `test-enforcer`, name: `flakes`) — read with `brain_list_get`. Flaky tests or local-only failure patterns worth remembering, with brief notes on fixes or hypotheses. Managed via `brain_list_push` / `brain_list_remove`.
+3. **Flakes** (collection: `test-enforcer`, name: `flakes`) — read with `brain_list_get`. Flaky tests or local-only failure patterns worth remembering, with brief notes on fixes or hypotheses. Managed via `brain_list_push` / `brain_list_remove`. Items with `source: "deferred-work-triage"` were reported by other agents — they may include evidence from the reporting agent's context.
 
 4. **Run history** — query with `brain_query_events(collection: "test-enforcer", kind: "run", subject: "test-enforcer", limit: 5)`. Read-only context — useful for PR descriptions and avoiding duplicate work.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,12 @@ Before marking any task as done, run the following checks and fix any failures:
 
   `pnpm tsx bin/embed-assisted-update.ts --check-only --metadata release-notes/next-assisted-update.json`
 
+## Deferred Work
+
+- When you discover follow-up work during a task that belongs to a recurring job (flaky tests, missing coverage, tech debt, oversized components, stale docs), report it with the `dispatch_report_deferred_work` MCP tool instead of writing directly into job-specific Brain collections.
+- The tool accepts a `kind` (flake, coverage_gap, tech_debt, componentization, docs_gap, bug, refactor, other), a `summary`, and optional `details`, `files`, `evidence`, `priority`, and `suggestedJob`.
+- Items land in a shared intake queue and are automatically triaged into the appropriate job's backlog by the deferred-work-triage recurring job.
+
 ## Personas
 
 - When asked to launch a persona (e.g., "run security review", "test this as an end user"), use the `dispatch_launch_persona` MCP tool.

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -84,6 +84,8 @@ const AGENT_TOOLS = new Set([
   "dispatch_share",
   "dispatch_list_media",
   "dispatch_feedback",
+  "dispatch_report_deferred_work",
+  "dispatch_list_deferred_work",
   "list_personas",
   "dispatch_launch_persona",
   "dispatch_get_feedback",
@@ -128,6 +130,8 @@ const JOB_TOOLS = new Set([
   "dispatch_pin",
   "dispatch_share",
   "dispatch_list_media",
+  "dispatch_report_deferred_work",
+  "dispatch_list_deferred_work",
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
@@ -855,6 +859,24 @@ async function createDispatchMcpServer(
     });
   }
 
+  // ── Deferred work tools ──────────────────────────────────────────
+  if (context.agent && context.repoRoot && context.brainStore) {
+    const dwCtx = {
+      repoRoot: context.repoRoot,
+      agentId: context.agent.id,
+      store: context.brainStore,
+      publishBrainChanged: context.publishBrainChanged
+        ? () => context.publishBrainChanged!(context.repoRoot!)
+        : undefined,
+    };
+    if (allowed.has("dispatch_report_deferred_work")) {
+      registerDeferredWorkTool(server, dwCtx);
+    }
+    if (allowed.has("dispatch_list_deferred_work")) {
+      registerListDeferredWorkTool(server, dwCtx);
+    }
+  }
+
   // ── Summary / analytics tools (available to both agents and jobs) ──
   registerAnalyticsTools(server, allowed, {
     getActivitySummary:
@@ -1227,4 +1249,220 @@ function buildParamSchema(params?: RepoToolParam[]): Record<string, z.ZodType> {
     }
   }
   return schema;
+}
+
+// ── Deferred work intake tool ───────────────────────────────────────
+
+const DEFERRED_WORK_COLLECTION = "deferred-work";
+const DEFERRED_WORK_INTAKE_LIST = "intake";
+const DEFERRED_WORK_MAX_ITEMS = 200;
+
+const DEFERRED_WORK_KINDS = [
+  "flake",
+  "coverage_gap",
+  "tech_debt",
+  "componentization",
+  "docs_gap",
+  "bug",
+  "refactor",
+  "other",
+] as const;
+
+function registerDeferredWorkTool(
+  server: McpServer,
+  ctx: {
+    repoRoot: string;
+    agentId: string;
+    store: BrainStore;
+    publishBrainChanged?: () => void;
+  }
+): void {
+  server.registerTool(
+    "dispatch_report_deferred_work",
+    {
+      description:
+        "Report work that should be handled later by a recurring job (e.g. flaky tests, " +
+        "coverage gaps, tech debt). Items are placed in a shared intake queue and triaged " +
+        "into the appropriate job's backlog automatically. Use this instead of writing " +
+        "directly into job-specific Brain collections.",
+      inputSchema: {
+        kind: z
+          .enum(DEFERRED_WORK_KINDS)
+          .describe(
+            "Category of deferred work: flake (flaky test), coverage_gap (missing test coverage), " +
+              "tech_debt (code quality), componentization (oversized component/file), " +
+              "docs_gap (missing/stale docs), bug (non-critical bug), refactor (structural improvement), " +
+              "other (anything else)."
+          ),
+        summary: z
+          .string()
+          .min(1)
+          .max(500)
+          .describe("Short description of the work to be done."),
+        details: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe(
+            "Longer explanation with context, reproduction steps, or analysis."
+          ),
+        files: z
+          .array(z.string())
+          .max(20)
+          .optional()
+          .describe("File paths relevant to this work item."),
+        evidence: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            "Supporting evidence: failed test names, error messages, commands run, " +
+              "screenshot references, commit SHAs, PR URLs, etc."
+          ),
+        priority: z
+          .enum(["low", "medium", "high"])
+          .default("medium")
+          .describe("Relative priority for triage."),
+        suggestedJob: z
+          .string()
+          .optional()
+          .describe(
+            "Hint for which recurring job should handle this (e.g. 'test-enforcer', " +
+              "'componentizer'). The triage job makes the final routing decision."
+          ),
+      },
+    },
+    async (args) => {
+      try {
+        const item = {
+          kind: args.kind,
+          summary: args.summary,
+          details: args.details ?? null,
+          files: args.files ?? [],
+          evidence: (args.evidence as Record<string, unknown>) ?? {},
+          priority: args.priority,
+          suggestedJob: args.suggestedJob ?? null,
+          reportedBy: ctx.agentId,
+          reportedAt: new Date().toISOString(),
+          status: "pending",
+        };
+
+        const result = await ctx.store.pushListItems(
+          ctx.repoRoot,
+          ctx.agentId,
+          {
+            collection: DEFERRED_WORK_COLLECTION,
+            name: DEFERRED_WORK_INTAKE_LIST,
+            items: [item],
+            maxItems: DEFERRED_WORK_MAX_ITEMS,
+          }
+        );
+
+        ctx.publishBrainChanged?.();
+
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Deferred work reported: "${args.summary}" (${args.kind}, ${args.priority} priority). ` +
+                `Intake queue now has ${result.length} item(s).`,
+            },
+          ],
+          structuredContent: {
+            kind: args.kind,
+            summary: args.summary,
+            priority: args.priority,
+            queueLength: result.length,
+            revision: result.revision,
+          },
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+}
+
+function registerListDeferredWorkTool(
+  server: McpServer,
+  ctx: {
+    repoRoot: string;
+    agentId: string;
+    store: BrainStore;
+  }
+): void {
+  server.registerTool(
+    "dispatch_list_deferred_work",
+    {
+      description:
+        "List pending deferred work items from the shared intake queue. " +
+        "Shows work reported by any agent via dispatch_report_deferred_work that has not yet " +
+        "been triaged into a job-specific backlog.",
+      inputSchema: {
+        kind: z
+          .enum(DEFERRED_WORK_KINDS)
+          .optional()
+          .describe("Filter by work category. Omit to list all kinds."),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(50)
+          .describe("Maximum number of items to return."),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await ctx.store.getListItems(ctx.repoRoot, {
+          collection: DEFERRED_WORK_COLLECTION,
+          name: DEFERRED_WORK_INTAKE_LIST,
+          limit: args.limit,
+          order: "desc",
+        });
+
+        let items = result.items;
+        if (args.kind) {
+          items = items.filter(
+            (item) =>
+              item.value != null &&
+              typeof item.value === "object" &&
+              (item.value as Record<string, unknown>).kind === args.kind
+          );
+        }
+
+        const summary =
+          `${items.length} item(s) in intake queue` +
+          (args.kind ? ` matching kind "${args.kind}"` : "") +
+          ` (${result.totalCount} total).`;
+
+        return {
+          content: [
+            { type: "text", text: summary },
+            {
+              type: "text",
+              text: JSON.stringify(
+                items.map((item) => ({
+                  index: item.index,
+                  ...(item.value as Record<string, unknown>),
+                })),
+                null,
+                2
+              ),
+            },
+          ],
+          structuredContent: {
+            items: items.map((item) => ({
+              index: item.index,
+              ...(item.value as Record<string, unknown>),
+            })),
+            totalCount: result.totalCount,
+            revision: result.revision,
+          },
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- Adds `dispatch_report_deferred_work` MCP tool — agents report follow-up work (flakes, coverage gaps, tech debt, etc.) into a shared `deferred-work/intake` Brain queue instead of writing directly into job-specific Brain collections
- Adds `dispatch_list_deferred_work` MCP tool — agents can query the intake queue with optional `kind` filtering
- Adds `deferred-work-triage` job prompt that reads the intake queue, dedupes against existing backlogs, and routes items into the correct recurring job's Brain collection (test-enforcer, componentizer, tech-debt, docs-audit)
- Updates Test Enforcer prompt to note items with `source: "deferred-work-triage"` provenance
- Documents the tool in CLAUDE.md

## Test plan
- [x] Type checking passes (`pnpm run check`)
- [x] Unit tests pass (1531 tests)
- [x] E2E tests pass (160 tests)
- [x] Verified `dispatch_report_deferred_work` on live dev instance — items persist in Brain with correct structure
- [x] Verified `dispatch_list_deferred_work` on live dev instance — returns items with kind filtering
- [x] Verified intake queue visible in Brain REST API

🤖 Generated with [Claude Code](https://claude.com/claude-code)