### PR TITLE
[codex] Fix Fast Refresh lint warnings

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,15 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Outlet,
-  useMatches,
-  useNavigate,
-  useOutletContext,
-} from "react-router-dom";
+import { Outlet, useMatches, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import "@xterm/xterm/css/xterm.css";
 
 import { type NavSection } from "@/components/app/sidebar-shell";
-import { type Agent, type ServiceState } from "@/components/app/types";
+import { type Agent } from "@/components/app/types";
+import { type DashboardContextValue } from "@/components/app/dashboard-context";
 import { initEnergyMetrics } from "@/lib/energy-metrics";
 import { api } from "@/lib/api";
 import { useAuthContext } from "@/contexts/auth-context";
@@ -30,7 +26,6 @@ import { type IdeType, sanitizeEnabledIdes } from "@/lib/ide-types";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { TipQueueProvider } from "@/components/tips/tip-queue-provider";
 import { TipsVersionInit } from "@/components/tips/tips-version-init";
-import { agentRoute } from "@/lib/agent-routes";
 import { ReleaseAvailableToast } from "@/components/app/release-available-toast";
 import { UpdateAvailableToast } from "@/components/app/update-available-toast";
 import { Toaster } from "sonner";
@@ -38,41 +33,6 @@ import { Toaster } from "sonner";
 type RouteHandle = {
   navSection?: NavSection;
 };
-
-export type DashboardContextValue = {
-  agents: Agent[];
-  enabledAgentTypes: AgentType[];
-  setEnabledAgentTypes: React.Dispatch<React.SetStateAction<AgentType[]>>;
-  enabledIdes: IdeType[];
-  setEnabledIdes: React.Dispatch<React.SetStateAction<IdeType[]>>;
-  handleLogout: () => void;
-  isMobile: boolean;
-  leftOpen: boolean;
-  leftPanelOpen: boolean;
-  mobileLeftOpen: boolean;
-  mobileMediaOpen: boolean;
-  setLeftOpen: (open: boolean) => void;
-  setMobileLeftOpen: (open: boolean) => void;
-  setMobileMediaOpen: (open: boolean) => void;
-  handleSetLeftPanelOpen: (open: boolean) => void;
-  apiState: ServiceState;
-  dbState: ServiceState;
-  pulsingNavItem: string | null;
-  triggerNavAnimation: (navItem: string) => void;
-  handleSidebarNavigate: (section: NavSection) => void;
-  currentNavItem: NavSection | null;
-  theme: ReturnType<typeof useTheme>["theme"];
-  setTheme: ReturnType<typeof useTheme>["setTheme"];
-  iconColor: ReturnType<typeof useIconColor>["iconColor"];
-  setIconColor: ReturnType<typeof useIconColor>["setIconColor"];
-  isIconColorSaving: boolean;
-  iconColorError: string | null;
-  clearIconColorError: () => void;
-};
-
-export function useDashboardContext(): DashboardContextValue {
-  return useOutletContext<DashboardContextValue>();
-}
 
 export function DashboardLayout(): JSX.Element {
   const navigate = useNavigate();
@@ -259,11 +219,4 @@ export function DashboardLayout(): JSX.Element {
       />
     </TipQueueProvider>
   );
-}
-
-export async function openAgentFromJobs(
-  navigate: ReturnType<typeof useNavigate>,
-  agent: Agent
-): Promise<void> {
-  navigate(agentRoute(agent.id));
 }

--- a/apps/web/src/components/app/activity-chart-utils.ts
+++ b/apps/web/src/components/app/activity-chart-utils.ts
@@ -1,0 +1,5 @@
+import { formatShortDate } from "@/lib/format";
+
+export function formatDate(iso: string): string {
+  return formatShortDate(iso);
+}

--- a/apps/web/src/components/app/activity-charts.tsx
+++ b/apps/web/src/components/app/activity-charts.tsx
@@ -16,10 +16,10 @@ import {
   ChartLegendContent,
   type ChartConfig,
 } from "@/components/ui/chart";
+import { formatDate } from "@/components/app/activity-chart-utils";
 import { cn } from "@/lib/utils";
 import {
   formatDuration,
-  formatShortDate,
   formatTokenCount,
   shortProjectName,
 } from "@/lib/format";
@@ -34,10 +34,6 @@ import type {
 } from "@/hooks/use-activity";
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-export function formatDate(iso: string): string {
-  return formatShortDate(iso);
-}
 
 function formatBucketLabel(
   iso: string,

--- a/apps/web/src/components/app/activity-pane.tsx
+++ b/apps/web/src/components/app/activity-pane.tsx
@@ -37,10 +37,10 @@ import { useRadixPopoverZFix } from "@/hooks/use-radix-popover-z-fix";
 import {
   DailyStackedBarChart,
   DailyTokenChart,
-  formatDate,
   ModelBreakdown,
   ProjectBreakdown,
 } from "@/components/app/activity-charts";
+import { formatDate } from "@/components/app/activity-chart-utils";
 import { ActiveHoursGrid, Heatmap } from "@/components/app/activity-heatmaps";
 import type { TokenStats } from "@/hooks/use-activity";
 

--- a/apps/web/src/components/app/agent-history-detail.tsx
+++ b/apps/web/src/components/app/agent-history-detail.tsx
@@ -16,7 +16,8 @@ import {
 } from "@/lib/format";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
 import { StatCard } from "@/components/app/stat-card";
-import { MediaLightbox, stripTimestamp } from "@/components/app/media-lightbox";
+import { MediaLightbox } from "@/components/app/media-lightbox";
+import { stripTimestamp } from "@/components/app/media-file-utils";
 import { PinItem } from "@/components/app/pins-panel";
 import { type AgentPin } from "@/components/app/types";
 import {
@@ -28,6 +29,8 @@ import {
 import {
   EVENT_TYPE_COLORS,
   EVENT_TYPE_LABELS,
+} from "@/components/app/agent-history-event-types";
+import {
   EventTimeline,
   FeedbackTimeline,
 } from "@/components/app/agent-history-timeline";

--- a/apps/web/src/components/app/agent-history-event-types.ts
+++ b/apps/web/src/components/app/agent-history-event-types.ts
@@ -1,0 +1,15 @@
+export const EVENT_TYPE_COLORS: Record<string, string> = {
+  working: "bg-status-working",
+  blocked: "bg-status-blocked",
+  waiting_user: "bg-status-waiting",
+  done: "bg-status-done",
+  idle: "bg-muted-foreground",
+};
+
+export const EVENT_TYPE_LABELS: Record<string, string> = {
+  working: "Working",
+  blocked: "Blocked",
+  waiting_user: "Waiting",
+  done: "Done",
+  idle: "Idle",
+};

--- a/apps/web/src/components/app/agent-history-timeline.tsx
+++ b/apps/web/src/components/app/agent-history-timeline.tsx
@@ -3,29 +3,15 @@ import { CheckCircle2, ChevronRight } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Markdown } from "@/components/ui/markdown";
+import {
+  EVENT_TYPE_COLORS,
+  EVENT_TYPE_LABELS,
+} from "@/components/app/agent-history-event-types";
 import { cn } from "@/lib/utils";
 import {
   type HistoryEvent,
   type HistoryFeedbackItem,
 } from "@/hooks/use-agent-history";
-
-// ── Shared constants ────────────────────────────────────────────────
-
-export const EVENT_TYPE_COLORS: Record<string, string> = {
-  working: "bg-status-working",
-  blocked: "bg-status-blocked",
-  waiting_user: "bg-status-waiting",
-  done: "bg-status-done",
-  idle: "bg-muted-foreground",
-};
-
-export const EVENT_TYPE_LABELS: Record<string, string> = {
-  working: "Working",
-  blocked: "Blocked",
-  waiting_user: "Waiting",
-  done: "Done",
-  idle: "Idle",
-};
 
 // ── Event timeline ──────────────────────────────────────────────────
 

--- a/apps/web/src/components/app/brain-cards.tsx
+++ b/apps/web/src/components/app/brain-cards.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 
 // ── Shared primitives ──────────────────────────────────────────
 
-export function formatRelative(date: Date): string {
+function formatRelative(date: Date): string {
   const diffMs = Date.now() - date.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
   const diffHr = Math.floor(diffMin / 60);
@@ -25,7 +25,7 @@ export function formatRelative(date: Date): string {
   return `${diffDay}d ago`;
 }
 
-export function RelativeTime({ iso }: { iso: string }): JSX.Element {
+function RelativeTime({ iso }: { iso: string }): JSX.Element {
   const date = new Date(iso);
   return (
     <time
@@ -38,7 +38,7 @@ export function RelativeTime({ iso }: { iso: string }): JSX.Element {
   );
 }
 
-export function CopyButton({
+function CopyButton({
   value,
   className,
 }: {
@@ -112,7 +112,7 @@ export function CollapsibleSection({
 
 // ── Value renderers ─────────────────────────────────────────────
 
-export function formatPrimitive(v: unknown): {
+function formatPrimitive(v: unknown): {
   text: string;
   className: string;
 } {
@@ -185,7 +185,7 @@ function AgentIdLabel({ agentId }: { agentId: string }): JSX.Element {
 
 // ── Kind styles ────────────────────────────────────────────────
 
-export const KIND_STYLES: Record<
+const KIND_STYLES: Record<
   string,
   { dot: string; text: string; badge: string }
 > = {
@@ -206,7 +206,7 @@ export const KIND_STYLES: Record<
   },
 };
 
-export function getKindStyle(kind: string) {
+function getKindStyle(kind: string) {
   return (
     KIND_STYLES[kind] ?? {
       dot: "bg-muted-foreground",

--- a/apps/web/src/components/app/brain-tab-content.tsx
+++ b/apps/web/src/components/app/brain-tab-content.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { ArrowRight, Brain, Database, List, Radio } from "lucide-react";
 
 import { useAgentBrainActivity } from "@/hooks/use-brain";
-import { encodeRepoRoot, decodeRepoRoot } from "@/lib/brain-encoding";
+import { encodeRepoRoot } from "@/lib/brain-encoding";
 import { cn } from "@/lib/utils";
 import {
   CollapsibleSection,
@@ -10,8 +10,6 @@ import {
   ListCard,
   EventCard,
 } from "@/components/app/brain-cards";
-
-export { encodeRepoRoot, decodeRepoRoot };
 
 type BrainTabContentProps = {
   agentId: string | null;

--- a/apps/web/src/components/app/dashboard-context.ts
+++ b/apps/web/src/components/app/dashboard-context.ts
@@ -1,0 +1,44 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useOutletContext } from "react-router-dom";
+
+import type { NavSection } from "@/components/app/sidebar-shell";
+import type { Agent, ServiceState } from "@/components/app/types";
+import type { AgentType } from "@/lib/agent-types";
+import type { IdeType } from "@/lib/ide-types";
+import type { useIconColor } from "@/hooks/use-icon-color";
+import type { useTheme } from "@/hooks/use-theme";
+
+export type DashboardContextValue = {
+  agents: Agent[];
+  enabledAgentTypes: AgentType[];
+  setEnabledAgentTypes: Dispatch<SetStateAction<AgentType[]>>;
+  enabledIdes: IdeType[];
+  setEnabledIdes: Dispatch<SetStateAction<IdeType[]>>;
+  handleLogout: () => void;
+  isMobile: boolean;
+  leftOpen: boolean;
+  leftPanelOpen: boolean;
+  mobileLeftOpen: boolean;
+  mobileMediaOpen: boolean;
+  setLeftOpen: (open: boolean) => void;
+  setMobileLeftOpen: (open: boolean) => void;
+  setMobileMediaOpen: (open: boolean) => void;
+  handleSetLeftPanelOpen: (open: boolean) => void;
+  apiState: ServiceState;
+  dbState: ServiceState;
+  pulsingNavItem: string | null;
+  triggerNavAnimation: (navItem: string) => void;
+  handleSidebarNavigate: (section: NavSection) => void;
+  currentNavItem: NavSection | null;
+  theme: ReturnType<typeof useTheme>["theme"];
+  setTheme: ReturnType<typeof useTheme>["setTheme"];
+  iconColor: ReturnType<typeof useIconColor>["iconColor"];
+  setIconColor: ReturnType<typeof useIconColor>["setIconColor"];
+  isIconColorSaving: boolean;
+  iconColorError: string | null;
+  clearIconColorError: () => void;
+};
+
+export function useDashboardContext(): DashboardContextValue {
+  return useOutletContext<DashboardContextValue>();
+}

--- a/apps/web/src/components/app/dashboard-navigation.ts
+++ b/apps/web/src/components/app/dashboard-navigation.ts
@@ -1,0 +1,11 @@
+import type { NavigateFunction } from "react-router-dom";
+
+import type { Agent } from "@/components/app/types";
+import { agentRoute } from "@/lib/agent-routes";
+
+export async function openAgentFromJobs(
+  navigate: NavigateFunction,
+  agent: Agent
+): Promise<void> {
+  navigate(agentRoute(agent.id));
+}

--- a/apps/web/src/components/app/feedback-mobile.tsx
+++ b/apps/web/src/components/app/feedback-mobile.tsx
@@ -23,7 +23,7 @@ import {
   getVerdict,
   getReviewSummary,
   getFilesReviewed,
-} from "@/components/app/persona-agent-row";
+} from "@/components/app/persona-agent-review-utils";
 import { type Agent, type FeedbackItem } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/components/app/feedback-panel.tsx
+++ b/apps/web/src/components/app/feedback-panel.tsx
@@ -5,10 +5,10 @@ import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { FrontTruncatedValue } from "@/components/app/agent-meta";
 import { reviewVerdictLabel } from "@/components/app/agent-event-utils";
 import {
-  PersonaAgentRow,
   getVerdict,
   getReviewSummary,
-} from "@/components/app/persona-agent-row";
+} from "@/components/app/persona-agent-review-utils";
+import { PersonaAgentRow } from "@/components/app/persona-agent-row";
 import {
   type FeedbackDetailState,
   bySeverity,

--- a/apps/web/src/components/app/media-file-utils.ts
+++ b/apps/web/src/components/app/media-file-utils.ts
@@ -1,0 +1,62 @@
+const TEXT_EXTENSIONS = new Set([
+  ".txt",
+  ".md",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".csv",
+  ".log",
+  ".xml",
+  ".html",
+  ".css",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".py",
+  ".go",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".diff",
+  ".patch",
+  ".env",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".swift",
+  ".kt",
+  ".java",
+  ".c",
+  ".cpp",
+  ".h",
+  ".hpp",
+  ".rb",
+  ".php",
+  ".lua",
+  ".zig",
+  ".nim",
+  ".r",
+  ".m",
+  ".ex",
+  ".exs",
+  ".erl",
+  ".hs",
+]);
+
+export function fileExtension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot === -1 ? "" : name.slice(dot).toLowerCase();
+}
+
+export function isTextFile(name: string): boolean {
+  const ext = fileExtension(name);
+  return ext !== "" && TEXT_EXTENSIONS.has(ext);
+}
+
+const TIMESTAMP_RE = /-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/;
+
+export function stripTimestamp(name: string): string {
+  return name.replace(TIMESTAMP_RE, "");
+}

--- a/apps/web/src/components/app/media-lightbox.tsx
+++ b/apps/web/src/components/app/media-lightbox.tsx
@@ -69,6 +69,11 @@ hljs.registerLanguage("nim", nim);
 import { Button } from "@/components/ui/button";
 import { LogStream } from "@/components/ui/log-stream";
 import { Markdown } from "@/components/ui/markdown";
+import {
+  fileExtension,
+  isTextFile,
+  stripTimestamp,
+} from "@/components/app/media-file-utils";
 import { useCopyText } from "@/hooks/use-copy";
 import { cn } from "@/lib/utils";
 
@@ -116,72 +121,8 @@ const EXT_TO_LANG: Record<string, string> = {
   ".m": "objectivec",
 };
 
-const TEXT_EXTENSIONS = new Set([
-  ".txt",
-  ".md",
-  ".json",
-  ".yaml",
-  ".yml",
-  ".toml",
-  ".csv",
-  ".log",
-  ".xml",
-  ".html",
-  ".css",
-  ".js",
-  ".jsx",
-  ".ts",
-  ".tsx",
-  ".py",
-  ".go",
-  ".rs",
-  ".sh",
-  ".sql",
-  ".diff",
-  ".patch",
-  ".env",
-  ".ini",
-  ".cfg",
-  ".conf",
-  ".swift",
-  ".kt",
-  ".java",
-  ".c",
-  ".cpp",
-  ".h",
-  ".hpp",
-  ".rb",
-  ".php",
-  ".lua",
-  ".zig",
-  ".nim",
-  ".r",
-  ".m",
-  ".ex",
-  ".exs",
-  ".erl",
-  ".hs",
-]);
-
-function fileExtension(name: string): string {
-  const dot = name.lastIndexOf(".");
-  return dot === -1 ? "" : name.slice(dot).toLowerCase();
-}
-
-export function isTextFile(name: string): boolean {
-  const ext = fileExtension(name);
-  return ext !== "" && TEXT_EXTENSIONS.has(ext);
-}
-
 function isMarkdownFile(name: string): boolean {
   return fileExtension(name) === ".md";
-}
-
-const TIMESTAMP_RE = /-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d+/;
-
-/** Strip the timestamp suffix that the server appends to media filenames. */
-export function stripTimestamp(name: string): string {
-  return name.replace(TIMESTAMP_RE, "");
 }
 
 const HAS_CLIPBOARD_WRITE =

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -17,11 +17,8 @@ import {
 
 import { type AgentPin, type MediaFile } from "@/components/app/types";
 import { type MediaSidebarTab } from "@/lib/store";
-import {
-  MediaActions,
-  isTextFile,
-  stripTimestamp,
-} from "@/components/app/media-lightbox";
+import { MediaActions } from "@/components/app/media-lightbox";
+import { isTextFile, stripTimestamp } from "@/components/app/media-file-utils";
 import { BrainTabContent } from "@/components/app/brain-tab-content";
 import { PinsPanel } from "@/components/app/pins-panel";
 import { ActivityBars } from "@/components/ui/activity-bars";

--- a/apps/web/src/components/app/persona-agent-review-utils.ts
+++ b/apps/web/src/components/app/persona-agent-review-utils.ts
@@ -1,0 +1,21 @@
+import type { ReviewVerdict } from "@/components/app/agent-event-utils";
+import type { Agent } from "@/components/app/types";
+
+export function getVerdict(child: Agent): ReviewVerdict | undefined {
+  const v = child.review?.verdict;
+  if (v === "approve" || v === "request_changes") return v;
+  return undefined;
+}
+
+export function getReviewSummary(child: Agent): string | undefined {
+  return child.review?.summary ?? undefined;
+}
+
+export function getFilesReviewed(child: Agent): string[] | undefined {
+  const f = child.review?.filesReviewed;
+  return Array.isArray(f) ? f : undefined;
+}
+
+export function getResolution(child: Agent) {
+  return child.review?.resolution ?? undefined;
+}

--- a/apps/web/src/components/app/persona-agent-row.tsx
+++ b/apps/web/src/components/app/persona-agent-row.tsx
@@ -12,6 +12,11 @@ import {
   reviewVerdictLabel,
   type ReviewVerdict,
 } from "@/components/app/agent-event-utils";
+import {
+  getResolution,
+  getReviewSummary,
+  getVerdict,
+} from "@/components/app/persona-agent-review-utils";
 import { type Agent, type AgentVisualState } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -144,25 +149,6 @@ function PersonaVerdictIcon({
       <Flag className="h-3 w-3" />
     </span>
   );
-}
-
-export function getVerdict(child: Agent): ReviewVerdict | undefined {
-  const v = child.review?.verdict;
-  if (v === "approve" || v === "request_changes") return v;
-  return undefined;
-}
-
-export function getReviewSummary(child: Agent): string | undefined {
-  return child.review?.summary ?? undefined;
-}
-
-export function getFilesReviewed(child: Agent): string[] | undefined {
-  const f = child.review?.filesReviewed;
-  return Array.isArray(f) ? f : undefined;
-}
-
-export function getResolution(child: Agent) {
-  return child.review?.resolution ?? undefined;
 }
 
 type StepColor = "orange" | "emerald" | "muted";

--- a/apps/web/src/components/app/review-summary-panel.tsx
+++ b/apps/web/src/components/app/review-summary-panel.tsx
@@ -12,7 +12,7 @@ import {
   getVerdict,
   getReviewSummary,
   getFilesReviewed,
-} from "@/components/app/persona-agent-row";
+} from "@/components/app/persona-agent-review-utils";
 import { type Agent } from "@/components/app/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -1,14 +1,4 @@
-import { useEffect, useState } from "react";
-import {
-  ArrowDownToLine,
-  Bell,
-  BookOpenText,
-  Database,
-  Package,
-  Server,
-  Settings,
-  Users,
-} from "lucide-react";
+import { Database, Server, Settings } from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { AppearanceSettings } from "@/components/app/appearance-settings";
@@ -28,53 +18,8 @@ import { useReleaseStream } from "@/hooks/use-release-stream";
 import { type ThemeId } from "@/hooks/use-theme";
 import { type AgentType } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
-import { api } from "@/lib/api";
+import { type SettingsSection } from "@/components/app/settings-state";
 import { cn } from "@/lib/utils";
-
-type SettingsSection =
-  | "general"
-  | "agents"
-  | "notifications"
-  | "updates"
-  | "help"
-  | "releases";
-
-const BASE_SECTIONS: Array<{
-  id: SettingsSection;
-  label: string;
-  icon: typeof ArrowDownToLine;
-}> = [
-  { id: "general", label: "General", icon: Settings },
-  { id: "agents", label: "Agents", icon: Users },
-  { id: "notifications", label: "Notifications", icon: Bell },
-  { id: "updates", label: "Updates", icon: ArrowDownToLine },
-];
-
-const RELEASES_SECTION = {
-  id: "releases" as SettingsSection,
-  label: "Releases",
-  icon: Package,
-};
-const HELP_SECTION = {
-  id: "help" as SettingsSection,
-  label: "Help",
-  icon: BookOpenText,
-};
-
-const ALL_VALID_SECTIONS: SettingsSection[] = [
-  "general",
-  "agents",
-  "notifications",
-  "updates",
-  "help",
-  "releases",
-];
-
-function isValidSection(value: string | undefined): value is SettingsSection {
-  return (
-    value !== undefined && ALL_VALID_SECTIONS.includes(value as SettingsSection)
-  );
-}
 
 export type SettingsPaneProps = {
   open: boolean;
@@ -98,44 +43,6 @@ export type SettingsPaneProps = {
   onSectionChange?: (section: string | null) => void;
   onSubsectionChange?: (subsection: string | null) => void;
 };
-
-export function useSettingsState(open: boolean, initialSection?: string) {
-  const resolvedInitial = isValidSection(initialSection)
-    ? initialSection
-    : "general";
-  const [activeSection, setActiveSectionState] =
-    useState<SettingsSection | null>(resolvedInitial);
-  const [isAdmin, setIsAdmin] = useState(false);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    void api<{ isAdmin: boolean }>("/api/v1/release/admin-check")
-      .then((data) => {
-        if (!cancelled) setIsAdmin(data.isAdmin);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
-  const sections = isAdmin
-    ? [...BASE_SECTIONS, RELEASES_SECTION, HELP_SECTION]
-    : [...BASE_SECTIONS, HELP_SECTION];
-
-  useEffect(() => {
-    if (open && isValidSection(initialSection)) {
-      if (initialSection === "releases" && !isAdmin) {
-        setActiveSectionState("general");
-      } else {
-        setActiveSectionState(initialSection);
-      }
-    }
-  }, [open, initialSection, isAdmin]);
-
-  return { activeSection, setActiveSectionState, isAdmin, sections };
-}
 
 /** Settings nav for the sidebar. */
 export function SettingsNavContent({

--- a/apps/web/src/components/app/settings-state.ts
+++ b/apps/web/src/components/app/settings-state.ts
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import {
+  ArrowDownToLine,
+  Bell,
+  BookOpenText,
+  Package,
+  Settings,
+  Users,
+} from "lucide-react";
+
+import { api } from "@/lib/api";
+
+export type SettingsSection =
+  | "general"
+  | "agents"
+  | "notifications"
+  | "updates"
+  | "help"
+  | "releases";
+
+const BASE_SECTIONS: Array<{
+  id: SettingsSection;
+  label: string;
+  icon: typeof ArrowDownToLine;
+}> = [
+  { id: "general", label: "General", icon: Settings },
+  { id: "agents", label: "Agents", icon: Users },
+  { id: "notifications", label: "Notifications", icon: Bell },
+  { id: "updates", label: "Updates", icon: ArrowDownToLine },
+];
+
+const RELEASES_SECTION = {
+  id: "releases" as SettingsSection,
+  label: "Releases",
+  icon: Package,
+};
+const HELP_SECTION = {
+  id: "help" as SettingsSection,
+  label: "Help",
+  icon: BookOpenText,
+};
+
+const ALL_VALID_SECTIONS: SettingsSection[] = [
+  "general",
+  "agents",
+  "notifications",
+  "updates",
+  "help",
+  "releases",
+];
+
+function isValidSection(value: string | undefined): value is SettingsSection {
+  return (
+    value !== undefined && ALL_VALID_SECTIONS.includes(value as SettingsSection)
+  );
+}
+
+export function useSettingsState(open: boolean, initialSection?: string) {
+  const resolvedInitial = isValidSection(initialSection)
+    ? initialSection
+    : "general";
+  const [activeSection, setActiveSectionState] =
+    useState<SettingsSection | null>(resolvedInitial);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api<{ isAdmin: boolean }>("/api/v1/release/admin-check")
+      .then((data) => {
+        if (!cancelled) setIsAdmin(data.isAdmin);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const sections = isAdmin
+    ? [...BASE_SECTIONS, RELEASES_SECTION, HELP_SECTION]
+    : [...BASE_SECTIONS, HELP_SECTION];
+
+  useEffect(() => {
+    if (open && isValidSection(initialSection)) {
+      if (initialSection === "releases" && !isAdmin) {
+        setActiveSectionState("general");
+      } else {
+        setActiveSectionState(initialSection);
+      }
+    }
+  }, [open, initialSection, isAdmin]);
+
+  return { activeSection, setActiveSectionState, isAdmin, sections };
+}

--- a/apps/web/src/components/tips/tip-queue-context.ts
+++ b/apps/web/src/components/tips/tip-queue-context.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+export type TipQueueContextValue = {
+  activeTipId: string | null;
+  requestOpen: (tipId: string) => boolean;
+  release: (tipId: string) => void;
+};
+
+export const TipQueueContext = createContext<TipQueueContextValue>({
+  activeTipId: null,
+  requestOpen: () => false,
+  release: () => {},
+});
+
+export function useTipQueue() {
+  return useContext(TipQueueContext);
+}

--- a/apps/web/src/components/tips/tip-queue-provider.tsx
+++ b/apps/web/src/components/tips/tip-queue-provider.tsx
@@ -1,27 +1,6 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
-type TipQueueContextValue = {
-  activeTipId: string | null;
-  requestOpen: (tipId: string) => boolean;
-  release: (tipId: string) => void;
-};
-
-const TipQueueContext = createContext<TipQueueContextValue>({
-  activeTipId: null,
-  requestOpen: () => false,
-  release: () => {},
-});
-
-export function useTipQueue() {
-  return useContext(TipQueueContext);
-}
+import { TipQueueContext } from "@/components/tips/tip-queue-context";
 
 export function TipQueueProvider({ children }: { children: React.ReactNode }) {
   const [activeTipId, setActiveTipId] = useState<string | null>(null);

--- a/apps/web/src/components/tips/tip-spot.tsx
+++ b/apps/web/src/components/tips/tip-spot.tsx
@@ -15,7 +15,7 @@ import {
 import { useTip } from "@/lib/tips/use-tip";
 
 import { TipPopoverContent } from "./tip-popover-content";
-import { useTipQueue } from "./tip-queue-provider";
+import { useTipQueue } from "./tip-queue-context";
 
 /** Check if the element is actually reachable (not covered by an overlay). */
 function isTriggerReachable(el: HTMLElement): boolean {

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -36,4 +36,4 @@ function Badge({ className, variant, ...props }: BadgeProps): JSX.Element {
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -59,4 +59,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-export { Button, buttonVariants };
+export { Button };

--- a/apps/web/src/contexts/auth-context-core.ts
+++ b/apps/web/src/contexts/auth-context-core.ts
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+import { type AuthState } from "@/components/app/types";
+
+export type AuthContextValue = {
+  authState: AuthState;
+  handleAuthenticated: () => void;
+  handleLogout: () => Promise<void>;
+  retryAuth: () => void;
+};
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/apps/web/src/contexts/auth-context-provider.tsx
+++ b/apps/web/src/contexts/auth-context-provider.tsx
@@ -1,0 +1,14 @@
+import {
+  AuthContext,
+  type AuthContextValue,
+} from "@/contexts/auth-context-core";
+
+export function AuthContextProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: AuthContextValue;
+}): JSX.Element {
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -1,16 +1,9 @@
-import { createContext, useContext } from "react";
-import { type AuthState } from "@/components/app/types";
+import { useContext } from "react";
 
-type AuthContextValue = {
-  authState: AuthState;
-  handleAuthenticated: () => void;
-  handleLogout: () => Promise<void>;
-  retryAuth: () => void;
-};
-
-const AuthContext = createContext<AuthContextValue | null>(null);
-
-export const AuthContextProvider = AuthContext.Provider;
+import {
+  AuthContext,
+  type AuthContextValue,
+} from "@/contexts/auth-context-core";
 
 export function useAuthContext(): AuthContextValue {
   const ctx = useContext(AuthContext);

--- a/apps/web/src/layouts/dashboard-sections.tsx
+++ b/apps/web/src/layouts/dashboard-sections.tsx
@@ -11,15 +11,15 @@ import {
 import {
   SettingsContent,
   SettingsNavContent,
-  useSettingsState,
 } from "@/components/app/settings-pane";
+import { useSettingsState } from "@/components/app/settings-state";
 import { type NavSection, SidebarShell } from "@/components/app/sidebar-shell";
 import { type ServiceState } from "@/components/app/types";
 import { DesignLab } from "@/components/app/design-lab";
 import { GlassSidebar } from "@/components/ui/glass-sidebar";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { useDashboardContext } from "@/App";
+import { useDashboardContext } from "@/components/app/dashboard-context";
 
 function serviceDotClass(state: ServiceState): string {
   if (state === "ok") return "bg-status-working";

--- a/apps/web/src/router-layouts.tsx
+++ b/apps/web/src/router-layouts.tsx
@@ -1,0 +1,28 @@
+import { Navigate, Outlet, useParams } from "react-router-dom";
+
+import { AuthContextProvider } from "@/contexts/auth-context-provider";
+import { useAuth } from "@/hooks/use-auth";
+
+export function RootLayout(): JSX.Element {
+  const auth = useAuth();
+  return (
+    <AuthContextProvider value={auth}>
+      <Outlet />
+    </AuthContextProvider>
+  );
+}
+
+export function LegacyDocsRedirect(): JSX.Element {
+  const { section } = useParams();
+  return (
+    <Navigate
+      to={section ? `/settings/help/${section}` : "/settings/help"}
+      replace
+    />
+  );
+}
+
+export function LegacyJobsRedirect(): JSX.Element {
+  const { "*": rest } = useParams();
+  return <Navigate to={`/automations/jobs/${rest ?? ""}`} replace />;
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,11 +1,4 @@
-import {
-  createBrowserRouter,
-  Navigate,
-  Outlet,
-  useParams,
-} from "react-router-dom";
-import { useAuth } from "@/hooks/use-auth";
-import { AuthContextProvider } from "@/contexts/auth-context";
+import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AuthLayout } from "@/layouts/auth-layout";
 import { DashboardLayout } from "@/App";
 import {
@@ -16,15 +9,11 @@ import {
   SettingsRoute,
 } from "@/layouts/dashboard-sections";
 import { LoginRoute } from "@/components/app/login-page";
-
-function RootLayout(): JSX.Element {
-  const auth = useAuth();
-  return (
-    <AuthContextProvider value={auth}>
-      <Outlet />
-    </AuthContextProvider>
-  );
-}
+import {
+  LegacyDocsRedirect,
+  LegacyJobsRedirect,
+  RootLayout,
+} from "@/router-layouts";
 
 export const router = createBrowserRouter([
   {
@@ -167,18 +156,3 @@ export const router = createBrowserRouter([
     ],
   },
 ]);
-
-function LegacyDocsRedirect(): JSX.Element {
-  const { section } = useParams();
-  return (
-    <Navigate
-      to={section ? `/settings/help/${section}` : "/settings/help"}
-      replace
-    />
-  );
-}
-
-function LegacyJobsRedirect(): JSX.Element {
-  const { "*": rest } = useParams();
-  return <Navigate to={`/automations/jobs/${rest ?? ""}`} replace />;
-}


### PR DESCRIPTION
## Summary

Fixes the React Fast Refresh lint warnings by moving non-component exports out of component-bearing files into nearby utility, context, and route helper modules.

Key changes:
- Split dashboard, auth, tip queue, settings state, and router layout helpers into companion modules.
- Moved shared media, activity chart, history event, and persona review helpers into `.ts` utility files.
- Removed unused `badgeVariants` and `buttonVariants` exports so UI component files export only components.

## Validation

- `pnpm run lint:web` passed with zero Fast Refresh warnings.
- `pnpm run check` passed.
- `pnpm run finalize:web` passed.
- `pnpm run test:e2e` passed: 171 passed, 12 skipped.
- `frontend-ux-review` persona approved rounds 1 and 2 with no findings.