### PR TITLE
Add quick comment to diff viewer (Phase 2)

### DIFF
--- a/apps/server/src/routes/agents/lifecycle-routes.ts
+++ b/apps/server/src/routes/agents/lifecycle-routes.ts
@@ -398,4 +398,145 @@ export async function registerAgentLifecycleRoutes(
       return reply.code(500).send({ error: "Failed to compute file diff." });
     }
   });
+
+  app.post("/api/v1/agents/:id/diff/comment", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const body = request.body as {
+      filePath?: string;
+      startLine?: number;
+      endLine?: number;
+      comment?: string;
+    } | null;
+
+    if (
+      !body?.filePath ||
+      typeof body.startLine !== "number" ||
+      typeof body.endLine !== "number" ||
+      !body.comment?.trim()
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "filePath, startLine, endLine, and comment required." });
+    }
+
+    if (body.filePath.includes("..")) {
+      return reply.code(400).send({ error: "Invalid file path." });
+    }
+
+    if (
+      body.startLine < 1 ||
+      body.endLine < body.startLine ||
+      !Number.isInteger(body.startLine) ||
+      !Number.isInteger(body.endLine)
+    ) {
+      return reply.code(400).send({ error: "Invalid line range." });
+    }
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    const gitContextWorktreePath = agent.gitContext?.isWorktree
+      ? agent.gitContext.worktreePath
+      : null;
+    const worktreePath =
+      agent.worktreePath ?? gitContextWorktreePath ?? agent.cwd ?? null;
+    if (!worktreePath) {
+      return reply
+        .code(404)
+        .send({ error: "Agent has no associated worktree." });
+    }
+
+    const baseRef =
+      agent.baseBranch ??
+      (agent.worktreePath || gitContextWorktreePath ? "main" : null);
+
+    let fileDiff;
+    try {
+      fileDiff = await getAgentFileDiff(worktreePath, baseRef, body.filePath);
+    } catch (error) {
+      deps.appLog.warn(
+        { err: error, agentId: id, filePath: body.filePath },
+        "Diff comment: failed to get file diff"
+      );
+      return reply.code(500).send({ error: "Failed to retrieve diff." });
+    }
+
+    if (!fileDiff) {
+      return reply.code(404).send({ error: "File not found in diff." });
+    }
+
+    const lines = extractNewFileLines(
+      fileDiff.diff,
+      body.startLine,
+      body.endLine
+    );
+
+    const lineLabel =
+      body.startLine === body.endLine
+        ? `Line ${body.startLine}`
+        : `Lines ${body.startLine}-${body.endLine}`;
+    const codeBlock =
+      lines.length > 0
+        ? "\n" + lines.map((l) => `│ ${l}`).join("\n") + "\n"
+        : "";
+
+    const prompt = [
+      "--- DISPATCH: Code Comment ---",
+      `File: ${body.filePath}`,
+      `${lineLabel}:`,
+      codeBlock,
+      `Comment: ${body.comment.trim()}`,
+      "--- END ---",
+    ].join("\n");
+
+    try {
+      await deps.sendAgentPrompt(id, prompt);
+    } catch (error) {
+      deps.appLog.warn(
+        { err: error, agentId: id },
+        "Diff comment: tmux delivery failed"
+      );
+      return reply
+        .code(500)
+        .send({ error: "Failed to deliver comment to agent." });
+    }
+
+    return { delivered: true };
+  });
+}
+
+function extractNewFileLines(
+  diffText: string,
+  startLine: number,
+  endLine: number
+): string[] {
+  const lines: string[] = [];
+  const diffLines = diffText.split("\n");
+  let newLineNum = 0;
+
+  for (const line of diffLines) {
+    const hunkMatch = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunkMatch) {
+      newLineNum = parseInt(hunkMatch[1]!, 10) - 1;
+      continue;
+    }
+
+    if (newLineNum === 0) continue;
+
+    if (line.startsWith("-")) continue;
+
+    if (line.startsWith("+") || line.startsWith(" ")) {
+      newLineNum++;
+      if (newLineNum >= startLine && newLineNum <= endLine) {
+        lines.push(line.slice(1));
+      }
+      if (newLineNum > endLine) break;
+    }
+  }
+
+  return lines;
 }

