### PR TITLE
Fix pool teardown race in JobService shutdown

### DIFF
--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -675,7 +675,7 @@ export class JobService {
   }
 
   private startMonitor(runId: string): void {
-    if (this.monitors.has(runId)) return;
+    if (this.stopping || this.monitors.has(runId)) return;
     const monitor = this.monitorRun(runId)
       .catch(async (error) => {
         this.logger.warn({ err: error, runId }, "Job monitor failed.");

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -611,13 +611,20 @@ export class JobService {
     );
   }
 
-  /** Stop all in-process schedulers and signal monitors to exit. Called on server shutdown. */
+  /** Stop all in-process schedulers and signal monitors to exit. */
   stopAllSchedulers(): void {
     this.stopping = true;
     for (const cron of this.schedulers.values()) {
       cron.stop();
     }
     this.schedulers.clear();
+  }
+
+  /** Stop schedulers and wait for all in-flight monitors to finish. */
+  async shutdown(): Promise<void> {
+    this.stopAllSchedulers();
+    const pending = [...this.monitors.values()];
+    await Promise.allSettled(pending);
   }
 
   private scheduleJob(job: JobRecord): void {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -730,7 +730,6 @@ async function cleanupAppResources(): Promise<void> {
   }
   shuttingDown = true;
 
-  jobService.stopAllSchedulers();
   streamManager.stopAll();
   agentLifecycleRuntime.stopReconcileLoop();
   authRuntime.stopSessionCleanupTimer();
@@ -738,6 +737,7 @@ async function cleanupAppResources(): Promise<void> {
 
   notificationRuntime.clearPendingWebNotifications();
 
+  await jobService.shutdown();
   await agentLifecycleRuntime.waitForActiveArchives(10_000);
 
   await pool.end().catch(() => null);

--- a/apps/server/test/jobs/service.test.ts
+++ b/apps/server/test/jobs/service.test.ts
@@ -157,7 +157,7 @@ describe("JobService", () => {
         "onRunStateChange callback error"
       );
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 
@@ -182,7 +182,7 @@ describe("JobService", () => {
       await service.startSchedulers();
 
       // stopAllSchedulers should clean up without error
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("startSchedulers is safe to call with no jobs", async () => {
@@ -193,7 +193,7 @@ describe("JobService", () => {
         mockConfig
       );
       await service.startSchedulers();
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 
@@ -206,7 +206,7 @@ describe("JobService", () => {
         mockConfig
       );
       await service.reconcileActiveRuns();
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 
@@ -233,7 +233,7 @@ describe("JobService", () => {
       expect(found!.nextRun).toBeTruthy();
       expect(new Date(found!.nextRun!).getTime()).toBeGreaterThan(Date.now());
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("nextRun is null for disabled jobs", async () => {
@@ -257,7 +257,7 @@ describe("JobService", () => {
       expect(found).toBeDefined();
       expect(found!.nextRun).toBeNull();
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 
@@ -327,7 +327,7 @@ describe("JobService", () => {
         summary: "done",
         tasks: [],
       });
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("runJob throws when job has no prompt", async () => {
@@ -349,7 +349,7 @@ describe("JobService", () => {
         service.runJob({ name: "no-prompt", directory: "/tmp/test-noprompt" })
       ).rejects.toThrow("no prompt configured");
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("removeJob throws when job has active run", async () => {
@@ -375,7 +375,7 @@ describe("JobService", () => {
         })
       ).rejects.toThrow("has active run");
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 
@@ -400,7 +400,7 @@ describe("JobService", () => {
       expect(typeof job.webhookSecret).toBe("string");
       expect(job.webhookSecret!.length).toBeGreaterThan(10);
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("addJob without webhookEnabled has no secret", async () => {
@@ -420,7 +420,7 @@ describe("JobService", () => {
       expect(job.webhookEnabled).toBe(false);
       expect(job.webhookSecret).toBeNull();
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("updateJob enabling webhook generates a new secret", async () => {
@@ -447,7 +447,7 @@ describe("JobService", () => {
       expect(updated.webhookEnabled).toBe(true);
       expect(updated.webhookSecret).toBeTruthy();
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("updateJob disabling webhook clears the secret", async () => {
@@ -474,7 +474,7 @@ describe("JobService", () => {
       expect(updated.webhookEnabled).toBe(false);
       expect(updated.webhookSecret).toBeNull();
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("updateJob re-enabling webhook does not change existing secret", async () => {
@@ -501,7 +501,7 @@ describe("JobService", () => {
 
       expect(updated.webhookSecret).toBe(originalSecret);
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("runJobByWebhook runs the matching job", async () => {
@@ -567,7 +567,7 @@ describe("JobService", () => {
         summary: "done",
         tasks: [],
       });
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("runJobByWebhook throws WebhookNotFoundError for unknown secret", async () => {
@@ -582,7 +582,7 @@ describe("JobService", () => {
         service.runJobByWebhook("nonexistent-secret")
       ).rejects.toThrow(WebhookNotFoundError);
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
 
     it("runJobByWebhook throws for disabled webhook", async () => {
@@ -611,7 +611,7 @@ describe("JobService", () => {
         WebhookNotFoundError
       );
 
-      service.stopAllSchedulers();
+      await service.shutdown();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added `shutdown()` method to `JobService` that stops schedulers and awaits all in-flight monitors via `Promise.allSettled` before returning
- Updated production shutdown (`server.ts`) to use `await jobService.shutdown()` instead of fire-and-forget `stopAllSchedulers()`, eliminating a race where `pool.end()` could fire while monitors were still polling
- Updated all test teardowns in `service.test.ts` to use `await service.shutdown()`, fixing the CI flake where `teardownTestDb()` would end the pool before monitors finished winding down

**What qualifies as tech debt:** `stopAllSchedulers()` was a fire-and-forget that set a `stopping` flag but never awaited the monitors it was signaling. This caused intermittent "Cannot use a pool after calling end on the pool" unhandled rejections in CI — a classic teardown race.

**Next up:** jobs-pane.tsx (1609 lines) — extract job-detail/job-list/job-form sections into a jobs/ directory.

## Test plan
- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 1614 server + 157 web tests pass
- [x] `pnpm run test:e2e` — 168 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)