### PR TITLE
Remove duplicate formatDate/cleanError from release-admin.tsx

### DIFF
--- a/apps/web/src/components/app/release-admin.tsx
+++ b/apps/web/src/components/app/release-admin.tsx
@@ -7,6 +7,7 @@ import {
   Zap,
 } from "lucide-react";
 import { OperationTakeover } from "@/components/app/release-operation-takeover";
+import { cleanError, formatDate } from "@/components/app/release-utils";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import type {
@@ -57,24 +58,6 @@ const VERSION_CONFIG: Record<
 };
 
 const CREATE_PHASES = ["preflight", "triggering", "watching", "done"] as const;
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function cleanError(raw: string): string {
-  const stderrMatch = raw.match(/stderr=(.+)$/s);
-  if (stderrMatch) {
-    const stderr = stderrMatch[1].trim();
-    return stderr.replace(/^fatal:\s*/i, "");
-  }
-  return raw;
-}
 
 type ReleasesAdminProps = {
   stream: UseReleaseStreamResult;


### PR DESCRIPTION
## Summary
- `release-admin.tsx` contained local copies of `formatDate` and `cleanError` that were exact duplicates of the exported versions in `release-utils.ts`
- Replaced the local declarations with imports — 17 lines removed, no behavior change
- Other release-related files (`release-manager.tsx`, `release-operation-takeover.tsx`, `use-release-updates.ts`) already import from `release-utils.ts`

## Tech debt context
Re-audited the codebase and seeded a fresh backlog with 6 items. Next run will tackle consolidating the remaining 3 `formatDate` implementations across the web frontend.

## Test plan
- [x] `pnpm run check` — TypeScript passes
- [x] `pnpm run finalize:web` — production build succeeds
- [x] `pnpm run test:e2e` — Playwright E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)