--- a/apps/server/src/routes/agents/lifecycle-routes.ts
+++ b/apps/server/src/routes/agents/lifecycle-routes.ts
@@ -434,6 +434,14 @@ export async function registerAgentLifecycleRoutes(
       return reply.code(400).send({ error: "Invalid line range." });
     }
 
+    if (body.endLine - body.startLine > 500) {
+      return reply.code(400).send({ error: "Line range too large." });
+    }
+
+    if (body.comment.length > 10_000) {
+      return reply.code(400).send({ error: "Comment too long." });
+    }
+
     const agent = await deps.agentManager.getAgent(id);
     if (!agent) {
       return reply.code(404).send({ error: "Agent not found." });

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   ChevronDown,
@@ -106,11 +106,17 @@ export const ChangesTab = memo(function ChangesTab({
   const { data, isLoading } = useAgentDiff(agentId, active);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const [showFileTree, setShowFileTree] = useState(true);
   const [lineSelection, setLineSelection] = useState<LineSelection | null>(
     null
   );
+  const [commentOpen, setCommentOpen] = useState(false);
+  const [fileTreeOpen, setFileTreeOpen] = useState(true);
   const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const handleLineSelection = useCallback((sel: LineSelection | null) => {
+    setLineSelection(sel);
+    setCommentOpen(false);
+  }, []);
 
   const files = useMemo(
     () => [...(data?.files ?? [])].sort((a, b) => a.path.localeCompare(b.path)),
@@ -153,20 +159,17 @@ export const ChangesTab = memo(function ChangesTab({
 
   return (
     <div className="flex h-full min-h-0">
-      {showFileTree && (
-        <FileTree
-          files={files}
-          selectedFile={selectedFile}
-          onSelectFile={scrollToFile}
-          onClose={() => setShowFileTree(false)}
-        />
-      )}
+      <FileTree
+        files={files}
+        selectedFile={selectedFile}
+        onSelectFile={scrollToFile}
+        open={fileTreeOpen}
+        onToggleOpen={() => setFileTreeOpen((v) => !v)}
+      />
       <DiffPane
         agentId={agentId}
         files={files}
         collapsedFiles={collapsedFiles}
-        showFileTreeToggle={!showFileTree}
-        onShowFileTree={() => setShowFileTree(true)}
         onToggleCollapse={(path) => {
           setCollapsedFiles((prev) => {
             const next = new Set(prev);
@@ -180,7 +183,9 @@ export const ChangesTab = memo(function ChangesTab({
         }}
         fileRefs={fileRefs}
         lineSelection={lineSelection}
-        onLineSelection={setLineSelection}
+        onLineSelection={handleLineSelection}
+        commentOpen={commentOpen}
+        onCommentOpen={setCommentOpen}
       />
     </div>
   );
@@ -213,7 +218,8 @@ type FileTreeProps = {
   files: DiffFile[];
   selectedFile: string | null;
   onSelectFile: (path: string) => void;
-  onClose: () => void;
+  open: boolean;
+  onToggleOpen: () => void;
 };
 
 type TreeNode = {
@@ -272,7 +278,8 @@ function FileTree({
   files,
   selectedFile,
   onSelectFile,
-  onClose,
+  open,
+  onToggleOpen,
 }: FileTreeProps): JSX.Element {
   const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set());
   const tree = useMemo(() => buildTree(files), [files]);
@@ -290,33 +297,46 @@ function FileTree({
   }, []);
 
   return (
-    <div className="flex w-56 shrink-0 flex-col border-r border-border/50 bg-muted/20">
-      <div className="flex shrink-0 items-center justify-between border-b border-border/40 bg-muted/30 px-3 py-2">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-          {files.length} file{files.length !== 1 ? "s" : ""} changed
-        </span>
+    <div
+      className="flex shrink-0 flex-col border-r border-border/50 bg-muted/20 overflow-hidden transition-[width] duration-200 ease-in-out"
+      style={{ width: open ? "14rem" : "2.25rem" }}
+    >
+      <div className="shrink-0 flex items-center border-b border-border/40 bg-muted/30">
+        {open && (
+          <span className="flex-1 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground whitespace-nowrap">
+            {files.length} file{files.length !== 1 ? "s" : ""} changed
+          </span>
+        )}
         <button
           type="button"
-          onClick={onClose}
-          className="min-h-7 min-w-7 rounded p-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
-          title="Hide file tree"
+          onClick={onToggleOpen}
+          className={cn(
+            "shrink-0 flex items-center justify-center text-muted-foreground hover:bg-muted/50 cursor-pointer",
+            open ? "p-2" : "flex-1 py-2"
+          )}
         >
-          <PanelLeftClose className="h-3.5 w-3.5" />
+          {open ? (
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          ) : (
+            <PanelLeftOpen className="h-3.5 w-3.5" />
+          )}
         </button>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto py-1">
-        {(tree.file ? [tree] : [...tree.children.values()]).map((child) => (
-          <TreeEntry
-            key={child.path}
-            node={child}
-            depth={0}
-            selectedFile={selectedFile}
-            onSelectFile={onSelectFile}
-            collapsedDirs={collapsedDirs}
-            onToggleDir={toggleDir}
-          />
-        ))}
-      </div>
+      {open && (
+        <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          {(tree.file ? [tree] : [...tree.children.values()]).map((child) => (
+            <TreeEntry
+              key={child.path}
+              node={child}
+              depth={0}
+              selectedFile={selectedFile}
+              onSelectFile={onSelectFile}
+              collapsedDirs={collapsedDirs}
+              onToggleDir={toggleDir}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -413,59 +433,47 @@ type DiffPaneProps = {
   agentId: string | null;
   files: DiffFile[];
   collapsedFiles: Set<string>;
-  showFileTreeToggle: boolean;
-  onShowFileTree: () => void;
   onToggleCollapse: (path: string) => void;
   fileRefs: React.RefObject<Map<string, HTMLDivElement> | null>;
   lineSelection: LineSelection | null;
   onLineSelection: (sel: LineSelection | null) => void;
+  commentOpen: boolean;
+  onCommentOpen: (open: boolean) => void;
 };
 
 function DiffPane({
   agentId,
   files,
   collapsedFiles,
-  showFileTreeToggle,
-  onShowFileTree,
   onToggleCollapse,
   fileRefs,
   lineSelection,
   onLineSelection,
+  commentOpen,
+  onCommentOpen,
 }: DiffPaneProps): JSX.Element {
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      {showFileTreeToggle && (
-        <div className="shrink-0 border-b border-border/40 bg-muted/20 px-2 py-1">
-          <button
-            type="button"
-            onClick={onShowFileTree}
-            className="min-h-7 min-w-7 rounded border border-border/50 bg-muted/60 p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-            title="Show file tree"
-          >
-            <PanelLeftOpen className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
-      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3">
-        {files.map((file) => (
-          <FileDiffSection
-            key={file.path}
-            agentId={agentId}
-            file={file}
-            collapsed={collapsedFiles.has(file.path)}
-            onToggleCollapse={() => onToggleCollapse(file.path)}
-            setRef={(el) => {
-              if (el) {
-                fileRefs.current?.set(file.path, el);
-              } else {
-                fileRefs.current?.delete(file.path);
-              }
-            }}
-            lineSelection={lineSelection}
-            onLineSelection={onLineSelection}
-          />
-        ))}
-      </div>
+    <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3">
+      {files.map((file) => (
+        <FileDiffSection
+          key={file.path}
+          agentId={agentId}
+          file={file}
+          collapsed={collapsedFiles.has(file.path)}
+          onToggleCollapse={() => onToggleCollapse(file.path)}
+          setRef={(el) => {
+            if (el) {
+              fileRefs.current?.set(file.path, el);
+            } else {
+              fileRefs.current?.delete(file.path);
+            }
+          }}
+          lineSelection={lineSelection}
+          onLineSelection={onLineSelection}
+          commentOpen={commentOpen}
+          onCommentOpen={onCommentOpen}
+        />
+      ))}
     </div>
   );
 }
@@ -478,6 +486,8 @@ type FileDiffSectionProps = {
   setRef: (el: HTMLDivElement | null) => void;
   lineSelection: LineSelection | null;
   onLineSelection: (sel: LineSelection | null) => void;
+  commentOpen: boolean;
+  onCommentOpen: (open: boolean) => void;
 };
 
 function FileDiffSection({
@@ -488,6 +498,8 @@ function FileDiffSection({
   setRef,
   lineSelection,
   onLineSelection,
+  commentOpen,
+  onCommentOpen,
 }: FileDiffSectionProps): JSX.Element {
   return (
     <div ref={setRef} className="rounded-md border border-border/50">
@@ -535,6 +547,8 @@ function FileDiffSection({
               file={file}
               lineSelection={lineSelection}
               onLineSelection={onLineSelection}
+              commentOpen={commentOpen}
+              onCommentOpen={onCommentOpen}
             />
           </motion.div>
         )}
@@ -548,6 +562,8 @@ type FileDiffContentProps = {
   file: DiffFile;
   lineSelection: LineSelection | null;
   onLineSelection: (sel: LineSelection | null) => void;
+  commentOpen: boolean;
+  onCommentOpen: (open: boolean) => void;
 };
 
 function FileDiffContent({
@@ -555,6 +571,8 @@ function FileDiffContent({
   file,
   lineSelection,
   onLineSelection,
+  commentOpen,
+  onCommentOpen,
 }: FileDiffContentProps): JSX.Element {
   const [forceLoad, setForceLoad] = useState(false);
   const { data: fileDiffData, isLoading: fileDiffLoading } = useAgentFileDiff(
@@ -615,6 +633,8 @@ function FileDiffContent({
         lineSelection?.filePath === file.path ? lineSelection : null
       }
       onLineSelection={onLineSelection}
+      commentOpen={commentOpen}
+      onCommentOpen={onCommentOpen}
     />
   );
 }
@@ -733,6 +753,8 @@ type UnifiedDiffViewProps = {
   filePath: string;
   lineSelection: LineSelection | null;
   onLineSelection: (sel: LineSelection | null) => void;
+  commentOpen: boolean;
+  onCommentOpen: (open: boolean) => void;
 };
 
 const UnifiedDiffView = memo(function UnifiedDiffView({
@@ -741,6 +763,8 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   filePath,
   lineSelection,
   onLineSelection,
+  commentOpen,
+  onCommentOpen,
 }: UnifiedDiffViewProps): JSX.Element {
   const parsed = useMemo(() => {
     try {
@@ -789,6 +813,12 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
             endLine: end,
             anchorLine: lineSelection.anchorLine,
           });
+        } else if (
+          lineSelection &&
+          ln >= lineSelection.startLine &&
+          ln <= lineSelection.endLine
+        ) {
+          onLineSelection(null);
         } else {
           onLineSelection({
             filePath,
@@ -814,7 +844,7 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   }, [file, lineSelection]);
 
   const widgets = useMemo(() => {
-    if (!file || !lineSelection || !agentId) return {};
+    if (!file || !lineSelection || !agentId || !commentOpen) return {};
     const lastKey = findLastChangeKeyInRange(
       file.hunks,
       lineSelection.startLine,
@@ -828,12 +858,65 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
           filePath={filePath}
           startLine={lineSelection.startLine}
           endLine={lineSelection.endLine}
-          onCancel={() => onLineSelection(null)}
-          onSubmitted={() => onLineSelection(null)}
+          onCancel={() => {
+            onCommentOpen(false);
+            onLineSelection(null);
+          }}
+          onSubmitted={() => {
+            onCommentOpen(false);
+            onLineSelection(null);
+          }}
         />
       ),
     };
-  }, [file, lineSelection, agentId, filePath, onLineSelection]);
+  }, [
+    file,
+    lineSelection,
+    agentId,
+    filePath,
+    onLineSelection,
+    commentOpen,
+    onCommentOpen,
+  ]);
+
+  const diffRef = useRef<HTMLDivElement>(null);
+  const [buttonPos, setButtonPos] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!lineSelection || commentOpen || !diffRef.current) {
+      setButtonPos(null);
+      return;
+    }
+    const container = diffRef.current;
+    const allSelected = container.querySelectorAll(".diff-gutter-selected");
+    if (allSelected.length === 0) {
+      setButtonPos(null);
+      return;
+    }
+    // Each row has two gutter cells with the class; pick the first per row
+    const firstGutters: Element[] = [];
+    for (const el of allSelected) {
+      const tr = el.closest("tr");
+      if (tr && el === tr.querySelector(".diff-gutter-selected")) {
+        firstGutters.push(el);
+      }
+    }
+    if (firstGutters.length === 0) {
+      setButtonPos(null);
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const firstRect = firstGutters[0]!.getBoundingClientRect();
+    const lastRect =
+      firstGutters[firstGutters.length - 1]!.getBoundingClientRect();
+    const centerY = (firstRect.top + lastRect.bottom) / 2 - containerRect.top;
+    const gutterLeft = firstRect.left - containerRect.left;
+    setButtonPos({ top: centerY, left: gutterLeft, width: firstRect.width });
+  }, [lineSelection, commentOpen, selectedChanges]);
 
   if (!file) {
     return (
@@ -853,20 +936,36 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
           : "modify";
 
   return (
-    <div className="changes-diff-view overflow-x-auto text-xs">
-      <Diff
-        viewType="unified"
-        diffType={diffType}
-        hunks={file.hunks}
-        tokens={tokens}
-        gutterEvents={gutterEvents}
-        selectedChanges={selectedChanges}
-        widgets={widgets}
-      >
-        {(hunks) =>
-          hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)
-        }
-      </Diff>
+    <div ref={diffRef} className="changes-diff-view text-xs relative">
+      <div className="overflow-x-auto">
+        <Diff
+          viewType="unified"
+          diffType={diffType}
+          hunks={file.hunks}
+          tokens={tokens}
+          gutterEvents={gutterEvents}
+          selectedChanges={selectedChanges}
+          widgets={widgets}
+        >
+          {(hunks) =>
+            hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)
+          }
+        </Diff>
+      </div>
+      {buttonPos !== null && !commentOpen && lineSelection && (
+        <button
+          type="button"
+          onClick={() => onCommentOpen(true)}
+          className="absolute z-10 flex items-center justify-center rounded-md bg-primary p-1 text-primary-foreground shadow-md hover:bg-primary/90 -translate-y-1/2"
+          style={{
+            top: buttonPos.top,
+            left: buttonPos.left + buttonPos.width / 2,
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          <MessageSquare className="h-3.5 w-3.5" />
+        </button>
+      )}
     </div>
   );
 });
@@ -976,12 +1075,8 @@ function InlineCommentForm({
           onClick={handleSubmit}
           disabled={!comment.trim() || submitting}
         >
-          {submitting ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <Send className="h-3 w-3" />
-          )}
-          Send
+          {submitting && <Loader2 className="h-3 w-3 animate-spin" />}
+          Chat Now
         </button>
       </div>
     </div>

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   ChevronDown,
   ChevronRight,
@@ -8,11 +9,23 @@ import {
   FilePlus,
   FileText,
   Loader2,
+  MessageSquare,
   PanelLeftClose,
   PanelLeftOpen,
+  X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Diff, Hunk, markEdits, parseDiff, tokenize } from "react-diff-view";
+import {
+  Diff,
+  Hunk,
+  markEdits,
+  parseDiff,
+  tokenize,
+  getChangeKey,
+  type ChangeData,
+  type HunkData,
+  type EventMap,
+} from "react-diff-view";
 import "react-diff-view/style/index.css";
 import { refractor as baseRefractor } from "refractor";
 import jsx from "refractor/jsx";
@@ -71,7 +84,15 @@ import {
   type DiffFile,
   type DiffFileStatus,
 } from "@/hooks/use-agent-diff";
+import { agentRoute } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
+
+type LineSelection = {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  anchorLine: number;
+};
 
 type ChangesTabProps = {
   agentId: string | null;
@@ -86,6 +107,9 @@ export const ChangesTab = memo(function ChangesTab({
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [showFileTree, setShowFileTree] = useState(true);
+  const [lineSelection, setLineSelection] = useState<LineSelection | null>(
+    null
+  );
   const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const files = useMemo(
@@ -155,6 +179,8 @@ export const ChangesTab = memo(function ChangesTab({
           });
         }}
         fileRefs={fileRefs}
+        lineSelection={lineSelection}
+        onLineSelection={setLineSelection}
       />
     </div>
   );
@@ -391,6 +417,8 @@ type DiffPaneProps = {
   onShowFileTree: () => void;
   onToggleCollapse: (path: string) => void;
   fileRefs: React.RefObject<Map<string, HTMLDivElement> | null>;
+  lineSelection: LineSelection | null;
+  onLineSelection: (sel: LineSelection | null) => void;
 };
 
 function DiffPane({
@@ -401,6 +429,8 @@ function DiffPane({
   onShowFileTree,
   onToggleCollapse,
   fileRefs,
+  lineSelection,
+  onLineSelection,
 }: DiffPaneProps): JSX.Element {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -431,6 +461,8 @@ function DiffPane({
                 fileRefs.current?.delete(file.path);
               }
             }}
+            lineSelection={lineSelection}
+            onLineSelection={onLineSelection}
           />
         ))}
       </div>
@@ -444,6 +476,8 @@ type FileDiffSectionProps = {
   collapsed: boolean;
   onToggleCollapse: () => void;
   setRef: (el: HTMLDivElement | null) => void;
+  lineSelection: LineSelection | null;
+  onLineSelection: (sel: LineSelection | null) => void;
 };
 
 function FileDiffSection({
@@ -452,6 +486,8 @@ function FileDiffSection({
   collapsed,
   onToggleCollapse,
   setRef,
+  lineSelection,
+  onLineSelection,
 }: FileDiffSectionProps): JSX.Element {
   return (
     <div ref={setRef} className="rounded-md border border-border/50">
@@ -494,7 +530,12 @@ function FileDiffSection({
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className="overflow-hidden"
           >
-            <FileDiffContent agentId={agentId} file={file} />
+            <FileDiffContent
+              agentId={agentId}
+              file={file}
+              lineSelection={lineSelection}
+              onLineSelection={onLineSelection}
+            />
           </motion.div>
         )}
       </AnimatePresence>
@@ -505,9 +546,16 @@ function FileDiffSection({
 type FileDiffContentProps = {
   agentId: string | null;
   file: DiffFile;
+  lineSelection: LineSelection | null;
+  onLineSelection: (sel: LineSelection | null) => void;
 };
 
-function FileDiffContent({ agentId, file }: FileDiffContentProps): JSX.Element {
+function FileDiffContent({
+  agentId,
+  file,
+  lineSelection,
+  onLineSelection,
+}: FileDiffContentProps): JSX.Element {
   const [forceLoad, setForceLoad] = useState(false);
   const { data: fileDiffData, isLoading: fileDiffLoading } = useAgentFileDiff(
     agentId,
@@ -558,7 +606,17 @@ function FileDiffContent({ agentId, file }: FileDiffContentProps): JSX.Element {
     );
   }
 
-  return <UnifiedDiffView diffText={diffText} filePath={file.path} />;
+  return (
+    <UnifiedDiffView
+      agentId={agentId}
+      diffText={diffText}
+      filePath={file.path}
+      lineSelection={
+        lineSelection?.filePath === file.path ? lineSelection : null
+      }
+      onLineSelection={onLineSelection}
+    />
+  );
 }
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
@@ -629,14 +687,60 @@ function languageFromPath(filePath: string): string | null {
   return lang;
 }
 
+function getNewLineNumber(change: ChangeData): number | null {
+  if (change.type === "insert") return change.lineNumber;
+  if (change.type === "normal") return change.newLineNumber;
+  return null;
+}
+
+function collectSelectedChangeKeys(
+  hunks: HunkData[],
+  startLine: number,
+  endLine: number
+): string[] {
+  const keys: string[] = [];
+  for (const hunk of hunks) {
+    for (const change of hunk.changes) {
+      const ln = getNewLineNumber(change);
+      if (ln !== null && ln >= startLine && ln <= endLine) {
+        keys.push(getChangeKey(change));
+      }
+    }
+  }
+  return keys;
+}
+
+function findLastChangeKeyInRange(
+  hunks: HunkData[],
+  startLine: number,
+  endLine: number
+): string | null {
+  let lastKey: string | null = null;
+  for (const hunk of hunks) {
+    for (const change of hunk.changes) {
+      const ln = getNewLineNumber(change);
+      if (ln !== null && ln >= startLine && ln <= endLine) {
+        lastKey = getChangeKey(change);
+      }
+    }
+  }
+  return lastKey;
+}
+
 type UnifiedDiffViewProps = {
+  agentId: string | null;
   diffText: string;
   filePath: string;
+  lineSelection: LineSelection | null;
+  onLineSelection: (sel: LineSelection | null) => void;
 };
 
 const UnifiedDiffView = memo(function UnifiedDiffView({
+  agentId,
   diffText,
   filePath,
+  lineSelection,
+  onLineSelection,
 }: UnifiedDiffViewProps): JSX.Element {
   const parsed = useMemo(() => {
     try {
@@ -667,7 +771,71 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
     }
   }, [parsed, language]);
 
-  if (parsed.length === 0) {
+  const gutterEvents: EventMap = useMemo(
+    () => ({
+      onClick: ({ change }, e) => {
+        if (!change) return;
+        const ln = getNewLineNumber(change);
+        if (ln === null) return;
+
+        const mouseEvent = e as unknown as MouseEvent;
+
+        if (mouseEvent.shiftKey && lineSelection) {
+          const start = Math.min(lineSelection.anchorLine, ln);
+          const end = Math.max(lineSelection.anchorLine, ln);
+          onLineSelection({
+            filePath,
+            startLine: start,
+            endLine: end,
+            anchorLine: lineSelection.anchorLine,
+          });
+        } else {
+          onLineSelection({
+            filePath,
+            startLine: ln,
+            endLine: ln,
+            anchorLine: ln,
+          });
+        }
+      },
+    }),
+    [filePath, lineSelection, onLineSelection]
+  );
+
+  const file = parsed.length > 0 ? parsed[0]! : null;
+
+  const selectedChanges = useMemo(() => {
+    if (!file || !lineSelection) return [];
+    return collectSelectedChangeKeys(
+      file.hunks,
+      lineSelection.startLine,
+      lineSelection.endLine
+    );
+  }, [file, lineSelection]);
+
+  const widgets = useMemo(() => {
+    if (!file || !lineSelection || !agentId) return {};
+    const lastKey = findLastChangeKeyInRange(
+      file.hunks,
+      lineSelection.startLine,
+      lineSelection.endLine
+    );
+    if (!lastKey) return {};
+    return {
+      [lastKey]: (
+        <InlineCommentForm
+          agentId={agentId}
+          filePath={filePath}
+          startLine={lineSelection.startLine}
+          endLine={lineSelection.endLine}
+          onCancel={() => onLineSelection(null)}
+          onSubmitted={() => onLineSelection(null)}
+        />
+      ),
+    };
+  }, [file, lineSelection, agentId, filePath, onLineSelection]);
+
+  if (!file) {
     return (
       <div className="px-4 py-3 text-xs text-muted-foreground">
         Unable to parse diff
@@ -675,7 +843,6 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
     );
   }
 
-  const file = parsed[0]!;
   const diffType =
     file.type === "add"
       ? "add"
@@ -692,6 +859,9 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
         diffType={diffType}
         hunks={file.hunks}
         tokens={tokens}
+        gutterEvents={gutterEvents}
+        selectedChanges={selectedChanges}
+        widgets={widgets}
       >
         {(hunks) =>
           hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)
@@ -700,3 +870,120 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
     </div>
   );
 });
+
+function InlineCommentForm({
+  agentId,
+  filePath,
+  startLine,
+  endLine,
+  onCancel,
+  onSubmitted,
+}: {
+  agentId: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  onCancel: () => void;
+  onSubmitted: () => void;
+}): JSX.Element {
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const navigate = useNavigate();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const lineLabel =
+    startLine === endLine
+      ? `Line ${startLine}`
+      : `Lines ${startLine}–${endLine}`;
+
+  const handleSubmit = useCallback(async () => {
+    if (!comment.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/v1/agents/${agentId}/diff/comment`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filePath, startLine, endLine, comment }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(data.error ?? "Failed to send comment");
+      }
+      onSubmitted();
+      navigate(agentRoute(agentId), { replace: true });
+    } catch {
+      setSubmitting(false);
+    }
+  }, [
+    agentId,
+    comment,
+    endLine,
+    filePath,
+    navigate,
+    onSubmitted,
+    startLine,
+    submitting,
+  ]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmit();
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [handleSubmit, onCancel]
+  );
+
+  return (
+    <div className="border-t border-border/50 bg-muted/20 px-4 py-3">
+      <div className="mb-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+        <MessageSquare className="h-3 w-3" />
+        <span className="font-mono">{filePath}</span>
+        <span>·</span>
+        <span>{lineLabel}</span>
+      </div>
+      <textarea
+        ref={textareaRef}
+        className="w-full resize-none rounded border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        placeholder="Leave a comment for the agent…"
+        rows={3}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        onKeyDown={handleKeyDown}
+        autoFocus
+        disabled={submitting}
+      />
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted/40"
+          onClick={onCancel}
+          disabled={submitting}
+        >
+          <X className="h-3 w-3" />
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          onClick={handleSubmit}
+          disabled={!comment.trim() || submitting}
+        >
+          {submitting ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Send className="h-3 w-3" />
+          )}
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1207,8 +1207,22 @@ html[data-hidden] .animate-sidebar-nav-pulse {
   border-right: 1px solid hsl(var(--diff-fg) / 0.1);
   padding: 0 8px;
   text-align: right;
-  cursor: default;
+  cursor: pointer;
   user-select: none;
+}
+.changes-diff-view .diff-gutter:hover {
+  background: hsl(var(--primary) / 0.15);
+}
+.changes-diff-view .diff-gutter-selected {
+  background: hsl(var(--primary) / 0.2) !important;
+  color: hsl(var(--primary)) !important;
+}
+.changes-diff-view .diff-code-selected {
+  background: hsl(var(--primary) / 0.08) !important;
+}
+.changes-diff-view .diff-widget {
+  border: none;
+  padding: 0;
 }
 .changes-diff-view .diff-code {
   background: transparent;


### PR DESCRIPTION
## Summary
- Add line-level commenting in the Changes tab diff viewer that injects formatted messages into the agent's tmux session
- Backend: `POST /api/v1/agents/:id/diff/comment` endpoint that extracts line content from unified diffs and injects via `sendAgentPrompt`
- Frontend: gutter click to select lines (with shift-click for ranges), floating comment bubble in the left gutter, inline comment form with "Chat Now" submit
- Collapsible file tree panel with smooth width animation and sidebar-style toggle icons
- Click-to-deselect: clicking a selected line (or any line in a multi-line block) clears the selection

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Web build passes (`pnpm run finalize:web`)
- [x] E2E tests pass (171/171)
- [x] Verified comment injection flow end-to-end on live dev instance with real agent session
- [x] Verified file tree toggle open/close with smooth animation
- [x] Verified line selection, shift-click range selection, and click-to-deselect

🤖 Generated with [Claude Code](https://claude.com/claude-code)