### PR TITLE
Fix sound cue count in Notifications docs section

### DIFF
--- a/apps/web/src/components/app/docs-sections/notifications.tsx
+++ b/apps/web/src/components/app/docs-sections/notifications.tsx
@@ -70,10 +70,11 @@ export function NotificationsContent() {
         <P>
           A soft synthesized tone on status changes. Cues are per-device — they
           don't touch server state and only play in tabs where you've enabled
-          them. Four cues are available: <Code>done</Code>,{" "}
+          them. Four status cues are available: <Code>done</Code>,{" "}
           <Code>waiting_user</Code>, <Code>blocked</Code>, and a distinct chord
-          when a persona reviewer completes its review. Use the preview buttons
-          in settings to hear each one.
+          when a persona reviewer completes its review. A fifth cue provides
+          tactile feedback for mobile toolbar taps. Use the preview buttons in
+          settings to hear each one.
         </P>
       </Section>
 


### PR DESCRIPTION
## Summary

- **Audited**: Media & Sharing docs section — all claims verified accurate against `dispatch_share`/`dispatch_list_media` tool schemas, `stream-manager.ts`, `media-sidebar.tsx`, and `media/store.ts`. No drift found.
- **Audited**: Notifications docs section — verified configurable events, browser/Slack fallback flow, focus-aware suppression (30s TTL), `dispatch_notify` tool params, and rate limiting (5/min/agent).
- **Fixed**: Sound cues paragraph said "Four cues are available" but the settings UI shows five preview buttons (done, waiting_user, blocked, review_finished, plus mobile tap). Updated to "Four status cues" and added mention of the fifth mobile tap cue.

## Deferred to next run

- Personalities section (never audited)
- Updates section (never audited, has backlog items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)