### PR TITLE
Fix diff view vertical trackpad scroll on iPadOS

### DIFF
--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -937,7 +937,7 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
 
   return (
     <div ref={diffRef} className="changes-diff-view text-xs relative">
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto overflow-y-clip">
         <Diff
           viewType="unified"
           diffType={diffType}


### PR DESCRIPTION
## Summary

- Add explicit `overflow-y-clip` to `.changes-diff-view` in the Changes tab to fix vertical trackpad scrolling on iPadOS tablets

## Problem

On iPadOS with a connected keyboard/trackpad, vertical scrolling with the trackpad doesn't work in the diff view, while horizontal scrolling and touch-based scrolling both work fine.

The root cause is a CSS spec interaction: when `overflow-x` is set to `auto`, `overflow-y` implicitly computes to `auto` as well (per the CSS Overflow spec, `visible` upgrades to `auto` when the other axis is non-visible). This makes `.changes-diff-view` a scroll container in both axes, even though it only needs horizontal scrolling. Combined with `touch-action: none` on `#root` (applied for tablets via `@media (pointer: coarse)`), vertical wheel events from the trackpad get trapped at this implicit scroll container instead of chaining up to the parent `overflow-y-auto` container that handles file-level vertical scrolling.

## Fix

Adding `overflow-y-clip` explicitly prevents the CSS spec auto-upgrade, so `.changes-diff-view` is only a horizontal scroll container. Vertical wheel events pass through to the parent container.

## Test plan

- [ ] Verify vertical trackpad scrolling works in the Changes/diff tab on iPad with keyboard+trackpad
- [ ] Verify horizontal trackpad scrolling still works for wide diffs
- [ ] Verify touch scrolling (both axes) still works on tablet
- [ ] Verify diff view scrolling still works on desktop browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)