### PR TITLE
Move keyboard shortcuts from cmd-k to Help

### DIFF
--- a/apps/web/src/components/app/command-palette.tsx
+++ b/apps/web/src/components/app/command-palette.tsx
@@ -4,15 +4,12 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Command } from "cmdk";
 import { Play, Search, type LucideIcon } from "lucide-react";
 import { glassOverlay } from "@/lib/glass";
-import { formatHotkeyForKbd } from "@/lib/hotkeys/format";
-import { type HotkeyId } from "@/lib/hotkeys/keymap";
 import { cn } from "@/lib/utils";
 
 export type CommandAction = {
   id: string;
   title: string;
   keywords?: string[];
-  hotkey?: HotkeyId;
   icon?: LucideIcon;
   disabled?: boolean;
   confirm?: { description: string };
@@ -269,16 +266,6 @@ function ConfirmPage({
   );
 }
 
-function HotkeyBadge({ id }: { id: HotkeyId }): JSX.Element {
-  const { modifiers, key } = formatHotkeyForKbd(id);
-  return (
-    <kbd className="ml-auto font-mono text-xs tracking-widest text-muted-foreground/50">
-      {modifiers}
-      {key}
-    </kbd>
-  );
-}
-
 const groupClassName = cn(
   "overflow-hidden p-1 text-foreground",
   "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
@@ -314,8 +301,6 @@ function CommandPaletteItem({
       {Icon ? <Icon className={iconClassName} aria-hidden /> : null}
 
       <span className="flex-1 truncate">{action.title}</span>
-
-      {action.hotkey ? <HotkeyBadge id={action.hotkey} /> : null}
     </Command.Item>
   );
 }

--- a/apps/web/src/components/app/docs-sections/shortcuts.tsx
+++ b/apps/web/src/components/app/docs-sections/shortcuts.tsx
@@ -4,16 +4,15 @@ export function ShortcutsContent() {
   return (
     <>
       <P>
-        Dispatch registers a small set of global keyboard shortcuts and a
-        command palette. These fire from anywhere in the page — including text
-        inputs and the xterm terminal — because they listen in the{" "}
-        <em>capture</em> phase of the document. To suppress them inside a
-        particular subtree (e.g. a modal), mark the subtree root with{" "}
-        <Code>data-hotkey-disable=&quot;true&quot;</Code>.
+        Dispatch registers a small set of global keyboard shortcuts that fire
+        from anywhere in the page — including text inputs and the xterm terminal
+        — because they listen in the <em>capture</em> phase of the document. To
+        suppress them inside a particular subtree (e.g. a modal), mark the
+        subtree root with <Code>data-hotkey-disable=&quot;true&quot;</Code>.
       </P>
 
       <Section>
-        <H3>Global hotkeys</H3>
+        <H3>Keyboard shortcuts</H3>
         <P>
           On macOS, <Code>Mod</Code> is <Code>⌘</Code>. On Windows/Linux it is{" "}
           <Code>Ctrl</Code>.
@@ -46,45 +45,14 @@ export function ShortcutsContent() {
         <P>
           Press <Code>Mod+K</Code> to open the palette. It shows a searchable
           list of actions — type to filter, then press Enter or click to run
-          one:
+          one.
         </P>
-        <ul className="grid gap-1.5 pl-4 text-sm text-muted-foreground list-disc">
-          <li>
-            <strong>New agent</strong> — opens the Create dialog.
-          </li>
-          <li>
-            <strong>Focus terminal input</strong> — same as{" "}
-            <Code>Mod+Shift+Space</Code>. Disabled when no tmux terminal is
-            attached.
-          </li>
-          <li>
-            <strong>Toggle media sidebar</strong> — same as{" "}
-            <Code>Mod+Shift+&gt;</Code>. Disabled when no agent is selected on
-            desktop (mobile always allows it).
-          </li>
-          <li>
-            <strong>Toggle agent sidebar</strong> — same as{" "}
-            <Code>Mod+Shift+&lt;</Code>.
-          </li>
-          <li>
-            <strong>Focus next agent</strong> — same as <Code>Mod+Shift+↓</Code>
-            .
-          </li>
-          <li>
-            <strong>Focus previous agent</strong> — same as{" "}
-            <Code>Mod+Shift+↑</Code>.
-          </li>
-        </ul>
         <P>
           Templates with <strong>Show in command palette</strong> enabled appear
-          in a separate <em>Templates</em> group below the built-in commands.
-          Templates without arguments show a confirmation step — press Enter
-          twice to launch immediately. Templates with arguments open a launch
-          dialog where you fill in each value before launching.
-        </P>
-        <P>
-          Each action shows its hotkey badge inline so you can learn the
-          shortcut as you use the palette.
+          in a <em>Templates</em> group below the built-in commands. Templates
+          without arguments show a confirmation step — press Enter twice to
+          launch immediately. Templates with arguments open a launch dialog
+          where you fill in each value before launching.
         </P>
       </Section>
     </>

--- a/apps/web/src/hooks/use-agent-hotkeys.ts
+++ b/apps/web/src/hooks/use-agent-hotkeys.ts
@@ -1,16 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  ArrowDown,
-  ArrowUp,
-  BetweenHorizonalStart,
-  PanelLeft,
-  PanelLeftOpen,
-  PanelRight,
-  PanelRightOpen,
-  Play,
-  Plus,
-} from "lucide-react";
+import { Keyboard, Play, Plus } from "lucide-react";
 
 import {
   type CommandAction,
@@ -117,66 +107,21 @@ export function useAgentHotkeys({
         run: () => openCreateDialog(),
       },
       {
-        id: "focus-terminal-input",
-        title: "Focus terminal input",
-        keywords: ["terminal", "input", "cursor", "shell"],
-        hotkey: "focus-terminal-input",
-        icon: BetweenHorizonalStart,
-        disabled: !canFocusTerminal,
-        run: () => {
-          if (!canFocusTerminal) return;
-          focusTerminal();
-        },
-      },
-      {
-        id: "toggle-media-sidebar",
-        title: "Toggle media sidebar",
-        keywords: ["pins", "media", "right"],
-        hotkey: "toggle-media-sidebar",
-        icon: mediaOpen ? PanelRight : PanelRightOpen,
-        disabled: !isMobile && !sidebarAgentId,
-        run: () => {
-          if (!isMobile && !sidebarAgentId) return;
-          setMediaOpen(!mediaOpen);
-        },
-      },
-      {
-        id: "toggle-agent-sidebar",
-        title: "Toggle agent sidebar",
-        keywords: ["agents", "left", "list"],
-        hotkey: "toggle-agent-sidebar",
-        icon: leftPanelOpen ? PanelLeft : PanelLeftOpen,
-        run: () => handleSetLeftPanelOpen(!leftPanelOpen),
-      },
-      {
-        id: "focus-next-agent",
-        title: "Focus next agent",
-        keywords: ["cycle", "switch", "down"],
-        hotkey: "focus-next-agent",
-        icon: ArrowDown,
-        run: () => cycleAgent(1),
-      },
-      {
-        id: "focus-prev-agent",
-        title: "Focus previous agent",
-        keywords: ["cycle", "switch", "up"],
-        hotkey: "focus-prev-agent",
-        icon: ArrowUp,
-        run: () => cycleAgent(-1),
+        id: "keyboard-shortcuts",
+        title: "Keyboard shortcuts",
+        keywords: [
+          "shortcut",
+          "hotkey",
+          "terminal",
+          "sidebar",
+          "focus",
+          "help",
+        ],
+        icon: Keyboard,
+        run: () => navigate("/settings/help/shortcuts"),
       },
     ],
-    [
-      canFocusTerminal,
-      cycleAgent,
-      focusTerminal,
-      handleSetLeftPanelOpen,
-      isMobile,
-      leftPanelOpen,
-      mediaOpen,
-      openCreateDialog,
-      setMediaOpen,
-      sidebarAgentId,
-    ]
+    [navigate, openCreateDialog]
   );
 
   const paletteGroups = useMemo<CommandGroup[]>(() => {


### PR DESCRIPTION
## Summary
- Removed 5 shortcut-duplicate entries from the cmd-k command palette (focus terminal, toggle sidebars, cycle agents) — users open it for Templates and New Agent, not shortcut discovery
- Added a "Keyboard shortcuts" action with broad search keywords that navigates to Help > Shortcuts, preserving discoverability
- Cleaned up dead code: `HotkeyBadge` component, `hotkey` field on `CommandAction`, related imports
- Updated Help > Shortcuts docs to match the new layout

## Test plan
- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — 171 passed, 12 skipped (pre-existing tmux tests)
- [x] Playwright validation: cmd-k shows "New agent" + "Keyboard shortcuts" only
- [x] Playwright validation: Help > Shortcuts page renders correctly
- [x] Frontend UX review persona approved (round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)