### PR TITLE
Skip recheck round-trip on clean approval

### DIFF
--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -366,21 +366,24 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
 
       const feedbackCount = await agentManager.countFeedbackForAgent(agentId);
       const isMidRoundTrip = review.roundNumber < 2;
-      const parentPrompt = isMidRoundTrip
-        ? buildParentRound1FeedbackPrompt({
-            persona: review.persona,
-            personaAgentId: agentId,
-            verdict: input.verdict,
-            feedbackCount,
-          })
-        : buildParentReviewCompletePrompt({
-            persona: review.persona,
-            personaAgentId: agentId,
-            verdict: input.verdict,
-            summary: input.summary,
-            feedbackCount,
-            roundNumber: review.roundNumber,
-          });
+      const cleanApproval =
+        isMidRoundTrip && input.verdict === "approve" && feedbackCount === 0;
+      const parentPrompt =
+        isMidRoundTrip && !cleanApproval
+          ? buildParentRound1FeedbackPrompt({
+              persona: review.persona,
+              personaAgentId: agentId,
+              verdict: input.verdict,
+              feedbackCount,
+            })
+          : buildParentReviewCompletePrompt({
+              persona: review.persona,
+              personaAgentId: agentId,
+              verdict: input.verdict,
+              summary: input.summary,
+              feedbackCount,
+              roundNumber: review.roundNumber,
+            });
       await sendAgentPrompt(review.parentAgentId, parentPrompt);
     },
 

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -556,7 +556,34 @@ describe("createMcpHandlers", () => {
   });
 
   describe("completeReview", () => {
-    it("sends round1 prompt when roundNumber < 2", async () => {
+    it("sends complete prompt on clean approval (round 1, approve, 0 feedback)", async () => {
+      deps.agentManager.completePersonaReview.mockResolvedValue({
+        id: 1,
+        parentAgentId: "agt_parent1",
+        persona: "security",
+        roundNumber: 1,
+        status: "complete",
+      });
+      deps.agentManager.countFeedbackForAgent.mockResolvedValue(0);
+      await handlers.completeReview("agt_child1", {
+        verdict: "approve",
+        summary: "all clear",
+      });
+      expect(buildParentReviewCompletePrompt).toHaveBeenCalledWith({
+        persona: "security",
+        personaAgentId: "agt_child1",
+        verdict: "approve",
+        summary: "all clear",
+        feedbackCount: 0,
+        roundNumber: 1,
+      });
+      expect(deps.sendAgentPrompt).toHaveBeenCalledWith(
+        "agt_parent1",
+        "complete-prompt"
+      );
+    });
+
+    it("sends round1 prompt when roundNumber < 2 with feedback", async () => {
       deps.agentManager.completePersonaReview.mockResolvedValue({
         id: 1,
         parentAgentId: "agt_parent1",


### PR DESCRIPTION
## Summary
- When a reviewer approves on round 1 with zero feedback items, the parent now receives the final "review complete" prompt directly instead of going through the unnecessary `submit_resolution` → `recheck` → `approve-again` round-trip.
- Adds a `cleanApproval` check in `completeReview` that short-circuits to `buildParentReviewCompletePrompt` when `verdict === "approve"` and `feedbackCount === 0` on round 1.

## Test plan
- [x] New unit test: clean approval (round 1, approve, 0 feedback) sends `buildParentReviewCompletePrompt`
- [x] Existing test renamed and still passes: round 1 with feedback sends `buildParentRound1FeedbackPrompt`
- [x] Existing test: round 2 completion still sends `buildParentReviewCompletePrompt`
- [x] All unit tests pass (1821)
- [x] All E2E tests pass (171)
- [x] Type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)