### PR TITLE
Document New branch name input in Agents create-agent docs

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -38,7 +38,9 @@ export function AgentsContent() {
             controls whether Dispatch forks a new working branch from the
             starting branch (on, default — the authoring flow) or just checks
             out the starting branch directly (off — review/investigation flows).
-            See the Worktrees section for details.
+            When on, a <strong>New branch name</strong> input appears — leave it
+            empty and Dispatch auto-generates a name, or type one to use a
+            specific branch. See the Worktrees section for details.
           </li>
           <li>
             <strong>Full access mode</strong> (CLI types only) — starts the CLI


### PR DESCRIPTION
## Summary

- Added missing documentation for the **New branch name** text input that appears in the Create Agent form when the "Create a new branch in this worktree" checkbox is checked. The input lets users specify a custom branch name or leave it empty for auto-generation.

## Audit scope

Deep-dive on the Agents docs section per `next_focus` from the previous run:
- **Agent details paragraph** — verified all claims (worktree/non-worktree metadata, diff-stats badge, full access badge, feedback panel, persona launcher) against `agent-card.tsx`. All accurate.
- **Diff-stats badge section** — verified hide-when-empty, flash-on-tick, stale opacity, click-to-refresh, tooltip file count against `diff-stat-badge.tsx`. All accurate.
- **Creating an agent form fields** — verified against `create-agent-dialog.tsx` and `create-agent-worktree-section.tsx`. Found the New branch name input was undocumented.
- **Diff since last audit** (7 commits): messaging-tools extraction (refactor, no new tools), iPadOS scroll fix, AmbientTipBar overlay fix, webhook toggle flake fix, tool registration tests. None introduced docs-relevant behavior changes.

## Deferred to next run

Next focus set to: audit Repo Tools docs section — verify the built-in MCP tools list against current `AGENT_TOOLS`/`JOB_TOOLS`/`PERSONA_TOOLS` in `server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)