### PR TITLE
Fix webhook-UI and worktree E2E flakes, add 8 webhook unit tests

### DIFF
--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -10,7 +10,7 @@ import {
 import type { Pool } from "pg";
 
 import { setupTestDb, teardownTestDb, runTestMigrations } from "../db/setup.js";
-import { JobService } from "../../src/jobs/service.js";
+import { JobService, WebhookNotFoundError } from "../../src/jobs/service.js";
 import { JobStore } from "../../src/jobs/store.js";
 import type { AgentManager } from "../../src/agents/manager.js";
 
@@ -93,9 +93,16 @@ afterAll(async () => {
 beforeEach(async () => {
   await pool.query("DELETE FROM job_runs");
   await pool.query("DELETE FROM jobs");
-  await pool.query("DELETE FROM agents WHERE id LIKE 'agt_cb_%'");
+  await pool.query(
+    "DELETE FROM agents WHERE id LIKE 'agt_cb_%' OR id LIKE 'agt_job_%' OR id LIKE 'agt_wh_%'"
+  );
   vi.mocked(mockLog.warn).mockClear();
   vi.mocked(mockAgentManager.createAgent).mockReset();
+  vi.mocked(mockAgentManager.getAgent).mockResolvedValue({
+    id: "mock",
+    status: "running",
+    tmuxSession: null,
+  } as Awaited<ReturnType<AgentManager["getAgent"]>>);
 });
 
 describe("JobService", () => {
@@ -315,6 +322,11 @@ describe("JobService", () => {
         })
       );
 
+      await service.completeRunForAgent("agt_job_rename", {
+        status: "completed",
+        summary: "done",
+        tasks: [],
+      });
       service.stopAllSchedulers();
     });
 
@@ -362,6 +374,242 @@ describe("JobService", () => {
           directory: "/tmp/test-activerun",
         })
       ).rejects.toThrow("has active run");
+
+      service.stopAllSchedulers();
+    });
+  });
+
+  describe("webhook triggers", () => {
+    it("addJob with webhookEnabled generates a secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      const job = await service.addJob({
+        name: "wh-create-test",
+        directory: "/tmp/test-wh-create",
+        prompt: "Test prompt",
+        webhookEnabled: true,
+      });
+
+      expect(job.webhookEnabled).toBe(true);
+      expect(job.webhookSecret).toBeTruthy();
+      expect(typeof job.webhookSecret).toBe("string");
+      expect(job.webhookSecret!.length).toBeGreaterThan(10);
+
+      service.stopAllSchedulers();
+    });
+
+    it("addJob without webhookEnabled has no secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      const job = await service.addJob({
+        name: "wh-no-enable",
+        directory: "/tmp/test-wh-no-enable",
+        prompt: "Test prompt",
+      });
+
+      expect(job.webhookEnabled).toBe(false);
+      expect(job.webhookSecret).toBeNull();
+
+      service.stopAllSchedulers();
+    });
+
+    it("updateJob enabling webhook generates a new secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      await service.addJob({
+        name: "wh-update-test",
+        directory: "/tmp/test-wh-update",
+        prompt: "Test prompt",
+        webhookEnabled: false,
+      });
+
+      const updated = await service.updateJob({
+        name: "wh-update-test",
+        directory: "/tmp/test-wh-update",
+        webhookEnabled: true,
+      });
+
+      expect(updated.webhookEnabled).toBe(true);
+      expect(updated.webhookSecret).toBeTruthy();
+
+      service.stopAllSchedulers();
+    });
+
+    it("updateJob disabling webhook clears the secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      await service.addJob({
+        name: "wh-disable-test",
+        directory: "/tmp/test-wh-disable",
+        prompt: "Test prompt",
+        webhookEnabled: true,
+      });
+
+      const updated = await service.updateJob({
+        name: "wh-disable-test",
+        directory: "/tmp/test-wh-disable",
+        webhookEnabled: false,
+      });
+
+      expect(updated.webhookEnabled).toBe(false);
+      expect(updated.webhookSecret).toBeNull();
+
+      service.stopAllSchedulers();
+    });
+
+    it("updateJob re-enabling webhook does not change existing secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      const created = await service.addJob({
+        name: "wh-reenable-test",
+        directory: "/tmp/test-wh-reenable",
+        prompt: "Test prompt",
+        webhookEnabled: true,
+      });
+      const originalSecret = created.webhookSecret;
+
+      const updated = await service.updateJob({
+        name: "wh-reenable-test",
+        directory: "/tmp/test-wh-reenable",
+        webhookEnabled: true,
+      });
+
+      expect(updated.webhookSecret).toBe(originalSecret);
+
+      service.stopAllSchedulers();
+    });
+
+    it("runJobByWebhook runs the matching job", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      const job = await service.addJob({
+        name: "wh-run-test",
+        directory: "/tmp/test-wh-run",
+        prompt: "Webhook prompt",
+        webhookEnabled: true,
+      });
+
+      const agentId = `agt_wh_${Date.now()}`;
+      vi.mocked(mockAgentManager.createAgent).mockImplementation(async () => {
+        const createdAt = new Date().toISOString();
+        await pool.query(
+          `INSERT INTO agents (id, name, type, status, cwd, codex_args, full_access)
+           VALUES ($1, 'wh-test-agent', 'claude', 'running', '/tmp/test-wh-run', '[]'::jsonb, false)`,
+          [agentId]
+        );
+        return {
+          id: agentId,
+          name: "wh-test-agent",
+          type: "claude",
+          status: "running",
+          cwd: "/tmp/test-wh-run",
+          tmuxSession: null,
+          createdAt,
+          updatedAt: createdAt,
+          metadata: null,
+          codexArgs: [],
+          claudeArgs: [],
+          opencodeArgs: [],
+          latestEvent: null,
+          fullAccess: false,
+          useWorktree: false,
+          worktreePath: null,
+          worktreeBranch: null,
+          setupPhase: null,
+          parentAgentId: null,
+          persona: null,
+          autoReview: false,
+          baseBranch: null,
+        } as Awaited<ReturnType<AgentManager["createAgent"]>>;
+      });
+
+      const result = await service.runJobByWebhook(job.webhookSecret!);
+
+      expect(result.jobId).toBe(job.id);
+      expect(result.status).toBe("running");
+
+      const store = new JobStore(pool);
+      const run = await store.getRun(result.runId);
+      expect(run?.config.triggerSource).toBe("webhook");
+
+      await service.completeRunForAgent(agentId, {
+        status: "completed",
+        summary: "done",
+        tasks: [],
+      });
+      service.stopAllSchedulers();
+    });
+
+    it("runJobByWebhook throws WebhookNotFoundError for unknown secret", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      await expect(
+        service.runJobByWebhook("nonexistent-secret")
+      ).rejects.toThrow(WebhookNotFoundError);
+
+      service.stopAllSchedulers();
+    });
+
+    it("runJobByWebhook throws for disabled webhook", async () => {
+      const service = new JobService(
+        pool,
+        mockAgentManager,
+        mockLog,
+        mockConfig
+      );
+
+      const job = await service.addJob({
+        name: "wh-disabled-run",
+        directory: "/tmp/test-wh-disabled-run",
+        prompt: "Test prompt",
+        webhookEnabled: true,
+      });
+      const secret = job.webhookSecret!;
+
+      await service.updateJob({
+        name: "wh-disabled-run",
+        directory: "/tmp/test-wh-disabled-run",
+        webhookEnabled: false,
+      });
+
+      await expect(service.runJobByWebhook(secret)).rejects.toThrow(
+        WebhookNotFoundError
+      );
 
       service.stopAllSchedulers();
     });

