### PR TITLE
Fix agent-routing E2E flake, add feedback routes and release-utils tests

### DIFF
--- a/apps/server/test/feedback-routes.test.ts
+++ b/apps/server/test/feedback-routes.test.ts
@@ -1,0 +1,398 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
+
+import { registerFeedbackRoutes } from "../src/routes/feedback.js";
+
+vi.mock("../src/shared/git/worktree.js", () => ({
+  resolveHeadSha: vi.fn(async () => "abc123"),
+}));
+
+const mockFeedback = {
+  id: 1,
+  agentId: "agt_test1",
+  status: "open",
+  message: "test feedback",
+};
+
+function createMockDeps() {
+  return {
+    agentManager: {
+      getAgent: vi.fn(async () => ({ id: "agt_test1", cwd: "/tmp" })),
+      listFeedback: vi.fn(async () => [mockFeedback]),
+      listFeedbackByParent: vi.fn(async () => [mockFeedback]),
+      updateFeedbackStatus: vi.fn(async () => ({
+        ...mockFeedback,
+        status: "fixed",
+      })),
+    },
+    publishUiEvent: vi.fn(),
+    handleAgentError: vi.fn((reply: FastifyReply, error: unknown) =>
+      reply.code(500).send({ error: String(error) })
+    ),
+  };
+}
+
+let app: FastifyInstance;
+let deps: ReturnType<typeof createMockDeps>;
+
+beforeAll(async () => {
+  app = Fastify();
+  deps = createMockDeps();
+  await registerFeedbackRoutes(
+    app,
+    deps as unknown as Parameters<typeof registerFeedbackRoutes>[1]
+  );
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deps.agentManager.getAgent.mockResolvedValue({
+    id: "agt_test1",
+    cwd: "/tmp",
+  });
+  deps.agentManager.listFeedback.mockResolvedValue([mockFeedback]);
+  deps.agentManager.listFeedbackByParent.mockResolvedValue([mockFeedback]);
+  deps.agentManager.updateFeedbackStatus.mockResolvedValue({
+    ...mockFeedback,
+    status: "fixed",
+  });
+});
+
+describe("GET /api/v1/agents/:id/feedback", () => {
+  it("returns feedback for a valid agent", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agents/agt_test1/feedback",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ feedback: [mockFeedback] });
+    expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
+    expect(deps.agentManager.listFeedback).toHaveBeenCalledWith("agt_test1");
+  });
+
+  it("returns 404 when agent is not found", async () => {
+    deps.agentManager.getAgent.mockResolvedValue(null);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agents/agt_missing/feedback",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Agent not found." });
+  });
+
+  it("calls listFeedbackByParent when scope=children", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agents/agt_test1/feedback?scope=children",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ feedback: [mockFeedback] });
+    expect(deps.agentManager.listFeedbackByParent).toHaveBeenCalledWith(
+      "agt_test1"
+    );
+    expect(deps.agentManager.getAgent).not.toHaveBeenCalled();
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.agentManager.getAgent.mockRejectedValue(new Error("db fail"));
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agents/agt_test1/feedback",
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
+  it("updates feedback status to dismissed", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "dismissed" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "dismissed",
+      { reason: null, resolutionCommit: null }
+    );
+  });
+
+  it("updates feedback status to forwarded", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "forwarded" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "forwarded",
+      { reason: null, resolutionCommit: null }
+    );
+  });
+
+  it("updates feedback status to open", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "open" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "open",
+      { reason: null, resolutionCommit: null }
+    );
+  });
+
+  it("resolves head sha when status is fixed", async () => {
+    const { resolveHeadSha } = await import("../src/shared/git/worktree.js");
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "fixed" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
+    expect(resolveHeadSha).toHaveBeenCalledWith("/tmp");
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "fixed",
+      { reason: null, resolutionCommit: "abc123" }
+    );
+  });
+
+  it("resolves head sha when status is ignored with reason", async () => {
+    const { resolveHeadSha } = await import("../src/shared/git/worktree.js");
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "ignored", reason: "not relevant" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
+    expect(resolveHeadSha).toHaveBeenCalledWith("/tmp");
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "ignored",
+      { reason: "not relevant", resolutionCommit: "abc123" }
+    );
+  });
+
+  it("does not fetch agent or resolve sha for non-resolving statuses", async () => {
+    const { resolveHeadSha } = await import("../src/shared/git/worktree.js");
+    await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "dismissed" },
+    });
+    expect(deps.agentManager.getAgent).not.toHaveBeenCalled();
+    expect(resolveHeadSha).not.toHaveBeenCalled();
+  });
+
+  it("publishes ui event on successful update", async () => {
+    const dismissedFeedback = { ...mockFeedback, status: "dismissed" };
+    deps.agentManager.updateFeedbackStatus.mockResolvedValueOnce(
+      dismissedFeedback
+    );
+    await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "dismissed" },
+    });
+    expect(deps.publishUiEvent).toHaveBeenCalledWith({
+      type: "feedback.updated",
+      agentId: "agt_test1",
+      feedback: dismissedFeedback,
+    });
+  });
+
+  it("returns 404 when feedback is not found", async () => {
+    deps.agentManager.updateFeedbackStatus.mockResolvedValue(null);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "dismissed" },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Feedback not found." });
+  });
+
+  describe("validation", () => {
+    it("rejects non-numeric feedback id", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/abc",
+        payload: { status: "dismissed" },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: "Invalid feedback id." });
+    });
+
+    it("rejects missing status", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/status must be one of/);
+    });
+
+    it("rejects invalid status value", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "invalid" },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/status must be one of/);
+    });
+
+    it("rejects non-string status", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: 123 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/status must be one of/);
+    });
+
+    it("rejects reason exceeding 10,000 chars", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "dismissed", reason: "x".repeat(10_001) },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/10,000 character limit/);
+    });
+
+    it("accepts reason at exactly 10,000 chars", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "dismissed", reason: "x".repeat(10_000) },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects non-string reason", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "dismissed", reason: 123 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/reason must be a string/);
+    });
+
+    it("allows null reason", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "dismissed", reason: null },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("allows omitted reason", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "dismissed" },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("requires reason when status is ignored", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "ignored" },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/reason is required.*ignored/i);
+    });
+
+    it("rejects whitespace-only reason when status is ignored", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "ignored", reason: "   " },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/reason is required.*ignored/i);
+    });
+
+    it("accepts non-empty reason when status is ignored", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/agents/agt_test1/feedback/1",
+        payload: { status: "ignored", reason: "not relevant" },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("does not require reason for non-ignored statuses", async () => {
+      for (const status of ["open", "dismissed", "forwarded", "fixed"]) {
+        const res = await app.inject({
+          method: "PATCH",
+          url: "/api/v1/agents/agt_test1/feedback/1",
+          payload: { status },
+        });
+        expect(res.statusCode).toBe(200);
+      }
+    });
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.agentManager.updateFeedbackStatus.mockRejectedValue(
+      new Error("db fail")
+    );
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "dismissed" },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+
+  it("handles null resolutionCommit when agent is not found for resolving status", async () => {
+    deps.agentManager.getAgent.mockResolvedValue(null);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/agents/agt_test1/feedback/1",
+      payload: { status: "fixed" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
+      1,
+      "agt_test1",
+      "fixed",
+      { reason: null, resolutionCommit: null }
+    );
+  });
+});

