### PR TITLE
Consolidate duplicated formatDuration into lib/format.ts

### DIFF
--- a/apps/web/src/components/app/jobs-charts.tsx
+++ b/apps/web/src/components/app/jobs-charts.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Bar, BarChart, XAxis } from "recharts";
 
-import { formatDuration } from "@/components/app/jobs-helpers";
+import { formatDuration } from "@/lib/format";
 import {
   ChartContainer,
   ChartLegend,

--- a/apps/web/src/components/app/jobs-helpers.ts
+++ b/apps/web/src/components/app/jobs-helpers.ts
@@ -47,15 +47,6 @@ export function formatDate(iso: string | null | undefined): string {
   return formatDateTime(iso);
 }
 
-export function formatDuration(ms: number | null | undefined): string {
-  if (!ms) return "n/a";
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remaining = seconds % 60;
-  return `${minutes}m ${remaining}s`;
-}
-
 export function minutesFromMs(ms: number | null | undefined): string {
   if (!ms) return "";
   return String(Math.max(1, Math.round(ms / 60_000)));

--- a/apps/web/src/components/app/jobs-pane.tsx
+++ b/apps/web/src/components/app/jobs-pane.tsx
@@ -34,7 +34,6 @@ import {
   cronError,
   errorMessage,
   formatDate,
-  formatDuration,
   formatTimeUntil,
   formatTimeUntilDate,
   humanSchedule,
@@ -68,7 +67,7 @@ import {
   useJobStats,
 } from "@/hooks/use-jobs";
 import { StatCard } from "@/components/app/stat-card";
-import { formatRelativeTime } from "@/lib/format";
+import { formatDuration, formatRelativeTime } from "@/lib/format";
 import {
   AGENT_TYPE_LABELS,
   type AgentType,

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -11,6 +11,11 @@ import {
 } from "./format";
 
 describe("formatDuration", () => {
+  it("returns n/a for null or undefined", () => {
+    expect(formatDuration(null)).toBe("n/a");
+    expect(formatDuration(undefined)).toBe("n/a");
+  });
+
   it("returns 0s for sub-second values", () => {
     expect(formatDuration(0)).toBe("0s");
     expect(formatDuration(999)).toBe("0s");

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,4 +1,5 @@
-export function formatDuration(ms: number): string {
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms == null) return "n/a";
   if (ms < 1000) return "0s";
   const secs = Math.floor(ms / 1000);
   if (secs < 60) return `${secs}s`;


### PR DESCRIPTION
## Summary
- Removed the duplicate `formatDuration` from `jobs-helpers.ts` (only handled minutes+seconds) and consolidated into the more comprehensive `lib/format.ts` version (handles days/hours/minutes/seconds)
- Widened `lib/format.ts` `formatDuration` to accept `number | null | undefined`, returning `"n/a"` for nullish values
- Updated imports in `jobs-charts.tsx` and `jobs-pane.tsx` to use the shared version
- Added test cases for null/undefined handling

## Why this is tech debt
Two `formatDuration` functions with the same name but different behavior — the jobs-helpers version was a simplified copy that diverged from the canonical implementation in `lib/format.ts`. This creates confusion about which to import and risks further divergence.

## Next up
Unused export `MAX_NOTE_BYTES` in `apps/server/src/shared/lib/agent-strings.ts:8` — dead code not imported anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)