### PR TITLE
Add opt-in cross-repo agent messaging (Agents settings toggle)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ MEDIA_ROOT=~/.dispatch/media
 # Virtual X display for clipboard image paste on Linux (requires Xvfb + xclip)
 # DISPATCH_COPY_DISPLAY=:99
 
+# Let agents message/list agents in OTHER repositories (dispatch_send_message,
+# list_agents). Default scopes the addressable peer set to the sender's repo.
+# Enable for local multi-repo workflows. ("1" | "true" | "yes")
+# DISPATCH_CROSS_REPO_MESSAGING=1
+
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ MEDIA_ROOT=~/.dispatch/media
 # Let agents message/list agents in OTHER repositories (dispatch_send_message,
 # list_agents). Default scopes the addressable peer set to the sender's repo.
 # Enable for local multi-repo workflows. ("1" | "true" | "yes")
+# NOTE: when enabled, name-based targeting matches agents across ALL repos, so a
+# name can resolve to a same-named agent in a different repo. Use the agent ID
+# (agt_...) to address a specific agent unambiguously.
 # DISPATCH_CROSS_REPO_MESSAGING=1
 
 # TLS (optional — both must be set to enable HTTPS)

--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,6 @@ MEDIA_ROOT=~/.dispatch/media
 # Virtual X display for clipboard image paste on Linux (requires Xvfb + xclip)
 # DISPATCH_COPY_DISPLAY=:99
 
-# Let agents message/list agents in OTHER repositories (dispatch_send_message,
-# list_agents). Default scopes the addressable peer set to the sender's repo.
-# Set to "true" to enable for local multi-repo workflows.
-# NOTE: when enabled, name-based targeting matches agents across ALL repos, so a
-# name can resolve to a same-named agent in a different repo. Use the agent ID
-# (agt_...) to address a specific agent unambiguously.
-# DISPATCH_CROSS_REPO_MESSAGING=true
-
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem

--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,11 @@ MEDIA_ROOT=~/.dispatch/media
 
 # Let agents message/list agents in OTHER repositories (dispatch_send_message,
 # list_agents). Default scopes the addressable peer set to the sender's repo.
-# Enable for local multi-repo workflows. ("1" | "true" | "yes")
+# Set to "true" to enable for local multi-repo workflows.
 # NOTE: when enabled, name-based targeting matches agents across ALL repos, so a
 # name can resolve to a same-named agent in a different repo. Use the agent ID
 # (agt_...) to address a specific agent unambiguously.
-# DISPATCH_CROSS_REPO_MESSAGING=1
+# DISPATCH_CROSS_REPO_MESSAGING=true
 
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem

--- a/apps/server/src/cross-repo-messaging-settings.ts
+++ b/apps/server/src/cross-repo-messaging-settings.ts
@@ -1,0 +1,28 @@
+import type { Pool } from "pg";
+
+import { getSetting, setSetting } from "./db/settings.js";
+
+/**
+ * Whether agent-to-agent messaging (dispatch_send_message / list_agents) may
+ * address agents in *other* repositories. By default the addressable peer set
+ * is scoped to the sender's git repo root; enabling this lifts that scoping for
+ * local multi-repo workflows. This is a single server-wide setting — the gate
+ * applies to every agent on this Dispatch server, not per device.
+ *
+ * The key and the "true"/"false" <-> boolean encoding live only here so the
+ * route and the MCP handler share one definition (mirrors agent-type-settings).
+ */
+const CROSS_REPO_MESSAGING_KEY = "cross_repo_messaging_enabled";
+
+export async function isCrossRepoMessagingEnabled(
+  pool: Pool
+): Promise<boolean> {
+  return (await getSetting(pool, CROSS_REPO_MESSAGING_KEY)) === "true";
+}
+
+export async function setCrossRepoMessagingEnabled(
+  pool: Pool,
+  enabled: boolean
+): Promise<void> {
+  await setSetting(pool, CROSS_REPO_MESSAGING_KEY, enabled ? "true" : "false");
+}

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -6,6 +6,10 @@ import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import type { Pool } from "pg";
 
 import { deleteSetting, getSetting, setSetting } from "../db/settings.js";
+import {
+  isCrossRepoMessagingEnabled,
+  setCrossRepoMessagingEnabled,
+} from "../cross-repo-messaging-settings.js";
 import { JobService } from "../jobs/service.js";
 import {
   AGENT_TYPES,
@@ -415,6 +419,22 @@ export async function registerSystemRoutes(
 
     return { enabledIdes: await setEnabledIdes(deps.pool, uniqueIdes) };
   });
