### PR TITLE
Exclude gitignored files from session diff stats

### DIFF
--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -92,6 +92,13 @@ export async function getDiffStats(
       ),
     ]);
 
+    const trackedPaths = extractPathsFromNumstat(tracked.stdout);
+    const ignoredPaths = await getGitIgnoredPaths(
+      worktreePath,
+      trackedPaths,
+      run
+    );
+
     let added = 0;
     let deleted = 0;
     const seenFiles = new Set<string>();
@@ -104,6 +111,7 @@ export async function getDiffStats(
       const filePath = rest.join("\t");
       if (!filePath) continue;
       if (shouldIgnoreDiffStatsPath(filePath)) continue;
+      if (ignoredPaths.has(filePath)) continue;
       if (seenFiles.has(filePath)) continue;
       seenFiles.add(filePath);
       if (a === "-" && d === "-") continue;
@@ -165,6 +173,47 @@ function countLines(content: string): number {
   if (content.length === 0) return 0;
   const parts = content.split("\n");
   return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}
+
+function extractPathsFromNumstat(numstatOutput: string): string[] {
+  const paths: string[] = [];
+  for (const line of numstatOutput.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    const filePath = parts.slice(2).join("\t");
+    if (filePath) paths.push(filePath);
+  }
+  return paths;
+}
+
+const CHECK_IGNORE_BATCH_SIZE = 500;
+
+async function getGitIgnoredPaths(
+  worktreePath: string,
+  paths: string[],
+  run: CommandRunner
+): Promise<Set<string>> {
+  if (paths.length === 0) return new Set();
+  const ignored = new Set<string>();
+  try {
+    for (let i = 0; i < paths.length; i += CHECK_IGNORE_BATCH_SIZE) {
+      const batch = paths.slice(i, i + CHECK_IGNORE_BATCH_SIZE);
+      const result = await run(
+        "git",
+        ["-C", worktreePath, "check-ignore", "--", ...batch],
+        { allowedExitCodes: [0, 1], timeoutMs: GIT_TIMEOUT_MS }
+      );
+      if (result.exitCode === 0 && result.stdout) {
+        for (const p of result.stdout.split("\n")) {
+          if (p) ignored.add(p);
+        }
+      }
+    }
+    return ignored;
+  } catch {
+    return ignored;
+  }
 }
 
 function shouldIgnoreDiffStatsPath(filePath: string): boolean {

--- a/apps/server/test/diff-stats.test.ts
+++ b/apps/server/test/diff-stats.test.ts
@@ -50,10 +50,14 @@ function withCommands(
   return vi.fn(async (_command: string, args: string[]) => {
     const key = args.join(" ");
     const handler = merged[key];
-    if (!handler) {
-      throw new Error(`Unexpected command: ${key}`);
+    if (handler) return handler();
+
+    // check-ignore args vary with tracked paths; default to "none ignored"
+    if (args.includes("check-ignore")) {
+      return { exitCode: 1, stdout: "", stderr: "" };
     }
-    return handler();
+
+    throw new Error(`Unexpected command: ${key}`);
   });
 }
 
@@ -246,6 +250,9 @@ describe("getDiffStats", () => {
       if (key === `-C ${worktreePath} ls-files --others --exclude-standard`) {
         return ok("");
       }
+      if (args.includes("check-ignore")) {
+        return fail("");
+      }
       throw new Error(`Unexpected command: ${key}`);
     });
 
@@ -270,6 +277,9 @@ describe("getDiffStats", () => {
       }
       if (key === `-C ${worktreePath} ls-files --others --exclude-standard`) {
         return ok("");
+      }
+      if (args.includes("check-ignore")) {
+        return fail("");
       }
       if (key === `-C ${worktreePath} rev-parse --verify --quiet main`) {
         throw new Error("resolveBaseRef should not consult local main first");
@@ -306,6 +316,34 @@ describe("getDiffStats", () => {
     for (const args of seen) {
       expect(args).not.toContain("--all");
     }
+  });
+
+  it("excludes gitignored tracked files from diff stats", async () => {
+    const worktreePath = tempRoot;
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(" ");
+      if (key === `-C ${worktreePath} rev-parse --verify --quiet main`) {
+        return ok("main");
+      }
+      if (key === `-C ${worktreePath} merge-base HEAD main`) {
+        return ok(MERGE_BASE_SHA);
+      }
+      if (key === `-C ${worktreePath} diff ${MERGE_BASE_SHA} --numstat`) {
+        return ok(
+          "10\t2\tsrc/foo.ts\n500\t0\tdist/bundle.js\n3\t1\tsrc/bar.ts"
+        );
+      }
+      if (key === `-C ${worktreePath} ls-files --others --exclude-standard`) {
+        return ok("");
+      }
+      if (args.includes("check-ignore")) {
+        return ok("dist/bundle.js");
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+
+    const result = await getDiffStats(worktreePath, "main", { runCommand });
+    expect(result).toMatchObject({ added: 13, deleted: 3, files: 2 });
   });
 
   it("does not follow symlinks for untracked-file line counting", async () => {


### PR DESCRIPTION
## Summary
- Filter tracked paths through `git check-ignore --` before accumulating diff stats so files matching `.gitignore` patterns (e.g. committed build artifacts) don't inflate the session diff badge.
- Batches paths in chunks of 500 to stay under OS `ARG_MAX` limits, with partial-result preservation on failure.
- Uses `--` end-of-options separator to prevent option injection via crafted filenames.

## Test plan
- [x] New unit test: "excludes gitignored tracked files from diff stats" — verifies ignored file excluded from both line and file counts
- [x] All 17 existing diff-stats tests pass with updated mock infrastructure
- [x] Type checking passes (`pnpm run check`)
- [x] Backend security review: approved (option injection + ARG_MAX batching)
- [x] Infra review: approved (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)