### PR TITLE
Add sidebar agent reordering

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -5,7 +5,9 @@ import {
   Check,
   ChevronDown,
   AlarmClock,
+  ArrowDown,
   ArrowDownToLine,
+  ArrowUp,
   Copy,
   Folder,
   FolderTree,
@@ -85,6 +87,20 @@ function hasDefaultSessionName(agent: Agent): boolean {
   return agent.name.trim() === `agent-${agent.id.slice(-6)}`;
 }
 
+type AgentCardNativeDragHandlers = Partial<{
+  dragstart: (event: DragEvent) => void;
+  dragenter: (event: DragEvent) => void;
+  dragover: (event: DragEvent) => void;
+  dragleave: (event: DragEvent) => void;
+  drop: (event: DragEvent) => void;
+}>;
+
+type AgentCardContainerProps = {
+  className?: string;
+  draggable?: boolean;
+  nativeDragHandlers?: AgentCardNativeDragHandlers;
+};
+
 export type AgentCardProps = {
   agent: Agent;
   agents: Agent[];
@@ -112,6 +128,11 @@ export type AgentCardProps = {
   closeOnSessionAction?: boolean;
   enabledAgentTypes: AgentType[];
   enabledIdes: IdeType[];
+  containerProps?: AgentCardContainerProps;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
 };
 
 function CompactMetaRow({
@@ -182,7 +203,18 @@ export function AgentCard({
   closeOnSessionAction = false,
   enabledAgentTypes,
   enabledIdes,
+  containerProps,
+  canMoveUp = false,
+  canMoveDown = false,
+  onMoveUp,
+  onMoveDown,
 }: AgentCardProps): JSX.Element {
+  const {
+    className: containerClassName,
+    nativeDragHandlers,
+    ...rootProps
+  } = containerProps ?? {};
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
   const state = getVisualState(agent);
   const hasActiveChild = childAgents.some(
     (child) => child.id === connectedAgentId
@@ -229,12 +261,34 @@ export function AgentCard({
     isExpanded
   );
 
+  React.useEffect(() => {
+    const node = rootRef.current;
+    if (!node || !nativeDragHandlers) return;
+
+    const entries = Object.entries(nativeDragHandlers) as Array<
+      [keyof AgentCardNativeDragHandlers, (event: DragEvent) => void]
+    >;
+    entries.forEach(([eventName, handler]) => {
+      node.addEventListener(eventName, handler);
+    });
+    return () => {
+      entries.forEach(([eventName, handler]) => {
+        node.removeEventListener(eventName, handler);
+      });
+    };
+  }, [nativeDragHandlers]);
+
   return (
     <React.Fragment>
-      <div
+      <motion.div
+        ref={rootRef}
+        {...rootProps}
+        layout="position"
+        transition={{ layout: { duration: 0.18, ease: "easeOut" } }}
         data-testid={`agent-card-${agent.id}`}
         className={cn(
           "border-b border-r-4 border-border px-2 py-2 transition-colors duration-300",
+          containerClassName,
           borderForAgentState(effectiveState),
           isSelected && "bg-muted/60",
           isStopped && "opacity-60"
@@ -377,6 +431,45 @@ export function AgentCard({
                 </span>
               </TooltipContent>
             </Tooltip>
+          ) : null}
+
+          {onMoveUp || onMoveDown ? (
+            <div className="flex shrink-0 items-center gap-0.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    data-agent-control="true"
+                    aria-label={`Move ${agent.name} up`}
+                    data-testid={`agent-move-up-${agent.id}`}
+                    className="h-7 w-7 text-muted-foreground/70 hover:text-foreground disabled:opacity-30"
+                    disabled={!canMoveUp}
+                    onClick={() => onMoveUp?.()}
+                  >
+                    <ArrowUp className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Move up</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    data-agent-control="true"
+                    aria-label={`Move ${agent.name} down`}
+                    data-testid={`agent-move-down-${agent.id}`}
+                    className="h-7 w-7 text-muted-foreground/70 hover:text-foreground disabled:opacity-30"
+                    disabled={!canMoveDown}
+                    onClick={() => onMoveDown?.()}
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Move down</TooltipContent>
+              </Tooltip>
+            </div>
           ) : null}
 
           <Tooltip>
@@ -762,7 +855,7 @@ export function AgentCard({
             </motion.div>
           ) : null}
         </AnimatePresence>
-      </div>
+      </motion.div>
       <SessionSettingsDialog
         agent={agent}
         open={settingsOpen}

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from "lucide-react";
+import { useAtom } from "jotai";
 
 import { AgentCard } from "@/components/app/agent-card";
 import { AgentTypeIcon } from "@/components/app/agent-type-icon";
@@ -12,13 +13,15 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import React, { useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   AGENT_TYPE_LABELS,
   type AgentType,
   sortAgentTypes,
 } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
+import { agentSidebarOrderAtom, reconcileAgentSidebarOrder } from "@/lib/store";
+import { cn } from "@/lib/utils";
 
 export type AgentListContentProps = {
   agents: Agent[];
@@ -81,6 +84,14 @@ export function AgentListContent({
   onRequestClose,
   closeOnSessionAction = false,
 }: AgentListContentProps): JSX.Element {
+  const [agentSidebarOrder, setAgentSidebarOrder] = useAtom(
+    agentSidebarOrderAtom
+  );
+  const [draggingAgentId, setDraggingAgentId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{
+    agentId: string;
+    position: "before" | "after";
+  } | null>(null);
   const sortedAgentTypes = useMemo(
     () => sortAgentTypes(enabledAgentTypes),
     [enabledAgentTypes]
@@ -90,6 +101,146 @@ export function AgentListContent({
       ? lastUsedAgentType
       : (enabledAgentTypes[0] ?? "codex");
   const showCreateTypePicker = enabledAgentTypes.length > 1;
+  const topLevelAgents = useMemo(
+    () => agents.filter((a) => !a.parentAgentId || !a.persona),
+    [agents]
+  );
+  const topLevelAgentIds = useMemo(
+    () => topLevelAgents.map((agent) => agent.id),
+    [topLevelAgents]
+  );
+  const orderedTopLevelAgents = useMemo(() => {
+    const reconciledOrder = reconcileAgentSidebarOrder(
+      agentSidebarOrder,
+      topLevelAgentIds
+    );
+    const agentById = new Map(topLevelAgents.map((agent) => [agent.id, agent]));
+    return reconciledOrder
+      .map((agentId) => agentById.get(agentId))
+      .filter((agent): agent is Agent => Boolean(agent));
+  }, [agentSidebarOrder, topLevelAgentIds, topLevelAgents]);
+
+  const moveAgent = (
+    draggedAgentId: string,
+    targetAgentId: string,
+    position: "before" | "after"
+  ) => {
+    if (draggedAgentId === targetAgentId) return;
+    setAgentSidebarOrder((currentOrder) => {
+      const reconciledOrder = reconcileAgentSidebarOrder(
+        currentOrder,
+        topLevelAgentIds
+      );
+      const nextOrder = reconciledOrder.filter(
+        (agentId) => agentId !== draggedAgentId
+      );
+      const targetIndex = nextOrder.indexOf(targetAgentId);
+      if (targetIndex === -1) return reconciledOrder;
+      nextOrder.splice(
+        position === "after" ? targetIndex + 1 : targetIndex,
+        0,
+        draggedAgentId
+      );
+      return nextOrder;
+    });
+  };
+
+  const moveAgentToBoundary = (
+    draggedAgentId: string,
+    position: "first" | "last"
+  ) => {
+    setAgentSidebarOrder((currentOrder) => {
+      const reconciledOrder = reconcileAgentSidebarOrder(
+        currentOrder,
+        topLevelAgentIds
+      );
+      if (!reconciledOrder.includes(draggedAgentId)) return reconciledOrder;
+      const nextOrder = reconciledOrder.filter(
+        (agentId) => agentId !== draggedAgentId
+      );
+      if (position === "first") {
+        nextOrder.unshift(draggedAgentId);
+      } else {
+        nextOrder.push(draggedAgentId);
+      }
+      return nextOrder;
+    });
+  };
+
+  const moveAgentByOffset = (agentId: string, offset: -1 | 1) => {
+    setAgentSidebarOrder((currentOrder) => {
+      const reconciledOrder = reconcileAgentSidebarOrder(
+        currentOrder,
+        topLevelAgentIds
+      );
+      const currentIndex = reconciledOrder.indexOf(agentId);
+      const nextIndex = currentIndex + offset;
+      if (
+        currentIndex === -1 ||
+        nextIndex < 0 ||
+        nextIndex >= reconciledOrder.length
+      ) {
+        return reconciledOrder;
+      }
+      const nextOrder = [...reconciledOrder];
+      [nextOrder[currentIndex], nextOrder[nextIndex]] = [
+        nextOrder[nextIndex],
+        nextOrder[currentIndex],
+      ];
+      return nextOrder;
+    });
+  };
+
+  const clearDragState = useCallback(() => {
+    setDraggingAgentId(null);
+    setDropTarget(null);
+  }, []);
+
+  useEffect(() => {
+    if (!draggingAgentId) return;
+    window.addEventListener("dragend", clearDragState);
+    window.addEventListener("drop", clearDragState);
+    return () => {
+      window.removeEventListener("dragend", clearDragState);
+      window.removeEventListener("drop", clearDragState);
+    };
+  }, [clearDragState, draggingAgentId]);
+
+  const dropPositionForEvent = (event: DragEvent): "before" | "after" => {
+    const target = event.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    return event.clientY > rect.top + rect.height / 2 ? "after" : "before";
+  };
+
+  const handleBoundaryDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    position: "first" | "last"
+  ) => {
+    if (!draggingAgentId || orderedTopLevelAgents.length === 0) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const boundaryAgent =
+      position === "first"
+        ? orderedTopLevelAgents[0]
+        : orderedTopLevelAgents[orderedTopLevelAgents.length - 1];
+    setDropTarget({
+      agentId: boundaryAgent.id,
+      position: position === "first" ? "before" : "after",
+    });
+  };
+
+  const handleBoundaryDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    position: "first" | "last"
+  ) => {
+    event.preventDefault();
+    const draggedAgentId =
+      event.dataTransfer.getData("text/plain") || draggingAgentId;
+    if (draggedAgentId) {
+      moveAgentToBoundary(draggedAgentId, position);
+    }
+    clearDragState();
+  };
 
   return (
     <div data-testid="agent-sidebar" className="flex h-full min-h-0 flex-col">
@@ -147,7 +298,7 @@ export function AgentListContent({
 
       <div
         data-testid="agent-sidebar-scroll"
-        className="min-h-0 flex-1 overflow-y-auto"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto"
       >
         <TooltipProvider delayDuration={120}>
           {agents.length === 0 ? (
@@ -159,39 +310,134 @@ export function AgentListContent({
             </div>
           ) : (
             <React.Fragment>
-              {agents
-                .filter((a) => !a.parentAgentId || !a.persona)
-                .map((agent) => (
-                  <AgentCard
-                    key={agent.id}
-                    agent={agent}
-                    agents={agents}
-                    childAgents={agents.filter(
-                      (a) => a.parentAgentId === agent.id && !!a.persona
-                    )}
-                    selectedAgentId={selectedAgentId}
-                    expandedAgentId={expandedAgentId}
-                    agentVisualState={agentVisualState}
-                    borderForAgentState={borderForAgentState}
-                    toggleAgentDetails={toggleAgentDetails}
-                    isFullAccessEnabled={isFullAccessEnabled}
-                    detachTerminal={detachTerminal}
-                    attachToAgent={attachToAgent}
-                    startAgent={startAgent}
-                    setDeleteTarget={setDeleteTarget}
-                    setDeleteConfirmOpen={setDeleteConfirmOpen}
-                    setStopTarget={setStopTarget}
-                    setStopConfirmOpen={setStopConfirmOpen}
-                    sendTerminalInput={sendTerminalInput}
-                    enabledAgentTypes={enabledAgentTypes}
-                    enabledIdes={enabledIdes}
-                    connectedAgentId={connectedAgentId}
-                    onOpenFeedbackDetail={onOpenFeedbackDetail}
-                    feedbackDetailState={feedbackDetailState}
-                    onRequestClose={onRequestClose}
-                    closeOnSessionAction={closeOnSessionAction}
-                  />
-                ))}
+              <div
+                aria-hidden="true"
+                className="h-3 shrink-0"
+                onDragOver={(event) => handleBoundaryDragOver(event, "first")}
+                onDrop={(event) => handleBoundaryDrop(event, "first")}
+              />
+              {orderedTopLevelAgents.map((agent, index) => (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  agents={agents}
+                  childAgents={agents.filter(
+                    (a) => a.parentAgentId === agent.id && !!a.persona
+                  )}
+                  selectedAgentId={selectedAgentId}
+                  expandedAgentId={expandedAgentId}
+                  agentVisualState={agentVisualState}
+                  borderForAgentState={borderForAgentState}
+                  toggleAgentDetails={toggleAgentDetails}
+                  isFullAccessEnabled={isFullAccessEnabled}
+                  detachTerminal={detachTerminal}
+                  attachToAgent={attachToAgent}
+                  startAgent={startAgent}
+                  setDeleteTarget={setDeleteTarget}
+                  setDeleteConfirmOpen={setDeleteConfirmOpen}
+                  setStopTarget={setStopTarget}
+                  setStopConfirmOpen={setStopConfirmOpen}
+                  sendTerminalInput={sendTerminalInput}
+                  enabledAgentTypes={enabledAgentTypes}
+                  enabledIdes={enabledIdes}
+                  connectedAgentId={connectedAgentId}
+                  onOpenFeedbackDetail={onOpenFeedbackDetail}
+                  feedbackDetailState={feedbackDetailState}
+                  onRequestClose={onRequestClose}
+                  closeOnSessionAction={closeOnSessionAction}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < orderedTopLevelAgents.length - 1}
+                  onMoveUp={() => moveAgentByOffset(agent.id, -1)}
+                  onMoveDown={() => moveAgentByOffset(agent.id, 1)}
+                  containerProps={{
+                    draggable: true,
+                    className: cn(
+                      "relative cursor-grab active:cursor-grabbing",
+                      draggingAgentId === agent.id && "opacity-55",
+                      dropTarget?.agentId === agent.id &&
+                        dropTarget.position === "before" &&
+                        draggingAgentId !== agent.id &&
+                        "before:absolute before:inset-x-0 before:top-0 before:z-10 before:h-0.5 before:bg-primary",
+                      dropTarget?.agentId === agent.id &&
+                        dropTarget.position === "after" &&
+                        draggingAgentId !== agent.id &&
+                        "after:absolute after:bottom-0 after:inset-x-0 after:z-10 after:h-0.5 after:bg-primary"
+                    ),
+                    nativeDragHandlers: {
+                      dragstart: (event) => {
+                        const target = event.target as HTMLElement;
+                        if (
+                          target.closest(
+                            "button,a,input,textarea,select,[data-agent-control='true']"
+                          )
+                        ) {
+                          event.preventDefault();
+                          return;
+                        }
+                        if (!event.dataTransfer) return;
+                        event.dataTransfer.effectAllowed = "move";
+                        event.dataTransfer.setData("text/plain", agent.id);
+                        setDraggingAgentId(agent.id);
+                      },
+                      dragenter: (event) => {
+                        event.preventDefault();
+                        if (!draggingAgentId || draggingAgentId === agent.id) {
+                          return;
+                        }
+                        setDropTarget({
+                          agentId: agent.id,
+                          position: dropPositionForEvent(event),
+                        });
+                      },
+                      dragover: (event) => {
+                        if (!draggingAgentId || draggingAgentId === agent.id) {
+                          return;
+                        }
+                        event.preventDefault();
+                        if (event.dataTransfer) {
+                          event.dataTransfer.dropEffect = "move";
+                        }
+                        setDropTarget({
+                          agentId: agent.id,
+                          position: dropPositionForEvent(event),
+                        });
+                      },
+                      dragleave: (event) => {
+                        if (
+                          (event.currentTarget as HTMLElement).contains(
+                            event.relatedTarget as Node | null
+                          )
+                        ) {
+                          return;
+                        }
+                        setDropTarget((current) =>
+                          current?.agentId === agent.id ? null : current
+                        );
+                      },
+                      drop: (event) => {
+                        event.preventDefault();
+                        const draggedAgentId =
+                          event.dataTransfer?.getData("text/plain") ||
+                          draggingAgentId;
+                        if (draggedAgentId) {
+                          moveAgent(
+                            draggedAgentId,
+                            agent.id,
+                            dropPositionForEvent(event)
+                          );
+                        }
+                        clearDragState();
+                      },
+                    },
+                  }}
+                />
+              ))}
+              <div
+                aria-hidden="true"
+                className="min-h-16 flex-1"
+                onDragOver={(event) => handleBoundaryDragOver(event, "last")}
+                onDrop={(event) => handleBoundaryDrop(event, "last")}
+              />
             </React.Fragment>
           )}
         </TooltipProvider>

--- a/apps/web/src/lib/store.test.ts
+++ b/apps/web/src/lib/store.test.ts
@@ -2,10 +2,31 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  reconcileAgentSidebarOrder,
   reconcileMediaSidebarStateStorage,
   MEDIA_SIDEBAR_STATE_STORAGE_PREFIX,
   defaultMediaSidebarState,
 } from "./store";
+
+describe("reconcileAgentSidebarOrder", () => {
+  it("puts new agents first and keeps stored order for live agents", () => {
+    expect(
+      reconcileAgentSidebarOrder(
+        ["agt_2", "agt_1"],
+        ["agt_1", "agt_2", "agt_3"]
+      )
+    ).toEqual(["agt_3", "agt_2", "agt_1"]);
+  });
+
+  it("drops archived and duplicate agent ids", () => {
+    expect(
+      reconcileAgentSidebarOrder(
+        ["agt_2", "agt_old", "agt_2", "agt_1"],
+        ["agt_1", "agt_2"]
+      )
+    ).toEqual(["agt_2", "agt_1"]);
+  });
+});
 
 describe("reconcileMediaSidebarStateStorage", () => {
   beforeEach(() => {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -99,6 +99,34 @@ export const diffFileTreeOpenAtom = atomWithLocalStorage<boolean>(
   true
 );
 
+export const agentSidebarOrderAtom = atomWithLocalStorage<string[]>(
+  "dispatch:agentSidebarOrder",
+  []
+);
+
+export function reconcileAgentSidebarOrder(
+  storedOrder: readonly string[],
+  agentIds: readonly string[]
+): string[] {
+  const liveIds = new Set(agentIds);
+  const seen = new Set<string>();
+  const nextOrder: string[] = [];
+
+  for (const agentId of agentIds) {
+    if (storedOrder.includes(agentId) || seen.has(agentId)) continue;
+    seen.add(agentId);
+    nextOrder.push(agentId);
+  }
+
+  for (const agentId of storedOrder) {
+    if (!liveIds.has(agentId) || seen.has(agentId)) continue;
+    seen.add(agentId);
+    nextOrder.push(agentId);
+  }
+
+  return nextOrder;
+}
+
 export type MediaSidebarTab = "pins" | "media" | "brain";
 
 export type MediaSidebarState = {


### PR DESCRIPTION
## Summary
- Add persisted drag-and-drop ordering for top-level agents in the sidebar
- Put newly created agents at the top when they are not yet in the saved order
- Add top/bottom drop zones, animated reorder motion, and keyboard-accessible Move up / Move down controls

## Validation
- pnpm --filter @dispatch/web test -- src/lib/store.test.ts
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e
- Playwright validation for drag/drop, boundary drop zones, new-agent-top behavior, reload persistence, and Move up/down controls