### PR TITLE
Extract agent lifecycle tools from MCP server.ts

### DIFF
--- a/apps/server/src/shared/mcp/agent-lifecycle-tools.ts
+++ b/apps/server/src/shared/mcp/agent-lifecycle-tools.ts
@@ -1,0 +1,220 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import type { NotifyInput } from "./server.js";
+import { toToolError } from "./tool-error.js";
+
+export type AgentLifecycleContext = {
+  agentId: string;
+  upsertEvent?: (
+    agentId: string,
+    event: { type: string; message: string; metadata?: Record<string, unknown> }
+  ) => Promise<void>;
+  renameSession?: (
+    agentId: string,
+    name: string
+  ) => Promise<{ id: string; name: string }>;
+  sendNotify?: (
+    agentId: string,
+    input: NotifyInput
+  ) => Promise<{
+    sent: boolean;
+    reason?: string;
+  }>;
+  listMedia?: (
+    agentId: string,
+    opts: { source?: string }
+  ) => Promise<
+    Array<{
+      fileName: string;
+      filePath: string;
+      source: string;
+      description: string | null;
+      sizeBytes: number;
+      createdAt: string;
+    }>
+  >;
+};
+
+export function registerAgentLifecycleTools(
+  server: McpServer,
+  allowed: Set<string>,
+  context: AgentLifecycleContext
+): void {
+  const { agentId } = context;
+
+  // ── dispatch_event ────────────────────────────────────────────────
+  if (allowed.has("dispatch_event") && context.upsertEvent) {
+    const upsertEvent = context.upsertEvent;
+
+    server.registerTool(
+      "dispatch_event",
+      {
+        description:
+          "Report agent status to Dispatch. Must be called at the start of each turn (working), when stuck and unable to proceed (blocked), waiting for user input (waiting_user), and before the final response (done or idle).",
+        inputSchema: {
+          type: z
+            .enum(["working", "blocked", "waiting_user", "done", "idle"])
+            .describe("The status event type."),
+          message: z
+            .string()
+            .describe("A short description of what is happening."),
+          metadata: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe("Optional metadata object."),
+        },
+      },
+      async (args) => {
+        try {
+          await upsertEvent(agentId, {
+            type: args.type,
+            message: args.message,
+            metadata: args.metadata as Record<string, unknown> | undefined,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Updated ${agentId}: ${args.type} - ${args.message}`,
+              },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_rename_session ───────────────────────────────────────
+  if (allowed.has("dispatch_rename_session") && context.renameSession) {
+    const renameSession = context.renameSession;
+
+    server.registerTool(
+      "dispatch_rename_session",
+      {
+        description:
+          "Update the current session's display name. Use this to rename a default-generated session to a short goal or topic, or when the user explicitly asks for a rename.",
+        inputSchema: {
+          name: z
+            .string()
+            .min(1)
+            .max(120)
+            .describe("New session display name."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await renameSession(agentId, args.name);
+          return {
+            content: [
+              { type: "text", text: `Renamed session to \"${result.name}\".` },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_notify ───────────────────────────────────────────────
+  if (allowed.has("dispatch_notify") && context.sendNotify) {
+    const sendNotify = context.sendNotify;
+
+    server.registerTool(
+      "dispatch_notify",
+      {
+        description:
+          "Send a Slack notification. Use this to proactively share summaries, results, or important updates " +
+          "with the user via Slack. The message supports Slack mrkdwn formatting. " +
+          "Requires a Slack webhook to be configured in Dispatch settings. " +
+          "Rate limited to 5 messages per minute.",
+        inputSchema: {
+          message: z
+            .string()
+            .max(3000)
+            .describe(
+              "The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc). Max 3000 characters."
+            ),
+          title: z
+            .string()
+            .max(150)
+            .optional()
+            .describe(
+              "Optional title displayed above the message. Defaults to 'Notification from <agent>'. Max 150 characters."
+            ),
+          level: z
+            .enum(["info", "success", "warning", "error"])
+            .default("info")
+            .describe(
+              "Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."
+            ),
+          respectFocus: z
+            .boolean()
+            .default(false)
+            .describe(
+              "When true, the notification is suppressed if the user is actively viewing this agent in Dispatch. Default false — notifications are always sent."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await sendNotify(agentId, {
+            message: args.message,
+            title: args.title,
+            level: args.level as NotifyInput["level"],
+            respectFocus: args.respectFocus,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: result.sent
+                  ? "Notification sent to Slack."
+                  : `Notification not sent: ${result.reason}`,
+              },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_list_media ──────────────────────────────────────────
+  if (allowed.has("dispatch_list_media") && context.listMedia) {
+    const listMedia = context.listMedia;
+
+    server.registerTool(
+      "dispatch_list_media",
+      {
+        description:
+          "List media files shared with or by this agent. Returns metadata only — use file reading tools to access content via filePath.",
+        inputSchema: {
+          source: z
+            .string()
+            .optional()
+            .describe(
+              'Optional source filter (e.g. "user", "screenshot", "text", "simulator", "stream"). Omit to list all media.'
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const items = await listMedia(agentId, { source: args.source });
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify(items, null, 2) },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+}

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -6,6 +6,7 @@ import * as z from "zod/v4";
 
 import type { AgentType as CliAgentType } from "../../agents/types.js";
 import type { BrainStore } from "../../brain/store.js";
+import { registerAgentLifecycleTools } from "./agent-lifecycle-tools.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
 import { registerCrudTools, type CrudToolCallbacks } from "./crud-tools.js";
@@ -461,197 +462,19 @@ async function createDispatchMcpServer(
     baseBranch: context.agent?.baseBranch ?? undefined,
   });
 
-  // ── dispatch_event ────────────────────────────────────────────────
-  // dispatch_event and dispatch_share are implemented as native MCP tools below.
-  if (allowed.has("dispatch_event") && context.agent && context.upsertEvent) {
-    const agentId = context.agent.id;
-    const upsertEvent = context.upsertEvent;
-
-    server.registerTool(
-      "dispatch_event",
-      {
-        description:
-          "Report agent status to Dispatch. Must be called at the start of each turn (working), when stuck and unable to proceed (blocked), waiting for user input (waiting_user), and before the final response (done or idle).",
-        inputSchema: {
-          type: z
-            .enum(["working", "blocked", "waiting_user", "done", "idle"])
-            .describe("The status event type."),
-          message: z
-            .string()
-            .describe("A short description of what is happening."),
-          metadata: z
-            .record(z.string(), z.unknown())
-            .optional()
-            .describe("Optional metadata object."),
-        },
-      },
-      async (args) => {
-        try {
-          await upsertEvent(agentId, {
-            type: args.type,
-            message: args.message,
-            metadata: args.metadata as Record<string, unknown> | undefined,
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Updated ${agentId}: ${args.type} - ${args.message}`,
-              },
-            ],
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_rename_session ───────────────────────────────────────
-  if (
-    allowed.has("dispatch_rename_session") &&
-    context.agent &&
-    context.renameSession
-  ) {
-    const agentId = context.agent.id;
-    const renameSession = context.renameSession;
-
-    server.registerTool(
-      "dispatch_rename_session",
-      {
-        description:
-          "Update the current session's display name. Use this to rename a default-generated session to a short goal or topic, or when the user explicitly asks for a rename.",
-        inputSchema: {
-          name: z
-            .string()
-            .min(1)
-            .max(120)
-            .describe("New session display name."),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await renameSession(agentId, args.name);
-          return {
-            content: [
-              { type: "text", text: `Renamed session to \"${result.name}\".` },
-            ],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  // ── dispatch_notify ───────────────────────────────────────────────
-  if (allowed.has("dispatch_notify") && context.agent && context.sendNotify) {
-    const agentId = context.agent.id;
-    const sendNotify = context.sendNotify;
-
-    server.registerTool(
-      "dispatch_notify",
-      {
-        description:
-          "Send a Slack notification. Use this to proactively share summaries, results, or important updates " +
-          "with the user via Slack. The message supports Slack mrkdwn formatting. " +
-          "Requires a Slack webhook to be configured in Dispatch settings. " +
-          "Rate limited to 5 messages per minute.",
-        inputSchema: {
-          message: z
-            .string()
-            .max(3000)
-            .describe(
-              "The notification message body. Supports Slack mrkdwn formatting (bold, links, lists, code blocks, etc). Max 3000 characters."
-            ),
-          title: z
-            .string()
-            .max(150)
-            .optional()
-            .describe(
-              "Optional title displayed above the message. Defaults to 'Notification from <agent>'. Max 150 characters."
-            ),
-          level: z
-            .enum(["info", "success", "warning", "error"])
-            .default("info")
-            .describe(
-              "Notification level — controls the color and emoji. info (blue), success (green), warning (amber), error (red)."
-            ),
-          respectFocus: z
-            .boolean()
-            .default(false)
-            .describe(
-              "When true, the notification is suppressed if the user is actively viewing this agent in Dispatch. Default false — notifications are always sent."
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await sendNotify(agentId, {
-            message: args.message,
-            title: args.title,
-            level: args.level as NotifyInput["level"],
-            respectFocus: args.respectFocus,
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: result.sent
-                  ? "Notification sent to Slack."
-                  : `Notification not sent: ${result.reason}`,
-              },
-            ],
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
+  // ── Agent lifecycle tools (dispatch_event, rename, notify, list_media) ──
+  if (context.agent) {
+    registerAgentLifecycleTools(server, allowed, {
+      agentId: context.agent.id,
+      upsertEvent: context.upsertEvent,
+      renameSession: context.renameSession,
+      sendNotify: context.sendNotify,
+      listMedia: context.listMedia,
+    });
   }
 
   if (allowed.has("dispatch_pin")) registerPinTool(server, context);
   if (allowed.has("dispatch_share")) registerShareTool(server, context);
-
-  // ── dispatch_list_media ──────────────────────────────────────────
-  if (
-    allowed.has("dispatch_list_media") &&
-    context.agent &&
-    context.listMedia
-  ) {
-    const agentId = context.agent.id;
-    const listMedia = context.listMedia;
-
-    server.registerTool(
-      "dispatch_list_media",
-      {
-        description:
-          "List media files shared with or by this agent. Returns metadata only — use file reading tools to access content via filePath.",
-        inputSchema: {
-          source: z
-            .string()
-            .optional()
-            .describe(
-              'Optional source filter (e.g. "user", "screenshot", "text", "simulator", "stream"). Omit to list all media.'
-            ),
-        },
-      },
-      async (args) => {
-        try {
-          const items = await listMedia(agentId, { source: args.source });
-          return {
-            content: [
-              { type: "text" as const, text: JSON.stringify(items, null, 2) },
-            ],
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
   if (allowed.has("dispatch_feedback")) registerFeedbackTool(server, context);
 
   // ── Parent-side persona interaction tools ─────────────────────────


### PR DESCRIPTION
## Summary

- Extracted `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, and `dispatch_list_media` tool registrations (~177 lines) from `server.ts` into a new `agent-lifecycle-tools.ts` module
- Follows the established `registerXTools(server, allowed, context)` pattern used by `pr-tools.ts`, `job-tools.ts`, `persona-tools.ts`, etc.
- `server.ts` drops from 1121 to 944 lines

## Why this is tech debt

The MCP `server.ts` file has been accumulating inline tool registrations. Previous runs extracted job-tools, analytics-tools, persona-tools, and pr-tools — this continues that cleanup. Each domain-grouped module owns its own schemas and handlers, keeping the main file focused on setup and orchestration.

## What's next

The next backlog item is extracting `dispatch_send_message` and `list_agents` inter-agent messaging tool registrations into a `messaging-tools.ts` module.

## Test plan

- [x] `pnpm run check` — TypeScript types pass
- [x] `pnpm run test` — 1865 server + 180 web unit tests pass
- [x] `pnpm run test:e2e` — 171 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)