### PR TITLE
Docs: add list_agents and dispatch_send_message to tool lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `dispatch_resolve_feedback`  | Mark a feedback item as fixed or ignored                                   |
 | `dispatch_submit_resolution` | Submit the parent agent's response package for a reviewer recheck          |
 | `dispatch_cancel_recheck`    | Cancel a pending reviewer recheck loop                                     |
+| `list_agents`                | List other agents in the same project with IDs, statuses, and activity     |
+| `dispatch_send_message`      | Send a message to another running agent by ID or name                      |
 | `get_activity_summary`       | Summarize agent activity over a time range                                 |
 | `get_agent_history`          | Get detailed agent session history                                         |
 | `get_feedback_summary`       | Aggregate persona review feedback for pattern detection                    |
@@ -201,7 +203,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `dispatch_send_message`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
 
 ### Repo-specific tools
 

--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -638,6 +638,14 @@ const SECTIONS: SectionDef[] = [
               the reviewer exits cleanly
             </li>
             <li>
+              <Code>list_agents</Code> — list other agents in the same project
+              with their IDs, statuses, and latest activity
+            </li>
+            <li>
+              <Code>dispatch_send_message</Code> — send a message to another
+              running agent by ID or name; the target can reply the same way
+            </li>
+            <li>
               <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,{" "}
               <Code>get_feedback_summary</Code> — analytics queries over recent
               Dispatch activity
@@ -1052,14 +1060,14 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               bumps, doc audits).
             </li>
             <li>
-              <strong>Discovery</strong> — <Code>list_agents</Code>,{" "}
+              <strong>Discovery &amp; messaging</strong> —{" "}
+              <Code>list_agents</Code>, <Code>dispatch_send_message</Code>,{" "}
               <Code>list_personas</Code>,{" "}
               <Code>list_recent_persona_reviews</Code>,{" "}
               <Code>list_recent_feedback</Code>,{" "}
               <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,
               and <Code>get_feedback_summary</Code> let a job sweep over recent
-              activity — for example, a triage job that reads what's been
-              happening and posts a summary.
+              activity, coordinate with other agents, or post a summary.
             </li>
             <li>
               <strong>Round-trip review</strong> —{" "}


### PR DESCRIPTION
## Summary

- Added `list_agents` and `dispatch_send_message` to the in-app docs Built-in tools list (standard agents)
- Added `dispatch_send_message` to the in-app docs "Tools available to job agents" section
- Added both tools to the README Interactive agents table and Job agents list

Both tools were added to `AGENT_TOOLS` and `JOB_TOOLS` in `server.ts` since the last audit but the doc surfaces weren't updated.

## Audited this run

- **Notifications section** (docs-pane) — verified all claims against `notification-settings.tsx`, `slack.ts`, and MCP handler. No drift found.
- **MCP tool lists** — cross-checked `AGENT_TOOLS`, `JOB_TOOLS`, `PERSONA_TOOLS` in `server.ts` against docs-pane and README. Found the two missing tools above.

## Deferred to next run

- Audit docs-pane Agents section against `create-agent-dialog.tsx` and recent `path-input.tsx` refactor
- Spot-check `docs/03-api-spec.md` for new inter-agent messaging endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)