--- a/apps/web/src/components/app/release-utils.test.ts
+++ b/apps/web/src/components/app/release-utils.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cleanError,
+  describeForceTriggers,
+  formatBytes,
+  formatInlineProgress,
+  formatProgressLabel,
+  progressPercent,
+} from "./release-utils";
+
+describe("cleanError", () => {
+  it("extracts stderr from a compound error message", () => {
+    expect(cleanError("command failed stderr=some error")).toBe("some error");
+  });
+
+  it("strips leading 'fatal:' from stderr", () => {
+    expect(cleanError("exit 128 stderr=fatal: not a git repo")).toBe(
+      "not a git repo"
+    );
+  });
+
+  it("returns the raw string when no stderr= marker is present", () => {
+    expect(cleanError("plain error message")).toBe("plain error message");
+  });
+
+  it("trims whitespace around the extracted stderr", () => {
+    expect(cleanError("stderr=  spaced  ")).toBe("spaced");
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(500)).toBe("500 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1536)).toBe("2 KB");
+    expect(formatBytes(1024 * 512)).toBe("512 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(1024 * 1024 * 5.5)).toBe("5.5 MB");
+  });
+
+  it("formats gigabytes", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GB");
+    expect(formatBytes(1024 * 1024 * 1024 * 2.3)).toBe("2.3 GB");
+  });
+});
+
+describe("formatProgressLabel", () => {
+  it("returns null when no progress exists", () => {
+    expect(formatProgressLabel({ progress: null } as never)).toBeNull();
+  });
+
+  it("formats percentage with byte counts when total is known", () => {
+    const result = formatProgressLabel({
+      progress: { bytesReceived: 512 * 1024, totalBytes: 1024 * 1024 },
+    } as never);
+    expect(result).toBe("50% · 512 KB / 1.0 MB");
+  });
+
+  it("clamps percentage to 100", () => {
+    const result = formatProgressLabel({
+      progress: { bytesReceived: 2000, totalBytes: 1000 },
+    } as never);
+    expect(result).toMatch(/^100%/);
+  });
+
+  it("shows downloaded bytes when total is unknown", () => {
+    const result = formatProgressLabel({
+      progress: {
+        bytesReceived: 1024 * 1024 * 3,
+        totalBytes: null,
+      },
+    } as never);
+    expect(result).toBe("3.0 MB downloaded");
+  });
+
+  it("returns null when bytesReceived is zero and total is unknown", () => {
+    const result = formatProgressLabel({
+      progress: { bytesReceived: 0, totalBytes: null },
+    } as never);
+    expect(result).toBeNull();
+  });
+
+  it("falls back to downloaded format when totalBytes is zero", () => {
+    const result = formatProgressLabel({
+      progress: { bytesReceived: 100, totalBytes: 0 },
+    } as never);
+    expect(result).toBe("100 B downloaded");
+  });
+});
+
+describe("formatInlineProgress", () => {
+  it("returns null when progress is null", () => {
+    expect(formatInlineProgress(null)).toBeNull();
+  });
+
+  it("includes label and percentage when total is known", () => {
+    const result = formatInlineProgress({
+      label: "Downloading",
+      bytesReceived: 500,
+      totalBytes: 1000,
+    } as never);
+    expect(result).toBe("Downloading · 50% · 500 B / 1000 B");
+  });
+
+  it("includes label and downloaded when total is unknown", () => {
+    const result = formatInlineProgress({
+      label: "Downloading",
+      bytesReceived: 2048,
+      totalBytes: null,
+    } as never);
+    expect(result).toBe("Downloading · 2 KB downloaded");
+  });
+
+  it("returns just the label when no byte info is available", () => {
+    const result = formatInlineProgress({
+      label: "Preparing",
+      bytesReceived: null,
+      totalBytes: null,
+    } as never);
+    expect(result).toBe("Preparing");
+  });
+});
+
+describe("progressPercent", () => {
+  it("returns null when progress is null", () => {
+    expect(progressPercent(null)).toBeNull();
+  });
+
+  it("returns null when bytesReceived is null", () => {
+    expect(
+      progressPercent({ bytesReceived: null, totalBytes: 1000 } as never)
+    ).toBeNull();
+  });
+
+  it("returns null when totalBytes is null", () => {
+    expect(
+      progressPercent({ bytesReceived: 500, totalBytes: null } as never)
+    ).toBeNull();
+  });
+
+  it("returns null when totalBytes is zero", () => {
+    expect(
+      progressPercent({ bytesReceived: 500, totalBytes: 0 } as never)
+    ).toBeNull();
+  });
+
+  it("returns null when totalBytes is negative", () => {
+    expect(
+      progressPercent({ bytesReceived: 500, totalBytes: -1 } as never)
+    ).toBeNull();
+  });
+
+  it("calculates percent correctly", () => {
+    expect(
+      progressPercent({ bytesReceived: 250, totalBytes: 1000 } as never)
+    ).toBe(25);
+  });
+
+  it("clamps to 100", () => {
+    expect(
+      progressPercent({ bytesReceived: 2000, totalBytes: 1000 } as never)
+    ).toBe(100);
+  });
+});
+
+describe("describeForceTriggers", () => {
+  it("describes pending migrations (singular)", () => {
+    expect(describeForceTriggers({ pendingMigrations: ["m1"] } as never)).toBe(
+      "has 1 complex update step; safer with the agent"
+    );
+  });
+
+  it("describes pending migrations (plural)", () => {
+    expect(
+      describeForceTriggers({ pendingMigrations: ["m1", "m2", "m3"] } as never)
+    ).toBe("has 3 complex update steps; safer with the agent");
+  });
+
+  it("describes required assisted mode", () => {
+    expect(
+      describeForceTriggers({
+        pendingMigrations: [],
+        assisted: { mode: "required" },
+      } as never)
+    ).toBe("needs the agent for a safe update");
+  });
+
+  it("describes migrations error", () => {
+    expect(
+      describeForceTriggers({
+        pendingMigrations: [],
+        assisted: null,
+        migrationsError: "timeout",
+      } as never)
+    ).toBe("couldn't be checked for complex update steps");
+  });
+
+  it("returns generic fallback when no specific trigger matches", () => {
+    expect(
+      describeForceTriggers({
+        pendingMigrations: [],
+        assisted: { mode: "recommended" },
+        migrationsError: null,
+      } as never)
+    ).toBe("is gated by the assisted-update flow");
+  });
+});

