### PR TITLE
Fix unsafe cast in job monitor shutdown path

### DIFF
--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -85,7 +85,10 @@ const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 export class JobService {
   private readonly store: JobStore;
   private readonly templateStore: TemplateStore;
-  private readonly monitors = new Map<string, Promise<JobRunRecord>>();
+  private readonly monitors = new Map<
+    string,
+    Promise<JobRunRecord | undefined>
+  >();
   private readonly schedulers = new Map<string, Cron>();
   private readonly onRunStateChangeCallbacks: JobRunCallback[] = [];
   private stopping = false;
@@ -676,7 +679,7 @@ export class JobService {
     if (this.stopping || this.monitors.has(runId)) return;
     const monitor = this.monitorRun(runId)
       .catch(async (error) => {
-        if (this.stopping) return undefined as unknown as JobRunRecord;
+        if (this.stopping) return;
         this.logger.warn({ err: error, runId }, "Job monitor failed.");
         const run = await this.store.getRun(runId);
         if (run && ACTIVE_RUN_STATUSES.has(run.status)) {
@@ -696,7 +699,10 @@ export class JobService {
 
   private async waitForTerminal(runId: string): Promise<JobRunRecord> {
     const monitor = this.monitors.get(runId);
-    if (monitor) return await monitor;
+    if (monitor) {
+      const result = await monitor;
+      if (result) return result;
+    }
     const run = await this.store.getRun(runId);
     if (!run) throw new Error(`Job run ${runId} not found.`);
     return run;


### PR DESCRIPTION
## Summary

- Removed an unsafe `undefined as unknown as JobRunRecord` double cast in `apps/server/src/jobs/service.ts` where the monitor's `.catch()` handler returns `undefined` during shutdown
- Widened the `monitors` Map type from `Promise<JobRunRecord>` to `Promise<JobRunRecord | undefined>` to reflect the actual runtime behavior
- Updated `waitForTerminal` to fall back to a DB lookup when the monitor resolves to `undefined`, which also fixes a latent bug where the caller would silently receive `undefined` typed as `JobRunRecord`

## Why this is tech debt

The unsafe cast masked a type-level lie — the Map claimed to hold `Promise<JobRunRecord>` but could actually resolve to `undefined`. This meant TypeScript couldn't catch callers that failed to handle the `undefined` case. The fix aligns the types with reality and adds a safe fallback.

## What's next

The backlog is empty after this fix. The next run will re-audit for new tech debt.

## Test plan

- [x] `pnpm run check` — type checking passes
- [x] `pnpm run test` — 180 unit tests pass
- [x] `pnpm run test:e2e` — 171 E2E tests pass (12 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)