### PR TITLE
Document file upload to agents and add ambient tip

### DIFF
--- a/apps/web/src/components/app/docs-sections/media.tsx
+++ b/apps/web/src/components/app/docs-sections/media.tsx
@@ -74,6 +74,26 @@ export function MediaContent() {
       </Section>
 
       <Section>
+        <H3 id="uploading-files">Uploading files to agents</H3>
+        <P>
+          You can send files directly to a running agent by{" "}
+          <strong>dragging and dropping</strong> them onto the terminal or by{" "}
+          <strong>pasting an image</strong> from your clipboard (
+          <Code>Cmd+V</Code> / <Code>Ctrl+V</Code>). Uploaded files are saved to
+          the agent's media store and automatically injected into the agent's
+          prompt — images go through the native clipboard when available, and
+          all other files are typed into tmux as{" "}
+          <Code>[File&nbsp;#N]&nbsp;/path/to/file</Code>.
+        </P>
+        <P>
+          You can also upload files via the <strong>Share file</strong> button
+          in the media sidebar. Sidebar uploads are <em>not</em> injected into
+          the terminal — tell the agent about the file afterward so it knows to
+          look.
+        </P>
+      </Section>
+
+      <Section>
         <H3>Media sidebar</H3>
         <P>
           Click any agent's media count badge (or press{" "}
@@ -102,9 +122,10 @@ export function MediaContent() {
         </P>
         <P>
           The <strong>Share file</strong> button at the top of the sidebar lets
-          you upload a file directly to the agent's media stream (stored with{" "}
-          <Code>source: "user"</Code>). Tell the agent afterward so it knows to
-          look.
+          you upload a file directly to the agent's media store (stored with{" "}
+          <Code>source: "user"</Code>). These uploads are not injected into the
+          terminal — see <em>Uploading files to agents</em> above for methods
+          that inject automatically.
         </P>
       </Section>
     </>

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -51,6 +51,14 @@ export const tips: Tip[] = [
     surfaces: ["inline", "ambient"],
   },
   {
+    id: "file-upload",
+    title: "File Upload",
+    body: "Drag and drop files onto the terminal to upload and inject them into the agent's prompt. You can also paste images from your clipboard.",
+    docsSection: "media#uploading-files",
+    since: "0.23.6",
+    surfaces: ["ambient"],
+  },
+  {
     id: "keyboard-shortcuts",
     title: "Keyboard Shortcuts",
     body: "Press ⌘K to open the command palette. Navigate agents, toggle sidebars, and control the terminal without touching the mouse.",


### PR DESCRIPTION
## Summary

- **Media docs**: Added "Uploading files to agents" section documenting drag-and-drop and clipboard paste upload onto the terminal (PR #660). Files are auto-injected into the agent's prompt via native clipboard or tmux path injection.
- **Media docs**: Updated the "Share file" sidebar button paragraph to clarify that sidebar uploads are not injected, distinguishing it from the terminal-based upload methods.
- **Tips**: Added `file-upload` ambient tip for feature discovery of the drag-and-drop upload.

## Docs audit context

Recurring docs audit run. Diff since last audit (`40faf3cd..HEAD`) showed PR #660 (unified file upload) changed the media upload flow without updating in-app docs. Deferred `docs/12-new-machine-setup.md` audit to next run.

## Test plan

- [x] `pnpm run format:write` — no drift
- [x] `pnpm run check` — type check passes
- [x] Tips registry test passes (unique IDs, required fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)