### PR TITLE
Add persona-reviews route tests, fix webhook toggle flake

### DIFF
--- a/apps/server/test/persona-reviews-routes.test.ts
+++ b/apps/server/test/persona-reviews-routes.test.ts
@@ -1,0 +1,762 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
+
+import { registerPersonaReviewRoutes } from "../src/routes/persona-reviews.js";
+import { CLI_AGENT_TYPES } from "../src/agent-type-settings.js";
+
+vi.mock("../src/personas/loader.js", () => ({
+  loadPersonas: vi.fn(async () => []),
+}));
+
+vi.mock("../src/shared/git/git-context.js", () => ({
+  resolveRepoRoot: vi.fn(async (cwd: string) => cwd),
+  resolveWorktreeRoot: vi.fn(async (cwd: string) => cwd),
+}));
+
+vi.mock("../src/shared/git/worktree.js", () => ({
+  resolveHeadSha: vi.fn(async () => "abc123"),
+}));
+
+vi.mock("../src/agent-type-settings.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getEnabledAgentTypes: vi.fn(async () => [
+      "claude",
+      "codex",
+      "cursor",
+      "opencode",
+    ]),
+  };
+});
+
+function createMockDeps() {
+  return {
+    pool: {} as never,
+    agentManager: {
+      getAgent: vi.fn(async () => ({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })),
+      getTerminalAccess: vi.fn(async () => ({ mode: "none" as const })),
+      submitReviewResolution: vi.fn(async () => ({
+        review: { id: 1 },
+        resolution: { id: 1 },
+      })),
+    },
+    mcpLaunchPersona: vi.fn(async () => ({
+      agentId: "agt_child",
+      persona: "security-review",
+      parentAgentId: "agt_parent",
+    })),
+    mcpCancelRecheck: vi.fn(async () => {}),
+    sendAgentPrompt: vi.fn(async () => {}),
+    publishUiEvent: vi.fn(),
+    withStreamFlag: vi.fn(<T extends Record<string, unknown>>(agent: T) => ({
+      ...agent,
+      hasStream: false,
+    })),
+    handleAgentError: vi.fn((reply: FastifyReply, error: unknown) =>
+      reply.code(500).send({ error: String(error) })
+    ),
+  };
+}
+
+let app: FastifyInstance;
+let deps: ReturnType<typeof createMockDeps>;
+
+beforeAll(async () => {
+  app = Fastify();
+  deps = createMockDeps();
+  await registerPersonaReviewRoutes(
+    app,
+    deps as unknown as Parameters<typeof registerPersonaReviewRoutes>[1]
+  );
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deps.agentManager.getAgent.mockResolvedValue({
+    id: "agt_parent",
+    name: "test-agent",
+    cwd: "/tmp",
+  });
+  deps.agentManager.getTerminalAccess.mockResolvedValue({
+    mode: "none" as const,
+  });
+  deps.mcpLaunchPersona.mockResolvedValue({
+    agentId: "agt_child",
+    persona: "security-review",
+    parentAgentId: "agt_parent",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/personas
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/personas", () => {
+  it("returns 400 when cwd is missing", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/personas",
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/cwd/);
+  });
+
+  it("returns personas array for a valid cwd", async () => {
+    const { loadPersonas } = await import("../src/personas/loader.js");
+    vi.mocked(loadPersonas).mockResolvedValueOnce([
+      { slug: "security-review", name: "Security Review" },
+    ] as never);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/personas?cwd=/tmp",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().personas).toHaveLength(1);
+    expect(res.json().personas[0].slug).toBe("security-review");
+  });
+
+  it("falls back to repo root when worktree returns empty", async () => {
+    const { loadPersonas } = await import("../src/personas/loader.js");
+    vi.mocked(loadPersonas)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { slug: "from-repo", name: "From Repo" },
+      ] as never);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/personas?cwd=/tmp",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().personas).toHaveLength(1);
+    expect(res.json().personas[0].slug).toBe("from-repo");
+    expect(loadPersonas).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty array on error", async () => {
+    const { loadPersonas } = await import("../src/personas/loader.js");
+    vi.mocked(loadPersonas).mockRejectedValueOnce(new Error("not a git repo"));
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/personas?cwd=/nonexistent",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().personas).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/launch-review
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/launch-review", () => {
+  it("returns 400 when persona is missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/persona/);
+  });
+
+  it("returns 400 when persona is empty", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "", agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/persona/);
+  });
+
+  it("returns 400 for invalid persona slug", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "bad slug!", agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/slug/);
+  });
+
+  it("returns 400 when agentType is missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/agentType/);
+  });
+
+  it("returns 400 for invalid agentType", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "security-review", agentType: "invalid" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/agentType/);
+  });
+
+  it("returns 400 when includeDiff is not boolean", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: {
+        persona: "security-review",
+        agentType: "codex",
+        includeDiff: "yes",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/includeDiff/);
+  });
+
+  it("returns 409 when agent has no tmux session", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "security-review", agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toMatch(/tmux/);
+  });
+
+  it("sends prompt when agent has tmux session", async () => {
+    deps.agentManager.getTerminalAccess.mockResolvedValueOnce({
+      mode: "tmux" as const,
+      session: "test-session",
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "security-review", agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+    expect(deps.sendAgentPrompt).toHaveBeenCalledWith(
+      "agt_parent",
+      expect.stringContaining("security-review")
+    );
+  });
+
+  it("includes includeDiff in prompt", async () => {
+    deps.agentManager.getTerminalAccess.mockResolvedValueOnce({
+      mode: "tmux" as const,
+      session: "test-session",
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: {
+        persona: "security-review",
+        agentType: "claude",
+        includeDiff: false,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.sendAgentPrompt).toHaveBeenCalledWith(
+      "agt_parent",
+      expect.stringContaining("includeDiff: false")
+    );
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.agentManager.getTerminalAccess.mockRejectedValueOnce(
+      new Error("agent gone")
+    );
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/launch-review",
+      payload: { persona: "security-review", agentType: "codex" },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+
+  it("accepts all valid CLI agent types", async () => {
+    for (const agentType of CLI_AGENT_TYPES) {
+      deps.agentManager.getTerminalAccess.mockResolvedValueOnce({
+        mode: "tmux" as const,
+        session: "test-session",
+      });
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/agt_parent/launch-review",
+        payload: { persona: "security-review", agentType },
+      });
+      expect(res.statusCode).toBe(200);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/persona-reviews
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/persona-reviews", () => {
+  it("returns 400 when persona is missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/persona/);
+  });
+
+  it("returns 400 when persona is empty", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: " " },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/persona/);
+  });
+
+  it("returns 400 for invalid persona slug", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "has spaces" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/slug/);
+  });
+
+  it("returns 400 for invalid agentType", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review", agentType: "invalid" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/agentType/);
+  });
+
+  it("returns 400 when includeDiff is not boolean", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review", includeDiff: "yes" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/includeDiff/);
+  });
+
+  it("returns 400 when context is not a string", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review", context: 123 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/context/);
+  });
+
+  it("returns 400 when includeDiff=false and context is empty", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review", includeDiff: false },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/context is required/);
+  });
+
+  it("returns 400 when includeDiff=false and context is whitespace", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: {
+        persona: "security-review",
+        includeDiff: false,
+        context: "   ",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/context is required/);
+  });
+
+  it("returns 404 when parent agent is not found", async () => {
+    deps.agentManager.getAgent.mockResolvedValueOnce(null);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_missing/persona-reviews",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/);
+  });
+
+  it("returns 400 when requested agentType is disabled", async () => {
+    const { getEnabledAgentTypes } =
+      await import("../src/agent-type-settings.js");
+    vi.mocked(getEnabledAgentTypes).mockResolvedValueOnce(["codex"] as never);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review", agentType: "claude" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/disabled/);
+  });
+
+  it("launches persona review successfully", async () => {
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "security-reviewer",
+        cwd: "/tmp",
+      });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().agentId).toBe("agt_child");
+    expect(deps.mcpLaunchPersona).toHaveBeenCalledWith("agt_parent", {
+      persona: "security-review",
+      context: expect.stringContaining("test-agent"),
+      agentType: undefined,
+      includeDiff: true,
+    });
+  });
+
+  it("uses custom context when provided", async () => {
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "security-reviewer",
+        cwd: "/tmp",
+      });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: {
+        persona: "security-review",
+        context: "Review the auth module",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.mcpLaunchPersona).toHaveBeenCalledWith("agt_parent", {
+      persona: "security-review",
+      context: "Review the auth module",
+      agentType: undefined,
+      includeDiff: true,
+    });
+  });
+
+  it("passes agentType and includeDiff to mcpLaunchPersona", async () => {
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "reviewer",
+        cwd: "/tmp",
+      });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: {
+        persona: "security-review",
+        agentType: "claude",
+        includeDiff: false,
+        context: "Check the auth flow",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(deps.mcpLaunchPersona).toHaveBeenCalledWith("agt_parent", {
+      persona: "security-review",
+      context: "Check the auth flow",
+      agentType: "claude",
+      includeDiff: false,
+    });
+  });
+
+  it("allows agentType to be omitted", async () => {
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "reviewer",
+        cwd: "/tmp",
+      });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.mcpLaunchPersona.mockRejectedValueOnce(new Error("launch failed"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+
+  it("returns null agent when child lookup returns null", async () => {
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "test-agent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce(null);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews",
+      payload: { persona: "security-review" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().agent).toBeNull();
+    expect(res.json().agentId).toBe("agt_child");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/resolution", () => {
+  it("returns 400 when summary is missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/summary/);
+  });
+
+  it("returns 400 when summary is empty", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: { summary: "" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/summary/);
+  });
+
+  it("returns 400 when summary is whitespace", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: { summary: "   " },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/summary/);
+  });
+
+  it("returns 404 when parent agent is not found", async () => {
+    deps.agentManager.getAgent.mockResolvedValueOnce(null);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_missing/persona-reviews/agt_child/resolution",
+      payload: { summary: "All issues resolved" },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/);
+  });
+
+  it("submits resolution successfully", async () => {
+    const mockReview = { id: 1, status: "resolved" };
+    const mockResolution = { id: 1, summary: "Fixed" };
+    deps.agentManager.submitReviewResolution.mockResolvedValueOnce({
+      review: mockReview,
+      resolution: mockResolution,
+    });
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "parent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "reviewer",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "parent",
+        cwd: "/tmp",
+      });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: { summary: "All issues resolved" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().review).toEqual(mockReview);
+    expect(res.json().resolution).toEqual(mockResolution);
+    expect(deps.agentManager.submitReviewResolution).toHaveBeenCalledWith({
+      parentAgentId: "agt_parent",
+      personaAgentId: "agt_child",
+      summary: "All issues resolved",
+      resolutionCommit: "abc123",
+    });
+  });
+
+  it("publishes ui events for child and parent", async () => {
+    deps.agentManager.submitReviewResolution.mockResolvedValueOnce({
+      review: { id: 1 },
+      resolution: { id: 1 },
+    });
+    deps.agentManager.getAgent
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "parent",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_child",
+        name: "reviewer",
+        cwd: "/tmp",
+      })
+      .mockResolvedValueOnce({
+        id: "agt_parent",
+        name: "parent",
+        cwd: "/tmp",
+      });
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: { summary: "Done" },
+    });
+    expect(deps.publishUiEvent).toHaveBeenCalledTimes(2);
+    expect(deps.publishUiEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent.upsert" })
+    );
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.agentManager.submitReviewResolution.mockRejectedValueOnce(
+      new Error("review not found")
+    );
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/resolution",
+      payload: { summary: "Done" },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/persona-reviews/:personaAgentId/cancel-recheck
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/persona-reviews/:personaAgentId/cancel-recheck", () => {
+  it("returns 400 when reason is not a string", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      payload: { reason: 123 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/reason/);
+  });
+
+  it("cancels recheck with no reason", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(204);
+    expect(deps.mcpCancelRecheck).toHaveBeenCalledWith("agt_parent", {
+      personaAgentId: "agt_child",
+      reason: undefined,
+    });
+  });
+
+  it("cancels recheck with a reason", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      payload: { reason: "Ship it" },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(deps.mcpCancelRecheck).toHaveBeenCalledWith("agt_parent", {
+      personaAgentId: "agt_child",
+      reason: "Ship it",
+    });
+  });
+
+  it("trims whitespace-only reason to undefined", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      payload: { reason: "   " },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(deps.mcpCancelRecheck).toHaveBeenCalledWith("agt_parent", {
+      personaAgentId: "agt_child",
+      reason: undefined,
+    });
+  });
+
+  it("calls handleAgentError on thrown errors", async () => {
+    deps.mcpCancelRecheck.mockRejectedValueOnce(new Error("cancel failed"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(500);
+    expect(deps.handleAgentError).toHaveBeenCalled();
+  });
+
+  it("accepts null body", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/agt_parent/persona-reviews/agt_child/cancel-recheck",
+      headers: { "content-type": "application/json" },
+      payload: "null",
+    });
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/docs/jobs/test-enforcer.md
+++ b/docs/jobs/test-enforcer.md
@@ -88,25 +88,32 @@ Do not spend meaningful time adding coverage while unresolved local failures sti
    - `pnpm run test`
    - `pnpm run test:e2e`
    - If any file under `apps/web/` changes during the run, also run `pnpm run finalize:web`
-2. Triage every failure from the first full run.
-3. Fix failures and flakiness.
-4. Re-run the affected tests, then the relevant full commands again to confirm stability.
-5. Once the suite is green, look for the highest-value coverage gaps.
-6. Add targeted tests.
-7. Re-run the affected suites and final validation commands.
-8. If files changed, launch exactly one review agent to review only the diff from this run.
+2. Check recent GitHub Actions CI runs for test failures:
+   - `gh run list --limit 50` and inspect any failed runs with `gh run view <id> --log-failed`
+   - look for test failures that differ from local results — these indicate CI-only flakes or environment-sensitive tests
+   - cross-reference failures across multiple unrelated branches to distinguish real flakes from branch-specific issues
+   - if a test passes locally but fails across multiple CI branches, investigate the root cause (timing, environment, fire-and-forget writes, timezone sensitivity, etc.)
+   - add confirmed CI-only flakes to the `flakes` brain list with enough context for the next run
+3. Triage every failure from the local run and the CI scan.
+4. Fix failures and flakiness.
+5. Re-run the affected tests, then the relevant full commands again to confirm stability.
+6. Once the suite is green, look for the highest-value coverage gaps.
+7. Add targeted tests.
+8. Re-run the affected suites and final validation commands.
+9. If files changed, launch exactly one review agent to review only the diff from this run.
    - the review agent should focus on correctness issues, flaky-test risk, cleanup leakage, and over-scoped or low-value test additions
    - if it finds actionable issues, fix them and re-run the relevant validation before continuing
    - do not launch multiple reviewers
    - do not turn review into an open-ended loop; one review round is enough
-9. If files changed, complete the landing flow:
-   - commit the changes on the job branch
-   - push the branch
-   - create a PR targeting `main`
-   - wait for CI to finish
-   - if CI fails because of your diff, fix it, push again, and keep polling
-   - if CI fails for a likely unrelated flake, retry once and re-check
-   - merge the PR only after CI is green
+10. If files changed, complete the landing flow:
+
+- commit the changes on the job branch
+- push the branch
+- create a PR targeting `main`
+- wait for CI to finish
+- if CI fails because of your diff, fix it, push again, and keep polling
+- if CI fails for a likely unrelated flake, retry once and re-check
+- merge the PR only after CI is green
 
 If required tooling, credentials, or environment capabilities are missing, document that precisely and use the appropriate terminal job report.
 

--- a/e2e/jobs-webhook-ui.spec.ts
+++ b/e2e/jobs-webhook-ui.spec.ts
@@ -56,6 +56,7 @@ test.describe("Jobs webhook UI", () => {
     });
     const toggle = page.getByRole("switch", { name: "Webhook trigger" });
     await toggle.waitFor();
+    await expect(toggle).not.toBeChecked();
     await toggle.click();
 
     await expect(toggle).toBeChecked();
@@ -105,6 +106,7 @@ test.describe("Jobs webhook UI", () => {
     });
     const toggle = page.getByRole("switch", { name: "Webhook trigger" });
     await toggle.waitFor();
+    await expect(toggle).toBeChecked();
     await expect(page.getByText("Webhook URL", { exact: true })).toBeVisible();
 
     await toggle.click();


### PR DESCRIPTION
## Summary
- Add 44 unit tests for persona-review route handlers (`apps/server/test/persona-reviews-routes.test.ts`) covering all 5 endpoints: GET personas, POST launch-review, POST persona-reviews, POST resolution, POST cancel-recheck
- Fix flaky E2E test in `jobs-webhook-ui.spec.ts` — toggle clicks were firing before the switch state had hydrated; added readiness assertions
- Add CI failure scanning step to test-enforcer job prompt in `docs/jobs/test-enforcer.md` (also updated the live Dispatch job definition via MCP)

## Test plan
- [x] All 44 new persona-reviews route tests pass
- [x] `pnpm run check` passes (type checking)
- [x] `pnpm run test` passes (1864 server + 180 web tests)
- [x] `pnpm run test:e2e` passes (171 tests including the fixed webhook toggle tests)
- [x] Webhook toggle test re-run confirmed the flake fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)