### PR TITLE
fix(mount-io): bound token-harvester gcsfuse reads behind a MountIO guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,20 @@ MEDIA_ROOT=~/.dispatch/media
 # TLS_KEY=~/.dispatch/tls/key.pem
 
 # gcsfuse mount-io guard (token harvester). Defaults shown.
-# DISPATCH_MOUNT_IO_TIMEOUT_MS=5000
+# TIMEOUT_MS is an idle (no-progress) deadline for streaming reads and a
+# whole-op deadline for readdir. Keep it generous enough to exceed worst-case
+# large-file / cold-cache latency on your mount — a too-tight value makes a
+# healthy-but-slow mount trip the breaker and pause all harvesting for the
+# cooldown. Raise it on high-latency mounts.
+# DISPATCH_MOUNT_IO_TIMEOUT_MS=10000
 # DISPATCH_MOUNT_IO_CONCURRENCY=2
 # DISPATCH_MOUNT_IO_BREAKER_THRESHOLD=3
 # DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS=60000
+
+# I/O thread-pool size. A stalled gcsfuse mount leaves uncancellable read/readdir
+# syscalls blocked on pool threads; enlarging the pool keeps a few wedged
+# harvester threads from starving other fs/dns/crypto work. Set before launch
+# (the launchd wrapper defaults this to 16). NOTE: the production Bun runtime
+# uses its own threadpool, not libuv, and may ignore this — it mainly hardens
+# Node dev/test; the mount-io breaker is the cross-runtime backstop.
+# UV_THREADPOOL_SIZE=16

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ MEDIA_ROOT=~/.dispatch/media
 # TLS (optional — both must be set to enable HTTPS)
 # TLS_CERT=~/.dispatch/tls/cert.pem
 # TLS_KEY=~/.dispatch/tls/key.pem
