### PR TITLE
Keep quick phrase send label stable

### DIFF
--- a/apps/web/src/components/app/quick-phrases/fill-variables-dialog.tsx
+++ b/apps/web/src/components/app/quick-phrases/fill-variables-dialog.tsx
@@ -74,7 +74,6 @@ export function FillVariablesDialog({
               </Button>
               <InjectSplitButton
                 disabled={requiredMissing || isPending}
-                isPending={isPending}
                 onInject={onInject}
               />
             </div>

--- a/apps/web/src/components/app/quick-phrases/inject-split-button.tsx
+++ b/apps/web/src/components/app/quick-phrases/inject-split-button.tsx
@@ -11,18 +11,17 @@ import { cn } from "@/lib/utils";
 
 export function InjectSplitButton({
   disabled,
-  isPending,
   onInject,
   size = "default",
   insidePopover = false,
 }: {
   disabled: boolean;
-  isPending: boolean;
   onInject: (submit: boolean) => void;
   size?: "sm" | "default";
   insidePopover?: boolean;
 }) {
   const isSm = size === "sm";
+  const label = isSm ? "Send" : "Send & Submit";
 
   return (
     <div className={cn("flex items-stretch", isSm && "min-w-[5.5rem]")}>
@@ -41,7 +40,7 @@ export function InjectSplitButton({
         }
       >
         {isSm ? <Play className="h-2.5 w-2.5 fill-current" /> : null}
-        {isPending ? "Sending…" : isSm ? "Send" : "Send & Submit"}
+        {label}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/src/components/app/quick-phrases/phrase-row.tsx
+++ b/apps/web/src/components/app/quick-phrases/phrase-row.tsx
@@ -44,7 +44,6 @@ export function PhraseRow({
           ) : (
             <InjectSplitButton
               disabled={isPending}
-              isPending={isPending}
               onInject={onInject}
               size="sm"
               insidePopover


### PR DESCRIPTION
## Summary
- Keep quick phrase send button labels stable while pending to avoid layout shift
- Remove the now-unneeded `isPending` prop from the split button and call sites

## Validation
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e` (171 passed, 12 skipped)