### PR TITLE
Add read-only Changes tab with unified diff viewer

### DIFF
--- a/apps/server/src/routes/agents/lifecycle-routes.ts
+++ b/apps/server/src/routes/agents/lifecycle-routes.ts
@@ -352,6 +352,10 @@ export async function registerAgentLifecycleRoutes(
       return reply.code(400).send({ error: "path query parameter required." });
     }
 
+    if (query.path.includes("..")) {
+      return reply.code(400).send({ error: "Invalid file path." });
+    }
+
     const agent = await deps.agentManager.getAgent(id);
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });

--- a/apps/server/src/routes/agents/lifecycle-routes.ts
+++ b/apps/server/src/routes/agents/lifecycle-routes.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agent-type-settings.js";
 import { RENAME_PROMPT } from "../../agents/auto-rename-prompter.js";
 import { shouldSuggestSessionRename } from "../../agents/tmux/session-name.js";
+import { getAgentDiff, getAgentFileDiff } from "../../shared/git/agent-diff.js";
 import {
   AGENT_LATEST_EVENT_TYPES,
   isAgentLatestEventType,
@@ -304,5 +305,85 @@ export async function registerAgentLifecycleRoutes(
     await deps.diffStatsRefresher.signal(id);
 
     return { diffStats: deps.diffStatsRefresher.getStats(id) };
+  });
+
+  app.get("/api/v1/agents/:id/diff", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const gitContextWorktreePath = agent.gitContext?.isWorktree
+      ? agent.gitContext.worktreePath
+      : null;
+    const worktreePath =
+      agent.worktreePath ?? gitContextWorktreePath ?? agent.cwd ?? null;
+    if (!worktreePath) {
+      return reply
+        .code(404)
+        .send({ error: "Agent has no associated worktree." });
+    }
+
+    const baseRef =
+      agent.baseBranch ??
+      (agent.worktreePath || gitContextWorktreePath ? "main" : null);
+
+    try {
+      const result = await getAgentDiff(worktreePath, baseRef);
+      if (!result) {
+        return { baseRef: null, files: [] };
+      }
+      return result;
+    } catch (error) {
+      deps.appLog.warn({ err: error, agentId: id }, "Agent diff failed");
+      return reply.code(500).send({ error: "Failed to compute diff." });
+    }
+  });
+
+  app.get("/api/v1/agents/:id/diff/file", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const query = request.query as { path?: string; force?: string };
+    const id = params.id ?? "";
+
+    if (!query.path) {
+      return reply.code(400).send({ error: "path query parameter required." });
+    }
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const gitContextWorktreePath = agent.gitContext?.isWorktree
+      ? agent.gitContext.worktreePath
+      : null;
+    const worktreePath =
+      agent.worktreePath ?? gitContextWorktreePath ?? agent.cwd ?? null;
+    if (!worktreePath) {
+      return reply
+        .code(404)
+        .send({ error: "Agent has no associated worktree." });
+    }
+
+    const baseRef =
+      agent.baseBranch ??
+      (agent.worktreePath || gitContextWorktreePath ? "main" : null);
+
+    try {
+      const result = await getAgentFileDiff(worktreePath, baseRef, query.path);
+      if (!result) {
+        return reply.code(404).send({ error: "File not found in diff." });
+      }
+      return result;
+    } catch (error) {
+      deps.appLog.warn(
+        { err: error, agentId: id, filePath: query.path },
+        "Agent file diff failed"
+      );
+      return reply.code(500).send({ error: "Failed to compute file diff." });
+    }
   });
 }

