### PR TITLE
Add webhook route/store tests and format function tests

### DIFF
--- a/apps/server/test/jobs-webhook-route.test.ts
+++ b/apps/server/test/jobs-webhook-route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useInjectApp } from "./helpers/inject-app.js";
+
+const ctx = useInjectApp();
+
+async function createWebhookJob(
+  name: string,
+  webhookEnabled: boolean
+): Promise<{ id: string; webhookSecret: string | null }> {
+  const cookie = await ctx.sessionCookie();
+  const res = await ctx.app.inject({
+    method: "POST",
+    url: "/api/v1/jobs",
+    headers: { cookie, "content-type": "application/json" },
+    payload: {
+      name,
+      directory: "/tmp",
+      prompt: "test prompt",
+      webhookEnabled,
+    },
+  });
+  expect(res.statusCode).toBe(200);
+  const body = res.json();
+  return { id: body.id, webhookSecret: body.webhookSecret };
+}
+
+beforeEach(async () => {
+  await ctx.pool.query("DELETE FROM job_runs");
+  await ctx.pool.query("DELETE FROM jobs");
+  await ctx.pool.query("DELETE FROM agents");
+});
+
+describe("POST /api/v1/jobs/webhook/:secret", () => {
+  it("returns jobId and runId for a valid webhook secret", async () => {
+    const job = await createWebhookJob("wh-route-ok", true);
+    expect(job.webhookSecret).toBeTruthy();
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/webhook/${job.webhookSecret}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.jobId).toBe(job.id);
+    expect(body.runId).toBeTruthy();
+  });
+
+  it("returns 404 for an unknown secret", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/jobs/webhook/nonexistent-secret-value",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({
+      error: expect.stringContaining("not found"),
+    });
+  });
+
+  it("returns 404 after disabling webhook (secret is cleared)", async () => {
+    const job = await createWebhookJob("wh-route-disabled", true);
+    const secret = job.webhookSecret!;
+
+    const cookie = await ctx.sessionCookie();
+    const disableRes = await ctx.app.inject({
+      method: "PATCH",
+      url: "/api/v1/jobs",
+      headers: { cookie, "content-type": "application/json" },
+      payload: {
+        name: "wh-route-disabled",
+        directory: "/tmp",
+        webhookEnabled: false,
+      },
+    });
+    expect(disableRes.statusCode).toBe(200);
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/webhook/${secret}`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("does not require authentication", async () => {
+    const job = await createWebhookJob("wh-no-auth", true);
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/webhook/${job.webhookSecret}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().runId).toBeTruthy();
+  });
+
+  it("sets triggerSource to webhook on the created run", async () => {
+    const job = await createWebhookJob("wh-trigger-src", true);
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/jobs/webhook/${job.webhookSecret}`,
+    });
+    expect(res.statusCode).toBe(200);
+
+    const runId = res.json().runId;
+    const dbResult = await ctx.pool.query(
+      `SELECT config FROM job_runs WHERE id = $1`,
+      [runId]
+    );
+    expect(dbResult.rows[0].config.triggerSource).toBe("webhook");
+  });
+});

--- a/apps/server/test/jobs/store-phase2.test.ts
+++ b/apps/server/test/jobs/store-phase2.test.ts
@@ -209,3 +209,55 @@ describe("JobStore Phase 2 — list, history, enable/disable", () => {
     expect(runs.length).toBe(1);
   });
 });
