### PR TITLE
Document dispatch_launch_agent, cross-repo messaging, sidebar reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 | `dispatch_resolve_feedback`  | Mark a feedback item as fixed or ignored                                   |
 | `dispatch_submit_resolution` | Submit the parent agent's response package for a reviewer recheck          |
 | `dispatch_cancel_recheck`    | Cancel a pending reviewer recheck loop                                     |
-| `list_agents`                | List other agents in the same project with IDs, statuses, and activity     |
+| `dispatch_launch_agent`      | Launch a new child agent to work on a subtask                              |
+| `list_agents`                | List other agents in the same repo with IDs, statuses, and activity        |
 | `dispatch_send_message`      | Send a message to another running agent by ID or name                      |
 | `get_activity_summary`       | Summarize agent activity over a time range                                 |
 | `get_agent_history`          | Get detailed agent session history                                         |
@@ -204,7 +205,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `list_agents`, `dispatch_send_message`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `dispatch_launch_agent`, `list_agents`, `dispatch_send_message`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
 
 ### Repo-specific tools
 

--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -258,6 +258,32 @@ export function AgentsContent() {
           their events, media, pins, and feedback.
         </P>
       </Section>
+
+      <Section>
+        <H3>Agent orchestration</H3>
+        <P>
+          Agents can launch other agents using the{" "}
+          <Code>dispatch_launch_agent</Code> tool. The child agent runs
+          independently and appears as a top-level entry in the sidebar — it
+          inherits the parent's working directory and full-access mode by
+          default. Each child is told which agent launched it and can coordinate
+          back using <Code>dispatch_send_message</Code>.
+        </P>
+        <P>
+          Archiving a parent does not archive its launched children — they
+          continue running on their own. This differs from persona reviewers,
+          which are always archived alongside their parent.
+        </P>
+      </Section>
+
+      <Section>
+        <H3>Reordering agents</H3>
+        <P>
+          Drag and drop agent cards in the sidebar to reorder them. You can also
+          focus a card and press <Code>Alt+↑</Code> or <Code>Alt+↓</Code> to
+          move it. The custom order is saved per session.
+        </P>
+      </Section>
     </>
   );
 }

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -171,8 +171,12 @@ export function ToolsContent() {
             the reviewer exits cleanly
           </li>
           <li>
-            <Code>list_agents</Code> — list other agents in the same project
-            with their IDs, statuses, and latest activity
+            <Code>dispatch_launch_agent</Code> — launch a new child agent to
+            work on a subtask (see the Agents section for details)
+          </li>
+          <li>
+            <Code>list_agents</Code> — list other agents in the same repo with
+            their IDs, statuses, and latest activity
           </li>
           <li>
             <Code>dispatch_send_message</Code> — send a message to another
@@ -211,6 +215,13 @@ export function ToolsContent() {
             templates
           </li>
         </ul>
+        <P>
+          By default, <Code>list_agents</Code> and{" "}
+          <Code>dispatch_send_message</Code> only see agents in the same git
+          repository. To let agents coordinate across repos, enable{" "}
+          <strong>Allow messaging agents in other repositories</strong> in{" "}
+          <strong>Settings → Agents</strong>.
+        </P>
       </Section>
 
       <Section>

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -14,7 +14,7 @@ export const tips: Tip[] = [
     id: "agent-orchestration",
     title: "Agent Orchestration",
     body: "Agents can now launch other agents using the dispatch_launch_agent tool. Delegate subtasks, run parallel workstreams, or hand off work — launched agents coordinate via messaging.",
-    docsSection: "tools#dispatch-launch-agent",
+    docsSection: "agents",
     since: "0.24.0",
     surfaces: ["ambient"],
   },
@@ -120,6 +120,14 @@ export const tips: Tip[] = [
     body: "Press Mod+K to search commands, open settings pages, or launch palette-enabled templates.",
     docsSection: "shortcuts",
     since: "0.24.0",
+    surfaces: ["ambient"],
+  },
+  {
+    id: "sidebar-reorder",
+    title: "Reorder Agents",
+    body: "Drag and drop agent cards in the sidebar to reorder them. You can also focus a card and press Alt+↑ or Alt+↓.",
+    docsSection: "agents",
+    since: "0.24.2",
     surfaces: ["ambient"],
   },
   {


### PR DESCRIPTION
## Summary

- Added `dispatch_launch_agent` to the built-in tools list in docs-pane and the README MCP tools tables (both interactive and job agent sections)
- Added "Agent orchestration" section to Agents docs explaining child agent launch, inheritance, and archive behavior
- Added "Reordering agents" section documenting drag-and-drop and Alt+Arrow sidebar reordering
- Documented cross-repo messaging toggle in the tools section (Settings → Agents)
- Fixed agent-orchestration tip's `docsSection` link (was pointing to nonexistent anchor)
- Added sidebar-reorder ambient tip
- Fixed "same project" → "same repo" wording for `list_agents`

## Test plan

- [ ] Verify docs-pane renders without errors (agents, tools sections)
- [ ] Verify tips render correctly in ambient tip bar
- [ ] No type errors (`pnpm run check` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)