### PR TITLE
Refine agent sidebar controls

### DIFF
--- a/apps/web/src/components/app/agent-card.tsx
+++ b/apps/web/src/components/app/agent-card.tsx
@@ -5,13 +5,12 @@ import {
   Check,
   ChevronDown,
   AlarmClock,
-  ArrowDown,
   ArrowDownToLine,
-  ArrowUp,
   Copy,
   Folder,
   FolderTree,
   GitBranch,
+  Pencil,
   Play,
   Pause,
   Tag,
@@ -96,8 +95,11 @@ type AgentCardNativeDragHandlers = Partial<{
 }>;
 
 type AgentCardContainerProps = {
+  "aria-describedby"?: string;
   className?: string;
   draggable?: boolean;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  tabIndex?: number;
   nativeDragHandlers?: AgentCardNativeDragHandlers;
 };
 
@@ -129,10 +131,6 @@ export type AgentCardProps = {
   enabledAgentTypes: AgentType[];
   enabledIdes: IdeType[];
   containerProps?: AgentCardContainerProps;
-  canMoveUp?: boolean;
-  canMoveDown?: boolean;
-  onMoveUp?: () => void;
-  onMoveDown?: () => void;
 };
 
 function CompactMetaRow({
@@ -204,10 +202,6 @@ export function AgentCard({
   enabledAgentTypes,
   enabledIdes,
   containerProps,
-  canMoveUp = false,
-  canMoveDown = false,
-  onMoveUp,
-  onMoveDown,
 }: AgentCardProps): JSX.Element {
   const {
     className: containerClassName,
@@ -332,19 +326,12 @@ export function AgentCard({
                 </TooltipTrigger>
                 <TooltipContent>{agent.cwd}</TooltipContent>
               </Tooltip>
-              <button
-                type="button"
+              <span
                 data-testid={`agent-session-name-${agent.id}`}
-                aria-label={`Session settings for ${agent.name}`}
-                title="Session settings"
-                className="min-w-0 truncate rounded-md px-1.5 py-0.5 -mx-1.5 -my-0.5 hover:bg-muted transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setSettingsOpen(true);
-                }}
+                className="min-w-0 truncate"
               >
                 {agent.name}
-              </button>
+              </span>
             </div>
             {canPromptRename ? (
               <Tooltip>
@@ -431,45 +418,6 @@ export function AgentCard({
                 </span>
               </TooltipContent>
             </Tooltip>
-          ) : null}
-
-          {onMoveUp || onMoveDown ? (
-            <div className="flex shrink-0 items-center gap-0.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    data-agent-control="true"
-                    aria-label={`Move ${agent.name} up`}
-                    data-testid={`agent-move-up-${agent.id}`}
-                    className="h-7 w-7 text-muted-foreground/70 hover:text-foreground disabled:opacity-30"
-                    disabled={!canMoveUp}
-                    onClick={() => onMoveUp?.()}
-                  >
-                    <ArrowUp className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Move up</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    data-agent-control="true"
-                    aria-label={`Move ${agent.name} down`}
-                    data-testid={`agent-move-down-${agent.id}`}
-                    className="h-7 w-7 text-muted-foreground/70 hover:text-foreground disabled:opacity-30"
-                    disabled={!canMoveDown}
-                    onClick={() => onMoveDown?.()}
-                  >
-                    <ArrowDown className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Move down</TooltipContent>
-              </Tooltip>
-            </div>
           ) : null}
 
           <Tooltip>
@@ -830,6 +778,17 @@ export function AgentCard({
                           <Pause className="h-3.5 w-3.5" />
                         </Button>
                       ) : null}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 w-8 rounded-full border border-blue-500/35 bg-blue-500/10 p-0 text-blue-400 hover:bg-blue-500/15 hover:text-blue-300"
+                        data-testid={`agent-session-settings-${agent.id}`}
+                        aria-label="Edit session settings"
+                        title="Edit session settings"
+                        onClick={() => setSettingsOpen(true)}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
                       <Button
                         size="sm"
                         variant="ghost-destructive"

--- a/apps/web/src/components/app/agent-sidebar.tsx
+++ b/apps/web/src/components/app/agent-sidebar.tsx
@@ -92,6 +92,7 @@ export function AgentListContent({
     agentId: string;
     position: "before" | "after";
   } | null>(null);
+  const [reorderAnnouncement, setReorderAnnouncement] = useState("");
   const sortedAgentTypes = useMemo(
     () => sortAgentTypes(enabledAgentTypes),
     [enabledAgentTypes]
@@ -167,13 +168,13 @@ export function AgentListContent({
     });
   };
 
-  const moveAgentByOffset = (agentId: string, offset: -1 | 1) => {
+  const moveAgentByOffset = (agent: Agent, offset: -1 | 1) => {
     setAgentSidebarOrder((currentOrder) => {
       const reconciledOrder = reconcileAgentSidebarOrder(
         currentOrder,
         topLevelAgentIds
       );
-      const currentIndex = reconciledOrder.indexOf(agentId);
+      const currentIndex = reconciledOrder.indexOf(agent.id);
       const nextIndex = currentIndex + offset;
       if (
         currentIndex === -1 ||
@@ -187,6 +188,11 @@ export function AgentListContent({
         nextOrder[nextIndex],
         nextOrder[currentIndex],
       ];
+      setReorderAnnouncement(
+        `${agent.name} moved ${offset < 0 ? "up" : "down"} to position ${
+          nextIndex + 1
+        } of ${reconciledOrder.length}.`
+      );
       return nextOrder;
     });
   };
@@ -310,13 +316,20 @@ export function AgentListContent({
             </div>
           ) : (
             <React.Fragment>
+              <p id="agent-sidebar-reorder-instructions" className="sr-only">
+                Focus an agent card and press Alt or Option plus Arrow Up or
+                Arrow Down to reorder it.
+              </p>
+              <p className="sr-only" aria-live="polite">
+                {reorderAnnouncement}
+              </p>
               <div
                 aria-hidden="true"
                 className="h-3 shrink-0"
                 onDragOver={(event) => handleBoundaryDragOver(event, "first")}
                 onDrop={(event) => handleBoundaryDrop(event, "first")}
               />
-              {orderedTopLevelAgents.map((agent, index) => (
+              {orderedTopLevelAgents.map((agent) => (
                 <AgentCard
                   key={agent.id}
                   agent={agent}
@@ -345,14 +358,23 @@ export function AgentListContent({
                   feedbackDetailState={feedbackDetailState}
                   onRequestClose={onRequestClose}
                   closeOnSessionAction={closeOnSessionAction}
-                  canMoveUp={index > 0}
-                  canMoveDown={index < orderedTopLevelAgents.length - 1}
-                  onMoveUp={() => moveAgentByOffset(agent.id, -1)}
-                  onMoveDown={() => moveAgentByOffset(agent.id, 1)}
                   containerProps={{
                     draggable: true,
+                    tabIndex: 0,
+                    "aria-describedby": "agent-sidebar-reorder-instructions",
+                    onKeyDown: (event) => {
+                      if (event.target !== event.currentTarget) return;
+                      if (!event.altKey) return;
+                      if (event.key === "ArrowUp") {
+                        event.preventDefault();
+                        moveAgentByOffset(agent, -1);
+                      } else if (event.key === "ArrowDown") {
+                        event.preventDefault();
+                        moveAgentByOffset(agent, 1);
+                      }
+                    },
                     className: cn(
-                      "relative cursor-grab active:cursor-grabbing",
+                      "relative cursor-grab active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                       draggingAgentId === agent.id && "opacity-55",
                       dropTarget?.agentId === agent.id &&
                         dropTarget.position === "before" &&

--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -242,9 +242,9 @@ export function AgentsContent() {
           persona agents, and job agents are excluded from both paths.
         </P>
         <P>
-          To rename any agent yourself, click the agent's name in the sidebar
-          card to open the <strong>Session settings</strong> dialog and type a
-          new name.
+          To rename any agent yourself, expand its sidebar card and click the
+          edit button to open the <strong>Session settings</strong> dialog and
+          type a new name.
         </P>
       </Section>
 

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -77,7 +77,7 @@ export const tips: Tip[] = [
   {
     id: "session-rename",
     title: "Rename Sessions",
-    body: "Click any agent's name in the sidebar to open session settings and rename it directly.",
+    body: "Expand an agent in the sidebar and click the edit button to open session settings and rename it directly.",
     docsSection: "agents",
     since: "0.23.13",
     surfaces: ["ambient"],


### PR DESCRIPTION
## Summary
- Remove visible up/down reorder buttons from agent sidebar cards while keeping drag reorder
- Stop opening session settings from session-name clicks and add a pencil edit button in the expanded action row
- Preserve accessible reorder via focused-card Alt/Option + ArrowUp/ArrowDown with hidden instructions and live announcements
- Update rename guidance in tips and docs

## Validation
- pnpm run check
- pnpm run finalize:web
- pnpm run test:e2e (171 passed, 12 skipped)
- Manual Playwright validation for session-name click behavior, edit settings button, no visible move buttons, and keyboard reorder

## Review
- frontend-ux-review approved after accessibility fix