### PR TITLE
Fix docs/04-agent-lifecycle.md drift (4 corrections)

### DIFF
--- a/docs/04-agent-lifecycle.md
+++ b/docs/04-agent-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## States
 
-`AgentStatus` (in `apps/server/src/agents/manager.ts`):
+`AgentStatus` (in `apps/server/src/agents/types.ts`):
 
 - `creating` — row inserted, setup script running, tmux session not yet ready
 - `running` — tmux session is up; agent CLI may still be initializing
@@ -79,7 +79,7 @@ For each agent with status in (`running`, `stopping`, `creating`, `archiving`):
 - **status `stopping`** for >60s: → `running` (revert; user can retry stop). Surfaces an "agent reverted" latest_event.
 - **status `archiving`** for >30s: archive is resumed.
 
-Cleanup of orphaned tmux sessions (sessions with the `<prefix>_agt_` prefix that no longer have a matching agent row) runs alongside reconciliation when `agentRuntime === "tmux"`.
+Cleanup of orphaned tmux sessions (sessions with the `<prefix>_agt_` prefix whose matching agent row is in a terminal state — `stopped` or `error`) runs alongside reconciliation when `agentRuntime === "tmux"`. Sessions with no matching DB record are left alone — they may belong to another server instance sharing the tmux namespace.
 
 ## tmux Session Contract
 
@@ -101,7 +101,7 @@ The generated setup script (`/tmp/dispatch_setup_<agentId>.sh`) does, in order:
 1. Source `~/.dispatch/env` (if it exists).
 2. POST `setup/phase: worktree`, then create the git worktree (if requested).
 3. POST `setup/phase: env`, then copy `.env` if present.
-4. POST `setup/phase: deps`, then install dependencies based on detected lockfile (npm/pnpm/yarn/bun/uv/poetry).
+4. POST `setup/phase: deps`, then install dependencies based on detected lockfile (pnpm/yarn/npm/bun). Skipped for `terminal` agent type.
 5. POST `setup/phase: session`, then `exec` into the agent CLI command.
 
 If any step fails non-recoverably, the script POSTs `setup/error` with a message before exiting.
@@ -155,7 +155,7 @@ There are three independent state axes attached to an agent. Code that talks abo
 
 ## Assisted-Update Phase Axis
 
-The assisted-update agent (role `assisted_update`) drives a separate state machine stored in `~/.dispatch/release/assisted-update.json` and managed by `apps/server/src/assisted-update-store.ts`. Phase order is:
+The assisted-update agent (role `assisted_update`) drives a separate state machine stored in `~/.dispatch/assisted-update.json` and managed by `apps/server/src/assisted-update-store.ts`. Phase order is:
 
 `inspect → prepare → apply → restarting → validate → done`
 


### PR DESCRIPTION
## Summary

Audited `docs/04-agent-lifecycle.md` against the actual agent state machine implementation and fixed 4 factual drifts:

- **AgentStatus location**: Referenced `manager.ts` but the type is defined in `types.ts`
- **Orphaned session cleanup**: Described killing sessions with no matching DB record, but code actually kills sessions whose DB record is in a terminal state (`stopped`/`error`) and explicitly leaves no-record sessions alone
- **Lockfile list**: Claimed uv/poetry support in the setup script, but only pnpm/yarn/npm/bun are implemented. Also noted the dep-install step is skipped for `terminal` agent type.
- **Assisted-update state path**: Said `~/.dispatch/release/assisted-update.json` but actual path is `~/.dispatch/assisted-update.json`

Deferred to next run: nothing new. Backlog items for this doc remain valid (link from in-app docs if a lifecycle section is added).

## Test plan

- [x] Verified each fix against source code (`types.ts`, `reconciler.ts`, `setup-script.ts`, `assisted-update-store.ts`)
- [x] Prettier check passes
- [x] Doc-only change — no type check or build needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)