### PR TITLE
Extract messaging tools from MCP server.ts

### DIFF
--- a/apps/server/src/shared/mcp/messaging-tools.ts
+++ b/apps/server/src/shared/mcp/messaging-tools.ts
@@ -1,0 +1,111 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import { toToolError } from "./tool-error.js";
+
+export type MessagingToolsContext = {
+  agentId: string;
+  repoRoot: string | null;
+  listAgentsForAgent?: (
+    agentId: string,
+    senderRepoRoot: string | null
+  ) => Promise<
+    Array<{
+      id: string;
+      name: string;
+      status: string;
+      latestEvent: { type: string; message: string } | null;
+    }>
+  >;
+  sendMessage?: (
+    agentId: string,
+    input: { target: string; message: string; senderRepoRoot: string | null }
+  ) => Promise<{
+    delivered: boolean;
+    targetAgentId: string;
+    targetAgentName: string;
+  }>;
+};
+
+export function registerMessagingTools(
+  server: McpServer,
+  allowed: Set<string>,
+  context: MessagingToolsContext
+): void {
+  if (allowed.has("list_agents") && context.listAgentsForAgent) {
+    const agentId = context.agentId;
+    const listAgentsForAgent = context.listAgentsForAgent;
+
+    server.registerTool(
+      "list_agents",
+      {
+        description:
+          "List other agents on this Dispatch server with their IDs, names, statuses, and latest activity. " +
+          "Use this to discover agents you can communicate with via dispatch_send_message.",
+        inputSchema: {},
+      },
+      async () => {
+        try {
+          const agents = await listAgentsForAgent(agentId, context.repoRoot);
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ agents }, null, 2) },
+            ],
+            structuredContent: { agents },
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  if (allowed.has("dispatch_send_message") && context.sendMessage) {
+    const agentId = context.agentId;
+    const sendMessage = context.sendMessage;
+
+    server.registerTool(
+      "dispatch_send_message",
+      {
+        description:
+          "Send a message to another running agent. The message is injected into the target agent's session. " +
+          "The target agent can reply using the same tool. Use list_agents to discover available agents. " +
+          "Target can be an agent ID (agt_xxx) or a name (partial match). " +
+          "Only works for agents that are currently running.",
+        inputSchema: {
+          target: z
+            .string()
+            .min(1)
+            .describe(
+              "Agent ID (agt_xxx) or name to send the message to. Names are fuzzy-matched against running agents."
+            ),
+          message: z
+            .string()
+            .min(1)
+            .max(10000)
+            .describe("The message content to send."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await sendMessage(agentId, {
+            target: args.target,
+            message: args.message,
+            senderRepoRoot: context.repoRoot,
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message delivered to "${result.targetAgentName}" (${result.targetAgentId}).`,
+              },
+            ],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+}

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -11,6 +11,7 @@ import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
 import { registerCrudTools, type CrudToolCallbacks } from "./crud-tools.js";
 import { registerJobTools, type JobTools } from "./job-tools.js";
+import { registerMessagingTools } from "./messaging-tools.js";
 import {
   registerPersonaInteractionTools,
   type LaunchPersonaAgentType,
@@ -492,91 +493,16 @@ async function createDispatchMcpServer(
   }
 
   // ── Inter-agent messaging tools ───────────────────────────────────
-  // list_agents for standard agents (job agents get it via registerJobTools)
-  if (
-    allowed.has("list_agents") &&
-    context.agent &&
-    context.listAgentsForAgent &&
-    !context.jobTools
-  ) {
-    const agentId = context.agent.id;
-    const listAgentsForAgent = context.listAgentsForAgent;
-
-    server.registerTool(
-      "list_agents",
-      {
-        description:
-          "List other agents on this Dispatch server with their IDs, names, statuses, and latest activity. " +
-          "Use this to discover agents you can communicate with via dispatch_send_message.",
-        inputSchema: {},
-      },
-      async () => {
-        try {
-          const agents = await listAgentsForAgent(agentId, context.repoRoot);
-          return {
-            content: [
-              { type: "text", text: JSON.stringify({ agents }, null, 2) },
-            ],
-            structuredContent: { agents },
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
-  }
-
-  if (
-    allowed.has("dispatch_send_message") &&
-    context.agent &&
-    context.sendMessage
-  ) {
-    const agentId = context.agent.id;
-    const sendMessage = context.sendMessage;
-
-    server.registerTool(
-      "dispatch_send_message",
-      {
-        description:
-          "Send a message to another running agent. The message is injected into the target agent's session. " +
-          "The target agent can reply using the same tool. Use list_agents to discover available agents. " +
-          "Target can be an agent ID (agt_xxx) or a name (partial match). " +
-          "Only works for agents that are currently running.",
-        inputSchema: {
-          target: z
-            .string()
-            .min(1)
-            .describe(
-              "Agent ID (agt_xxx) or name to send the message to. Names are fuzzy-matched against running agents."
-            ),
-          message: z
-            .string()
-            .min(1)
-            .max(10000)
-            .describe("The message content to send."),
-        },
-      },
-      async (args) => {
-        try {
-          const result = await sendMessage(agentId, {
-            target: args.target,
-            message: args.message,
-            senderRepoRoot: context.repoRoot,
-          });
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Message delivered to "${result.targetAgentName}" (${result.targetAgentId}).`,
-              },
-            ],
-            structuredContent: result,
-          };
-        } catch (error) {
-          return toToolError(error);
-        }
-      }
-    );
+  if (context.agent) {
+    registerMessagingTools(server, allowed, {
+      agentId: context.agent.id,
+      repoRoot: context.repoRoot,
+      // Job agents get list_agents via registerJobTools
+      listAgentsForAgent: context.jobTools
+        ? undefined
+        : context.listAgentsForAgent,
+      sendMessage: context.sendMessage,
+    });
   }
 
   // ── Brain tools (shared memory for agents) ────────────────────────


### PR DESCRIPTION
## Summary

- Extracted `list_agents` and `dispatch_send_message` MCP tool registrations (~85 lines) from `server.ts` into a new `messaging-tools.ts` module
- Follows the same `registerXTools(server, allowed, context)` pattern used by all other extracted tool modules (analytics-tools, brain-tools, pr-tools, etc.)
- `server.ts` drops from 944 to 870 lines
- Job agents continue to get `list_agents` via `registerJobTools` (the existing behavior is preserved by conditionally omitting the callback)

**Why this is tech debt:** The messaging tools were the last remaining inline tool registrations in `server.ts` aside from `dispatch_pin`, `dispatch_share`, and `dispatch_feedback` (which are shared across agent types). Extracting them continues the pattern established in prior runs of moving domain-grouped tool registrations into their own modules.

**Next up:** The backlog has the unsafe `undefined as unknown as JobRunRecord` cast in `jobs/service.ts` queued for the next run.

## Test plan

- [x] `pnpm run check` — TypeScript passes
- [x] `pnpm run test` — all unit tests pass
- [x] `pnpm run test:e2e` — 171 E2E tests pass (12 skipped, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)