+
+# gcsfuse mount-io guard (token harvester). Defaults shown.
+# DISPATCH_MOUNT_IO_TIMEOUT_MS=5000
+# DISPATCH_MOUNT_IO_CONCURRENCY=2
+# DISPATCH_MOUNT_IO_BREAKER_THRESHOLD=3
+# DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS=60000

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -66,8 +66,9 @@ export function cwdToClaudeProjectDir(cwd: string): string {
 export async function discoverSessionFiles(dir: string): Promise<string[]> {
   let entries: string[];
   try {
-    entries = await mountIO.run("readdir:claude-projects", (signal) =>
-      readdir(dir, { signal }),
+    // @types/node@24 readdir has no {signal} overload; bounded by MountIO timeout only
+    entries = await mountIO.run("readdir:claude-projects", (_signal) =>
+      readdir(dir)
     );
   } catch {
     return [];
@@ -78,7 +79,7 @@ export async function discoverSessionFiles(dir: string): Promise<string[]> {
 }
 
 async function parseClaudeSessionTokenUsage(
-  filePath: string,
+  filePath: string
 ): Promise<SessionTokenSummary> {
   const sessionId = path.basename(filePath, ".jsonl");
   return mountIO.run(`read:claude:${sessionId}`, async (signal) => {
@@ -157,7 +158,10 @@ async function harvestClaudeTokenUsage(
 
   for (const file of files) {
     if (!mountIO.available()) {
-      logger?.warn({ projectDir }, "mount unavailable, aborting Claude harvest");
+      logger?.warn(
+        { projectDir },
+        "mount unavailable, aborting Claude harvest"
+      );
       break;
     }
     try {
@@ -210,8 +214,9 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
   async function walk(dir: string): Promise<void> {
     let entries: import("node:fs").Dirent[];
     try {
-      entries = await mountIO.run("readdir:codex-sessions", (signal) =>
-        readdir(dir, { withFileTypes: true, signal }),
+      // @types/node@24 readdir has no {signal} overload; bounded by MountIO timeout only
+      entries = await mountIO.run("readdir:codex-sessions", (_signal) =>
+        readdir(dir, { withFileTypes: true })
       );
     } catch {
       return;
@@ -241,62 +246,65 @@ export function discoverCodexRolloutFilesForTest(): Promise<string[]> {
  */
 async function parseCodexRolloutForAgent(
   filePath: string,
-  agentId: string,
+  agentId: string
 ): Promise<{
   usage: CodexTokenUsage;
   model: string;
   sessionStart: string | null;
   sessionEnd: string | null;
 } | null> {
-  return mountIO.run(`read:codex:${path.basename(filePath)}`, async (signal) => {
-    let matched = false;
-    let lastUsage: CodexTokenUsage | null = null;
-    let model = "unknown";
-    let sessionStart: string | null = null;
-    let sessionEnd: string | null = null;
-    let linesRead = 0;
+  return mountIO.run(
+    `read:codex:${path.basename(filePath)}`,
+    async (signal) => {
+      let matched = false;
+      let lastUsage: CodexTokenUsage | null = null;
+      let model = "unknown";
+      let sessionStart: string | null = null;
+      let sessionEnd: string | null = null;
+      let linesRead = 0;
 
-    const rl = createInterface({
-      input: createReadStream(filePath, { encoding: "utf-8", signal }),
-      crlfDelay: Infinity,
-    });
+      const rl = createInterface({
+        input: createReadStream(filePath, { encoding: "utf-8", signal }),
+        crlfDelay: Infinity,
+      });
 
-    for await (const line of rl) {
-      linesRead++;
-      if (!matched) {
-        if (linesRead > 20) break;
-        const tagMatch = DISPATCH_TAG_RE.exec(line);
-        if (tagMatch && tagMatch[1] === agentId) matched = true;
-        continue;
-      }
-      if (!line.trim()) continue;
-      let entry: Record<string, unknown>;
-      try {
-        entry = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      const ts = entry.timestamp as string | undefined;
-      if (ts && !sessionStart) sessionStart = ts;
-      if (ts) sessionEnd = ts;
-      if (entry.type === "turn_context") {
-        const payload = entry.payload as Record<string, unknown> | undefined;
-        if (payload?.model) model = payload.model as string;
-      }
-      if (entry.type === "event_msg") {
-        const payload = entry.payload as Record<string, unknown> | undefined;
-        if (payload?.type === "token_count") {
-          const info = payload.info as Record<string, unknown> | undefined;
-          if (info?.total_token_usage) {
-            lastUsage = info.total_token_usage as CodexTokenUsage;
+      for await (const line of rl) {
+        linesRead++;
+        if (!matched) {
+          if (linesRead > 20) break;
+          const tagMatch = DISPATCH_TAG_RE.exec(line);
+          if (tagMatch && tagMatch[1] === agentId) matched = true;
+          continue;
+        }
+        if (!line.trim()) continue;
+        let entry: Record<string, unknown>;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const ts = entry.timestamp as string | undefined;
+        if (ts && !sessionStart) sessionStart = ts;
+        if (ts) sessionEnd = ts;
+        if (entry.type === "turn_context") {
+          const payload = entry.payload as Record<string, unknown> | undefined;
+          if (payload?.model) model = payload.model as string;
+        }
+        if (entry.type === "event_msg") {
+          const payload = entry.payload as Record<string, unknown> | undefined;
+          if (payload?.type === "token_count") {
+            const info = payload.info as Record<string, unknown> | undefined;
+            if (info?.total_token_usage) {
+              lastUsage = info.total_token_usage as CodexTokenUsage;
+            }
           }
         }
       }
-    }
 
-    if (!matched || !lastUsage) return null;
-    return { usage: lastUsage, model, sessionStart, sessionEnd };
-  });
+      if (!matched || !lastUsage) return null;
+      return { usage: lastUsage, model, sessionStart, sessionEnd };
+    }
+  );
 }
 
 async function harvestCodexTokenUsage(

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -82,7 +82,7 @@ async function parseClaudeSessionTokenUsage(
   filePath: string
 ): Promise<SessionTokenSummary> {
   const sessionId = path.basename(filePath, ".jsonl");
-  return mountIO.run(`read:claude:${sessionId}`, async (signal) => {
+  return mountIO.run(`read:claude:${sessionId}`, async (signal, heartbeat) => {
     const totals = new Map<string, ModelTokenTotals>();
     let sessionStart: string | null = null;
     let sessionEnd: string | null = null;
@@ -93,6 +93,9 @@ async function parseClaudeSessionTokenUsage(
     });
 
     for await (const line of rl) {
+      // Progress made — re-arm the idle deadline so a slow-but-streaming read
+      // is not mistaken for a stall.
+      heartbeat();
       if (!line.trim()) continue;
       let entry: Record<string, unknown>;
       try {
@@ -208,7 +211,8 @@ type CodexTokenUsage = {
  * Recursively discover all rollout JSONL files under ~/.codex/sessions/.
  * Files are organized as YYYY/MM/DD/rollout-*.jsonl.
  */
-async function discoverCodexRolloutFiles(): Promise<string[]> {
+/** Exported for testing (stall behavior); no production caller besides harvest. */
+export async function discoverCodexRolloutFiles(): Promise<string[]> {
   const files: string[] = [];
 
   async function walk(dir: string): Promise<void> {
@@ -235,10 +239,6 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
   return files;
 }
 
-export function discoverCodexRolloutFilesForTest(): Promise<string[]> {
-  return discoverCodexRolloutFiles();
-}
-
 /**
  * Parse a Codex rollout JSONL in a single pass: check for the agent tag
  * in the first 20 lines, then extract model and cumulative token usage.
@@ -255,7 +255,7 @@ async function parseCodexRolloutForAgent(
 } | null> {
   return mountIO.run(
     `read:codex:${path.basename(filePath)}`,
-    async (signal) => {
+    async (signal, heartbeat) => {
       let matched = false;
       let lastUsage: CodexTokenUsage | null = null;
       let model = "unknown";
@@ -269,6 +269,8 @@ async function parseCodexRolloutForAgent(
       });
 
       for await (const line of rl) {
+        // Progress made — re-arm the idle deadline (see Claude parser above).
+        heartbeat();
         linesRead++;
         if (!matched) {
           if (linesRead > 20) break;

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -6,6 +6,7 @@ import { createInterface } from "node:readline";
 
 import type { Pool } from "pg";
 
+import { mountIO } from "../shared/mount-io/index.js";
 import type { AgentRecord } from "./manager.js";
 
 type ModelTokenTotals = {
@@ -65,7 +66,9 @@ export function cwdToClaudeProjectDir(cwd: string): string {
 export async function discoverSessionFiles(dir: string): Promise<string[]> {
   let entries: string[];
   try {
-    entries = await readdir(dir);
+    entries = await mountIO.run("readdir:claude-projects", (signal) =>
+      readdir(dir, { signal }),
+    );
   } catch {
     return [];
   }
@@ -75,60 +78,62 @@ export async function discoverSessionFiles(dir: string): Promise<string[]> {
 }
 
 async function parseClaudeSessionTokenUsage(
-  filePath: string
+  filePath: string,
 ): Promise<SessionTokenSummary> {
   const sessionId = path.basename(filePath, ".jsonl");
-  const totals = new Map<string, ModelTokenTotals>();
-  let sessionStart: string | null = null;
-  let sessionEnd: string | null = null;
+  return mountIO.run(`read:claude:${sessionId}`, async (signal) => {
+    const totals = new Map<string, ModelTokenTotals>();
+    let sessionStart: string | null = null;
+    let sessionEnd: string | null = null;
 
-  const rl = createInterface({
-    input: createReadStream(filePath, { encoding: "utf-8" }),
-    crlfDelay: Infinity,
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf-8", signal }),
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (entry.type !== "assistant") continue;
+      const message = entry.message as Record<string, unknown> | undefined;
+      if (!message?.usage) continue;
+
+      const usage = message.usage as Record<string, number>;
+      const model = (message.model as string) ?? "unknown";
+      const ts = entry.timestamp as string | undefined;
+
+      if (ts) {
+        if (!sessionStart) sessionStart = ts;
+        sessionEnd = ts;
+      }
+
+      let bucket = totals.get(model);
+      if (!bucket) {
+        bucket = {
+          inputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          outputTokens: 0,
+          messageCount: 0,
+        };
+        totals.set(model, bucket);
+      }
+
+      bucket.inputTokens += usage.input_tokens ?? 0;
+      bucket.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
+      bucket.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+      bucket.outputTokens += usage.output_tokens ?? 0;
+      bucket.messageCount += 1;
+    }
+
+    return { sessionId, totals, sessionStart, sessionEnd };
   });
-
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    let entry: Record<string, unknown>;
-    try {
-      entry = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
-    if (entry.type !== "assistant") continue;
-    const message = entry.message as Record<string, unknown> | undefined;
-    if (!message?.usage) continue;
-
-    const usage = message.usage as Record<string, number>;
-    const model = (message.model as string) ?? "unknown";
-    const ts = entry.timestamp as string | undefined;
-
-    if (ts) {
-      if (!sessionStart) sessionStart = ts;
-      sessionEnd = ts;
-    }
-
-    let bucket = totals.get(model);
-    if (!bucket) {
-      bucket = {
-        inputTokens: 0,
-        cacheCreationTokens: 0,
-        cacheReadTokens: 0,
-        outputTokens: 0,
-        messageCount: 0,
-      };
-      totals.set(model, bucket);
-    }
-
-    bucket.inputTokens += usage.input_tokens ?? 0;
-    bucket.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
-    bucket.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
-    bucket.outputTokens += usage.output_tokens ?? 0;
-    bucket.messageCount += 1;
-  }
-
-  return { sessionId, totals, sessionStart, sessionEnd };
 }
 
 async function harvestClaudeTokenUsage(
@@ -151,6 +156,10 @@ async function harvestClaudeTokenUsage(
   }
 
   for (const file of files) {
+    if (!mountIO.available()) {
+      logger?.warn({ projectDir }, "mount unavailable, aborting Claude harvest");
+      break;
+    }
     try {
       const summary = await parseClaudeSessionTokenUsage(file);
 

--- a/apps/server/src/agents/token-harvester.ts
+++ b/apps/server/src/agents/token-harvester.ts
@@ -210,9 +210,9 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
   async function walk(dir: string): Promise<void> {
     let entries: import("node:fs").Dirent[];
     try {
-      entries = (await readdir(dir, {
-        withFileTypes: true,
-      })) as import("node:fs").Dirent[];
+      entries = await mountIO.run("readdir:codex-sessions", (signal) =>
+        readdir(dir, { withFileTypes: true, signal }),
+      );
     } catch {
       return;
     }
@@ -230,6 +230,10 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
   return files;
 }
 
+export function discoverCodexRolloutFilesForTest(): Promise<string[]> {
+  return discoverCodexRolloutFiles();
+}
+
 /**
  * Parse a Codex rollout JSONL in a single pass: check for the agent tag
  * in the first 20 lines, then extract model and cumulative token usage.
@@ -237,66 +241,62 @@ async function discoverCodexRolloutFiles(): Promise<string[]> {
  */
 async function parseCodexRolloutForAgent(
   filePath: string,
-  agentId: string
+  agentId: string,
 ): Promise<{
   usage: CodexTokenUsage;
   model: string;
   sessionStart: string | null;
   sessionEnd: string | null;
 } | null> {
-  let matched = false;
-  let lastUsage: CodexTokenUsage | null = null;
-  let model = "unknown";
-  let sessionStart: string | null = null;
-  let sessionEnd: string | null = null;
-  let linesRead = 0;
+  return mountIO.run(`read:codex:${path.basename(filePath)}`, async (signal) => {
+    let matched = false;
+    let lastUsage: CodexTokenUsage | null = null;
+    let model = "unknown";
+    let sessionStart: string | null = null;
+    let sessionEnd: string | null = null;
+    let linesRead = 0;
 
-  const rl = createInterface({
-    input: createReadStream(filePath, { encoding: "utf-8" }),
-    crlfDelay: Infinity,
-  });
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf-8", signal }),
+      crlfDelay: Infinity,
+    });
 
-  for await (const line of rl) {
-    linesRead++;
-
-    // Check for agent tag in the first 20 lines
-    if (!matched) {
-      if (linesRead > 20) break;
-      const tagMatch = DISPATCH_TAG_RE.exec(line);
-      if (tagMatch && tagMatch[1] === agentId) matched = true;
-      continue;
-    }
-
-    if (!line.trim()) continue;
-    let entry: Record<string, unknown>;
-    try {
-      entry = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
-    const ts = entry.timestamp as string | undefined;
-    if (ts && !sessionStart) sessionStart = ts;
-    if (ts) sessionEnd = ts;
-
-    if (entry.type === "turn_context") {
-      const payload = entry.payload as Record<string, unknown> | undefined;
-      if (payload?.model) model = payload.model as string;
-    }
-
-    if (entry.type === "event_msg") {
-      const payload = entry.payload as Record<string, unknown> | undefined;
-      if (payload?.type === "token_count") {
-        const info = payload.info as Record<string, unknown> | undefined;
-        if (info?.total_token_usage) {
-          lastUsage = info.total_token_usage as CodexTokenUsage;
+    for await (const line of rl) {
+      linesRead++;
+      if (!matched) {
+        if (linesRead > 20) break;
+        const tagMatch = DISPATCH_TAG_RE.exec(line);
+        if (tagMatch && tagMatch[1] === agentId) matched = true;
+        continue;
+      }
+      if (!line.trim()) continue;
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const ts = entry.timestamp as string | undefined;
+      if (ts && !sessionStart) sessionStart = ts;
+      if (ts) sessionEnd = ts;
+      if (entry.type === "turn_context") {
+        const payload = entry.payload as Record<string, unknown> | undefined;
+        if (payload?.model) model = payload.model as string;
+      }
+      if (entry.type === "event_msg") {
+        const payload = entry.payload as Record<string, unknown> | undefined;
+        if (payload?.type === "token_count") {
+          const info = payload.info as Record<string, unknown> | undefined;
+          if (info?.total_token_usage) {
+            lastUsage = info.total_token_usage as CodexTokenUsage;
+          }
         }
       }
     }
-  }
 
-  if (!matched || !lastUsage) return null;
-  return { usage: lastUsage, model, sessionStart, sessionEnd };
+    if (!matched || !lastUsage) return null;
+    return { usage: lastUsage, model, sessionStart, sessionEnd };
+  });
 }
 
 async function harvestCodexTokenUsage(
@@ -308,6 +308,10 @@ async function harvestCodexTokenUsage(
   if (rolloutFiles.length === 0) return;
 
   for (const file of rolloutFiles) {
+    if (!mountIO.available()) {
+      logger?.warn({}, "mount unavailable, aborting Codex harvest");
+      break;
+    }
     try {
       const result = await parseCodexRolloutForAgent(file, agent.id);
       if (!result) continue;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -36,6 +36,7 @@ import { deleteSetting, getSetting, setSetting } from "./db/settings.js";
 import { runCommand } from "./shared/lib/run-command.js";
 import { shouldSkipAutomaticMacPathProbe } from "./shared/mac-path-privacy.js";
 import { mimeType, resolveMediaDir } from "./shared/media.js";
+import { mountIO } from "./shared/mount-io/index.js";
 import { handleMcpRequest } from "./shared/mcp/server.js";
 import { readReleaseStore, writeReleaseStore } from "./release-store.js";
 import {
@@ -151,6 +152,9 @@ const app = Fastify({
   ...(config.tls && { https: { cert: config.tls.cert, key: config.tls.key } }),
 });
 const pool = createPool(config);
+// Route mount-io breaker open/recover transitions to the app logger so
+// operators get clear timestamps for a stalled gcsfuse mount.
+mountIO.setLogger(app.log);
 const agentManager = new AgentManager(pool, app.log, config);
 const focusTracker = new FocusTracker();
 const slackNotifier = new SlackNotifier(pool, app.log);

--- a/apps/server/src/shared/mount-io/circuit-breaker.ts
+++ b/apps/server/src/shared/mount-io/circuit-breaker.ts
@@ -1,0 +1,43 @@
+export type BreakerState = "closed" | "open" | "half-open";
+
+export class CircuitBreaker {
+  private failures = 0;
+  private openedAt: number | null = null;
+
+  constructor(
+    private readonly threshold: number,
+    private readonly cooldownMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  state(): BreakerState {
+    if (this.openedAt === null) return "closed";
+    if (this.now() - this.openedAt >= this.cooldownMs) return "half-open";
+    return "open";
+  }
+
+  canProceed(): boolean {
+    return this.state() !== "open";
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.openedAt = null;
+  }
+
+  recordFailure(): void {
+    if (this.state() === "half-open") {
+      this.openedAt = this.now();
+      return;
+    }
+    this.failures++;
+    if (this.failures >= this.threshold) {
+      this.openedAt = this.now();
+    }
+  }
+
+  reset(): void {
+    this.failures = 0;
+    this.openedAt = null;
+  }
+}

--- a/apps/server/src/shared/mount-io/circuit-breaker.ts
+++ b/apps/server/src/shared/mount-io/circuit-breaker.ts
@@ -7,7 +7,7 @@ export class CircuitBreaker {
   constructor(
     private readonly threshold: number,
     private readonly cooldownMs: number,
-    private readonly now: () => number = Date.now,
+    private readonly now: () => number = Date.now
   ) {}
 
   state(): BreakerState {

--- a/apps/server/src/shared/mount-io/index.ts
+++ b/apps/server/src/shared/mount-io/index.ts
@@ -3,11 +3,7 @@ import { MountIO } from "./mount-io.js";
 export { Semaphore } from "./semaphore.js";
 export { CircuitBreaker } from "./circuit-breaker.js";
 export type { BreakerState } from "./circuit-breaker.js";
-export {
-  MountIO,
-  MountStallError,
-  MountUnavailableError,
-} from "./mount-io.js";
+export { MountIO, MountStallError, MountUnavailableError } from "./mount-io.js";
 export type { MountIOConfig } from "./mount-io.js";
 
 const num = (raw: string | undefined, fallback: number): number => {
@@ -19,5 +15,8 @@ export const mountIO = new MountIO({
   timeoutMs: num(process.env.DISPATCH_MOUNT_IO_TIMEOUT_MS, 5_000),
   maxConcurrency: num(process.env.DISPATCH_MOUNT_IO_CONCURRENCY, 2),
   breakerThreshold: num(process.env.DISPATCH_MOUNT_IO_BREAKER_THRESHOLD, 3),
-  breakerCooldownMs: num(process.env.DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS, 60_000),
+  breakerCooldownMs: num(
+    process.env.DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS,
+    60_000
+  ),
 });

--- a/apps/server/src/shared/mount-io/index.ts
+++ b/apps/server/src/shared/mount-io/index.ts
@@ -11,8 +11,23 @@ const num = (raw: string | undefined, fallback: number): number => {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 };
 
+// Process-wide singleton. The breaker and semaphore are global (not keyed by
+// label), which assumes every caller reads the SAME mount — true today: both
+// token-harvester sources (~/.claude/projects and ~/.codex/sessions) live under
+// the home dir on the same gcsfuse mount, so a shared breaker is desirable (it
+// avoids hammering a stalled mount from multiple sources). If a future caller
+// reads a *different* mount root, key the breaker/semaphore by mount root (the
+// `label` prefix passed to run() is the natural seam) so a stall in one mount
+// does not suppress I/O against a healthy one.
+//
+// Default timeout is deliberately lenient (10s): harvesting is a periodic
+// background task, and a healthy-but-slow mount (cold metadata cache, large
+// readdir, transient GCS latency) can momentarily exceed a tight client
+// timeout. A lenient timeout trades a little stall-detection latency for far
+// fewer false breaker trips. Operators on high-latency mounts can raise it
+// further via DISPATCH_MOUNT_IO_TIMEOUT_MS.
 export const mountIO = new MountIO({
-  timeoutMs: num(process.env.DISPATCH_MOUNT_IO_TIMEOUT_MS, 5_000),
+  timeoutMs: num(process.env.DISPATCH_MOUNT_IO_TIMEOUT_MS, 10_000),
   maxConcurrency: num(process.env.DISPATCH_MOUNT_IO_CONCURRENCY, 2),
   breakerThreshold: num(process.env.DISPATCH_MOUNT_IO_BREAKER_THRESHOLD, 3),
   breakerCooldownMs: num(

--- a/apps/server/src/shared/mount-io/index.ts
+++ b/apps/server/src/shared/mount-io/index.ts
@@ -1,0 +1,23 @@
+import { MountIO } from "./mount-io.js";
+
+export { Semaphore } from "./semaphore.js";
+export { CircuitBreaker } from "./circuit-breaker.js";
+export type { BreakerState } from "./circuit-breaker.js";
+export {
+  MountIO,
+  MountStallError,
+  MountUnavailableError,
+} from "./mount-io.js";
+export type { MountIOConfig } from "./mount-io.js";
+
+const num = (raw: string | undefined, fallback: number): number => {
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+export const mountIO = new MountIO({
+  timeoutMs: num(process.env.DISPATCH_MOUNT_IO_TIMEOUT_MS, 5_000),
+  maxConcurrency: num(process.env.DISPATCH_MOUNT_IO_CONCURRENCY, 2),
+  breakerThreshold: num(process.env.DISPATCH_MOUNT_IO_BREAKER_THRESHOLD, 3),
+  breakerCooldownMs: num(process.env.DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS, 60_000),
+});

--- a/apps/server/src/shared/mount-io/mount-io.ts
+++ b/apps/server/src/shared/mount-io/mount-io.ts
@@ -1,0 +1,85 @@
+import { CircuitBreaker } from "./circuit-breaker.js";
+import { Semaphore } from "./semaphore.js";
+
+export class MountStallError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`mount op "${label}" exceeded ${timeoutMs}ms`);
+    this.name = "MountStallError";
+  }
+}
+
+export class MountUnavailableError extends Error {
+  constructor(label: string) {
+    super(`mount unavailable (circuit open), skipped "${label}"`);
+    this.name = "MountUnavailableError";
+  }
+}
+
+export type MountIOConfig = {
+  timeoutMs: number;
+  maxConcurrency: number;
+  breakerThreshold: number;
+  breakerCooldownMs: number;
+  now?: () => number;
+};
+
+export class MountIO {
+  private readonly sem: Semaphore;
+  private readonly breaker: CircuitBreaker;
+  private readonly timeoutMs: number;
+
+  constructor(cfg: MountIOConfig) {
+    this.sem = new Semaphore(cfg.maxConcurrency);
+    this.breaker = new CircuitBreaker(
+      cfg.breakerThreshold,
+      cfg.breakerCooldownMs,
+      cfg.now,
+    );
+    this.timeoutMs = cfg.timeoutMs;
+  }
+
+  available(): boolean {
+    return this.breaker.canProceed();
+  }
+
+  async run<T>(
+    label: string,
+    fn: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    if (!this.breaker.canProceed()) {
+      throw new MountUnavailableError(label);
+    }
+
+    await this.sem.acquire();
+    const ac = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    try {
+      const work = fn(ac.signal);
+      work.catch(() => {});
+
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          ac.abort(new MountStallError(label, this.timeoutMs));
+          reject(new MountStallError(label, this.timeoutMs));
+        }, this.timeoutMs);
+      });
+
+      const result = await Promise.race([work, timeout]);
+      this.breaker.recordSuccess();
+      return result;
+    } catch (err) {
+      if (err instanceof MountStallError) {
+        this.breaker.recordFailure();
+      }
+      throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+      this.sem.release();
+    }
+  }
+
+  reset(): void {
+    this.breaker.reset();
+  }
+}

--- a/apps/server/src/shared/mount-io/mount-io.ts
+++ b/apps/server/src/shared/mount-io/mount-io.ts
@@ -60,8 +60,9 @@ export class MountIO {
 
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
-          ac.abort(new MountStallError(label, this.timeoutMs));
-          reject(new MountStallError(label, this.timeoutMs));
+          const err = new MountStallError(label, this.timeoutMs);
+          ac.abort(err);
+          reject(err);
         }, this.timeoutMs);
       });
 

--- a/apps/server/src/shared/mount-io/mount-io.ts
+++ b/apps/server/src/shared/mount-io/mount-io.ts
@@ -33,7 +33,7 @@ export class MountIO {
     this.breaker = new CircuitBreaker(
       cfg.breakerThreshold,
       cfg.breakerCooldownMs,
-      cfg.now,
+      cfg.now
     );
     this.timeoutMs = cfg.timeoutMs;
   }
@@ -44,7 +44,7 @@ export class MountIO {
 
   async run<T>(
     label: string,
-    fn: (signal: AbortSignal) => Promise<T>,
+    fn: (signal: AbortSignal) => Promise<T>
   ): Promise<T> {
     if (!this.breaker.canProceed()) {
       throw new MountUnavailableError(label);

--- a/apps/server/src/shared/mount-io/mount-io.ts
+++ b/apps/server/src/shared/mount-io/mount-io.ts
@@ -1,4 +1,4 @@
-import { CircuitBreaker } from "./circuit-breaker.js";
+import { CircuitBreaker, type BreakerState } from "./circuit-breaker.js";
 import { Semaphore } from "./semaphore.js";
 
 export class MountStallError extends Error {
@@ -15,18 +15,27 @@ export class MountUnavailableError extends Error {
   }
 }
 
+/** Minimal structural logger (satisfied by pino / FastifyBaseLogger). */
+export type MountIOLogger = {
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  info: (obj: Record<string, unknown>, msg: string) => void;
+};
+
 export type MountIOConfig = {
   timeoutMs: number;
   maxConcurrency: number;
   breakerThreshold: number;
   breakerCooldownMs: number;
   now?: () => number;
+  logger?: MountIOLogger;
 };
 
 export class MountIO {
   private readonly sem: Semaphore;
   private readonly breaker: CircuitBreaker;
   private readonly timeoutMs: number;
+  private readonly breakerCooldownMs: number;
+  private logger?: MountIOLogger;
 
   constructor(cfg: MountIOConfig) {
     this.sem = new Semaphore(cfg.maxConcurrency);
@@ -36,15 +45,59 @@ export class MountIO {
       cfg.now
     );
     this.timeoutMs = cfg.timeoutMs;
+    this.breakerCooldownMs = cfg.breakerCooldownMs;
+    this.logger = cfg.logger;
+  }
+
+  /**
+   * Attach a logger after construction (the process-wide singleton is built at
+   * import time, before the app logger exists).
+   */
+  setLogger(logger: MountIOLogger): void {
+    this.logger = logger;
   }
 
   available(): boolean {
     return this.breaker.canProceed();
   }
 
+  /**
+   * Run a single filesystem operation against the (possibly stalled) mount,
+   * guarded by a circuit breaker, a bounded-concurrency semaphore, and a
+   * timeout.
+   *
+   * IMPORTANT — the timeout *abandons*, it does not *cancel*. When the timeout
+   * fires we abort the signal, release the semaphore permit, and reject the
+   * caller with a `MountStallError`. But the underlying syscall keeps running
+   * on its libuv/Bun I/O thread until the kernel/gcsfuse unblocks it (which on
+   * a hard mount wedge may be never). Consequences callers must understand:
+   *
+   *   1. `fn` MUST honor the supplied `AbortSignal` (e.g. pass it to
+   *      `createReadStream({ signal })`). A `fn` that ignores the signal turns
+   *      every timeout into a *leaked* background op holding an I/O-pool
+   *      thread. With enough leaks the pool is exhausted and ALL threadpool
+   *      work server-wide (fs, dns, crypto, zlib) stalls — the exact failure
+   *      this guard exists to prevent. Where the underlying API genuinely
+   *      cannot take a signal (e.g. `fs.readdir`), the op is bounded only by
+   *      the caller-side timeout and the residual leak risk is real — keep
+   *      `maxConcurrency` and `breakerThreshold` low and raise
+   *      `UV_THREADPOOL_SIZE` for the server process so a few wedged threads
+   *      cannot starve the pool.
+   *   2. `available()` and the semaphore track JS-tracked ops, not in-flight
+   *      kernel work. A released permit lets a new op dispatch even though the
+   *      abandoned syscall's thread is still stuck.
+   *
+   * `fn` receives a `heartbeat()` callback. The timeout starts as a
+   * whole-operation deadline; each `heartbeat()` call re-arms it, turning it
+   * into an *idle* (no-progress) deadline. Streaming readers should call
+   * `heartbeat()` per chunk/line so a slow-but-progressing read over a healthy
+   * mount is not mistaken for a stall — only a genuine no-data stall trips the
+   * breaker. Single-shot ops (e.g. readdir) simply never heartbeat and keep
+   * the whole-operation deadline.
+   */
   async run<T>(
     label: string,
-    fn: (signal: AbortSignal) => Promise<T>
+    fn: (signal: AbortSignal, heartbeat: () => void) => Promise<T>
   ): Promise<T> {
     if (!this.breaker.canProceed()) {
       throw new MountUnavailableError(label);
@@ -53,30 +106,70 @@ export class MountIO {
     await this.sem.acquire();
     const ac = new AbortController();
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
 
     try {
-      const work = fn(ac.signal);
-      work.catch(() => {});
-
+      let rejectTimeout!: (err: Error) => void;
       const timeout = new Promise<never>((_, reject) => {
+        rejectTimeout = reject;
+      });
+
+      // (Re)arm the deadline. Called once up front (whole-op deadline) and
+      // again on every heartbeat (turning it into an idle deadline).
+      const arm = (): void => {
+        if (settled) return;
+        if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
           const err = new MountStallError(label, this.timeoutMs);
           ac.abort(err);
-          reject(err);
+          rejectTimeout(err);
         }, this.timeoutMs);
-      });
+      };
+      arm();
+
+      const work = fn(ac.signal, arm);
+      // Load-bearing: when the timeout wins the race, `work` has no other
+      // rejection handler and rejects later (once the abandoned op settles via
+      // abort). Without this no-op catch that becomes an unhandledRejection,
+      // which under Node's default policy can terminate the process. Do not
+      // remove.
+      work.catch(() => {});
 
       const result = await Promise.race([work, timeout]);
-      this.breaker.recordSuccess();
+      this.recordSuccess();
       return result;
     } catch (err) {
+      // Only a genuine stall trips the breaker. Per-file errors (ENOENT, parse
+      // failures, permission errors) are intentionally neutral — a single bad
+      // or absent session file must never open the process-wide circuit and
+      // suppress harvesting for every agent. Do not broaden this to all errors.
       if (err instanceof MountStallError) {
-        this.breaker.recordFailure();
+        this.recordFailure();
       }
       throw err;
     } finally {
+      settled = true;
       if (timer) clearTimeout(timer);
       this.sem.release();
+    }
+  }
+
+  private recordSuccess(): void {
+    const prev = this.breaker.state();
+    this.breaker.recordSuccess();
+    if (prev !== "closed") {
+      this.logger?.info({}, "mount-io: mount recovered, harvesting resumed");
+    }
+  }
+
+  private recordFailure(): void {
+    const prev: BreakerState = this.breaker.state();
+    this.breaker.recordFailure();
+    if (prev !== "open" && this.breaker.state() === "open") {
+      this.logger?.warn(
+        { cooldownMs: this.breakerCooldownMs },
+        "mount-io: breaker opened after mount stall, pausing harvest"
+      );
     }
   }
 

--- a/apps/server/src/shared/mount-io/semaphore.ts
+++ b/apps/server/src/shared/mount-io/semaphore.ts
@@ -1,0 +1,29 @@
+export class Semaphore {
+  private permits: number;
+  private waiters: Array<() => void> = [];
+
+  constructor(max: number) {
+    this.permits = max;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+
+  get available(): number {
+    return this.permits;
+  }
+}

--- a/apps/server/test/mount-io/circuit-breaker.test.ts
+++ b/apps/server/test/mount-io/circuit-breaker.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { CircuitBreaker } from "../../src/shared/mount-io/circuit-breaker.js";
+
+const clock = (start = 0) => {
+  let t = start;
+  const now = () => t;
+  return { now, advance: (ms: number) => (t += ms) };
+};
+
+describe("CircuitBreaker", () => {
+  it("stays closed below the failure threshold", () => {
+    const b = new CircuitBreaker(3, 1000, () => 0);
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.state()).toBe("closed");
+    expect(b.canProceed()).toBe(true);
+  });
+
+  it("opens at the failure threshold and blocks", () => {
+    const b = new CircuitBreaker(3, 1000, () => 0);
+    b.recordFailure();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.state()).toBe("open");
+    expect(b.canProceed()).toBe(false);
+  });
+
+  it("moves to half-open after the cooldown elapses", () => {
+    const c = clock();
+    const b = new CircuitBreaker(1, 1000, c.now);
+    b.recordFailure();
+    expect(b.state()).toBe("open");
+    c.advance(1000);
+    expect(b.state()).toBe("half-open");
+    expect(b.canProceed()).toBe(true);
+  });
+
+  it("re-opens when the half-open probe fails", () => {
+    const c = clock();
+    const b = new CircuitBreaker(1, 1000, c.now);
+    b.recordFailure();
+    c.advance(1000);
+    expect(b.state()).toBe("half-open");
+    b.recordFailure();
+    expect(b.state()).toBe("open");
+  });
+
+  it("closes when the half-open probe succeeds", () => {
+    const c = clock();
+    const b = new CircuitBreaker(1, 1000, c.now);
+    b.recordFailure();
+    c.advance(1000);
+    b.recordSuccess();
+    expect(b.state()).toBe("closed");
+    expect(b.canProceed()).toBe(true);
+  });
+
+  it("resets failure count on success", () => {
+    const b = new CircuitBreaker(3, 1000, () => 0);
+    b.recordFailure();
+    b.recordFailure();
+    b.recordSuccess();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.state()).toBe("closed");
+  });
+});

--- a/apps/server/test/mount-io/mount-io.test.ts
+++ b/apps/server/test/mount-io/mount-io.test.ts
@@ -53,7 +53,7 @@ describe("MountIO", () => {
       io.run("blocked", async () => {
         called = true;
         return 1;
-      }),
+      })
     ).rejects.toBeInstanceOf(MountUnavailableError);
     expect(called).toBe(false);
   });
@@ -82,8 +82,8 @@ describe("MountIO", () => {
       "late-reject",
       () =>
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("late")), 10_000),
-        ),
+          setTimeout(() => reject(new Error("late")), 10_000)
+        )
     );
     const a = expect(p).rejects.toBeInstanceOf(MountStallError);
     await vi.advanceTimersByTimeAsync(5001);

--- a/apps/server/test/mount-io/mount-io.test.ts
+++ b/apps/server/test/mount-io/mount-io.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MountIO,
+  MountStallError,
+  MountUnavailableError,
+} from "../../src/shared/mount-io/mount-io.js";
+
+const cfg = {
+  timeoutMs: 5000,
+  maxConcurrency: 2,
+  breakerThreshold: 2,
+  breakerCooldownMs: 60_000,
+};
+
+describe("MountIO", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns the result of a fast op", async () => {
+    const io = new MountIO(cfg);
+    await expect(io.run("ok", async () => 42)).resolves.toBe(42);
+    expect(io.available()).toBe(true);
+  });
+
+  it("times out a hanging op and aborts its signal", async () => {
+    const io = new MountIO(cfg);
+    let aborted = false;
+    const p = io.run("hang", (signal) => {
+      signal.addEventListener("abort", () => (aborted = true));
+      return new Promise<never>(() => {});
+    });
+    const assertion = expect(p).rejects.toBeInstanceOf(MountStallError);
+    await vi.advanceTimersByTimeAsync(5001);
+    await assertion;
+    expect(aborted).toBe(true);
+  });
+
+  it("opens the breaker after threshold timeouts, then skips fn", async () => {
+    const io = new MountIO(cfg);
+    const hang = () => new Promise<never>(() => {});
+
+    for (let i = 0; i < 2; i++) {
+      const p = io.run(`hang-${i}`, hang);
+      const a = expect(p).rejects.toBeInstanceOf(MountStallError);
+      await vi.advanceTimersByTimeAsync(5001);
+      await a;
+    }
+
+    expect(io.available()).toBe(false);
+    let called = false;
+    await expect(
+      io.run("blocked", async () => {
+        called = true;
+        return 1;
+      }),
+    ).rejects.toBeInstanceOf(MountUnavailableError);
+    expect(called).toBe(false);
+  });
+
+  it("never runs more than maxConcurrency fns at once", async () => {
+    const io = new MountIO({ ...cfg, maxConcurrency: 2 });
+    let active = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+
+    const starts = Array.from({ length: 5 }, (_, i) =>
+      io.run(`c-${i}`, () => {
+        active++;
+        peak = Math.max(peak, active);
+        return new Promise<number>((resolve) => {
+          release.push(() => {
+            active--;
+            resolve(i);
+          });
+        });
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(peak).toBeLessThanOrEqual(2);
+    release.forEach((r) => r());
+    await Promise.all(starts);
+  });
+
+  it("does not emit an unhandled rejection when fn rejects after timeout", async () => {
+    const io = new MountIO(cfg);
+    const p = io.run(
+      "late-reject",
+      () =>
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("late")), 10_000),
+        ),
+    );
+    const a = expect(p).rejects.toBeInstanceOf(MountStallError);
+    await vi.advanceTimersByTimeAsync(5001);
+    await a;
+    await vi.advanceTimersByTimeAsync(6000);
+  });
+});

--- a/apps/server/test/mount-io/mount-io.test.ts
+++ b/apps/server/test/mount-io/mount-io.test.ts
@@ -62,25 +62,18 @@ describe("MountIO", () => {
     const io = new MountIO({ ...cfg, maxConcurrency: 2 });
     let active = 0;
     let peak = 0;
-    const release: Array<() => void> = [];
 
-    const starts = Array.from({ length: 5 }, (_, i) =>
-      io.run(`c-${i}`, () => {
+    const task = (i: number) =>
+      io.run(`c-${i}`, async () => {
         active++;
         peak = Math.max(peak, active);
-        return new Promise<number>((resolve) => {
-          release.push(() => {
-            active--;
-            resolve(i);
-          });
-        });
-      }),
-    );
+        await Promise.resolve();
+        active--;
+        return i;
+      });
 
-    await vi.advanceTimersByTimeAsync(0);
+    await Promise.all(Array.from({ length: 10 }, (_, i) => task(i)));
     expect(peak).toBeLessThanOrEqual(2);
-    release.forEach((r) => r());
-    await Promise.all(starts);
   });
 
   it("does not emit an unhandled rejection when fn rejects after timeout", async () => {

--- a/apps/server/test/mount-io/semaphore.test.ts
+++ b/apps/server/test/mount-io/semaphore.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { Semaphore } from "../../src/shared/mount-io/semaphore.js";
+
+describe("Semaphore", () => {
+  it("grants permits immediately while capacity remains", async () => {
+    const sem = new Semaphore(2);
+    await sem.acquire();
+    await sem.acquire();
+    expect(sem.available).toBe(0);
+  });
+
+  it("queues acquisitions beyond capacity until release", async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+
+    let third = false;
+    const pending = sem.acquire().then(() => {
+      third = true;
+    });
+
+    await Promise.resolve();
+    expect(third).toBe(false);
+
+    sem.release();
+    await pending;
+    expect(third).toBe(true);
+  });
+
+  it("never lets more than max run at once", async () => {
+    const sem = new Semaphore(2);
+    let active = 0;
+    let peak = 0;
+
+    const task = async () => {
+      await sem.acquire();
+      active++;
+      peak = Math.max(peak, active);
+      await Promise.resolve();
+      active--;
+      sem.release();
+    };
+
+    await Promise.all(Array.from({ length: 10 }, task));
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/server/test/token-harvester-stall.test.ts
+++ b/apps/server/test/token-harvester-stall.test.ts
@@ -9,7 +9,7 @@ import { readdir } from "node:fs/promises";
 
 import {
   discoverSessionFiles,
-  discoverCodexRolloutFilesForTest,
+  discoverCodexRolloutFiles,
 } from "../src/agents/token-harvester.js";
 import { mountIO } from "../src/shared/mount-io/index.js";
 
@@ -31,7 +31,7 @@ describe("discoverSessionFiles under a stalled mount", () => {
 
     const p = discoverSessionFiles("/mnt/claude/projects/whatever");
     const assertion = expect(p).resolves.toEqual([]);
-    await vi.advanceTimersByTimeAsync(5001);
+    await vi.advanceTimersByTimeAsync(10_001);
     await assertion;
   });
 
@@ -64,9 +64,9 @@ describe("codex rollout discovery under a stalled mount", () => {
     vi.mocked(readdir).mockReturnValue(
       new Promise(() => {}) as unknown as ReturnType<typeof readdir>
     );
-    const p = discoverCodexRolloutFilesForTest();
+    const p = discoverCodexRolloutFiles();
     const assertion = expect(p).resolves.toEqual([]);
-    await vi.advanceTimersByTimeAsync(5001);
+    await vi.advanceTimersByTimeAsync(10_001);
     await assertion;
   });
 });

--- a/apps/server/test/token-harvester-stall.test.ts
+++ b/apps/server/test/token-harvester-stall.test.ts
@@ -7,7 +7,10 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 import { readdir } from "node:fs/promises";
 
-import { discoverSessionFiles } from "../src/agents/token-harvester.js";
+import {
+  discoverSessionFiles,
+  discoverCodexRolloutFilesForTest,
+} from "../src/agents/token-harvester.js";
 import { mountIO } from "../src/shared/mount-io/index.js";
 
 describe("discoverSessionFiles under a stalled mount", () => {
@@ -43,5 +46,27 @@ describe("discoverSessionFiles under a stalled mount", () => {
       "/p/a.jsonl",
       "/p/c.jsonl",
     ]);
+  });
+});
+
+describe("codex rollout discovery under a stalled mount", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mountIO.reset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(readdir).mockReset();
+    mountIO.reset();
+  });
+
+  it("returns [] instead of hanging when the top-level readdir never resolves", async () => {
+    vi.mocked(readdir).mockReturnValue(
+      new Promise(() => {}) as unknown as ReturnType<typeof readdir>,
+    );
+    const p = discoverCodexRolloutFilesForTest();
+    const assertion = expect(p).resolves.toEqual([]);
+    await vi.advanceTimersByTimeAsync(5001);
+    await assertion;
   });
 });

--- a/apps/server/test/token-harvester-stall.test.ts
+++ b/apps/server/test/token-harvester-stall.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, readdir: vi.fn() };
+});
+
+import { readdir } from "node:fs/promises";
+
+import { discoverSessionFiles } from "../src/agents/token-harvester.js";
+import { mountIO } from "../src/shared/mount-io/index.js";
+
+describe("discoverSessionFiles under a stalled mount", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mountIO.reset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(readdir).mockReset();
+    mountIO.reset();
+  });
+
+  it("returns [] instead of hanging when readdir never resolves", async () => {
+    vi.mocked(readdir).mockReturnValue(
+      new Promise(() => {}) as unknown as ReturnType<typeof readdir>,
+    );
+
+    const p = discoverSessionFiles("/mnt/claude/projects/whatever");
+    const assertion = expect(p).resolves.toEqual([]);
+    await vi.advanceTimersByTimeAsync(5001);
+    await assertion;
+  });
+
+  it("returns parsed file list when readdir resolves normally", async () => {
+    vi.mocked(readdir).mockResolvedValue([
+      "a.jsonl",
+      "b.txt",
+      "c.jsonl",
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    await expect(discoverSessionFiles("/p")).resolves.toEqual([
+      "/p/a.jsonl",
+      "/p/c.jsonl",
+    ]);
+  });
+});

--- a/apps/server/test/token-harvester-stall.test.ts
+++ b/apps/server/test/token-harvester-stall.test.ts
@@ -26,7 +26,7 @@ describe("discoverSessionFiles under a stalled mount", () => {
 
   it("returns [] instead of hanging when readdir never resolves", async () => {
     vi.mocked(readdir).mockReturnValue(
-      new Promise(() => {}) as unknown as ReturnType<typeof readdir>,
+      new Promise(() => {}) as unknown as ReturnType<typeof readdir>
     );
 
     const p = discoverSessionFiles("/mnt/claude/projects/whatever");
@@ -62,7 +62,7 @@ describe("codex rollout discovery under a stalled mount", () => {
 
   it("returns [] instead of hanging when the top-level readdir never resolves", async () => {
     vi.mocked(readdir).mockReturnValue(
-      new Promise(() => {}) as unknown as ReturnType<typeof readdir>,
+      new Promise(() => {}) as unknown as ReturnType<typeof readdir>
     );
     const p = discoverCodexRolloutFilesForTest();
     const assertion = expect(p).resolves.toEqual([]);

--- a/bin/dispatch-launchd-wrapper
+++ b/bin/dispatch-launchd-wrapper
@@ -11,6 +11,17 @@
 
 export TERM="${TERM:-xterm-256color}"
 
+# Enlarge the I/O thread pool. The token harvester reads agent session files
+# from a gcsfuse mount; on a mount stall an in-flight readdir/read syscall
+# cannot be cancelled and stays blocked on an I/O-pool thread until the kernel
+# unblocks it. The default libuv pool is small (4), so a few wedged harvester
+# threads could otherwise starve all other fs/dns/crypto work server-wide.
+# NOTE: production runs the Bun binary, which uses its own I/O threadpool (not
+# libuv) and may not honor this knob — it hardens Node-based dev/test paths,
+# and the mount-io breaker's low concurrency/threshold is the primary backstop
+# on the wedged-syscall leak regardless of runtime. Override before launch.
+export UV_THREADPOOL_SIZE="${UV_THREADPOOL_SIZE:-16}"
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OS_NAME="$(uname -s)"
 ARCH_NAME="$(uname -m)"


### PR DESCRIPTION
## Problem

The token harvester reads Claude/Codex session JSONL files directly from a **gcsfuse**-backed directory. When that mount stalls, `read()`/`readdir()` syscalls block indefinitely, freezing the recurring harvest loop on the first wedged file.

## What this does

Introduces a reusable **`MountIO`** guard (`apps/server/src/shared/mount-io/`) and routes every harvester filesystem read through it:

- **Per-op timeout** — a stalled op is abandoned and the caller is unblocked with a `MountStallError` instead of hanging forever.
- **Bounded concurrency** (semaphore, default 2) — caps how much in-flight mount I/O can pile up.
- **Circuit breaker** (default: open after 3 stalls, 60s cooldown) — once the mount looks wedged, harvest loops short-circuit via `available()` and resume on the next healthy cycle. Only `MountStallError` trips it, so a single missing/corrupt file never opens the process-wide circuit.
- Streaming reads pass the `AbortSignal` into `createReadStream` so a stalled stream's fd is actually closed.

All four `fs` entry points (2 streaming JSONL parsers + 2 `readdir` discovery walks) are wrapped. Token stats become eventually-consistent during a stall (no data loss — re-harvested next cycle).

## Persona review hardening

This branch was reviewed by four persona reviewers (architecture, backend-security, infra, release-readiness) — all **approved**. Resulting changes:

- **Idle (no-progress) timeout** for streaming reads via a `heartbeat()` re-arm per line, so a slow-but-progressing large file over a healthy mount no longer false-trips the mount-wide breaker. `readdir` keeps the whole-op deadline.
- **`UV_THREADPOOL_SIZE=16`** in the launchd wrapper + `.env.example` — an uncancellable `readdir` syscall wedged on a stalled mount can otherwise leak I/O-pool threads and starve fs/dns/crypto work server-wide. Documented that the production **Bun** runtime may ignore this knob (own threadpool, not libuv), with the breaker as the cross-runtime backstop.
- Default timeout **5s → 10s** with tuning docs.
- **Breaker open/recover transition logging** via `mountIO.setLogger(app.log)` for operator visibility.
- Thorough `run()` JSDoc contract (signal mandatory; timeout abandons, not cancels; `available()`/semaphore track JS ops, not kernel work).

## Config (all optional, defaults shown)

```
DISPATCH_MOUNT_IO_TIMEOUT_MS=10000
DISPATCH_MOUNT_IO_CONCURRENCY=2
DISPATCH_MOUNT_IO_BREAKER_THRESHOLD=3
DISPATCH_MOUNT_IO_BREAKER_COOLDOWN_MS=60000
UV_THREADPOOL_SIZE=16
```

## Release posture

Code + env only. No DB migrations, schema, or API/SSE contract changes. Breaker state is in-memory; reverting fully restores prior behavior.

## Testing

- New unit tests: `mount-io/{mount-io,circuit-breaker,semaphore}.test.ts` and `token-harvester-stall.test.ts`.
- Server `tsc --noEmit` clean; 17/17 mount-io + stall tests pass.
- ⚠️ The repo-wide `pnpm run check` currently fails on **pre-existing** `apps/web` missing-dependency errors (`refractor`, `react-diff-view`, `@testing-library/react`) in files untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)