### PR TITLE
Add split view diff toggle and Changes settings popover

### DIFF
--- a/apps/server/src/routes/agents/lifecycle-routes.ts
+++ b/apps/server/src/routes/agents/lifecycle-routes.ts
@@ -332,8 +332,11 @@ export async function registerAgentLifecycleRoutes(
       (agent.worktreePath || gitContextWorktreePath ? "main" : null);
 
     try {
+      const ignoreWhitespace =
+        (request.query as { ignoreWhitespace?: string }).ignoreWhitespace !==
+        "false";
       const result = await getAgentDiff(worktreePath, baseRef, undefined, {
-        ignoreWhitespace: true,
+        ignoreWhitespace,
       });
       if (!result) {
         return { baseRef: null, files: [] };
@@ -379,12 +382,15 @@ export async function registerAgentLifecycleRoutes(
       (agent.worktreePath || gitContextWorktreePath ? "main" : null);
 
     try {
+      const ignoreWhitespace =
+        (request.query as { ignoreWhitespace?: string }).ignoreWhitespace !==
+        "false";
       const result = await getAgentFileDiff(
         worktreePath,
         baseRef,
         query.path,
         undefined,
-        { ignoreWhitespace: true }
+        { ignoreWhitespace }
       );
       if (!result) {
         return reply.code(404).send({ error: "File not found in diff." });

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, useParams } from "react-router-dom";
 import { PanelLeftOpen, PanelRightOpen } from "lucide-react";
 
 import { ChangesTab } from "@/components/app/changes-tab";
+import { ChangesSettingsPopover } from "@/components/app/changes-settings-popover";
 import { CenterPaneTabBar } from "@/components/app/center-pane-tab-bar";
 import { useAgentDiffStats } from "@/hooks/use-agent-diff-stats";
 
@@ -529,6 +530,9 @@ export function AgentsView({
                   ) : null}
                 </div>
                 <div className="flex items-center gap-1">
+                  {changesMatch && !isMobile ? (
+                    <ChangesSettingsPopover />
+                  ) : null}
                   {hasActiveAgent && (!mediaPanelOpen || isMobile) ? (
                     <Button
                       size="icon"
@@ -578,7 +582,11 @@ export function AgentsView({
                   <Route
                     path="changes"
                     element={
-                      <ChangesTab agentId={focusedAgentId} active={true} />
+                      <ChangesTab
+                        agentId={focusedAgentId}
+                        active={true}
+                        isMobile={isMobile}
+                      />
                     }
                   />
                 </Routes>

--- a/apps/web/src/components/app/changes-settings-popover.tsx
+++ b/apps/web/src/components/app/changes-settings-popover.tsx
@@ -1,0 +1,89 @@
+import { useAtom } from "jotai";
+import { Settings } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  type DiffViewType,
+  diffViewTypeAtom,
+  diffIgnoreWhitespaceAtom,
+} from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+const VIEW_OPTIONS: { value: DiffViewType; label: string }[] = [
+  { value: "unified", label: "Unified" },
+  { value: "split", label: "Split" },
+];
+
+export function ChangesSettingsPopover(): JSX.Element {
+  const [viewType, setViewType] = useAtom(diffViewTypeAtom);
+  const [ignoreWhitespace, setIgnoreWhitespace] = useAtom(
+    diffIgnoreWhitespaceAtom
+  );
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          size="icon"
+          variant="ghost"
+          title="Diff settings"
+          data-testid="changes-settings-button"
+        >
+          <Settings className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="bottom" className="w-56 p-3">
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Diff view
+            </span>
+            <div
+              role="group"
+              aria-label="Diff view"
+              className="flex rounded-md border border-border/60 bg-muted/30 p-0.5"
+            >
+              {VIEW_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  aria-pressed={viewType === opt.value}
+                  className={cn(
+                    "flex-1 rounded-[3px] px-2 py-1 text-xs font-medium transition-colors",
+                    viewType === opt.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                  onClick={() => setViewType(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Whitespace
+            </span>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <Checkbox
+                checked={ignoreWhitespace}
+                onCheckedChange={(v) => setIgnoreWhitespace(v === true)}
+                data-testid="changes-ignore-whitespace"
+              />
+              <span className="text-xs text-foreground">
+                Hide whitespace changes
+              </span>
+            </label>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 import {
   ChevronDown,
@@ -85,6 +86,12 @@ import {
   type DiffFileStatus,
 } from "@/hooks/use-agent-diff";
 import { agentRoute } from "@/lib/agent-routes";
+import {
+  type DiffViewType,
+  diffViewTypeAtom,
+  diffIgnoreWhitespaceAtom,
+  diffFileTreeOpenAtom,
+} from "@/lib/store";
 import { cn } from "@/lib/utils";
 
 type LineSelection = {
@@ -97,20 +104,25 @@ type LineSelection = {
 type ChangesTabProps = {
   agentId: string | null;
   active: boolean;
+  isMobile?: boolean;
 };
 
 export const ChangesTab = memo(function ChangesTab({
   agentId,
   active,
+  isMobile,
 }: ChangesTabProps): JSX.Element {
-  const { data, isLoading } = useAgentDiff(agentId, active);
+  const storedViewType = useAtomValue(diffViewTypeAtom);
+  const viewType = isMobile ? "unified" : storedViewType;
+  const ignoreWhitespace = useAtomValue(diffIgnoreWhitespaceAtom);
+  const { data, isLoading } = useAgentDiff(agentId, active, ignoreWhitespace);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [lineSelection, setLineSelection] = useState<LineSelection | null>(
     null
   );
   const [commentOpen, setCommentOpen] = useState(false);
-  const [fileTreeOpen, setFileTreeOpen] = useState(true);
+  const [fileTreeOpen, setFileTreeOpen] = useAtom(diffFileTreeOpenAtom);
   const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const handleLineSelection = useCallback((sel: LineSelection | null) => {
@@ -186,6 +198,8 @@ export const ChangesTab = memo(function ChangesTab({
         onLineSelection={handleLineSelection}
         commentOpen={commentOpen}
         onCommentOpen={setCommentOpen}
+        viewType={viewType}
+        ignoreWhitespace={ignoreWhitespace}
       />
     </div>
   );
@@ -439,6 +453,8 @@ type DiffPaneProps = {
   onLineSelection: (sel: LineSelection | null) => void;
   commentOpen: boolean;
   onCommentOpen: (open: boolean) => void;
+  viewType: DiffViewType;
+  ignoreWhitespace: boolean;
 };
 
 function DiffPane({
@@ -451,6 +467,8 @@ function DiffPane({
   onLineSelection,
   commentOpen,
   onCommentOpen,
+  viewType,
+  ignoreWhitespace,
 }: DiffPaneProps): JSX.Element {
   return (
     <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3">
@@ -472,6 +490,8 @@ function DiffPane({
           onLineSelection={onLineSelection}
           commentOpen={commentOpen}
           onCommentOpen={onCommentOpen}
+          viewType={viewType}
+          ignoreWhitespace={ignoreWhitespace}
         />
       ))}
     </div>
@@ -488,6 +508,8 @@ type FileDiffSectionProps = {
   onLineSelection: (sel: LineSelection | null) => void;
   commentOpen: boolean;
   onCommentOpen: (open: boolean) => void;
+  viewType: DiffViewType;
+  ignoreWhitespace: boolean;
 };
 
 function FileDiffSection({
@@ -500,6 +522,8 @@ function FileDiffSection({
   onLineSelection,
   commentOpen,
   onCommentOpen,
+  viewType,
+  ignoreWhitespace,
 }: FileDiffSectionProps): JSX.Element {
   return (
     <div ref={setRef} className="rounded-md border border-border/50">
@@ -549,6 +573,8 @@ function FileDiffSection({
               onLineSelection={onLineSelection}
               commentOpen={commentOpen}
               onCommentOpen={onCommentOpen}
+              viewType={viewType}
+              ignoreWhitespace={ignoreWhitespace}
             />
           </motion.div>
         )}
@@ -564,6 +590,8 @@ type FileDiffContentProps = {
   onLineSelection: (sel: LineSelection | null) => void;
   commentOpen: boolean;
   onCommentOpen: (open: boolean) => void;
+  viewType: DiffViewType;
+  ignoreWhitespace: boolean;
 };
 
 function FileDiffContent({
@@ -573,12 +601,15 @@ function FileDiffContent({
   onLineSelection,
   commentOpen,
   onCommentOpen,
+  viewType,
+  ignoreWhitespace,
 }: FileDiffContentProps): JSX.Element {
   const [forceLoad, setForceLoad] = useState(false);
   const { data: fileDiffData, isLoading: fileDiffLoading } = useAgentFileDiff(
     agentId,
     file.path,
-    file.truncated && forceLoad
+    file.truncated && forceLoad,
+    ignoreWhitespace
   );
 
   const diffText = file.truncated
@@ -635,6 +666,7 @@ function FileDiffContent({
       onLineSelection={onLineSelection}
       commentOpen={commentOpen}
       onCommentOpen={onCommentOpen}
+      viewType={viewType}
     />
   );
 }
@@ -755,6 +787,7 @@ type UnifiedDiffViewProps = {
   onLineSelection: (sel: LineSelection | null) => void;
   commentOpen: boolean;
   onCommentOpen: (open: boolean) => void;
+  viewType: DiffViewType;
 };
 
 const UnifiedDiffView = memo(function UnifiedDiffView({
@@ -765,6 +798,7 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   onLineSelection,
   commentOpen,
   onCommentOpen,
+  viewType,
 }: UnifiedDiffViewProps): JSX.Element {
   const parsed = useMemo(() => {
     try {
@@ -939,7 +973,7 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
     <div ref={diffRef} className="changes-diff-view text-xs relative">
       <div className="overflow-x-auto overflow-y-clip">
         <Diff
-          viewType="unified"
+          viewType={viewType}
           diffType={diffType}
           hunks={file.hunks}
           tokens={tokens}

--- a/apps/web/src/hooks/use-agent-diff.ts
+++ b/apps/web/src/hooks/use-agent-diff.ts
@@ -35,7 +35,8 @@ export function agentDiffQueryKey(agentId: string): [string, string] {
 
 export function useAgentDiff(
   agentId: string | null,
-  enabled: boolean
+  enabled: boolean,
+  ignoreWhitespace = true
 ): {
   data: DiffResponse | undefined;
   isLoading: boolean;
@@ -44,9 +45,11 @@ export function useAgentDiff(
   const queryClient = useQueryClient();
 
   const query = useQuery<DiffResponse>({
-    queryKey: agentDiffQueryKey(agentId ?? ""),
+    queryKey: [...agentDiffQueryKey(agentId ?? ""), ignoreWhitespace],
     queryFn: async () => {
-      return api<DiffResponse>(`/api/v1/agents/${agentId}/diff`);
+      return api<DiffResponse>(
+        `/api/v1/agents/${agentId}/diff?ignoreWhitespace=${ignoreWhitespace}`
+      );
     },
     enabled: enabled && !!agentId,
     refetchOnWindowFocus: true,
@@ -67,16 +70,17 @@ export function useAgentDiff(
 export function useAgentFileDiff(
   agentId: string | null,
   filePath: string | null,
-  enabled: boolean
+  enabled: boolean,
+  ignoreWhitespace = true
 ): {
   data: FileDiffResponse | undefined;
   isLoading: boolean;
 } {
   const query = useQuery<FileDiffResponse>({
-    queryKey: ["agent-diff-file", agentId, filePath],
+    queryKey: ["agent-diff-file", agentId, filePath, ignoreWhitespace],
     queryFn: async () => {
       return api<FileDiffResponse>(
-        `/api/v1/agents/${agentId}/diff/file?path=${encodeURIComponent(filePath!)}&force=true`
+        `/api/v1/agents/${agentId}/diff/file?path=${encodeURIComponent(filePath!)}&force=true&ignoreWhitespace=${ignoreWhitespace}`
       );
     },
     enabled: enabled && !!agentId && !!filePath,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1264,6 +1264,17 @@ html[data-hidden] .animate-sidebar-nav-pulse {
   padding: 4px 12px;
 }
 
+/* Split diff view adjustments */
+.changes-diff-view .diff-split .diff-gutter-col {
+  width: 40px;
+}
+.changes-diff-view .diff-split .diff-gutter {
+  padding: 0 4px;
+}
+.changes-diff-view .diff-split .diff-code {
+  padding: 0 8px;
+}
+
 /* Syntax highlighting — dark mode (GitHub Dark) */
 .changes-diff-view .token.comment,
 .changes-diff-view .token.prolog,

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -82,6 +82,23 @@ export const dismissedReleaseToastAtomFamily = atomFamily((tag: string) =>
   atomWithLocalStorage<boolean>(`dispatch:dismissedReleaseToast:${tag}`, false)
 );
 
+export type DiffViewType = "unified" | "split";
+
+export const diffViewTypeAtom = atomWithLocalStorage<DiffViewType>(
+  "dispatch:diffViewType",
+  "unified"
+);
+
+export const diffIgnoreWhitespaceAtom = atomWithLocalStorage<boolean>(
+  "dispatch:diffIgnoreWhitespace",
+  true
+);
+
+export const diffFileTreeOpenAtom = atomWithLocalStorage<boolean>(
+  "dispatch:diffFileTreeOpen",
+  true
+);
+
 export type MediaSidebarTab = "pins" | "media" | "brain";
 
 export type MediaSidebarState = {


### PR DESCRIPTION
## Summary
- Adds a gear icon button in the center pane header (visible only when Changes tab is active, desktop only) that opens a settings popover
- Popover contains a **Unified/Split** diff view toggle and a **Hide whitespace changes** checkbox
- Server diff routes now accept `ignoreWhitespace` query param instead of hardcoding `true`
- Settings persist via Jotai atoms backed by localStorage, with cross-tab sync
- Mobile viewports force unified view regardless of persisted setting
- File tree open/close state also persisted via Jotai atom
- Accessible segmented toggle with `aria-pressed` and `role="group"`

## Test plan
- [x] `pnpm run check` — type checks pass
- [x] `pnpm run finalize:web` — production build succeeds
- [x] `pnpm run test:e2e` — 126/127 pass (1 pre-existing flaky test)
- [x] Playwright validation: settings button visibility, popover open/close, split toggle, whitespace checkbox
- [x] Frontend UX review persona approved (2 findings fixed in round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)