### PR TITLE
Extract PR tool registrations into pr-tools.ts

### DIFF
--- a/apps/server/src/shared/mcp/pr-tools.ts
+++ b/apps/server/src/shared/mcp/pr-tools.ts
@@ -1,0 +1,132 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import { createPr, getPrStatus } from "../github/pr.js";
+import { toToolError } from "./tool-error.js";
+
+export type PrToolContext = {
+  defaultCwd: string | undefined;
+  baseBranch: string | undefined;
+};
+
+function cwdSchema(
+  defaultCwd: string | undefined,
+  description: string
+): z.ZodType<string | undefined> {
+  const suffix = defaultCwd
+    ? ` Defaults to the agent working directory (${defaultCwd}) when omitted on agent-scoped MCP routes.`
+    : "";
+  return defaultCwd
+    ? z.string().optional().describe(`${description}${suffix}`)
+    : z.string().describe(description);
+}
+
+function resolveCwd(
+  value: string | undefined,
+  defaultCwd: string | undefined
+): string {
+  const cwd = value?.trim() || defaultCwd?.trim();
+  if (!cwd) {
+    throw new Error("cwd is required.");
+  }
+  return cwd;
+}
+
+export function registerPrTools(
+  server: McpServer,
+  allowed: Set<string>,
+  context: PrToolContext
+): void {
+  const { defaultCwd } = context;
+  const defaultBaseBranch = context.baseBranch || "main";
+
+  if (allowed.has("create_pr")) {
+    server.registerTool(
+      "create_pr",
+      {
+        description: "Create a GitHub pull request for the current branch.",
+        inputSchema: {
+          cwd: cwdSchema(
+            defaultCwd,
+            "Absolute path inside the git repository."
+          ),
+          baseBranch: z
+            .string()
+            .default(defaultBaseBranch)
+            .describe("Base branch to target."),
+          title: z.string().optional().describe("Explicit PR title."),
+          body: z.string().optional().describe("Explicit PR body."),
+          draft: z
+            .boolean()
+            .default(false)
+            .describe("Create the PR as a draft."),
+          fillFromCommits: z
+            .boolean()
+            .default(false)
+            .describe("Let gh derive title/body from commits."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await createPr({
+            ...args,
+            cwd: resolveCwd(args.cwd, defaultCwd),
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.`,
+              },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (allowed.has("get_pr_status")) {
+    server.registerTool(
+      "get_pr_status",
+      {
+        description: "Fetch status details for a pull request.",
+        inputSchema: {
+          cwd: cwdSchema(
+            defaultCwd,
+            "Absolute path inside the git repository."
+          ),
+          prNumber: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Specific PR number. Defaults to the PR for the current branch."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await getPrStatus({
+            ...args,
+            cwd: resolveCwd(args.cwd, defaultCwd),
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.`,
+              },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+}

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -5,7 +5,6 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import * as z from "zod/v4";
 
 import type { BrainStore } from "../../brain/store.js";
-import { createPr, getPrStatus } from "../github/pr.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
 import { registerCrudTools, type CrudToolCallbacks } from "./crud-tools.js";
@@ -15,6 +14,7 @@ import {
   type LaunchPersonaAgentType,
 } from "./persona-interaction-tools.js";
 import { registerPersonaTools } from "./persona-tools.js";
+import { registerPrTools } from "./pr-tools.js";
 import { loadRepoTools, type RepoToolParam } from "./repo-tools.js";
 import { toToolError } from "./tool-error.js";
 
@@ -453,99 +453,11 @@ async function createDispatchMcpServer(
     });
   }
 
-  // ── create_pr ─────────────────────────────────────────────────────
-  if (allowed.has("create_pr")) {
-    const agentBaseBranch = context.agent?.baseBranch;
-    const defaultBaseBranch = agentBaseBranch || "main";
-    server.registerTool(
-      "create_pr",
-      {
-        description: "Create a GitHub pull request for the current branch.",
-        inputSchema: {
-          cwd: cwdSchema(
-            defaultCwd,
-            "Absolute path inside the git repository."
-          ),
-          baseBranch: z
-            .string()
-            .default(defaultBaseBranch)
-            .describe("Base branch to target."),
-          title: z.string().optional().describe("Explicit PR title."),
-          body: z.string().optional().describe("Explicit PR body."),
-          draft: z
-            .boolean()
-            .default(false)
-            .describe("Create the PR as a draft."),
-          fillFromCommits: z
-            .boolean()
-            .default(false)
-            .describe("Let gh derive title/body from commits."),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await createPr({
-            ...args,
-            cwd: resolveCwd(args.cwd, defaultCwd),
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Created PR ${result.url} from ${result.branchName} into ${result.baseBranch}.`,
-              },
-            ],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── get_pr_status ─────────────────────────────────────────────────
-  if (allowed.has("get_pr_status")) {
-    server.registerTool(
-      "get_pr_status",
-      {
-        description: "Fetch status details for a pull request.",
-        inputSchema: {
-          cwd: cwdSchema(
-            defaultCwd,
-            "Absolute path inside the git repository."
-          ),
-          prNumber: z
-            .number()
-            .int()
-            .positive()
-            .optional()
-            .describe(
-              "Specific PR number. Defaults to the PR for the current branch."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await getPrStatus({
-            ...args,
-            cwd: resolveCwd(args.cwd, defaultCwd),
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: `PR #${result.number} is ${result.state} with merge state ${result.mergeStateStatus ?? "unknown"}.`,
-              },
-            ],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
+  // ── PR tools (create_pr, get_pr_status) ────────────────────────────
+  registerPrTools(server, allowed, {
+    defaultCwd,
+    baseBranch: context.agent?.baseBranch ?? undefined,
+  });
 
   // ── dispatch_event ────────────────────────────────────────────────
   // dispatch_event and dispatch_share are implemented as native MCP tools below.
@@ -1191,29 +1103,6 @@ function registerFeedbackTool(
       }
     }
   );
-}
-
-function cwdSchema(
-  defaultCwd: string | undefined,
-  description: string
-): z.ZodType<string | undefined> {
-  const suffix = defaultCwd
-    ? ` Defaults to the agent working directory (${defaultCwd}) when omitted on agent-scoped MCP routes.`
-    : "";
-  return defaultCwd
-    ? z.string().optional().describe(`${description}${suffix}`)
-    : z.string().describe(description);
-}
-
-function resolveCwd(
-  value: string | undefined,
-  defaultCwd: string | undefined
-): string {
-  const cwd = value?.trim() || defaultCwd?.trim();
-  if (!cwd) {
-    throw new Error("cwd is required.");
-  }
-  return cwd;
 }
 
 function buildParamSchema(params?: RepoToolParam[]): Record<string, z.ZodType> {


### PR DESCRIPTION
## Summary

- Extracted `create_pr` and `get_pr_status` MCP tool registrations (~90 lines) from the monolithic `server.ts` into a new `pr-tools.ts` module
- Moved the `cwdSchema` and `resolveCwd` helper functions (only used by PR tools) into the new module
- Follows the same `registerXTools(server, allowed, context)` pattern used by `job-tools.ts`, `persona-tools.ts`, and other extracted modules
- `server.ts` drops from 1230 to 1119 lines (111 lines removed)

**Why this is tech debt:** `server.ts` has been accumulating inline tool registrations, making it harder to navigate and maintain. Previous runs extracted job-tools, analytics-tools, persona-tools, and brain-tools; this continues that pattern for PR tools.

**Next up:** Extract `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_list_media` into `agent-lifecycle-tools.ts`

## Test plan
- [x] `pnpm run check` — TypeScript type checking passes
- [x] `pnpm run test:e2e` — 168 E2E tests pass
- [x] `pnpm run test` — 1965 unit tests pass (1808 server + 157 web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)