### PR TITLE
Add dispatch_launch_agent MCP tool for agent orchestration

### DIFF
--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -52,6 +52,7 @@ type McpRouteDeps = {
   mcpSubmitFeedback: unknown;
   mcpListPersonas: unknown;
   mcpLaunchPersona: unknown;
+  mcpLaunchAgent: unknown;
   mcpGetFeedback: unknown;
   mcpResolveFeedback: unknown;
   mcpSubmitResolution: unknown;
@@ -208,6 +209,7 @@ export async function registerMcpRoutes(
       deletePin: deps.mcpDeletePin,
       listPersonas: deps.mcpListPersonas,
       launchPersona: deps.mcpLaunchPersona,
+      launchAgent: deps.mcpLaunchAgent,
       getFeedback: deps.mcpGetFeedback,
       resolveFeedback: deps.mcpResolveFeedback,
       submitResolution: deps.mcpSubmitResolution,
@@ -290,6 +292,7 @@ export async function registerMcpRoutes(
       submitFeedback: deps.mcpSubmitFeedback,
       listPersonas: deps.mcpListPersonas,
       launchPersona: deps.mcpLaunchPersona,
+      launchAgent: deps.mcpLaunchAgent,
       getFeedback: deps.mcpGetFeedback,
       resolveFeedback: deps.mcpResolveFeedback,
       submitResolution: deps.mcpSubmitResolution,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -478,6 +478,7 @@ async function registerRoutes() {
     mcpSubmitFeedback: mcpHandlers.submitFeedback,
     mcpListPersonas: mcpHandlers.listPersonas,
     mcpLaunchPersona: mcpHandlers.launchPersona,
+    mcpLaunchAgent: mcpHandlers.launchAgent,
     mcpGetFeedback: mcpHandlers.getFeedback,
     mcpResolveFeedback: mcpHandlers.resolveFeedback,
     mcpSubmitResolution: mcpHandlers.submitResolution,

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -684,7 +684,6 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         baseBranch?: string;
         worktreeBranch?: string;
         fullAccess?: boolean;
-        agentArgs?: string;
         templateId?: string;
         cwd?: string;
       }
@@ -717,22 +716,10 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
 
       const cliSessionId = agentType === "claude" ? randomUUID() : undefined;
 
-      const DANGEROUS_FLAGS = [
-        "--dangerously-skip-permissions",
-        "--dangerously-bypass-approvals-and-sandbox",
-      ];
-      const agentArgs: string[] = input.agentArgs
-        ? input.agentArgs
-            .split(/\s+/)
-            .filter(Boolean)
-            .filter((arg) => !DANGEROUS_FLAGS.includes(arg))
-        : [];
-
       const agent = await agentManager.createAgent({
         name: input.name,
         type: agentType as (typeof CLI_AGENT_TYPES)[number],
         cwd: input.cwd ?? parentCwd,
-        agentArgs,
         fullAccess,
         useWorktree,
         createNewBranch,

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -673,6 +673,78 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       };
     },
 
+    async launchAgent(
+      agentId: string,
+      input: {
+        name: string;
+        prompt: string;
+        type?: string;
+        useWorktree?: boolean;
+        createNewBranch?: boolean;
+        baseBranch?: string;
+        worktreeBranch?: string;
+        fullAccess?: boolean;
+        agentArgs?: string;
+        templateId?: string;
+        cwd?: string;
+      }
+    ): Promise<{ agentId: string; name: string }> {
+      const parent = await agentManager.getAgent(agentId);
+      if (!parent) throw new Error("Parent agent not found.");
+
+      const agentType = input.type ?? parent.type ?? "claude";
+      if (
+        !CLI_AGENT_TYPES.includes(agentType as (typeof CLI_AGENT_TYPES)[number])
+      ) {
+        throw new Error(
+          `Unsupported agent type "${agentType}". Must be one of: ${CLI_AGENT_TYPES.join(", ")}.`
+        );
+      }
+
+      const enabledAgentTypes = await getEnabledAgentTypes(pool);
+      if (
+        !enabledAgentTypes.includes(
+          agentType as (typeof CLI_AGENT_TYPES)[number]
+        )
+      ) {
+        throw new Error(`${agentType} agents are disabled in settings.`);
+      }
+
+      const parentCwd = parent.worktreePath ?? parent.cwd;
+      const useWorktree = input.useWorktree ?? false;
+      const createNewBranch = input.createNewBranch ?? false;
+      const fullAccess = input.fullAccess ?? parent.fullAccess;
+
+      const cliSessionId = agentType === "claude" ? randomUUID() : undefined;
+
+      const agentArgs: string[] = input.agentArgs
+        ? input.agentArgs.split(/\s+/).filter(Boolean)
+        : [];
+
+      const agent = await agentManager.createAgent({
+        name: input.name,
+        type: agentType as (typeof CLI_AGENT_TYPES)[number],
+        cwd: input.cwd ?? parentCwd,
+        agentArgs,
+        fullAccess,
+        useWorktree,
+        createNewBranch,
+        baseBranch: input.baseBranch,
+        worktreeBranch: input.worktreeBranch,
+        parentAgentId: agentId,
+        cliSessionId,
+        initialPrompt: input.prompt,
+        templateId: input.templateId,
+      });
+
+      publishUiEvent({
+        type: "agent.upsert",
+        agent: withStreamFlag(agent),
+      });
+
+      return { agentId: agent.id, name: agent.name };
+    },
+
     async shareMedia(
       agentId: string,
       opts: {

--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -713,12 +713,19 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
       const parentCwd = parent.worktreePath ?? parent.cwd;
       const useWorktree = input.useWorktree ?? false;
       const createNewBranch = input.createNewBranch ?? false;
-      const fullAccess = input.fullAccess ?? parent.fullAccess;
+      const fullAccess = parent.fullAccess && input.fullAccess !== false;
 
       const cliSessionId = agentType === "claude" ? randomUUID() : undefined;
 
+      const DANGEROUS_FLAGS = [
+        "--dangerously-skip-permissions",
+        "--dangerously-bypass-approvals-and-sandbox",
+      ];
       const agentArgs: string[] = input.agentArgs
-        ? input.agentArgs.split(/\s+/).filter(Boolean)
+        ? input.agentArgs
+            .split(/\s+/)
+            .filter(Boolean)
+            .filter((arg) => !DANGEROUS_FLAGS.includes(arg))
         : [];
 
       const agent = await agentManager.createAgent({

--- a/apps/server/src/shared/mcp/agent-launch-tools.ts
+++ b/apps/server/src/shared/mcp/agent-launch-tools.ts
@@ -18,7 +18,6 @@ export type LaunchAgentInput = {
   baseBranch?: string;
   worktreeBranch?: string;
   fullAccess?: boolean;
-  agentArgs?: string;
   templateId?: string;
   cwd?: string;
 };
@@ -88,10 +87,6 @@ export function registerAgentLaunchTools(
           .describe(
             "Run the agent with full tool access (no permission prompts). Defaults to the parent's setting."
           ),
-        agentArgs: z
-          .string()
-          .optional()
-          .describe("Additional CLI arguments passed to the agent."),
         templateId: z
           .string()
           .optional()
@@ -119,7 +114,6 @@ export function registerAgentLaunchTools(
         if (args.worktreeBranch !== undefined)
           input.worktreeBranch = args.worktreeBranch;
         if (args.fullAccess !== undefined) input.fullAccess = args.fullAccess;
-        if (args.agentArgs !== undefined) input.agentArgs = args.agentArgs;
         if (args.templateId !== undefined) input.templateId = args.templateId;
         if (args.cwd !== undefined) input.cwd = args.cwd;
 

--- a/apps/server/src/shared/mcp/agent-launch-tools.ts
+++ b/apps/server/src/shared/mcp/agent-launch-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 
+import { CLI_AGENT_TYPES } from "../../agent-type-settings.js";
 import { toToolError } from "./tool-error.js";
 
 export type LaunchAgentResult = {
@@ -58,7 +59,7 @@ export function registerAgentLaunchTools(
           .max(100000)
           .describe("Initial prompt describing what the agent should do."),
         type: z
-          .enum(["claude", "codex", "cursor", "opencode"])
+          .enum(CLI_AGENT_TYPES)
           .optional()
           .describe(
             "Agent type. Defaults to the same type as the launching agent."

--- a/apps/server/src/shared/mcp/agent-launch-tools.ts
+++ b/apps/server/src/shared/mcp/agent-launch-tools.ts
@@ -1,0 +1,140 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+
+import { toToolError } from "./tool-error.js";
+
+export type LaunchAgentResult = {
+  agentId: string;
+  name: string;
+};
+
+export type LaunchAgentInput = {
+  name: string;
+  prompt: string;
+  type?: string;
+  useWorktree?: boolean;
+  createNewBranch?: boolean;
+  baseBranch?: string;
+  worktreeBranch?: string;
+  fullAccess?: boolean;
+  agentArgs?: string;
+  templateId?: string;
+  cwd?: string;
+};
+
+export type AgentLaunchToolsContext = {
+  agentId: string;
+  launchAgent?: (
+    agentId: string,
+    input: LaunchAgentInput
+  ) => Promise<LaunchAgentResult>;
+};
+
+export function registerAgentLaunchTools(
+  server: McpServer,
+  allowed: Set<string>,
+  context: AgentLaunchToolsContext
+): void {
+  if (!allowed.has("dispatch_launch_agent") || !context.launchAgent) return;
+
+  const agentId = context.agentId;
+  const launchAgent = context.launchAgent;
+
+  server.registerTool(
+    "dispatch_launch_agent",
+    {
+      description:
+        "Launch a new agent to work on a task. The new agent runs independently " +
+        "— use dispatch_send_message to coordinate and list_agents to check status.",
+      inputSchema: {
+        name: z
+          .string()
+          .min(1)
+          .max(100)
+          .describe("Display name for the new agent."),
+        prompt: z
+          .string()
+          .min(1)
+          .max(100000)
+          .describe("Initial prompt describing what the agent should do."),
+        type: z
+          .enum(["claude", "codex", "cursor", "opencode"])
+          .optional()
+          .describe(
+            "Agent type. Defaults to the same type as the launching agent."
+          ),
+        useWorktree: z
+          .boolean()
+          .optional()
+          .describe(
+            "Create a new git worktree for the agent. Default: false (shares parent's worktree)."
+          ),
+        createNewBranch: z
+          .boolean()
+          .optional()
+          .describe("Create a new branch for the worktree. Default: false."),
+        baseBranch: z
+          .string()
+          .optional()
+          .describe("Branch to base the worktree on."),
+        worktreeBranch: z
+          .string()
+          .optional()
+          .describe("Explicit branch name for the worktree."),
+        fullAccess: z
+          .boolean()
+          .optional()
+          .describe(
+            "Run the agent with full tool access (no permission prompts). Defaults to the parent's setting."
+          ),
+        agentArgs: z
+          .string()
+          .optional()
+          .describe("Additional CLI arguments passed to the agent."),
+        templateId: z
+          .string()
+          .optional()
+          .describe("Template to apply to the new agent."),
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            "Working directory for the new agent. Defaults to the parent's working directory."
+          ),
+      },
+    },
+    async (args) => {
+      try {
+        const input: LaunchAgentInput = {
+          name: args.name,
+          prompt: args.prompt,
+        };
+        if (args.type !== undefined) input.type = args.type;
+        if (args.useWorktree !== undefined)
+          input.useWorktree = args.useWorktree;
+        if (args.createNewBranch !== undefined)
+          input.createNewBranch = args.createNewBranch;
+        if (args.baseBranch !== undefined) input.baseBranch = args.baseBranch;
+        if (args.worktreeBranch !== undefined)
+          input.worktreeBranch = args.worktreeBranch;
+        if (args.fullAccess !== undefined) input.fullAccess = args.fullAccess;
+        if (args.agentArgs !== undefined) input.agentArgs = args.agentArgs;
+        if (args.templateId !== undefined) input.templateId = args.templateId;
+        if (args.cwd !== undefined) input.cwd = args.cwd;
+
+        const result = await launchAgent(agentId, input);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Launched agent "${result.name}" (${result.agentId}).`,
+            },
+          ],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return toToolError(error);
+      }
+    }
+  );
+}

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -6,6 +6,7 @@ import * as z from "zod/v4";
 
 import type { AgentType as CliAgentType } from "../../agents/types.js";
 import type { BrainStore } from "../../brain/store.js";
+import { registerAgentLaunchTools } from "./agent-launch-tools.js";
 import { registerAgentLifecycleTools } from "./agent-lifecycle-tools.js";
 import { registerAnalyticsTools } from "./analytics-tools.js";
 import { registerBrainTools } from "./brain-tools.js";
@@ -96,6 +97,7 @@ const AGENT_TOOLS = new Set([
   "dispatch_cancel_recheck",
   "list_agents",
   "dispatch_send_message",
+  "dispatch_launch_agent",
   "get_activity_summary",
   "get_agent_history",
   "get_feedback_summary",
@@ -143,6 +145,7 @@ const JOB_TOOLS = new Set([
   "job_log",
   "list_agents",
   "dispatch_send_message",
+  "dispatch_launch_agent",
   "list_personas",
   "list_recent_persona_reviews",
   "list_recent_feedback",
@@ -310,6 +313,22 @@ export type McpRequestContext = {
       includeDiff?: boolean;
     }
   ) => Promise<{ agentId: string; persona: string; parentAgentId: string }>;
+  launchAgent?: (
+    agentId: string,
+    input: {
+      name: string;
+      prompt: string;
+      type?: string;
+      useWorktree?: boolean;
+      createNewBranch?: boolean;
+      baseBranch?: string;
+      worktreeBranch?: string;
+      fullAccess?: boolean;
+      agentArgs?: string;
+      templateId?: string;
+      cwd?: string;
+    }
+  ) => Promise<{ agentId: string; name: string }>;
   getFeedback?: (
     agentId: string,
     opts: { persona?: string; limit?: number }
@@ -502,6 +521,14 @@ async function createDispatchMcpServer(
         ? undefined
         : context.listAgentsForAgent,
       sendMessage: context.sendMessage,
+    });
+  }
+
+  // ── Agent launch tools ───────────────────────────────────────────
+  if (context.agent) {
+    registerAgentLaunchTools(server, allowed, {
+      agentId: context.agent.id,
+      launchAgent: context.launchAgent,
     });
   }
 

--- a/apps/server/test/agent-launch-tools.test.ts
+++ b/apps/server/test/agent-launch-tools.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type AgentLaunchToolsContext,
+  registerAgentLaunchTools,
+} from "../src/shared/mcp/agent-launch-tools.js";
+
+type RegisteredCall = {
+  name: string;
+  config: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+};
+
+function createMockServer() {
+  const tools: RegisteredCall[] = [];
+  return {
+    registerTool: vi.fn(
+      (
+        name: string,
+        config: Record<string, unknown>,
+        handler: (args: Record<string, unknown>) => Promise<unknown>
+      ) => {
+        tools.push({ name, config, handler });
+      }
+    ),
+    tools,
+  };
+}
+
+const AGENT_ID = "agt_launch_test";
+
+function baseContext(): AgentLaunchToolsContext {
+  return {
+    agentId: AGENT_ID,
+    launchAgent: vi.fn(async () => ({
+      agentId: "agt_child_123",
+      name: "test-child",
+    })),
+  };
+}
+
+describe("registerAgentLaunchTools", () => {
+  let server: ReturnType<typeof createMockServer>;
+
+  beforeEach(() => {
+    server = createMockServer();
+  });
+
+  describe("conditional registration", () => {
+    it("registers dispatch_launch_agent when allowed and context is complete", () => {
+      registerAgentLaunchTools(
+        server as never,
+        new Set(["dispatch_launch_agent"]),
+        baseContext()
+      );
+      const names = server.tools.map((t) => t.name);
+      expect(names).toEqual(["dispatch_launch_agent"]);
+    });
+
+    it("registers nothing when allowed set is empty", () => {
+      registerAgentLaunchTools(server as never, new Set(), baseContext());
+      expect(server.tools).toHaveLength(0);
+    });
+
+    it("skips when launchAgent callback is missing", () => {
+      const ctx = baseContext();
+      delete (ctx as Record<string, unknown>).launchAgent;
+      registerAgentLaunchTools(
+        server as never,
+        new Set(["dispatch_launch_agent"]),
+        ctx
+      );
+      expect(server.tools).toHaveLength(0);
+    });
+  });
+
+  describe("dispatch_launch_agent handler", () => {
+    it("calls launchAgent with name and prompt", async () => {
+      const ctx = baseContext();
+      registerAgentLaunchTools(
+        server as never,
+        new Set(["dispatch_launch_agent"]),
+        ctx
+      );
+
+      const tool = server.tools.find(
+        (t) => t.name === "dispatch_launch_agent"
+      )!;
+      const result = await tool.handler({
+        name: "test-child",
+        prompt: "Do stuff",
+      });
+
+      expect(ctx.launchAgent).toHaveBeenCalledWith(AGENT_ID, {
+        name: "test-child",
+        prompt: "Do stuff",
+      });
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: 'Launched agent "test-child" (agt_child_123).',
+          },
+        ],
+        structuredContent: { agentId: "agt_child_123", name: "test-child" },
+      });
+    });
+
+    it("passes optional parameters through", async () => {
+      const ctx = baseContext();
+      registerAgentLaunchTools(
+        server as never,
+        new Set(["dispatch_launch_agent"]),
+        ctx
+      );
+
+      const tool = server.tools.find(
+        (t) => t.name === "dispatch_launch_agent"
+      )!;
+      await tool.handler({
+        name: "isolated-worker",
+        prompt: "Do stuff in isolation",
+        type: "codex",
+        useWorktree: true,
+        createNewBranch: true,
+        baseBranch: "main",
+        fullAccess: false,
+      });
+
+      expect(ctx.launchAgent).toHaveBeenCalledWith(AGENT_ID, {
+        name: "isolated-worker",
+        prompt: "Do stuff in isolation",
+        type: "codex",
+        useWorktree: true,
+        createNewBranch: true,
+        baseBranch: "main",
+        fullAccess: false,
+      });
+    });
+
+    it("returns tool error on failure", async () => {
+      const ctx = baseContext();
+      (ctx.launchAgent as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Agent type disabled")
+      );
+      registerAgentLaunchTools(
+        server as never,
+        new Set(["dispatch_launch_agent"]),
+        ctx
+      );
+
+      const tool = server.tools.find(
+        (t) => t.name === "dispatch_launch_agent"
+      )!;
+      const result = (await tool.handler({
+        name: "child",
+        prompt: "hello",
+      })) as { isError: boolean };
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -160,14 +160,14 @@ export function AgentListContent({
           ) : (
             <React.Fragment>
               {agents
-                .filter((a) => !a.parentAgentId)
+                .filter((a) => !a.parentAgentId || !a.persona)
                 .map((agent) => (
                   <AgentCard
                     key={agent.id}
                     agent={agent}
                     agents={agents}
                     childAgents={agents.filter(
-                      (a) => a.parentAgentId === agent.id
+                      (a) => a.parentAgentId === agent.id && !!a.persona
                     )}
                     selectedAgentId={selectedAgentId}
                     expandedAgentId={expandedAgentId}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -283,7 +283,10 @@ export function AgentsView({
   const selectedExpansionTarget = useMemo(() => {
     if (!validatedSelectedAgentId) return null;
     const selected = agents.find((a) => a.id === validatedSelectedAgentId);
-    return selected?.parentAgentId ?? validatedSelectedAgentId;
+    return (
+      (selected?.persona ? selected.parentAgentId : null) ??
+      validatedSelectedAgentId
+    );
   }, [agents, validatedSelectedAgentId]);
   const prevSelectedExpansionTargetRef = useRef<string | null>(null);
 

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -88,7 +88,7 @@ export function useAgentHotkeys({
 
   const cycleAgent = useCallback(
     (direction: -1 | 1) => {
-      const cycleAgents = agents.filter((a) => !a.parentAgentId);
+      const cycleAgents = agents.filter((a) => !a.parentAgentId || !a.persona);
       if (cycleAgents.length === 0) return;
       const currentIdx = validatedSelectedAgentId
         ? cycleAgents.findIndex((a) => a.id === validatedSelectedAgentId)


### PR DESCRIPTION
## Summary

- Add `dispatch_launch_agent` MCP tool that lets agents launch other agents, enabling delegation, parallel work, escalation, and hand-off workflows
- New tool follows existing `dispatch_launch_persona` / `messaging-tools` patterns — Zod schema, handler in `mcp-handlers.ts`, wired through routes and server
- Defaults favor simplicity: child shares parent's worktree, inherits parent's agent type and `fullAccess`, fire-and-forget lifecycle
- Fix sidebar to only nest persona/review children under parent cards — general launched agents show as top-level entries so agent-launches-agent chains don't disappear

## Test plan

- [x] Unit tests for tool registration (6 tests: conditional registration, handler with required/optional params, error handling)
- [x] Type check (`pnpm run check`) passes
- [x] Full unit test suite passes (2064 server + 180 web)
- [x] E2E tests pass (171 passed, 12 pre-existing skips)
- [x] Live testing with `live=true` dev instance: basic launch, optional param overrides, invalid type rejection, tool discovery
- [x] Architecture review passed (round 1 approve + 1 low finding fixed, round 2 approve clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)