### PR TITLE
Add Quick Phrases documentation (PR #661 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Give this prompt to a coding agent to get Dispatch installed as a persistent ser
 - Theming with multiple color themes and per-theme terminal palettes.
 - Password-based login with first-run setup and per-device session cookies.
 - Browser UI with:
+  - quick phrases — reusable text snippets with template variables, injectable into agent terminals
   - interactive terminal access (xterm.js over WebSocket, resumable after browser reconnect)
   - agent lifecycle controls (create, start, stop, delete — with background archive cleanup)
   - media pane for screenshots, video, text snippets, and live Playwright browser streaming (MJPEG over CDP)

--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -165,6 +165,42 @@ export function AgentsContent() {
       </Section>
 
       <Section>
+        <H3>Quick Phrases</H3>
+        <P>
+          The <strong>Quick Phrases</strong> button (speech-bubble icon) in the
+          terminal top rail lets you save reusable text snippets and inject them
+          into agent sessions. Phrases are always available for management; the
+          inject action is enabled when you're connected to an agent session.
+        </P>
+        <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
+          <li>
+            <strong>Creating</strong> — click the <Code>+</Code> button in the
+            popover to open the Add Phrase dialog. Each phrase has an optional{" "}
+            <strong>Label</strong> (short display name) and the{" "}
+            <strong>Phrase text</strong> that gets injected.
+          </li>
+          <li>
+            <strong>Variables</strong> — use{" "}
+            <Code>{"{{D:Variable Name}}"}</Code> placeholders in the phrase
+            text. Add <Code>|required</Code> or <Code>|multiline</Code>{" "}
+            modifiers after the name (same syntax as Templates). When injecting
+            a phrase with variables, a fill-in dialog appears first.
+          </li>
+          <li>
+            <strong>Injecting</strong> — phrases without variables show a split
+            button: <strong>Send</strong> pastes the text and submits it; the
+            dropdown offers <strong>Paste without submitting</strong> which
+            pastes only. Phrases with variables show a <strong>Send…</strong>{" "}
+            button that opens the fill-in dialog.
+          </li>
+          <li>
+            <strong>Editing and deleting</strong> — each phrase row has edit and
+            delete buttons. Deleting prompts for confirmation.
+          </li>
+        </ul>
+      </Section>
+
+      <Section>
         <H3>Renaming agents</H3>
         <P>
           Agents created without an explicit name start with a placeholder (

--- a/docs/03-api-spec.md
+++ b/docs/03-api-spec.md
@@ -182,6 +182,20 @@ Server-Sent Events stream. Used by the frontend for real-time UI updates. Event 
 
 The WebSocket provides bidirectional terminal I/O with resize support, bridging to the agent's tmux session.
 
+## Quick Phrases
+
+Reusable text snippets that can be injected into agent terminal sessions.
+
+| Method | Path                                 | Description                                         |
+| ------ | ------------------------------------ | --------------------------------------------------- |
+| GET    | `/quick-phrases`                     | List all phrases (with parsed template args)        |
+| POST   | `/quick-phrases`                     | Create a phrase (`text` required, `label` optional) |
+| PATCH  | `/quick-phrases/:id`                 | Update phrase `text` and/or `label`                 |
+| DELETE | `/quick-phrases/:id`                 | Delete a phrase                                     |
+| POST   | `/agents/:id/terminal/inject-phrase` | Inject a phrase into an agent's tmux session        |
+
+The inject-phrase endpoint accepts `phraseId`, optional `args` (key-value map for template variables), and optional `submit` (default `true` — sends Enter after pasting; `false` pastes only). Text is capped at 1000 chars per phrase, 2000 chars per arg value, and 10000 chars after variable substitution.
+
 ## Media
 
 | Method | Path                      | Description                                                |


### PR DESCRIPTION
## Summary

- Added a **Quick Phrases** subsection to the in-app Agents docs (`docs-sections/agents.tsx`) covering creating, variables, injecting, editing, and deleting phrases
- Added a **Quick Phrases** section to `docs/03-api-spec.md` with all 5 endpoints (CRUD + inject-phrase) and parameter details
- Added a quick phrases bullet to the README features list

## What was audited

This run focused on diff-driven doc updates for commits since `cb2004fd`. The main gap was PR #661 (Quick Phrases injection button) landing without any documentation. The operations runbook audit (`next_focus`) is deferred to the next run.

## Deferred to next run

- `docs/10-operations-runbook.md` full audit (carried forward as `next_focus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)