### PR TITLE
Persist diff view state across tab switches and reloads

### DIFF
--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -218,13 +218,13 @@ export const ChangesTab = memo(function ChangesTab({
     };
   }, [setViewState]);
 
-  const hasRestoredScroll = useRef(false);
+  const restoredScrollForAgent = useRef<string | null>(null);
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || !viewState.scrollTop || hasRestoredScroll.current) return;
+    if (!el || restoredScrollForAgent.current === agentId) return;
     el.scrollTop = viewState.scrollTop;
-    hasRestoredScroll.current = true;
-  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
+    restoredScrollForAgent.current = agentId;
+  }, [agentId, data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!active) return <div />;
 

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -195,6 +195,7 @@ export const ChangesTab = memo(function ChangesTab({
   const handleScroll = useCallback(() => {
     if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
     scrollTimerRef.current = setTimeout(() => {
+      scrollTimerRef.current = null;
       const top = scrollRef.current?.scrollTop ?? 0;
       setViewState((prev) => {
         if (prev.scrollTop === top) return prev;

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -91,6 +91,7 @@ import {
   diffViewTypeAtom,
   diffIgnoreWhitespaceAtom,
   diffFileTreeOpenAtom,
+  diffViewStateAtomFamily,
 } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
@@ -116,7 +117,43 @@ export const ChangesTab = memo(function ChangesTab({
   const viewType = isMobile ? "unified" : storedViewType;
   const ignoreWhitespace = useAtomValue(diffIgnoreWhitespaceAtom);
   const { data, isLoading } = useAgentDiff(agentId, active, ignoreWhitespace);
-  const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const [viewState, setViewState] = useAtom(
+    diffViewStateAtomFamily(agentId ?? "")
+  );
+
+  const collapsedFiles = useMemo(
+    () => new Set(viewState.collapsedFiles),
+    [viewState.collapsedFiles]
+  );
+  const collapsedDirs = useMemo(
+    () => new Set(viewState.collapsedDirs),
+    [viewState.collapsedDirs]
+  );
+
+  const toggleCollapseFile = useCallback(
+    (path: string) => {
+      setViewState((prev) => {
+        const s = new Set(prev.collapsedFiles);
+        if (s.has(path)) s.delete(path);
+        else s.add(path);
+        return { ...prev, collapsedFiles: [...s] };
+      });
+    },
+    [setViewState]
+  );
+
+  const toggleCollapseDir = useCallback(
+    (path: string) => {
+      setViewState((prev) => {
+        const s = new Set(prev.collapsedDirs);
+        if (s.has(path)) s.delete(path);
+        else s.add(path);
+        return { ...prev, collapsedDirs: [...s] };
+      });
+    },
+    [setViewState]
+  );
+
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [lineSelection, setLineSelection] = useState<LineSelection | null>(
     null
@@ -135,19 +172,58 @@ export const ChangesTab = memo(function ChangesTab({
     [data?.files]
   );
 
-  const scrollToFile = useCallback((path: string) => {
-    setSelectedFile(path);
-    const el = fileRefs.current.get(path);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-    setCollapsedFiles((prev) => {
-      if (!prev.has(path)) return prev;
-      const next = new Set(prev);
-      next.delete(path);
-      return next;
-    });
-  }, []);
+  const scrollToFile = useCallback(
+    (path: string) => {
+      setSelectedFile(path);
+      const el = fileRefs.current.get(path);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      setViewState((prev) => {
+        const s = new Set(prev.collapsedFiles);
+        if (!s.has(path)) return prev;
+        s.delete(path);
+        return { ...prev, collapsedFiles: [...s] };
+      });
+    },
+    [setViewState]
+  );
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleScroll = useCallback(() => {
+    if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    scrollTimerRef.current = setTimeout(() => {
+      const top = scrollRef.current?.scrollTop ?? 0;
+      setViewState((prev) => {
+        if (prev.scrollTop === top) return prev;
+        return { ...prev, scrollTop: top };
+      });
+    }, 300);
+  }, [setViewState]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    return () => {
+      if (scrollTimerRef.current) {
+        clearTimeout(scrollTimerRef.current);
+        const top = el?.scrollTop ?? 0;
+        setViewState((prev) => {
+          if (prev.scrollTop === top) return prev;
+          return { ...prev, scrollTop: top };
+        });
+      }
+    };
+  }, [setViewState]);
+
+  const hasRestoredScroll = useRef(false);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !viewState.scrollTop || hasRestoredScroll.current) return;
+    el.scrollTop = viewState.scrollTop;
+    hasRestoredScroll.current = true;
+  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!active) return <div />;
 
@@ -177,22 +253,14 @@ export const ChangesTab = memo(function ChangesTab({
         onSelectFile={scrollToFile}
         open={fileTreeOpen}
         onToggleOpen={() => setFileTreeOpen((v) => !v)}
+        collapsedDirs={collapsedDirs}
+        onToggleDir={toggleCollapseDir}
       />
       <DiffPane
         agentId={agentId}
         files={files}
         collapsedFiles={collapsedFiles}
-        onToggleCollapse={(path) => {
-          setCollapsedFiles((prev) => {
-            const next = new Set(prev);
-            if (next.has(path)) {
-              next.delete(path);
-            } else {
-              next.add(path);
-            }
-            return next;
-          });
-        }}
+        onToggleCollapse={toggleCollapseFile}
         fileRefs={fileRefs}
         lineSelection={lineSelection}
         onLineSelection={handleLineSelection}
@@ -200,6 +268,8 @@ export const ChangesTab = memo(function ChangesTab({
         onCommentOpen={setCommentOpen}
         viewType={viewType}
         ignoreWhitespace={ignoreWhitespace}
+        scrollRef={scrollRef}
+        onScroll={handleScroll}
       />
     </div>
   );
@@ -234,6 +304,8 @@ type FileTreeProps = {
   onSelectFile: (path: string) => void;
   open: boolean;
   onToggleOpen: () => void;
+  collapsedDirs: Set<string>;
+  onToggleDir: (path: string) => void;
 };
 
 type TreeNode = {
@@ -294,21 +366,10 @@ function FileTree({
   onSelectFile,
   open,
   onToggleOpen,
+  collapsedDirs,
+  onToggleDir,
 }: FileTreeProps): JSX.Element {
-  const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set());
   const tree = useMemo(() => buildTree(files), [files]);
-
-  const toggleDir = useCallback((path: string) => {
-    setCollapsedDirs((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  }, []);
 
   return (
     <div
@@ -346,7 +407,7 @@ function FileTree({
               selectedFile={selectedFile}
               onSelectFile={onSelectFile}
               collapsedDirs={collapsedDirs}
-              onToggleDir={toggleDir}
+              onToggleDir={onToggleDir}
             />
           ))}
         </div>
@@ -455,6 +516,8 @@ type DiffPaneProps = {
   onCommentOpen: (open: boolean) => void;
   viewType: DiffViewType;
   ignoreWhitespace: boolean;
+  scrollRef: React.RefObject<HTMLDivElement>;
+  onScroll: () => void;
 };
 
 function DiffPane({
@@ -469,9 +532,15 @@ function DiffPane({
   onCommentOpen,
   viewType,
   ignoreWhitespace,
+  scrollRef,
+  onScroll,
 }: DiffPaneProps): JSX.Element {
   return (
-    <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3">
+    <div
+      ref={scrollRef}
+      onScroll={onScroll}
+      className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-3 pb-3"
+    >
       {files.map((file) => (
         <FileDiffSection
           key={file.path}

--- a/apps/web/src/hooks/use-media-sidebar-state.ts
+++ b/apps/web/src/hooks/use-media-sidebar-state.ts
@@ -6,6 +6,7 @@ import {
   inactiveMediaSidebarStateAtom,
   mediaSidebarStateAtomFamily,
   reconcileMediaSidebarStateStorage,
+  reconcileDiffViewStateStorage,
   type MediaSidebarTab,
 } from "@/lib/store";
 
@@ -94,6 +95,7 @@ export function useMediaSidebarState({
   useEffect(() => {
     if (agentIds.length === 0) return;
     reconcileMediaSidebarStateStorage(agentIds as string[]);
+    reconcileDiffViewStateStorage(agentIds as string[]);
   }, [agentIds]);
 
   useEffect(() => {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -186,3 +186,48 @@ export function reconcileMediaSidebarStateStorage(
 
   keysToDelete.forEach((key) => window.localStorage.removeItem(key));
 }
+
+// ---------------------------------------------------------------------------
+// Diff view state — per-agent collapsed files/dirs and scroll position
+// ---------------------------------------------------------------------------
+
+export type DiffViewState = {
+  collapsedFiles: string[];
+  collapsedDirs: string[];
+  scrollTop: number;
+};
+
+const defaultDiffViewState: DiffViewState = {
+  collapsedFiles: [],
+  collapsedDirs: [],
+  scrollTop: 0,
+};
+
+export const DIFF_VIEW_STATE_STORAGE_PREFIX = "dispatch:diffViewState:";
+
+export const diffViewStateAtomFamily = atomFamily((agentId: string) =>
+  atomWithLocalStorage<DiffViewState>(
+    `${DIFF_VIEW_STATE_STORAGE_PREFIX}${agentId}`,
+    defaultDiffViewState
+  )
+);
+
+export function reconcileDiffViewStateStorage(
+  agentIds: Iterable<string>
+): void {
+  if (typeof window === "undefined") return;
+
+  const liveAgentIds = new Set(agentIds);
+  const keysToDelete: string[] = [];
+
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    if (!key?.startsWith(DIFF_VIEW_STATE_STORAGE_PREFIX)) continue;
+
+    const agentId = key.slice(DIFF_VIEW_STATE_STORAGE_PREFIX.length).trim();
+    if (!agentId || liveAgentIds.has(agentId)) continue;
+    keysToDelete.push(key);
+  }
+
+  keysToDelete.forEach((key) => window.localStorage.removeItem(key));
+}


### PR DESCRIPTION
## Summary

- Persist collapsed files, collapsed directories, and scroll position in the Changes tab per agent via Jotai `atomFamily` backed by localStorage
- Scroll position is debounced (300ms) and restored once when landing on an agent's tab (survives page reloads and tab switches without fighting background refetches)
- Stale localStorage entries are cleaned up when agents are archived

## Changed files

- `apps/web/src/lib/store.ts` — `DiffViewState` type, `diffViewStateAtomFamily`, `reconcileDiffViewStateStorage`
- `apps/web/src/components/app/changes-tab.tsx` — replaced ephemeral `useState` with atom-backed state, lifted `collapsedDirs` from `FileTree`, added scroll tracking/restore
- `apps/web/src/hooks/use-media-sidebar-state.ts` — added diff view state cleanup call

## Test plan

- [x] Type check (`pnpm run check`)
- [x] Production build (`pnpm run finalize:web`)
- [x] E2E tests (172 passed)
- [x] Store unit tests (8 passed)
- [x] Frontend UX review (approved after 2 rounds)
- [x] Product review (approved after 2 rounds)
- [ ] Manual: collapse files, scroll, switch to Terminal and back — state preserved
- [ ] Manual: reload the page — collapse state and scroll position restored
- [ ] Manual: switch between agents — each agent has its own collapse/scroll state
- [ ] Manual: archive an agent — its localStorage entry is cleaned up