### PR TITLE
Add server-side activity monitor for agent status accuracy

### DIFF
--- a/apps/server/src/agents/activity-monitor.ts
+++ b/apps/server/src/agents/activity-monitor.ts
@@ -22,6 +22,7 @@ type AgentActivityRow = {
   id: string;
   tmuxSession: string;
   latestEventType: AgentLatestEventType | null;
+  latestEventUpdatedAt: string | null;
 };
 
 type ActivityState = {
@@ -32,10 +33,13 @@ type ActivityState = {
 export type ActivityMonitorDeps = {
   pool: Pool;
   logger: FastifyBaseLogger;
-  setSystemLatestEvent: (
+  /** Conditionally write a corrective event — only succeeds if the
+   *  agent's latest event hasn't changed since `expectedUpdatedAt`. */
+  correctLatestEvent: (
     id: string,
+    expectedUpdatedAt: string,
     input: AgentLatestEventInput
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 };
 
 export type ActivityMonitor = {
@@ -53,6 +57,10 @@ export type ActivityMonitor = {
  *   - Pane active + status is blocked/idle/done/waiting_user → working
  *   - Pane stale (3+ min) + status is working → idle
  *
+ * Corrections are conditional — they only apply when the agent's latest
+ * event hasn't changed between the monitor's read and write, preventing
+ * a stale snapshot from overwriting a newer agent-reported event.
+ *
  * Runs on the same cadence as the reconciler (called from the reconcile
  * loop) but is a separate concern — the reconciler handles session
  * lifecycle, the activity monitor handles status accuracy.
@@ -69,7 +77,8 @@ export function createActivityMonitor(
       const result = await pool.query(
         `SELECT id,
                 tmux_session   AS "tmuxSession",
-                latest_event_type AS "latestEventType"
+                latest_event_type AS "latestEventType",
+                latest_event_updated_at AS "latestEventUpdatedAt"
          FROM agents
          WHERE deleted_at IS NULL
            AND status = 'running'
@@ -104,7 +113,8 @@ export function createActivityMonitor(
           });
 
           const eventType = row.latestEventType;
-          if (!eventType) continue;
+          const eventUpdatedAt = row.latestEventUpdatedAt;
+          if (!eventType || !eventUpdatedAt) continue;
 
           if (paneChanged && eventType !== "working") {
             logger.info(
@@ -112,10 +122,17 @@ export function createActivityMonitor(
               "Activity monitor: pane active, correcting %s → working",
               eventType
             );
-            await deps.setSystemLatestEvent(row.id, {
-              type: "working",
-              message: "Activity detected",
-            });
+            const applied = await deps.correctLatestEvent(
+              row.id,
+              eventUpdatedAt,
+              { type: "working", message: "Activity detected" }
+            );
+            if (!applied) {
+              logger.debug(
+                { agentId: row.id },
+                "Activity monitor: correction skipped — event was updated concurrently"
+              );
+            }
           } else if (!paneChanged && eventType === "working") {
             const staleDurationMs = now - prev.lastChangeAt;
             if (staleDurationMs >= STALE_WORKING_MS) {
@@ -124,10 +141,17 @@ export function createActivityMonitor(
                 "Activity monitor: pane stale for %dms, correcting working → idle",
                 staleDurationMs
               );
-              await deps.setSystemLatestEvent(row.id, {
-                type: "idle",
-                message: "No recent activity detected",
-              });
+              const applied = await deps.correctLatestEvent(
+                row.id,
+                eventUpdatedAt,
+                { type: "idle", message: "No recent activity detected" }
+              );
+              if (!applied) {
+                logger.debug(
+                  { agentId: row.id },
+                  "Activity monitor: correction skipped — event was updated concurrently"
+                );
+              }
             }
           }
         } catch (err) {

--- a/apps/server/src/agents/activity-monitor.ts
+++ b/apps/server/src/agents/activity-monitor.ts
@@ -78,7 +78,7 @@ export function createActivityMonitor(
         `SELECT id,
                 tmux_session   AS "tmuxSession",
                 latest_event_type AS "latestEventType",
-                latest_event_updated_at AS "latestEventUpdatedAt"
+                latest_event_updated_at::text AS "latestEventUpdatedAt"
          FROM agents
          WHERE deleted_at IS NULL
            AND status = 'running'

--- a/apps/server/src/agents/activity-monitor.ts
+++ b/apps/server/src/agents/activity-monitor.ts
@@ -1,0 +1,153 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Pool } from "pg";
+
+import { TmuxTerminal } from "../terminal/tmux-terminal.js";
+import type { AgentLatestEventInput, AgentLatestEventType } from "./types.js";
+
+/**
+ * How long a pane must be silent before correcting `working` → `idle`.
+ * Set conservatively — agent CLIs can pause for extended thinking phases
+ * that produce no visible output, so too short a window risks false
+ * positives.
+ */
+const STALE_WORKING_MS = 180_000; // 3 minutes
+
+/**
+ * Number of recent pane lines to capture for change detection. Enough to
+ * detect output scrolling without capturing the entire scrollback.
+ */
+const CAPTURE_LINES = 100;
+
+type AgentActivityRow = {
+  id: string;
+  tmuxSession: string;
+  latestEventType: AgentLatestEventType | null;
+};
+
+type ActivityState = {
+  lastDigest: string;
+  lastChangeAt: number;
+};
+
+export type ActivityMonitorDeps = {
+  pool: Pool;
+  logger: FastifyBaseLogger;
+  setSystemLatestEvent: (
+    id: string,
+    input: AgentLatestEventInput
+  ) => Promise<void>;
+};
+
+export type ActivityMonitor = {
+  /** Run one activity-check pass across all running agents. */
+  check(): Promise<void>;
+  /** Drop tracked state for an agent (e.g. on stop/archive). */
+  forget(agentId: string): void;
+};
+
+/**
+ * Server-side activity monitor that compares each running agent's
+ * self-reported status against observed tmux pane activity.
+ *
+ * Corrections:
+ *   - Pane active + status is blocked/idle/done/waiting_user → working
+ *   - Pane stale (3+ min) + status is working → idle
+ *
+ * Runs on the same cadence as the reconciler (called from the reconcile
+ * loop) but is a separate concern — the reconciler handles session
+ * lifecycle, the activity monitor handles status accuracy.
+ */
+export function createActivityMonitor(
+  deps: ActivityMonitorDeps
+): ActivityMonitor {
+  const state = new Map<string, ActivityState>();
+
+  return {
+    async check(): Promise<void> {
+      const { pool, logger } = deps;
+
+      const result = await pool.query(
+        `SELECT id,
+                tmux_session   AS "tmuxSession",
+                latest_event_type AS "latestEventType"
+         FROM agents
+         WHERE deleted_at IS NULL
+           AND status = 'running'
+           AND tmux_session IS NOT NULL`
+      );
+
+      const runningIds = new Set<string>();
+
+      for (const row of result.rows as AgentActivityRow[]) {
+        runningIds.add(row.id);
+
+        try {
+          const terminal = new TmuxTerminal(row.tmuxSession);
+          if (!(await terminal.hasSession())) continue;
+
+          const paneContent = await terminal.captureRecentLines(CAPTURE_LINES);
+          const digest = terminal.digest(paneContent);
+
+          const prev = state.get(row.id);
+          const now = Date.now();
+
+          if (!prev) {
+            state.set(row.id, { lastDigest: digest, lastChangeAt: now });
+            continue;
+          }
+
+          const paneChanged = prev.lastDigest !== digest;
+
+          state.set(row.id, {
+            lastDigest: digest,
+            lastChangeAt: paneChanged ? now : prev.lastChangeAt,
+          });
+
+          const eventType = row.latestEventType;
+          if (!eventType) continue;
+
+          if (paneChanged && eventType !== "working") {
+            logger.info(
+              { agentId: row.id, from: eventType },
+              "Activity monitor: pane active, correcting %s → working",
+              eventType
+            );
+            await deps.setSystemLatestEvent(row.id, {
+              type: "working",
+              message: "Activity detected",
+            });
+          } else if (!paneChanged && eventType === "working") {
+            const staleDurationMs = now - prev.lastChangeAt;
+            if (staleDurationMs >= STALE_WORKING_MS) {
+              logger.info(
+                { agentId: row.id, staleDurationMs },
+                "Activity monitor: pane stale for %dms, correcting working → idle",
+                staleDurationMs
+              );
+              await deps.setSystemLatestEvent(row.id, {
+                type: "idle",
+                message: "No recent activity detected",
+              });
+            }
+          }
+        } catch (err) {
+          logger.debug(
+            { err, agentId: row.id },
+            "Activity monitor: failed to check agent pane"
+          );
+        }
+      }
+
+      // Prune state for agents no longer running
+      for (const id of state.keys()) {
+        if (!runningIds.has(id)) {
+          state.delete(id);
+        }
+      }
+    },
+
+    forget(agentId: string): void {
+      state.delete(agentId);
+    },
+  };
+}

--- a/apps/server/src/agents/events.ts
+++ b/apps/server/src/agents/events.ts
@@ -67,6 +67,66 @@ export async function writeLatestEvent(
     );
 }
 
+/**
+ * Conditional variant of `writeLatestEvent`. Only updates the agent's
+ * latest-event columns when `latest_event_updated_at` still matches
+ * `expectedUpdatedAt` — i.e. no other event was written between the
+ * caller's read and this write. Returns `true` when the row was updated,
+ * `false` when the precondition failed (another event landed first).
+ */
+export async function writeLatestEventIfCurrent(
+  pool: Pool,
+  logger: FastifyBaseLogger,
+  id: string,
+  expectedUpdatedAt: string,
+  input: AgentLatestEventInput
+): Promise<boolean> {
+  const message = input.message.trim();
+  if (!message) {
+    throw new AgentError(
+      "Latest event message must be a non-empty string.",
+      400
+    );
+  }
+
+  const result = await pool.query(
+    `
+    UPDATE agents
+    SET latest_event_type = $2,
+        latest_event_message = $3,
+        latest_event_metadata = $4::jsonb,
+        latest_event_updated_at = NOW(),
+        updated_at = NOW()
+    WHERE id = $1 AND deleted_at IS NULL
+      AND latest_event_updated_at = $5
+    `,
+    [
+      id,
+      input.type,
+      message,
+      JSON.stringify(input.metadata ?? {}),
+      expectedUpdatedAt,
+    ]
+  );
+
+  if (result.rowCount !== 1) {
+    return false;
+  }
+
+  pool
+    .query(
+      `INSERT INTO agent_events (agent_id, event_type, message, metadata, agent_type, agent_name, project_dir)
+       SELECT $1, $2, $3, $4::jsonb, type, name, COALESCE(git_context->>'repoRoot', cwd)
+       FROM agents WHERE id = $1`,
+      [id, input.type, message, JSON.stringify(input.metadata ?? {})]
+    )
+    .catch((err) =>
+      logger.warn({ err }, "Failed to insert agent event history")
+    );
+
+  return true;
+}
+
 export type AgentEventBus = {
   /** Register a callback invoked after every successful upsert + agent fetch. */
   subscribe(listener: AgentEventListener): void;

--- a/apps/server/src/agents/events.ts
+++ b/apps/server/src/agents/events.ts
@@ -98,7 +98,7 @@ export async function writeLatestEventIfCurrent(
         latest_event_updated_at = NOW(),
         updated_at = NOW()
     WHERE id = $1 AND deleted_at IS NULL
-      AND latest_event_updated_at = $5
+      AND latest_event_updated_at::text = $5
     `,
     [
       id,

--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -34,6 +34,7 @@ import {
   type AgentEventBus,
   createAgentEventBus,
   writeLatestEvent,
+  writeLatestEventIfCurrent,
 } from "./events.js";
 import { runLifecycleHook } from "./lifecycle-hooks.js";
 import { seedInitialMedia } from "./media-seed.js";
@@ -966,6 +967,27 @@ export class AgentManager {
     // Fire-and-forget: refresher swallows its own errors, throttles bursts,
     // and dedupes concurrent signals. We just nudge it on every status
     // transition so the diff badge tracks scope as work lands.
+    void this.diffStatsRefresher?.signal(id);
+    return agent;
+  }
+
+  async upsertLatestEventIfCurrent(
+    id: string,
+    expectedUpdatedAt: string,
+    input: AgentLatestEventInput
+  ): Promise<AgentRecord | null> {
+    const updated = await writeLatestEventIfCurrent(
+      this.pool,
+      this.logger,
+      id,
+      expectedUpdatedAt,
+      input
+    );
+    if (!updated) return null;
+
+    const agent = await this.getAgent(id);
+    if (!agent) return null;
+    this.eventBus.publish(agent);
     void this.diffStatsRefresher?.signal(id);
     return agent;
   }

--- a/apps/server/src/agents/tmux/command-builder.ts
+++ b/apps/server/src/agents/tmux/command-builder.ts
@@ -165,7 +165,7 @@ export function buildLaunchGuidance(
       );
     }
     rules.push(
-      "Report status with dispatch_event. Types: working (making progress), blocked (stuck, cannot proceed alone), waiting_user (need input), done (task fully complete), idle (answered a question, no code changes). Emit working at turn start and when shifting phases (e.g. research → coding → testing). Emit a terminal event before your final response. Use blocked only when truly stuck — not for errors you're actively fixing."
+      "Report status with dispatch_event. Types: working (making progress — includes debugging, fixing test failures, investigating errors), blocked (completely stuck with no further approach to try — NOT for errors or test failures you plan to fix next), waiting_user (need a decision or approval), done (task complete), idle (no-op, just answered a question). Emit working at turn start and when shifting phases. Emit a terminal event before your final response. Your reported status is verified against session activity and auto-corrected when it doesn't match."
     );
     rules.push(
       "Pin key info with dispatch_pin so it surfaces in the sidebar — especially values users may need to copy/paste: URLs, commands, branch names, IDs, tokens, simulator UDIDs. Types: url (dev servers, docs), port (server ports), pr (PR links), filename (key files), code (short snippets, env vars, IDs), string (status, decisions), markdown (short structured summaries). Update or delete stale pins. For longer artifacts, write a file via dispatch_share and pin a reference."

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -261,11 +261,16 @@ const autoCheckRuntime = createAutoCheckRuntime({
 const activityMonitor = createActivityMonitor({
   pool,
   logger: app.log,
-  setSystemLatestEvent: async (id, input) => {
-    await agentManager.upsertLatestEvent(id, {
-      ...input,
-      metadata: { ...(input.metadata ?? {}), source: "activity-monitor" },
-    });
+  correctLatestEvent: async (id, expectedUpdatedAt, input) => {
+    const agent = await agentManager.upsertLatestEventIfCurrent(
+      id,
+      expectedUpdatedAt,
+      {
+        ...input,
+        metadata: { ...(input.metadata ?? {}), source: "activity-monitor" },
+      }
+    );
+    return agent !== null;
   },
 });
 const agentLifecycleRuntime = createAgentLifecycleRuntime({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -140,6 +140,7 @@ import {
   VALID_ICON_COLORS,
 } from "./server/static-theme.js";
 import { UiEventBroker, type UiEvent } from "./server/ui-events.js";
+import { createActivityMonitor } from "./agents/activity-monitor.js";
 import { createAutoRenamePrompter } from "./agents/auto-rename-prompter.js";
 import { DiffStatsRefresher } from "./agents/diff-stats-refresher.js";
 
@@ -257,11 +258,22 @@ const autoCheckRuntime = createAutoCheckRuntime({
   logger: app.log,
 });
 
+const activityMonitor = createActivityMonitor({
+  pool,
+  logger: app.log,
+  setSystemLatestEvent: async (id, input) => {
+    await agentManager.upsertLatestEvent(id, {
+      ...input,
+      metadata: { ...(input.metadata ?? {}), source: "activity-monitor" },
+    });
+  },
+});
 const agentLifecycleRuntime = createAgentLifecycleRuntime({
   agentManager,
   streamManager,
   appLog: app.log,
   reconcileIntervalMs: AGENT_STATUS_RECONCILE_INTERVAL_MS,
+  activityMonitor,
   withStreamFlag,
   publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
 });

--- a/apps/server/src/server/agent-lifecycle-runtime.ts
+++ b/apps/server/src/server/agent-lifecycle-runtime.ts
@@ -1,5 +1,6 @@
 import type { FastifyBaseLogger } from "fastify";
 
+import type { ActivityMonitor } from "../agents/activity-monitor.js";
 import type { AgentManager, AgentRecord } from "../agents/manager.js";
 import type { StreamManager } from "../stream-manager.js";
 
@@ -8,6 +9,7 @@ type CreateAgentLifecycleRuntimeDeps = {
   streamManager: StreamManager;
   appLog: FastifyBaseLogger;
   reconcileIntervalMs: number;
+  activityMonitor?: ActivityMonitor;
   withStreamFlag: <T extends AgentRecord>(
     agent: T
   ) => T & { hasStream: boolean };
@@ -22,6 +24,7 @@ export function createAgentLifecycleRuntime(
     streamManager,
     appLog,
     reconcileIntervalMs,
+    activityMonitor,
     withStreamFlag,
     publishUiEvent,
   } = deps;
@@ -144,6 +147,16 @@ export function createAgentLifecycleRuntime(
         }
       } catch (error) {
         appLog.warn({ err: error }, "Agent status reconciliation failed.");
+      }
+
+      // Activity monitor: compare self-reported status against tmux pane
+      // activity and auto-correct mismatches (runs on the same cadence).
+      if (activityMonitor) {
+        try {
+          await activityMonitor.check();
+        } catch (error) {
+          appLog.warn({ err: error }, "Activity monitor check failed.");
+        }
       }
     },
 

--- a/apps/server/test/activity-monitor.test.ts
+++ b/apps/server/test/activity-monitor.test.ts
@@ -36,6 +36,8 @@ vi.mock("../src/terminal/tmux-terminal.js", () => {
   };
 });
 
+const UPDATED_AT = "2026-01-01T00:00:00.000Z";
+
 function makePool(rows: Array<Record<string, unknown>>) {
   return {
     query: vi.fn().mockResolvedValue({ rows }),
@@ -49,7 +51,24 @@ function makeDeps(
   return {
     pool: makePool(rows),
     logger: fakeLogger,
-    setSystemLatestEvent: vi.fn().mockResolvedValue(undefined),
+    correctLatestEvent: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+function agentRow(
+  overrides: Partial<{
+    id: string;
+    tmuxSession: string;
+    latestEventType: string;
+    latestEventUpdatedAt: string;
+  }> = {}
+) {
+  return {
+    id: "agt_001",
+    tmuxSession: "sess_001",
+    latestEventType: "idle",
+    latestEventUpdatedAt: UPDATED_AT,
     ...overrides,
   };
 }
@@ -62,20 +81,16 @@ describe("createActivityMonitor", () => {
   });
 
   it("records baseline on first tick without correcting", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-    ]);
+    const deps = makeDeps([agentRow()]);
     const monitor = createActivityMonitor(deps);
 
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
   });
 
   it("corrects blocked → working when pane changes", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "blocked" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "blocked" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -84,16 +99,15 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
-      type: "working",
-      message: "Activity detected",
-    });
+    expect(deps.correctLatestEvent).toHaveBeenCalledWith(
+      "agt_001",
+      UPDATED_AT,
+      { type: "working", message: "Activity detected" }
+    );
   });
 
   it("corrects idle → working when pane changes", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "idle" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -102,16 +116,15 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
-      type: "working",
-      message: "Activity detected",
-    });
+    expect(deps.correctLatestEvent).toHaveBeenCalledWith(
+      "agt_001",
+      UPDATED_AT,
+      { type: "working", message: "Activity detected" }
+    );
   });
 
   it("corrects done → working when pane changes", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "done" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "done" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -120,20 +133,15 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
-      type: "working",
-      message: "Activity detected",
-    });
+    expect(deps.correctLatestEvent).toHaveBeenCalledWith(
+      "agt_001",
+      UPDATED_AT,
+      { type: "working", message: "Activity detected" }
+    );
   });
 
   it("corrects waiting_user → working when pane changes", async () => {
-    const deps = makeDeps([
-      {
-        id: "agt_001",
-        tmuxSession: "sess_001",
-        latestEventType: "waiting_user",
-      },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "waiting_user" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -142,16 +150,15 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
-      type: "working",
-      message: "Activity detected",
-    });
+    expect(deps.correctLatestEvent).toHaveBeenCalledWith(
+      "agt_001",
+      UPDATED_AT,
+      { type: "working", message: "Activity detected" }
+    );
   });
 
   it("does not correct when already working and pane active", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "working" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -160,13 +167,11 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
   });
 
   it("corrects working → idle after stale threshold", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "working" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "static-content";
@@ -176,18 +181,17 @@ describe("createActivityMonitor", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + 200_000);
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
-      type: "idle",
-      message: "No recent activity detected",
-    });
+    expect(deps.correctLatestEvent).toHaveBeenCalledWith(
+      "agt_001",
+      UPDATED_AT,
+      { type: "idle", message: "No recent activity detected" }
+    );
 
     vi.restoreAllMocks();
   });
 
   it("does not correct working → idle before threshold", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
-    ]);
+    const deps = makeDeps([agentRow({ latestEventType: "working" })]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "static-content";
@@ -197,15 +201,13 @@ describe("createActivityMonitor", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });
 
   it("skips agents whose tmux session is gone", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-    ]);
+    const deps = makeDeps([agentRow()]);
     sessionExists = false;
     const monitor = createActivityMonitor(deps);
 
@@ -215,13 +217,28 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite when correction loses the race", async () => {
+    const correctLatestEvent = vi.fn().mockResolvedValue(false);
+    const deps = makeDeps([agentRow({ latestEventType: "blocked" })], {
+      correctLatestEvent,
+    });
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(correctLatestEvent).toHaveBeenCalledOnce();
+    // The correction was attempted but returned false (race lost) — no crash
   });
 
   it("prunes state for agents no longer running", async () => {
-    const pool = makePool([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-    ]);
+    const pool = makePool([agentRow()]);
     const deps = makeDeps([], { pool });
     const monitor = createActivityMonitor(deps);
 
@@ -234,20 +251,16 @@ describe("createActivityMonitor", () => {
 
     // Agent reappears with new content — should be baseline (no correction)
     (pool.query as ReturnType<typeof vi.fn>).mockResolvedValue({
-      rows: [
-        { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-      ],
+      rows: [agentRow()],
     });
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
   });
 
   it("forget() drops state for a specific agent", async () => {
-    const deps = makeDeps([
-      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
-    ]);
+    const deps = makeDeps([agentRow()]);
     const monitor = createActivityMonitor(deps);
 
     paneContent = "content-A";
@@ -259,6 +272,6 @@ describe("createActivityMonitor", () => {
     paneContent = "content-B";
     await monitor.check();
 
-    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+    expect(deps.correctLatestEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/test/activity-monitor.test.ts
+++ b/apps/server/test/activity-monitor.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  createActivityMonitor,
+  type ActivityMonitorDeps,
+} from "../src/agents/activity-monitor.js";
+
+const fakeLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: () => fakeLogger,
+  level: "info",
+  silent: vi.fn(),
+} as unknown as import("fastify").FastifyBaseLogger;
+
+let paneContent = "initial";
+let sessionExists = true;
+
+vi.mock("../src/terminal/tmux-terminal.js", () => {
+  return {
+    TmuxTerminal: class MockTmuxTerminal {
+      async hasSession() {
+        return sessionExists;
+      }
+      async captureRecentLines() {
+        return paneContent;
+      }
+      digest(content: string) {
+        return content;
+      }
+    },
+  };
+});
+
+function makePool(rows: Array<Record<string, unknown>>) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows }),
+  } as unknown as import("pg").Pool;
+}
+
+function makeDeps(
+  rows: Array<Record<string, unknown>>,
+  overrides: Partial<ActivityMonitorDeps> = {}
+): ActivityMonitorDeps {
+  return {
+    pool: makePool(rows),
+    logger: fakeLogger,
+    setSystemLatestEvent: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("createActivityMonitor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    paneContent = "initial";
+    sessionExists = true;
+  });
+
+  it("records baseline on first tick without correcting", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+  });
+
+  it("corrects blocked → working when pane changes", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "blocked" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
+      type: "working",
+      message: "Activity detected",
+    });
+  });
+
+  it("corrects idle → working when pane changes", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
+      type: "working",
+      message: "Activity detected",
+    });
+  });
+
+  it("corrects done → working when pane changes", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "done" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
+      type: "working",
+      message: "Activity detected",
+    });
+  });
+
+  it("corrects waiting_user → working when pane changes", async () => {
+    const deps = makeDeps([
+      {
+        id: "agt_001",
+        tmuxSession: "sess_001",
+        latestEventType: "waiting_user",
+      },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
+      type: "working",
+      message: "Activity detected",
+    });
+  });
+
+  it("does not correct when already working and pane active", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+  });
+
+  it("corrects working → idle after stale threshold", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "static-content";
+    await monitor.check();
+
+    // Advance time past the 3-minute threshold
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 200_000);
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).toHaveBeenCalledWith("agt_001", {
+      type: "idle",
+      message: "No recent activity detected",
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it("does not correct working → idle before threshold", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "working" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "static-content";
+    await monitor.check();
+
+    // Advance time but not past threshold
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it("skips agents whose tmux session is gone", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+    ]);
+    sessionExists = false;
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+  });
+
+  it("prunes state for agents no longer running", async () => {
+    const pool = makePool([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+    ]);
+    const deps = makeDeps([], { pool });
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    // Agent disappears
+    (pool.query as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+    await monitor.check();
+
+    // Agent reappears with new content — should be baseline (no correction)
+    (pool.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [
+        { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+      ],
+    });
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+  });
+
+  it("forget() drops state for a specific agent", async () => {
+    const deps = makeDeps([
+      { id: "agt_001", tmuxSession: "sess_001", latestEventType: "idle" },
+    ]);
+    const monitor = createActivityMonitor(deps);
+
+    paneContent = "content-A";
+    await monitor.check();
+
+    monitor.forget("agt_001");
+
+    // Next tick is baseline again — no correction
+    paneContent = "content-B";
+    await monitor.check();
+
+    expect(deps.setSystemLatestEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a tmux pane activity monitor that runs on the reconciler's 30s cadence, comparing each agent's self-reported status against observed pane output
- Auto-corrects mismatches: pane active + non-working status → `working`; pane stale 3+ min + working status → `idle`
- Sharpens launch guidance to clarify `blocked` is NOT for fixable errors and warns agents their status is verified

## How it works

The monitor captures each running agent's tmux pane content, hashes it, and compares to the previous tick. When the hash changes but the agent reported `blocked`/`idle`/`done`/`waiting_user`, the server overrides to `working` via a system event. When the pane is stale for 3+ minutes but the agent claims `working`, it corrects to `idle`.

Corrections flow through the existing event bus, so the auto-rename prompter naturally fires when idle/done agents are corrected to working — no additional rename nudge code needed.

## Verified

- Unit tests (11 cases covering all correction paths, thresholds, pruning)
- Live-tested with a real agent on `repo_dev_up live=true`:
  - Agent reported `done` → pane still active → monitor corrected to `working`
  - Pane went stale → after 3 min → monitor corrected to `idle`
  - Auto-rename prompter fired on the working correction

## Test plan

- [ ] Type check passes (`pnpm run check`)
- [ ] Unit tests pass (`pnpm run test`)
- [ ] E2E tests pass (`pnpm run test:e2e`)
- [ ] Live validation: launch agent, observe status corrections in event history