### PR TITLE
Fix repo tool scope docs — remove non-functional "reviewer" scope

### DIFF
--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -85,10 +85,10 @@ export function ToolsContent() {
         <P>
           By default a repo tool is exposed to every agent type. Add an optional{" "}
           <Code>scope</Code> array to restrict where a tool shows up. Valid
-          scopes are <Code>"agent"</Code> (standard agents),{" "}
-          <Code>"reviewer"</Code> (persona reviewers), and <Code>"job"</Code>{" "}
-          (scheduled job runs). Useful for job-only maintenance commands that
-          shouldn't clutter a regular agent's toolset.
+          scopes are <Code>"agent"</Code> (standard agents and persona
+          reviewers) and <Code>"job"</Code> (scheduled job runs). Useful for
+          job-only maintenance commands that shouldn't clutter a regular agent's
+          toolset.
         </P>
         <CodeBlock>{`
 {


### PR DESCRIPTION
## Summary
- The in-app docs claimed `"reviewer"` was a valid repo tool scope for persona reviewers, but persona agents actually use `"agent"` scope (the per-agent MCP route doesn't set `toolScope`, so it defaults to `"agent"` in server.ts)
- A tool with `scope: ["reviewer"]` would be invisible to all agents — the scope value is parsed but never matched
- Updated the scope description to say `"agent"` covers both standard agents and persona reviewers

## Audit details
- **Focus area**: Repo Tools section of docs-pane (next_focus from prior run)
- **Verified**: Built-in tools list in docs-pane matches AGENT_TOOLS/JOB_TOOLS/PERSONA_TOOLS sets in server.ts exactly — no tools added or removed
- **Deferred**: The `"reviewer"` scope code bug (backlog item) is a separate fix

## Test plan
- [x] `pnpm run finalize:web` passes (type check + production build)
- [x] `pnpm run format:write` applied
- [x] Pre-commit hooks pass (prettier, eslint, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)