### PR TITLE
Fix worktree docs: controls are disabled, not collapsed

### DIFF
--- a/apps/web/src/components/app/docs-pane.tsx
+++ b/apps/web/src/components/app/docs-pane.tsx
@@ -1190,8 +1190,8 @@ export GH_TOKEN="ghp_..."`}</CodeBlock>
           <P>
             The <strong>Create managed git worktree</strong> checkbox in the
             create dialog is enabled by default. When the working directory
-            isn't a git repository, the checkbox disables itself and the
-            controls collapse, with a note explaining why.
+            isn't a git repository, the checkbox and its controls are disabled,
+            with a note explaining why.
           </P>
           <P>
             When enabled, Dispatch creates a linked worktree directory, copies{" "}


### PR DESCRIPTION
## Summary
- Fixed factual drift in docs-pane Worktrees section: the create-agent worktree controls are **disabled** (dimmed with opacity-60) when the working directory isn't a git repo — they don't **collapse** (hide). Updated wording to match actual component behavior in `create-agent-worktree-section.tsx`.

## What was audited
- Full Worktrees section in `docs-pane.tsx` (lines 1175–1268) verified against:
  - `create-agent-worktree-section.tsx` — checkbox labels, disabled states, layout behavior
  - `create-agent-dialog.tsx` + `create-agent-dialog-utils.ts` — worktree default (true), per-cwd persistence
  - `apps/server/src/shared/git/worktree.ts` — creation logic, branch options, path resolution
  - `apps/server/src/agents/workspace-prep.ts` — .env copy, dep-install lockfile list
  - `apps/server/src/agents/archive.ts` + `delete-agent-dialog.tsx` — cleanup flow, branch ownership
  - `apps/server/src/agents/manager.ts` — worktree location (sibling/nested), createNewBranch default

## Verified accurate (no changes needed)
- Checkbox label ("Create managed git worktree"), default (enabled)
- .env copy + lockfile dep-install list (pnpm-lock.yaml, yarn.lock, package-lock.json, bun.lockb)
- "Starting branch" dropdown label, "Create a new branch in this worktree" checkbox label
- On (default) / Off branch behavior
- Per-cwd new-branch preference persistence (atomFamily + atomWithLocalStorage)
- Worktree location: sibling default, nested at `.dispatch/worktrees/`
- Cleanup: checks unmerged/uncommitted, auto-remove when clean, user dialog when dirty
- Existing-branch cleanup preserves the branch

## Deferred to next run
- Audit docs-pane Reviewers (Personas) section against `dispatch_launch_persona` MCP tool, persona definitions, and `delete-agent-dialog.tsx` review flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)