### PR TITLE
Add Cursor CLI to preflight check and setup docs

### DIFF
--- a/bin/preflight
+++ b/bin/preflight
@@ -81,6 +81,13 @@ else
   warn "opencode — needed to spawn OpenCode agents: npm install -g opencode"
 fi
 
+# Cursor CLI (binary is called "agent")
+if command -v agent &>/dev/null; then
+  ok "cursor/agent ($(which agent))"
+else
+  warn "cursor (agent) — needed to spawn Cursor agents: install Cursor (https://www.cursor.com/)"
+fi
+
 # Playwright browsers
 PW_CHROMIUM_DIR="$HOME/Library/Caches/ms-playwright"
 if [[ -d "$PW_CHROMIUM_DIR" ]] && ls "$PW_CHROMIUM_DIR"/chromium-* &>/dev/null 2>&1; then

--- a/docs/12-new-machine-setup.md
+++ b/docs/12-new-machine-setup.md
@@ -40,7 +40,7 @@ Set up Dispatch on this machine. The repo is at https://github.com/selfcontained
 7. Install the launchd service: bin/install-launchd --port 6767. This should install and run the compiled Bun binary.
 8. Verify production: curl http://127.0.0.1:6767/api/v1/health and launchctl list com.dispatch.server
 9. Optional: if you want agents to open PRs or work with GitHub from this machine, install GitHub CLI and run gh auth login.
-10. Configure enabled agent types: check which agent CLIs are already installed (claude --version, codex --version, opencode --version), then use the API to enable only those types: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to match installed CLIs).
+10. Configure enabled agent types: check which agent CLIs are already installed (claude --version, codex --version, agent --version, opencode --version), then use the API to enable only those types: curl -X POST http://127.0.0.1:6767/api/v1/app/settings/agent-types -H 'Content-Type: application/json' -d '{"enabledAgentTypes": ["claude"]}' (adjust the array to match installed CLIs).
 Read docs/12-new-machine-setup.md for full details and troubleshooting. Report any issues you hit.
 ```
 
@@ -153,12 +153,16 @@ claude --version
 npm install -g codex
 codex --version
 
+# Cursor CLI (binary is called "agent")
+# Install Cursor from https://www.cursor.com/
+agent --version
+
 # OpenCode CLI
 npm install -g opencode
 opencode --version
 ```
 
-The config defaults to `claude`, `codex`, and `opencode` on PATH. To override, set `DISPATCH_CLAUDE_BIN`, `DISPATCH_CODEX_BIN`, or `DISPATCH_OPENCODE_BIN` in `.env`.
+The config defaults to `claude`, `codex`, `agent` (Cursor), and `opencode` on PATH. To override, set `DISPATCH_CLAUDE_BIN`, `DISPATCH_CODEX_BIN`, `DISPATCH_CURSOR_BIN`, or `DISPATCH_OPENCODE_BIN` in `.env`.
 
 After setup, configure which agent types are available in the create-agent dialog. In the Dispatch UI go to **Settings > Agent Types** and enable only the CLIs you have installed. Or use the API:
 


### PR DESCRIPTION
## Summary

- Added Cursor CLI (`agent` binary) check to `bin/preflight` — it was the only agent type missing from the optional checks
- Updated `docs/12-new-machine-setup.md`:
  - Added Cursor CLI install instructions to the Agent CLIs section (binary is `agent`, installed via the Cursor IDE)
  - Added `DISPATCH_CURSOR_BIN` to the env var override list
  - Added `agent --version` to the Agent Setup Prompt's version-check step

## What was audited

Deep-dive on `docs/12-new-machine-setup.md` per the `next_focus` from the previous run. Cross-checked against `bin/preflight`, `bin/install-launchd`, `.env.example`, `apps/server/src/config.ts` (agent binary config), and `apps/web/src/lib/agent-types.ts`.

Also checked the diff since the last audit (7 commits, mostly test additions + PR #679 reviewer optimization). No other doc-relevant changes found.

## Deferred to next run

- `next_focus`: Audit docs-pane Reviewers section against `apps/server/src/server/mcp-handlers.ts` — PR #679 changed the recheck round-trip behavior, verify the docs-pane description of the review lifecycle is still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)