### PR TITLE
Remove source build fallback from release update flow

### DIFF
--- a/apps/server/src/server/release-runtime.ts
+++ b/apps/server/src/server/release-runtime.ts
@@ -505,45 +505,29 @@ Suggested workflow:
   async function deployFromArtifact(
     job: ReleaseJob,
     tag: string
-  ): Promise<boolean> {
-    let repo: string;
-    try {
-      repo = await getGitHubRepo();
-    } catch {
-      appendReleaseLog(
-        job,
-        "could not resolve GitHub repo, skipping artifact download"
-      );
-      return false;
-    }
+  ): Promise<void> {
+    const repo = await getGitHubRepo();
 
-    let cached: { path: string };
-    try {
-      cached = await deps.ensureCachedTarball({
-        tag,
-        repo,
-        onProgress: ({ message, bytesReceived, totalBytes }) => {
-          appendReleaseLog(job, message);
-          setReleaseProgress(job, {
-            step:
-              bytesReceived !== undefined
-                ? "downloading-artifact"
-                : "preparing-artifact",
-            label:
-              bytesReceived !== undefined
-                ? "Downloading release package"
-                : "Preparing release package",
-            detail: message,
-            bytesReceived: bytesReceived ?? null,
-            totalBytes: totalBytes ?? null,
-          });
-        },
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      appendReleaseLog(job, `release artifact download failed: ${message}`);
-      return false;
-    }
+    const cached = await deps.ensureCachedTarball({
+      tag,
+      repo,
+      onProgress: ({ message, bytesReceived, totalBytes }) => {
+        appendReleaseLog(job, message);
+        setReleaseProgress(job, {
+          step:
+            bytesReceived !== undefined
+              ? "downloading-artifact"
+              : "preparing-artifact",
+          label:
+            bytesReceived !== undefined
+              ? "Downloading release package"
+              : "Preparing release package",
+          detail: message,
+          bytesReceived: bytesReceived ?? null,
+          totalBytes: totalBytes ?? null,
+        });
+      },
+    });
 
     appendReleaseLog(job, `==> checking out ${tag} (for version metadata)`);
     setReleaseProgress(job, {
@@ -607,7 +591,6 @@ Suggested workflow:
       "==> deployed from pre-built artifact (no build needed)"
     );
     await deps.pruneCacheExcept([tag]);
-    return true;
   }
 
   function currentReleaseBinaryGlob(): string {
@@ -661,68 +644,11 @@ Suggested workflow:
     );
   }
 
-  async function assertCommandOnPath(
-    job: ReleaseJob,
-    command: string,
-    purpose: string
-  ): Promise<void> {
-    const quotedCommand = `'${command.replace(/'/g, `'\\''`)}'`;
-    const result = await deps.runCommand(
-      "bash",
-      ["-lc", `command -v -- ${quotedCommand} >/dev/null 2>&1`],
-      { cwd: deps.serverDir, allowedExitCodes: [0, 1] }
-    );
-
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `${command} is required to ${purpose}, but was not found on PATH`
-      );
-    }
-
-    appendReleaseLog(job, `==> found ${command} on PATH`);
-  }
-
   async function deployTag(job: ReleaseJob, tag: string): Promise<void> {
     setReleasePhase(job, "deploying");
     appendReleaseLog(job, `==> deploying ${tag}`);
 
-    const usedArtifact = await deployFromArtifact(job, tag);
-
-    if (!usedArtifact) {
-      appendReleaseLog(job, "==> falling back to build from source");
-      appendReleaseLog(job, `==> checking out ${tag}`);
-      setReleaseProgress(job, {
-        step: "checking-out-source",
-        label: `Loading ${tag}`,
-        detail: "Preparing the source checkout for a local build.",
-      });
-      await deps.runCommand("git", ["-C", deps.serverDir, "checkout", tag]);
-      await assertCommandOnPath(job, "pnpm", "build Dispatch from source");
-      appendReleaseLog(job, "==> installing dependencies");
-      setReleaseProgress(job, {
-        step: "installing-dependencies",
-        label: "Installing dependencies",
-        detail: "Preparing the source build environment.",
-      });
-      await streamProcess(
-        "pnpm",
-        ["install", "--frozen-lockfile"],
-        { cwd: deps.serverDir },
-        job
-      );
-      appendReleaseLog(job, "==> building from source");
-      setReleaseProgress(job, {
-        step: "building-release",
-        label: "Building release",
-        detail: "Compiling Dispatch from source because no artifact was used.",
-      });
-      await streamProcess(
-        "pnpm",
-        ["run", "build:bun"],
-        { cwd: deps.serverDir },
-        job
-      );
-    }
+    await deployFromArtifact(job, tag);
 
     setReleaseProgress(job, {
       step: "verifying-runtime",


### PR DESCRIPTION
## Summary

- **Remove source build fallback from `deployTag`** — the `if (!usedArtifact)` block that ran `git checkout`, `pnpm install`, and `pnpm run build:bun` from source is gone. `deployTag` now calls `await deployFromArtifact(job, tag)` directly, so download failures surface as thrown errors instead of silently falling through to a dangerous build path.
- **Change `deployFromArtifact` from `Promise<boolean>` to `Promise<void>`** — removed try/catch blocks that swallowed errors and returned `false`. Errors now propagate naturally.
- **Delete `assertCommandOnPath` helper** — only called from the removed fallback.

## Motivation

The v0.23.9 update wiped compiled binaries in `dist/bun/`, preventing the server from restarting. Root cause: `deployFromArtifact` caught errors and returned `false`, triggering the source build fallback. The build script (`scripts/build-bun-binaries.mjs` line 171) does `rmSync(outDir, { recursive: true, force: true })` before building — when the build then failed, the binaries were gone and the server couldn't restart.

The source build fallback is inherently unsafe because it deletes existing binaries before attempting to build replacements. Removing it ensures artifact download failures are surfaced immediately rather than cascading into a worse state.

## Test plan

- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — all unit tests pass (2135 total)
- [x] `pnpm run test:e2e` — 171 passed, 12 skipped (terminal-live, needs tmux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)