+
+describe("JobStore — getJobByWebhookSecret", () => {
+  it("returns the job when secret matches and webhook is enabled", async () => {
+    const job = await store.createJob({
+      ...jobDefaults,
+      name: "wh-store-match",
+      directory: "/tmp/wh-store-test",
+      prompt: "Webhook store test",
+      webhookEnabled: true,
+      webhookSecret: "test-secret-abc123",
+    });
+
+    const found = await store.getJobByWebhookSecret("test-secret-abc123");
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(job.id);
+    expect(found!.webhookEnabled).toBe(true);
+    expect(found!.webhookSecret).toBe("test-secret-abc123");
+  });
+
+  it("returns null when secret matches but webhook is disabled", async () => {
+    await store.createJob({
+      ...jobDefaults,
+      name: "wh-store-disabled",
+      directory: "/tmp/wh-store-disabled",
+      prompt: "Webhook disabled",
+      webhookEnabled: false,
+      webhookSecret: "disabled-secret-xyz",
+    });
+
+    const found = await store.getJobByWebhookSecret("disabled-secret-xyz");
+    expect(found).toBeNull();
+  });
+
+  it("returns null for an unknown secret", async () => {
+    const found = await store.getJobByWebhookSecret("no-such-secret");
+    expect(found).toBeNull();
+  });
+
+  it("returns null for an empty-string lookup against a null-secret row", async () => {
+    await store.createJob({
+      ...jobDefaults,
+      name: "wh-store-null",
+      directory: "/tmp/wh-store-null",
+      prompt: "No secret",
+      webhookEnabled: false,
+      webhookSecret: null,
+    });
+
+    const found = await store.getJobByWebhookSecret("");
+    expect(found).toBeNull();
+  });
+});

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -5,6 +5,9 @@ import {
   formatTokenCount,
   shortProjectName,
   formatRelativeTime,
+  formatDateTime,
+  formatShortDateTime,
+  formatShortDate,
 } from "./format";
 
 describe("formatDuration", () => {
@@ -101,5 +104,50 @@ describe("formatRelativeTime", () => {
     const iso = new Date(2026, 0, 15).toISOString();
     const result = formatRelativeTime(iso);
     expect(result).toContain("Jan");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("includes date and time parts", () => {
+    const result = formatDateTime("2026-03-15T14:30:00Z");
+    expect(result).toMatch(/2026/);
+    expect(result).toMatch(/:/);
+  });
+
+  it("produces different output for different timestamps", () => {
+    const a = formatDateTime("2026-01-01T00:00:00Z");
+    const b = formatDateTime("2026-06-15T12:00:00Z");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("formatShortDateTime", () => {
+  it("contains the day number", () => {
+    const result = formatShortDateTime("2026-06-15T09:15:00Z");
+    expect(result).toMatch(/15/);
+  });
+
+  it("produces different output for different months", () => {
+    const jan = formatShortDateTime("2026-01-15T09:00:00Z");
+    const jun = formatShortDateTime("2026-06-15T09:00:00Z");
+    expect(jan).not.toBe(jun);
+  });
+});
+
+describe("formatShortDate", () => {
+  it("contains the day number", () => {
+    const result = formatShortDate("2026-01-15");
+    expect(result).toMatch(/15/);
+  });
+
+  it("does not shift dates due to timezone offset", () => {
+    const result = formatShortDate("2026-12-31");
+    expect(result).toMatch(/31/);
+  });
+
+  it("produces different output for different months", () => {
+    const jan = formatShortDate("2026-01-15");
+    const dec = formatShortDate("2026-12-15");
+    expect(jan).not.toBe(dec);
   });
 });


### PR DESCRIPTION
## Summary
- Add 5 route-level integration tests for `POST /api/v1/jobs/webhook/:secret` (success, 404 unknown, 404 disabled, no-auth, triggerSource verification)
- Add 4 store-level tests for `getJobByWebhookSecret` (enabled match, disabled guard, unknown secret, empty string vs null)
- Add 7 tests for previously-untested `formatDateTime`, `formatShortDateTime`, and `formatShortDate` functions

## Test plan
- [x] `pnpm run check` passes
- [x] `pnpm run test` passes (1588 server + 156 web)
- [x] `pnpm run test:e2e` passes (168 passed, 12 skipped terminal-live)
- [x] `pnpm run finalize:web` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)