### PR TITLE
Add quick-phrases and auth route tests

### DIFF
--- a/apps/server/test/auth-routes.test.ts
+++ b/apps/server/test/auth-routes.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import { useInjectApp } from "./helpers/inject-app.js";
+
+const ctx = useInjectApp();
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/auth/status
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/auth/status", () => {
+  it("returns passwordSet=true and authenticated=false without cookie", async () => {
+    const res = await ctx.app.inject({
+      method: "GET",
+      url: "/api/v1/auth/status",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().passwordSet).toBe(true);
+    expect(res.json().authenticated).toBe(false);
+  });
+
+  it("returns authenticated=true with valid session cookie", async () => {
+    const loginRes = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { password: "hunter2hunter2" },
+    });
+    const cookie = loginRes.headers["set-cookie"] as string;
+
+    const res = await ctx.app.inject({
+      method: "GET",
+      url: "/api/v1/auth/status",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().authenticated).toBe(true);
+    expect(res.json().passwordSet).toBe(true);
+  });
+
+  it("returns authenticated=false with invalid cookie", async () => {
+    const res = await ctx.app.inject({
+      method: "GET",
+      url: "/api/v1/auth/status",
+      headers: { cookie: "dispatch_session=s:bogus.invalidsig" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().authenticated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/auth/setup
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/auth/setup", () => {
+  it("rejects when password is already set", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/setup",
+      payload: { password: "anotherpass1" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/already set/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/auth/login
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/auth/login", () => {
+  it("rejects missing password", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects empty password", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { password: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects incorrect password", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { password: "wrongpassword" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toMatch(/invalid password/i);
+  });
+
+  it("succeeds with correct password and returns session cookie", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { password: "hunter2hunter2" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+    expect(res.headers["set-cookie"]).toBeTruthy();
+    const cookie = res.headers["set-cookie"] as string;
+    expect(cookie).toMatch(/dispatch_session=/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/auth/logout
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/auth/logout", () => {
+  it("invalidates session and clears cookie", async () => {
+    const cookie = await ctx.sessionCookie();
+
+    const logoutRes = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/logout",
+      headers: { cookie },
+    });
+    expect(logoutRes.statusCode).toBe(200);
+    expect(logoutRes.json().ok).toBe(true);
+
+    const statusRes = await ctx.app.inject({
+      method: "GET",
+      url: "/api/v1/auth/status",
+      headers: { cookie },
+    });
+    expect(statusRes.json().authenticated).toBe(false);
+  });
+
+  it("succeeds without a session cookie", async () => {
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/logout",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/auth/change-password
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/auth/change-password", () => {
+  it("rejects missing fields", async () => {
+    const cookie = await ctx.sessionCookie();
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/change-password",
+      headers: { cookie },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects short new password", async () => {
+    const cookie = await ctx.sessionCookie();
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/change-password",
+      headers: { cookie },
+      payload: {
+        currentPassword: "hunter2hunter2",
+        newPassword: "short",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects wrong current password", async () => {
+    const cookie = await ctx.sessionCookie();
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/change-password",
+      headers: { cookie },
+      payload: {
+        currentPassword: "wrongpassword",
+        newPassword: "newpass12345",
+      },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toMatch(/incorrect/i);
+  });
+
+  it("succeeds with correct current password and issues new session", async () => {
+    const cookie = await ctx.sessionCookie();
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/api/v1/auth/change-password",
+      headers: { cookie },
+      payload: {
+        currentPassword: "hunter2hunter2",
+        newPassword: "newpass123456",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+    expect(res.headers["set-cookie"]).toBeTruthy();
+
+    const statusRes = await ctx.app.inject({
+      method: "GET",
+      url: "/api/v1/auth/status",
+      headers: { cookie },
+    });
+    expect(statusRes.json().authenticated).toBe(false);
+  });
+});

--- a/apps/server/test/quick-phrases-routes.test.ts
+++ b/apps/server/test/quick-phrases-routes.test.ts
@@ -1,0 +1,353 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import { registerQuickPhraseRoutes } from "../src/routes/quick-phrases.js";
+import * as quickPhraseQueries from "../src/db/quick-phrases.js";
+
+vi.mock("../src/db/quick-phrases.js", () => ({
+  listQuickPhrases: vi.fn(),
+  createQuickPhrase: vi.fn(),
+  updateQuickPhrase: vi.fn(),
+  deleteQuickPhrase: vi.fn(),
+}));
+
+const mockPhrase = {
+  id: "qp-1",
+  label: "Greet",
+  text: "Hello, {{D:name}}!",
+  sortOrder: 0,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const mockPhraseNoArgs = {
+  id: "qp-2",
+  label: null,
+  text: "Ship it",
+  sortOrder: 1,
+  createdAt: "2026-01-02T00:00:00.000Z",
+};
+
+let app: FastifyInstance;
+const pool = {} as never;
+
+beforeAll(async () => {
+  app = Fastify();
+  await registerQuickPhraseRoutes(app, { pool });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(quickPhraseQueries.listQuickPhrases).mockResolvedValue([
+    mockPhrase,
+    mockPhraseNoArgs,
+  ] as never);
+  vi.mocked(quickPhraseQueries.createQuickPhrase).mockResolvedValue(
+    mockPhrase as never
+  );
+  vi.mocked(quickPhraseQueries.updateQuickPhrase).mockResolvedValue(
+    mockPhrase as never
+  );
+  vi.mocked(quickPhraseQueries.deleteQuickPhrase).mockResolvedValue(
+    true as never
+  );
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/quick-phrases
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/quick-phrases", () => {
+  it("returns phrases with parsed args", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/quick-phrases",
+    });
+    expect(res.statusCode).toBe(200);
+    const { phrases } = res.json();
+    expect(phrases).toHaveLength(2);
+    expect(phrases[0].id).toBe("qp-1");
+    expect(phrases[0].args).toBeDefined();
+    expect(phrases[0].args.length).toBeGreaterThan(0);
+    expect(phrases[0].args[0].name).toBe("name");
+    expect(phrases[1].args).toEqual([]);
+  });
+
+  it("returns empty array when no phrases exist", async () => {
+    vi.mocked(quickPhraseQueries.listQuickPhrases).mockResolvedValue([]);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/quick-phrases",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().phrases).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/quick-phrases
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/quick-phrases", () => {
+  it("creates a phrase with text and label", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "Hello world", label: "Greet" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().phrase.id).toBe("qp-1");
+    expect(res.json().phrase.args).toBeDefined();
+    expect(quickPhraseQueries.createQuickPhrase).toHaveBeenCalledWith(pool, {
+      text: "Hello world",
+      label: "Greet",
+    });
+  });
+
+  it("creates a phrase with text only (no label)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "Ship it" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(quickPhraseQueries.createQuickPhrase).toHaveBeenCalledWith(pool, {
+      text: "Ship it",
+      label: null,
+    });
+  });
+
+  it("returns 400 when text is missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { label: "No text" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/text is required/i);
+  });
+
+  it("returns 400 when text is empty string", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "   " },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/text is required/i);
+  });
+
+  it("returns 400 when text exceeds maximum length", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "x".repeat(1001) },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/1000 characters/i);
+  });
+
+  it("returns 400 when label exceeds maximum length", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "Valid text", label: "x".repeat(201) },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/200 characters/i);
+  });
+
+  it("trims whitespace from text", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "  hello  " },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(quickPhraseQueries.createQuickPhrase).toHaveBeenCalledWith(pool, {
+      text: "hello",
+      label: null,
+    });
+  });
+
+  it("stores whitespace-only label as null", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "Hello", label: "   " },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(quickPhraseQueries.createQuickPhrase).toHaveBeenCalledWith(pool, {
+      text: "Hello",
+      label: null,
+    });
+  });
+
+  it("accepts text at exactly maximum length", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/quick-phrases",
+      payload: { text: "x".repeat(1000) },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/quick-phrases/:id
+// ---------------------------------------------------------------------------
+describe("PATCH /api/v1/quick-phrases/:id", () => {
+  it("updates text only", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { text: "Updated" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(quickPhraseQueries.updateQuickPhrase).toHaveBeenCalledWith(
+      pool,
+      "qp-1",
+      { text: "Updated" }
+    );
+  });
+
+  it("updates label only", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { label: "New Label" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(quickPhraseQueries.updateQuickPhrase).toHaveBeenCalledWith(
+      pool,
+      "qp-1",
+      { label: "New Label" }
+    );
+  });
+
+  it("updates both text and label", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { text: "New text", label: "New label" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(quickPhraseQueries.updateQuickPhrase).toHaveBeenCalledWith(
+      pool,
+      "qp-1",
+      { text: "New text", label: "New label" }
+    );
+  });
+
+  it("clears label when set to null", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { label: null },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(quickPhraseQueries.updateQuickPhrase).toHaveBeenCalledWith(
+      pool,
+      "qp-1",
+      { label: null }
+    );
+  });
+
+  it("returns 400 when text is empty", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { text: "" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/text must not be empty/i);
+  });
+
+  it("returns 400 when text exceeds maximum length", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { text: "x".repeat(1001) },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/1000 characters/i);
+  });
+
+  it("returns 400 when label exceeds maximum length", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { label: "x".repeat(201) },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/200 characters/i);
+  });
+
+  it("returns 400 when no fields are provided", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/at least one field/i);
+  });
+
+  it("returns 404 when phrase does not exist", async () => {
+    vi.mocked(quickPhraseQueries.updateQuickPhrase).mockResolvedValue(null);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/nonexistent",
+      payload: { text: "Updated" },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("response includes parsed args", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/quick-phrases/qp-1",
+      payload: { text: "Updated" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().phrase.args).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/quick-phrases/:id
+// ---------------------------------------------------------------------------
+describe("DELETE /api/v1/quick-phrases/:id", () => {
+  it("deletes an existing phrase", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/quick-phrases/qp-1",
+    });
+    expect(res.statusCode).toBe(204);
+    expect(quickPhraseQueries.deleteQuickPhrase).toHaveBeenCalledWith(
+      pool,
+      "qp-1"
+    );
+  });
+
+  it("returns 404 when phrase does not exist", async () => {
+    vi.mocked(quickPhraseQueries.deleteQuickPhrase).mockResolvedValue(false);
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/quick-phrases/nonexistent",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Added 23 route-level unit tests for `quick-phrases.ts` covering all 4 CRUD endpoints with validation edge cases (text/label length limits, whitespace trimming, empty fields)
- Added 14 integration tests for `auth.ts` routes covering status, setup, login, logout, and change-password flows including cookie handling and session invalidation
- Scanned 50 recent CI runs — no new flakes; prior `activity-routes` CI flake was already fixed by commit a9c533a4

## Test plan
- [x] `pnpm run check` passes
- [x] `pnpm run test` — server: 1937 tests (116 files), web: 180 tests (15 files)
- [x] `pnpm run test:e2e` — 171 passed, 12 skipped
- [x] Review agent verified no correctness or flaky-test issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)