--- a/apps/server/src/shared/git/agent-diff.ts
+++ b/apps/server/src/shared/git/agent-diff.ts
@@ -21,6 +21,7 @@ export type DiffFile = {
 export type DiffResponse = {
   baseRef: string;
   files: DiffFile[];
+  truncatedFileCount?: number;
 };
 
 export type FileDiffResponse = {
@@ -35,6 +36,7 @@ export type FileDiffResponse = {
 const GIT_TIMEOUT_MS = 15_000;
 const DIFF_TRUNCATION_BYTES = 100_000;
 const DIFF_TRUNCATION_LINES = 2_000;
+const MAX_FILES = 1_000;
 
 type CommandRunner = (
   command: string,
@@ -255,36 +257,39 @@ export async function getAgentDiff(
     .split("\n")
     .filter((p) => p && !shouldExcludePath(p) && !trackedPaths.has(p));
 
-  const untrackedFiles = await Promise.all(
-    untrackedPaths.map(async (filePath) => {
-      const { lines, content } = await readUntrackedFile(
-        worktreePath,
-        filePath
-      );
-      if (lines === 0 && content === null) {
-        return {
-          path: filePath,
-          status: "added" as DiffFileStatus,
-          added: 0,
-          deleted: 0,
-          diff: null,
-          truncated: false,
-        };
-      }
+  for (const filePath of untrackedPaths) {
+    const { lines, content } = await readUntrackedFile(worktreePath, filePath);
+    if (lines === 0 && content === null) {
+      files.push({
+        path: filePath,
+        status: "added" as DiffFileStatus,
+        added: 0,
+        deleted: 0,
+        diff: null,
+        truncated: false,
+      });
+    } else {
       const syntheticDiff = buildUntrackedDiff(filePath, content!);
       const truncated = isFileTruncated(syntheticDiff);
-      return {
+      files.push({
         path: filePath,
         status: "added" as DiffFileStatus,
         added: lines,
         deleted: 0,
         diff: truncated ? null : syntheticDiff,
         truncated,
-      };
-    })
-  );
+      });
+    }
+  }
 
-  files.push(...untrackedFiles);
+  const totalFiles = files.length;
+  if (totalFiles > MAX_FILES) {
+    return {
+      baseRef: mergeBaseSha,
+      files: files.slice(0, MAX_FILES),
+      truncatedFileCount: totalFiles,
+    };
+  }
 
   return { baseRef: mergeBaseSha, files };
 }

--- a/apps/server/src/shared/git/agent-diff.ts
+++ b/apps/server/src/shared/git/agent-diff.ts
@@ -1,0 +1,374 @@
+import { resolveBaseRef } from "./base-ref.js";
+import {
+  countLines,
+  readUntrackedFile,
+  shouldExcludePath,
+} from "./diff-file-rules.js";
+import { runCommand, type RunCommandResult } from "../lib/run-command.js";
+
+export type DiffFileStatus = "modified" | "added" | "deleted" | "renamed";
+
+export type DiffFile = {
+  path: string;
+  status: DiffFileStatus;
+  oldPath?: string;
+  added: number;
+  deleted: number;
+  diff: string | null;
+  truncated: boolean;
+};
+
+export type DiffResponse = {
+  baseRef: string;
+  files: DiffFile[];
+};
+
+export type FileDiffResponse = {
+  path: string;
+  status: DiffFileStatus;
+  oldPath?: string;
+  added: number;
+  deleted: number;
+  diff: string;
+};
+
+const GIT_TIMEOUT_MS = 15_000;
+const DIFF_TRUNCATION_BYTES = 100_000;
+const DIFF_TRUNCATION_LINES = 2_000;
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; allowedExitCodes?: number[]; timeoutMs?: number }
+) => Promise<RunCommandResult>;
+
+function parseStatusLetter(letter: string): DiffFileStatus {
+  switch (letter) {
+    case "A":
+      return "added";
+    case "D":
+      return "deleted";
+    case "M":
+      return "modified";
+    default:
+      if (letter.startsWith("R")) return "renamed";
+      return "modified";
+  }
+}
+
+type NumstatEntry = {
+  path: string;
+  oldPath?: string;
+  status: DiffFileStatus;
+  added: number;
+  deleted: number;
+};
+
+function resolveRenamePath(raw: string): { dest: string; src?: string } {
+  const braceMatch = /^(.*)\{(.+) => (.+)\}(.*)$/.exec(raw);
+  if (!braceMatch) return { dest: raw };
+  const prefix = braceMatch[1]!;
+  const oldPart = braceMatch[2]!;
+  const newPart = braceMatch[3]!;
+  const suffix = braceMatch[4]!;
+  return {
+    dest: prefix + newPart + suffix,
+    src: prefix + oldPart + suffix,
+  };
+}
+
+function parseNumstatWithStatus(
+  numstatOutput: string,
+  statusOutput: string
+): NumstatEntry[] {
+  const statusMap = new Map<
+    string,
+    { status: DiffFileStatus; oldPath?: string }
+  >();
+  for (const line of statusOutput.split("\n")) {
+    if (!line) continue;
+    const letter = line[0];
+    if (!letter) continue;
+    const rest = line.slice(1).trim();
+    if (letter === "R" || line[0] === "R") {
+      const parts = rest.split("\t");
+      if (parts.length >= 2) {
+        statusMap.set(parts[1]!, {
+          status: "renamed",
+          oldPath: parts[0],
+        });
+      }
+    } else {
+      statusMap.set(rest, { status: parseStatusLetter(letter) });
+    }
+  }
+
+  const entries: NumstatEntry[] = [];
+  for (const line of numstatOutput.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    const [a, d, ...rest] = parts;
+    const rawPath = rest.join("\t");
+    if (!rawPath) continue;
+
+    const resolved = resolveRenamePath(rawPath);
+    const filePath = resolved.dest;
+    if (shouldExcludePath(filePath)) continue;
+
+    const isBinary = a === "-" && d === "-";
+    const statusInfo = statusMap.get(filePath);
+
+    entries.push({
+      path: filePath,
+      oldPath: statusInfo?.oldPath ?? resolved.src,
+      status: statusInfo?.status ?? (resolved.src ? "renamed" : "modified"),
+      added: isBinary ? 0 : Number.parseInt(a!, 10) || 0,
+      deleted: isBinary ? 0 : Number.parseInt(d!, 10) || 0,
+    });
+  }
+
+  return entries;
+}
+
+function splitUnifiedDiffByFile(rawDiff: string): Map<string, string> {
+  const fileMap = new Map<string, string>();
+  const diffHeaderRe = /^diff --git a\/.+ b\/(.+)$/;
+  let currentPath: string | null = null;
+  let currentLines: string[] = [];
+
+  for (const line of rawDiff.split("\n")) {
+    const match = diffHeaderRe.exec(line);
+    if (match) {
+      if (currentPath !== null) {
+        fileMap.set(currentPath, currentLines.join("\n"));
+      }
+      currentPath = match[1]!;
+      currentLines = [line];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentPath !== null) {
+    fileMap.set(currentPath, currentLines.join("\n"));
+  }
+
+  return fileMap;
+}
+
+function isFileTruncated(diff: string): boolean {
+  const byteSize = Buffer.byteLength(diff, "utf-8");
+  if (byteSize > DIFF_TRUNCATION_BYTES) return true;
+  let lineCount = 0;
+  for (const ch of diff) {
+    if (ch === "\n") lineCount++;
+    if (lineCount > DIFF_TRUNCATION_LINES) return true;
+  }
+  return false;
+}
+
+function buildUntrackedDiff(filePath: string, content: string): string {
+  const lines = content.split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  const header = [
+    `diff --git a/${filePath} b/${filePath}`,
+    "new file mode 100644",
+    "--- /dev/null",
+    `+++ b/${filePath}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+  ];
+  const added = lines.map((l) => `+${l}`);
+  return [...header, ...added].join("\n");
+}
+
+export async function getAgentDiff(
+  worktreePath: string,
+  baseRef: string | null,
+  run: CommandRunner = runCommand
+): Promise<DiffResponse | null> {
+  const resolvedBase = await resolveBaseRef(worktreePath, baseRef, {
+    runCommand: run,
+  });
+  if (!resolvedBase) return null;
+
+  const mergeBaseResult = await run(
+    "git",
+    ["-C", worktreePath, "merge-base", "HEAD", resolvedBase],
+    { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
+  );
+  if (mergeBaseResult.exitCode !== 0 || !mergeBaseResult.stdout.trim()) {
+    return null;
+  }
+  const mergeBaseSha = mergeBaseResult.stdout.trim();
+
+  const [numstatResult, statusResult, diffResult, untrackedResult] =
+    await Promise.all([
+      run("git", ["-C", worktreePath, "diff", mergeBaseSha, "--numstat"], {
+        allowedExitCodes: [0],
+        timeoutMs: GIT_TIMEOUT_MS,
+      }),
+      run("git", ["-C", worktreePath, "diff", mergeBaseSha, "--name-status"], {
+        allowedExitCodes: [0],
+        timeoutMs: GIT_TIMEOUT_MS,
+      }),
+      run(
+        "git",
+        ["-C", worktreePath, "diff", mergeBaseSha, "-U3", "--no-color"],
+        {
+          allowedExitCodes: [0],
+          timeoutMs: GIT_TIMEOUT_MS,
+        }
+      ),
+      run(
+        "git",
+        ["-C", worktreePath, "ls-files", "--others", "--exclude-standard"],
+        {
+          allowedExitCodes: [0],
+          timeoutMs: GIT_TIMEOUT_MS,
+        }
+      ),
+    ]);
+
+  const entries = parseNumstatWithStatus(
+    numstatResult.stdout,
+    statusResult.stdout
+  );
+  const fileDiffs = splitUnifiedDiffByFile(diffResult.stdout);
+
+  const files: DiffFile[] = entries.map((entry) => {
+    const rawDiff = fileDiffs.get(entry.path) ?? null;
+    const truncated = rawDiff !== null && isFileTruncated(rawDiff);
+    return {
+      path: entry.path,
+      status: entry.status,
+      ...(entry.oldPath ? { oldPath: entry.oldPath } : {}),
+      added: entry.added,
+      deleted: entry.deleted,
+      diff: truncated ? null : rawDiff,
+      truncated,
+    };
+  });
+
+  const trackedPaths = new Set(entries.map((e) => e.path));
+  const untrackedPaths = untrackedResult.stdout
+    .split("\n")
+    .filter((p) => p && !shouldExcludePath(p) && !trackedPaths.has(p));
+
+  const untrackedFiles = await Promise.all(
+    untrackedPaths.map(async (filePath) => {
+      const { lines, content } = await readUntrackedFile(
+        worktreePath,
+        filePath
+      );
+      if (lines === 0 && content === null) {
+        return {
+          path: filePath,
+          status: "added" as DiffFileStatus,
+          added: 0,
+          deleted: 0,
+          diff: null,
+          truncated: false,
+        };
+      }
+      const syntheticDiff = buildUntrackedDiff(filePath, content!);
+      const truncated = isFileTruncated(syntheticDiff);
+      return {
+        path: filePath,
+        status: "added" as DiffFileStatus,
+        added: lines,
+        deleted: 0,
+        diff: truncated ? null : syntheticDiff,
+        truncated,
+      };
+    })
+  );
+
+  files.push(...untrackedFiles);
+
+  return { baseRef: mergeBaseSha, files };
+}
+
+export async function getAgentFileDiff(
+  worktreePath: string,
+  baseRef: string | null,
+  filePath: string,
+  run: CommandRunner = runCommand
+): Promise<FileDiffResponse | null> {
+  const resolvedBase = await resolveBaseRef(worktreePath, baseRef, {
+    runCommand: run,
+  });
+  if (!resolvedBase) return null;
+
+  const mergeBaseResult = await run(
+    "git",
+    ["-C", worktreePath, "merge-base", "HEAD", resolvedBase],
+    { allowedExitCodes: [0, 1, 128], timeoutMs: 5_000 }
+  );
+  if (mergeBaseResult.exitCode !== 0 || !mergeBaseResult.stdout.trim()) {
+    return null;
+  }
+  const mergeBaseSha = mergeBaseResult.stdout.trim();
+
+  const [numstatResult, statusResult, diffResult] = await Promise.all([
+    run(
+      "git",
+      ["-C", worktreePath, "diff", mergeBaseSha, "--numstat", "--", filePath],
+      { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
+    ),
+    run(
+      "git",
+      [
+        "-C",
+        worktreePath,
+        "diff",
+        mergeBaseSha,
+        "--name-status",
+        "--",
+        filePath,
+      ],
+      { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
+    ),
+    run(
+      "git",
+      [
+        "-C",
+        worktreePath,
+        "diff",
+        mergeBaseSha,
+        "-U3",
+        "--no-color",
+        "--",
+        filePath,
+      ],
+      { allowedExitCodes: [0], timeoutMs: GIT_TIMEOUT_MS }
+    ),
+  ]);
+
+  const entries = parseNumstatWithStatus(
+    numstatResult.stdout,
+    statusResult.stdout
+  );
+
+  if (entries.length === 0) {
+    const { lines, content } = await readUntrackedFile(worktreePath, filePath);
+    if (lines === 0 && content === null) return null;
+    return {
+      path: filePath,
+      status: "added" as DiffFileStatus,
+      added: lines,
+      deleted: 0,
+      diff: buildUntrackedDiff(filePath, content!),
+    };
+  }
+
+  const entry = entries[0]!;
+  return {
+    path: entry.path,
+    status: entry.status,
+    ...(entry.oldPath ? { oldPath: entry.oldPath } : {}),
+    added: entry.added,
+    deleted: entry.deleted,
+    diff: diffResult.stdout,
+  };
+}

--- a/apps/server/src/shared/git/diff-file-rules.ts
+++ b/apps/server/src/shared/git/diff-file-rules.ts
@@ -42,7 +42,14 @@ export async function readUntrackedFile(
   worktreePath: string,
   filePath: string
 ): Promise<{ lines: number; content: string | null }> {
-  const fullPath = path.join(worktreePath, filePath);
+  const fullPath = path.resolve(worktreePath, filePath);
+  const realWorktree = path.resolve(worktreePath);
+  if (
+    !fullPath.startsWith(realWorktree + path.sep) &&
+    fullPath !== realWorktree
+  ) {
+    return { lines: 0, content: null };
+  }
   try {
     const info = await lstat(fullPath);
     if (!info.isFile()) return { lines: 0, content: null };

--- a/apps/server/src/shared/git/diff-file-rules.ts
+++ b/apps/server/src/shared/git/diff-file-rules.ts
@@ -1,0 +1,58 @@
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const EXCLUDED_BASENAMES = new Set([
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lockb",
+  "bun.lock",
+  "Cargo.lock",
+  "Gemfile.lock",
+  "poetry.lock",
+  "uv.lock",
+  "Podfile.lock",
+  "Package.resolved",
+  "composer.lock",
+  "mix.lock",
+]);
+
+const UNTRACKED_MAX_BYTES = 1_024 * 1_024;
+const BINARY_PROBE_BYTES = 8_192;
+
+export function shouldExcludePath(filePath: string): boolean {
+  return EXCLUDED_BASENAMES.has(path.basename(filePath));
+}
+
+export function looksBinary(buffer: Buffer): boolean {
+  const probeLength = Math.min(buffer.length, BINARY_PROBE_BYTES);
+  for (let i = 0; i < probeLength; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+export function countLines(content: string): number {
+  if (content.length === 0) return 0;
+  const parts = content.split("\n");
+  return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}
+
+export async function readUntrackedFile(
+  worktreePath: string,
+  filePath: string
+): Promise<{ lines: number; content: string | null }> {
+  const fullPath = path.join(worktreePath, filePath);
+  try {
+    const info = await lstat(fullPath);
+    if (!info.isFile()) return { lines: 0, content: null };
+    if (info.size === 0) return { lines: 0, content: null };
+    if (info.size > UNTRACKED_MAX_BYTES) return { lines: 0, content: null };
+    const buffer = await readFile(fullPath);
+    if (looksBinary(buffer)) return { lines: 0, content: null };
+    const text = buffer.toString("utf8");
+    return { lines: countLines(text), content: text };
+  } catch {
+    return { lines: 0, content: null };
+  }
+}

--- a/apps/server/src/shared/git/diff-stats.ts
+++ b/apps/server/src/shared/git/diff-stats.ts
@@ -1,7 +1,5 @@
-import { lstat, readFile } from "node:fs/promises";
-import path from "node:path";
-
 import { resolveBaseRef } from "./base-ref.js";
+import { readUntrackedFile, shouldExcludePath } from "./diff-file-rules.js";
 import { runCommand, type RunCommandResult } from "../lib/run-command.js";
 
 export type DiffStats = {
@@ -11,24 +9,7 @@ export type DiffStats = {
   computedAt: number;
 };
 
-const UNTRACKED_LINE_COUNT_MAX_BYTES = 1_000_000;
 const GIT_TIMEOUT_MS = 15_000;
-const BINARY_PROBE_BYTES = 8 * 1024;
-const DIFF_STATS_EXCLUDED_BASENAMES = new Set([
-  "pnpm-lock.yaml",
-  "package-lock.json",
-  "yarn.lock",
-  "bun.lockb",
-  "bun.lock",
-  "Cargo.lock",
-  "Gemfile.lock",
-  "poetry.lock",
-  "uv.lock",
-  "Podfile.lock",
-  "Package.resolved",
-  "composer.lock",
-  "mix.lock",
-]);
 
 type CommandRunner = (
   command: string,
@@ -110,7 +91,7 @@ export async function getDiffStats(
       const [a, d, ...rest] = parts;
       const filePath = rest.join("\t");
       if (!filePath) continue;
-      if (shouldIgnoreDiffStatsPath(filePath)) continue;
+      if (shouldExcludePath(filePath)) continue;
       if (ignoredPaths.has(filePath)) continue;
       if (seenFiles.has(filePath)) continue;
       seenFiles.add(filePath);
@@ -121,10 +102,10 @@ export async function getDiffStats(
 
     for (const filePath of untracked.stdout.split("\n")) {
       if (!filePath) continue;
-      if (shouldIgnoreDiffStatsPath(filePath)) continue;
+      if (shouldExcludePath(filePath)) continue;
       if (seenFiles.has(filePath)) continue;
       seenFiles.add(filePath);
-      const lines = await countUntrackedLines(worktreePath, filePath);
+      const { lines } = await readUntrackedFile(worktreePath, filePath);
       added += lines;
     }
 
@@ -137,42 +118,6 @@ export async function getDiffStats(
   } catch {
     return null;
   }
-}
-
-async function countUntrackedLines(
-  worktreePath: string,
-  filePath: string
-): Promise<number> {
-  const fullPath = path.join(worktreePath, filePath);
-  try {
-    // `lstat` does NOT follow symlinks. Untracked symlinks pointing outside
-    // the worktree would otherwise let the badge act as a small file-content
-    // oracle for arbitrary paths the server can read. Skip them entirely —
-    // they still count as 1 file via the seenFiles set above.
-    const info = await lstat(fullPath);
-    if (!info.isFile()) return 0;
-    if (info.size === 0) return 0;
-    if (info.size > UNTRACKED_LINE_COUNT_MAX_BYTES) return 0;
-    const buffer = await readFile(fullPath);
-    if (looksBinary(buffer)) return 0;
-    return countLines(buffer.toString("utf8"));
-  } catch {
-    return 0;
-  }
-}
-
-function looksBinary(buffer: Buffer): boolean {
-  const probeLength = Math.min(buffer.length, BINARY_PROBE_BYTES);
-  for (let i = 0; i < probeLength; i++) {
-    if (buffer[i] === 0) return true;
-  }
-  return false;
-}
-
-function countLines(content: string): number {
-  if (content.length === 0) return 0;
-  const parts = content.split("\n");
-  return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
 }
 
 function extractPathsFromNumstat(numstatOutput: string): string[] {
@@ -214,8 +159,4 @@ async function getGitIgnoredPaths(
   } catch {
     return ignored;
   }
-}
-
-function shouldIgnoreDiffStatsPath(filePath: string): boolean {
-  return DIFF_STATS_EXCLUDED_BASENAMES.has(path.basename(filePath));
 }

--- a/apps/server/test/agent-diff.test.ts
+++ b/apps/server/test/agent-diff.test.ts
@@ -1,0 +1,437 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { RunCommandResult } from "../src/shared/lib/run-command.js";
+import {
+  getAgentDiff,
+  getAgentFileDiff,
+} from "../src/shared/git/agent-diff.js";
+
+const WORKTREE = "/fake/worktree";
+const BASE_REF = "main";
+const MERGE_BASE_SHA = "abc123";
+
+function ok(stdout = ""): RunCommandResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function generateDiffLines(filePath: string, lineCount: number): string {
+  const header = [
+    `diff --git a/${filePath} b/${filePath}`,
+    `new file mode 100644`,
+    `index 0000000..1234567`,
+    `--- /dev/null`,
+    `+++ b/${filePath}`,
+    `@@ -0,0 +1,${lineCount} @@`,
+  ];
+  const added = Array.from({ length: lineCount }, (_, i) => `+line ${i + 1}`);
+  return [...header, ...added].join("\n");
+}
+
+function makeMockRunner(
+  numstat: string,
+  nameStatus: string,
+  unifiedDiff: string,
+  untrackedFiles = ""
+) {
+  return async (
+    _cmd: string,
+    args: string[],
+    _opts?: { cwd?: string; allowedExitCodes?: number[]; timeoutMs?: number }
+  ): Promise<RunCommandResult> => {
+    const joined = args.join(" ");
+    if (joined.includes("rev-parse --verify")) return ok(BASE_REF);
+    if (joined.includes("merge-base")) return ok(MERGE_BASE_SHA);
+    if (joined.includes("ls-files")) return ok(untrackedFiles);
+    if (joined.includes("--numstat")) return ok(numstat);
+    if (joined.includes("--name-status")) return ok(nameStatus);
+    if (joined.includes("-U3")) return ok(unifiedDiff);
+    return ok();
+  };
+}
+
+describe("getAgentDiff truncation", () => {
+  it("marks a file as truncated when diff exceeds 2000 lines", async () => {
+    const diff = generateDiffLines("big-file.ts", 2100);
+    const runner = makeMockRunner(
+      "2100\t0\tbig-file.ts",
+      "A\tbig-file.ts",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result).not.toBeNull();
+    const file = result!.files.find((f) => f.path === "big-file.ts");
+    expect(file).toBeDefined();
+    expect(file!.truncated).toBe(true);
+    expect(file!.diff).toBeNull();
+    expect(file!.added).toBe(2100);
+    expect(file!.status).toBe("added");
+  });
+
+  it("does not truncate a file under 2000 lines", async () => {
+    const diff = generateDiffLines("small-file.ts", 500);
+    const runner = makeMockRunner(
+      "500\t0\tsmall-file.ts",
+      "A\tsmall-file.ts",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result).not.toBeNull();
+    const file = result!.files.find((f) => f.path === "small-file.ts");
+    expect(file).toBeDefined();
+    expect(file!.truncated).toBe(false);
+    expect(file!.diff).not.toBeNull();
+  });
+
+  it("marks a file as truncated when diff exceeds 100KB", async () => {
+    const longLine = "x".repeat(200);
+    const header = [
+      "diff --git a/big.bin b/big.bin",
+      "new file mode 100644",
+      "index 0000000..1234567",
+      "--- /dev/null",
+      "+++ b/big.bin",
+      "@@ -0,0 +1,600 @@",
+    ];
+    const lines = Array.from({ length: 600 }, () => `+${longLine}`);
+    const diff = [...header, ...lines].join("\n");
+
+    const runner = makeMockRunner("600\t0\tbig.bin", "A\tbig.bin", diff);
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    const file = result!.files.find((f) => f.path === "big.bin");
+    expect(file).toBeDefined();
+    expect(file!.truncated).toBe(true);
+    expect(file!.diff).toBeNull();
+  });
+
+  it("preserves truncated files in the file list with stats", async () => {
+    const smallDiff = generateDiffLines("small.ts", 10);
+    const bigDiff = generateDiffLines("big.ts", 2500);
+    const combined = smallDiff + "\n" + bigDiff;
+
+    const runner = makeMockRunner(
+      "10\t0\tsmall.ts\n2500\t0\tbig.ts",
+      "A\tsmall.ts\nA\tbig.ts",
+      combined
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result).not.toBeNull();
+    expect(result!.files).toHaveLength(2);
+
+    const small = result!.files.find((f) => f.path === "small.ts");
+    expect(small!.truncated).toBe(false);
+    expect(small!.diff).not.toBeNull();
+    expect(small!.added).toBe(10);
+
+    const big = result!.files.find((f) => f.path === "big.ts");
+    expect(big!.truncated).toBe(true);
+    expect(big!.diff).toBeNull();
+    expect(big!.added).toBe(2500);
+    expect(big!.status).toBe("added");
+  });
+
+  it("handles a modified file with many added lines", async () => {
+    const header = [
+      "diff --git a/existing.ts b/existing.ts",
+      "index 1234567..abcdef0 100644",
+      "--- a/existing.ts",
+      "+++ b/existing.ts",
+      "@@ -1,3 +1,2103 @@",
+    ];
+    const context = [" const x = 1;", " const y = 2;", " const z = 3;"];
+    const added = Array.from({ length: 2100 }, (_, i) => `+new line ${i + 1}`);
+    const diff = [...header, ...context, ...added].join("\n");
+
+    const runner = makeMockRunner(
+      "2100\t0\texisting.ts",
+      "M\texisting.ts",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    const file = result!.files.find((f) => f.path === "existing.ts");
+    expect(file).toBeDefined();
+    expect(file!.truncated).toBe(true);
+    expect(file!.diff).toBeNull();
+    expect(file!.status).toBe("modified");
+    expect(file!.added).toBe(2100);
+  });
+
+  it("handles renamed files with brace syntax in numstat", async () => {
+    const diff = [
+      "diff --git a/src/new-name.ts b/src/new-name.ts",
+      "similarity index 90%",
+      "rename from src/old-name.ts",
+      "rename to src/new-name.ts",
+      "--- a/src/old-name.ts",
+      "+++ b/src/new-name.ts",
+      "@@ -1,3 +1,5 @@",
+      " const a = 1;",
+      "+const b = 2;",
+      "+const c = 3;",
+      " const d = 4;",
+    ].join("\n");
+
+    const runner = makeMockRunner(
+      "2\t0\tsrc/{old-name.ts => new-name.ts}",
+      "R100\tsrc/old-name.ts\tsrc/new-name.ts",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result!.files).toHaveLength(1);
+    const file = result!.files[0]!;
+    expect(file.path).toBe("src/new-name.ts");
+    expect(file.oldPath).toBe("src/old-name.ts");
+    expect(file.status).toBe("renamed");
+    expect(file.added).toBe(2);
+    expect(file.diff).toBe(diff);
+  });
+
+  it("handles cross-directory renames with brace syntax", async () => {
+    const diff = [
+      "diff --git a/lib/util.ts b/src/util.ts",
+      "similarity index 100%",
+      "rename from lib/util.ts",
+      "rename to src/util.ts",
+    ].join("\n");
+
+    const runner = makeMockRunner(
+      "0\t0\t{lib => src}/util.ts",
+      "R100\tlib/util.ts\tsrc/util.ts",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result!.files).toHaveLength(1);
+    const file = result!.files[0]!;
+    expect(file.path).toBe("src/util.ts");
+    expect(file.oldPath).toBe("lib/util.ts");
+    expect(file.status).toBe("renamed");
+  });
+
+  it("excludes lock files from results", async () => {
+    const diff = generateDiffLines("pnpm-lock.yaml", 100);
+    const runner = makeMockRunner(
+      "5000\t2000\tpnpm-lock.yaml",
+      "M\tpnpm-lock.yaml",
+      diff
+    );
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    expect(result!.files).toHaveLength(0);
+  });
+});
+
+describe("getAgentDiff untracked files", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "agent-diff-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("includes small untracked files with synthetic diff", async () => {
+    const content = "line 1\nline 2\nline 3\n";
+    await writeFile(path.join(tmpDir, "new-file.ts"), content);
+
+    const runner = makeMockRunner("", "", "", "new-file.ts");
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    expect(result).not.toBeNull();
+    expect(result!.files).toHaveLength(1);
+
+    const file = result!.files[0]!;
+    expect(file.path).toBe("new-file.ts");
+    expect(file.status).toBe("added");
+    expect(file.added).toBe(3);
+    expect(file.deleted).toBe(0);
+    expect(file.truncated).toBe(false);
+    expect(file.diff).toContain("+line 1");
+    expect(file.diff).toContain("+line 2");
+    expect(file.diff).toContain("+line 3");
+    expect(file.diff).toContain("--- /dev/null");
+  });
+
+  it("marks large untracked files as truncated", async () => {
+    const lines = Array.from({ length: 2500 }, (_, i) => `line ${i}`).join(
+      "\n"
+    );
+    await writeFile(path.join(tmpDir, "huge.ts"), lines);
+
+    const runner = makeMockRunner("", "", "", "huge.ts");
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    const file = result!.files[0]!;
+    expect(file.path).toBe("huge.ts");
+    expect(file.status).toBe("added");
+    expect(file.added).toBe(2500);
+    expect(file.truncated).toBe(true);
+    expect(file.diff).toBeNull();
+  });
+
+  it("includes untracked files alongside tracked files", async () => {
+    const trackedDiff = generateDiffLines("tracked.ts", 10);
+    await writeFile(path.join(tmpDir, "untracked.ts"), "hello\nworld\n");
+
+    const runner = makeMockRunner(
+      "10\t0\ttracked.ts",
+      "A\ttracked.ts",
+      trackedDiff,
+      "untracked.ts"
+    );
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    expect(result!.files).toHaveLength(2);
+
+    const tracked = result!.files.find((f) => f.path === "tracked.ts");
+    expect(tracked).toBeDefined();
+    expect(tracked!.status).toBe("added");
+
+    const untracked = result!.files.find((f) => f.path === "untracked.ts");
+    expect(untracked).toBeDefined();
+    expect(untracked!.status).toBe("added");
+    expect(untracked!.added).toBe(2);
+  });
+
+  it("excludes untracked lock files", async () => {
+    await writeFile(path.join(tmpDir, "pnpm-lock.yaml"), "content\n");
+
+    const runner = makeMockRunner("", "", "", "pnpm-lock.yaml");
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    expect(result!.files).toHaveLength(0);
+  });
+
+  it("handles untracked files in subdirectories", async () => {
+    await mkdir(path.join(tmpDir, "src", "lib"), { recursive: true });
+    await writeFile(path.join(tmpDir, "src", "lib", "util.ts"), "export {};\n");
+
+    const runner = makeMockRunner("", "", "", "src/lib/util.ts");
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    expect(result!.files).toHaveLength(1);
+    expect(result!.files[0]!.path).toBe("src/lib/util.ts");
+    expect(result!.files[0]!.added).toBe(1);
+  });
+});
+
+describe("getAgentDiff stats consistency", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "agent-diff-stats-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("file count includes both tracked and untracked files", async () => {
+    const trackedDiff = generateDiffLines("a.ts", 5);
+    await writeFile(path.join(tmpDir, "b.ts"), "new\nfile\n");
+
+    const runner = makeMockRunner("5\t0\ta.ts", "A\ta.ts", trackedDiff, "b.ts");
+
+    const result = await getAgentDiff(tmpDir, BASE_REF, runner);
+    expect(result!.files).toHaveLength(2);
+
+    const totalAdded = result!.files.reduce((sum, f) => sum + f.added, 0);
+    const totalDeleted = result!.files.reduce((sum, f) => sum + f.deleted, 0);
+    expect(totalAdded).toBe(7);
+    expect(totalDeleted).toBe(0);
+  });
+
+  it("truncated files preserve their added/deleted counts", async () => {
+    const bigDiff = generateDiffLines("big.ts", 2500);
+    const runner = makeMockRunner("2500\t3\tbig.ts", "M\tbig.ts", bigDiff);
+
+    const result = await getAgentDiff(WORKTREE, BASE_REF, runner);
+    const file = result!.files[0]!;
+    expect(file.truncated).toBe(true);
+    expect(file.added).toBe(2500);
+    expect(file.deleted).toBe(3);
+  });
+});
+
+describe("getAgentFileDiff (force load)", () => {
+  it("returns full diff for a truncated file when force-loaded", async () => {
+    const diff = generateDiffLines("big-file.ts", 2500);
+
+    const runner = async (
+      _cmd: string,
+      args: string[],
+      _opts?: {
+        cwd?: string;
+        allowedExitCodes?: number[];
+        timeoutMs?: number;
+      }
+    ): Promise<RunCommandResult> => {
+      const joined = args.join(" ");
+      if (joined.includes("rev-parse --verify")) return ok(BASE_REF);
+      if (joined.includes("merge-base")) return ok(MERGE_BASE_SHA);
+      if (joined.includes("--numstat")) return ok("2500\t0\tbig-file.ts");
+      if (joined.includes("--name-status")) return ok("A\tbig-file.ts");
+      if (joined.includes("-U3")) return ok(diff);
+      return ok();
+    };
+
+    const result = await getAgentFileDiff(
+      WORKTREE,
+      BASE_REF,
+      "big-file.ts",
+      runner
+    );
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe("big-file.ts");
+    expect(result!.diff).toBe(diff);
+    expect(result!.added).toBe(2500);
+  });
+
+  it("returns synthetic diff for untracked file force-load", async () => {
+    const tmpDir = await mkdtemp(
+      path.join(os.tmpdir(), "agent-diff-file-test-")
+    );
+    try {
+      await writeFile(path.join(tmpDir, "new.ts"), "hello\nworld\n");
+
+      const runner = async (
+        _cmd: string,
+        args: string[],
+        _opts?: {
+          cwd?: string;
+          allowedExitCodes?: number[];
+          timeoutMs?: number;
+        }
+      ): Promise<RunCommandResult> => {
+        const joined = args.join(" ");
+        if (joined.includes("rev-parse --verify")) return ok(BASE_REF);
+        if (joined.includes("merge-base")) return ok(MERGE_BASE_SHA);
+        if (joined.includes("--numstat")) return ok("");
+        if (joined.includes("--name-status")) return ok("");
+        if (joined.includes("-U3")) return ok("");
+        return ok();
+      };
+
+      const result = await getAgentFileDiff(tmpDir, BASE_REF, "new.ts", runner);
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe("new.ts");
+      expect(result!.status).toBe("added");
+      expect(result!.added).toBe(2);
+      expect(result!.diff).toContain("+hello");
+      expect(result!.diff).toContain("+world");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,15 +38,18 @@
     "mermaid": "^11.15.0",
     "react": "^18.3.1",
     "react-day-picker": "^9",
+    "react-diff-view": "^3.3.3",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.0",
     "react-slot-counter": "^3.3.3",
     "recharts": "^3.8.1",
+    "refractor": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "simple-icons": "^16.11.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^2.5.4"
+    "tailwind-merge": "^2.5.4",
+    "unidiff": "^1.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -1,6 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import {
+  Routes,
+  Route,
+  useMatch,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
+
+import { ChangesTab } from "@/components/app/changes-tab";
+import { CenterPaneTabBar } from "@/components/app/center-pane-tab-bar";
+import { useAgentDiffStats } from "@/hooks/use-agent-diff-stats";
 
 import { AgentListContent } from "@/components/app/agent-sidebar";
 import {
@@ -43,6 +53,7 @@ import { uploadAgentMedia } from "@/lib/media-upload";
 import { type AgentType, isCliAgentType } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
 import {
+  agentChangesRoute,
   agentFeedbackRoute,
   agentReviewRoute,
   agentRoute,
@@ -92,7 +103,12 @@ export function AgentsView({
   onNavigateSection,
 }: AgentsViewProps): JSX.Element {
   const navigate = useNavigate();
-  const { agentId: routeAgentId, itemId, summaryAgentId } = useParams();
+  const { agentId: routeAgentId } = useParams();
+  const feedbackMatch = useMatch("/agents/:agentId/feedback/:itemId");
+  const reviewMatch = useMatch("/agents/:agentId/review/:summaryAgentId");
+  const changesMatch = useMatch("/agents/:agentId/changes");
+  const itemId = feedbackMatch?.params.itemId;
+  const summaryAgentId = reviewMatch?.params.summaryAgentId;
 
   const [sharedConnectedAgentId, setSharedConnectedAgentId] = useState<
     string | null
@@ -247,6 +263,23 @@ export function AgentsView({
   }, [focusedAgentHasStream, setMediaOpen]);
 
   useAgentFocus(focusedAgentId, "authenticated");
+
+  const onTabChange = useCallback(
+    (tab: "terminal" | "changes") => {
+      if (!routeAgentId) return;
+      navigate(
+        tab === "changes"
+          ? agentChangesRoute(routeAgentId)
+          : agentRoute(routeAgentId),
+        { replace: true }
+      );
+    },
+    [navigate, routeAgentId]
+  );
+  const { diffStats: focusedDiffStats } = useAgentDiffStats(
+    focusedAgentId ?? "",
+    !!focusedAgentId
+  );
 
   const prevLeftOpenRef = useRef(leftPanelOpen);
   const prevMediaOpenRef = useRef(mediaPanelOpen);
@@ -571,16 +604,23 @@ export function AgentsView({
                 </TipSpot>
               </div>
               <div className="relative h-full min-h-0 min-w-0 pb-14 pt-14">
-                {focusedAgent?.name ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 items-center justify-center px-16">
-                    <div
-                      data-testid="current-session-name"
-                      className="max-w-full truncate text-center text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground"
-                    >
-                      {focusedAgent.name}
-                    </div>
-                  </div>
-                ) : null}
+                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-14 flex-col items-center justify-center bg-background px-16">
+                  {focusedAgent?.name ? (
+                    <>
+                      <span
+                        data-testid="current-session-name"
+                        className="sr-only"
+                      >
+                        {focusedAgent.name}
+                      </span>
+                      <CenterPaneTabBar
+                        activeTab={changesMatch ? "changes" : "terminal"}
+                        onTabChange={onTabChange}
+                        diffStats={focusedDiffStats}
+                      />
+                    </>
+                  ) : null}
+                </div>
                 {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
                   <div className="pointer-events-none absolute right-3 top-3 z-10">
                     <Button
@@ -605,22 +645,32 @@ export function AgentsView({
                     <div className="dispatch-reconnect-scan h-full w-1/3 will-change-transform bg-[linear-gradient(to_right,transparent,hsl(var(--status-blocked)),hsl(var(--status-waiting)),hsl(var(--status-working)),hsl(var(--status-done)),transparent)] saturate-[1.35] brightness-[1.05] animate-[reconnect-scan_1350ms_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:translate-x-[140%]" />
                   </div>
                 ) : null}
-                <TerminalPane
-                  isAttached={isAttached}
-                  connState={connState}
-                  statusMessage={statusMessage}
-                  terminalMode={terminalMode}
-                  terminalPlaceholderMessage={terminalPlaceholderMessage}
-                  terminalHostRef={terminalHostRef}
-                  resyncing={resyncing}
-                  draggingFiles={draggingFiles}
-                  uploadingFiles={uploadingFiles}
-                  archivePhase={
-                    selectedAgent?.status === "archiving"
-                      ? selectedAgent.archivePhase
-                      : null
-                  }
-                />
+                <div className={cn("h-full", changesMatch && "hidden")}>
+                  <TerminalPane
+                    isAttached={isAttached}
+                    connState={connState}
+                    statusMessage={statusMessage}
+                    terminalMode={terminalMode}
+                    terminalPlaceholderMessage={terminalPlaceholderMessage}
+                    terminalHostRef={terminalHostRef}
+                    resyncing={resyncing}
+                    draggingFiles={draggingFiles}
+                    uploadingFiles={uploadingFiles}
+                    archivePhase={
+                      selectedAgent?.status === "archiving"
+                        ? selectedAgent.archivePhase
+                        : null
+                    }
+                  />
+                </div>
+                <Routes>
+                  <Route
+                    path="changes"
+                    element={
+                      <ChangesTab agentId={focusedAgentId} active={true} />
+                    }
+                  />
+                </Routes>
                 {!isMobile ? (
                   <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-14">
                     <AmbientTipBar />

--- a/apps/web/src/components/app/center-pane-tab-bar.tsx
+++ b/apps/web/src/components/app/center-pane-tab-bar.tsx
@@ -20,9 +20,11 @@ export const CenterPaneTabBar = memo(function CenterPaneTabBar({
     diffStats && (diffStats.added > 0 || diffStats.deleted > 0);
 
   return (
-    <div className="pointer-events-auto flex items-center">
+    <div role="tablist" className="pointer-events-auto flex items-center">
       <button
         type="button"
+        role="tab"
+        aria-selected={activeTab === "terminal"}
         data-testid="center-tab-terminal"
         className={cn(
           "px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors",
@@ -41,6 +43,8 @@ export const CenterPaneTabBar = memo(function CenterPaneTabBar({
       </button>
       <button
         type="button"
+        role="tab"
+        aria-selected={activeTab === "changes"}
         data-testid="center-tab-changes"
         className={cn(
           "flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors",

--- a/apps/web/src/components/app/center-pane-tab-bar.tsx
+++ b/apps/web/src/components/app/center-pane-tab-bar.tsx
@@ -1,0 +1,68 @@
+import { memo } from "react";
+
+import type { DiffStats } from "@/components/app/types";
+import { cn } from "@/lib/utils";
+
+type CenterTab = "terminal" | "changes";
+
+type CenterPaneTabBarProps = {
+  activeTab: CenterTab;
+  onTabChange: (tab: CenterTab) => void;
+  diffStats: DiffStats | null | undefined;
+};
+
+export const CenterPaneTabBar = memo(function CenterPaneTabBar({
+  activeTab,
+  onTabChange,
+  diffStats,
+}: CenterPaneTabBarProps): JSX.Element {
+  const hasChanges =
+    diffStats && (diffStats.added > 0 || diffStats.deleted > 0);
+
+  return (
+    <div className="pointer-events-auto flex items-center">
+      <button
+        type="button"
+        data-testid="center-tab-terminal"
+        className={cn(
+          "px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors",
+          activeTab === "terminal"
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground/80"
+        )}
+        onClick={() => onTabChange("terminal")}
+      >
+        <span className="relative pb-1.5 -mb-1.5">
+          Terminal
+          {activeTab === "terminal" ? (
+            <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-foreground" />
+          ) : null}
+        </span>
+      </button>
+      <button
+        type="button"
+        data-testid="center-tab-changes"
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors",
+          activeTab === "changes"
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground/80"
+        )}
+        onClick={() => onTabChange("changes")}
+      >
+        <span className="relative pb-1.5 -mb-1.5">
+          Changes
+          {activeTab === "changes" ? (
+            <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-foreground" />
+          ) : null}
+        </span>
+        {hasChanges ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-border/50 bg-muted/30 px-1.5 py-0 font-mono text-[10px] font-normal normal-case tracking-normal">
+            <span className="text-status-working">+{diffStats.added}</span>
+            <span className="text-status-blocked">−{diffStats.deleted}</span>
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+});

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -43,6 +43,7 @@ export const ChangesTab = memo(function ChangesTab({
 }: ChangesTabProps): JSX.Element {
   const { data, isLoading } = useAgentDiff(agentId, active);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const files = useMemo(
@@ -51,6 +52,7 @@ export const ChangesTab = memo(function ChangesTab({
   );
 
   const scrollToFile = useCallback((path: string) => {
+    setSelectedFile(path);
     const el = fileRefs.current.get(path);
     if (el) {
       el.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -85,7 +87,11 @@ export const ChangesTab = memo(function ChangesTab({
 
   return (
     <div className="flex h-full min-h-0">
-      <FileTree files={files} selectedFile={null} onSelectFile={scrollToFile} />
+      <FileTree
+        files={files}
+        selectedFile={selectedFile}
+        onSelectFile={scrollToFile}
+      />
       <DiffPane
         agentId={agentId}
         files={files}
@@ -260,6 +266,7 @@ function TreeEntry({
           type="button"
           className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs text-muted-foreground hover:bg-muted/40"
           style={{ paddingLeft: `${indent}px` }}
+          title={node.name}
           onClick={() => onToggleDir(node.path)}
         >
           {isCollapsed ? (
@@ -308,6 +315,7 @@ function TreeEntry({
         isSelected && "bg-muted/60 text-foreground"
       )}
       style={{ paddingLeft: `${indent}px` }}
+      title={node.file.path}
       onClick={() => onSelectFile(node.file!.path)}
     >
       {treeFileIcon(node.file)}
@@ -369,13 +377,10 @@ function FileDiffSection({
   setRef,
 }: FileDiffSectionProps): JSX.Element {
   return (
-    <div
-      ref={setRef}
-      className="overflow-hidden rounded-md border border-border/50"
-    >
+    <div ref={setRef} className="rounded-md border border-border/50">
       <button
         type="button"
-        className="sticky top-0 z-10 flex w-full items-center gap-2 border-b border-border/50 bg-muted/40 px-3 py-2 text-left text-xs hover:bg-muted/60"
+        className="sticky top-0 z-10 flex w-full items-center gap-2 rounded-t-md border-b border-border/50 bg-muted/40 px-3 py-2 text-left text-xs hover:bg-muted/60"
         onClick={onToggleCollapse}
       >
         {collapsed ? (

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -1,0 +1,585 @@
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileCode2,
+  FileDiff,
+  FileMinus,
+  FilePlus,
+  FileText,
+  Loader2,
+} from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Diff, Hunk, parseDiff, tokenize } from "react-diff-view";
+import "react-diff-view/style/index.css";
+import { refractor as baseRefractor } from "refractor";
+
+const refractorAdapter = {
+  highlight(code: string, language: string) {
+    const root = baseRefractor.highlight(code, language);
+    return root.children;
+  },
+  registered(language: string) {
+    return baseRefractor.registered(language);
+  },
+};
+
+import {
+  useAgentDiff,
+  useAgentFileDiff,
+  type DiffFile,
+  type DiffFileStatus,
+} from "@/hooks/use-agent-diff";
+import { cn } from "@/lib/utils";
+
+type ChangesTabProps = {
+  agentId: string | null;
+  active: boolean;
+};
+
+export const ChangesTab = memo(function ChangesTab({
+  agentId,
+  active,
+}: ChangesTabProps): JSX.Element {
+  const { data, isLoading } = useAgentDiff(agentId, active);
+  const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const files = useMemo(
+    () => [...(data?.files ?? [])].sort((a, b) => a.path.localeCompare(b.path)),
+    [data?.files]
+  );
+
+  const scrollToFile = useCallback((path: string) => {
+    const el = fileRefs.current.get(path);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    setCollapsedFiles((prev) => {
+      if (!prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.delete(path);
+      return next;
+    });
+  }, []);
+
+  if (!active) return <div />;
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        <span className="text-sm">Loading changes…</span>
+      </div>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <FileDiff className="h-8 w-8" />
+        <p className="text-sm">No changes yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      <FileTree files={files} selectedFile={null} onSelectFile={scrollToFile} />
+      <DiffPane
+        agentId={agentId}
+        files={files}
+        collapsedFiles={collapsedFiles}
+        onToggleCollapse={(path) => {
+          setCollapsedFiles((prev) => {
+            const next = new Set(prev);
+            if (next.has(path)) {
+              next.delete(path);
+            } else {
+              next.add(path);
+            }
+            return next;
+          });
+        }}
+        fileRefs={fileRefs}
+      />
+    </div>
+  );
+});
+
+function statusIcon(status: DiffFileStatus): JSX.Element {
+  switch (status) {
+    case "added":
+      return <FilePlus className="h-3.5 w-3.5 text-status-working" />;
+    case "deleted":
+      return <FileMinus className="h-3.5 w-3.5 text-status-blocked" />;
+    case "renamed":
+      return <FileCode2 className="h-3.5 w-3.5 text-purple-400" />;
+    default:
+      return <FileText className="h-3.5 w-3.5 text-muted-foreground" />;
+  }
+}
+
+function treeFileIcon(file: DiffFile): JSX.Element {
+  if (file.status === "renamed")
+    return <FileCode2 className="h-3.5 w-3.5 text-purple-400" />;
+  if (file.status === "deleted" || (file.deleted > 0 && file.added === 0))
+    return <FileMinus className="h-3.5 w-3.5 text-status-blocked" />;
+  if (file.status === "added" || (file.added > 0 && file.deleted === 0))
+    return <FilePlus className="h-3.5 w-3.5 text-status-working" />;
+  return <FileDiff className="h-3.5 w-3.5 text-muted-foreground" />;
+}
+
+type FileTreeProps = {
+  files: DiffFile[];
+  selectedFile: string | null;
+  onSelectFile: (path: string) => void;
+};
+
+type TreeNode = {
+  name: string;
+  path: string;
+  file?: DiffFile;
+  children: Map<string, TreeNode>;
+};
+
+function buildTree(files: DiffFile[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", children: new Map() };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let node = root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]!;
+      const partPath = parts.slice(0, i + 1).join("/");
+      if (!node.children.has(part)) {
+        node.children.set(part, {
+          name: part,
+          path: partPath,
+          children: new Map(),
+        });
+      }
+      node = node.children.get(part)!;
+    }
+    node.file = file;
+  }
+  return collapseTree(root);
+}
+
+function collapseTree(node: TreeNode): TreeNode {
+  if (node.children.size === 1 && !node.file) {
+    const child = [...node.children.values()][0]!;
+    if (child.file && child.children.size === 0) {
+      const newChildren = new Map<string, TreeNode>();
+      newChildren.set(child.name, child);
+      return { ...node, children: newChildren };
+    }
+    const collapsed: TreeNode = {
+      name: node.name ? `${node.name}/${child.name}` : child.name,
+      path: child.path,
+      file: child.file,
+      children: child.children,
+    };
+    return collapseTree(collapsed);
+  }
+  const newChildren = new Map<string, TreeNode>();
+  for (const [key, child] of node.children) {
+    newChildren.set(key, collapseTree(child));
+  }
+  return { ...node, children: newChildren };
+}
+
+function FileTree({
+  files,
+  selectedFile,
+  onSelectFile,
+}: FileTreeProps): JSX.Element {
+  const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set());
+  const tree = useMemo(() => buildTree(files), [files]);
+
+  const toggleDir = useCallback((path: string) => {
+    setCollapsedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="flex w-56 shrink-0 flex-col border-r border-border/50 bg-muted/20">
+      <div className="shrink-0 border-b border-border/40 bg-muted/30 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {files.length} file{files.length !== 1 ? "s" : ""} changed
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {(tree.file ? [tree] : [...tree.children.values()]).map((child) => (
+          <TreeEntry
+            key={child.path}
+            node={child}
+            depth={0}
+            selectedFile={selectedFile}
+            onSelectFile={onSelectFile}
+            collapsedDirs={collapsedDirs}
+            onToggleDir={toggleDir}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type TreeEntryProps = {
+  node: TreeNode;
+  depth: number;
+  selectedFile: string | null;
+  onSelectFile: (path: string) => void;
+  collapsedDirs: Set<string>;
+  onToggleDir: (path: string) => void;
+};
+
+function TreeEntry({
+  node,
+  depth,
+  selectedFile,
+  onSelectFile,
+  collapsedDirs,
+  onToggleDir,
+}: TreeEntryProps): JSX.Element {
+  const isDir = node.children.size > 0 && !node.file;
+  const isCollapsed = collapsedDirs.has(node.path);
+  const isSelected = node.file && selectedFile === node.file.path;
+
+  const indent = depth * 16 + 8;
+
+  if (isDir) {
+    return (
+      <>
+        <button
+          type="button"
+          className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs text-muted-foreground hover:bg-muted/40"
+          style={{ paddingLeft: `${indent}px` }}
+          onClick={() => onToggleDir(node.path)}
+        >
+          {isCollapsed ? (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          )}
+          <span className="truncate">{node.name}</span>
+        </button>
+        <AnimatePresence initial={false}>
+          {!isCollapsed && (
+            <motion.div
+              key="children"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.15, ease: "easeInOut" }}
+              className="overflow-hidden border-l border-border"
+              style={{ marginLeft: `${indent + 7}px` }}
+            >
+              {[...node.children.values()].map((child) => (
+                <TreeEntry
+                  key={child.path}
+                  node={child}
+                  depth={0}
+                  selectedFile={selectedFile}
+                  onSelectFile={onSelectFile}
+                  collapsedDirs={collapsedDirs}
+                  onToggleDir={onToggleDir}
+                />
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </>
+    );
+  }
+
+  if (!node.file) return <></>;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-muted/40",
+        isSelected && "bg-muted/60 text-foreground"
+      )}
+      style={{ paddingLeft: `${indent}px` }}
+      onClick={() => onSelectFile(node.file!.path)}
+    >
+      {treeFileIcon(node.file)}
+      <span className="min-w-0 flex-1 truncate">{node.name}</span>
+    </button>
+  );
+}
+
+type DiffPaneProps = {
+  agentId: string | null;
+  files: DiffFile[];
+  collapsedFiles: Set<string>;
+  onToggleCollapse: (path: string) => void;
+  fileRefs: React.RefObject<Map<string, HTMLDivElement> | null>;
+};
+
+function DiffPane({
+  agentId,
+  files,
+  collapsedFiles,
+  onToggleCollapse,
+  fileRefs,
+}: DiffPaneProps): JSX.Element {
+  return (
+    <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3">
+      {files.map((file) => (
+        <FileDiffSection
+          key={file.path}
+          agentId={agentId}
+          file={file}
+          collapsed={collapsedFiles.has(file.path)}
+          onToggleCollapse={() => onToggleCollapse(file.path)}
+          setRef={(el) => {
+            if (el) {
+              fileRefs.current?.set(file.path, el);
+            } else {
+              fileRefs.current?.delete(file.path);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+type FileDiffSectionProps = {
+  agentId: string | null;
+  file: DiffFile;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  setRef: (el: HTMLDivElement | null) => void;
+};
+
+function FileDiffSection({
+  agentId,
+  file,
+  collapsed,
+  onToggleCollapse,
+  setRef,
+}: FileDiffSectionProps): JSX.Element {
+  return (
+    <div
+      ref={setRef}
+      className="overflow-hidden rounded-md border border-border/50"
+    >
+      <button
+        type="button"
+        className="sticky top-0 z-10 flex w-full items-center gap-2 border-b border-border/50 bg-muted/40 px-3 py-2 text-left text-xs hover:bg-muted/60"
+        onClick={onToggleCollapse}
+      >
+        {collapsed ? (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        {statusIcon(file.status)}
+        <span className="min-w-0 flex-1 truncate font-mono text-xs">
+          {file.oldPath ? (
+            <>
+              <span className="text-muted-foreground">{file.oldPath}</span>
+              <span className="text-muted-foreground"> → </span>
+            </>
+          ) : null}
+          {file.path}
+        </span>
+        <span className="ml-auto shrink-0 font-mono text-[10px]">
+          {file.added > 0 ? (
+            <span className="text-status-working">+{file.added}</span>
+          ) : null}
+          {file.deleted > 0 ? (
+            <span className="ml-1 text-status-blocked">−{file.deleted}</span>
+          ) : null}
+        </span>
+      </button>
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <FileDiffContent agentId={agentId} file={file} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+type FileDiffContentProps = {
+  agentId: string | null;
+  file: DiffFile;
+};
+
+function FileDiffContent({ agentId, file }: FileDiffContentProps): JSX.Element {
+  const [forceLoad, setForceLoad] = useState(false);
+  const { data: fileDiffData, isLoading: fileDiffLoading } = useAgentFileDiff(
+    agentId,
+    file.path,
+    file.truncated && forceLoad
+  );
+
+  const diffText = file.truncated
+    ? forceLoad
+      ? (fileDiffData?.diff ?? null)
+      : null
+    : file.diff;
+
+  if (file.truncated && !forceLoad) {
+    return (
+      <div className="flex items-center justify-between bg-muted/10 px-4 py-3 text-xs text-muted-foreground">
+        <span>
+          Large file ({file.added > 0 ? `+${file.added}` : ""}
+          {file.deleted > 0 ? ` −${file.deleted}` : ""}) — diff truncated
+        </span>
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-0.5 text-xs text-foreground hover:bg-muted/40"
+          onClick={() => setForceLoad(true)}
+        >
+          Load diff
+        </button>
+      </div>
+    );
+  }
+
+  if (file.truncated && forceLoad && fileDiffLoading) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading…
+      </div>
+    );
+  }
+
+  if (!diffText) {
+    return (
+      <div className="px-4 py-3 text-xs text-muted-foreground">
+        {file.status === "deleted"
+          ? "File deleted"
+          : "Binary file or no textual diff available"}
+      </div>
+    );
+  }
+
+  return <UnifiedDiffView diffText={diffText} filePath={file.path} />;
+}
+
+const EXT_TO_LANGUAGE: Record<string, string> = {
+  ts: "typescript",
+  tsx: "tsx",
+  js: "javascript",
+  jsx: "jsx",
+  json: "json",
+  css: "css",
+  scss: "css",
+  html: "markup",
+  md: "markdown",
+  yaml: "yaml",
+  yml: "yaml",
+  sql: "sql",
+  sh: "bash",
+  bash: "bash",
+  py: "python",
+  rs: "rust",
+  go: "go",
+  rb: "ruby",
+  java: "java",
+  swift: "swift",
+  kt: "kotlin",
+  c: "c",
+  cpp: "cpp",
+  h: "c",
+  hpp: "cpp",
+};
+
+function languageFromPath(filePath: string): string | null {
+  const ext = filePath.split(".").pop()?.toLowerCase();
+  if (!ext) return null;
+  const lang = EXT_TO_LANGUAGE[ext];
+  if (!lang) return null;
+  if (!refractorAdapter.registered(lang)) return null;
+  return lang;
+}
+
+type UnifiedDiffViewProps = {
+  diffText: string;
+  filePath: string;
+};
+
+const UnifiedDiffView = memo(function UnifiedDiffView({
+  diffText,
+  filePath,
+}: UnifiedDiffViewProps): JSX.Element {
+  const parsed = useMemo(() => {
+    try {
+      return parseDiff(diffText, { nearbySequences: "zip" });
+    } catch {
+      return [];
+    }
+  }, [diffText]);
+
+  const language = useMemo(() => languageFromPath(filePath), [filePath]);
+
+  const tokens = useMemo(() => {
+    if (parsed.length === 0) return undefined;
+    const file = parsed[0]!;
+    if (!language) return undefined;
+    try {
+      return tokenize(file.hunks, {
+        highlight: true,
+        refractor: refractorAdapter,
+        language,
+      });
+    } catch {
+      return undefined;
+    }
+  }, [parsed, language]);
+
+  if (parsed.length === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-muted-foreground">
+        Unable to parse diff
+      </div>
+    );
+  }
+
+  const file = parsed[0]!;
+  const diffType =
+    file.type === "add"
+      ? "add"
+      : file.type === "delete"
+        ? "delete"
+        : file.type === "rename"
+          ? "rename"
+          : "modify";
+
+  return (
+    <div className="changes-diff-view overflow-x-auto text-xs">
+      <Diff
+        viewType="unified"
+        diffType={diffType}
+        hunks={file.hunks}
+        tokens={tokens}
+      >
+        {(hunks) =>
+          hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)
+        }
+      </Diff>
+    </div>
+  );
+});

--- a/apps/web/src/hooks/use-agent-diff.ts
+++ b/apps/web/src/hooks/use-agent-diff.ts
@@ -1,0 +1,87 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+
+export type DiffFileStatus = "modified" | "added" | "deleted" | "renamed";
+
+export type DiffFile = {
+  path: string;
+  status: DiffFileStatus;
+  oldPath?: string;
+  added: number;
+  deleted: number;
+  diff: string | null;
+  truncated: boolean;
+};
+
+export type DiffResponse = {
+  baseRef: string | null;
+  files: DiffFile[];
+};
+
+export type FileDiffResponse = {
+  path: string;
+  status: DiffFileStatus;
+  oldPath?: string;
+  added: number;
+  deleted: number;
+  diff: string;
+};
+
+export function agentDiffQueryKey(agentId: string): [string, string] {
+  return ["agent-diff-content", agentId];
+}
+
+export function useAgentDiff(
+  agentId: string | null,
+  enabled: boolean
+): {
+  data: DiffResponse | undefined;
+  isLoading: boolean;
+  refresh: () => void;
+} {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<DiffResponse>({
+    queryKey: agentDiffQueryKey(agentId ?? ""),
+    queryFn: async () => {
+      return api<DiffResponse>(`/api/v1/agents/${agentId}/diff`);
+    },
+    enabled: enabled && !!agentId,
+    refetchOnWindowFocus: true,
+    staleTime: 5_000,
+  });
+
+  const refresh = useCallback(() => {
+    if (agentId) {
+      void queryClient.invalidateQueries({
+        queryKey: agentDiffQueryKey(agentId),
+      });
+    }
+  }, [agentId, queryClient]);
+
+  return { data: query.data, isLoading: query.isLoading, refresh };
+}
+
+export function useAgentFileDiff(
+  agentId: string | null,
+  filePath: string | null,
+  enabled: boolean
+): {
+  data: FileDiffResponse | undefined;
+  isLoading: boolean;
+} {
+  const query = useQuery<FileDiffResponse>({
+    queryKey: ["agent-diff-file", agentId, filePath],
+    queryFn: async () => {
+      return api<FileDiffResponse>(
+        `/api/v1/agents/${agentId}/diff/file?path=${encodeURIComponent(filePath!)}&force=true`
+      );
+    },
+    enabled: enabled && !!agentId && !!filePath,
+    staleTime: 10_000,
+  });
+
+  return { data: query.data, isLoading: query.isLoading };
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -7,6 +7,7 @@ import {
   type MediaFile,
   type TerminalUiState,
 } from "@/components/app/types";
+import { agentDiffQueryKey } from "@/hooks/use-agent-diff";
 import { diffStatsQueryKey } from "@/hooks/use-agent-diff-stats";
 import { sortAgentsByCreatedAtDesc } from "@/lib/agent-sort";
 import { recordSSEEvent, recordSSEReconnect } from "@/lib/energy-metrics";
@@ -121,6 +122,9 @@ export function useSSE(authState: AuthState): void {
             diffStatsQueryKey(payload.agentId),
             payload.diffStats
           );
+          void queryClient.invalidateQueries({
+            queryKey: agentDiffQueryKey(payload.agentId),
+          });
           return;
         }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1161,3 +1161,105 @@ html[data-hidden] .animate-sidebar-nav-pulse {
   -webkit-backdrop-filter: none !important;
   animation-duration: 300ms !important;
 }
+
+/* react-diff-view dark theme overrides */
+.changes-diff-view .diff {
+  font-family: var(--font-terminal);
+  font-size: 12px;
+  line-height: 1.5;
+  color: hsl(var(--foreground));
+  border: none;
+}
+.changes-diff-view .diff-gutter-col {
+  width: 50px;
+}
+.changes-diff-view .diff-gutter {
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--muted) / 0.3);
+  border-right: 1px solid hsl(var(--border) / 0.4);
+  padding: 0 8px;
+  text-align: right;
+  cursor: default;
+  user-select: none;
+}
+.changes-diff-view .diff-code {
+  background: transparent;
+  padding: 0 12px;
+  white-space: pre;
+}
+.changes-diff-view .diff-code-insert {
+  background: hsl(158 64% 52% / 0.08);
+}
+.changes-diff-view .diff-code-delete {
+  background: hsl(0 84% 60% / 0.08);
+}
+.changes-diff-view .diff-gutter-insert {
+  background: hsl(158 64% 52% / 0.12);
+  color: hsl(var(--status-working));
+}
+.changes-diff-view .diff-gutter-delete {
+  background: hsl(0 84% 60% / 0.12);
+  color: hsl(var(--status-blocked));
+}
+.changes-diff-view .diff-hunk-header {
+  background: hsl(var(--muted) / 0.5);
+  color: hsl(var(--muted-foreground));
+}
+.changes-diff-view .diff-hunk-header-gutter {
+  background: hsl(var(--muted) / 0.5);
+}
+.changes-diff-view .diff-hunk-header-content {
+  padding: 4px 12px;
+}
+
+/* Syntax highlighting tokens (refractor/Prism) */
+.changes-diff-view .token.comment,
+.changes-diff-view .token.prolog,
+.changes-diff-view .token.doctype,
+.changes-diff-view .token.cdata {
+  color: #6a737d;
+}
+.changes-diff-view .token.punctuation {
+  color: #b3b9c5;
+}
+.changes-diff-view .token.property,
+.changes-diff-view .token.tag,
+.changes-diff-view .token.constant,
+.changes-diff-view .token.symbol,
+.changes-diff-view .token.deleted {
+  color: #f97583;
+}
+.changes-diff-view .token.boolean,
+.changes-diff-view .token.number {
+  color: #79b8ff;
+}
+.changes-diff-view .token.selector,
+.changes-diff-view .token.attr-name,
+.changes-diff-view .token.string,
+.changes-diff-view .token.char,
+.changes-diff-view .token.builtin,
+.changes-diff-view .token.inserted {
+  color: #9ecbff;
+}
+.changes-diff-view .token.operator,
+.changes-diff-view .token.entity,
+.changes-diff-view .token.url {
+  color: #b3b9c5;
+}
+.changes-diff-view .token.atrule,
+.changes-diff-view .token.attr-value,
+.changes-diff-view .token.keyword {
+  color: #f97583;
+}
+.changes-diff-view .token.function,
+.changes-diff-view .token.class-name {
+  color: #b392f0;
+}
+.changes-diff-view .token.regex,
+.changes-diff-view .token.important,
+.changes-diff-view .token.variable {
+  color: #ffab70;
+}
+.changes-diff-view .token.template-string .token.interpolation {
+  color: #ffab70;
+}

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -2,6 +2,10 @@ export function agentRoute(agentId: string): string {
   return `/agents/${agentId}`;
 }
 
+export function agentChangesRoute(agentId: string): string {
+  return `/agents/${agentId}/changes`;
+}
+
 export function agentFeedbackRoute(agentId: string, itemId: number): string {
   return `/agents/${agentId}/feedback/${itemId}`;
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -36,17 +36,7 @@ export const router = createBrowserRouter([
                 handle: { navSection: "agents" },
               },
               {
-                path: "agents/:agentId",
-                element: <AgentsRoute />,
-                handle: { navSection: "agents" },
-              },
-              {
-                path: "agents/:agentId/feedback/:itemId",
-                element: <AgentsRoute />,
-                handle: { navSection: "agents" },
-              },
-              {
-                path: "agents/:agentId/review/:summaryAgentId",
+                path: "agents/:agentId/*",
                 element: <AgentsRoute />,
                 handle: { navSection: "agents" },
               },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       react-day-picker:
         specifier: ^9
         version: 9.14.0(react@18.3.1)
+      react-diff-view:
+        specifier: ^3.3.3
+        version: 3.3.3(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -187,7 +190,10 @@ importers:
         version: 3.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^3.8.1
-        version: 3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1)
+        version: 3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1)
+      refractor:
+        specifier: ^5.0.0
+        version: 5.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -200,6 +206,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.1
+      unidiff:
+        specifier: ^1.0.4
+        version: 1.0.4
     devDependencies:
       "@eslint/js":
         specifier: ^9.39.4
@@ -3631,6 +3640,12 @@ packages:
         integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==,
       }
 
+  "@types/prismjs@1.26.6":
+    resolution:
+      {
+        integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==,
+      }
+
   "@types/prop-types@15.7.15":
     resolution:
       {
@@ -4439,6 +4454,12 @@ packages:
         integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==,
       }
 
+  classnames@2.5.1:
+    resolution:
+      {
+        integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==,
+      }
+
   cli-cursor@5.0.0:
     resolution:
       {
@@ -5097,6 +5118,19 @@ packages:
       {
         integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
       }
+
+  diff-match-patch@1.0.5:
+    resolution:
+      {
+        integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==,
+      }
+
+  diff@5.2.2:
+    resolution:
+      {
+        integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==,
+      }
+    engines: { node: ">=0.3.1" }
 
   dlv@1.1.3:
     resolution:
@@ -5815,6 +5849,12 @@ packages:
         integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
       }
 
+  gitdiff-parser@0.3.1:
+    resolution:
+      {
+        integrity: sha512-YQJnY8aew65id8okGxKCksH3efDCJ9HzV7M9rsvd65habf39Pkh4cgYJ27AaoDMqo1X98pgNJhNMrm/kpV7UVQ==,
+      }
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -5941,6 +5981,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  hast-util-parse-selector@4.0.0:
+    resolution:
+      {
+        integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==,
+      }
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution:
       {
@@ -5951,6 +5997,12 @@ packages:
     resolution:
       {
         integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
+      }
+
+  hastscript@9.0.1:
+    resolution:
+      {
+        integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==,
       }
 
   highlight.js@11.11.1:
@@ -7870,6 +7922,14 @@ packages:
     peerDependencies:
       react: ">=16.8.0"
 
+  react-diff-view@3.3.3:
+    resolution:
+      {
+        integrity: sha512-CPveApk6n7ZbkW7T6PoptR7LWAvD9hohTHZ7WnKnu3GZkTfUB5rvg486apPo94iYVi4fZd3Nt+rtBZ5877exoQ==,
+      }
+    peerDependencies:
+      react: ">=16.14.0"
+
   react-dom@18.3.1:
     resolution:
       {
@@ -8058,6 +8118,12 @@ packages:
         integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
       }
     engines: { node: ">= 0.4" }
+
+  refractor@5.0.0:
+    resolution:
+      {
+        integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==,
+      }
 
   regenerate-unicode-properties@10.2.2:
     resolution:
@@ -8378,6 +8444,12 @@ packages:
     resolution:
       {
         integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
+
+  shallow-equal@3.1.0:
+    resolution:
+      {
+        integrity: sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==,
       }
 
   sharp@0.34.5:
@@ -9078,6 +9150,12 @@ packages:
       }
     engines: { node: ">=4" }
 
+  unidiff@1.0.4:
+    resolution:
+      {
+        integrity: sha512-ynU0vsAXw0ir8roa+xPCUHmnJ5goc5BTM2Kuc3IJd8UwgaeRs7VSD5+eeaQL+xp1JtB92hu/Zy/Lgy7RZcr1pQ==,
+      }
+
   unified@11.0.5:
     resolution:
       {
@@ -9401,6 +9479,12 @@ packages:
         integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
       }
     engines: { node: ">=18" }
+
+  warning@4.0.3:
+    resolution:
+      {
+        integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==,
+      }
 
   webidl-conversions@4.0.2:
     resolution:
@@ -11808,6 +11892,8 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
+  "@types/prismjs@1.26.6": {}
+
   "@types/prop-types@15.7.15": {}
 
   "@types/react-dom@18.3.7(@types/react@18.3.28)":
@@ -12377,6 +12463,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classnames@2.5.1: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -12746,6 +12834,10 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-match-patch@1.0.5: {}
+
+  diff@5.2.2: {}
 
   dlv@1.1.3: {}
 
@@ -13354,6 +13446,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
     optional: true
 
+  gitdiff-parser@0.3.1: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -13424,6 +13518,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      "@types/hast": 3.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       "@types/estree": 1.0.8
@@ -13447,6 +13545,14 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       "@types/hast": 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      "@types/hast": 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   highlight.js@11.11.1: {}
 
@@ -14692,6 +14798,16 @@ snapshots:
       date-fns-jalali: 4.1.0-0
       react: 18.3.1
 
+  react-diff-view@3.3.3(react@18.3.1):
+    dependencies:
+      classnames: 2.5.1
+      diff-match-patch: 1.0.5
+      gitdiff-parser: 0.3.1
+      lodash: 4.17.23
+      react: 18.3.1
+      shallow-equal: 3.1.0
+      warning: 4.0.3
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -14797,7 +14913,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1):
+  recharts@3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1):
     dependencies:
       "@reduxjs/toolkit": 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       clsx: 2.1.1
@@ -14807,7 +14923,7 @@ snapshots:
       immer: 10.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -14833,6 +14949,13 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  refractor@5.0.0:
+    dependencies:
+      "@types/hast": 3.0.4
+      "@types/prismjs": 1.26.6
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -15092,6 +15215,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
+
+  shallow-equal@3.1.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -15559,6 +15684,10 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unidiff@1.0.4:
+    dependencies:
+      diff: 5.2.2
+
   unified@11.0.5:
     dependencies:
       "@types/unist": 3.0.3
@@ -15788,6 +15917,10 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   webidl-conversions@4.0.2: {}
 


### PR DESCRIPTION
## Summary

- Adds a **Changes** tab to the agent detail center pane showing GitHub-style unified diffs with syntax highlighting, a collapsible file tree, and file-level stats
- URL-driven tab state via React Router descendant routes (`/agents/:agentId/changes`) — removes the old `centerTab` concept
- Backend diff engine (`agent-diff.ts`) with support for untracked files, git rename brace syntax, per-file truncation (2K lines / 100KB), and force-load for truncated files
- Shared `diff-file-rules.ts` module ensures sidebar diff stats and Changes tab use identical accounting (lock file exclusion, binary detection, line counting)
- Security hardening: path traversal guard (route-level + containment check), sequential fd usage for untracked reads, 1,000-file response cap
- Accessibility: ARIA tab semantics, title tooltips on truncated tree entries, sticky file headers, selected-file highlight

## Test plan

- [x] 17 unit tests covering truncation, renames, untracked files, stats consistency, and force-load
- [x] Type checking passes (`pnpm run check`)
- [x] E2E tests pass (126/127, 1 pre-existing brains-page flake)
- [x] Architecture review — approved (rename handling, shared module, component split deferred)
- [x] Backend security review — approved (path traversal, fd exhaustion, file cap)
- [x] Frontend UX review — approved (sticky headers, selection, tooltips, ARIA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)