### PR TITLE
Fix docs drift from always-on scrollback assist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ dispatch/
 │   │   │   ├── reviews/       # review injection prompts
 │   │   │   ├── routes/        # HTTP route handlers
 │   │   │   ├── server/        # server runtime helpers (lifecycle, auth, prompts)
-│   │   │   ├── shared/        # shared utilities — git/, github/, mcp/, lib/ (run-command)
+│   │   │   ├── shared/        # shared utilities — git/, github/, lib/, mcp/, terminal/
 │   │   │   ├── templates/     # template service and storage
 │   │   │   └── terminal/      # tmux terminal bridge
 │   │   └── test/              # unit tests (vitest)

--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -156,17 +156,11 @@ export function AgentsContent() {
       <Section>
         <H3>Tmux scrollback</H3>
         <P>
-          By default, attaching to an agent puts you in tmux's live mode and
-          scrolling the wheel sends arrow-key events to whatever program is
-          running. Turn on{" "}
-          <strong>Settings → Agents → Tmux scrollback assist</strong> (off by
-          default) to enable a passive copy-mode helper: when you scroll up (or
-          otherwise enter tmux copy mode), Dispatch shows an{" "}
+          Attaching to an agent puts you in tmux's live mode. When you scroll up
+          (or otherwise enter tmux copy mode), Dispatch shows an{" "}
           <em>Input paused — scroll · click · Esc</em> banner over the terminal.
           Clicking the banner or pressing <Code>Esc</Code> drops you back to
-          live so your next keystroke goes to the agent. With the assist off,
-          Dispatch makes no changes to tmux's mouse mode and does not observe
-          copy mode at all.
+          live so your next keystroke goes to the agent.
         </P>
       </Section>
 

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -352,12 +352,12 @@ Returns `204` regardless of whether the notification was still pending.
 
 ## Settings
 
-| Method | Path                        | Description                                                                         |
-| ------ | --------------------------- | ----------------------------------------------------------------------------------- |
-| GET    | `/agents/settings`          | Get agent settings (worktree location, icon color, instance name, copy-mode assist) |
-| POST   | `/agents/settings`          | Update agent settings (all fields optional)                                         |
-| GET    | `/app/settings/agent-types` | Get enabled agent types                                                             |
-| POST   | `/app/settings/agent-types` | Set enabled agent types (`claude`, `codex`, `cursor`, `opencode`, `terminal`)       |
+| Method | Path                        | Description                                                                   |
+| ------ | --------------------------- | ----------------------------------------------------------------------------- |
+| GET    | `/agents/settings`          | Get agent settings (worktree location, icon color, instance name)             |
+| POST   | `/agents/settings`          | Update agent settings (all fields optional)                                   |
+| GET    | `/app/settings/agent-types` | Get enabled agent types                                                       |
+| POST   | `/app/settings/agent-types` | Set enabled agent types (`claude`, `codex`, `cursor`, `opencode`, `terminal`) |
 
 ## System
 


### PR DESCRIPTION
## Summary

- **In-app docs (agents.tsx)**: Tmux scrollback assist is now always-on (#655 removed the toggle). Updated the "Tmux scrollback" section to remove "off by default" and the settings path — the feature is unconditional.
- **API spec (03-api-spec.md)**: Removed `copy-mode assist` from the `/agents/settings` GET description — the endpoint no longer returns that field.
- **CLAUDE.md**: Added `terminal/` to the `shared/` subdirectory annotation (missing since PR #414).

## Deferred to next run

- Audit README.md MCP tools tables (verified accurate this run, no changes needed)
- Next focus: audit `docs/04-agent-lifecycle.md` against actual agent state machine in `apps/server/src/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)