### PR TITLE
Fix terminal input clipped by AmbientTipBar overlay

### DIFF
--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -553,7 +553,9 @@ export function AgentsView({
                   </div>
                 ) : null}
               </div>
-              <div className="relative min-h-0 flex-1">
+              <div
+                className={cn("relative min-h-0 flex-1", !isMobile && "pb-14")}
+              >
                 <div className={cn("h-full", changesMatch && "hidden")}>
                   <TerminalPane
                     isAttached={isAttached}


### PR DESCRIPTION
## Summary
- The terminal container in `agents-view.tsx` lost its `pb-14` bottom padding during the Changes tab refactor (`7410bfa5`), causing the absolutely-positioned AmbientTipBar (56px) to overlay the terminal input area and clip it.
- Added conditional `pb-14` on desktop (matching the AmbientTipBar's `!isMobile` guard) to reserve space for the overlay.

## Test plan
- [x] Type check passes (`pnpm run check`)
- [x] Production build passes (`pnpm run finalize:web`)
- [x] All 171 E2E tests pass
- [x] Visual validation via Playwright — terminal and Changes tab render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)