### PR TITLE
Remove 8 AgentManager passthrough methods from route files

### DIFF
--- a/apps/server/src/agents/manager.ts
+++ b/apps/server/src/agents/manager.ts
@@ -68,12 +68,6 @@ import type {
   WorktreeStatus,
 } from "./types.js";
 import * as telemetry from "./telemetry.js";
-import type {
-  ActivitySummaryResult,
-  AgentHistoryEntry,
-  AgentHistoryResult,
-  FeedbackSummaryResult,
-} from "./telemetry.js";
 import * as personaReviews from "./persona-reviews.js";
 import type {
   PersonaReviewRecord,
@@ -93,12 +87,6 @@ export type {
   AgentTerminalAccess,
   WorktreeStatus,
 } from "./types.js";
-export type {
-  ActivitySummaryResult,
-  AgentHistoryEntry,
-  AgentHistoryResult,
-  FeedbackSummaryResult,
-} from "./telemetry.js";
 export type {
   PersonaReviewRecord,
   PersonaReviewResolutionItem,
@@ -1161,51 +1149,6 @@ export class AgentManager {
     return personaReviews.getPersonaReview(this.pool, agentId);
   }
 
-  async listRecentPersonaReviews(
-    sinceDays: number
-  ): Promise<PersonaReviewRecord[]> {
-    return personaReviews.listRecentPersonaReviews(this.pool, sinceDays);
-  }
-
-  async listRecentFeedback(
-    sinceDays: number
-  ): Promise<Array<FeedbackRecord & { persona: string }>> {
-    return feedbackQueries.listRecentFeedback(this.pool, sinceDays);
-  }
-
-  // --- Activity / History / Feedback Summaries ---
-
-  async getActivitySummary(params: {
-    start: Date;
-    end: Date;
-    project?: string;
-  }): Promise<ActivitySummaryResult> {
-    return telemetry.getActivitySummary(this.pool, params);
-  }
-
-  async getAgentHistory(params: {
-    start: Date;
-    end: Date;
-    project?: string;
-    limit: number;
-    offset: number;
-    includeEvents: boolean;
-    includeFeedback: boolean;
-    includeReviews: boolean;
-    includeChildren: boolean;
-  }): Promise<AgentHistoryResult> {
-    return telemetry.getAgentHistory(this.pool, params);
-  }
-
-  async getFeedbackSummary(params: {
-    start: Date;
-    end: Date;
-    project?: string;
-    groupBy: "persona" | "severity" | "directory";
-  }): Promise<FeedbackSummaryResult> {
-    return telemetry.getFeedbackSummary(this.pool, params);
-  }
-
   // --- Media ---
 
   async listMedia(agentId: string): Promise<
@@ -1232,14 +1175,6 @@ export class AgentManager {
     return feedbackQueries.submitFeedback(this.pool, agentId, feedback);
   }
 
-  async listFeedback(agentId: string): Promise<FeedbackRecord[]> {
-    return feedbackQueries.listFeedback(this.pool, agentId);
-  }
-
-  async listFeedbackByParent(parentAgentId: string): Promise<FeedbackRecord[]> {
-    return feedbackQueries.listFeedbackByParent(this.pool, parentAgentId);
-  }
-
   async listFeedbackByParentGrouped(
     parentAgentId: string,
     persona?: string,
@@ -1256,21 +1191,6 @@ export class AgentManager {
       parentAgentId,
       persona,
       limit
-    );
-  }
-
-  async updateFeedbackStatus(
-    feedbackId: number,
-    agentId: string,
-    status: "open" | "dismissed" | "forwarded" | "fixed" | "ignored",
-    options: { reason?: string | null; resolutionCommit?: string | null } = {}
-  ): Promise<FeedbackRecord | null> {
-    return feedbackQueries.updateFeedbackStatus(
-      this.pool,
-      feedbackId,
-      agentId,
-      status,
-      options
     );
   }
 

--- a/apps/server/src/routes/feedback.ts
+++ b/apps/server/src/routes/feedback.ts
@@ -1,9 +1,12 @@
 import type { FastifyInstance, FastifyReply } from "fastify";
+import type { Pool } from "pg";
 
 import type { AgentManager } from "../agents/manager.js";
+import * as feedbackQueries from "../agents/feedback.js";
 import { resolveHeadSha } from "../shared/git/worktree.js";
 
 type FeedbackRouteDeps = {
+  pool: Pool;
   agentManager: AgentManager;
   publishUiEvent: (event: unknown) => void;
   handleAgentError: (reply: FastifyReply, error: unknown) => FastifyReply;
@@ -19,12 +22,15 @@ export async function registerFeedbackRoutes(
     const id = params.id ?? "";
     try {
       if (query.scope === "children") {
-        const feedback = await deps.agentManager.listFeedbackByParent(id);
+        const feedback = await feedbackQueries.listFeedbackByParent(
+          deps.pool,
+          id
+        );
         return { feedback };
       }
       const agent = await deps.agentManager.getAgent(id);
       if (!agent) return reply.code(404).send({ error: "Agent not found." });
-      const feedback = await deps.agentManager.listFeedback(id);
+      const feedback = await feedbackQueries.listFeedback(deps.pool, id);
       return { feedback };
     } catch (error) {
       return deps.handleAgentError(reply, error);
@@ -91,7 +97,8 @@ export async function registerFeedbackRoutes(
           : null;
         const resolutionCommit =
           isResolving && agent ? await resolveHeadSha(agent.cwd) : null;
-        const updated = await deps.agentManager.updateFeedbackStatus(
+        const updated = await feedbackQueries.updateFeedbackStatus(
+          deps.pool,
           feedbackId,
           agentId,
           body.status as

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -1,8 +1,12 @@
 import path from "node:path";
 
 import type { FastifyInstance } from "fastify";
+import type { Pool } from "pg";
 
 import type { AgentManager } from "../agents/manager.js";
+import * as feedbackQueries from "../agents/feedback.js";
+import * as personaReviews from "../agents/persona-reviews.js";
+import * as telemetry from "../agents/telemetry.js";
 import type { BrainStore } from "../brain/store.js";
 import type { AddJobInput, JobService } from "../jobs/service.js";
 import type {
@@ -20,6 +24,7 @@ type McpRouteDeps = {
   config: {
     authToken: string;
   };
+  pool: Pool;
   agentManager: AgentManager;
   jobService: JobService;
   templateService: TemplateService;
@@ -168,15 +173,15 @@ export async function registerMcpRoutes(
             }));
           },
           listRecentPersonaReviews: (sinceDays: number) =>
-            deps.agentManager.listRecentPersonaReviews(sinceDays),
+            personaReviews.listRecentPersonaReviews(deps.pool, sinceDays),
           listRecentFeedback: (sinceDays: number) =>
-            deps.agentManager.listRecentFeedback(sinceDays),
+            feedbackQueries.listRecentFeedback(deps.pool, sinceDays),
           getActivitySummary: (params: Record<string, unknown>) =>
-            deps.agentManager.getActivitySummary(params as never),
+            telemetry.getActivitySummary(deps.pool, params as never),
           getAgentHistory: (params: Record<string, unknown>) =>
-            deps.agentManager.getAgentHistory(params as never),
+            telemetry.getAgentHistory(deps.pool, params as never),
           getFeedbackSummary: (params: Record<string, unknown>) =>
-            deps.agentManager.getFeedbackSummary(params as never),
+            telemetry.getFeedbackSummary(deps.pool, params as never),
         }
       : undefined;
 
@@ -209,15 +214,15 @@ export async function registerMcpRoutes(
       sendMessage: deps.mcpSendMessage,
       listAgentsForAgent: deps.mcpListAgentsForAgent,
       getActivitySummary: (params: Record<string, unknown>) =>
-        deps.agentManager.getActivitySummary(params as never) as Promise<
+        telemetry.getActivitySummary(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       getAgentHistory: (params: Record<string, unknown>) =>
-        deps.agentManager.getAgentHistory(params as never) as Promise<
+        telemetry.getAgentHistory(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       getFeedbackSummary: (params: Record<string, unknown>) =>
-        deps.agentManager.getFeedbackSummary(params as never) as Promise<
+        telemetry.getFeedbackSummary(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       toolScope: run ? "job" : "agent",
@@ -247,7 +252,7 @@ export async function registerMcpRoutes(
     }
 
     const review = agent.persona
-      ? await deps.agentManager.getPersonaReview(agentId)
+      ? await personaReviews.getPersonaReview(deps.pool, agentId)
       : null;
     const activeJobRun = await deps.jobService.getActiveRunForAgent(agentId);
     if (activeJobRun) {
@@ -296,15 +301,15 @@ export async function registerMcpRoutes(
       updateReviewStatus: deps.mcpUpdateReviewStatus,
       completeReview: deps.mcpCompleteReview,
       getActivitySummary: (params: Record<string, unknown>) =>
-        deps.agentManager.getActivitySummary(params as never) as Promise<
+        telemetry.getActivitySummary(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       getAgentHistory: (params: Record<string, unknown>) =>
-        deps.agentManager.getAgentHistory(params as never) as Promise<
+        telemetry.getAgentHistory(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       getFeedbackSummary: (params: Record<string, unknown>) =>
-        deps.agentManager.getFeedbackSummary(params as never) as Promise<
+        telemetry.getFeedbackSummary(deps.pool, params as never) as Promise<
           Record<string, unknown>
         >,
       crudTools: buildCrudCallbacks(deps),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -458,6 +458,7 @@ async function registerRoutes() {
 
   await registerMcpRoutes(app, {
     config,
+    pool,
     agentManager,
     jobService,
     templateService,
@@ -627,6 +628,7 @@ async function registerRoutes() {
   // --- Feedback ---
 
   await registerFeedbackRoutes(app, {
+    pool,
     agentManager,
     publishUiEvent: (event) => uiEventBroker.publish(event as UiEvent),
     handleAgentError,

--- a/apps/server/test/db/agent-manager.test.ts
+++ b/apps/server/test/db/agent-manager.test.ts
@@ -40,6 +40,9 @@ vi.mock("../../src/shared/lib/run-command.js", () => ({
 // We need to dynamically import AgentManager AFTER the mock is in place
 const { AgentManager, AgentError } =
   await import("../../src/agents/manager.js");
+const feedbackQueries = await import("../../src/agents/feedback.js");
+const personaReviewQueries =
+  await import("../../src/agents/persona-reviews.js");
 const { createAgentMcpToken } = await import("../../src/auth.js");
 const execFileAsync = promisify(execFile);
 
@@ -1598,7 +1601,12 @@ describe("AgentManager", () => {
         });
 
         await expect(
-          manager.updateFeedbackStatus(feedback.id, child.id, "ignored")
+          feedbackQueries.updateFeedbackStatus(
+            pool,
+            feedback.id,
+            child.id,
+            "ignored"
+          )
         ).rejects.toThrow(/reason is required/);
       });
 
@@ -1609,9 +1617,15 @@ describe("AgentManager", () => {
         });
 
         await expect(
-          manager.updateFeedbackStatus(feedback.id, child.id, "ignored", {
-            reason: "   ",
-          })
+          feedbackQueries.updateFeedbackStatus(
+            pool,
+            feedback.id,
+            child.id,
+            "ignored",
+            {
+              reason: "   ",
+            }
+          )
         ).rejects.toThrow(/reason is required/);
       });
 
@@ -1622,7 +1636,8 @@ describe("AgentManager", () => {
         });
 
         const before = Date.now();
-        const updated = await manager.updateFeedbackStatus(
+        const updated = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "ignored",
@@ -1648,7 +1663,8 @@ describe("AgentManager", () => {
           description: "finding",
         });
 
-        const updated = await manager.updateFeedbackStatus(
+        const updated = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "fixed",
@@ -1667,7 +1683,8 @@ describe("AgentManager", () => {
           description: "finding",
         });
 
-        const updated = await manager.updateFeedbackStatus(
+        const updated = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "fixed",
@@ -1684,13 +1701,20 @@ describe("AgentManager", () => {
           description: "finding",
         });
 
-        await manager.updateFeedbackStatus(feedback.id, child.id, "ignored", {
-          reason: "Won't fix",
-          resolutionCommit: "sha1",
-        });
+        await feedbackQueries.updateFeedbackStatus(
+          pool,
+          feedback.id,
+          child.id,
+          "ignored",
+          {
+            reason: "Won't fix",
+            resolutionCommit: "sha1",
+          }
+        );
         // Re-resolve as fixed without passing reason/commit — the original
         // audit trail must be preserved (COALESCE behavior).
-        const second = await manager.updateFeedbackStatus(
+        const second = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "fixed"
@@ -1707,7 +1731,8 @@ describe("AgentManager", () => {
           description: "finding",
         });
 
-        const first = await manager.updateFeedbackStatus(
+        const first = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "fixed"
@@ -1716,7 +1741,8 @@ describe("AgentManager", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        const second = await manager.updateFeedbackStatus(
+        const second = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "ignored",
@@ -1734,8 +1760,14 @@ describe("AgentManager", () => {
           description: "finding",
         });
 
-        await manager.updateFeedbackStatus(feedback.id, child.id, "fixed");
-        const reopened = await manager.updateFeedbackStatus(
+        await feedbackQueries.updateFeedbackStatus(
+          pool,
+          feedback.id,
+          child.id,
+          "fixed"
+        );
+        const reopened = await feedbackQueries.updateFeedbackStatus(
+          pool,
           feedback.id,
           child.id,
           "open"
@@ -1904,7 +1936,12 @@ describe("AgentManager", () => {
         const fixedItem = await manager.submitFeedback(child.id, {
           description: "done",
         });
-        await manager.updateFeedbackStatus(fixedItem.id, child.id, "fixed");
+        await feedbackQueries.updateFeedbackStatus(
+          pool,
+          fixedItem.id,
+          child.id,
+          "fixed"
+        );
 
         const err = await manager
           .submitReviewResolution({
@@ -1975,9 +2012,15 @@ describe("AgentManager", () => {
         const item = await manager.submitFeedback(child.id, {
           description: "a thing",
         });
-        await manager.updateFeedbackStatus(item.id, child.id, "ignored", {
-          reason: "rejected by design",
-        });
+        await feedbackQueries.updateFeedbackStatus(
+          pool,
+          item.id,
+          child.id,
+          "ignored",
+          {
+            reason: "rejected by design",
+          }
+        );
 
         const result = await manager.submitReviewResolution({
           parentAgentId: parent.id,
@@ -2174,10 +2217,16 @@ describe("AgentManager", () => {
           filePath: "apps/server/src/server.ts",
           lineNumber: 42,
         });
-        await manager.updateFeedbackStatus(original.id, child.id, "fixed", {
-          reason: "patched",
-          resolutionCommit: "fixsha",
-        });
+        await feedbackQueries.updateFeedbackStatus(
+          pool,
+          original.id,
+          child.id,
+          "fixed",
+          {
+            reason: "patched",
+            resolutionCommit: "fixsha",
+          }
+        );
         await manager.submitReviewResolution({
           parentAgentId: parent.id,
           personaAgentId: child.id,
@@ -2487,7 +2536,10 @@ describe("AgentManager", () => {
         summary: "Looks good",
       });
 
-      const reviews = await manager.listRecentPersonaReviews(7);
+      const reviews = await personaReviewQueries.listRecentPersonaReviews(
+        pool,
+        7
+      );
       expect(reviews.length).toBeGreaterThanOrEqual(1);
       const review = reviews.find((r) => r.agentId === child.id);
       expect(review).toBeDefined();
@@ -2497,7 +2549,10 @@ describe("AgentManager", () => {
     });
 
     it("should return empty array when no reviews exist in the window", async () => {
-      const reviews = await manager.listRecentPersonaReviews(7);
+      const reviews = await personaReviewQueries.listRecentPersonaReviews(
+        pool,
+        7
+      );
       expect(reviews).toEqual([]);
     });
   });
@@ -2527,7 +2582,7 @@ describe("AgentManager", () => {
         description: "Minor style issue",
       });
 
-      const feedback = await manager.listRecentFeedback(7);
+      const feedback = await feedbackQueries.listRecentFeedback(pool, 7);
       expect(feedback.length).toBeGreaterThanOrEqual(2);
       const items = feedback.filter((f) => f.agentId === child.id);
       expect(items).toHaveLength(2);
@@ -2538,7 +2593,7 @@ describe("AgentManager", () => {
     });
 
     it("should return empty array when no feedback exists in the window", async () => {
-      const feedback = await manager.listRecentFeedback(7);
+      const feedback = await feedbackQueries.listRecentFeedback(pool, 7);
       expect(feedback).toEqual([]);
     });
   });

--- a/apps/server/test/db/summary-tools.test.ts
+++ b/apps/server/test/db/summary-tools.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../src/shared/lib/run-command.js", () => ({
 }));
 
 const { AgentManager } = await import("../../src/agents/manager.js");
+const telemetry = await import("../../src/agents/telemetry.js");
 
 let pool: Pool;
 
@@ -186,7 +187,7 @@ function hoursAgo(hours: number): Date {
 
 describe("getActivitySummary", () => {
   it("returns empty results when no data exists", async () => {
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(7),
       end: new Date(),
     });
@@ -207,7 +208,7 @@ describe("getActivitySummary", () => {
     await insertEvent("a1", "working", start);
     await insertEvent("a1", "done", afterOneHour);
 
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(1),
       end: new Date(),
     });
@@ -247,7 +248,7 @@ describe("getActivitySummary", () => {
       [created, JSON.stringify(gitA)]
     );
 
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(7),
       end: new Date(),
     });
@@ -276,7 +277,7 @@ describe("getActivitySummary", () => {
     await insertAgent("a1", { gitContext: gitA, latestEventType: "done" });
     await insertAgent("a2", { gitContext: gitB, latestEventType: "done" });
 
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       project: "/projects/alpha",
@@ -292,7 +293,7 @@ describe("getActivitySummary", () => {
     await insertAgent("a2", { latestEventType: "done" });
     await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
 
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(7),
       end: new Date(),
     });
@@ -312,7 +313,7 @@ describe("getActivitySummary", () => {
     await insertEvent("a2", "working", hoursAgo(6));
     await insertEvent("a2", "done", hoursAgo(3));
 
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: daysAgo(1),
       end: new Date(),
     });
@@ -333,7 +334,7 @@ describe("getActivitySummary", () => {
     await insertEvent("a1", "done", hoursAgo(8));
 
     // Query a 9-hour window — the working event is before range start
-    const result = await manager.getActivitySummary({
+    const result = await telemetry.getActivitySummary(pool, {
       start: hoursAgo(9),
       end: new Date(),
     });
@@ -349,7 +350,7 @@ describe("getActivitySummary", () => {
 
 describe("getAgentHistory", () => {
   it("returns empty results when no agents exist", async () => {
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -373,7 +374,7 @@ describe("getAgentHistory", () => {
       parentAgentId: "parent",
     });
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -396,7 +397,7 @@ describe("getAgentHistory", () => {
       parentAgentId: "parent",
     });
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -416,7 +417,7 @@ describe("getAgentHistory", () => {
     await insertAgent("a2", { createdAt: hoursAgo(2) });
     await insertAgent("a3", { createdAt: hoursAgo(1) });
 
-    const page1 = await manager.getAgentHistory({
+    const page1 = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 2,
@@ -431,7 +432,7 @@ describe("getAgentHistory", () => {
     expect(page1.total).toBe(3);
     expect(page1.hasMore).toBe(true);
 
-    const page2 = await manager.getAgentHistory({
+    const page2 = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 2,
@@ -451,7 +452,7 @@ describe("getAgentHistory", () => {
     await insertEvent("a1", "working", hoursAgo(2));
     await insertEvent("a1", "done", hoursAgo(1));
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -484,7 +485,7 @@ describe("getAgentHistory", () => {
       description: "Missing type annotation",
     });
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -513,7 +514,7 @@ describe("getAgentHistory", () => {
       summary: "All clear",
     });
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -537,7 +538,7 @@ describe("getAgentHistory", () => {
     await insertAgent("a1", { gitContext: gitA });
     await insertAgent("a2", { gitContext: gitB });
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       project: "/projects/alpha",
@@ -559,7 +560,7 @@ describe("getAgentHistory", () => {
     await insertAgent("a2");
     await pool.query("UPDATE agents SET deleted_at = NOW() WHERE id = 'a2'");
 
-    const result = await manager.getAgentHistory({
+    const result = await telemetry.getAgentHistory(pool, {
       start: daysAgo(7),
       end: new Date(),
       limit: 20,
@@ -579,7 +580,7 @@ describe("getAgentHistory", () => {
 
 describe("getFeedbackSummary", () => {
   it("returns empty results when no feedback exists", async () => {
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(14),
       end: new Date(),
       groupBy: "persona",
@@ -600,7 +601,7 @@ describe("getFeedbackSummary", () => {
     await insertFeedback("reviewer", { severity: "low", status: "ignored" });
     await insertFeedback("reviewer", { severity: "info", status: "open" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",
@@ -634,7 +635,7 @@ describe("getFeedbackSummary", () => {
     await insertFeedback("sec-rev", { description: "XSS risk" });
     await insertFeedback("ux-rev", { description: "Poor contrast" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",
@@ -657,7 +658,7 @@ describe("getFeedbackSummary", () => {
     await insertFeedback("rev", { severity: "high" });
     await insertFeedback("rev", { severity: "low" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "severity",
@@ -687,7 +688,7 @@ describe("getFeedbackSummary", () => {
     });
     await insertFeedback("rev", { filePath: "/projects/test/src/db/query.ts" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "directory",
@@ -724,7 +725,7 @@ describe("getFeedbackSummary", () => {
       severity: "high",
     });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",
@@ -750,7 +751,7 @@ describe("getFeedbackSummary", () => {
     await insertReview("r2", "p2", "sec", { verdict: "request_changes" });
     await insertReview("r3", "p1", "ux", { verdict: "approve" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",
@@ -781,7 +782,7 @@ describe("getFeedbackSummary", () => {
     await insertFeedback("r1", { description: "Alpha finding" });
     await insertFeedback("r2", { description: "Beta finding" });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       project: "/projects/alpha",
@@ -805,7 +806,7 @@ describe("getFeedbackSummary", () => {
       createdAt: daysAgo(30),
     });
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",
@@ -826,7 +827,7 @@ describe("getFeedbackSummary", () => {
       "UPDATE agents SET deleted_at = NOW() WHERE id = 'parent'"
     );
 
-    const result = await manager.getFeedbackSummary({
+    const result = await telemetry.getFeedbackSummary(pool, {
       start: daysAgo(7),
       end: new Date(),
       groupBy: "persona",

--- a/apps/server/test/feedback-routes.test.ts
+++ b/apps/server/test/feedback-routes.test.ts
@@ -10,9 +10,16 @@ import {
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
 
 import { registerFeedbackRoutes } from "../src/routes/feedback.js";
+import * as feedbackQueries from "../src/agents/feedback.js";
 
 vi.mock("../src/shared/git/worktree.js", () => ({
   resolveHeadSha: vi.fn(async () => "abc123"),
+}));
+
+vi.mock("../src/agents/feedback.js", () => ({
+  listFeedback: vi.fn(),
+  listFeedbackByParent: vi.fn(),
+  updateFeedbackStatus: vi.fn(),
 }));
 
 const mockFeedback = {
@@ -24,14 +31,9 @@ const mockFeedback = {
 
 function createMockDeps() {
   return {
+    pool: {} as never,
     agentManager: {
       getAgent: vi.fn(async () => ({ id: "agt_test1", cwd: "/tmp" })),
-      listFeedback: vi.fn(async () => [mockFeedback]),
-      listFeedbackByParent: vi.fn(async () => [mockFeedback]),
-      updateFeedbackStatus: vi.fn(async () => ({
-        ...mockFeedback,
-        status: "fixed",
-      })),
     },
     publishUiEvent: vi.fn(),
     handleAgentError: vi.fn((reply: FastifyReply, error: unknown) =>
@@ -63,12 +65,16 @@ beforeEach(() => {
     id: "agt_test1",
     cwd: "/tmp",
   });
-  deps.agentManager.listFeedback.mockResolvedValue([mockFeedback]);
-  deps.agentManager.listFeedbackByParent.mockResolvedValue([mockFeedback]);
-  deps.agentManager.updateFeedbackStatus.mockResolvedValue({
+  vi.mocked(feedbackQueries.listFeedback).mockResolvedValue([
+    mockFeedback,
+  ] as never);
+  vi.mocked(feedbackQueries.listFeedbackByParent).mockResolvedValue([
+    mockFeedback,
+  ] as never);
+  vi.mocked(feedbackQueries.updateFeedbackStatus).mockResolvedValue({
     ...mockFeedback,
     status: "fixed",
-  });
+  } as never);
 });
 
 describe("GET /api/v1/agents/:id/feedback", () => {
@@ -80,7 +86,10 @@ describe("GET /api/v1/agents/:id/feedback", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ feedback: [mockFeedback] });
     expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
-    expect(deps.agentManager.listFeedback).toHaveBeenCalledWith("agt_test1");
+    expect(feedbackQueries.listFeedback).toHaveBeenCalledWith(
+      deps.pool,
+      "agt_test1"
+    );
   });
 
   it("returns 404 when agent is not found", async () => {
@@ -100,7 +109,8 @@ describe("GET /api/v1/agents/:id/feedback", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ feedback: [mockFeedback] });
-    expect(deps.agentManager.listFeedbackByParent).toHaveBeenCalledWith(
+    expect(feedbackQueries.listFeedbackByParent).toHaveBeenCalledWith(
+      deps.pool,
       "agt_test1"
     );
     expect(deps.agentManager.getAgent).not.toHaveBeenCalled();
@@ -125,12 +135,12 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
       payload: { status: "dismissed" },
     });
     expect(res.statusCode).toBe(200);
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "dismissed",
-      { reason: null, resolutionCommit: null }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "dismissed", {
+      reason: null,
+      resolutionCommit: null,
+    });
   });
 
   it("updates feedback status to forwarded", async () => {
@@ -140,12 +150,12 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
       payload: { status: "forwarded" },
     });
     expect(res.statusCode).toBe(200);
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "forwarded",
-      { reason: null, resolutionCommit: null }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "forwarded", {
+      reason: null,
+      resolutionCommit: null,
+    });
   });
 
   it("updates feedback status to open", async () => {
@@ -155,12 +165,12 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
       payload: { status: "open" },
     });
     expect(res.statusCode).toBe(200);
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "open",
-      { reason: null, resolutionCommit: null }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "open", {
+      reason: null,
+      resolutionCommit: null,
+    });
   });
 
   it("resolves head sha when status is fixed", async () => {
@@ -173,12 +183,12 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
     expect(res.statusCode).toBe(200);
     expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
     expect(resolveHeadSha).toHaveBeenCalledWith("/tmp");
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "fixed",
-      { reason: null, resolutionCommit: "abc123" }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "fixed", {
+      reason: null,
+      resolutionCommit: "abc123",
+    });
   });
 
   it("resolves head sha when status is ignored with reason", async () => {
@@ -191,12 +201,12 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
     expect(res.statusCode).toBe(200);
     expect(deps.agentManager.getAgent).toHaveBeenCalledWith("agt_test1");
     expect(resolveHeadSha).toHaveBeenCalledWith("/tmp");
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "ignored",
-      { reason: "not relevant", resolutionCommit: "abc123" }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "ignored", {
+      reason: "not relevant",
+      resolutionCommit: "abc123",
+    });
   });
 
   it("does not fetch agent or resolve sha for non-resolving statuses", async () => {
@@ -212,7 +222,7 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
 
   it("publishes ui event on successful update", async () => {
     const dismissedFeedback = { ...mockFeedback, status: "dismissed" };
-    deps.agentManager.updateFeedbackStatus.mockResolvedValueOnce(
+    vi.mocked(feedbackQueries.updateFeedbackStatus).mockResolvedValueOnce(
       dismissedFeedback
     );
     await app.inject({
@@ -228,7 +238,7 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
   });
 
   it("returns 404 when feedback is not found", async () => {
-    deps.agentManager.updateFeedbackStatus.mockResolvedValue(null);
+    vi.mocked(feedbackQueries.updateFeedbackStatus).mockResolvedValue(null);
     const res = await app.inject({
       method: "PATCH",
       url: "/api/v1/agents/agt_test1/feedback/1",
@@ -368,7 +378,7 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
   });
 
   it("calls handleAgentError on thrown errors", async () => {
-    deps.agentManager.updateFeedbackStatus.mockRejectedValue(
+    vi.mocked(feedbackQueries.updateFeedbackStatus).mockRejectedValue(
       new Error("db fail")
     );
     const res = await app.inject({
@@ -388,11 +398,11 @@ describe("PATCH /api/v1/agents/:id/feedback/:feedbackId", () => {
       payload: { status: "fixed" },
     });
     expect(res.statusCode).toBe(200);
-    expect(deps.agentManager.updateFeedbackStatus).toHaveBeenCalledWith(
-      1,
-      "agt_test1",
-      "fixed",
-      { reason: null, resolutionCommit: null }
-    );
+    expect(
+      vi.mocked(feedbackQueries.updateFeedbackStatus)
+    ).toHaveBeenCalledWith(deps.pool, 1, "agt_test1", "fixed", {
+      reason: null,
+      resolutionCommit: null,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **routes/mcp.ts** and **routes/feedback.ts** now call `telemetry`, `persona-reviews`, and `feedback` modules directly via `pool` instead of routing through `AgentManager` passthrough methods
- Removed 8 pure-delegation methods from `manager.ts`: `listRecentPersonaReviews`, `listRecentFeedback`, `getActivitySummary`, `getAgentHistory`, `getFeedbackSummary`, `listFeedback`, `listFeedbackByParent`, `updateFeedbackStatus`
- Also removed unused type re-exports (`ActivitySummaryResult`, `AgentHistoryEntry`, `AgentHistoryResult`, `FeedbackSummaryResult`) from manager.ts
- Updated 3 test files to match the new call patterns
- `getPersonaReview` passthrough kept — still used by `mcp-handlers.ts`

This continues the manager.ts passthrough cleanup series (PRs #598, #602, #608, #615, #622).

## What qualifies as tech debt

These methods added indirection without value — each was a one-liner that forwarded to the underlying module. Making route files call the modules directly makes the data flow explicit and reduces the surface area of the AgentManager class.

## Next run

The backlog item for next run is: **manager.ts `createAgent` method (~300 lines) could be split into setup-script path vs inert path.**

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — all unit tests pass
- [x] `pnpm run test:e2e` — 160/160 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)