### PR TITLE
Fix expected_runtime_artifact check for binary-only installs

### DIFF
--- a/apps/server/src/release-checks.ts
+++ b/apps/server/src/release-checks.ts
@@ -57,19 +57,13 @@ async function runCheck(
 }
 
 async function checkRuntimeArtifact(ctx: CheckContext): Promise<CheckResult> {
-  const webDist = path.join(ctx.serverDir, "apps/web/dist/index.html");
   const platformBinary = selectPlatformBinary(ctx.serverDir);
-  const missing = [
-    ...(existsSync(webDist) ? [] : [webDist]),
-    ...(platformBinary.ok ? [] : [platformBinary.message]),
-  ];
   return {
     name: "expected_runtime_artifact",
-    ok: missing.length === 0,
-    message:
-      missing.length === 0
-        ? `Runtime assets present: ${webDist}, ${platformBinary.message}`
-        : `Missing: ${missing.join(", ")}`,
+    ok: platformBinary.ok,
+    message: platformBinary.ok
+      ? `Platform binary present: ${platformBinary.message}`
+      : platformBinary.message,
   };
 }
 

--- a/apps/server/test/release-checks.test.ts
+++ b/apps/server/test/release-checks.test.ts
@@ -46,18 +46,12 @@ function setReleaseRecord(record: StoreRecord) {
 }
 
 describe("expected_runtime_artifact", () => {
-  it("passes when the web build and host Bun binary exist", async () => {
+  it("passes when the host Bun binary exists", async () => {
     const bunDist = path.join(tmpServerDir, "dist/bun");
-    const webDist = path.join(tmpServerDir, "apps/web/dist");
     await mkdir(bunDist, { recursive: true });
-    await mkdir(webDist, { recursive: true });
     await writeFile(
       path.join(bunDist, `dispatch-0.19.0-bun-${hostPlatform()}-${hostArch()}`),
       "binary"
-    );
-    await writeFile(
-      path.join(webDist, "index.html"),
-      "<!doctype html><html></html>"
     );
 
     const [result] = await runRequiredChecks(["expected_runtime_artifact"], {
@@ -66,24 +60,16 @@ describe("expected_runtime_artifact", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toMatch(/Runtime assets present/);
+    expect(result.message).toMatch(/Platform binary present/);
   });
 
-  it("fails when an artifact is missing", async () => {
-    const bunDist = path.join(tmpServerDir, "dist/bun");
-    await mkdir(bunDist, { recursive: true });
-    await writeFile(
-      path.join(bunDist, `dispatch-0.19.0-bun-${hostPlatform()}-${hostArch()}`),
-      "binary"
-    );
-
+  it("fails when no platform binary exists", async () => {
     const [result] = await runRequiredChecks(["expected_runtime_artifact"], {
       serverDir: tmpServerDir,
       targetTag: "v0.19.0",
     });
 
     expect(result.ok).toBe(false);
-    expect(result.message).toMatch(/Missing:.*apps\/web\/dist\/index\.html/);
   });
 });
 

--- a/docs/10-operations-runbook.md
+++ b/docs/10-operations-runbook.md
@@ -175,7 +175,7 @@ inspect → prepare → apply → restarting → validate → done
 
 When the agent moves to `validate`, the server runs `runAndRecordChecks`, which evaluates the required checks listed in the manifests/metadata. The known check names (defined in `apps/server/src/release-metadata.ts`):
 
-- `expected_runtime_artifact` — the platform-matching `dist/bun/dispatch-*` binary and `apps/web/dist/index.html` both exist after deploy
+- `expected_runtime_artifact` — the platform-matching `dist/bun/dispatch-*` binary exists after deploy
 - `service_entrypoint` — `apps/server/package.json` has a `scripts.start` entry
 - `service_restarted` — `~/.dispatch/release.json` is present (lenient proxy for restart; the deeper check is `health_endpoint`)
 - `version_converged` — `~/.dispatch/release.json` tag matches the target tag


### PR DESCRIPTION
## Summary

- Simplified `checkRuntimeArtifact()` to only validate the platform Bun binary in `dist/bun/`, removing the stale `apps/web/dist/index.html` requirement that was failing on every binary install
- Updated tests to cover binary-only validation (pass/fail)
- Updated operations runbook to match the new check behavior

## Context

The assisted update validation check `expected_runtime_artifact` required `apps/web/dist/index.html` to exist on the host filesystem. Since the source install path was removed and all installs now use prebuilt Bun binaries with embedded web assets, this file never exists — causing the check to fail and block assisted update validation on every update.

## Test plan

- [x] Unit tests pass (`pnpm vitest run apps/server/test/release-checks.test.ts` — 19 tests)
- [x] Type checking passes (`pnpm run check`)
- [x] Release-readiness review: approved (2 rounds)
- [x] Backend security review: approved (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)