### PR TITLE
Fix brain value display: no clipping, responsive containers

### DIFF
--- a/apps/web/src/components/app/brain-cards.tsx
+++ b/apps/web/src/components/app/brain-cards.tsx
@@ -126,23 +126,8 @@ export function formatPrimitive(v: unknown): {
   if (typeof v === "string") {
     return { text: `"${v}"`, className: "text-emerald-400" };
   }
-  if (Array.isArray(v)) {
-    const inner = v
-      .slice(0, 3)
-      .map((item) =>
-        typeof item === "string"
-          ? `"${item.length > 30 ? item.slice(0, 27) + "…" : item}"`
-          : JSON.stringify(item)
-      );
-    const suffix = v.length > 3 ? `, …+${v.length - 3}` : "";
-    return {
-      text: `[${inner.join(", ")}${suffix}]`,
-      className: "text-muted-foreground",
-    };
-  }
-  const keys = Object.keys(v as Record<string, unknown>);
   return {
-    text: `{${keys.slice(0, 3).join(", ")}${keys.length > 3 ? ", …" : ""}}`,
+    text: JSON.stringify(v),
     className: "text-muted-foreground",
   };
 }
@@ -172,7 +157,9 @@ export function KeyValueTable({ value }: { value: unknown }): JSX.Element {
             className="flex gap-2 text-xs font-mono leading-relaxed min-w-0"
           >
             <span className="text-sky-400 shrink-0">{key}</span>
-            <span className={cn(fmt.className, "truncate")}>{fmt.text}</span>
+            <span className={cn(fmt.className, "whitespace-nowrap")}>
+              {fmt.text}
+            </span>
           </div>
         );
       })}
@@ -260,7 +247,7 @@ export function ObjectCard({
           <RelativeTime iso={obj.updatedAt} />
         </div>
       </div>
-      <div className="rounded bg-muted/30 px-2.5 py-2 overflow-hidden">
+      <div className="rounded bg-muted/30 px-2.5 py-2 overflow-x-auto">
         <KeyValueTable
           value={{
             ...(typeof obj.value === "object" &&
@@ -304,7 +291,7 @@ function ListItemRow({
       <span className="text-muted-foreground shrink-0 w-4 text-right pt-px">
         {index}
       </span>
-      <div className="flex-1 min-w-0 overflow-hidden">
+      <div className="flex-1 min-w-0 overflow-x-auto">
         {entries.map(([k, v]) => {
           const fmt = formatPrimitive(v);
           return (
@@ -313,7 +300,9 @@ function ListItemRow({
               className="flex gap-1.5 leading-relaxed min-w-0"
             >
               <span className="text-sky-400 shrink-0">{k as string}:</span>
-              <span className={cn(fmt.className, "truncate")}>{fmt.text}</span>
+              <span className={cn(fmt.className, "whitespace-nowrap")}>
+                {fmt.text}
+              </span>
             </div>
           );
         })}
@@ -431,7 +420,7 @@ export function EventCard({
           <RelativeTime iso={event.createdAt} />
         </div>
       </div>
-      <div className="rounded bg-muted/30 px-2.5 py-2 overflow-hidden">
+      <div className="rounded bg-muted/30 px-2.5 py-2 overflow-x-auto">
         <KeyValueTable value={allEntries} />
       </div>
     </div>

--- a/apps/web/src/components/app/brains-pane.tsx
+++ b/apps/web/src/components/app/brains-pane.tsx
@@ -16,7 +16,6 @@ import {
   EventCard,
 } from "@/components/app/brain-cards";
 import { decodeRepoRoot, encodeRepoRoot } from "@/lib/brain-encoding";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -434,8 +433,8 @@ function BrainCollectionView({
     (objects.length >= 100 || lists.length >= 100 || events.length >= 100);
 
   return (
-    <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
-      <div className="mx-auto max-w-5xl space-y-1 px-1 pt-4 pb-12 sm:px-2 md:px-5 overflow-hidden">
+    <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+      <div className="space-y-1 px-1 pt-4 pb-12 sm:px-2 md:px-5">
         {isCapped && !search ? (
           <div className="mx-3 mb-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
             Showing the first 100 items per section. Select a collection to see
@@ -483,6 +482,6 @@ function BrainCollectionView({
           ))}
         </CollapsibleSection>
       </div>
-    </ScrollArea>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Remove value clipping**: Replace CSS `truncate` (ellipsis) with `whitespace-nowrap` + `overflow-x-auto` on value containers so brain values (objects, lists, events) are horizontally scrollable instead of clipped
- **Show full values**: Replace `formatPrimitive` truncation of arrays (first 3 items, 27-char strings) and objects (first 3 keys) with full `JSON.stringify` output
- **Fix responsive layout**: Replace Radix `ScrollArea` with plain `overflow-y-auto` div to avoid `display:table` wrapper that prevented cards from being constrained to viewport width; remove `max-w-5xl` so cards fill available space

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Web production build passes (`pnpm run finalize:web`)
- [x] All 160 E2E tests pass
- [x] Validated desktop (1200px), tablet (768px), and mobile (375px) viewports
- [x] Confirmed value areas are horizontally scrollable at all viewport sizes
- [x] Cards properly contained within viewport at all widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)