### PR TITLE
Fix terminal-drag-drop E2E flake, add lifecycle-routes tests

### DIFF
--- a/apps/server/test/lifecycle-routes.test.ts
+++ b/apps/server/test/lifecycle-routes.test.ts
@@ -1,0 +1,408 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useInjectApp } from "./helpers/inject-app.js";
+
+const ctx = useInjectApp();
+
+async function authedInject(
+  method: string,
+  url: string,
+  payload?: unknown
+): Promise<ReturnType<typeof ctx.app.inject>> {
+  const cookie = await ctx.sessionCookie();
+  const headers: Record<string, string> = { cookie };
+  if (payload !== undefined) {
+    headers["content-type"] = "application/json";
+  }
+  return ctx.app.inject({
+    method: method as "GET" | "POST" | "PATCH" | "DELETE",
+    url,
+    headers,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+}
+
+async function createAgent(
+  overrides: Record<string, unknown> = {}
+): Promise<Record<string, unknown>> {
+  const res = await authedInject("POST", "/api/v1/agents", {
+    cwd: "/tmp",
+    useWorktree: false,
+    ...overrides,
+  });
+  expect(res.statusCode).toBe(201);
+  return res.json().agent;
+}
+
+beforeEach(async () => {
+  await ctx.pool.query("DELETE FROM agents");
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/diff-stats
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/agents/:id/diff-stats", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject(
+      "GET",
+      "/api/v1/agents/nonexistent/diff-stats"
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns diffStats for a valid agent", async () => {
+    const agent = await createAgent({ name: "diff-stats-test" });
+    const res = await authedInject(
+      "GET",
+      `/api/v1/agents/${agent.id}/diff-stats`
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty("diffStats");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/diff
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/agents/:id/diff", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject("GET", "/api/v1/agents/nonexistent/diff");
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns empty files when agent has no git-backed worktree", async () => {
+    const agent = await createAgent({ name: "no-worktree" });
+    const res = await authedInject("GET", `/api/v1/agents/${agent.id}/diff`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().files).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/diff/file
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/agents/:id/diff/file", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject(
+      "GET",
+      "/api/v1/agents/nonexistent/diff/file?path=foo.ts"
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns 400 when path query param is missing", async () => {
+    const agent = await createAgent({ name: "missing-path" });
+    const res = await authedInject(
+      "GET",
+      `/api/v1/agents/${agent.id}/diff/file`
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/path query parameter required/i);
+  });
+
+  it("rejects path traversal with 400", async () => {
+    const agent = await createAgent({ name: "traversal-test" });
+    const res = await authedInject(
+      "GET",
+      `/api/v1/agents/${agent.id}/diff/file?path=../../etc/passwd`
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid file path/i);
+  });
+
+  it("returns 404 when file not found in diff", async () => {
+    const agent = await createAgent({ name: "no-wt-file" });
+    const res = await authedInject(
+      "GET",
+      `/api/v1/agents/${agent.id}/diff/file?path=src/foo.ts`
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/file not found in diff/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/diff/comment
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/diff/comment", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject(
+      "POST",
+      "/api/v1/agents/nonexistent/diff/comment",
+      { filePath: "foo.ts", startLine: 1, endLine: 5, comment: "looks good" }
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns 400 when body is empty", async () => {
+    const agent = await createAgent({ name: "empty-body" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      {}
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/filePath.*startLine.*endLine.*comment/i);
+  });
+
+  it("returns 400 when filePath is missing", async () => {
+    const agent = await createAgent({ name: "no-filepath" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { startLine: 1, endLine: 5, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/filePath.*startLine.*endLine.*comment/i);
+  });
+
+  it("returns 400 when startLine is not a number", async () => {
+    const agent = await createAgent({ name: "bad-start" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: "abc", endLine: 5, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when comment is empty/whitespace", async () => {
+    const agent = await createAgent({ name: "empty-comment" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 1, endLine: 5, comment: "   " }
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects path traversal in filePath", async () => {
+    const agent = await createAgent({ name: "traversal-comment" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      {
+        filePath: "../../etc/passwd",
+        startLine: 1,
+        endLine: 1,
+        comment: "bad",
+      }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid file path/i);
+  });
+
+  it("rejects startLine < 1", async () => {
+    const agent = await createAgent({ name: "bad-start-line" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 0, endLine: 5, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid line range/i);
+  });
+
+  it("rejects endLine < startLine", async () => {
+    const agent = await createAgent({ name: "reversed-range" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 10, endLine: 5, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid line range/i);
+  });
+
+  it("rejects non-integer line numbers", async () => {
+    const agent = await createAgent({ name: "float-lines" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 1.5, endLine: 5, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid line range/i);
+  });
+
+  it("rejects line range > 500", async () => {
+    const agent = await createAgent({ name: "huge-range" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 1, endLine: 502, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/line range too large/i);
+  });
+
+  it("rejects comment > 10000 chars", async () => {
+    const agent = await createAgent({ name: "long-comment" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      {
+        filePath: "foo.ts",
+        startLine: 1,
+        endLine: 1,
+        comment: "x".repeat(10_001),
+      }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/comment too long/i);
+  });
+
+  it("returns 404 when diff unavailable for agent", async () => {
+    const agent = await createAgent({ name: "no-wt-comment" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/diff/comment`,
+      { filePath: "foo.ts", startLine: 1, endLine: 1, comment: "hello" }
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/file not found in diff/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/prompt-rename
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/prompt-rename", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject(
+      "POST",
+      "/api/v1/agents/nonexistent/prompt-rename"
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns 409 when agent already has a custom name", async () => {
+    const agent = await createAgent({ name: "my-custom-name" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/prompt-rename`
+    );
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toMatch(/already has a custom session name/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/agents/:id/review-agent-type
+// ---------------------------------------------------------------------------
+describe("PATCH /api/v1/agents/:id/review-agent-type", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await authedInject(
+      "PATCH",
+      "/api/v1/agents/nonexistent/review-agent-type",
+      { reviewAgentType: "claude" }
+    );
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("clears review agent type with null", async () => {
+    const agent = await createAgent({ name: "clear-rat" });
+    const res = await authedInject(
+      "PATCH",
+      `/api/v1/agents/${agent.id}/review-agent-type`,
+      { reviewAgentType: null }
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty("agent");
+  });
+
+  it("rejects invalid review agent type", async () => {
+    const agent = await createAgent({ name: "bad-rat" });
+    const res = await authedInject(
+      "PATCH",
+      `/api/v1/agents/${agent.id}/review-agent-type`,
+      { reviewAgentType: "invalid-runtime" }
+    );
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/setup/phase
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/setup/phase", () => {
+  it("returns 400 for invalid phase", async () => {
+    const agent = await createAgent({ name: "bad-phase" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/setup/phase`,
+      { phase: "invalid" }
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/phase must be one of/i);
+  });
+
+  it("returns 400 when phase is missing", async () => {
+    const agent = await createAgent({ name: "no-phase" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/setup/phase`,
+      {}
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts valid phase values", async () => {
+    const agent = await createAgent({ name: "valid-phase" });
+    for (const phase of ["worktree", "env", "deps", "session"]) {
+      const res = await authedInject(
+        "POST",
+        `/api/v1/agents/${agent.id}/setup/phase`,
+        { phase }
+      );
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/setup/complete
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/setup/complete", () => {
+  it("returns 400 when effectiveCwd is missing", async () => {
+    const agent = await createAgent({ name: "no-cwd" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/setup/complete`,
+      {}
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/effectiveCwd/i);
+  });
+
+  it("returns 409 when agent is not in creating state", async () => {
+    const agent = await createAgent({ name: "setup-not-creating" });
+    const res = await authedInject(
+      "POST",
+      `/api/v1/agents/${agent.id}/setup/complete`,
+      { effectiveCwd: "/tmp/test" }
+    );
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toMatch(/not in creating state/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/stop
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/stop", () => {
+  it("returns 400 when force is not a boolean", async () => {
+    const agent = await createAgent({ name: "bad-force" });
+    const res = await authedInject("POST", `/api/v1/agents/${agent.id}/stop`, {
+      force: "yes",
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/force must be a boolean/i);
+  });
+});

--- a/e2e/terminal-drag-drop.spec.ts
+++ b/e2e/terminal-drag-drop.spec.ts
@@ -72,10 +72,17 @@ test.describe("Terminal drag-and-drop file upload", () => {
     });
 
     await loadApp(page);
+    const tokenReady = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/agents/${agent.id}/terminal/token`) &&
+        r.status() === 200,
+      { timeout: 30_000 }
+    );
     await page.getByTestId(`agent-row-${agent.id}`).click();
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
+    await tokenReady;
     await expect(page.getByTestId("terminal-connected-state")).toBeAttached({
-      timeout: 15_000,
+      timeout: 5_000,
     });
 
     const overlay = page.getByTestId("terminal-drop-overlay");
@@ -101,7 +108,15 @@ test.describe("Terminal drag-and-drop file upload", () => {
 
     // Wait for the upload response (not just the request) so the DB write
     // has committed before we query the media list.
+    let uploadSent = false;
     let uploadDone = false;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/media`)
+      )
+        uploadSent = true;
+    });
     page.on("response", (res) => {
       if (
         res.request().method() === "POST" &&
@@ -114,11 +129,13 @@ test.describe("Terminal drag-and-drop file upload", () => {
     await expect
       .poll(
         async () => {
-          await dispatchDragEvent(page, "dragover", TXT);
-          await dispatchDragEvent(page, "drop", TXT);
+          if (!uploadSent) {
+            await dispatchDragEvent(page, "dragover", TXT);
+            await dispatchDragEvent(page, "drop", TXT);
+          }
           return uploadDone;
         },
-        { timeout: 15_000, intervals: [200, 300, 500] }
+        { timeout: 30_000, intervals: [200, 300, 500] }
       )
       .toBe(true);
 
@@ -144,14 +161,34 @@ test.describe("Terminal drag-and-drop file upload", () => {
     });
 
     await loadApp(page);
+    const tokenReady = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/agents/${agent.id}/terminal/token`) &&
+        r.status() === 200,
+      { timeout: 30_000 }
+    );
     await page.getByTestId(`agent-row-${agent.id}`).click();
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
+    await tokenReady;
     await expect(page.getByTestId("terminal-connected-state")).toBeAttached({
-      timeout: 15_000,
+      timeout: 5_000,
     });
 
+    let uploadSent = false;
     let uploadDone = false;
     let clipboardSeen = false;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/media`)
+      )
+        uploadSent = true;
+      if (
+        req.method() === "POST" &&
+        req.url().includes("/api/v1/clipboard/image")
+      )
+        clipboardSeen = true;
+    });
     page.on("response", (res) => {
       if (
         res.request().method() === "POST" &&
@@ -160,22 +197,17 @@ test.describe("Terminal drag-and-drop file upload", () => {
       )
         uploadDone = true;
     });
-    page.on("request", (req) => {
-      if (
-        req.method() === "POST" &&
-        req.url().includes("/api/v1/clipboard/image")
-      )
-        clipboardSeen = true;
-    });
 
     await expect
       .poll(
         async () => {
-          await dispatchDragEvent(page, "dragover", IMG);
-          await dispatchDragEvent(page, "drop", IMG);
+          if (!uploadSent) {
+            await dispatchDragEvent(page, "dragover", IMG);
+            await dispatchDragEvent(page, "drop", IMG);
+          }
           return uploadDone;
         },
-        { timeout: 15_000, intervals: [200, 300, 500] }
+        { timeout: 30_000, intervals: [200, 300, 500] }
       )
       .toBe(true);
 
@@ -199,7 +231,15 @@ test.describe("Terminal drag-and-drop file upload", () => {
       name: `e2e-agent-paste-${Date.now()}`,
     });
 
+    let uploadSent = false;
     let uploadDone = false;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/v1/agents/${agent.id}/media`)
+      )
+        uploadSent = true;
+    });
     page.on("response", (res) => {
       if (
         res.request().method() === "POST" &&
@@ -210,19 +250,28 @@ test.describe("Terminal drag-and-drop file upload", () => {
     });
 
     await loadApp(page);
+    const tokenReady = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/agents/${agent.id}/terminal/token`) &&
+        r.status() === 200,
+      { timeout: 30_000 }
+    );
     await page.getByTestId(`agent-row-${agent.id}`).click();
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
+    await tokenReady;
     await expect(page.getByTestId("terminal-connected-state")).toBeAttached({
-      timeout: 15_000,
+      timeout: 5_000,
     });
 
     await expect
       .poll(
         async () => {
-          await dispatchPaste(page, IMG);
+          if (!uploadSent) {
+            await dispatchPaste(page, IMG);
+          }
           return uploadDone;
         },
-        { timeout: 15_000, intervals: [200, 300, 500] }
+        { timeout: 30_000, intervals: [200, 300, 500] }
       )
       .toBe(true);
 


### PR DESCRIPTION
## Summary

- **Fixed terminal-drag-drop E2E flake** — Two sources of nondeterminism under parallel E2E load:
  - Wait for `terminal/token` network response before checking DOM connected state, removing dependency on frontend retry loop timing
  - Track upload request state to stop dispatching duplicate drop/paste events once an upload is in flight, preventing server flooding
- **Added 31 lifecycle-routes unit tests** covering diff-stats, diff, diff/file, diff/comment, prompt-rename, review-agent-type, setup/phase, setup/complete, and stop endpoints — input validation, path traversal rejection, line range checks, and error paths

## Test plan

- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 2053 server + 180 web tests pass
- [x] `pnpm run test:e2e` — 171 passed, 0 failed, 12 skipped
- [x] Terminal-drag-drop tests pass both isolated and in full suite
- [x] Review agent found no correctness bugs or flake risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)