### PR TITLE
Consolidate duplicated formatDate implementations into lib/format.ts

### DIFF
--- a/apps/web/src/components/app/activity-charts.tsx
+++ b/apps/web/src/components/app/activity-charts.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   formatDuration,
+  formatShortDate,
   formatTokenCount,
   shortProjectName,
 } from "@/lib/format";
@@ -35,8 +36,7 @@ import type {
 // ── Helpers ─────────────────────────────────────────────────────────
 
 export function formatDate(iso: string): string {
-  const d = new Date(iso + "T00:00:00");
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return formatShortDate(iso);
 }
 
 function formatBucketLabel(

--- a/apps/web/src/components/app/jobs-helpers.ts
+++ b/apps/web/src/components/app/jobs-helpers.ts
@@ -1,6 +1,7 @@
 import cronstrue from "cronstrue";
 
 import { type JobRun, type JobRunStatus } from "@/hooks/use-jobs";
+import { formatDateTime } from "@/lib/format";
 
 export const ACTIVE_RUN_STATUSES: JobRunStatus[] = [
   "started",
@@ -43,10 +44,7 @@ export function formatDate(iso: string | null | undefined): string {
   if (!iso) return "Not scheduled";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return "Unknown";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
+  return formatDateTime(iso);
 }
 
 export function formatDuration(ms: number | null | undefined): string {

--- a/apps/web/src/components/app/release-utils.ts
+++ b/apps/web/src/components/app/release-utils.ts
@@ -4,6 +4,7 @@ import type {
   ReleaseProgress,
 } from "@/hooks/use-release-stream";
 import type { ReleaseInfoSnapshot } from "@/hooks/use-cached-release-info";
+import { formatShortDateTime } from "@/lib/format";
 
 export type AppVersionInfo = {
   releaseTag: string | null;
@@ -21,12 +22,7 @@ export const UPDATE_PHASES = [
 ] as const;
 
 export function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return formatShortDateTime(iso);
 }
 
 export function cleanError(raw: string): string {

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -23,6 +23,27 @@ export function shortProjectName(project: string): string {
   return parts.length <= 2 ? project : parts.slice(-2).join("/");
 }
 
+export function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(iso));
+}
+
+export function formatShortDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatShortDate(dateOnlyIso: string): string {
+  const d = new Date(dateOnlyIso + "T00:00:00");
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
 export function formatRelativeTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
   if (Number.isNaN(ms)) return "";


### PR DESCRIPTION
## Summary

- Added `formatDateTime`, `formatShortDateTime`, and `formatShortDate` to the shared `lib/format.ts` module
- Replaced inline date formatting logic in `jobs-helpers.ts`, `release-utils.ts`, and `activity-charts.tsx` with imports from the shared module
- No behavior changes — each call site produces the same output as before

## Why this is tech debt

Three separate files each re-implemented date formatting with slightly different `Intl.DateTimeFormat` / `toLocaleString` options. This is the same copy-paste-between-modules pattern that previous debt runs fixed for `errorMessage`, `resolveTilde`, and `sanitizeUploadedFileName`. Centralizing the formatters prevents future drift and makes it easy to adjust formatting in one place.

## What's next

Next run will consolidate the duplicated `formatDuration` in `jobs-helpers.ts` with the more complete version in `lib/format.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)