+
+  app.get("/api/v1/app/settings/cross-repo-messaging", async () => {
+    return { enabled: await isCrossRepoMessagingEnabled(deps.pool) };
+  });
+
+  app.post(
+    "/api/v1/app/settings/cross-repo-messaging",
+    async (request, reply) => {
+      const body = request.body as { enabled?: unknown } | null;
+      if (typeof body?.enabled !== "boolean") {
+        return reply.code(400).send({ error: "enabled must be a boolean." });
+      }
+      await setCrossRepoMessagingEnabled(deps.pool, body.enabled);
+      return { enabled: body.enabled };
+    }
+  );
 
   app.post("/api/v1/energy-report", async (request, reply) => {
     try {

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -844,9 +844,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         const lowerTarget = input.target.toLowerCase();
         const matches = allAgents.filter(
           (a) =>
-            a.id !== agentId &&
-            a.status === "running" &&
-            a.name.toLowerCase().includes(lowerTarget)
+            a.status === "running" && a.name.toLowerCase().includes(lowerTarget)
         );
         if (matches.length === 1) {
           target = matches[0];
@@ -860,16 +858,12 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
 
       if (!target) {
         const running = allAgents
-          .filter((a) => a.id !== agentId && a.status === "running")
+          .filter((a) => a.status === "running")
           .map((a) => `  ${a.id} "${a.name}"`)
           .join("\n");
         throw new Error(
           `No agent found matching "${input.target}".${running ? ` Running agents:\n${running}` : " No other agents are running."}`
         );
-      }
-
-      if (target.id === agentId) {
-        throw new Error("Cannot send a message to yourself.");
       }
 
       if (target.status !== "running") {

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -18,6 +18,7 @@ import {
   getEnabledAgentTypes,
   isCliAgentType,
 } from "../agent-type-settings.js";
+import { isCrossRepoMessagingEnabled } from "../cross-repo-messaging-settings.js";
 import type { JobService } from "../jobs/service.js";
 import type {
   NotifyInput,
@@ -111,19 +112,6 @@ export function mcpMethodNotAllowed(): {
 }
 
 /**
- * Opt-in flag that lets agent-to-agent messaging (dispatch_send_message /
- * list_agents) address agents in *other* repositories. By default the
- * addressable peer set is scoped to the sender's git repo root; for local
- * multi-repo workflows (e.g. an agent in repo A messaging an agent in repo B)
- * set DISPATCH_CROSS_REPO_MESSAGING=true to lift that scoping.
- */
-const CROSS_REPO_MESSAGING_ENV = "DISPATCH_CROSS_REPO_MESSAGING";
-
-function crossRepoMessagingEnabled(): boolean {
-  return process.env[CROSS_REPO_MESSAGING_ENV] === "true";
-}
-
-/**
  * The set of agents a sender may address via dispatch_send_message and
  * list_agents: every other agent (self excluded), scoped to the sender's git
  * repo root unless cross-repo messaging is enabled. This is the single
@@ -133,9 +121,9 @@ function crossRepoMessagingEnabled(): boolean {
 async function addressableAgents<T extends { id: string; cwd: string }>(
   all: T[],
   agentId: string,
-  senderRepoRoot: string | null
+  senderRepoRoot: string | null,
+  crossRepo: boolean
 ): Promise<T[]> {
-  const crossRepo = crossRepoMessagingEnabled();
   const result: T[] = [];
   for (const a of all) {
     if (a.id === agentId) continue;
@@ -833,7 +821,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       if (!sender) throw new Error("Sender agent not found.");
 
       const senderRepoRoot = input.senderRepoRoot;
-      if (!crossRepoMessagingEnabled() && !senderRepoRoot) {
+      const crossRepo = await isCrossRepoMessagingEnabled(pool);
+      if (!crossRepo && !senderRepoRoot) {
         throw new Error(
           "Cannot send messages: unable to determine your project's repository root."
         );
@@ -842,7 +831,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const allAgents = await addressableAgents(
         await agentManager.listAgents(),
         agentId,
-        senderRepoRoot
+        senderRepoRoot,
+        crossRepo
       );
 
       const isAgentId = input.target.startsWith("agt_");
@@ -928,7 +918,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         latestEvent: { type: string; message: string } | null;
       }>
     > {
-      if (!crossRepoMessagingEnabled() && !senderRepoRoot) {
+      const crossRepo = await isCrossRepoMessagingEnabled(pool);
+      if (!crossRepo && !senderRepoRoot) {
         throw new Error(
           "Cannot list agents: unable to determine your project's repository root."
         );
@@ -937,7 +928,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const agents = await addressableAgents(
         await agentManager.listAgents(),
         agentId,
-        senderRepoRoot
+        senderRepoRoot,
+        crossRepo
       );
       const result: Array<{
         id: string;

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -110,6 +110,20 @@ export function mcpMethodNotAllowed(): {
   };
 }
 
+/**
+ * Opt-in flag that lets agent-to-agent messaging (dispatch_send_message /
+ * list_agents) address agents in *other* repositories. By default the
+ * addressable peer set is scoped to the sender's git repo root; for local
+ * multi-repo workflows (e.g. an agent in repo A messaging an agent in repo B)
+ * set DISPATCH_CROSS_REPO_MESSAGING=1 to lift that scoping.
+ */
+const CROSS_REPO_MESSAGING_ENV = "DISPATCH_CROSS_REPO_MESSAGING";
+
+function crossRepoMessagingEnabled(): boolean {
+  const value = process.env[CROSS_REPO_MESSAGING_ENV]?.toLowerCase();
+  return value === "1" || value === "true" || value === "yes";
+}
+
 export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
   const {
     pool,
@@ -790,7 +804,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       if (!sender) throw new Error("Sender agent not found.");
 
       const senderRepoRoot = input.senderRepoRoot;
-      if (!senderRepoRoot) {
+      const crossRepo = crossRepoMessagingEnabled();
+      if (!crossRepo && !senderRepoRoot) {
         throw new Error(
           "Cannot send messages: unable to determine your project's repository root."
         );
@@ -800,6 +815,11 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const allAgents: typeof allAgentsRaw = [];
       for (const a of allAgentsRaw) {
         if (a.id === agentId) continue;
+        if (crossRepo) {
+          // Cross-repo messaging enabled: address every other agent.
+          allAgents.push(a);
+          continue;
+        }
         try {
           const aRoot = await resolveRepoRoot(a.cwd);
           if (aRoot === senderRepoRoot) allAgents.push(a);
@@ -891,7 +911,8 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         latestEvent: { type: string; message: string } | null;
       }>
     > {
-      if (!senderRepoRoot) {
+      const crossRepo = crossRepoMessagingEnabled();
+      if (!crossRepo && !senderRepoRoot) {
         throw new Error(
           "Cannot list agents: unable to determine your project's repository root."
         );
@@ -906,11 +927,14 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       }> = [];
       for (const a of agents) {
         if (a.id === agentId) continue;
-        try {
-          const aRoot = await resolveRepoRoot(a.cwd);
-          if (aRoot !== senderRepoRoot) continue;
-        } catch {
-          continue;
+        if (!crossRepo) {
+          // Default: only list agents sharing the sender's repo root.
+          try {
+            const aRoot = await resolveRepoRoot(a.cwd);
+            if (aRoot !== senderRepoRoot) continue;
+          } catch {
+            continue;
+          }
         }
         result.push({
           id: a.id,

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -115,13 +115,42 @@ export function mcpMethodNotAllowed(): {
  * list_agents) address agents in *other* repositories. By default the
  * addressable peer set is scoped to the sender's git repo root; for local
  * multi-repo workflows (e.g. an agent in repo A messaging an agent in repo B)
- * set DISPATCH_CROSS_REPO_MESSAGING=1 to lift that scoping.
+ * set DISPATCH_CROSS_REPO_MESSAGING=true to lift that scoping.
  */
 const CROSS_REPO_MESSAGING_ENV = "DISPATCH_CROSS_REPO_MESSAGING";
 
 function crossRepoMessagingEnabled(): boolean {
-  const value = process.env[CROSS_REPO_MESSAGING_ENV]?.toLowerCase();
-  return value === "1" || value === "true" || value === "yes";
+  return process.env[CROSS_REPO_MESSAGING_ENV] === "true";
+}
+
+/**
+ * The set of agents a sender may address via dispatch_send_message and
+ * list_agents: every other agent (self excluded), scoped to the sender's git
+ * repo root unless cross-repo messaging is enabled. This is the single
+ * definition of that visibility boundary — both message delivery and agent
+ * listing consult it, so they can never disagree about who is reachable.
+ */
+async function addressableAgents<T extends { id: string; cwd: string }>(
+  all: T[],
+  agentId: string,
+  senderRepoRoot: string | null
+): Promise<T[]> {
+  const crossRepo = crossRepoMessagingEnabled();
+  const result: T[] = [];
+  for (const a of all) {
+    if (a.id === agentId) continue;
+    if (crossRepo) {
+      result.push(a);
+      continue;
+    }
+    try {
+      const aRoot = await resolveRepoRoot(a.cwd);
+      if (aRoot === senderRepoRoot) result.push(a);
+    } catch {
+      // agent cwd not in a git repo — skip
+    }
+  }
+  return result;
 }
 
 export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
@@ -804,29 +833,17 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       if (!sender) throw new Error("Sender agent not found.");
 
       const senderRepoRoot = input.senderRepoRoot;
-      const crossRepo = crossRepoMessagingEnabled();
-      if (!crossRepo && !senderRepoRoot) {
+      if (!crossRepoMessagingEnabled() && !senderRepoRoot) {
         throw new Error(
           "Cannot send messages: unable to determine your project's repository root."
         );
       }
 
-      const allAgentsRaw = await agentManager.listAgents();
-      const allAgents: typeof allAgentsRaw = [];
-      for (const a of allAgentsRaw) {
-        if (a.id === agentId) continue;
-        if (crossRepo) {
-          // Cross-repo messaging enabled: address every other agent.
-          allAgents.push(a);
-          continue;
-        }
-        try {
-          const aRoot = await resolveRepoRoot(a.cwd);
-          if (aRoot === senderRepoRoot) allAgents.push(a);
-        } catch {
-          // agent cwd not in a git repo — skip
-        }
-      }
+      const allAgents = await addressableAgents(
+        await agentManager.listAgents(),
+        agentId,
+        senderRepoRoot
+      );
 
       const isAgentId = input.target.startsWith("agt_");
 
@@ -911,14 +928,17 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         latestEvent: { type: string; message: string } | null;
       }>
     > {
-      const crossRepo = crossRepoMessagingEnabled();
-      if (!crossRepo && !senderRepoRoot) {
+      if (!crossRepoMessagingEnabled() && !senderRepoRoot) {
         throw new Error(
           "Cannot list agents: unable to determine your project's repository root."
         );
       }
 
-      const agents = await agentManager.listAgents();
+      const agents = await addressableAgents(
+        await agentManager.listAgents(),
+        agentId,
+        senderRepoRoot
+      );
       const result: Array<{
         id: string;
         name: string;
@@ -926,16 +946,6 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         latestEvent: { type: string; message: string } | null;
       }> = [];
       for (const a of agents) {
-        if (a.id === agentId) continue;
-        if (!crossRepo) {
-          // Default: only list agents sharing the sender's repo root.
-          try {
-            const aRoot = await resolveRepoRoot(a.cwd);
-            if (aRoot !== senderRepoRoot) continue;
-          } catch {
-            continue;
-          }
-        }
         result.push({
           id: a.id,
           name: a.name,

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -1123,32 +1123,29 @@ describe("createMcpHandlers", () => {
       ).rejects.toThrow('No agent found matching "other"');
     });
 
-    it("delivers cross-repo when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
-      process.env.DISPATCH_CROSS_REPO_MESSAGING = "true";
-      try {
-        deps.agentManager.listAgents.mockResolvedValue([
-          {
-            id: "agt_test1",
-            name: "sender",
-            cwd: "/repo-a",
-            status: "running",
-          },
-          { id: "agt_other", name: "other", cwd: "/repo-b", status: "running" },
-        ]);
-        vi.mocked(resolveRepoRoot).mockImplementation(
-          async (cwd) => cwd as string
-        );
-        // senderRepoRoot null is tolerated once cross-repo messaging is on.
-        const result = await handlers.sendMessage("agt_test1", {
-          target: "other",
-          message: "hi",
-          senderRepoRoot: null,
-        });
-        expect(result.delivered).toBe(true);
-        expect(result.targetAgentId).toBe("agt_other");
-      } finally {
-        delete process.env.DISPATCH_CROSS_REPO_MESSAGING;
-      }
+    it("delivers cross-repo when the cross-repo messaging setting is enabled", async () => {
+      // getSetting(cross_repo_messaging_enabled) -> "true"
+      deps.pool.query.mockResolvedValue({ rows: [{ value: "true" }] });
+      deps.agentManager.listAgents.mockResolvedValue([
+        {
+          id: "agt_test1",
+          name: "sender",
+          cwd: "/repo-a",
+          status: "running",
+        },
+        { id: "agt_other", name: "other", cwd: "/repo-b", status: "running" },
+      ]);
+      vi.mocked(resolveRepoRoot).mockImplementation(
+        async (cwd) => cwd as string
+      );
+      // senderRepoRoot null is tolerated once cross-repo messaging is on.
+      const result = await handlers.sendMessage("agt_test1", {
+        target: "other",
+        message: "hi",
+        senderRepoRoot: null,
+      });
+      expect(result.delivered).toBe(true);
+      expect(result.targetAgentId).toBe("agt_other");
     });
   });
 
@@ -1197,34 +1194,31 @@ describe("createMcpHandlers", () => {
       ).rejects.toThrow("Cannot list agents");
     });
 
-    it("lists agents across repos when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
-      process.env.DISPATCH_CROSS_REPO_MESSAGING = "true";
-      try {
-        deps.agentManager.listAgents.mockResolvedValue([
-          {
-            id: "agt_self",
-            name: "self",
-            cwd: "/repo",
-            status: "running",
-            latestEvent: null,
-          },
-          {
-            id: "agt_other",
-            name: "other",
-            cwd: "/other-repo",
-            status: "running",
-            latestEvent: null,
-          },
-        ]);
-        vi.mocked(resolveRepoRoot).mockImplementation(
-          async (cwd) => cwd as string
-        );
-        // senderRepoRoot null is tolerated once cross-repo messaging is on.
-        const result = await handlers.listAgentsForAgent("agt_self", null);
-        expect(result.map((a) => a.id)).toEqual(["agt_other"]);
-      } finally {
-        delete process.env.DISPATCH_CROSS_REPO_MESSAGING;
-      }
+    it("lists agents across repos when the cross-repo messaging setting is enabled", async () => {
+      // getSetting(cross_repo_messaging_enabled) -> "true"
+      deps.pool.query.mockResolvedValue({ rows: [{ value: "true" }] });
+      deps.agentManager.listAgents.mockResolvedValue([
+        {
+          id: "agt_self",
+          name: "self",
+          cwd: "/repo",
+          status: "running",
+          latestEvent: null,
+        },
+        {
+          id: "agt_other",
+          name: "other",
+          cwd: "/other-repo",
+          status: "running",
+          latestEvent: null,
+        },
+      ]);
+      vi.mocked(resolveRepoRoot).mockImplementation(
+        async (cwd) => cwd as string
+      );
+      // senderRepoRoot null is tolerated once cross-repo messaging is on.
+      const result = await handlers.listAgentsForAgent("agt_self", null);
+      expect(result.map((a) => a.id)).toEqual(["agt_other"]);
     });
   });
 

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -1122,6 +1122,34 @@ describe("createMcpHandlers", () => {
         })
       ).rejects.toThrow('No agent found matching "other"');
     });
+
+    it("delivers cross-repo when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
+      process.env.DISPATCH_CROSS_REPO_MESSAGING = "1";
+      try {
+        deps.agentManager.listAgents.mockResolvedValue([
+          {
+            id: "agt_test1",
+            name: "sender",
+            cwd: "/repo-a",
+            status: "running",
+          },
+          { id: "agt_other", name: "other", cwd: "/repo-b", status: "running" },
+        ]);
+        vi.mocked(resolveRepoRoot).mockImplementation(
+          async (cwd) => cwd as string
+        );
+        // senderRepoRoot null is tolerated once cross-repo messaging is on.
+        const result = await handlers.sendMessage("agt_test1", {
+          target: "other",
+          message: "hi",
+          senderRepoRoot: null,
+        });
+        expect(result.delivered).toBe(true);
+        expect(result.targetAgentId).toBe("agt_other");
+      } finally {
+        delete process.env.DISPATCH_CROSS_REPO_MESSAGING;
+      }
+    });
   });
 
   describe("listAgentsForAgent", () => {
@@ -1167,6 +1195,36 @@ describe("createMcpHandlers", () => {
       await expect(
         handlers.listAgentsForAgent("agt_self", null)
       ).rejects.toThrow("Cannot list agents");
+    });
+
+    it("lists agents across repos when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
+      process.env.DISPATCH_CROSS_REPO_MESSAGING = "1";
+      try {
+        deps.agentManager.listAgents.mockResolvedValue([
+          {
+            id: "agt_self",
+            name: "self",
+            cwd: "/repo",
+            status: "running",
+            latestEvent: null,
+          },
+          {
+            id: "agt_other",
+            name: "other",
+            cwd: "/other-repo",
+            status: "running",
+            latestEvent: null,
+          },
+        ]);
+        vi.mocked(resolveRepoRoot).mockImplementation(
+          async (cwd) => cwd as string
+        );
+        // senderRepoRoot null is tolerated once cross-repo messaging is on.
+        const result = await handlers.listAgentsForAgent("agt_self", null);
+        expect(result.map((a) => a.id)).toEqual(["agt_other"]);
+      } finally {
+        delete process.env.DISPATCH_CROSS_REPO_MESSAGING;
+      }
     });
   });
 

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -1124,7 +1124,7 @@ describe("createMcpHandlers", () => {
     });
 
     it("delivers cross-repo when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
-      process.env.DISPATCH_CROSS_REPO_MESSAGING = "1";
+      process.env.DISPATCH_CROSS_REPO_MESSAGING = "true";
       try {
         deps.agentManager.listAgents.mockResolvedValue([
           {
@@ -1198,7 +1198,7 @@ describe("createMcpHandlers", () => {
     });
 
     it("lists agents across repos when DISPATCH_CROSS_REPO_MESSAGING is enabled", async () => {
-      process.env.DISPATCH_CROSS_REPO_MESSAGING = "1";
+      process.env.DISPATCH_CROSS_REPO_MESSAGING = "true";
       try {
         deps.agentManager.listAgents.mockResolvedValue([
           {

--- a/apps/web/src/components/app/cross-repo-messaging-settings.tsx
+++ b/apps/web/src/components/app/cross-repo-messaging-settings.tsx
@@ -21,16 +21,17 @@ const ENDPOINT = "/api/v1/app/settings/cross-repo-messaging";
 export function CrossRepoMessagingSettings(): JSX.Element {
   const [enabled, setEnabled] = useAtom(crossRepoMessagingEnabledAtom);
   const [error, setError] = useState("");
-  // Monotonic id for the most recent request (mount GET or a toggle). A
-  // response only applies if it is still the latest, so a stale mount GET or
-  // an out-of-order toggle response can't clobber a newer user intent.
   const latestReq = useRef(0);
+  const confirmedValue = useRef(enabled);
 
   useEffect(() => {
     const seq = (latestReq.current += 1);
     void api<CrossRepoMessagingResponse>(ENDPOINT)
       .then((data) => {
-        if (seq === latestReq.current) setEnabled(data.enabled);
+        if (seq === latestReq.current) {
+          confirmedValue.current = data.enabled;
+          setEnabled(data.enabled);
+        }
       })
       .catch(() => {
         if (seq === latestReq.current) {
@@ -47,16 +48,19 @@ export function CrossRepoMessagingSettings(): JSX.Element {
       void api<CrossRepoMessagingResponse>(ENDPOINT, {
         method: "POST",
         body: JSON.stringify({ enabled: next }),
-      }).catch((err) => {
-        if (seq !== latestReq.current) return;
-        // Revert the optimistic change — the server gate is unchanged.
-        setEnabled(!next);
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Failed to save cross-repo messaging setting."
-        );
-      });
+      })
+        .then(() => {
+          if (seq === latestReq.current) confirmedValue.current = next;
+        })
+        .catch((err) => {
+          if (seq !== latestReq.current) return;
+          setEnabled(confirmedValue.current);
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to save cross-repo messaging setting."
+          );
+        });
     },
     [setEnabled]
   );

--- a/apps/web/src/components/app/cross-repo-messaging-settings.tsx
+++ b/apps/web/src/components/app/cross-repo-messaging-settings.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { api } from "@/lib/api";
+import { crossRepoMessagingEnabledAtom } from "@/lib/store";
+
+type CrossRepoMessagingResponse = { enabled: boolean };
+
+const ENDPOINT = "/api/v1/app/settings/cross-repo-messaging";
+
+/**
+ * Toggle for the server-wide cross-repo messaging gate. The gate is enforced
+ * server-side (a single settings row read by the MCP handler for every agent),
+ * so the server is the source of truth: on mount we GET the current value and
+ * hydrate the jotai atom from it, and we only ever POST in response to an
+ * explicit user toggle. The atom is a cached view that keeps the checkbox
+ * reactive and gives an instant first paint; it is never re-asserted to the
+ * server on its own.
+ */
+export function CrossRepoMessagingSettings(): JSX.Element {
+  const [enabled, setEnabled] = useAtom(crossRepoMessagingEnabledAtom);
+  const [error, setError] = useState("");
+  // Monotonic id for the most recent request (mount GET or a toggle). A
+  // response only applies if it is still the latest, so a stale mount GET or
+  // an out-of-order toggle response can't clobber a newer user intent.
+  const latestReq = useRef(0);
+
+  useEffect(() => {
+    const seq = (latestReq.current += 1);
+    void api<CrossRepoMessagingResponse>(ENDPOINT)
+      .then((data) => {
+        if (seq === latestReq.current) setEnabled(data.enabled);
+      })
+      .catch(() => {
+        if (seq === latestReq.current) {
+          setError("Failed to load cross-repo messaging setting.");
+        }
+      });
+  }, [setEnabled]);
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      const seq = (latestReq.current += 1);
+      setError("");
+      setEnabled(next);
+      void api<CrossRepoMessagingResponse>(ENDPOINT, {
+        method: "POST",
+        body: JSON.stringify({ enabled: next }),
+      }).catch((err) => {
+        if (seq !== latestReq.current) return;
+        // Revert the optimistic change — the server gate is unchanged.
+        setEnabled(!next);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to save cross-repo messaging setting."
+        );
+      });
+    },
+    [setEnabled]
+  );
+
+  return (
+    <div className="p-6">
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+        Cross-repo messaging
+      </div>
+      <p className="mb-3 max-w-2xl text-sm text-muted-foreground">
+        By default agents can only message and list other agents in the same git
+        repository. Enable this to let agents coordinate across repositories for
+        local multi-repo workflows. Applies to all agents on this Dispatch
+        server.
+      </p>
+      <div className="max-w-lg">
+        <label className="flex cursor-pointer items-center gap-3 rounded border border-border px-3 py-2.5 transition-colors hover:bg-muted/50">
+          <Checkbox
+            checked={enabled}
+            onCheckedChange={(checked) => handleToggle(checked === true)}
+            data-testid="cross-repo-messaging-toggle"
+          />
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              Allow messaging agents in other repositories
+            </div>
+            <div className="text-xs text-muted-foreground">
+              When on, name-based targeting can match agents across all repos —
+              use the agent ID (agt_…) to address one unambiguously.
+            </div>
+          </div>
+        </label>
+      </div>
+      {error ? (
+        <p role="alert" className="mt-3 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/app/settings-pane.tsx
+++ b/apps/web/src/components/app/settings-pane.tsx
@@ -2,6 +2,7 @@ import { Database, Server, Settings } from "lucide-react";
 
 import { AgentTypeSettings } from "@/components/app/agent-type-settings";
 import { AppearanceSettings } from "@/components/app/appearance-settings";
+import { CrossRepoMessagingSettings } from "@/components/app/cross-repo-messaging-settings";
 import { IdeSettings } from "@/components/app/ide-settings";
 import { InstanceNameSettings } from "@/components/app/instance-name-settings";
 import { DocsContent, DOCS_SECTION_NAV } from "@/components/app/docs-pane";
@@ -216,6 +217,9 @@ export function SettingsContent({
                 enabledIdes={enabledIdes}
                 onChange={onEnabledIdesChange}
               />
+            </div>
+            <div className="border-t border-border">
+              <CrossRepoMessagingSettings />
             </div>
             <div className="px-6 pb-6">
               <WorktreeLocationSettings />

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -69,6 +69,16 @@ export const preferredIdeAtom = atomWithLocalStorage<IdeType>(
   "vscode"
 );
 
+// Cached view of the server-wide cross-repo messaging gate (lets agents
+// message/list agents in OTHER repositories). The server enforces and owns the
+// value; CrossRepoMessagingSettings hydrates this atom from the GET endpoint on
+// mount and writes back only on an explicit toggle. localStorage just gives an
+// instant first paint before the GET resolves. Default off.
+export const crossRepoMessagingEnabledAtom = atomWithLocalStorage<boolean>(
+  "dispatch:crossRepoMessaging",
+  false
+);
+
 // Per-cwd preferences for the Create Agent dialog. Each cwd gets its own
 // atom backed by localStorage; the family caches them by trimmed cwd.
 export const createNewBranchPrefAtom = atomFamily((cwd: string) =>

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -17,6 +17,12 @@ test.describe("Settings pane", () => {
         webNotifyEvents: ["done", "waiting_user", "blocked"],
       },
     });
+    await request.post("/api/v1/app/settings/cross-repo-messaging", {
+      headers: {
+        Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+      },
+      data: { enabled: false },
+    });
   });
 
   test("opens and closes the settings pane", async ({ page }) => {
@@ -89,6 +95,41 @@ test.describe("Settings pane", () => {
     await expect(
       page.getByRole("option", { name: "Claude" })
     ).not.toBeVisible();
+  });
+
+  test("cross-repo messaging toggle defaults off and persists to the server", async ({
+    page,
+    request,
+  }) => {
+    await loadApp(page);
+
+    await page.getByTestId("settings-button").click();
+    await page
+      .getByTestId("sidebar-shell")
+      .getByText("Agents", { exact: true })
+      .click();
+
+    const toggle = page.getByTestId("cross-repo-messaging-toggle");
+    await toggle.scrollIntoViewIfNeeded();
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+
+    // The local toggle is mirrored to the server, which enforces the boundary.
+    await expect
+      .poll(async () => {
+        const res = await request.get(
+          "/api/v1/app/settings/cross-repo-messaging",
+          {
+            headers: {
+              Authorization: `Bearer ${process.env.AUTH_TOKEN ?? "dev-token"}`,
+            },
+          }
+        );
+        return (await res.json()).enabled;
+      })
+      .toBe(true);
   });
 
   test("single enabled agent type removes split buttons", async ({


### PR DESCRIPTION
## Summary

<img width="721" height="213" alt="cross-repo-on" src="https://github.com/user-attachments/assets/939fc2b7-a55a-4fbd-8185-d8e03ac80abb" />

Agent-to-agent messaging (`dispatch_send_message` and `list_agents`) scopes the addressable peer set to the sender's **git repo root** — an agent in one repo can't message or even see an agent in another. That's the right default, but it blocks local multi-repo workflows (e.g. an agent in `neo` coordinating with an agent in `brane-uis`).

This adds an **opt-in toggle** that lifts the scoping. When enabled, `senderRepoRoot` is no longer required and every other agent is addressable. **Default behavior is unchanged (off).**

> Supersedes the original `DISPATCH_CROSS_REPO_MESSAGING` env-var approach. Per review feedback, the control is now a setting in the **Agents** settings page instead of an environment variable.

## How it works

- **Server is the source of truth.** The gate is a single server-wide setting (`cross_repo_messaging_enabled`) in the existing `settings` table, read by the MCP handler for every agent. It is *not* per-device.
- **UI toggle** lives in **Settings → Agents**. It's backed by a jotai atom for reactive state / instant first paint, but the atom is a cached *view*: the component GETs the value on mount to hydrate it and only POSTs on an explicit user toggle. There is no mount-time write, so opening settings on one device never clobbers the global gate.

## Changes

- **`apps/server/src/cross-repo-messaging-settings.ts`** (new): accessor module owning the settings key and the `"true"`/`"false"` ↔ boolean encoding — `isCrossRepoMessagingEnabled(pool)` / `setCrossRepoMessagingEnabled(pool, bool)`. Mirrors `agent-type-settings.ts`, so the encoding lives in exactly one place.
- **`apps/server/src/server/mcp-handlers.ts`**: the addressable-peer gate reads the setting via the accessor; the boolean is resolved once per call and threaded into a single `addressableAgents()` helper shared by both message delivery and agent listing.
- **`apps/server/src/routes/system.ts`**: `GET`/`POST /api/v1/app/settings/cross-repo-messaging` (mirrors the existing agent-types / IDE settings routes; validates `enabled` is a boolean).
- **`apps/web`**: `crossRepoMessagingEnabledAtom` + a `CrossRepoMessagingSettings` component rendered in the Agents settings section. Server-authoritative hydration, `role="alert"` on errors, and a request-sequence guard against out-of-order responses.
- Removed the env var from `.env.example`; updated unit tests to drive the setting; added an e2e regression test.

> ⚠️ Name-based targeting caveat (unchanged from before): when enabled, a name can resolve to a same-named agent in a different repo — use the agent ID (`agt_…`) to address one unambiguously. This is called out in the toggle's helper text.

## Testing

- `pnpm run check` (tsc, server + web) — clean
- Backend unit tests (`mcp-handlers.test.ts`) — 73 pass, incl. the gate logic driven by the setting
- Settings e2e suite — 5/5 pass, incl. a new regression test for the toggle
- Manual browser validation: default off; enabling persists to the server; a fresh second browser context hydrates from the server and does **not** flip the gate just by viewing settings

## Review

Reviewed by three persona agents (backend-security, architecture, frontend-ux) — all **approved** after one round of changes that moved the toggle to a server-authoritative model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
