### PR TITLE
Fix job docs: add callable field, move singleton to basic section

### DIFF
--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -951,6 +951,15 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               agent to drive the run to a terminal state. Required before a run
               can start.
             </li>
+            <li>
+              <strong>Show in command palette</strong> — when on, the job
+              appears in the <Code>Mod+K</Code> palette for quick launch.
+            </li>
+            <li>
+              <strong>Single instance</strong> — when on (the default), only one
+              run can be active at a time. Turn off to allow overlapping runs of
+              the same job.
+            </li>
           </ul>
           <P>
             Open <strong>Advanced settings</strong> for the rest:
@@ -980,11 +989,6 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
               <strong>Keep agent after run completes</strong> — by default the
               agent is auto-archived once a run reaches a terminal state. Check
               this to leave the agent (and its worktree) around for inspection.
-            </li>
-            <li>
-              <strong>Single instance</strong> — when on (the default), only one
-              run can be active at a time. Turn off to allow overlapping runs of
-              the same job.
             </li>
           </ul>
         </Section>


### PR DESCRIPTION
## Summary

- Added missing **Show in command palette** (callable) field to the in-app job docs — it's been a basic field in both the create and settings forms but was never documented
- Moved **Single instance** from the Advanced settings section to the basic fields list — it's actually rendered before the Advanced collapsible in the create form

## Audit scope

Audited the full Automations section (Templates & Jobs, lines 758–1171) of `docs-pane.tsx` against `automations-form-fields.tsx`, `jobs-add-dialog.tsx`, `jobs-form-fields.tsx`, `jobs-pane.tsx`, and the MCP tool definitions in `server.ts` / `job-tools.ts`.

Everything else in the section verified accurate: template fields, runtime arguments, launch dialog, job lifecycle tools, job agent tool list, brain tools, auto-review flow, state-across-runs, and Automations UI tabs.

## Deferred to next run

Next focus set to: audit docs-pane Worktrees section against `packages/shared/src/git/worktree.ts` and `create-agent-dialog.tsx` worktree controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)