### PR TITLE
Add webhook triggers for jobs

### DIFF
--- a/apps/server/src/db/migrations/0027_jobs-webhook.sql
+++ b/apps/server/src/db/migrations/0027_jobs-webhook.sql
@@ -1,0 +1,7 @@
+ALTER TABLE jobs
+  ADD COLUMN webhook_enabled BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN webhook_secret  TEXT;
+
+CREATE UNIQUE INDEX jobs_webhook_secret_unique
+  ON jobs (webhook_secret)
+  WHERE webhook_secret IS NOT NULL;

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
 import type { FastifyBaseLogger } from "fastify";
@@ -33,7 +34,7 @@ type RunJobInput = {
   name: string;
   directory: string;
   wait?: boolean;
-  triggerSource?: "manual" | "scheduled";
+  triggerSource?: "manual" | "scheduled" | "webhook";
 };
 
 export type AddJobInput = {
@@ -52,6 +53,7 @@ export type AddJobInput = {
   autoArchive?: boolean;
   callable?: boolean;
   singleton?: boolean;
+  webhookEnabled?: boolean;
   defaultArgs?: Record<string, string>;
   enabled?: boolean;
 };
@@ -209,6 +211,17 @@ export class JobService {
     }
   }
 
+  async runJobByWebhook(secret: string): Promise<RunJobResult> {
+    const job = await this.store.getJobByWebhookSecret(secret);
+    if (!job) throw new WebhookNotFoundError();
+    return this.runJob({
+      name: job.name,
+      directory: job.directory,
+      wait: false,
+      triggerSource: "webhook",
+    });
+  }
+
   async reconcileActiveRuns(): Promise<void> {
     const runs = await this.store.listActiveRuns();
     for (const run of runs) {
@@ -294,6 +307,9 @@ export class JobService {
       allowMedia: false,
     });
 
+    const webhookEnabled = input.webhookEnabled ?? false;
+    const webhookSecret = webhookEnabled ? generateWebhookSecret() : null;
+
     let job: JobRecord;
     try {
       job = await this.store.createJob({
@@ -312,6 +328,8 @@ export class JobService {
         autoArchive: input.autoArchive ?? true,
         callable: input.callable ?? false,
         singleton: input.singleton ?? true,
+        webhookEnabled,
+        webhookSecret,
         templateId: template.id,
         defaultArgs: {},
         enabled: input.enabled ?? false,
@@ -381,6 +399,14 @@ export class JobService {
     if (input.autoArchive !== undefined) config.autoArchive = input.autoArchive;
     if (input.callable !== undefined) config.callable = input.callable;
     if (input.singleton !== undefined) config.singleton = input.singleton;
+    if (input.webhookEnabled !== undefined) {
+      config.webhookEnabled = input.webhookEnabled;
+      if (input.webhookEnabled && !existing.webhookEnabled) {
+        config.webhookSecret = generateWebhookSecret();
+      } else if (!input.webhookEnabled) {
+        config.webhookSecret = null;
+      }
+    }
     if (input.enabled !== undefined) config.enabled = input.enabled;
 
     const updated = await this.store.updateJobConfig(existing.id, config);
@@ -842,7 +868,7 @@ function buildAgentArgs(
 
 function buildRunConfig(
   job: JobRecord,
-  triggerSource: "manual" | "scheduled"
+  triggerSource: "manual" | "scheduled" | "webhook"
 ): JobRunConfig {
   return {
     directory: job.directory,
@@ -881,6 +907,17 @@ function normalizeOptionalString(
 ): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+export class WebhookNotFoundError extends Error {
+  constructor() {
+    super("Webhook not found or disabled.");
+    this.name = "WebhookNotFoundError";
+  }
+}
+
+function generateWebhookSecret(): string {
+  return randomBytes(24).toString("base64url");
 }
 
 function normalizeNullableString(

--- a/apps/server/src/jobs/store.ts
+++ b/apps/server/src/jobs/store.ts
@@ -44,6 +44,8 @@ export type JobRecord = {
   autoArchive: boolean;
   callable: boolean;
   singleton: boolean;
+  webhookEnabled: boolean;
+  webhookSecret: string | null;
   templateId: string | null;
   defaultArgs: Record<string, string>;
   createdAt: string;
@@ -87,7 +89,7 @@ export type JobRunConfig = {
   timeoutMs: number;
   needsInputTimeoutMs: number;
   notify: JobNotifyConfig;
-  triggerSource?: "manual" | "scheduled";
+  triggerSource?: "manual" | "scheduled" | "webhook";
   autoArchive?: boolean;
 };
 
@@ -105,6 +107,8 @@ export type JobConfigUpdate = {
   autoArchive?: boolean;
   callable?: boolean;
   singleton?: boolean;
+  webhookEnabled?: boolean;
+  webhookSecret?: string | null;
   templateId?: string | null;
   defaultArgs?: Record<string, string>;
   enabled?: boolean;
@@ -128,6 +132,8 @@ export class JobStore {
     autoArchive: boolean;
     callable: boolean;
     singleton: boolean;
+    webhookEnabled: boolean;
+    webhookSecret: string | null;
     templateId?: string | null;
     defaultArgs?: Record<string, string>;
     enabled: boolean;
@@ -136,8 +142,8 @@ export class JobStore {
     try {
       const result = await this.pool.query(
         `
-        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, base_branch, branch_name, auto_archive, callable, singleton, template_id, default_args, enabled)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb, $18)
+        INSERT INTO jobs (id, directory, name, schedule, timeout_ms, needs_input_timeout_ms, prompt, full_access, agent_type, use_worktree, base_branch, branch_name, auto_archive, callable, singleton, webhook_enabled, webhook_secret, template_id, default_args, enabled)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20)
         RETURNING ${this.jobColumns()}
         `,
         [
@@ -156,6 +162,8 @@ export class JobStore {
           input.autoArchive,
           input.callable,
           input.singleton,
+          input.webhookEnabled,
+          input.webhookSecret,
           input.templateId ?? null,
           JSON.stringify(input.defaultArgs ?? {}),
           input.enabled,
@@ -391,6 +399,8 @@ export class JobStore {
         j.auto_archive AS "autoArchive",
         j.callable,
         j.singleton,
+        j.webhook_enabled AS "webhookEnabled",
+        j.webhook_secret AS "webhookSecret",
         j.template_id AS "templateId",
         j.default_args AS "defaultArgs",
         j.created_at AS "createdAt",
@@ -520,6 +530,14 @@ export class JobStore {
     return result.rows[0] ? mapJob(result.rows[0]) : null;
   }
 
+  async getJobByWebhookSecret(secret: string): Promise<JobRecord | null> {
+    const result = await this.pool.query(
+      `SELECT ${this.jobColumns()} FROM jobs WHERE webhook_secret = $1 AND webhook_enabled = true`,
+      [secret]
+    );
+    return result.rows[0] ? mapJob(result.rows[0]) : null;
+  }
+
   async getJobByDirectoryAndName(
     directory: string,
     name: string
@@ -569,6 +587,8 @@ export class JobStore {
             singleton = COALESCE($19, singleton),
             template_id = CASE WHEN $20 THEN $21 ELSE template_id END,
             default_args = CASE WHEN $22 THEN $23::jsonb ELSE default_args END,
+            webhook_enabled = COALESCE($24, webhook_enabled),
+            webhook_secret = CASE WHEN $25 THEN $26 ELSE webhook_secret END,
             updated_at = NOW()
         WHERE id = $1
         RETURNING ${this.jobColumns()}
@@ -597,6 +617,9 @@ export class JobStore {
           input.templateId ?? null,
           Object.prototype.hasOwnProperty.call(input, "defaultArgs"),
           input.defaultArgs ? JSON.stringify(input.defaultArgs) : "{}",
+          input.webhookEnabled,
+          Object.prototype.hasOwnProperty.call(input, "webhookSecret"),
+          input.webhookSecret ?? null,
         ]
       );
       if (!result.rows[0]) throw new Error(`Job ${jobId} not found.`);
@@ -681,6 +704,8 @@ export class JobStore {
       auto_archive AS "autoArchive",
       callable,
       singleton,
+      webhook_enabled AS "webhookEnabled",
+      webhook_secret AS "webhookSecret",
       template_id AS "templateId",
       default_args AS "defaultArgs",
       created_at AS "createdAt",

--- a/apps/server/src/routes/jobs.ts
+++ b/apps/server/src/routes/jobs.ts
@@ -155,17 +155,21 @@ export async function registerJobRoutes(
     }
   });
 
-  app.post("/api/v1/jobs/webhook/:secret", async (request, reply) => {
-    const { secret } = request.params as { secret: string };
-    try {
-      const result = await deps.jobService.runJobByWebhook(secret);
-      return { jobId: result.jobId, runId: result.runId };
-    } catch (error) {
-      if (error instanceof WebhookNotFoundError) {
-        return reply.code(404).send({ error: error.message });
+  app.post(
+    "/api/v1/jobs/webhook/:secret",
+    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      const { secret } = request.params as { secret: string };
+      try {
+        const result = await deps.jobService.runJobByWebhook(secret);
+        return { jobId: result.jobId, runId: result.runId };
+      } catch (error) {
+        if (error instanceof WebhookNotFoundError) {
+          return reply.code(404).send({ error: error.message });
+        }
+        const message = errorMessage(error);
+        return reply.code(500).send({ error: message });
       }
-      const message = errorMessage(error);
-      return reply.code(500).send({ error: message });
     }
-  });
+  );
 }

--- a/apps/server/src/routes/jobs.ts
+++ b/apps/server/src/routes/jobs.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import * as z from "zod/v4";
 
 import { CLI_AGENT_TYPES } from "../agent-type-settings.js";
-import type { JobService } from "../jobs/service.js";
+import { type JobService, WebhookNotFoundError } from "../jobs/service.js";
 import { errorMessage } from "../shared/lib/error-message.js";
 import { parseInput } from "../shared/lib/parse-input.js";
 import { resolveTilde } from "../shared/lib/resolve-tilde.js";
@@ -34,6 +34,7 @@ const AddJobBodySchema = JobEnableDisableBodySchema.extend({
   autoArchive: z.boolean().optional(),
   callable: z.boolean().optional(),
   singleton: z.boolean().optional(),
+  webhookEnabled: z.boolean().optional(),
   defaultArgs: z.record(z.string(), z.string()).optional(),
   enabled: z.boolean().optional(),
 });
@@ -151,6 +152,20 @@ export async function registerJobRoutes(
     } catch (error) {
       const message = errorMessage(error);
       return reply.code(404).send({ error: message });
+    }
+  });
+
+  app.post("/api/v1/jobs/webhook/:secret", async (request, reply) => {
+    const { secret } = request.params as { secret: string };
+    try {
+      const result = await deps.jobService.runJobByWebhook(secret);
+      return { jobId: result.jobId, runId: result.runId };
+    } catch (error) {
+      if (error instanceof WebhookNotFoundError) {
+        return reply.code(404).send({ error: error.message });
+      }
+      const message = errorMessage(error);
+      return reply.code(500).send({ error: message });
     }
   });
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -396,6 +396,7 @@ async function registerRoutes() {
     if (url.startsWith("/api/v1/auth/")) return;
     if (url === "/api/v1/health") return;
     if (url === "/api/v1/app/branding") return;
+    if (url.startsWith("/api/v1/jobs/webhook/")) return;
     if (/^\/api\/v1\/agents\/[^/]+\/terminal\/ws$/.test(url)) return;
     // The assisted-update phase endpoint authenticates via a per-job nonce
     // embedded in the launched agent's prompt — see assisted-update.ts. The

--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -64,6 +64,8 @@ function makeJob(
     autoArchive: true,
     callable: false,
     singleton: true,
+    webhookEnabled: false,
+    webhookSecret: null,
     enabled: false,
   });
 }

--- a/apps/server/test/jobs/store-phase2.test.ts
+++ b/apps/server/test/jobs/store-phase2.test.ts
@@ -29,6 +29,8 @@ const jobDefaults = {
   autoArchive: true,
   callable: false,
   singleton: true,
+  webhookEnabled: false,
+  webhookSecret: null,
   enabled: false,
 };
 

--- a/apps/server/test/jobs/store.test.ts
+++ b/apps/server/test/jobs/store.test.ts
@@ -40,6 +40,8 @@ describe("JobStore", () => {
       autoArchive: true,
       callable: false,
       singleton: true,
+      webhookEnabled: false,
+      webhookSecret: null,
       enabled: false,
     });
     const run = await store.createRun(job.id, {

--- a/apps/web/src/components/app/jobs-form-fields.tsx
+++ b/apps/web/src/components/app/jobs-form-fields.tsx
@@ -1,4 +1,5 @@
-import { GitBranch } from "lucide-react";
+import { Check, Copy, GitBranch } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
 
 import { BranchSelect } from "@/components/app/branch-select";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -142,5 +143,45 @@ export function JobFullAccessOption({
         </span>
       </span>
     </label>
+  );
+}
+
+export function WebhookUrl({ secret }: { secret: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const url = `${window.location.origin}/api/v1/jobs/webhook/${secret}`;
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    });
+  }, [url]);
+
+  return (
+    <div className="mt-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5">
+      <div className="text-xs font-medium text-muted-foreground">
+        Webhook URL
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <code className="min-w-0 flex-1 truncate text-xs">{url}</code>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground"
+          onClick={copy}
+          aria-label="Copy webhook URL"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-status-done" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      <div className="mt-1 text-[11px] text-muted-foreground/70">
+        POST to this URL to trigger a run. No auth header required.
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/app/jobs-helpers.ts
+++ b/apps/web/src/components/app/jobs-helpers.ts
@@ -99,7 +99,9 @@ export function humanSchedule(schedule: string | null): string {
 }
 
 export function triggerSourceLabel(run: JobRun): string {
-  return run.config.triggerSource === "scheduled" ? "Scheduled" : "Manual";
+  if (run.config.triggerSource === "scheduled") return "Scheduled";
+  if (run.config.triggerSource === "webhook") return "Webhook";
+  return "Manual";
 }
 
 export function formatTimeUntil(iso: string): string {

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -2,8 +2,10 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   Activity,
   AlarmClock,
+  Check,
   CheckCircle2,
   Clock,
+  Copy,
   History,
   MessageSquareText,
   Play,
@@ -12,7 +14,15 @@ import {
   Trash2,
   XCircle,
 } from "lucide-react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { type Agent } from "@/components/app/types";
@@ -1002,6 +1012,46 @@ function TabButton({
   );
 }
 
+function WebhookUrl({ secret }: { secret: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const url = `${window.location.origin}/api/v1/jobs/webhook/${secret}`;
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    });
+  }, [url]);
+
+  return (
+    <div className="mt-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5">
+      <div className="text-xs font-medium text-muted-foreground">
+        Webhook URL
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <code className="min-w-0 flex-1 truncate text-xs">{url}</code>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground"
+          onClick={copy}
+          aria-label="Copy webhook URL"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-status-done" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      <div className="mt-1 text-[11px] text-muted-foreground/70">
+        POST to this URL to trigger a run. No auth header required.
+      </div>
+    </div>
+  );
+}
+
 function SettingsTab({
   job,
   enabledAgentTypes,
@@ -1033,6 +1083,7 @@ function SettingsTab({
   const [keepAgent, setKeepAgent] = useState(!job.autoArchive);
   const [callable, setCallable] = useState(job.callable);
   const [singleton, setSingleton] = useState(job.singleton);
+  const [webhookEnabled, setWebhookEnabled] = useState(job.webhookEnabled);
   const [enabled, setEnabled] = useState(job.enabled);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
@@ -1059,6 +1110,7 @@ function SettingsTab({
     setKeepAgent(!job.autoArchive);
     setCallable(job.callable);
     setSingleton(job.singleton);
+    setWebhookEnabled(job.webhookEnabled);
     setEnabled(job.enabled);
     setSaveError(null);
     setRemoveError(null);
@@ -1182,7 +1234,7 @@ function SettingsTab({
             />
           </div>
         </div>
-        <div className="mt-4 grid gap-3">
+        <div className="mt-4 flex flex-col gap-3">
           <JobWorktreeOption
             checked={useWorktree}
             cwd={job.directory}
@@ -1231,6 +1283,30 @@ function SettingsTab({
               ariaLabel="Single instance"
             />
           </label>
+          <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm">
+            <label className="flex items-center justify-between gap-3">
+              <span>
+                <span className="block font-medium text-foreground">
+                  Webhook trigger
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Trigger this job via an HTTP POST to a secret URL.
+                </span>
+              </span>
+              <SwitchToggle
+                checked={webhookEnabled}
+                onCheckedChange={setWebhookEnabled}
+                ariaLabel="Webhook trigger"
+              />
+            </label>
+            {webhookEnabled && job.webhookSecret ? (
+              <WebhookUrl secret={job.webhookSecret} />
+            ) : webhookEnabled && !job.webhookSecret ? (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Save to generate a webhook URL.
+              </div>
+            ) : null}
+          </div>
         </div>
         {saveError ? (
           <div className="mt-4 rounded-md border border-status-blocked/40 bg-status-blocked/10 p-3 text-sm text-status-blocked">
@@ -1264,6 +1340,7 @@ function SettingsTab({
                 autoArchive: !keepAgent,
                 callable,
                 singleton,
+                webhookEnabled,
                 enabled: effectiveEnabled,
               })
                 .then(() => {

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -2,10 +2,8 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   Activity,
   AlarmClock,
-  Check,
   CheckCircle2,
   Clock,
-  Copy,
   History,
   MessageSquareText,
   Play,
@@ -14,15 +12,7 @@ import {
   Trash2,
   XCircle,
 } from "lucide-react";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { type Agent } from "@/components/app/types";
@@ -37,6 +27,7 @@ import {
   JobKeepAgentOption,
   JobWorktreeOption,
   SwitchToggle,
+  WebhookUrl,
 } from "@/components/app/jobs-form-fields";
 import {
   ACTIVE_RUN_STATUSES,
@@ -1009,46 +1000,6 @@ function TabButton({
       {icon}
       {children}
     </button>
-  );
-}
-
-function WebhookUrl({ secret }: { secret: string }) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
-  const url = `${window.location.origin}/api/v1/jobs/webhook/${secret}`;
-
-  const copy = useCallback(() => {
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 2000);
-    });
-  }, [url]);
-
-  return (
-    <div className="mt-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5">
-      <div className="text-xs font-medium text-muted-foreground">
-        Webhook URL
-      </div>
-      <div className="mt-1 flex items-center gap-2">
-        <code className="min-w-0 flex-1 truncate text-xs">{url}</code>
-        <button
-          type="button"
-          className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground"
-          onClick={copy}
-          aria-label="Copy webhook URL"
-        >
-          {copied ? (
-            <Check className="h-3.5 w-3.5 text-status-done" />
-          ) : (
-            <Copy className="h-3.5 w-3.5" />
-          )}
-        </button>
-      </div>
-      <div className="mt-1 text-[11px] text-muted-foreground/70">
-        POST to this URL to trigger a run. No auth header required.
-      </div>
-    </div>
   );
 }
 

--- a/apps/web/src/hooks/use-jobs.ts
+++ b/apps/web/src/hooks/use-jobs.ts
@@ -11,7 +11,7 @@ export type JobRunStatus =
   | "timed_out"
   | "crashed";
 export type JobAgentType = "claude" | "codex" | "opencode" | "cursor";
-export type JobRunTriggerSource = "manual" | "scheduled";
+export type JobRunTriggerSource = "manual" | "scheduled" | "webhook";
 
 export type JobNotifyConfig = {
   onComplete: string[];
@@ -53,6 +53,8 @@ export type Job = {
   autoArchive: boolean;
   callable: boolean;
   singleton: boolean;
+  webhookEnabled: boolean;
+  webhookSecret: string | null;
   templateId: string | null;
   defaultArgs: Record<string, string>;
   createdAt: string;
@@ -105,6 +107,7 @@ export type AddJobConfig = {
   autoArchive?: boolean;
   callable?: boolean;
   singleton?: boolean;
+  webhookEnabled?: boolean;
   enabled?: boolean;
 };
 

--- a/e2e/jobs-api.spec.ts
+++ b/e2e/jobs-api.spec.ts
@@ -293,4 +293,108 @@ test.describe("Jobs API", () => {
     });
     expect(res.status()).toBe(500);
   });
+
+  test("webhook trigger creates and runs a job via secret URL", async ({
+    request,
+  }) => {
+    const webhookDir = join(tmpdir(), `dispatch-e2e-webhook-${Date.now()}`);
+    mkdirSync(webhookDir, { recursive: true });
+    const createRes = await request.post("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook Job",
+        directory: webhookDir,
+        prompt: "Call job_complete immediately.",
+        timeoutMs: 120000,
+        needsInputTimeoutMs: 86400000,
+        webhookEnabled: true,
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = await createRes.json();
+    expect(created.webhookEnabled).toBe(true);
+    expect(created.webhookSecret).toBeTruthy();
+
+    // POST to webhook URL without auth headers
+    const webhookRes = await request.post(
+      `/api/v1/jobs/webhook/${created.webhookSecret}`,
+      {}
+    );
+    const webhookBody = await webhookRes.json();
+    expect(
+      webhookRes.ok(),
+      `Webhook failed: ${JSON.stringify(webhookBody)}`
+    ).toBeTruthy();
+    expect(webhookBody.jobId).toBeTruthy();
+    expect(webhookBody.runId).toBeTruthy();
+
+    // Verify triggerSource is "webhook"
+    const params = new URLSearchParams({
+      name: "Webhook Job",
+      directory: webhookDir,
+    });
+    const historyRes = await request.get(`/api/v1/jobs/history?${params}`, {
+      headers: AUTH_HEADER,
+    });
+    expect(historyRes.ok()).toBeTruthy();
+    const history = await historyRes.json();
+    const run = history.runs.find(
+      (entry: { id: string }) => entry.id === webhookBody.runId
+    );
+    expect(run.config.triggerSource).toBe("webhook");
+  });
+
+  test("webhook trigger returns 404 for invalid secret", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      "/api/v1/jobs/webhook/totally-invalid-secret",
+      {}
+    );
+    expect(res.status()).toBe(404);
+  });
+
+  test("disabling webhook clears secret and rejects requests", async ({
+    request,
+  }) => {
+    const webhookDir2 = join(
+      tmpdir(),
+      `dispatch-e2e-webhook-disable-${Date.now()}`
+    );
+    mkdirSync(webhookDir2, { recursive: true });
+    // Create with webhook enabled
+    const createRes = await request.post("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook Disable Job",
+        directory: webhookDir2,
+        prompt: "Call job_complete immediately.",
+        timeoutMs: 120000,
+        needsInputTimeoutMs: 86400000,
+        webhookEnabled: true,
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = await createRes.json();
+    const secret = created.webhookSecret;
+    expect(secret).toBeTruthy();
+
+    // Disable webhook
+    const updateRes = await request.patch("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook Disable Job",
+        directory: webhookDir2,
+        webhookEnabled: false,
+      },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+    const updated = await updateRes.json();
+    expect(updated.webhookEnabled).toBe(false);
+    expect(updated.webhookSecret).toBeNull();
+
+    // Old secret should now return 404
+    const webhookRes = await request.post(`/api/v1/jobs/webhook/${secret}`, {});
+    expect(webhookRes.status()).toBe(404);
+  });
 });

--- a/e2e/jobs-webhook-ui.spec.ts
+++ b/e2e/jobs-webhook-ui.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+};
+const HEADERS = { ...AUTH_HEADER, "Content-Type": "application/json" };
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Jobs webhook UI", () => {
+  const jobDir = join(tmpdir(), `dispatch-e2e-webhook-ui-${Date.now()}`);
+  mkdirSync(jobDir, { recursive: true });
+  let jobId: string;
+
+  test("webhook toggle off hides URL section", async ({ page, request }) => {
+    const res = await request.post("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook UI Test",
+        directory: jobDir,
+        prompt: "Test prompt.",
+        timeoutMs: 120000,
+        needsInputTimeoutMs: 86400000,
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const job = await res.json();
+    jobId = job.id;
+    expect(job.webhookEnabled).toBe(false);
+    expect(job.webhookSecret).toBeNull();
+
+    await page.goto(`/automations/jobs/${jobId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("switch", { name: "Webhook trigger" }).waitFor();
+
+    await expect(
+      page.getByRole("switch", { name: "Webhook trigger" })
+    ).not.toBeChecked();
+    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Save to generate a webhook URL.")
+    ).not.toBeVisible();
+  });
+
+  test("toggling webhook on shows save prompt when no secret exists", async ({
+    page,
+  }) => {
+    await page.goto(`/automations/jobs/${jobId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    const toggle = page.getByRole("switch", { name: "Webhook trigger" });
+    await toggle.waitFor();
+    await toggle.click();
+
+    await expect(toggle).toBeChecked();
+    await expect(
+      page.getByText("Save to generate a webhook URL.")
+    ).toBeVisible();
+    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+  });
+
+  test("saving with webhook on generates and displays URL", async ({
+    page,
+    request,
+  }) => {
+    // Enable webhook via API so we don't rely on UI toggle + save race
+    const updateRes = await request.patch("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook UI Test",
+        directory: jobDir,
+        webhookEnabled: true,
+      },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+    const updated = await updateRes.json();
+    expect(updated.webhookEnabled).toBe(true);
+    expect(updated.webhookSecret).toBeTruthy();
+
+    await page.goto(`/automations/jobs/${jobId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    const toggle = page.getByRole("switch", { name: "Webhook trigger" });
+    await toggle.waitFor();
+    await expect(toggle).toBeChecked();
+
+    await expect(page.getByText("Webhook URL")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Copy webhook URL" })
+    ).toBeVisible();
+    await expect(page.getByText("/api/v1/jobs/webhook/")).toBeVisible();
+  });
+
+  test("toggling webhook off hides URL immediately", async ({ page }) => {
+    await page.goto(`/automations/jobs/${jobId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByText("Webhook URL")).toBeVisible();
+
+    const toggle = page.getByRole("switch", { name: "Webhook trigger" });
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Save to generate a webhook URL.")
+    ).not.toBeVisible();
+  });
+
+  test("saving with webhook off clears the secret", async ({
+    page,
+    request,
+  }) => {
+    // Disable webhook via API
+    const updateRes = await request.patch("/api/v1/jobs", {
+      headers: HEADERS,
+      data: {
+        name: "Webhook UI Test",
+        directory: jobDir,
+        webhookEnabled: false,
+      },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+    const updated = await updateRes.json();
+    expect(updated.webhookEnabled).toBe(false);
+    expect(updated.webhookSecret).toBeNull();
+
+    // Verify UI reflects the disabled state
+    await page.goto(`/automations/jobs/${jobId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    const toggle = page.getByRole("switch", { name: "Webhook trigger" });
+    await toggle.waitFor();
+    await expect(toggle).not.toBeChecked();
+    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Jobs can now be optionally triggered via HTTP POST to a unique secret URL (`/api/v1/jobs/webhook/:secret`), in addition to cron schedules and manual runs
- The webhook route bypasses session/bearer auth — the secret in the URL is the credential
- Frontend adds a webhook toggle in job settings with an inline URL display and copy-to-clipboard button; URL visibility is reactive to the toggle state

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run finalize:web` — web build passes
- [x] `pnpm run test` — all unit tests pass
- [x] `pnpm run test:e2e` — 168 tests pass (8 new webhook tests)
- [x] Live dev stack validation: created job with webhook, triggered via `curl -X POST` without auth, confirmed agent started with `triggerSource: "webhook"`
- [x] UI validation: verified toggle on/off hides/shows URL, "Save to generate" prompt for new webhooks, copy button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)