--- a/e2e/agent-routing.spec.ts
+++ b/e2e/agent-routing.spec.ts
@@ -2,10 +2,18 @@ import { expect, test } from "@playwright/test";
 import { cleanupE2EAgents, createAgentViaAPI } from "./helpers";
 
 async function waitForAppShell(
-  page: import("@playwright/test").Page
+  page: import("@playwright/test").Page,
+  agentName?: string
 ): Promise<void> {
   await page.getByTestId("agent-sidebar").waitFor({ state: "visible" });
   await page.getByTestId("terminal-pane").waitFor({ state: "visible" });
+  if (agentName) {
+    await page
+      .getByTestId("agent-sidebar")
+      .getByText(agentName)
+      .first()
+      .waitFor({ state: "visible" });
+  }
 }
 
 test.describe("Agent routing", () => {
@@ -22,7 +30,7 @@ test.describe("Agent routing", () => {
     });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
-    await waitForAppShell(page);
+    await waitForAppShell(page, agent.name);
 
     await expect(page).toHaveURL(new RegExp(`/agents/${agent.id}$`));
     await expect(page.getByTestId("current-session-name")).toContainText(
@@ -40,7 +48,7 @@ test.describe("Agent routing", () => {
     });
 
     await page.goto(`/agents/${agent.id}`, { waitUntil: "domcontentloaded" });
-    await waitForAppShell(page);
+    await waitForAppShell(page, agent.name);
     await expect(page.getByTestId("terminal-inert-state")).toBeVisible();
 
     await page.getByTestId("settings-button").click();
@@ -65,13 +73,13 @@ test.describe("Agent routing", () => {
     await page.goto(`/agents/${agent.id}/feedback/not-a-number`, {
       waitUntil: "domcontentloaded",
     });
-    await waitForAppShell(page);
+    await waitForAppShell(page, agent.name);
     await expect(page).toHaveURL(new RegExp(`/agents/${agent.id}$`));
 
     await page.goto(`/agents/${agent.id}/review/not-a-real-agent`, {
       waitUntil: "domcontentloaded",
     });
-    await waitForAppShell(page);
+    await waitForAppShell(page, agent.name);
     await expect(page).toHaveURL(new RegExp(`/agents/${agent.id}$`));
   });
 
@@ -96,7 +104,7 @@ test.describe("Agent routing", () => {
     await page.goto(`/agents/${agent.id}/feedback/99999`, {
       waitUntil: "domcontentloaded",
     });
-    await waitForAppShell(page);
+    await waitForAppShell(page, agent.name);
 
     await expect(page).toHaveURL(
       new RegExp(`/agents/${agent.id}/feedback/99999$`)


### PR DESCRIPTION
## Summary
- Fix the `agent-routing:34` E2E flake by making `waitForAppShell` wait for the agent row to appear in the sidebar before asserting terminal state — ensures API data has loaded before the auto-attach flow runs
- Add 27 unit tests for `routes/feedback.ts` covering GET scope filtering, PATCH status/reason validation, resolution commit logic, and error paths
- Add 30 unit tests for `release-utils.ts` covering `cleanError`, `formatBytes`, `formatProgressLabel`, `formatInlineProgress`, `progressPercent`, and `describeForceTriggers`

## Test plan
- [x] `pnpm run check` passes
- [x] `pnpm run test` passes (server: 1444, web: 149)
- [x] `pnpm run test:e2e` passes (160 passed, 12 skipped)
- [x] Agent-routing tests pass consistently with the flake fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)