### PR TITLE
Docs: session rename dialog, diff settings, and card click fix

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -112,7 +112,7 @@ export function AgentsContent() {
         <H3>Starting and stopping</H3>
         <P>
           Press the play button to resume a stopped agent. Press the stop button
-          to terminate it. Click an agent's name to attach your terminal to its
+          to terminate it. Click an agent card to attach your terminal to its
           session, or click again to detach without stopping.
         </P>
       </Section>
@@ -159,12 +159,20 @@ export function AgentsContent() {
         <H3>Changes tab</H3>
         <P>
           The <strong>Changes</strong> tab next to <strong>Terminal</strong> in
-          the center pane shows a unified diff of the agent's uncommitted work
-          against its base branch. Each file is syntax-highlighted and can be
-          collapsed individually. A file tree sidebar lists all changed files
-          with their status (added, modified, deleted) and line counts — click a
-          file to scroll to it. Large diffs are truncated by default with a
-          button to load the full content.
+          the center pane shows a diff of the agent's uncommitted work against
+          its base branch. Each file is syntax-highlighted and can be collapsed
+          individually. A file tree sidebar lists all changed files with their
+          status (added, modified, deleted) and line counts — click a file to
+          scroll to it. Large diffs are truncated by default with a button to
+          load the full content.
+        </P>
+        <P>
+          Click the <strong>gear icon</strong> in the tab bar to open diff
+          settings. Toggle between <strong>Unified</strong> and{" "}
+          <strong>Split</strong> view, and check{" "}
+          <strong>Hide whitespace changes</strong> to filter out whitespace-only
+          edits. These settings persist across sessions. On mobile, the diff
+          always renders in unified mode.
         </P>
         <P>
           Select one or more lines in a diff, then click the comment icon to
@@ -232,6 +240,11 @@ export function AgentsContent() {
           manually by clicking the <strong>Tag</strong> icon that appears next
           to a running agent that still has a default name. Terminal agents,
           persona agents, and job agents are excluded from both paths.
+        </P>
+        <P>
+          To rename any agent yourself, click the agent's name in the sidebar
+          card to open the <strong>Session settings</strong> dialog and type a
+          new name.
         </P>
       </Section>
 

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -61,9 +61,17 @@ export const tips: Tip[] = [
   {
     id: "changes-tab",
     title: "Changes Tab",
-    body: "Switch to the Changes tab next to Terminal to browse an agent's diff with syntax highlighting. Select lines to leave inline comments.",
+    body: "Switch to the Changes tab next to Terminal to browse an agent's diff. Use the gear icon to toggle split/unified view and hide whitespace changes.",
     docsSection: "agents",
     since: "0.23.9",
+    surfaces: ["ambient"],
+  },
+  {
+    id: "session-rename",
+    title: "Rename Sessions",
+    body: "Click any agent's name in the sidebar to open session settings and rename it directly.",
+    docsSection: "agents",
+    since: "0.23.13",
     surfaces: ["ambient"],
   },
   {


### PR DESCRIPTION
## Summary
- **Changes tab**: Updated docs to describe the new split/unified view toggle and "Hide whitespace changes" option from PR #704. Removed the hardcoded "unified" claim since it's now configurable.
- **Renaming agents**: Added paragraph about clicking the agent name to open the Session settings dialog (PR #705).
- **Starting and stopping**: Fixed "Click an agent's name" → "Click an agent card" since clicking the name now opens settings, not the terminal attach.
- **Tips**: Updated the changes-tab tip to mention diff settings. Added a new `session-rename` ambient tip.

## What's deferred
- Automations section deep-dive (next_focus for next run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)