### PR TITLE
Include parent id in child launch prompts

### DIFF
--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -65,6 +65,18 @@ const AGENT_LATEST_EVENT_TYPES = [
 const CODEX_FULL_ACCESS_ARG = "--dangerously-bypass-approvals-and-sandbox";
 const CLAUDE_FULL_ACCESS_ARG = "--dangerously-skip-permissions";
 
+function buildChildAgentInitialPrompt(
+  parentAgentId: string,
+  prompt: string
+): string {
+  return [
+    `You were launched by Dispatch agent "${parentAgentId}" via dispatch_launch_agent.`,
+    "Use that parent agent ID when coordinating back with dispatch_send_message.",
+    "",
+    prompt,
+  ].join("\n");
+}
+
 type AgentLatestEventType = (typeof AGENT_LATEST_EVENT_TYPES)[number];
 
 type PublishUiEvent = (event: unknown) => void;
@@ -727,7 +739,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         worktreeBranch: input.worktreeBranch,
         parentAgentId: agentId,
         cliSessionId,
-        initialPrompt: input.prompt,
+        initialPrompt: buildChildAgentInitialPrompt(agentId, input.prompt),
         templateId: input.templateId,
       });
 

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -983,6 +983,30 @@ describe("createMcpHandlers", () => {
     });
   });
 
+  describe("launchAgent", () => {
+    it("includes the launching agent id in the child initial prompt", async () => {
+      await handlers.launchAgent("agt_test1", {
+        name: "worker",
+        prompt: "Investigate the flaky test.",
+      });
+
+      expect(deps.agentManager.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "worker",
+          parentAgentId: "agt_test1",
+          initialPrompt: expect.stringContaining(
+            'You were launched by Dispatch agent "agt_test1"'
+          ),
+        })
+      );
+      expect(deps.agentManager.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialPrompt: expect.stringContaining("Investigate the flaky test."),
+        })
+      );
+    });
+  });
+
   describe("sendMessage", () => {
     it("delivers message to matching running agent", async () => {
       const target = {


### PR DESCRIPTION
## Summary
- Prepend server-generated parent-agent context to generic `dispatch_launch_agent` child startup prompts
- Preserve the original caller prompt after the parent-id context
- Add handler coverage verifying the parent id and original prompt are passed into `createAgent`

## Validation
- `pnpm vitest run apps/server/test/mcp-handlers.test.ts`
- `pnpm run check`
- `pnpm run test:e2e`
- `pnpm run test`
- Pre-commit hook: `pnpm run check`