### PR TITLE
Extract terminal connection logic into terminal-connect.ts (#tech-debt)

### DIFF
--- a/apps/web/src/hooks/terminal-connect.ts
+++ b/apps/web/src/hooks/terminal-connect.ts
@@ -1,0 +1,307 @@
+import type { MutableRefObject } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { Agent, ConnState } from "@/components/app/types";
+import { api } from "@/lib/api";
+import { recordWSReconnect } from "@/lib/energy-metrics";
+import {
+  type SocketHealth,
+  clearSocketHealth,
+  isRetriableTerminalFailure,
+  isTerminalSessionGone,
+  markSocketHealthy,
+  noteSocketError,
+  openTerminalSocket,
+} from "@/hooks/terminal-socket";
+
+export interface TerminalConnectRefs {
+  shouldKeepAttachedRef: MutableRefObject<boolean>;
+  reconnectInFlightRef: MutableRefObject<{
+    agentId: string;
+    promise: Promise<void>;
+  } | null>;
+  attachNonceRef: MutableRefObject<number>;
+  agentsRef: MutableRefObject<Agent[]>;
+  reconnectAttemptsRef: MutableRefObject<number>;
+  reconnectTimerRef: MutableRefObject<number | null>;
+  wsRef: MutableRefObject<WebSocket | null>;
+  connectedAgentIdRef: MutableRefObject<string | null>;
+  terminalRef: MutableRefObject<XTerm | null>;
+  fitAddonRef: MutableRefObject<FitAddon | null>;
+  socketHealthRef: MutableRefObject<SocketHealth>;
+  reconnectRef: MutableRefObject<
+    (
+      clearScreen: boolean,
+      userInitiated: boolean,
+      targetAgentId?: string
+    ) => Promise<void>
+  >;
+}
+
+export interface TerminalConnectCallbacks {
+  selectedAgentId: string | null;
+  queryClient: QueryClient;
+  clearReconnectTimer: () => void;
+  closeSocket: (announce?: boolean) => void;
+  closeSocketTransport: () => void;
+  hasFreshSocket: (agentId: string) => boolean;
+  probeSocket: (agentId: string) => Promise<boolean>;
+  resetTerminalState: () => void;
+  resetTerminalSurface: () => void;
+  restoreConnectedState: (
+    agent: Agent,
+    mode: "tmux" | "inert",
+    message?: string
+  ) => void;
+  sendResize: () => void;
+  focusTerminalSurface: (term: XTerm | null) => void;
+  setConnState: (state: ConnState) => void;
+  setConnectedAgentId: (id: string | null) => void;
+  setTerminalMode: (mode: "tmux" | "inert" | null) => void;
+  setTerminalPlaceholderMessage: (msg: string | null) => void;
+  setStatusMessage: (msg: string) => void;
+}
+
+export async function connectTerminal(
+  refs: TerminalConnectRefs,
+  cbs: TerminalConnectCallbacks,
+  clearScreen: boolean,
+  userInitiated: boolean,
+  targetAgentId?: string
+): Promise<void> {
+  if (userInitiated) {
+    refs.shouldKeepAttachedRef.current = true;
+  }
+
+  const resolvedAgentId = targetAgentId ?? cbs.selectedAgentId;
+  if (!refs.shouldKeepAttachedRef.current || !resolvedAgentId) return;
+
+  if (
+    !userInitiated &&
+    refs.reconnectInFlightRef.current?.agentId === resolvedAgentId
+  ) {
+    await refs.reconnectInFlightRef.current.promise;
+    return;
+  }
+
+  let attemptNonce = refs.attachNonceRef.current;
+  const isCurrentAttempt = () =>
+    refs.shouldKeepAttachedRef.current &&
+    attemptNonce === refs.attachNonceRef.current;
+
+  const scheduleReconnect = (message: string) => {
+    if (!isCurrentAttempt() || !refs.shouldKeepAttachedRef.current) {
+      return;
+    }
+
+    refs.reconnectAttemptsRef.current += 1;
+    recordWSReconnect();
+    const delay = Math.min(1200 * refs.reconnectAttemptsRef.current, 8000);
+    cbs.setConnState("reconnecting");
+    cbs.setStatusMessage(message);
+    cbs.clearReconnectTimer();
+    refs.reconnectTimerRef.current = window.setTimeout(() => {
+      refs.reconnectTimerRef.current = null;
+      if (!refs.shouldKeepAttachedRef.current || document.hidden) return;
+      void refs.reconnectRef.current(false, false, resolvedAgentId);
+    }, delay);
+  };
+
+  const connectPromise = (async () => {
+    let agent: Agent | null = userInitiated
+      ? (refs.agentsRef.current.find((item) => item.id === resolvedAgentId) ??
+        null)
+      : null;
+
+    if (!agent || agent.status !== "running") {
+      try {
+        const payload = await api<{ agent: Agent }>(
+          `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
+        );
+        agent = payload.agent;
+      } catch {
+        if (!isCurrentAttempt()) return;
+        scheduleReconnect("Session disconnected, reconnecting...");
+        return;
+      }
+    }
+
+    if (!isCurrentAttempt() || !agent) return;
+
+    if (agent.status !== "running" && agent.status !== "creating") {
+      refs.shouldKeepAttachedRef.current = false;
+      cbs.clearReconnectTimer();
+      cbs.closeSocket(false);
+      cbs.resetTerminalSurface();
+      cbs.setConnState("disconnected");
+      cbs.setStatusMessage("Session ended.");
+      return;
+    }
+
+    if (cbs.hasFreshSocket(agent.id)) {
+      cbs.restoreConnectedState(agent, "tmux");
+      cbs.sendResize();
+      return;
+    }
+
+    if (
+      refs.wsRef.current?.readyState === WebSocket.OPEN &&
+      refs.connectedAgentIdRef.current === agent.id
+    ) {
+      const alive = await cbs.probeSocket(agent.id);
+      if (!isCurrentAttempt()) return;
+      if (alive) {
+        cbs.restoreConnectedState(agent, "tmux");
+        cbs.sendResize();
+        return;
+      }
+    }
+
+    attemptNonce = ++refs.attachNonceRef.current;
+
+    if (
+      refs.wsRef.current &&
+      refs.wsRef.current.readyState === WebSocket.OPEN &&
+      refs.connectedAgentIdRef.current === agent.id
+    ) {
+      cbs.closeSocketTransport();
+    }
+
+    cbs.clearReconnectTimer();
+    cbs.closeSocket(false);
+    cbs.resetTerminalSurface();
+
+    if (clearScreen) {
+      refs.terminalRef.current?.clear();
+    }
+
+    refs.fitAddonRef.current?.fit();
+    cbs.setConnState("reconnecting");
+    cbs.setStatusMessage(`Connecting to session ${agent.name}...`);
+
+    try {
+      const terminalSession = await api<
+        | { mode: "tmux"; token: string; wsUrl: string }
+        | { mode: "inert"; message: string }
+      >(`/api/v1/agents/${agent.id}/terminal/token`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      if (!isCurrentAttempt()) {
+        return;
+      }
+
+      if (terminalSession.mode === "inert") {
+        cbs.resetTerminalState();
+        cbs.restoreConnectedState(agent, "inert", terminalSession.message);
+        return;
+      }
+
+      const term = refs.terminalRef.current;
+      const cols = term?.cols ?? 140;
+      const rows = term?.rows ?? 42;
+      cbs.setTerminalMode("tmux");
+      cbs.setTerminalPlaceholderMessage(null);
+      const ws = openTerminalSocket(
+        terminalSession.wsUrl,
+        cols,
+        rows,
+        {
+          onOpen: () => {
+            markSocketHealthy(refs.socketHealthRef.current, "open");
+            cbs.restoreConnectedState(agent, "tmux");
+            cbs.focusTerminalSurface(refs.terminalRef.current);
+            void cbs.queryClient.invalidateQueries({
+              queryKey: ["terminal-state", agent.id],
+              exact: true,
+            });
+          },
+          onHeartbeat: () =>
+            markSocketHealthy(refs.socketHealthRef.current, "heartbeat"),
+          onOutput: (data) => {
+            markSocketHealthy(refs.socketHealthRef.current, "output");
+            refs.terminalRef.current?.write(data);
+          },
+          onError: (message) => {
+            noteSocketError(refs.socketHealthRef.current, message);
+            cbs.setStatusMessage(`Session error: ${message}`);
+            if (isTerminalSessionGone(message)) {
+              refs.shouldKeepAttachedRef.current = false;
+            }
+          },
+          onSessionEnd: () => {
+            noteSocketError(refs.socketHealthRef.current, "Session ended.");
+            refs.socketHealthRef.current.sessionGone = true;
+            refs.shouldKeepAttachedRef.current = false;
+            cbs.setStatusMessage("Session ended.");
+          },
+          onClose: (event) => {
+            refs.wsRef.current = null;
+            const lastErrorMessage =
+              refs.socketHealthRef.current.lastErrorMessage;
+            const sessionGone = refs.socketHealthRef.current.sessionGone;
+            clearSocketHealth(refs.socketHealthRef.current);
+
+            if (sessionGone) {
+              refs.shouldKeepAttachedRef.current = false;
+              cbs.setConnectedAgentId(null);
+              cbs.setTerminalMode(null);
+              cbs.resetTerminalSurface();
+              cbs.setConnState("disconnected");
+              return;
+            }
+
+            if (
+              event.code === 1008 &&
+              lastErrorMessage &&
+              isRetriableTerminalFailure(lastErrorMessage)
+            ) {
+              scheduleReconnect("Session token expired, retrying...");
+              return;
+            }
+
+            scheduleReconnect("Session disconnected, reconnecting...");
+          },
+        },
+        () => refs.wsRef.current !== ws || !isCurrentAttempt()
+      );
+      refs.wsRef.current = ws;
+    } catch (error) {
+      if (!isCurrentAttempt()) {
+        return;
+      }
+
+      const message =
+        error instanceof Error ? error.message : "Session connection failed.";
+      if (isTerminalSessionGone(message)) {
+        refs.shouldKeepAttachedRef.current = false;
+        cbs.clearReconnectTimer();
+        cbs.closeSocket(false);
+        cbs.resetTerminalSurface();
+        cbs.setConnState("disconnected");
+        cbs.setStatusMessage(message);
+        return;
+      }
+
+      scheduleReconnect(
+        isRetriableTerminalFailure(message)
+          ? "Session token expired, retrying..."
+          : "Session connection failed, retrying..."
+      );
+    }
+  })();
+
+  refs.reconnectInFlightRef.current = {
+    agentId: resolvedAgentId,
+    promise: connectPromise,
+  };
+  try {
+    await connectPromise;
+  } finally {
+    if (refs.reconnectInFlightRef.current?.promise === connectPromise) {
+      refs.reconnectInFlightRef.current = null;
+    }
+  }
+}

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -18,21 +18,17 @@ import {
   type TerminalUiState,
 } from "@/components/app/types";
 import { api } from "@/lib/api";
-import { recordWSReconnect } from "@/lib/energy-metrics";
 import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
 import {
   RESUME_RECONNECT_DEDUPE_MS,
   clearSocketHealth,
   createSocketHealth,
-  isRetriableTerminalFailure,
   isSocketFresh,
-  isTerminalSessionGone,
   markSocketHealthy,
-  noteSocketError,
-  openTerminalSocket,
   probeTerminalSocket,
 } from "@/hooks/terminal-socket";
 import { createTerminalSurface } from "@/hooks/terminal-surface";
+import { connectTerminal } from "@/hooks/terminal-connect";
 
 function focusTerminalSurface(term: XTerm | null): void {
   if (!term) return;
@@ -137,6 +133,13 @@ export function useTerminal(args: {
   } | null>(null);
   const lastResumeTriggerAtRef = useRef(0);
   const socketHealthRef = useRef(createSocketHealth());
+  const reconnectRef = useRef<
+    (
+      clearScreen: boolean,
+      userInitiated: boolean,
+      targetAgentId?: string
+    ) => Promise<void>
+  >(async () => {});
 
   // Ref for agents so ensureTerminalConnected doesn't get recreated on every
   // SSE-driven agents array update (which would trigger the visibility/focus
@@ -296,249 +299,44 @@ export function useTerminal(args: {
       userInitiated = false,
       targetAgentId?: string
     ) => {
-      if (userInitiated) {
-        shouldKeepAttachedRef.current = true;
-      }
-
-      const resolvedAgentId = targetAgentId ?? selectedAgentId;
-      if (!shouldKeepAttachedRef.current || !resolvedAgentId) return;
-
-      if (
-        !userInitiated &&
-        reconnectInFlightRef.current?.agentId === resolvedAgentId
-      ) {
-        await reconnectInFlightRef.current.promise;
-        return;
-      }
-
-      // Nonce is incremented later (just before opening a new WebSocket) so
-      // that reusing a fresh socket doesn't invalidate its existing message
-      // handler.  Read the current value here for the in-flight guard only.
-      let attemptNonce = attachNonceRef.current;
-      const isCurrentAttempt = () =>
-        shouldKeepAttachedRef.current &&
-        attemptNonce === attachNonceRef.current;
-
-      const scheduleReconnect = (message: string) => {
-        if (!isCurrentAttempt() || !shouldKeepAttachedRef.current) {
-          return;
-        }
-
-        reconnectAttemptsRef.current += 1;
-        recordWSReconnect();
-        const delay = Math.min(1200 * reconnectAttemptsRef.current, 8000);
-        setConnState("reconnecting");
-        setStatusMessage(message);
-        clearReconnectTimer();
-        reconnectTimerRef.current = window.setTimeout(() => {
-          reconnectTimerRef.current = null;
-          if (!shouldKeepAttachedRef.current || document.hidden) return;
-          void ensureTerminalConnected(false, false, resolvedAgentId);
-        }, delay);
-      };
-
-      const connectPromise = (async () => {
-        let agent: Agent | null = userInitiated
-          ? (agentsRef.current.find((item) => item.id === resolvedAgentId) ??
-            null)
-          : null;
-
-        if (!agent || agent.status !== "running") {
-          try {
-            const payload = await api<{ agent: Agent }>(
-              `/api/v1/agents/${resolvedAgentId}?includeGitContext=false`
-            );
-            agent = payload.agent;
-          } catch {
-            if (!isCurrentAttempt()) return;
-            scheduleReconnect("Session disconnected, reconnecting...");
-            return;
-          }
-        }
-
-        if (!isCurrentAttempt() || !agent) return;
-
-        if (agent.status !== "running" && agent.status !== "creating") {
-          shouldKeepAttachedRef.current = false;
-          clearReconnectTimer();
-          closeSocket(false);
-          resetTerminalSurface();
-          setConnState("disconnected");
-          setStatusMessage("Session ended.");
-          return;
-        }
-
-        if (hasFreshSocket(agent.id)) {
-          restoreConnectedState(agent, "tmux");
-          sendResize();
-          return;
-        }
-
-        // Socket is open but stale (no heartbeat during background throttle).
-        // Probe it before tearing down — avoids a full reconnect cycle.
-        if (
-          wsRef.current?.readyState === WebSocket.OPEN &&
-          connectedAgentIdRef.current === agent.id
-        ) {
-          const alive = await probeSocket(agent.id);
-          if (!isCurrentAttempt()) return;
-          if (alive) {
-            restoreConnectedState(agent, "tmux");
-            sendResize();
-            return;
-          }
-        }
-
-        // We're about to create a new WebSocket — NOW increment the nonce to
-        // invalidate any previous handler that is still attached.
-        attemptNonce = ++attachNonceRef.current;
-
-        if (
-          wsRef.current &&
-          wsRef.current.readyState === WebSocket.OPEN &&
-          connectedAgentIdRef.current === agent.id
-        ) {
-          closeSocketTransport();
-        }
-
-        clearReconnectTimer();
-        closeSocket(false);
-        resetTerminalSurface();
-
-        if (clearScreen) {
-          terminalRef.current?.clear();
-        }
-
-        fitAddonRef.current?.fit();
-        setConnState("reconnecting");
-        setStatusMessage(`Connecting to session ${agent.name}...`);
-
-        try {
-          const terminalSession = await api<
-            | { mode: "tmux"; token: string; wsUrl: string }
-            | { mode: "inert"; message: string }
-          >(`/api/v1/agents/${agent.id}/terminal/token`, {
-            method: "POST",
-            body: JSON.stringify({}),
-          });
-
-          if (!isCurrentAttempt()) {
-            return;
-          }
-
-          if (terminalSession.mode === "inert") {
-            resetTerminalState();
-            restoreConnectedState(agent, "inert", terminalSession.message);
-            return;
-          }
-
-          const term = terminalRef.current;
-          const cols = term?.cols ?? 140;
-          const rows = term?.rows ?? 42;
-          setTerminalMode("tmux");
-          setTerminalPlaceholderMessage(null);
-          const ws = openTerminalSocket(
-            terminalSession.wsUrl,
-            cols,
-            rows,
-            {
-              onOpen: () => {
-                markSocketHealthy(socketHealthRef.current, "open");
-                restoreConnectedState(agent, "tmux");
-                focusTerminalSurface(terminalRef.current);
-                void queryClient.invalidateQueries({
-                  queryKey: ["terminal-state", agent.id],
-                  exact: true,
-                });
-              },
-              onHeartbeat: () =>
-                markSocketHealthy(socketHealthRef.current, "heartbeat"),
-              onOutput: (data) => {
-                markSocketHealthy(socketHealthRef.current, "output");
-                terminalRef.current?.write(data);
-              },
-              onError: (message) => {
-                noteSocketError(socketHealthRef.current, message);
-                setStatusMessage(`Session error: ${message}`);
-                if (isTerminalSessionGone(message)) {
-                  shouldKeepAttachedRef.current = false;
-                }
-              },
-              onSessionEnd: () => {
-                noteSocketError(socketHealthRef.current, "Session ended.");
-                socketHealthRef.current.sessionGone = true;
-                shouldKeepAttachedRef.current = false;
-                setStatusMessage("Session ended.");
-              },
-              onClose: (event) => {
-                wsRef.current = null;
-                const lastErrorMessage =
-                  socketHealthRef.current.lastErrorMessage;
-                const sessionGone = socketHealthRef.current.sessionGone;
-                clearSocketHealth(socketHealthRef.current);
-
-                if (sessionGone) {
-                  shouldKeepAttachedRef.current = false;
-                  setConnectedAgentId(null);
-                  setTerminalMode(null);
-                  resetTerminalSurface();
-                  setConnState("disconnected");
-                  return;
-                }
-
-                if (
-                  event.code === 1008 &&
-                  lastErrorMessage &&
-                  isRetriableTerminalFailure(lastErrorMessage)
-                ) {
-                  scheduleReconnect("Session token expired, retrying...");
-                  return;
-                }
-
-                scheduleReconnect("Session disconnected, reconnecting...");
-              },
-            },
-            () => wsRef.current !== ws || !isCurrentAttempt()
-          );
-          wsRef.current = ws;
-        } catch (error) {
-          if (!isCurrentAttempt()) {
-            return;
-          }
-
-          const message =
-            error instanceof Error
-              ? error.message
-              : "Session connection failed.";
-          if (isTerminalSessionGone(message)) {
-            shouldKeepAttachedRef.current = false;
-            clearReconnectTimer();
-            closeSocket(false);
-            resetTerminalSurface();
-            setConnState("disconnected");
-            setStatusMessage(message);
-            return;
-          }
-
-          scheduleReconnect(
-            isRetriableTerminalFailure(message)
-              ? "Session token expired, retrying..."
-              : "Session connection failed, retrying..."
-          );
-        }
-      })();
-
-      reconnectInFlightRef.current = {
-        agentId: resolvedAgentId,
-        promise: connectPromise,
-      };
-      try {
-        await connectPromise;
-      } finally {
-        if (reconnectInFlightRef.current?.promise === connectPromise) {
-          reconnectInFlightRef.current = null;
-        }
-      }
+      await connectTerminal(
+        {
+          shouldKeepAttachedRef,
+          reconnectInFlightRef,
+          attachNonceRef,
+          agentsRef,
+          reconnectAttemptsRef,
+          reconnectTimerRef,
+          wsRef,
+          connectedAgentIdRef,
+          terminalRef,
+          fitAddonRef,
+          socketHealthRef,
+          reconnectRef,
+        },
+        {
+          selectedAgentId,
+          queryClient,
+          clearReconnectTimer,
+          closeSocket,
+          closeSocketTransport,
+          hasFreshSocket,
+          probeSocket,
+          resetTerminalState,
+          resetTerminalSurface,
+          restoreConnectedState,
+          sendResize,
+          focusTerminalSurface,
+          setConnState,
+          setConnectedAgentId,
+          setTerminalMode,
+          setTerminalPlaceholderMessage,
+          setStatusMessage,
+        },
+        clearScreen,
+        userInitiated,
+        targetAgentId
+      );
     },
     [
       clearReconnectTimer,
@@ -554,6 +352,7 @@ export function useTerminal(args: {
       sendResize,
     ]
   );
+  reconnectRef.current = ensureTerminalConnected;
 
   const detachTerminal = useCallback(() => {
     shouldKeepAttachedRef.current = false;


### PR DESCRIPTION
## Summary

- Extracted the `ensureTerminalConnected` callback (~250 lines) from `use-terminal.ts` into a standalone `connectTerminal` function in a new `terminal-connect.ts` module
- Reduces `use-terminal.ts` from 846 → 647 lines (199 lines removed)
- The extracted module handles WebSocket attach, reconnect scheduling, output/heartbeat message handling, and terminal mode detection
- Follows the same extraction pattern as `terminal-socket.ts` and `terminal-surface.ts` from previous tech-debt runs

## Why this is tech debt

`use-terminal.ts` was the largest hook in the frontend at 846 lines. The `ensureTerminalConnected` callback was the largest single function (~250 lines), making the file harder to navigate and reason about. This is the fourth extraction in a series that has progressively reduced the file from ~1270 lines to 647 lines.

## What's next

Next run will extract inline `create_pr` and `get_pr_status` tool registrations from `apps/server/src/shared/mcp/server.ts` into a `pr-tools.ts` module.

## Test plan

- [x] `pnpm run check` — TypeScript type checking passes
- [x] `pnpm run finalize:web` — production build succeeds
- [x] `pnpm run test:e2e` — 168 passed, 12 skipped (terminal-live tests require real terminal)