--- a/e2e/jobs-webhook-ui.spec.ts
+++ b/e2e/jobs-webhook-ui.spec.ts
@@ -40,7 +40,9 @@ test.describe("Jobs webhook UI", () => {
     await expect(
       page.getByRole("switch", { name: "Webhook trigger" })
     ).not.toBeChecked();
-    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Webhook URL", { exact: true })
+    ).not.toBeVisible();
     await expect(
       page.getByText("Save to generate a webhook URL.")
     ).not.toBeVisible();
@@ -60,7 +62,9 @@ test.describe("Jobs webhook UI", () => {
     await expect(
       page.getByText("Save to generate a webhook URL.")
     ).toBeVisible();
-    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Webhook URL", { exact: true })
+    ).not.toBeVisible();
   });
 
   test("saving with webhook on generates and displays URL", async ({
@@ -88,7 +92,7 @@ test.describe("Jobs webhook UI", () => {
     await toggle.waitFor();
     await expect(toggle).toBeChecked();
 
-    await expect(page.getByText("Webhook URL")).toBeVisible();
+    await expect(page.getByText("Webhook URL", { exact: true })).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Copy webhook URL" })
     ).toBeVisible();
@@ -99,13 +103,16 @@ test.describe("Jobs webhook UI", () => {
     await page.goto(`/automations/jobs/${jobId}`, {
       waitUntil: "domcontentloaded",
     });
-    await expect(page.getByText("Webhook URL")).toBeVisible();
-
     const toggle = page.getByRole("switch", { name: "Webhook trigger" });
+    await toggle.waitFor();
+    await expect(page.getByText("Webhook URL", { exact: true })).toBeVisible();
+
     await toggle.click();
     await expect(toggle).not.toBeChecked();
 
-    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Webhook URL", { exact: true })
+    ).not.toBeVisible();
     await expect(
       page.getByText("Save to generate a webhook URL.")
     ).not.toBeVisible();
@@ -136,6 +143,8 @@ test.describe("Jobs webhook UI", () => {
     const toggle = page.getByRole("switch", { name: "Webhook trigger" });
     await toggle.waitFor();
     await expect(toggle).not.toBeChecked();
-    await expect(page.getByText("Webhook URL")).not.toBeVisible();
+    await expect(
+      page.getByText("Webhook URL", { exact: true })
+    ).not.toBeVisible();
   });
 });

--- a/e2e/worktree.spec.ts
+++ b/e2e/worktree.spec.ts
@@ -98,13 +98,16 @@ test.describe("Worktree", () => {
       await expect(form).toBeVisible();
 
       const cwdInput = page.getByTestId("create-agent-cwd");
+      const pathInfoResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/system/path-info") &&
+          resp.status() === 200
+      );
       await cwdInput.fill(repoPath);
-      // Wait for path validation to finish. exact:true avoids a false match
-      // against the WorktreeSection description ("Working directory isn't a
-      // git repository…") which is always visible before validation completes.
+      await pathInfoResponse;
       await expect(
         form.getByText("Git repository", { exact: true })
-      ).toBeVisible({ timeout: 15000 });
+      ).toBeVisible();
 
       // Worktree checkbox should exist and be checked by default
       const worktreeCheckbox = page.getByTestId("create-agent-worktree");
@@ -128,10 +131,16 @@ test.describe("Worktree", () => {
       await expect(form).toBeVisible();
 
       const cwdInput = page.getByTestId("create-agent-cwd");
+      const pathInfoResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/system/path-info") &&
+          resp.status() === 200
+      );
       await cwdInput.fill(repoPath);
+      await pathInfoResponse;
       await expect(
         form.getByText("Git repository", { exact: true })
-      ).toBeVisible({ timeout: 15000 });
+      ).toBeVisible();
 
       const worktreeCheckbox = page.getByTestId("create-agent-worktree");
       await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "true");


### PR DESCRIPTION
## Summary
- Fixed two E2E test bugs in `jobs-webhook-ui.spec.ts`: added `{ exact: true }` to all `getByText("Webhook URL")` calls (prevented false substring matches against "Save to generate a webhook URL."), and added `toggle.waitFor()` before asserting visibility in the toggle-off test.
- Fixed the `worktree.spec.ts:121` flake by replacing 15s DOM timeout with deterministic `waitForResponse` on the `/api/v1/system/path-info` API call.
- Added 8 webhook trigger unit tests covering create/update/run-by-webhook secret lifecycle and error paths.
- Fixed a pre-existing unhandled rejection in `service.test.ts` where the `runJob` test left a background monitor orphaned.

## Test plan
- [x] `pnpm run check` — type check passes
- [x] `pnpm run test` — 1579 unit tests pass, 0 unhandled rejections
- [x] `pnpm run test:e2e` — 168 E2E tests pass, 12 skipped (terminal-live/no tmux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)