### PR TITLE
[codex] Improve working directory input

### DIFF
--- a/apps/server/src/routes/activity.ts
+++ b/apps/server/src/routes/activity.ts
@@ -311,16 +311,67 @@ export async function registerActivityRoutes(
     return { ok: true };
   });
 
-  app.get("/api/v1/history/projects", async () => {
-    const result = await deps.pool.query<{ project: string }>(
-      `SELECT DISTINCT COALESCE(git_context->>'repoRoot', cwd) AS project
-       FROM agents
-       WHERE parent_agent_id IS NULL
-         AND deleted_at IS NOT NULL
-         AND COALESCE(git_context->>'repoRoot', cwd) IS NOT NULL
-       ORDER BY project`
+  app.get("/api/v1/history/projects", async (request) => {
+    const query = request.query as Record<string, unknown>;
+    const search =
+      typeof query.search === "string" ? query.search.trim().toLowerCase() : "";
+    const limit = Math.min(
+      Math.max(parseInt(String(query.limit ?? "20"), 10) || 20, 1),
+      50
     );
-    return { projects: result.rows.map((row) => row.project) };
+    const params: unknown[] = [];
+    const where = [
+      "parent_agent_id IS NULL",
+      "COALESCE(git_context->>'repoRoot', cwd) IS NOT NULL",
+    ];
+
+    if (search) {
+      params.push(`%${search}%`);
+      where.push(
+        `(LOWER(COALESCE(git_context->>'repoRoot', cwd)) LIKE $${params.length} OR LOWER(regexp_replace(COALESCE(git_context->>'repoRoot', cwd), '/+$', '')) LIKE $${params.length})`
+      );
+    }
+    params.push(limit);
+
+    const result = await deps.pool.query<{
+      project: string;
+      usage_count: number;
+      latest_created_at: Date;
+      agent_id: string;
+      icon_agent_id: string | null;
+    }>(
+      `SELECT project,
+              COUNT(*)::int AS usage_count,
+              MAX(created_at) AS latest_created_at,
+              (ARRAY_AGG(id ORDER BY created_at DESC))[1] AS agent_id,
+              (ARRAY_AGG(id ORDER BY created_at DESC) FILTER (WHERE repo_icon_path IS NOT NULL))[1] AS icon_agent_id
+       FROM (
+         SELECT id,
+                created_at,
+                COALESCE(git_context->>'repoRoot', cwd) AS project,
+                git_context->>'repoIconPath' AS repo_icon_path
+         FROM agents
+         WHERE ${where.join(" AND ")}
+       ) project_agents
+       GROUP BY project
+       ORDER BY usage_count DESC, latest_created_at DESC, project ASC
+       LIMIT $${params.length}`,
+      params
+    );
+
+    const projectOptions = result.rows.map((row) => ({
+      path: row.project,
+      usageCount: row.usage_count,
+      latestCreatedAt: row.latest_created_at.toISOString(),
+      iconUrl: row.icon_agent_id
+        ? `/api/v1/agents/${encodeURIComponent(row.icon_agent_id)}/repo-icon`
+        : undefined,
+    }));
+
+    return {
+      projects: projectOptions.map((project) => project.path),
+      projectOptions,
+    };
   });
 
   app.get("/api/v1/history/agents", async (request) => {

--- a/apps/web/src/components/app/automations-create-dialog.tsx
+++ b/apps/web/src/components/app/automations-create-dialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
 import { TemplateConfigFields } from "@/components/app/automations-form-fields";
+import { useCwdHistory } from "@/components/app/create-agent-dialog-utils";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import {
@@ -56,6 +57,7 @@ function CreateTemplateDialogContent({
   const [callable, setCallable] = useState(true);
   const [allowMedia, setAllowMedia] = useState(true);
   const [creating, setCreating] = useState(false);
+  const { add: addCwdHistory } = useCwdHistory();
 
   const handleCreate = useCallback(() => {
     const isTerminal = agentType === "terminal";
@@ -75,6 +77,7 @@ function CreateTemplateDialogContent({
         allowMedia: isTerminal ? false : allowMedia,
       })
       .then(() => {
+        addCwdHistory(directory);
         onOpenChange(false);
         toast.success("Template created.");
       })
@@ -95,6 +98,7 @@ function CreateTemplateDialogContent({
     fullAccess,
     callable,
     allowMedia,
+    addCwdHistory,
     onOpenChange,
   ]);
 

--- a/apps/web/src/components/app/automations-form-fields.tsx
+++ b/apps/web/src/components/app/automations-form-fields.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback, useRef, useState } from "react";
 import { Check, ChevronDown, GitBranch, Paperclip } from "lucide-react";
 
 import { BranchSelect } from "@/components/app/branch-select";
+import { useCwdHistory } from "@/components/app/create-agent-dialog-utils";
 import { PathInput } from "@/components/app/path-input";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -244,6 +245,12 @@ export function TemplateConfigFields({
   autoFocusName,
 }: TemplateConfigFieldsProps): JSX.Element {
   const isTerminal = agentType === "terminal";
+  const {
+    history: cwdHistory,
+    removableHistory: removableCwdHistory,
+    historyMetadata: cwdHistoryMetadata,
+    remove: removeCwdHistory,
+  } = useCwdHistory();
 
   const detectedArgs = useMemo(
     () => (prompt ? parseTemplateArgs(prompt) : []),
@@ -288,6 +295,10 @@ export function TemplateConfigFields({
           value={directory}
           onChange={onDirectoryChange}
           placeholder="/path/to/repo"
+          history={cwdHistory}
+          removableHistory={removableCwdHistory}
+          historyMetadata={cwdHistoryMetadata}
+          onRemoveHistory={removeCwdHistory}
         />
       </div>
 

--- a/apps/web/src/components/app/automations-template-detail.tsx
+++ b/apps/web/src/components/app/automations-template-detail.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { TemplateConfigFields } from "@/components/app/automations-form-fields";
 import { LaunchTemplateDialog } from "@/components/app/automations-launch-dialog";
+import { useCwdHistory } from "@/components/app/create-agent-dialog-utils";
 import type { AgentType } from "@/lib/agent-types";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
@@ -63,6 +64,7 @@ function TemplateDetail({
   const navigate = useNavigate();
   const { updateTemplate, removeTemplate, launchTemplate } =
     useTemplateActions();
+  const { add: addCwdHistory } = useCwdHistory();
 
   const [displayName, setDisplayName] = useState(template.name);
   const [description, setDescription] = useState(template.description ?? "");
@@ -126,7 +128,10 @@ function TemplateDetail({
         callable,
         allowMedia: isTerminal ? false : allowMedia,
       })
-      .then(() => toast.success("Settings saved."))
+      .then(() => {
+        addCwdHistory(directory);
+        toast.success("Settings saved.");
+      })
       .catch((err: Error) => setSaveError(err.message));
   }, [
     updateTemplate,
@@ -142,6 +147,7 @@ function TemplateDetail({
     fullAccess,
     callable,
     allowMedia,
+    addCwdHistory,
   ]);
 
   const handleDelete = useCallback(() => {

--- a/apps/web/src/components/app/branch-select.tsx
+++ b/apps/web/src/components/app/branch-select.tsx
@@ -36,6 +36,8 @@ export type BranchSelectProps = {
   baseBranchHelper?: string;
   /** When false, hide the "new branch name" text input. Defaults to true. */
   showNewBranchInput?: boolean;
+  /** Disable branch controls while preserving their layout. */
+  disabled?: boolean;
 };
 
 export function BranchSelect({
@@ -49,6 +51,7 @@ export function BranchSelect({
   baseBranchLabel = "Base branch",
   baseBranchHelper,
   showNewBranchInput = true,
+  disabled = false,
 }: BranchSelectProps): JSX.Element {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
@@ -63,7 +66,7 @@ export function BranchSelect({
 
   const fetchBranches = useCallback(async () => {
     const trimmed = cwd.trim();
-    if (!trimmed) return;
+    if (!trimmed || disabled) return;
     setBranchesLoading(true);
     setFetchError(null);
     try {
@@ -80,15 +83,16 @@ export function BranchSelect({
       setBranchesLoading(false);
       setFetchedForCwd(trimmed);
     }
-  }, [cwd]);
+  }, [cwd, disabled]);
 
   const openDropdown = useCallback(() => {
+    if (disabled) return;
     setDropdownOpen(true);
     if (fetchedForCwd !== cwd.trim()) {
       void fetchBranches();
     }
     requestAnimationFrame(() => inputRef.current?.focus());
-  }, [fetchBranches, fetchedForCwd, cwd, setDropdownOpen]);
+  }, [disabled, fetchBranches, fetchedForCwd, cwd, setDropdownOpen]);
 
   // Keep the saved baseBranch selectable even if the fetched list doesn't
   // include it (branch renamed/deleted upstream). We flag it visually in
@@ -119,6 +123,7 @@ export function BranchSelect({
           type="button"
           role="combobox"
           tabIndex={0}
+          disabled={disabled}
           aria-expanded={dropdownOpen}
           data-testid={`${testIdPrefix}-base-branch`}
           onClick={() =>
@@ -132,7 +137,8 @@ export function BranchSelect({
           }}
           className={cn(
             "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 font-mono text-xs shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
-            "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+            "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring",
+            disabled && "cursor-not-allowed opacity-60"
           )}
         >
           {baseBranch}
@@ -239,6 +245,7 @@ export function BranchSelect({
           onChange={(event) => onWorktreeBranchChange(event.target.value)}
           placeholder={worktreeBranchPlaceholder}
           data-testid={`${testIdPrefix}-worktree-branch`}
+          disabled={disabled}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/app/create-agent-dialog-utils.ts
+++ b/apps/web/src/components/app/create-agent-dialog-utils.ts
@@ -1,17 +1,27 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 
 import { type AgentType, isAgentType } from "@/lib/agent-types";
+import { api } from "@/lib/api";
 import { createNewBranchPrefAtom } from "@/lib/store";
 
 export const LAST_USED_CWD_KEY = "dispatch:lastUsedAgentCwd";
 export const LAST_USED_TYPE_KEY = "dispatch:lastUsedAgentType";
 export const CWD_HISTORY_KEY = "dispatch:cwdHistory";
+export const CWD_HISTORY_USAGE_KEY = "dispatch:cwdHistoryUsage";
 export const CWD_HISTORY_MAX = 20;
 export const FULL_ACCESS_PREFIX = "dispatch:fullAccess:";
 export const AUTO_REVIEW_PREFIX = "dispatch:autoReview:";
 export const BASE_BRANCH_PREFIX = "dispatch:baseBranch:";
 export const CONTEXT_PROMPT_ID = "create-agent-context-prompt";
+
+type ProjectHistoryOption = {
+  path: string;
+  usageCount: number;
+  latestCreatedAt: string;
+  iconUrl?: string;
+};
 
 export function readStoredString(key: string): string {
   if (typeof window === "undefined") return "";
@@ -48,24 +58,145 @@ export function readCwdHistory(): string[] {
   }
 }
 
+export function readCwdHistoryUsage(): Record<string, number> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(CWD_HISTORY_USAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, number] =>
+          typeof entry[0] === "string" &&
+          typeof entry[1] === "number" &&
+          Number.isFinite(entry[1]) &&
+          entry[1] > 0
+      )
+    );
+  } catch {
+    return {};
+  }
+}
+
 function writeCwdHistory(nextHistory: string[]): void {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(CWD_HISTORY_KEY, JSON.stringify(nextHistory));
 }
 
+function writeCwdHistoryUsage(nextUsage: Record<string, number>): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(CWD_HISTORY_USAGE_KEY, JSON.stringify(nextUsage));
+}
+
 export function addToCwdHistory(cwd: string): string[] {
   const trimmed = cwd.trim();
   if (!trimmed) return readCwdHistory();
+  const usage = readCwdHistoryUsage();
+  usage[trimmed] = (usage[trimmed] ?? 0) + 1;
   const existing = readCwdHistory().filter((entry) => entry !== trimmed);
   const updated = [trimmed, ...existing].slice(0, CWD_HISTORY_MAX);
+  const nextUsage = Object.fromEntries(
+    updated.map((entry) => [entry, usage[entry] ?? 1])
+  );
   writeCwdHistory(updated);
+  writeCwdHistoryUsage(nextUsage);
   return updated;
 }
 
 export function removeCwdFromHistory(cwd: string): string[] {
   const next = readCwdHistory().filter((entry) => entry !== cwd);
+  const usage = readCwdHistoryUsage();
+  delete usage[cwd];
   writeCwdHistory(next);
+  writeCwdHistoryUsage(usage);
   return next;
+}
+
+export function useCwdHistory() {
+  const [history, setHistory] = useState<string[]>(() => readCwdHistory());
+  const [usage, setUsage] = useState<Record<string, number>>(() =>
+    readCwdHistoryUsage()
+  );
+  const { data: projectOptions = [] } = useQuery<ProjectHistoryOption[]>({
+    queryKey: ["history", "projects", "cwd-suggestions"],
+    queryFn: async () => {
+      const payload = await api<{
+        projectOptions?: ProjectHistoryOption[];
+        projects: string[];
+      }>("/api/v1/history/projects?limit=50");
+
+      return (
+        payload.projectOptions ??
+        payload.projects.map((path) => ({
+          path,
+          usageCount: 0,
+          latestCreatedAt: "",
+        }))
+      );
+    },
+    staleTime: 60_000,
+  });
+
+  const apiHistory = useMemo(
+    () => projectOptions.map((option) => option.path),
+    [projectOptions]
+  );
+
+  const historyMetadata = useMemo(
+    () => ({
+      ...Object.fromEntries(
+        history.map((cwd) => [cwd, { usageCount: usage[cwd] ?? 0 }])
+      ),
+      ...Object.fromEntries(
+        projectOptions.map((option) => [
+          option.path,
+          {
+            usageCount: Math.max(option.usageCount, usage[option.path] ?? 0),
+            iconUrl: option.iconUrl,
+          },
+        ])
+      ),
+    }),
+    [history, projectOptions, usage]
+  );
+
+  const mergedHistory = useMemo(
+    () => Array.from(new Set([...apiHistory, ...history])),
+    [apiHistory, history]
+  );
+
+  const refresh = useCallback(() => {
+    setHistory(readCwdHistory());
+    setUsage(readCwdHistoryUsage());
+  }, []);
+
+  const add = useCallback(
+    (cwd: string) => {
+      addToCwdHistory(cwd);
+      refresh();
+    },
+    [refresh]
+  );
+
+  const remove = useCallback(
+    (cwd: string) => {
+      removeCwdFromHistory(cwd);
+      refresh();
+    },
+    [refresh]
+  );
+
+  return {
+    history: mergedHistory,
+    removableHistory: history,
+    historyMetadata,
+    add,
+    remove,
+    refresh,
+  };
 }
 
 export function useCreateAgentPrefs(cwd: string) {

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -17,14 +17,12 @@ import {
   startupFileKey,
 } from "@/components/app/create-agent-dialog-clipboard";
 import {
-  addToCwdHistory,
   CONTEXT_PROMPT_ID,
   LAST_USED_CWD_KEY,
   LAST_USED_TYPE_KEY,
-  readCwdHistory,
   readLastUsedAgentType,
   readLastUsedCwd,
-  removeCwdFromHistory,
+  useCwdHistory,
   useCreateAgentPrefs,
 } from "@/components/app/create-agent-dialog-utils";
 import { WorktreeSection } from "@/components/app/create-agent-worktree-section";
@@ -123,9 +121,13 @@ function CreateAgentDialogContent({
   const [draggingFiles, setDraggingFiles] = useState(false);
   const [contextDraftInvalid, setContextDraftInvalid] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [cwdHistory, setCwdHistory] = useState<string[]>(() =>
-    readCwdHistory()
-  );
+  const {
+    history: cwdHistory,
+    removableHistory: removableCwdHistory,
+    historyMetadata: cwdHistoryMetadata,
+    add: addCwdHistory,
+    remove: removeCwdHistory,
+  } = useCwdHistory();
   const {
     fullAccess: createFullAccess,
     setFullAccess: setCreateFullAccess,
@@ -190,10 +192,6 @@ function CreateAgentDialogContent({
   const typeTriggerRef = useRef<HTMLButtonElement>(null);
   const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
   useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
-
-  const handleRemoveCwdHistory = useCallback((cwd: string) => {
-    setCwdHistory(removeCwdFromHistory(cwd));
-  }, []);
 
   const handlePathInfoChange = useCallback(
     (info: { isGitRepo: boolean } | null) => {
@@ -379,7 +377,7 @@ function CreateAgentDialogContent({
           window.localStorage.setItem(LAST_USED_CWD_KEY, cwd);
           window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
         }
-        setCwdHistory(addToCwdHistory(cwd));
+        addCwdHistory(cwd);
         await onCreated(payload.agent, createType);
       } finally {
         setCreating(false);
@@ -396,6 +394,7 @@ function CreateAgentDialogContent({
       createUseWorktree,
       createWorktreeBranch,
       initialPrompt,
+      addCwdHistory,
       onCreated,
       startupFiles,
       startupLinks,
@@ -403,7 +402,7 @@ function CreateAgentDialogContent({
     ]
   );
 
-  const worktreeAvailable = cwdIsGitRepo !== false;
+  const worktreeAvailable = cwdIsGitRepo === true;
   const worktreeChecked = worktreeAvailable && createUseWorktree;
 
   return (
@@ -537,7 +536,9 @@ function CreateAgentDialogContent({
                   onChange={setCreateCwd}
                   label="Working directory"
                   history={cwdHistory}
-                  onRemoveHistory={handleRemoveCwdHistory}
+                  removableHistory={removableCwdHistory}
+                  historyMetadata={cwdHistoryMetadata}
+                  onRemoveHistory={removeCwdHistory}
                   onPathInfoChange={handlePathInfoChange}
                   data-testid="create-agent-cwd"
                   historyItemTestId="create-agent-cwd-history-option"

--- a/apps/web/src/components/app/create-agent-worktree-section.tsx
+++ b/apps/web/src/components/app/create-agent-worktree-section.tsx
@@ -78,6 +78,7 @@ export function WorktreeSection({
         </span>
       </label>
       <div
+        aria-disabled={controlsDisabled}
         className={cn(
           "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
           branchOptionsEnabled
@@ -99,7 +100,10 @@ export function WorktreeSection({
               testIdPrefix="create-agent"
               disabled={controlsDisabled}
             />
-            <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
+            <div
+              aria-disabled={controlsDisabled}
+              className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3"
+            >
               <label
                 className={cn(
                   "flex items-start gap-3",
@@ -127,6 +131,7 @@ export function WorktreeSection({
                 </span>
               </label>
               <div
+                aria-disabled={controlsDisabled || !newBranchChecked}
                 className={cn(
                   "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
                   newBranchChecked

--- a/apps/web/src/components/app/create-agent-worktree-section.tsx
+++ b/apps/web/src/components/app/create-agent-worktree-section.tsx
@@ -32,6 +32,10 @@ export function WorktreeSection({
   createNewBranch,
   onCreateNewBranchChange,
 }: WorktreeSectionProps): JSX.Element {
+  const controlsDisabled = !worktreeAvailable || !worktreeChecked;
+  const branchOptionsEnabled = worktreeAvailable && worktreeChecked;
+  const newBranchChecked = branchOptionsEnabled && createNewBranch;
+
   return (
     <div
       className={cn(
@@ -48,7 +52,10 @@ export function WorktreeSection({
       >
         <Checkbox
           checked={worktreeChecked}
-          onCheckedChange={() => onUseWorktreeChange(!useWorktree)}
+          onCheckedChange={() => {
+            const nextUseWorktree = !useWorktree;
+            onUseWorktreeChange(nextUseWorktree);
+          }}
           disabled={!worktreeAvailable}
           className="mt-0.5"
           title={
@@ -73,14 +80,12 @@ export function WorktreeSection({
       <div
         className={cn(
           "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-          worktreeChecked
+          branchOptionsEnabled
             ? "grid-rows-[1fr] opacity-100"
-            : "grid-rows-[0fr] opacity-0"
+            : "grid-rows-[1fr] opacity-60"
         )}
-        aria-hidden={!worktreeChecked}
-        {...(!worktreeChecked ? ({ inert: "" } as Record<string, string>) : {})}
       >
-        <div className="min-h-0 overflow-hidden">
+        <div className="min-h-0">
           <div className="ml-8 w-[calc(100%-2rem)] space-y-3 pt-1">
             <BranchSelect
               cwd={cwd}
@@ -92,17 +97,24 @@ export function WorktreeSection({
               baseBranchHelper="The branch to check out in the worktree."
               showNewBranchInput={false}
               testIdPrefix="create-agent"
+              disabled={controlsDisabled}
             />
             <div className="space-y-2 rounded-md border border-border/60 bg-background/40 px-3 py-3">
-              <label className="flex cursor-pointer items-start gap-3">
+              <label
+                className={cn(
+                  "flex items-start gap-3",
+                  controlsDisabled ? "cursor-not-allowed" : "cursor-pointer"
+                )}
+              >
                 <Checkbox
-                  checked={createNewBranch}
+                  checked={newBranchChecked}
                   onCheckedChange={() =>
                     onCreateNewBranchChange(!createNewBranch)
                   }
                   className="mt-0.5"
                   title="Toggle new branch creation"
                   data-testid="create-agent-new-branch"
+                  disabled={controlsDisabled}
                 />
                 <span className="space-y-1">
                   <span className="block text-sm font-medium text-foreground">
@@ -117,16 +129,12 @@ export function WorktreeSection({
               <div
                 className={cn(
                   "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
-                  createNewBranch
+                  newBranchChecked
                     ? "grid-rows-[1fr] opacity-100"
-                    : "grid-rows-[0fr] opacity-0"
+                    : "grid-rows-[1fr] opacity-60"
                 )}
-                aria-hidden={!createNewBranch}
-                {...(!createNewBranch
-                  ? ({ inert: "" } as Record<string, string>)
-                  : {})}
               >
-                <div className="min-h-0 overflow-hidden">
+                <div className="min-h-0">
                   <div className="space-y-1 pt-2">
                     <label className="block text-xs text-muted-foreground">
                       New branch name
@@ -138,6 +146,7 @@ export function WorktreeSection({
                       }
                       placeholder="auto-generated if empty"
                       data-testid="create-agent-worktree-branch"
+                      disabled={controlsDisabled || !newBranchChecked}
                     />
                   </div>
                 </div>

--- a/apps/web/src/components/app/design-lab.tsx
+++ b/apps/web/src/components/app/design-lab.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { THEMES, useTheme, type ThemeId } from "@/hooks/use-theme";
+import { PathInput } from "@/components/app/path-input";
 
 // Canvas for one-off component experiments. Add sections below as needed and
 // remove them once the work ships — this page intentionally stays empty
@@ -46,6 +47,15 @@ function ThemePicker({
 
 export function DesignLab() {
   const { theme, setTheme } = useTheme();
+  const [cwd, setCwd] = useState("~/dev/apps/dispatch");
+
+  const projectHistory = [
+    "~/dev/apps/dispatch",
+    "~/dev/apps/dispatch-ios",
+    "~/dev/tools/codex",
+    "~/work/customer-portal",
+    "~/experiments/agent-sandbox",
+  ];
 
   useEffect(() => {
     const style = document.createElement("style");
@@ -66,7 +76,7 @@ export function DesignLab() {
           </h1>
           <p className="text-sm text-muted-foreground">
             Sandbox for previewing component variations against different
-            themes. Currently empty — add experiments as sections below.
+            themes.
           </p>
         </header>
 
@@ -74,14 +84,69 @@ export function DesignLab() {
           <ThemePicker theme={theme} setTheme={setTheme} />
         </div>
 
-        <div className="rounded-xl border border-dashed border-border bg-card/30 px-8 py-16 text-center">
-          <p className="text-sm text-muted-foreground">
-            No active experiments. Add a section to{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">
-              apps/web/src/components/app/design-lab.tsx
-            </code>{" "}
-            to preview a component.
-          </p>
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,520px)_minmax(0,1fr)]">
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">
+                Working Directory Input
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Shared input used by agents, templates, and jobs.
+              </p>
+            </div>
+
+            <PathInput
+              value={cwd}
+              onChange={setCwd}
+              label="Working directory"
+              history={projectHistory}
+              historyMetadata={{
+                "~/dev/apps/dispatch": {
+                  label: "dispatch",
+                  usageCount: 32,
+                  iconUrl: "/icons/teal/brand-icon.svg",
+                },
+                "~/dev/apps/dispatch-ios": {
+                  label: "dispatch-ios",
+                  usageCount: 11,
+                },
+                "~/dev/tools/codex": {
+                  label: "codex",
+                  usageCount: 18,
+                },
+                "~/work/customer-portal": {
+                  label: "customer-portal",
+                  usageCount: 7,
+                },
+                "~/experiments/agent-sandbox": {
+                  label: "agent-sandbox",
+                  usageCount: 3,
+                },
+              }}
+              onRemoveHistory={() => undefined}
+              data-testid="design-lab-path-input"
+              historyItemTestId="design-lab-path-option"
+            />
+          </section>
+
+          <section className="space-y-3 text-sm text-muted-foreground">
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+              Interaction Targets
+            </h2>
+            <div className="rounded-md border border-border bg-card/50 p-4">
+              <ul className="list-disc space-y-2 pl-5">
+                <li>
+                  Tab accepts the inline completion without adding a slash.
+                </li>
+                <li>Arrow up/down moves through project rows.</li>
+                <li>Enter or Space selects the highlighted project.</li>
+                <li>
+                  Frequently used projects sort above recent-but-rare ones.
+                </li>
+                <li>Known projects can render as compact names with icons.</li>
+              </ul>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/app/jobs-add-dialog.tsx
+++ b/apps/web/src/components/app/jobs-add-dialog.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, X } from "lucide-react";
 import { useState } from "react";
 
 import { PathInput } from "@/components/app/path-input";
+import { useCwdHistory } from "@/components/app/create-agent-dialog-utils";
 import {
   JobFullAccessOption,
   JobKeepAgentOption,
@@ -106,6 +107,13 @@ export function AddJobFlow({
   const [enableImmediately, setEnableImmediately] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const {
+    history: cwdHistory,
+    removableHistory: removableCwdHistory,
+    historyMetadata: cwdHistoryMetadata,
+    add: addCwdHistory,
+    remove: removeCwdHistory,
+  } = useCwdHistory();
   const effectiveEnabled = schedule.trim() ? enableImmediately : false;
   const scheduleError = cronError(schedule, effectiveEnabled);
   const canAdd =
@@ -154,6 +162,10 @@ export function AddJobFlow({
                   label=""
                   placeholder="~/code/project"
                   id="job-directory"
+                  history={cwdHistory}
+                  removableHistory={removableCwdHistory}
+                  historyMetadata={cwdHistoryMetadata}
+                  onRemoveHistory={removeCwdHistory}
                   data-testid="job-directory-input"
                 />
               </div>
@@ -382,9 +394,10 @@ export function AddJobFlow({
           disabled={!canAdd || isAdding}
           onClick={() => {
             setSubmitError(null);
+            const trimmedDirectory = directory.trim();
             void onAddJob({
               name: displayName.trim(),
-              directory: directory.trim(),
+              directory: trimmedDirectory,
               displayName: displayName.trim(),
               prompt: prompt.trim(),
               schedule: schedule.trim() || null,
@@ -399,7 +412,9 @@ export function AddJobFlow({
               callable,
               singleton,
               enabled: effectiveEnabled,
-            }).catch((error) => setSubmitError(errorMessage(error)));
+            })
+              .then(() => addCwdHistory(trimmedDirectory))
+              .catch((error) => setSubmitError(errorMessage(error)));
           }}
         >
           {isAdding ? <ActivityBars size={16} className="mr-2" /> : null}

--- a/apps/web/src/components/app/path-input-utils.ts
+++ b/apps/web/src/components/app/path-input-utils.ts
@@ -1,0 +1,79 @@
+export type PathHistoryMetadata = {
+  label?: string;
+  usageCount?: number;
+  iconUrl?: string;
+};
+
+export type HistoryOption = {
+  path: string;
+  label: string;
+  usageCount: number;
+  iconUrl?: string;
+  originalIndex: number;
+};
+
+export function displayPathLabel(path: string): string {
+  const normalized = path.replace(/\/$/, "");
+  const parts = normalized.split("/").filter(Boolean);
+  return (parts.at(-1) ?? normalized) || path;
+}
+
+export function ghostCompletionSuffix(
+  value: string,
+  completion: string
+): string {
+  const base = value.replace(/\/$/, "");
+  if (!completion.startsWith(base)) return "";
+  let suffix = completion.slice(base.length);
+  if (value.endsWith("/") && suffix.startsWith("/")) {
+    suffix = suffix.slice(1);
+  }
+  return suffix;
+}
+
+export function acceptGhostCompletion(value: string, suffix: string): string {
+  return value + suffix;
+}
+
+export function getHistoryOptions(
+  history: string[],
+  historyMetadata: Record<string, PathHistoryMetadata>
+): HistoryOption[] {
+  return history
+    .map((path, originalIndex) => {
+      const metadata = historyMetadata[path];
+      return {
+        path,
+        label: metadata?.label ?? displayPathLabel(path),
+        usageCount: metadata?.usageCount ?? 0,
+        iconUrl: metadata?.iconUrl,
+        originalIndex,
+      };
+    })
+    .sort((left, right) => {
+      if (right.usageCount !== left.usageCount) {
+        return right.usageCount - left.usageCount;
+      }
+      return left.originalIndex - right.originalIndex;
+    });
+}
+
+export function filterHistoryOptions(
+  options: HistoryOption[],
+  query: string
+): HistoryOption[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return options;
+
+  return options.filter((option) => {
+    const label = option.label.toLowerCase();
+    const path = option.path.toLowerCase();
+    const pathSegments = path.split("/").filter(Boolean);
+
+    return (
+      label.includes(trimmed) ||
+      path.includes(trimmed) ||
+      pathSegments.some((segment) => segment.includes(trimmed))
+    );
+  });
+}

--- a/apps/web/src/components/app/path-input.test.ts
+++ b/apps/web/src/components/app/path-input.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acceptGhostCompletion,
+  filterHistoryOptions,
+  getHistoryOptions,
+  ghostCompletionSuffix,
+} from "./path-input-utils";
+
+describe("path input completion", () => {
+  it("accepts a directory completion without appending a trailing slash", () => {
+    const suffix = ghostCompletionSuffix("~/dev/apps", "~/dev/apps/dispatch");
+
+    expect(acceptGhostCompletion("~/dev/apps", suffix)).toBe(
+      "~/dev/apps/dispatch"
+    );
+  });
+
+  it("does not duplicate a slash when completing inside a typed directory", () => {
+    const suffix = ghostCompletionSuffix("~/dev/apps/", "~/dev/apps/dispatch");
+
+    expect(acceptGhostCompletion("~/dev/apps/", suffix)).toBe(
+      "~/dev/apps/dispatch"
+    );
+  });
+});
+
+describe("path input history", () => {
+  it("sorts frequently used projects before recent entries", () => {
+    const options = getHistoryOptions(
+      ["~/work/customer-portal", "~/dev/apps/dispatch", "~/dev/tools/codex"],
+      {
+        "~/work/customer-portal": { usageCount: 7 },
+        "~/dev/apps/dispatch": { usageCount: 32, label: "dispatch" },
+        "~/dev/tools/codex": { usageCount: 18 },
+      }
+    );
+
+    expect(options.map((option) => option.path)).toEqual([
+      "~/dev/apps/dispatch",
+      "~/dev/tools/codex",
+      "~/work/customer-portal",
+    ]);
+    expect(options[0].label).toBe("dispatch");
+  });
+
+  it("falls back to recent order when usage counts match", () => {
+    const options = getHistoryOptions(["~/a", "~/b"], {});
+
+    expect(options.map((option) => option.path)).toEqual(["~/a", "~/b"]);
+  });
+
+  it("filters by compact project label", () => {
+    const options = getHistoryOptions(
+      ["~/dev/apps/dispatch", "~/tools/codex"],
+      {
+        "~/dev/apps/dispatch": { label: "dispatch", usageCount: 4 },
+        "~/tools/codex": { label: "codex", usageCount: 9 },
+      }
+    );
+
+    expect(
+      filterHistoryOptions(options, "dispatch").map((option) => option.path)
+    ).toEqual(["~/dev/apps/dispatch"]);
+  });
+
+  it("filters by full path prefix or segment", () => {
+    const options = getHistoryOptions(
+      ["~/dev/apps/dispatch", "~/work/customer-portal"],
+      {}
+    );
+
+    expect(
+      filterHistoryOptions(options, "~/dev/apps").map((option) => option.path)
+    ).toEqual(["~/dev/apps/dispatch"]);
+    expect(
+      filterHistoryOptions(options, "customer").map((option) => option.path)
+    ).toEqual(["~/work/customer-portal"]);
+  });
+});

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -109,11 +109,19 @@ export function PathInput({
   }, [filteredHistoryOptions, projectSuggestionOptions]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const projectSuggestionsRequestRef = useRef(0);
+  const listboxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!dropdownOpen) return;
     setSelectedIndex(0);
   }, [dropdownOpen, options.length, historyFilter]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    listboxRef.current
+      ?.querySelector('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [dropdownOpen, selectedIndex]);
 
   const selectOption = useCallback(
     (option: HistoryOption) => {
@@ -352,11 +360,7 @@ export function PathInput({
                 }
                 setSelectedIndex((index) => Math.max(index - 1, 0));
               }
-              if (
-                (e.key === "Enter" || e.key === " ") &&
-                dropdownOpen &&
-                selectedOption
-              ) {
+              if (e.key === "Enter" && dropdownOpen && selectedOption) {
                 e.preventDefault();
                 e.stopPropagation();
                 selectOption(selectedOption);
@@ -398,6 +402,7 @@ export function PathInput({
               Suggestions
             </div>
             <div
+              ref={listboxRef}
               role="listbox"
               className="max-h-[240px] overflow-y-auto overflow-x-hidden"
             >
@@ -425,18 +430,7 @@ export function PathInput({
                     onMouseMove={() => setSelectedIndex(index)}
                   >
                     <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded border border-border/70 bg-muted/40">
-                      {option.iconUrl ? (
-                        <img
-                          src={option.iconUrl}
-                          alt=""
-                          onError={(event) => {
-                            event.currentTarget.style.display = "none";
-                          }}
-                          className="h-4 w-4 object-contain"
-                        />
-                      ) : (
-                        <FolderGit2 className="h-3.5 w-3.5 text-muted-foreground" />
-                      )}
+                      <PathOptionIcon iconUrl={option.iconUrl} />
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm font-medium leading-4">
@@ -517,4 +511,21 @@ export function PathInput({
       ) : null}
     </div>
   );
+}
+
+function PathOptionIcon({ iconUrl }: { iconUrl?: string }): JSX.Element {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  if (iconUrl && !imageFailed) {
+    return (
+      <img
+        src={iconUrl}
+        alt=""
+        onError={() => setImageFailed(true)}
+        className="h-4 w-4 object-contain"
+      />
+    );
+  }
+
+  return <FolderGit2 className="h-3.5 w-3.5 text-muted-foreground" />;
 }

--- a/apps/web/src/components/app/path-input.tsx
+++ b/apps/web/src/components/app/path-input.tsx
@@ -3,17 +3,20 @@ import {
   AlertCircle,
   CheckCircle2,
   ChevronDown,
+  FolderGit2,
   GitBranch,
   X,
 } from "lucide-react";
 
 import { ActivityBars } from "@/components/ui/activity-bars";
 import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+  acceptGhostCompletion,
+  filterHistoryOptions,
+  getHistoryOptions,
+  ghostCompletionSuffix,
+  type HistoryOption,
+  type PathHistoryMetadata,
+} from "@/components/app/path-input-utils";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -33,6 +36,10 @@ type PathInputProps = {
   showValidation?: boolean;
   /** Recent directory history for dropdown */
   history?: string[];
+  /** History entries that can be removed from this client. Defaults to history. */
+  removableHistory?: string[];
+  /** Extra presentation data for history entries, keyed by full path. */
+  historyMetadata?: Record<string, PathHistoryMetadata>;
   /** Called when a history entry is removed */
   onRemoveHistory?: (dir: string) => void;
   /**
@@ -59,6 +66,8 @@ export function PathInput({
   placeholder = "~/path/to/project",
   showValidation = true,
   history = [],
+  removableHistory,
+  historyMetadata = {},
   onRemoveHistory,
   onPathInfoChange,
   label,
@@ -72,37 +81,134 @@ export function PathInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const closeDropdown = useCallback(() => setDropdownOpen(false), []);
   useClickOutside(cmdRef, dropdownOpen, closeDropdown);
-  const sortedHistory = useMemo(
-    () => [...history].sort((left, right) => left.localeCompare(right)),
-    [history]
+  const [historyFilter, setHistoryFilter] = useState("");
+  const historyOptions = useMemo<HistoryOption[]>(
+    () => getHistoryOptions(history, historyMetadata),
+    [history, historyMetadata]
+  );
+  const filteredHistoryOptions = useMemo<HistoryOption[]>(
+    () => filterHistoryOptions(historyOptions, historyFilter),
+    [historyOptions, historyFilter]
+  );
+  const [projectSuggestionOptions, setProjectSuggestionOptions] = useState<
+    HistoryOption[]
+  >([]);
+  const removableHistoryPathSet = useMemo(
+    () => new Set(removableHistory ?? history),
+    [history, removableHistory]
+  );
+  const options = useMemo<HistoryOption[]>(() => {
+    const seen = new Set<string>();
+    return [...filteredHistoryOptions, ...projectSuggestionOptions].filter(
+      (option) => {
+        if (seen.has(option.path)) return false;
+        seen.add(option.path);
+        return true;
+      }
+    );
+  }, [filteredHistoryOptions, projectSuggestionOptions]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const projectSuggestionsRequestRef = useRef(0);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    setSelectedIndex(0);
+  }, [dropdownOpen, options.length, historyFilter]);
+
+  const selectOption = useCallback(
+    (option: HistoryOption) => {
+      onChange(option.path);
+      setDropdownOpen(false);
+      inputRef.current?.focus();
+    },
+    [onChange]
   );
 
   // --- Path validation state ---
   const [pathValidation, setPathValidation] = useState<PathInfo | null>(null);
   const [validating, setValidating] = useState(false);
+  const validationRequestRef = useRef(0);
 
   // --- Inline ghost autocomplete ---
   const [ghostSuffix, setGhostSuffix] = useState("");
+  const completionRequestRef = useRef(0);
+
+  // Debounced project suggestions from agent history. This is intentionally
+  // separate from filesystem path completions: the dropdown shows known
+  // projects, while arbitrary full paths still validate and can use Tab.
+  useEffect(() => {
+    if (!dropdownOpen) {
+      projectSuggestionsRequestRef.current += 1;
+      setProjectSuggestionOptions([]);
+      return;
+    }
+
+    const requestId = ++projectSuggestionsRequestRef.current;
+    const query = historyFilter.trim();
+    const timer = setTimeout(() => {
+      const params = new URLSearchParams({ limit: "20" });
+      if (query) params.set("search", query);
+
+      api<{
+        projectOptions?: Array<{
+          path: string;
+          usageCount: number;
+          iconUrl?: string;
+        }>;
+        projects: string[];
+      }>(`/api/v1/history/projects?${params.toString()}`)
+        .then((payload) => {
+          if (requestId !== projectSuggestionsRequestRef.current) return;
+          const metadata = Object.fromEntries(
+            (payload.projectOptions ?? []).map((option) => [
+              option.path,
+              {
+                usageCount: option.usageCount,
+                iconUrl: option.iconUrl,
+              },
+            ])
+          );
+          setProjectSuggestionOptions(
+            getHistoryOptions(payload.projects, metadata)
+          );
+        })
+        .catch(() => {
+          if (requestId === projectSuggestionsRequestRef.current) {
+            setProjectSuggestionOptions([]);
+          }
+        });
+    }, 120);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [dropdownOpen, historyFilter]);
 
   // Debounced path validation
   useEffect(() => {
     const trimmed = value.trim();
     if (!trimmed) {
+      validationRequestRef.current += 1;
       setPathValidation(null);
       onPathInfoChange?.(null);
       return;
     }
     if (!showValidation) return;
+    const requestId = ++validationRequestRef.current;
     // Treat the path as unknown until the new validation lands so callers
     // don't act on stale info from the previous value during the debounce.
     setPathValidation(null);
     onPathInfoChange?.(null);
     setValidating(true);
     const timer = setTimeout(() => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
       api<PathInfo & { resolvedPath: string }>(
-        `/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`
+        `/api/v1/system/path-info?path=${encodeURIComponent(trimmed)}`,
+        { signal: controller.signal }
       )
         .then((result) => {
+          if (requestId !== validationRequestRef.current) return;
           if (result.privacyRestricted) {
             setPathValidation(null);
             onPathInfoChange?.(null);
@@ -117,13 +223,20 @@ export function PathInput({
           onPathInfoChange?.(info);
         })
         .catch(() => {
+          if (requestId !== validationRequestRef.current) return;
           setPathValidation(null);
           onPathInfoChange?.(null);
         })
-        .finally(() => setValidating(false));
+        .finally(() => {
+          clearTimeout(timeout);
+          if (requestId === validationRequestRef.current) {
+            setValidating(false);
+          }
+        });
     }, 400);
     return () => {
       clearTimeout(timer);
+      validationRequestRef.current += 1;
       setValidating(false);
     };
   }, [value, showValidation, onPathInfoChange]);
@@ -132,36 +245,39 @@ export function PathInput({
   useEffect(() => {
     const trimmed = value.trim();
     if (!trimmed || (!trimmed.startsWith("/") && !trimmed.startsWith("~"))) {
+      completionRequestRef.current += 1;
       setGhostSuffix("");
       return;
     }
+    const requestId = ++completionRequestRef.current;
+    setGhostSuffix("");
     const timer = setTimeout(() => {
       api<{ completions: string[]; privacyRestricted?: boolean }>(
         `/api/v1/system/path-completions?prefix=${encodeURIComponent(trimmed)}`
       )
         .then((result) => {
+          if (requestId !== completionRequestRef.current) return;
           if (result.privacyRestricted) {
             setGhostSuffix("");
             return;
           }
           if (result.completions.length > 0) {
-            const best = result.completions[0];
-            if (best.startsWith(trimmed.replace(/\/$/, ""))) {
-              let suffix = best.slice(trimmed.replace(/\/$/, "").length);
-              if (trimmed.endsWith("/") && suffix.startsWith("/")) {
-                suffix = suffix.slice(1);
-              }
-              setGhostSuffix(suffix);
-            } else {
-              setGhostSuffix("");
-            }
+            setGhostSuffix(
+              ghostCompletionSuffix(trimmed, result.completions[0])
+            );
           } else {
             setGhostSuffix("");
           }
         })
-        .catch(() => setGhostSuffix(""));
+        .catch(() => {
+          if (requestId === completionRequestRef.current) {
+            setGhostSuffix("");
+          }
+        });
     }, 150);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+    };
   }, [value]);
 
   return (
@@ -193,31 +309,62 @@ export function PathInput({
             ref={inputRef}
             id={id}
             value={value}
+            aria-expanded={dropdownOpen}
+            aria-haspopup="listbox"
+            aria-activedescendant={
+              dropdownOpen && options[selectedIndex]
+                ? `${id ?? testId ?? "path-input"}-option-${selectedIndex}`
+                : undefined
+            }
             onChange={(event) => {
-              onChange(event.target.value);
-              if (history.length > 0) {
-                setDropdownOpen(true);
-              }
+              const nextValue = event.target.value;
+              onChange(nextValue);
+              setHistoryFilter(nextValue);
+              setDropdownOpen(true);
+            }}
+            onFocus={() => {
+              setHistoryFilter("");
+              setDropdownOpen(true);
             }}
             onKeyDown={(e) => {
+              const selectedOption = options[selectedIndex];
               if (e.key === "Escape" && dropdownOpen) {
                 e.preventDefault();
                 e.stopPropagation();
                 setDropdownOpen(false);
               }
+              if (e.key === "ArrowDown" && options.length > 0) {
+                e.preventDefault();
+                if (!dropdownOpen) {
+                  setDropdownOpen(true);
+                  return;
+                }
+                setSelectedIndex((index) =>
+                  Math.min(index + 1, options.length - 1)
+                );
+              }
+              if (e.key === "ArrowUp" && options.length > 0) {
+                e.preventDefault();
+                if (!dropdownOpen) {
+                  setDropdownOpen(true);
+                  setSelectedIndex(options.length - 1);
+                  return;
+                }
+                setSelectedIndex((index) => Math.max(index - 1, 0));
+              }
               if (
-                (e.key === "Enter" || e.key === "ArrowDown") &&
-                !dropdownOpen &&
-                history.length > 0
+                (e.key === "Enter" || e.key === " ") &&
+                dropdownOpen &&
+                selectedOption
               ) {
                 e.preventDefault();
-                setDropdownOpen(true);
+                e.stopPropagation();
+                selectOption(selectedOption);
               }
               if (e.key === "Tab" && ghostSuffix) {
                 e.preventDefault();
                 e.stopPropagation();
-                const accepted = value.replace(/\/$/, "") + ghostSuffix + "/";
-                onChange(accepted);
+                onChange(acceptGhostCompletion(value, ghostSuffix));
                 setGhostSuffix("");
               }
             }}
@@ -245,52 +392,86 @@ export function PathInput({
             </button>
           ) : null}
         </div>
-        {dropdownOpen && sortedHistory.length > 0 ? (
-          <div className="absolute left-0 right-0 z-[60] mt-1.5 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] backdrop-blur-2xl p-1 shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)]">
-            <Command
-              shouldFilter={false}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  setDropdownOpen(false);
-                  inputRef.current?.focus();
-                }
-              }}
+        {dropdownOpen && options.length > 0 ? (
+          <div className="absolute left-0 right-0 z-[60] mt-1.5 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] p-1 shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
+            <div className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+              Suggestions
+            </div>
+            <div
+              role="listbox"
+              className="max-h-[240px] overflow-y-auto overflow-x-hidden"
             >
-              <CommandList>
-                <CommandGroup heading="Recent">
-                  {sortedHistory.map((dir) => (
-                    <CommandItem
-                      key={dir}
-                      value={dir}
-                      data-testid={historyItemTestId}
-                      className="group font-mono text-xs"
-                      onSelect={() => {
-                        onChange(dir);
-                        setDropdownOpen(false);
-                        inputRef.current?.focus();
-                      }}
-                    >
-                      <span className="truncate">{dir}</span>
-                      {onRemoveHistory ? (
-                        <button
-                          type="button"
-                          className="ml-auto shrink-0 p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-data-[selected=true]:opacity-100"
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            onRemoveHistory(dir);
+              {options.map((option, index) => {
+                const selected = index === selectedIndex;
+                const isRemovableOption = removableHistoryPathSet.has(
+                  option.path
+                );
+                return (
+                  <div
+                    key={option.path}
+                    id={`${id ?? testId ?? "path-input"}-option-${index}`}
+                    role="option"
+                    aria-selected={selected}
+                    data-testid={historyItemTestId}
+                    data-selected={selected}
+                    className={cn(
+                      "group flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-xs outline-none",
+                      selected && "bg-primary/20 text-foreground"
+                    )}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      selectOption(option);
+                    }}
+                    onMouseMove={() => setSelectedIndex(index)}
+                  >
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded border border-border/70 bg-muted/40">
+                      {option.iconUrl ? (
+                        <img
+                          src={option.iconUrl}
+                          alt=""
+                          onError={(event) => {
+                            event.currentTarget.style.display = "none";
                           }}
-                          title="Remove from history"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      ) : null}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
+                          className="h-4 w-4 object-contain"
+                        />
+                      ) : (
+                        <FolderGit2 className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium leading-4">
+                        {option.label}
+                      </span>
+                      <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                        {option.path}
+                      </span>
+                    </span>
+                    {option.usageCount > 0 ? (
+                      <span
+                        className="shrink-0 rounded border border-border/70 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                        title={`${option.usageCount} uses`}
+                      >
+                        {option.usageCount}
+                      </span>
+                    ) : null}
+                    {onRemoveHistory && isRemovableOption ? (
+                      <button
+                        type="button"
+                        className="ml-auto shrink-0 p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-data-[selected=true]:opacity-100"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onRemoveHistory(option.path);
+                        }}
+                        title="Remove from history"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
           </div>
         ) : null}
       </div>

--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -77,6 +77,14 @@ test.describe("Create agent dialog", () => {
       "data-selected",
       "true"
     );
+    await cwdInput.press(" ");
+    await expect(cwdInput).toHaveValue("myapp ");
+
+    await cwdInput.fill("myapp");
+    await expect(recentOptions.first()).toHaveAttribute(
+      "data-selected",
+      "true"
+    );
     await cwdInput.press("Enter");
     await expect(cwdInput).toHaveValue("/home/user/projects/myapp");
 

--- a/e2e/create-agent-dropdown.spec.ts
+++ b/e2e/create-agent-dropdown.spec.ts
@@ -48,7 +48,7 @@ test.describe("Create agent dialog", () => {
     await expect(form).not.toBeVisible({ timeout: 3_000 });
   });
 
-  test("recent directories remain visible while typing a new path", async ({
+  test("recent directories filter by typed project name or path", async ({
     page,
   }) => {
     await page.addInitScript(() => {
@@ -65,16 +65,24 @@ test.describe("Create agent dialog", () => {
     await expect(form).toBeVisible();
 
     const cwdInput = form.getByTestId("create-agent-cwd");
-    await cwdInput.fill("/brand/new/path");
+    await cwdInput.fill("myapp");
     const recentOptions = form.getByTestId("create-agent-cwd-history-option");
 
+    await expect(recentOptions).toHaveCount(1);
+    await expect(recentOptions.first()).toContainText("myapp");
+    await expect(cwdInput).toHaveValue("myapp");
+
+    await cwdInput.press("ArrowDown");
+    await expect(recentOptions.first()).toHaveAttribute(
+      "data-selected",
+      "true"
+    );
+    await cwdInput.press("Enter");
+    await expect(cwdInput).toHaveValue("/home/user/projects/myapp");
+
+    await cwdInput.fill("/tmp");
     await expect(
-      page.getByRole("option", { name: "/home/user/projects/myapp" })
+      recentOptions.filter({ hasText: "/tmp/existing-project" })
     ).toBeVisible();
-    await expect(
-      page.getByRole("option", { name: "/tmp/existing-project" })
-    ).toBeVisible();
-    await expect(recentOptions).toHaveCount(2);
-    await expect(cwdInput).toHaveValue("/brand/new/path");
   });
 });


### PR DESCRIPTION
## Summary
- Replace local-only working directory suggestions with API-backed project history sorted by usage and recency.
- Reuse the shared path input across agent creation, templates, template detail, and job creation.
- Improve keyboard navigation, focus behavior, filtered suggestions, and Tab ghost completion behavior.
- Keep the managed worktree section layout stable and derive nested branch control state from the effective worktree state.

## Impact
Users can type a known project name like `dispatch` and choose a frequently used project root, while still typing arbitrary full paths. The create-agent worktree controls no longer jump or show misleading checked disabled states.

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e` (160 passed, 12 skipped)
- Playwright validation of the create-agent working directory dropdown and worktree control states