### PR TITLE
Add "Clear app data & reload" button to connection error screens

### DIFF
--- a/apps/web/src/layouts/auth-layout.tsx
+++ b/apps/web/src/layouts/auth-layout.tsx
@@ -7,12 +7,11 @@ function ClearReloadButton() {
   return (
     <div className="fixed bottom-4 right-4">
       <Button
-        variant="ghost"
+        variant="default"
         size="sm"
-        className="text-xs text-muted-foreground/50 hover:text-muted-foreground"
         onClick={() => void clearCachesAndReload()}
       >
-        Clear app data & reload
+        Clear cache & reload
       </Button>
     </div>
   );

--- a/apps/web/src/layouts/auth-layout.tsx
+++ b/apps/web/src/layouts/auth-layout.tsx
@@ -1,6 +1,22 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { useAuthContext } from "@/contexts/auth-context";
 import { Button } from "@/components/ui/button";
+import { clearCachesAndReload } from "@/lib/pwa-update";
+
+function ClearReloadButton() {
+  return (
+    <div className="fixed bottom-4 right-4">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-xs text-muted-foreground/50 hover:text-muted-foreground"
+        onClick={() => void clearCachesAndReload()}
+      >
+        Clear app data & reload
+      </Button>
+    </div>
+  );
+}
 
 export function AuthLayout(): JSX.Element {
   const { authState, retryAuth } = useAuthContext();
@@ -9,6 +25,7 @@ export function AuthLayout(): JSX.Element {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
         <span className="text-sm">Connecting to server...</span>
+        <ClearReloadButton />
       </div>
     );
   }
@@ -20,6 +37,7 @@ export function AuthLayout(): JSX.Element {
         <Button variant="ghost" size="sm" onClick={retryAuth}>
           Retry
         </Button>
+        <ClearReloadButton />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Adds a subtle "Clear app data & reload" button in the bottom-right corner of the pre-auth screens (both "Connecting to server..." loading and "Unable to reach the server" error states)
- Reuses the existing `clearCachesAndReload()` from `pwa-update.ts` — unregisters service workers, deletes all CacheStorage entries, and reloads
- Provides a quick escape hatch for PWA cert/cache issues without needing to reinstall the app

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Web build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (160 passed, 12 skipped pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)