### PR TITLE
Document dispatch_launch_agent tool and sidebar reordering

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -109,6 +109,16 @@ export function AgentsContent() {
       </Section>
 
       <Section>
+        <H3>Reordering agents</H3>
+        <P>
+          Drag and drop agent cards in the sidebar to reorder them. The order
+          persists across sessions. You can also reorder with the keyboard:
+          focus an agent card, then press <Code>Alt+↑</Code> /{" "}
+          <Code>Alt+↓</Code> to move it.
+        </P>
+      </Section>
+
+      <Section>
         <H3>Starting and stopping</H3>
         <P>
           Press the play button to resume a stopped agent. Press the stop button

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -179,6 +179,11 @@ export function ToolsContent() {
             running agent by ID or name; the target can reply the same way
           </li>
           <li>
+            <Code>dispatch_launch_agent</Code> — launch a new agent as a child
+            of the current session with a name, prompt, and optional agent type,
+            worktree settings, full access mode, or template
+          </li>
+          <li>
             <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,{" "}
             <Code>get_feedback_summary</Code> — analytics queries over recent
             Dispatch activity
@@ -237,6 +242,22 @@ export function ToolsContent() {
           structured observations that other agents can query. You can inspect
           an agent's Brain activity in the <strong>Brain</strong> tab of the
           sidebar.
+        </P>
+      </Section>
+
+      <Section>
+        <H3 id="dispatch-launch-agent">Agent orchestration</H3>
+        <P>
+          Agents can spawn other agents using <Code>dispatch_launch_agent</Code>
+          . The launched agent runs independently and appears as a top-level
+          entry in the sidebar — it is not nested under its parent like persona
+          reviewers. Archiving the parent does not cascade to launched agents.
+        </P>
+        <P>
+          Use <Code>list_agents</Code> to discover running agents and{" "}
+          <Code>dispatch_send_message</Code> to coordinate between them. The
+          launched agent receives the parent's ID in its startup context so it
+          can message back.
         </P>
       </Section>
 

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -83,6 +83,14 @@ export const tips: Tip[] = [
     surfaces: ["ambient"],
   },
   {
+    id: "sidebar-reorder",
+    title: "Reorder Agents",
+    body: "Drag and drop agent cards to reorder them, or focus a card and press Alt+↑ / Alt+↓. The order persists across sessions.",
+    docsSection: "agents",
+    since: "0.24.3",
+    surfaces: ["ambient"],
+  },
+  {
     id: "keyboard-shortcuts",
     title: "Keyboard Shortcuts",
     body: "Press ⌘K to open the command palette. Navigate agents, toggle sidebars, and control the terminal without touching the mouse.",


### PR DESCRIPTION
## Summary
- Added `dispatch_launch_agent` to the built-in tools list in docs-pane with an "Agent orchestration" subsection explaining how launched agents work (top-level sidebar entries, no cascade archive, coordinate via messaging)
- Added "Reordering agents" section to the Agents docs covering drag-and-drop and keyboard shortcuts (Alt+↑/↓)
- Added `sidebar-reorder` ambient tip for discoverability of the keyboard shortcut

## What was audited
Diff-driven audit of changes since SHA `5898f1d4` (PRs #708–#719). Focused on:
- `dispatch_launch_agent` MCP tool (PR #708) — missing from docs entirely
- Sidebar agent reordering (PR #716) — undocumented new feature
- Agent sidebar controls refinement (PR #717) — docs already accurate (edit button wording matches)
- Keyboard shortcuts move from cmd-k to Help (PR #718) — docs still accurate (generic palette description)

## Deferred to next run
- Automations section deep-dive (was `next_focus`, pivoted to diff-driven updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)