### PR TITLE
Fix Reviewers recheck claim, add Changes tab docs

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -154,6 +154,25 @@ export function AgentsContent() {
       </Section>
 
       <Section>
+        <H3>Changes tab</H3>
+        <P>
+          The <strong>Changes</strong> tab next to <strong>Terminal</strong> in
+          the center pane shows a unified diff of the agent's uncommitted work
+          against its base branch. Each file is syntax-highlighted and can be
+          collapsed individually. A file tree sidebar lists all changed files
+          with their status (added, modified, deleted) and line counts — click a
+          file to scroll to it. Large diffs are truncated by default with a
+          button to load the full content.
+        </P>
+        <P>
+          Select one or more lines in a diff, then click the comment icon to
+          leave a note for the agent. The comment is injected into the agent's
+          terminal with the file path and line range so the agent can act on it
+          immediately.
+        </P>
+      </Section>
+
+      <Section>
         <H3>Tmux scrollback</H3>
         <P>
           Attaching to an agent puts you in tmux's live mode. When you scroll up

--- a/apps/web/src/components/app/docs-sections/personas.tsx
+++ b/apps/web/src/components/app/docs-sections/personas.tsx
@@ -111,10 +111,12 @@ issues caused or worsened by this diff.`}</CodeBlock>
       <Section>
         <H3>Round-trip reviews</H3>
         <P>
-          Every review includes a recheck pass. The reviewer stays alive after
-          its round-1 verdict, waiting for the parent to resolve feedback and
-          submit a resolution — then performs a second pass and emits a final
-          verdict.
+          When a reviewer finishes round 1 with <Code>request_changes</Code> (or{" "}
+          <Code>approve</Code> with feedback), the review enters a recheck pass.
+          The reviewer stays alive, waiting for the parent to resolve feedback
+          and submit a resolution — then performs a second pass and emits a
+          final verdict. If the reviewer approves with no feedback, the recheck
+          is skipped and the review completes immediately.
         </P>
         <P>
           The handoff is push-based: when each round transitions, the server

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -59,6 +59,14 @@ export const tips: Tip[] = [
     surfaces: ["ambient"],
   },
   {
+    id: "changes-tab",
+    title: "Changes Tab",
+    body: "Switch to the Changes tab next to Terminal to browse an agent's diff with syntax highlighting. Select lines to leave inline comments.",
+    docsSection: "agents",
+    since: "0.23.9",
+    surfaces: ["ambient"],
+  },
+  {
     id: "keyboard-shortcuts",
     title: "Keyboard Shortcuts",
     body: "Press ⌘K to open the command palette. Navigate agents, toggle sidebars, and control the terminal without touching the mouse.",


### PR DESCRIPTION
## Summary

- **Reviewers docs**: Fixed inaccurate claim that "every review includes a recheck pass." Since PR #679, clean approvals (approve + zero feedback) skip the round-trip — updated the paragraph to describe both paths.
- **Agents docs**: Added "Changes tab" section documenting the unified diff viewer (file tree, syntax highlighting, inline commenting) introduced in v0.23.9.
- **Tips**: Added ambient tip for the Changes tab to help users discover it.

## Deferred to next run

- Deep-dive the Agents docs section generally (the `next_focus` for the next run)
- Backlog items unchanged

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/components/app/docs-sections/personas.tsx` | Fixed recheck-skip wording |
| `apps/web/src/components/app/docs-sections/agents.tsx` | Added Changes tab section |
| `apps/web/src/lib/tips/tips.ts` | Added `changes-tab` ambient tip |

🤖 Generated by docs-audit job