### PR TITLE
Fix split diff layout — equal 50% panes with line wrapping

### DIFF
--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -970,7 +970,16 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
           : "modify";
 
   return (
-    <div ref={diffRef} className="changes-diff-view text-xs relative">
+    <div
+      ref={diffRef}
+      className={cn(
+        "changes-diff-view text-xs relative",
+        "[&_.diff.diff-split]:table-fixed [&_.diff.diff-split]:w-full",
+        "[&_.diff.diff-split_.diff-gutter-col]:w-10",
+        "[&_.diff.diff-split_.diff-gutter]:px-1 [&_.diff.diff-split_.diff-gutter]:py-0",
+        "[&_.diff.diff-split_.diff-code]:px-2 [&_.diff.diff-split_.diff-code]:py-0 [&_.diff.diff-split_.diff-code]:whitespace-pre-wrap [&_.diff.diff-split_.diff-code]:break-words"
+      )}
+    >
       <div className="overflow-x-auto overflow-y-clip">
         <Diff
           viewType={viewType}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1264,17 +1264,6 @@ html[data-hidden] .animate-sidebar-nav-pulse {
   padding: 4px 12px;
 }
 
-/* Split diff view adjustments */
-.changes-diff-view .diff-split .diff-gutter-col {
-  width: 40px;
-}
-.changes-diff-view .diff-split .diff-gutter {
-  padding: 0 4px;
-}
-.changes-diff-view .diff-split .diff-code {
-  padding: 0 8px;
-}
-
 /* Syntax highlighting — dark mode (GitHub Dark) */
 .changes-diff-view .token.comment,
 .changes-diff-view .token.prolog,


### PR DESCRIPTION
## Summary

- Split diff view now renders left/right panes at equal 50% width using `table-layout: fixed`, matching GitHub's split diff behavior
- Long lines wrap within each pane (`white-space: pre-wrap` + `overflow-wrap: break-word`) instead of causing horizontal overflow or per-row scrollbars
- Moved split-mode CSS overrides from global `index.css` into Tailwind arbitrary variant classes in the component, using `.diff.diff-split` selectors for correct specificity
- Unified mode is untouched — still uses `white-space: pre` with horizontal scroll

## Test plan

- [x] Playwright verification: equal column widths (275px each), `tableLayout: "fixed"`, `whiteSpace: "pre-wrap"`, `overflowWrap: "break-word"`, no cell overflow
- [x] Visual comparison with GitHub PR #704 split diff — wrapping behavior matches
- [x] Unified mode unaffected (`table-layout: auto`, `white-space: pre`, horizontal scroll)
- [x] `pnpm run finalize:web` passes (type check + production build)
- [x] 171/171 E2E tests pass
- [x] Frontend UX review persona approved (round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)