### PR TITLE
Extract toStructuredContent helper in brain-tools.ts

### DIFF
--- a/apps/server/src/shared/mcp/brain-tools.ts
+++ b/apps/server/src/shared/mcp/brain-tools.ts
@@ -26,12 +26,16 @@ type ToolResult = {
   structuredContent?: Record<string, unknown>;
 };
 
+function toStructuredContent(obj: object): Record<string, unknown> {
+  return obj as Record<string, unknown>;
+}
+
 function toBrainError(error: unknown): ToolResult {
   if (error instanceof BrainRevisionConflictError) {
     return {
       content: [{ type: "text", text: error.message }],
       isError: true,
-      structuredContent: {
+      structuredContent: toStructuredContent({
         error: {
           code: error.code,
           message: error.message,
@@ -42,7 +46,7 @@ function toBrainError(error: unknown): ToolResult {
             ...("value" in error.current ? { value: error.current.value } : {}),
           },
         },
-      } as Record<string, unknown>,
+      }),
     };
   }
   if (
@@ -55,9 +59,9 @@ function toBrainError(error: unknown): ToolResult {
     return {
       content: [{ type: "text", text: error.message }],
       isError: true,
-      structuredContent: {
+      structuredContent: toStructuredContent({
         error: { code: error.code, message: error.message },
-      } as Record<string, unknown>,
+      }),
     };
   }
   return toToolError(error);
@@ -110,7 +114,7 @@ export function registerBrainTools(
           }
           return {
             content: [{ type: "text", text: JSON.stringify(obj, null, 2) }],
-            structuredContent: obj as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(obj),
           };
         } catch (error) {
           return toBrainError(error);
@@ -161,7 +165,7 @@ export function registerBrainTools(
           publishBrainChanged?.();
           return {
             content: [{ type: "text", text: JSON.stringify(obj, null, 2) }],
-            structuredContent: obj as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(obj),
           };
         } catch (error) {
           return toBrainError(error);
@@ -221,7 +225,7 @@ export function registerBrainTools(
           publishBrainChanged?.();
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -281,7 +285,7 @@ export function registerBrainTools(
           publishBrainChanged?.();
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -333,7 +337,7 @@ export function registerBrainTools(
           });
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -385,7 +389,7 @@ export function registerBrainTools(
           publishBrainChanged?.();
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -428,7 +432,7 @@ export function registerBrainTools(
                   : `List "${args.collection}/${args.name}" not found.`,
               },
             ],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -478,7 +482,7 @@ export function registerBrainTools(
           const result = { objects };
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -521,7 +525,7 @@ export function registerBrainTools(
                   : `Object "${args.collection}/${args.name}" not found.`,
               },
             ],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);
@@ -573,7 +577,7 @@ export function registerBrainTools(
           publishBrainChanged?.();
           return {
             content: [{ type: "text", text: JSON.stringify(event, null, 2) }],
-            structuredContent: event as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(event),
           };
         } catch (error) {
           return toBrainError(error);
@@ -643,7 +647,7 @@ export function registerBrainTools(
           const result = { events };
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toStructuredContent(result),
           };
         } catch (error) {
           return toBrainError(error);


### PR DESCRIPTION
## Summary
- Extracted a `toStructuredContent()` helper function to replace 13 repetitive type casts (`as unknown as Record<string, unknown>`) in brain-tools.ts
- Every brain tool handler was double-casting its return value to satisfy the MCP SDK's `structuredContent` field type — the helper consolidates this to a single cast in one place
- No behavior changes; purely a type-level cleanup

## Why this is tech debt
The double-cast pattern (`as unknown as Record<string, unknown>`) was copy-pasted across all 11 tool handlers plus 2 error builders. If the upstream MCP SDK type changes or the Brain store return types evolve, every handler would need updating. Now there's one place to change.

## Next up
Top backlog item: `docs-pane.tsx` is 2018 lines with 11 hardcoded doc sections as inline JSX — extract into separate files.

## Test plan
- [x] `pnpm run check` — TypeScript passes
- [x] `pnpm run test` — all unit tests pass
- [x] `pnpm run test:e2e` — 160 passed, 12 skipped (terminal-live, pre-existing)