### PR TITLE
Add Phase 3a: review submission, feedback sidebar, and inline annotations

### DIFF
--- a/apps/server/src/agents/reviews.ts
+++ b/apps/server/src/agents/reviews.ts
@@ -1,0 +1,304 @@
+import type { Pool } from "pg";
+
+export type ReviewRecord = {
+  id: string;
+  agentId: string;
+  assignedAgentId: string | null;
+  reviewerType: string;
+  reviewerAgentId: string | null;
+  summary: string | null;
+  status: string;
+  baseRef: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReviewFeedbackItemRecord = {
+  id: string;
+  reviewId: string;
+  filePath: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  diffSnapshot: string | null;
+  baseRef: string | null;
+  status: string;
+  resolution: string | null;
+  resolutionNote: string | null;
+  resolvedBy: string | null;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReviewThreadMessageRecord = {
+  id: string;
+  feedbackItemId: string;
+  authorType: string;
+  authorAgentId: string | null;
+  type: string;
+  content: { body: string } | Record<string, unknown>;
+  createdAt: string;
+};
+
+export type ReviewWithItems = ReviewRecord & {
+  items: Array<
+    ReviewFeedbackItemRecord & { messages: ReviewThreadMessageRecord[] }
+  >;
+};
+
+export type ReviewListEntry = ReviewRecord & {
+  itemCount: number;
+  resolvedCount: number;
+};
+
+const REVIEW_RETURNING = `
+  RETURNING id, agent_id AS "agentId", assigned_agent_id AS "assignedAgentId",
+            reviewer_type AS "reviewerType", reviewer_agent_id AS "reviewerAgentId",
+            summary, status, base_ref AS "baseRef",
+            created_at AS "createdAt", updated_at AS "updatedAt"
+`;
+
+const REVIEW_SELECT = `
+  id, agent_id AS "agentId", assigned_agent_id AS "assignedAgentId",
+  reviewer_type AS "reviewerType", reviewer_agent_id AS "reviewerAgentId",
+  summary, status, base_ref AS "baseRef",
+  created_at AS "createdAt", updated_at AS "updatedAt"
+`;
+
+const ITEM_RETURNING = `
+  RETURNING id, review_id AS "reviewId", file_path AS "filePath",
+            line_start AS "lineStart", line_end AS "lineEnd",
+            diff_snapshot AS "diffSnapshot", base_ref AS "baseRef",
+            status, resolution, resolution_note AS "resolutionNote",
+            resolved_by AS "resolvedBy", resolved_at AS "resolvedAt",
+            created_at AS "createdAt", updated_at AS "updatedAt"
+`;
+
+const ITEM_SELECT = `
+  id, review_id AS "reviewId", file_path AS "filePath",
+  line_start AS "lineStart", line_end AS "lineEnd",
+  diff_snapshot AS "diffSnapshot", base_ref AS "baseRef",
+  status, resolution, resolution_note AS "resolutionNote",
+  resolved_by AS "resolvedBy", resolved_at AS "resolvedAt",
+  created_at AS "createdAt", updated_at AS "updatedAt"
+`;
+
+const MESSAGE_RETURNING = `
+  RETURNING id, feedback_item_id AS "feedbackItemId",
+            author_type AS "authorType", author_agent_id AS "authorAgentId",
+            type, content, created_at AS "createdAt"
+`;
+
+const MESSAGE_SELECT = `
+  id, feedback_item_id AS "feedbackItemId",
+  author_type AS "authorType", author_agent_id AS "authorAgentId",
+  type, content, created_at AS "createdAt"
+`;
+
+export type CreateReviewInput = {
+  agentId: string;
+  assignedAgentId: string;
+  reviewerType: "human" | "agent";
+  reviewerAgentId: string | null;
+  summary: string | null;
+  baseRef: string | null;
+  items: Array<{
+    filePath?: string;
+    lineStart?: number;
+    lineEnd?: number;
+    diffSnapshot?: string;
+    comment: string;
+  }>;
+};
+
+export async function createReview(
+  pool: Pool,
+  input: CreateReviewInput
+): Promise<ReviewWithItems> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const reviewResult = await client.query<ReviewRecord>(
+      `INSERT INTO reviews (agent_id, assigned_agent_id, reviewer_type, reviewer_agent_id, summary, base_ref)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ${REVIEW_RETURNING}`,
+      [
+        input.agentId,
+        input.assignedAgentId,
+        input.reviewerType,
+        input.reviewerAgentId,
+        input.summary,
+        input.baseRef,
+      ]
+    );
+    const review = reviewResult.rows[0]!;
+
+    const items: Array<
+      ReviewFeedbackItemRecord & { messages: ReviewThreadMessageRecord[] }
+    > = [];
+
+    for (const item of input.items) {
+      const itemResult = await client.query<ReviewFeedbackItemRecord>(
+        `INSERT INTO review_feedback_items (review_id, file_path, line_start, line_end, diff_snapshot, base_ref)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ${ITEM_RETURNING}`,
+        [
+          review.id,
+          item.filePath ?? null,
+          item.lineStart ?? null,
+          item.lineEnd ?? null,
+          item.diffSnapshot ?? null,
+          input.baseRef,
+        ]
+      );
+      const feedbackItem = itemResult.rows[0]!;
+
+      const messageResult = await client.query<ReviewThreadMessageRecord>(
+        `INSERT INTO review_thread_messages (feedback_item_id, author_type, author_agent_id, type, content)
+         VALUES ($1, $2, $3, 'text', $4::jsonb)
+         ${MESSAGE_RETURNING}`,
+        [
+          feedbackItem.id,
+          input.reviewerType,
+          input.reviewerAgentId,
+          JSON.stringify({ body: item.comment }),
+        ]
+      );
+
+      items.push({
+        ...feedbackItem,
+        messages: [messageResult.rows[0]!],
+      });
+    }
+
+    await client.query("COMMIT");
+    return { ...review, items };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listReviews(
+  pool: Pool,
+  agentId: string
+): Promise<ReviewListEntry[]> {
+  const result = await pool.query<ReviewListEntry>(
+    `SELECT r.id, r.agent_id AS "agentId", r.assigned_agent_id AS "assignedAgentId",
+            r.reviewer_type AS "reviewerType", r.reviewer_agent_id AS "reviewerAgentId",
+            r.summary, r.status, r.base_ref AS "baseRef",
+            r.created_at AS "createdAt", r.updated_at AS "updatedAt",
+            COUNT(fi.id)::int AS "itemCount",
+            COUNT(fi.id) FILTER (WHERE fi.status = 'resolved')::int AS "resolvedCount"
+     FROM reviews r
+     LEFT JOIN review_feedback_items fi ON fi.review_id = r.id
+     WHERE r.agent_id = $1
+     GROUP BY r.id
+     ORDER BY r.created_at DESC`,
+    [agentId]
+  );
+  return result.rows;
+}
+
+/**
+ * Return all feedback items (with first thread message) for an agent,
+ * across all reviews. Used by the diff view to render inline annotations.
+ */
+export async function listFeedbackItemsForAgent(
+  pool: Pool,
+  agentId: string
+): Promise<
+  Array<
+    ReviewFeedbackItemRecord & {
+      reviewerType: string;
+      firstMessage: ReviewThreadMessageRecord | null;
+    }
+  >
+> {
+  const itemsResult = await pool.query<
+    ReviewFeedbackItemRecord & { reviewerType: string }
+  >(
+    `SELECT fi.id, fi.review_id AS "reviewId", fi.file_path AS "filePath",
+            fi.line_start AS "lineStart", fi.line_end AS "lineEnd",
+            fi.diff_snapshot AS "diffSnapshot", fi.base_ref AS "baseRef",
+            fi.status, fi.resolution, fi.resolution_note AS "resolutionNote",
+            fi.resolved_by AS "resolvedBy", fi.resolved_at AS "resolvedAt",
+            fi.created_at AS "createdAt", fi.updated_at AS "updatedAt",
+            r.reviewer_type AS "reviewerType"
+     FROM review_feedback_items fi
+     JOIN reviews r ON r.id = fi.review_id
+     WHERE r.agent_id = $1
+     ORDER BY fi.created_at ASC`,
+    [agentId]
+  );
+
+  if (itemsResult.rows.length === 0) return [];
+
+  const itemIds = itemsResult.rows.map((i) => i.id);
+  // Fetch only the first message per item using DISTINCT ON
+  const messagesResult = await pool.query<ReviewThreadMessageRecord>(
+    `SELECT DISTINCT ON (feedback_item_id)
+            ${MESSAGE_SELECT}
+     FROM review_thread_messages
+     WHERE feedback_item_id = ANY($1)
+     ORDER BY feedback_item_id, created_at ASC`,
+    [itemIds]
+  );
+  const firstMessageByItem = new Map<string, ReviewThreadMessageRecord>();
+  for (const msg of messagesResult.rows) {
+    firstMessageByItem.set(msg.feedbackItemId, msg);
+  }
+
+  return itemsResult.rows.map((item) => ({
+    ...item,
+    firstMessage: firstMessageByItem.get(item.id) ?? null,
+  }));
+}
+
+export async function getReview(
+  pool: Pool,
+  reviewId: string
+): Promise<ReviewWithItems | null> {
+  const reviewResult = await pool.query<ReviewRecord>(
+    `SELECT ${REVIEW_SELECT} FROM reviews WHERE id = $1`,
+    [reviewId]
+  );
+  const review = reviewResult.rows[0];
+  if (!review) return null;
+
+  const itemsResult = await pool.query<ReviewFeedbackItemRecord>(
+    `SELECT ${ITEM_SELECT} FROM review_feedback_items WHERE review_id = $1 ORDER BY created_at ASC`,
+    [reviewId]
+  );
+
+  const itemIds = itemsResult.rows.map((i) => i.id);
+  const messagesByItem = new Map<string, ReviewThreadMessageRecord[]>();
+
+  if (itemIds.length > 0) {
+    const messagesResult = await pool.query<ReviewThreadMessageRecord>(
+      `SELECT ${MESSAGE_SELECT}
+       FROM review_thread_messages
+       WHERE feedback_item_id = ANY($1)
+       ORDER BY created_at ASC`,
+      [itemIds]
+    );
+    for (const msg of messagesResult.rows) {
+      const list = messagesByItem.get(msg.feedbackItemId);
+      if (list) {
+        list.push(msg);
+      } else {
+        messagesByItem.set(msg.feedbackItemId, [msg]);
+      }
+    }
+  }
+
+  const items = itemsResult.rows.map((item) => ({
+    ...item,
+    messages: messagesByItem.get(item.id) ?? [],
+  }));
+
+  return { ...review, items };
+}

--- a/apps/server/src/db/migrations/0029_reviews.sql
+++ b/apps/server/src/db/migrations/0029_reviews.sql
@@ -1,0 +1,45 @@
+-- Reviews: structured review system for agent diffs (Phase 3a)
+
+CREATE TABLE IF NOT EXISTS reviews (
+  id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  agent_id            TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  assigned_agent_id   TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  reviewer_type       TEXT NOT NULL,
+  reviewer_agent_id   TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  summary             TEXT,
+  status              TEXT NOT NULL DEFAULT 'open',
+  base_ref            TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_reviews_agent ON reviews(agent_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_assigned ON reviews(assigned_agent_id);
+
+CREATE TABLE IF NOT EXISTS review_feedback_items (
+  id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  review_id       TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+  file_path       TEXT,
+  line_start      INTEGER,
+  line_end        INTEGER,
+  diff_snapshot   TEXT,
+  base_ref        TEXT,
+  status          TEXT NOT NULL DEFAULT 'open',
+  resolution      TEXT,
+  resolution_note TEXT,
+  resolved_by     TEXT,
+  resolved_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_review_feedback_items_review ON review_feedback_items(review_id);
+
+CREATE TABLE IF NOT EXISTS review_thread_messages (
+  id                TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  feedback_item_id  TEXT NOT NULL REFERENCES review_feedback_items(id) ON DELETE CASCADE,
+  author_type       TEXT NOT NULL,
+  author_agent_id   TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  type              TEXT NOT NULL DEFAULT 'text',
+  content           JSONB NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_review_thread_messages_item ON review_thread_messages(feedback_item_id);

--- a/apps/server/src/routes/agents/index.ts
+++ b/apps/server/src/routes/agents/index.ts
@@ -5,6 +5,7 @@ import { registerAgentCrudRoutes } from "./crud-routes.js";
 import { registerAgentEventRoutes } from "./events-routes.js";
 import { registerAgentLifecycleRoutes } from "./lifecycle-routes.js";
 import { registerAgentStreamingRoutes } from "./streaming-routes.js";
+import { registerAgentReviewRoutes } from "./review-routes.js";
 import { registerAgentTerminalRoutes } from "./terminal-routes.js";
 
 export type { AgentRouteDeps } from "./shared.js";
@@ -16,6 +17,7 @@ export async function registerAgentRoutes(
   await registerAgentEventRoutes(app, deps);
   await registerAgentCrudRoutes(app, deps);
   await registerAgentLifecycleRoutes(app, deps);
+  await registerAgentReviewRoutes(app, deps);
   await registerAgentStreamingRoutes(app, deps);
   await registerAgentTerminalRoutes(app, deps);
 }

--- a/apps/server/src/routes/agents/review-routes.ts
+++ b/apps/server/src/routes/agents/review-routes.ts
@@ -1,0 +1,368 @@
+import type { FastifyInstance } from "fastify";
+
+import { getAgentFileDiff } from "../../shared/git/agent-diff.js";
+import {
+  createReview,
+  listReviews,
+  getReview,
+  listFeedbackItemsForAgent,
+  type CreateReviewInput,
+} from "../../agents/reviews.js";
+import type { AgentRouteDeps } from "./shared.js";
+
+export async function registerAgentReviewRoutes(
+  app: FastifyInstance,
+  deps: AgentRouteDeps
+): Promise<void> {
+  // --- POST /api/v1/agents/:id/reviews — Submit a review ---
+  app.post("/api/v1/agents/:id/reviews", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const body = request.body as {
+      summary?: string;
+      items?: Array<{
+        filePath?: string;
+        startLine?: number;
+        endLine?: number;
+        comment?: string;
+      }>;
+    } | null;
+
+    // Validate items
+    if (!Array.isArray(body?.items) || body.items.length === 0) {
+      return reply
+        .code(400)
+        .send({ error: "At least one feedback item is required." });
+    }
+
+    // Validate each item
+    for (let i = 0; i < body.items.length; i++) {
+      const item = body.items[i]!;
+      if (
+        !item.comment ||
+        typeof item.comment !== "string" ||
+        !item.comment.trim()
+      ) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: comment is required.` });
+      }
+      if (item.comment.length > 10_000) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: comment too long.` });
+      }
+      if (item.filePath !== undefined && typeof item.filePath !== "string") {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: invalid filePath.` });
+      }
+      if (item.filePath && item.filePath.includes("..")) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: invalid file path.` });
+      }
+      if (
+        item.startLine !== undefined &&
+        (typeof item.startLine !== "number" ||
+          !Number.isInteger(item.startLine) ||
+          item.startLine < 1)
+      ) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: invalid startLine.` });
+      }
+      if (
+        item.endLine !== undefined &&
+        (typeof item.endLine !== "number" ||
+          !Number.isInteger(item.endLine) ||
+          item.endLine < 1)
+      ) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: invalid endLine.` });
+      }
+      if (
+        item.startLine !== undefined &&
+        item.endLine !== undefined &&
+        item.endLine < item.startLine
+      ) {
+        return reply
+          .code(400)
+          .send({ error: `Item ${i + 1}: endLine must be >= startLine.` });
+      }
+    }
+
+    if (body.summary !== undefined && typeof body.summary !== "string") {
+      return reply.code(400).send({ error: "summary must be a string." });
+    }
+    if (body.summary && body.summary.length > 10_000) {
+      return reply.code(400).send({ error: "Summary too long." });
+    }
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    // Resolve worktree path for diff snapshot
+    const gitContextWorktreePath = agent.gitContext?.isWorktree
+      ? agent.gitContext.worktreePath
+      : null;
+    const worktreePath =
+      agent.worktreePath ?? gitContextWorktreePath ?? agent.cwd ?? null;
+    const baseRef =
+      agent.baseBranch ??
+      (agent.worktreePath || gitContextWorktreePath ? "main" : null);
+
+    // Build items with diff snapshots
+    const reviewItems: CreateReviewInput["items"] = [];
+    for (const item of body.items) {
+      let diffSnapshot: string | undefined;
+
+      if (item.filePath && worktreePath) {
+        try {
+          const fileDiff = await getAgentFileDiff(
+            worktreePath,
+            baseRef,
+            item.filePath
+          );
+          if (
+            fileDiff &&
+            item.startLine !== undefined &&
+            item.endLine !== undefined
+          ) {
+            // Extract the relevant hunk around the selected lines
+            diffSnapshot = extractHunkAroundLines(
+              fileDiff.diff,
+              item.startLine,
+              item.endLine
+            );
+          } else if (fileDiff) {
+            // General file comment — snapshot the whole diff (truncated)
+            diffSnapshot =
+              fileDiff.diff.length > 5_000
+                ? fileDiff.diff.slice(0, 5_000) + "\n... (truncated)"
+                : fileDiff.diff;
+          }
+        } catch {
+          // Diff snapshot is best-effort — don't fail the review
+        }
+      }
+
+      reviewItems.push({
+        filePath: item.filePath,
+        lineStart: item.startLine,
+        lineEnd: item.endLine,
+        diffSnapshot,
+        comment: item.comment!.trim(),
+      });
+    }
+
+    try {
+      const review = await createReview(deps.pool, {
+        agentId: id,
+        assignedAgentId: id,
+        reviewerType: "human",
+        reviewerAgentId: null,
+        summary: body.summary?.trim() || null,
+        baseRef: baseRef,
+        items: reviewItems,
+      });
+
+      // Publish SSE event
+      deps.publishUiEvent({
+        type: "review.created",
+        agentId: id,
+        reviewId: review.id,
+      } as never);
+
+      // Send tmux notification to the assigned agent
+      try {
+        const notification = formatReviewNotification(review, reviewItems);
+        await deps.sendAgentPrompt(id, notification);
+      } catch (err) {
+        deps.appLog.warn(
+          { err, agentId: id, reviewId: review.id },
+          "Review created but tmux notification failed"
+        );
+      }
+
+      return { review };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+
+  // --- GET /api/v1/agents/:id/reviews — List reviews for an agent ---
+  app.get("/api/v1/agents/:id/reviews", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    try {
+      const reviews = await listReviews(deps.pool, id);
+      return { reviews };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+
+  // --- GET /api/v1/agents/:id/reviews/feedback --- All feedback items for inline annotations
+  // Registered before the :reviewId route so "feedback" isn't captured as a param
+  app.get("/api/v1/agents/:id/reviews/feedback", async (request, reply) => {
+    const params = request.params as { id?: string };
+    const id = params.id ?? "";
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    try {
+      const items = await listFeedbackItemsForAgent(deps.pool, id);
+      return { items };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+
+  // --- GET /api/v1/agents/:id/reviews/:reviewId — Get review detail ---
+  app.get("/api/v1/agents/:id/reviews/:reviewId", async (request, reply) => {
+    const params = request.params as { id?: string; reviewId?: string };
+    const id = params.id ?? "";
+    const reviewId = params.reviewId ?? "";
+
+    if (!reviewId) {
+      return reply.code(400).send({ error: "Review ID is required." });
+    }
+
+    const agent = await deps.agentManager.getAgent(id);
+    if (!agent) {
+      return reply.code(404).send({ error: "Agent not found." });
+    }
+
+    try {
+      const review = await getReview(deps.pool, reviewId);
+      if (!review || review.agentId !== id) {
+        return reply.code(404).send({ error: "Review not found." });
+      }
+      return { review };
+    } catch (error) {
+      return deps.handleAgentError(reply, error);
+    }
+  });
+}
+
+/**
+ * Extract the diff hunk(s) that contain the given line range.
+ * Returns the relevant portion of the unified diff for snapshotting.
+ */
+function extractHunkAroundLines(
+  diffText: string,
+  startLine: number,
+  endLine: number
+): string {
+  const lines = diffText.split("\n");
+  const result: string[] = [];
+  let newLineNum = 0;
+  let inRelevantHunk = false;
+  let hunkHeader = "";
+
+  for (const line of lines) {
+    const hunkMatch = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunkMatch) {
+      newLineNum = parseInt(hunkMatch[1]!, 10) - 1;
+      hunkHeader = line;
+      inRelevantHunk = false;
+      continue;
+    }
+
+    if (newLineNum === 0) continue;
+
+    if (line.startsWith("-")) {
+      if (inRelevantHunk) result.push(line);
+      continue;
+    }
+
+    if (line.startsWith("+") || line.startsWith(" ")) {
+      newLineNum++;
+      if (newLineNum >= startLine && newLineNum <= endLine) {
+        if (!inRelevantHunk) {
+          if (hunkHeader) result.push(hunkHeader);
+          inRelevantHunk = true;
+        }
+        result.push(line);
+      } else if (inRelevantHunk) {
+        // Include a few trailing context lines
+        result.push(line);
+        if (newLineNum > endLine + 3) {
+          inRelevantHunk = false;
+        }
+      }
+    }
+  }
+
+  return result.join("\n");
+}
+
+/**
+ * Format the tmux notification message for a submitted review.
+ */
+function formatReviewNotification(
+  review: { summary: string | null },
+  items: Array<{
+    filePath?: string;
+    lineStart?: number;
+    lineEnd?: number;
+    comment: string;
+  }>
+): string {
+  const parts: string[] = [
+    "--- DISPATCH: Review Submitted ---",
+    "Reviewer: human",
+  ];
+
+  if (review.summary) {
+    parts.push(`Summary: ${review.summary}`);
+  }
+
+  parts.push(`Feedback items (${items.length}):`);
+  parts.push("");
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!;
+    let location: string;
+    if (item.filePath && item.lineStart !== undefined) {
+      const lineRef =
+        item.lineEnd !== undefined && item.lineEnd !== item.lineStart
+          ? `${item.lineStart}-${item.lineEnd}`
+          : `${item.lineStart}`;
+      location = `${item.filePath}:${lineRef}`;
+    } else if (item.filePath) {
+      location = item.filePath;
+    } else {
+      location = "General";
+    }
+
+    // Truncate comment for notification summary
+    const shortComment =
+      item.comment.length > 120
+        ? item.comment.slice(0, 117) + "..."
+        : item.comment;
+    parts.push(`${i + 1}. ${location} — ${shortComment}`);
+  }
+
+  parts.push("");
+  parts.push(
+    "Use dispatch_list_review_feedback to see full details and work through items."
+  );
+  parts.push("--- END ---");
+
+  return parts.join("\n");
+}

--- a/apps/server/src/server/ui-events.ts
+++ b/apps/server/src/server/ui-events.ts
@@ -31,6 +31,14 @@ export type UiEvent =
       agentId: string;
       feedback: FeedbackRecord;
     }
+  | { type: "review.created"; agentId: string; reviewId: string }
+  | { type: "review.updated"; agentId: string; reviewId: string }
+  | {
+      type: "review_feedback.updated";
+      agentId: string;
+      reviewId: string;
+      itemId: string;
+    }
   | { type: "job.changed" }
   | { type: "template.changed" }
   | { type: "brain.changed"; repoRoot: string }

--- a/apps/web/src/components/app/changes-tab.tsx
+++ b/apps/web/src/components/app/changes-tab.tsx
@@ -13,6 +13,14 @@ import {
   MessageSquare,
   PanelLeftClose,
   PanelLeftOpen,
+  Bot,
+  CheckCircle2,
+  Circle,
+  Clock,
+  Pencil,
+  Send,
+  Trash2,
+  User,
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -85,6 +93,11 @@ import {
   type DiffFile,
   type DiffFileStatus,
 } from "@/hooks/use-agent-diff";
+import {
+  useSubmitReview,
+  useAgentFeedbackItems,
+  type FeedbackItemAnnotation,
+} from "@/hooks/use-agent-reviews";
 import { agentRoute } from "@/lib/agent-routes";
 import {
   type DiffViewType,
@@ -94,6 +107,7 @@ import {
   diffViewStateAtomFamily,
 } from "@/lib/store";
 import { cn } from "@/lib/utils";
+import type { DraftReviewComment } from "@/components/app/types";
 
 type LineSelection = {
   filePath: string;
@@ -161,6 +175,64 @@ export const ChangesTab = memo(function ChangesTab({
   const [commentOpen, setCommentOpen] = useState(false);
   const [fileTreeOpen, setFileTreeOpen] = useAtom(diffFileTreeOpenAtom);
   const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Review mode state
+  const [reviewMode, setReviewMode] = useState(false);
+  const [draftComments, setDraftComments] = useState<DraftReviewComment[]>([]);
+  const [reviewSummary, setReviewSummary] = useState("");
+  const [showSubmitPanel, setShowSubmitPanel] = useState(false);
+  const submitReview = useSubmitReview(agentId);
+
+  // Fetch persisted feedback items for inline annotations
+  const { data: feedbackItems } = useAgentFeedbackItems(agentId, active);
+
+  const addDraftComment = useCallback(
+    (filePath: string, startLine: number, endLine: number, comment: string) => {
+      setDraftComments((prev) => [
+        ...prev,
+        {
+          id: `draft-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          filePath,
+          startLine,
+          endLine,
+          comment,
+        },
+      ]);
+    },
+    []
+  );
+
+  const removeDraftComment = useCallback((id: string) => {
+    setDraftComments((prev) => prev.filter((d) => d.id !== id));
+  }, []);
+
+  const updateDraftComment = useCallback((id: string, comment: string) => {
+    setDraftComments((prev) =>
+      prev.map((d) => (d.id === id ? { ...d, comment } : d))
+    );
+  }, []);
+
+  const handleSubmitReview = useCallback(async () => {
+    if (draftComments.length === 0) return;
+    try {
+      await submitReview.mutateAsync({
+        summary: reviewSummary.trim() || undefined,
+        items: draftComments.map((d) => ({
+          filePath: d.filePath,
+          startLine: d.startLine,
+          endLine: d.endLine,
+          comment: d.comment,
+        })),
+      });
+      // Clear review state on success
+      setReviewMode(false);
+      setDraftComments([]);
+      setReviewSummary("");
+      setShowSubmitPanel(false);
+    } catch {
+      // Error is handled by the mutation
+    }
+  }, [draftComments, reviewSummary, submitReview]);
 
   const handleLineSelection = useCallback((sel: LineSelection | null) => {
     setLineSelection(sel);
@@ -247,31 +319,82 @@ export const ChangesTab = memo(function ChangesTab({
   }
 
   return (
-    <div className="flex h-full min-h-0">
-      <FileTree
-        files={files}
-        selectedFile={selectedFile}
-        onSelectFile={scrollToFile}
-        open={fileTreeOpen}
-        onToggleOpen={() => setFileTreeOpen((v) => !v)}
-        collapsedDirs={collapsedDirs}
-        onToggleDir={toggleCollapseDir}
-      />
-      <DiffPane
-        agentId={agentId}
-        files={files}
-        collapsedFiles={collapsedFiles}
-        onToggleCollapse={toggleCollapseFile}
-        fileRefs={fileRefs}
-        lineSelection={lineSelection}
-        onLineSelection={handleLineSelection}
-        commentOpen={commentOpen}
-        onCommentOpen={setCommentOpen}
-        viewType={viewType}
-        ignoreWhitespace={ignoreWhitespace}
-        scrollRef={scrollRef}
-        onScroll={handleScroll}
-      />
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Review mode toolbar */}
+      {agentId ? (
+        <ReviewToolbar
+          reviewMode={reviewMode}
+          draftCount={draftComments.length}
+          submitting={submitReview.isPending}
+          onStartReview={() => {
+            setReviewMode(true);
+            setShowSubmitPanel(false);
+          }}
+          onCancelReview={() => {
+            setReviewMode(false);
+            setDraftComments([]);
+            setReviewSummary("");
+            setShowSubmitPanel(false);
+          }}
+          onToggleSubmitPanel={() => setShowSubmitPanel((v) => !v)}
+        />
+      ) : null}
+
+      {/* Submit review panel */}
+      <AnimatePresence>
+        {showSubmitPanel && reviewMode && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden border-b border-border/50"
+          >
+            <SubmitReviewPanel
+              summary={reviewSummary}
+              onSummaryChange={setReviewSummary}
+              draftComments={draftComments}
+              onRemoveDraft={removeDraftComment}
+              onSubmit={handleSubmitReview}
+              submitting={submitReview.isPending}
+              error={submitReview.error?.message ?? null}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="flex min-h-0 flex-1">
+        <FileTree
+          files={files}
+          selectedFile={selectedFile}
+          onSelectFile={scrollToFile}
+          open={fileTreeOpen}
+          onToggleOpen={() => setFileTreeOpen((v) => !v)}
+          collapsedDirs={collapsedDirs}
+          onToggleDir={toggleCollapseDir}
+        />
+        <DiffPane
+          agentId={agentId}
+          files={files}
+          collapsedFiles={collapsedFiles}
+          onToggleCollapse={toggleCollapseFile}
+          fileRefs={fileRefs}
+          lineSelection={lineSelection}
+          onLineSelection={handleLineSelection}
+          commentOpen={commentOpen}
+          onCommentOpen={setCommentOpen}
+          viewType={viewType}
+          ignoreWhitespace={ignoreWhitespace}
+          scrollRef={scrollRef}
+          onScroll={handleScroll}
+          reviewMode={reviewMode}
+          draftComments={draftComments}
+          onAddDraftComment={addDraftComment}
+          onRemoveDraftComment={removeDraftComment}
+          onUpdateDraftComment={updateDraftComment}
+          feedbackItems={feedbackItems}
+        />
+      </div>
     </div>
   );
 });
@@ -519,6 +642,17 @@ type DiffPaneProps = {
   ignoreWhitespace: boolean;
   scrollRef: React.RefObject<HTMLDivElement>;
   onScroll: () => void;
+  reviewMode: boolean;
+  draftComments: DraftReviewComment[];
+  onAddDraftComment: (
+    filePath: string,
+    startLine: number,
+    endLine: number,
+    comment: string
+  ) => void;
+  onRemoveDraftComment: (id: string) => void;
+  onUpdateDraftComment: (id: string, comment: string) => void;
+  feedbackItems?: FeedbackItemAnnotation[];
 };
 
 function DiffPane({
@@ -535,6 +669,12 @@ function DiffPane({
   ignoreWhitespace,
   scrollRef,
   onScroll,
+  reviewMode,
+  draftComments,
+  onAddDraftComment,
+  onRemoveDraftComment,
+  onUpdateDraftComment,
+  feedbackItems,
 }: DiffPaneProps): JSX.Element {
   return (
     <div
@@ -562,6 +702,14 @@ function DiffPane({
           onCommentOpen={onCommentOpen}
           viewType={viewType}
           ignoreWhitespace={ignoreWhitespace}
+          reviewMode={reviewMode}
+          draftComments={draftComments.filter((d) => d.filePath === file.path)}
+          onAddDraftComment={onAddDraftComment}
+          onRemoveDraftComment={onRemoveDraftComment}
+          onUpdateDraftComment={onUpdateDraftComment}
+          feedbackItems={feedbackItems?.filter(
+            (fi) => fi.filePath === file.path
+          )}
         />
       ))}
     </div>
@@ -580,6 +728,17 @@ type FileDiffSectionProps = {
   onCommentOpen: (open: boolean) => void;
   viewType: DiffViewType;
   ignoreWhitespace: boolean;
+  reviewMode: boolean;
+  draftComments: DraftReviewComment[];
+  onAddDraftComment: (
+    filePath: string,
+    startLine: number,
+    endLine: number,
+    comment: string
+  ) => void;
+  onRemoveDraftComment: (id: string) => void;
+  onUpdateDraftComment: (id: string, comment: string) => void;
+  feedbackItems?: FeedbackItemAnnotation[];
 };
 
 function FileDiffSection({
@@ -594,6 +753,12 @@ function FileDiffSection({
   onCommentOpen,
   viewType,
   ignoreWhitespace,
+  reviewMode,
+  draftComments,
+  onAddDraftComment,
+  onRemoveDraftComment,
+  onUpdateDraftComment,
+  feedbackItems,
 }: FileDiffSectionProps): JSX.Element {
   return (
     <div ref={setRef} className="rounded-md border border-border/50">
@@ -645,6 +810,12 @@ function FileDiffSection({
               onCommentOpen={onCommentOpen}
               viewType={viewType}
               ignoreWhitespace={ignoreWhitespace}
+              reviewMode={reviewMode}
+              draftComments={draftComments}
+              onAddDraftComment={onAddDraftComment}
+              onRemoveDraftComment={onRemoveDraftComment}
+              onUpdateDraftComment={onUpdateDraftComment}
+              feedbackItems={feedbackItems}
             />
           </motion.div>
         )}
@@ -662,6 +833,17 @@ type FileDiffContentProps = {
   onCommentOpen: (open: boolean) => void;
   viewType: DiffViewType;
   ignoreWhitespace: boolean;
+  reviewMode: boolean;
+  draftComments: DraftReviewComment[];
+  onAddDraftComment: (
+    filePath: string,
+    startLine: number,
+    endLine: number,
+    comment: string
+  ) => void;
+  onRemoveDraftComment: (id: string) => void;
+  onUpdateDraftComment: (id: string, comment: string) => void;
+  feedbackItems?: FeedbackItemAnnotation[];
 };
 
 function FileDiffContent({
@@ -673,6 +855,12 @@ function FileDiffContent({
   onCommentOpen,
   viewType,
   ignoreWhitespace,
+  reviewMode,
+  draftComments,
+  onAddDraftComment,
+  onRemoveDraftComment,
+  onUpdateDraftComment,
+  feedbackItems,
 }: FileDiffContentProps): JSX.Element {
   const [forceLoad, setForceLoad] = useState(false);
   const { data: fileDiffData, isLoading: fileDiffLoading } = useAgentFileDiff(
@@ -737,6 +925,12 @@ function FileDiffContent({
       commentOpen={commentOpen}
       onCommentOpen={onCommentOpen}
       viewType={viewType}
+      reviewMode={reviewMode}
+      draftComments={draftComments}
+      onAddDraftComment={onAddDraftComment}
+      onRemoveDraftComment={onRemoveDraftComment}
+      onUpdateDraftComment={onUpdateDraftComment}
+      feedbackItems={feedbackItems}
     />
   );
 }
@@ -858,6 +1052,17 @@ type UnifiedDiffViewProps = {
   commentOpen: boolean;
   onCommentOpen: (open: boolean) => void;
   viewType: DiffViewType;
+  reviewMode: boolean;
+  draftComments: DraftReviewComment[];
+  onAddDraftComment: (
+    filePath: string,
+    startLine: number,
+    endLine: number,
+    comment: string
+  ) => void;
+  onRemoveDraftComment: (id: string) => void;
+  onUpdateDraftComment: (id: string, comment: string) => void;
+  feedbackItems?: FeedbackItemAnnotation[];
 };
 
 const UnifiedDiffView = memo(function UnifiedDiffView({
@@ -869,6 +1074,12 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   commentOpen,
   onCommentOpen,
   viewType,
+  reviewMode,
+  draftComments,
+  onAddDraftComment,
+  onRemoveDraftComment,
+  onUpdateDraftComment,
+  feedbackItems,
 }: UnifiedDiffViewProps): JSX.Element {
   const parsed = useMemo(() => {
     try {
@@ -948,31 +1159,95 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   }, [file, lineSelection]);
 
   const widgets = useMemo(() => {
-    if (!file || !lineSelection || !agentId || !commentOpen) return {};
-    const lastKey = findLastChangeKeyInRange(
-      file.hunks,
-      lineSelection.startLine,
-      lineSelection.endLine
-    );
-    if (!lastKey) return {};
-    return {
-      [lastKey]: (
-        <InlineCommentForm
-          agentId={agentId}
-          filePath={filePath}
-          startLine={lineSelection.startLine}
-          endLine={lineSelection.endLine}
-          onCancel={() => {
-            onCommentOpen(false);
-            onLineSelection(null);
-          }}
-          onSubmitted={() => {
-            onCommentOpen(false);
-            onLineSelection(null);
-          }}
-        />
-      ),
-    };
+    if (!file) return {};
+    const result: Record<string, React.ReactNode> = {};
+
+    // Add draft comment widgets (review mode)
+    for (const draft of draftComments) {
+      const lastKey = findLastChangeKeyInRange(
+        file.hunks,
+        draft.startLine,
+        draft.endLine
+      );
+      if (lastKey) {
+        result[lastKey] = (
+          <DraftCommentWidget
+            key={draft.id}
+            draft={draft}
+            onRemove={() => onRemoveDraftComment(draft.id)}
+            onUpdate={(comment) => onUpdateDraftComment(draft.id, comment)}
+          />
+        );
+      }
+    }
+
+    // Add persisted feedback item annotations
+    if (feedbackItems) {
+      for (const fi of feedbackItems) {
+        if (fi.lineStart == null) continue;
+        const lastKey = findLastChangeKeyInRange(
+          file.hunks,
+          fi.lineStart,
+          fi.lineEnd ?? fi.lineStart
+        );
+        if (lastKey && !result[lastKey]) {
+          result[lastKey] = <FeedbackAnnotationWidget key={fi.id} item={fi} />;
+        }
+      }
+    }
+
+    // Add quick comment / review draft form widget
+    if (lineSelection && agentId && commentOpen) {
+      const lastKey = findLastChangeKeyInRange(
+        file.hunks,
+        lineSelection.startLine,
+        lineSelection.endLine
+      );
+      if (lastKey && !result[lastKey]) {
+        if (reviewMode) {
+          result[lastKey] = (
+            <ReviewDraftCommentForm
+              filePath={filePath}
+              startLine={lineSelection.startLine}
+              endLine={lineSelection.endLine}
+              onCancel={() => {
+                onCommentOpen(false);
+                onLineSelection(null);
+              }}
+              onAdd={(comment) => {
+                onAddDraftComment(
+                  filePath,
+                  lineSelection.startLine,
+                  lineSelection.endLine,
+                  comment
+                );
+                onCommentOpen(false);
+                onLineSelection(null);
+              }}
+            />
+          );
+        } else {
+          result[lastKey] = (
+            <InlineCommentForm
+              agentId={agentId}
+              filePath={filePath}
+              startLine={lineSelection.startLine}
+              endLine={lineSelection.endLine}
+              onCancel={() => {
+                onCommentOpen(false);
+                onLineSelection(null);
+              }}
+              onSubmitted={() => {
+                onCommentOpen(false);
+                onLineSelection(null);
+              }}
+            />
+          );
+        }
+      }
+    }
+
+    return result;
   }, [
     file,
     lineSelection,
@@ -981,6 +1256,12 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
     onLineSelection,
     commentOpen,
     onCommentOpen,
+    reviewMode,
+    draftComments,
+    onAddDraftComment,
+    onRemoveDraftComment,
+    onUpdateDraftComment,
+    feedbackItems,
   ]);
 
   const diffRef = useRef<HTMLDivElement>(null);
@@ -1192,6 +1473,494 @@ function InlineCommentForm({
           Chat Now
         </button>
       </div>
+    </div>
+  );
+}
+
+// --- Review Mode Components ---
+
+function ReviewToolbar({
+  reviewMode,
+  draftCount,
+  submitting,
+  onStartReview,
+  onCancelReview,
+  onToggleSubmitPanel,
+}: {
+  reviewMode: boolean;
+  draftCount: number;
+  submitting: boolean;
+  onStartReview: () => void;
+  onCancelReview: () => void;
+  onToggleSubmitPanel: () => void;
+}): JSX.Element {
+  if (!reviewMode) {
+    return (
+      <div className="flex shrink-0 items-center justify-end border-b border-border/50 bg-muted/20 px-3 py-1.5">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-muted/40 transition-colors"
+          onClick={onStartReview}
+        >
+          <Pencil className="h-3 w-3" />
+          Start Review
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-primary/30 bg-primary/5 px-3 py-1.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-primary">
+        <Pencil className="h-3 w-3" />
+        Review Mode
+      </div>
+      {draftCount > 0 ? (
+        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+          {draftCount} comment{draftCount !== 1 ? "s" : ""}
+        </span>
+      ) : (
+        <span className="text-[11px] text-muted-foreground">
+          Click line numbers to add comments
+        </span>
+      )}
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted/40 transition-colors"
+          onClick={onCancelReview}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors",
+            draftCount > 0
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "bg-muted text-muted-foreground cursor-not-allowed"
+          )}
+          onClick={onToggleSubmitPanel}
+          disabled={draftCount === 0 || submitting}
+        >
+          {submitting ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Send className="h-3 w-3" />
+          )}
+          Submit Review
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SubmitReviewPanel({
+  summary,
+  onSummaryChange,
+  draftComments,
+  onRemoveDraft,
+  onSubmit,
+  submitting,
+  error,
+}: {
+  summary: string;
+  onSummaryChange: (v: string) => void;
+  draftComments: DraftReviewComment[];
+  onRemoveDraft: (id: string) => void;
+  onSubmit: () => void;
+  submitting: boolean;
+  error: string | null;
+}): JSX.Element {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onSubmit();
+      }
+    },
+    [onSubmit]
+  );
+
+  return (
+    <div className="bg-muted/10 p-4">
+      <div className="mb-3">
+        <label className="mb-1.5 block text-xs font-medium text-foreground">
+          Review Summary (optional)
+        </label>
+        <textarea
+          className="w-full resize-none rounded border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          placeholder="Overall feedback or context for this review…"
+          rows={2}
+          value={summary}
+          onChange={(e) => onSummaryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="mb-3">
+        <div className="mb-1.5 text-xs font-medium text-foreground">
+          Feedback Items ({draftComments.length})
+        </div>
+        <div className="max-h-40 space-y-1.5 overflow-y-auto">
+          {draftComments.map((draft, i) => {
+            const lineRef =
+              draft.startLine === draft.endLine
+                ? `:${draft.startLine}`
+                : `:${draft.startLine}-${draft.endLine}`;
+            return (
+              <div
+                key={draft.id}
+                className="flex items-start gap-2 rounded bg-background/60 px-2.5 py-1.5 text-xs"
+              >
+                <span className="shrink-0 text-muted-foreground">{i + 1}.</span>
+                <div className="min-w-0 flex-1">
+                  <span className="font-mono text-[11px] text-muted-foreground">
+                    {draft.filePath}
+                    {lineRef}
+                  </span>
+                  <p className="mt-0.5 truncate text-foreground">
+                    {draft.comment}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+                  onClick={() => onRemoveDraft(draft.id)}
+                  title="Remove"
+                  disabled={submitting}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mb-3 rounded border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          onClick={onSubmit}
+          disabled={draftComments.length === 0 || submitting}
+        >
+          {submitting ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Send className="h-3 w-3" />
+          )}
+          Submit Review ({draftComments.length} item
+          {draftComments.length !== 1 ? "s" : ""})
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ReviewDraftCommentForm({
+  filePath,
+  startLine,
+  endLine,
+  onCancel,
+  onAdd,
+}: {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  onCancel: () => void;
+  onAdd: (comment: string) => void;
+}): JSX.Element {
+  const [comment, setComment] = useState("");
+
+  const lineLabel =
+    startLine === endLine
+      ? `Line ${startLine}`
+      : `Lines ${startLine}–${endLine}`;
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (comment.trim()) onAdd(comment.trim());
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [comment, onAdd, onCancel]
+  );
+
+  return (
+    <div className="border-t border-primary/30 bg-primary/5 px-4 py-3">
+      <div className="mb-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+        <Pencil className="h-3 w-3 text-primary" />
+        <span className="font-mono">{filePath}</span>
+        <span>·</span>
+        <span>{lineLabel}</span>
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+          Draft
+        </span>
+      </div>
+      <textarea
+        className="w-full resize-none rounded border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        placeholder="Add a review comment…"
+        rows={3}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        onKeyDown={handleKeyDown}
+        autoFocus
+      />
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted/40"
+          onClick={onCancel}
+        >
+          <X className="h-3 w-3" />
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          onClick={() => {
+            if (comment.trim()) onAdd(comment.trim());
+          }}
+          disabled={!comment.trim()}
+        >
+          <Pencil className="h-3 w-3" />
+          Add to Review
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DraftCommentWidget({
+  draft,
+  onRemove,
+  onUpdate,
+}: {
+  draft: DraftReviewComment;
+  onRemove: () => void;
+  onUpdate: (comment: string) => void;
+}): JSX.Element {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(draft.comment);
+
+  const lineLabel =
+    draft.startLine === draft.endLine
+      ? `Line ${draft.startLine}`
+      : `Lines ${draft.startLine}–${draft.endLine}`;
+
+  const handleSaveEdit = useCallback(() => {
+    if (editText.trim()) {
+      onUpdate(editText.trim());
+      setEditing(false);
+    }
+  }, [editText, onUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSaveEdit();
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setEditing(false);
+        setEditText(draft.comment);
+      }
+    },
+    [handleSaveEdit, draft.comment]
+  );
+
+  return (
+    <div className="border-t border-primary/30 bg-primary/5 px-4 py-2.5">
+      <div className="mb-1.5 flex items-center gap-2 text-[11px]">
+        <Pencil className="h-3 w-3 text-primary" />
+        <span className="font-mono text-muted-foreground">{lineLabel}</span>
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+          Draft
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          {!editing && (
+            <button
+              type="button"
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+              onClick={() => {
+                setEditing(true);
+                setEditText(draft.comment);
+              }}
+              title="Edit"
+            >
+              <Pencil className="h-3 w-3" />
+            </button>
+          )}
+          <button
+            type="button"
+            className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            onClick={onRemove}
+            title="Remove"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+      {editing ? (
+        <>
+          <textarea
+            className="w-full resize-none rounded border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            rows={3}
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoFocus
+          />
+          <div className="mt-1.5 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted/40"
+              onClick={() => {
+                setEditing(false);
+                setEditText(draft.comment);
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded bg-primary px-2 py-1 text-xs text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              onClick={handleSaveEdit}
+              disabled={!editText.trim()}
+            >
+              Save
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="whitespace-pre-wrap text-xs text-foreground">
+          {draft.comment}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline annotation for persisted review feedback items
+// ---------------------------------------------------------------------------
+
+function FeedbackAnnotationWidget({
+  item,
+}: {
+  item: FeedbackItemAnnotation;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(item.status !== "resolved");
+  const isResolved = item.status === "resolved";
+
+  const lineLabel =
+    item.lineStart != null
+      ? item.lineEnd != null && item.lineEnd !== item.lineStart
+        ? `Lines ${item.lineStart}-${item.lineEnd}`
+        : `Line ${item.lineStart}`
+      : "General";
+
+  const StatusIcon =
+    item.status === "resolved"
+      ? CheckCircle2
+      : item.status === "in_progress"
+        ? Clock
+        : Circle;
+
+  const statusColor =
+    item.status === "resolved"
+      ? "text-status-working"
+      : item.status === "in_progress"
+        ? "text-primary"
+        : "text-status-waiting";
+
+  const statusLabel =
+    item.status === "resolved"
+      ? "Resolved"
+      : item.status === "in_progress"
+        ? "In progress"
+        : "Open";
+
+  return (
+    <div
+      className={cn(
+        "border-t border-border/50",
+        isResolved ? "bg-muted/10 opacity-60" : "bg-muted/20"
+      )}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-4 py-2 text-left text-[11px] hover:bg-muted/30"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <StatusIcon className={cn("h-3 w-3 shrink-0", statusColor)} />
+        <span className={cn("text-[10px] font-medium uppercase", statusColor)}>
+          {statusLabel}
+        </span>
+        <span className="font-mono text-muted-foreground">{lineLabel}</span>
+        <span className="ml-auto inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+          {item.reviewerType === "human" ? (
+            <User className="h-2.5 w-2.5" />
+          ) : (
+            <Bot className="h-2.5 w-2.5" />
+          )}
+          {item.reviewerType === "human" ? "Human" : "Agent"}
+        </span>
+      </button>
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            key="annotation-body"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-2.5">
+              {item.firstMessage ? (
+                <p className="whitespace-pre-wrap text-xs text-foreground/80">
+                  {item.firstMessage.content.body}
+                </p>
+              ) : null}
+              {isResolved && item.resolution ? (
+                <div className="mt-1.5 flex items-center gap-1 text-[10px] text-status-working">
+                  <CheckCircle2 className="h-3 w-3" />
+                  <span className="capitalize">
+                    {item.resolution.replace("_", " ")}
+                  </span>
+                  {item.resolutionNote ? (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      -- {item.resolutionNote}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/src/components/app/media-sidebar.tsx
+++ b/apps/web/src/components/app/media-sidebar.tsx
@@ -21,6 +21,7 @@ import { MediaActions } from "@/components/app/media-lightbox";
 import { isTextFile, stripTimestamp } from "@/components/app/media-file-utils";
 import { BrainTabContent } from "@/components/app/brain-tab-content";
 import { PinsPanel } from "@/components/app/pins-panel";
+import { ReviewsTabContent } from "@/components/app/reviews-tab-content";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { glassPanel } from "@/lib/glass";
@@ -470,6 +471,20 @@ export function MediaSidebarContent({
               <span className="absolute bottom-0 left-4 right-4 h-0.5 bg-foreground" />
             ) : null}
           </button>
+          <button
+            onClick={() => setActiveTab("reviews")}
+            className={cn(
+              "relative flex items-center gap-1.5 px-4 py-2.5 text-xs font-semibold uppercase tracking-wide transition-colors",
+              activeTab === "reviews"
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground/80"
+            )}
+          >
+            Reviews
+            {activeTab === "reviews" ? (
+              <span className="absolute bottom-0 left-4 right-4 h-0.5 bg-foreground" />
+            ) : null}
+          </button>
         </div>
         <div className="flex items-center gap-1 px-2">
           {onTogglePin ? (
@@ -549,6 +564,14 @@ export function MediaSidebarContent({
           agentId={selectedAgentId}
           repoRoot={selectedAgentRepoRoot}
         />
+      </div>
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col",
+          activeTab !== "reviews" && "hidden"
+        )}
+      >
+        <ReviewsTabContent agentId={selectedAgentId} />
       </div>
     </aside>
   );

--- a/apps/web/src/components/app/reviews-tab-content.tsx
+++ b/apps/web/src/components/app/reviews-tab-content.tsx
@@ -1,0 +1,314 @@
+import { useState } from "react";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Clock,
+  FileCode2,
+  Loader2,
+  MessageSquareText,
+  User,
+  Bot,
+} from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import type { Review, ReviewFeedbackItem } from "@/components/app/types";
+import {
+  useAgentReviews,
+  useAgentReviewDetail,
+} from "@/hooks/use-agent-reviews";
+import { cn } from "@/lib/utils";
+
+type ReviewsTabContentProps = {
+  agentId: string | null;
+};
+
+export function ReviewsTabContent({
+  agentId,
+}: ReviewsTabContentProps): JSX.Element {
+  const { data: reviews, isLoading } = useAgentReviews(agentId);
+
+  if (!agentId) {
+    return (
+      <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
+        Focus an agent to view reviews.
+      </div>
+    );
+  }
+
+  if (isLoading && !reviews) {
+    return (
+      <div className="flex items-center justify-center gap-2 p-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading reviews…
+      </div>
+    );
+  }
+
+  if (!reviews || reviews.length === 0) {
+    return (
+      <div className="grid h-full place-items-center p-4 text-center text-sm text-muted-foreground">
+        <div className="flex flex-col items-center gap-2">
+          <MessageSquareText className="h-8 w-8" />
+          <p>No reviews yet</p>
+          <p className="text-xs">
+            Submit a review from the Changes tab to leave structured feedback.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {reviews.map((review) => (
+        <ReviewCard key={review.id} agentId={agentId} review={review} />
+      ))}
+    </div>
+  );
+}
+
+function ReviewCard({
+  agentId,
+  review,
+}: {
+  agentId: string;
+  review: Review;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+
+  const itemCount = review.itemCount ?? review.items?.length ?? 0;
+  const resolvedCount = review.resolvedCount ?? 0;
+  const allResolved = itemCount > 0 && resolvedCount === itemCount;
+
+  return (
+    <div className="border-b-2 border-border">
+      <button
+        type="button"
+        className="flex w-full items-start gap-2 px-3 py-3 text-left hover:bg-muted/30"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="mt-0.5 shrink-0">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <ReviewerBadge reviewerType={review.reviewerType} />
+            <span className="text-[10px] text-muted-foreground">
+              {formatRelativeDate(review.createdAt)}
+            </span>
+            <ReviewStatusChip status={review.status} />
+          </div>
+          {review.summary ? (
+            <p className="mt-1 line-clamp-2 text-xs text-foreground/90">
+              {review.summary}
+            </p>
+          ) : null}
+          <div className="mt-1.5 flex items-center gap-2">
+            <span className="text-[10px] text-muted-foreground">
+              {itemCount} item{itemCount !== 1 ? "s" : ""}
+            </span>
+            {itemCount > 0 ? (
+              <div className="flex items-center gap-1.5">
+                <div className="h-1 w-12 overflow-hidden rounded-full bg-border">
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all",
+                      allResolved ? "bg-status-working" : "bg-primary"
+                    )}
+                    style={{
+                      width: `${Math.round((resolvedCount / itemCount) * 100)}%`,
+                    }}
+                  />
+                </div>
+                <span className="text-[10px] text-muted-foreground">
+                  {resolvedCount}/{itemCount}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </button>
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            key="items"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <ReviewItemsList agentId={agentId} reviewId={review.id} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function ReviewItemsList({
+  agentId,
+  reviewId,
+}: {
+  agentId: string;
+  reviewId: string;
+}): JSX.Element {
+  const { data: review, isLoading } = useAgentReviewDetail(agentId, reviewId);
+
+  if (isLoading && !review) {
+    return (
+      <div className="flex items-center gap-2 px-3 pb-3 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading…
+      </div>
+    );
+  }
+
+  if (!review?.items?.length) {
+    return (
+      <div className="px-3 pb-3 text-xs text-muted-foreground">
+        No feedback items.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1 px-3 pb-3">
+      {review.items.map((item) => (
+        <FeedbackItemRow key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function FeedbackItemRow({ item }: { item: ReviewFeedbackItem }): JSX.Element {
+  const isResolved = item.status === "resolved";
+  const firstMessage = item.messages?.[0];
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border/50 px-2.5 py-2",
+        isResolved && "opacity-60"
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <FeedbackStatusChip status={item.status} />
+        {item.filePath ? (
+          <span className="min-w-0 truncate font-mono text-[10px] text-muted-foreground">
+            <FileCode2 className="mr-0.5 inline h-3 w-3" />
+            {item.filePath}
+            {item.lineStart != null ? (
+              <span>
+                :{item.lineStart}
+                {item.lineEnd != null && item.lineEnd !== item.lineStart
+                  ? `-${item.lineEnd}`
+                  : ""}
+              </span>
+            ) : null}
+          </span>
+        ) : (
+          <span className="text-[10px] text-muted-foreground">General</span>
+        )}
+      </div>
+      {firstMessage ? (
+        <p className="mt-1 line-clamp-3 text-xs text-foreground/80">
+          {firstMessage.content.body}
+        </p>
+      ) : null}
+      {isResolved && item.resolution ? (
+        <div className="mt-1 flex items-center gap-1 text-[10px] text-status-working">
+          <CheckCircle2 className="h-3 w-3" />
+          <span className="capitalize">
+            {item.resolution.replace("_", " ")}
+          </span>
+          {item.resolutionNote ? (
+            <span className="text-muted-foreground">
+              — {item.resolutionNote}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ReviewerBadge({
+  reviewerType,
+}: {
+  reviewerType: "human" | "agent";
+}): JSX.Element {
+  if (reviewerType === "human") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+        <User className="h-2.5 w-2.5" />
+        Human
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-purple-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-purple-400">
+      <Bot className="h-2.5 w-2.5" />
+      Agent
+    </span>
+  );
+}
+
+function ReviewStatusChip({ status }: { status: string }): JSX.Element | null {
+  if (status === "resolved") {
+    return (
+      <span className="ml-auto inline-flex items-center gap-0.5 text-[10px] font-medium text-status-working">
+        <CheckCircle2 className="h-3 w-3" />
+        Resolved
+      </span>
+    );
+  }
+  return null;
+}
+
+function FeedbackStatusChip({ status }: { status: string }): JSX.Element {
+  if (status === "resolved") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-sm bg-status-working/10 px-1 py-0.5 text-[9px] font-semibold uppercase text-status-working">
+        <CheckCircle2 className="h-2.5 w-2.5" />
+        Resolved
+      </span>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-sm bg-primary/10 px-1 py-0.5 text-[9px] font-semibold uppercase text-primary">
+        <Clock className="h-2.5 w-2.5" />
+        In progress
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-0.5 rounded-sm bg-status-waiting/10 px-1 py-0.5 text-[9px] font-semibold uppercase text-status-waiting">
+      <Circle className="h-2.5 w-2.5" />
+      Open
+    </span>
+  );
+}
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -122,3 +122,57 @@ export type DiffStats = {
   files: number;
   computedAt: number;
 };
+
+// --- Review system types (Phase 3a) ---
+
+export type ReviewThreadMessage = {
+  id: string;
+  feedbackItemId: string;
+  authorType: "human" | "agent";
+  authorAgentId: string | null;
+  type: string;
+  content: { body: string } & Record<string, unknown>;
+  createdAt: string;
+};
+
+export type ReviewFeedbackItem = {
+  id: string;
+  reviewId: string;
+  filePath: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  diffSnapshot: string | null;
+  baseRef: string | null;
+  status: "open" | "in_progress" | "resolved";
+  resolution: string | null;
+  resolutionNote: string | null;
+  resolvedBy: string | null;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  messages: ReviewThreadMessage[];
+};
+
+export type Review = {
+  id: string;
+  agentId: string;
+  assignedAgentId: string | null;
+  reviewerType: "human" | "agent";
+  reviewerAgentId: string | null;
+  summary: string | null;
+  status: "open" | "in_progress" | "resolved";
+  baseRef: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items: ReviewFeedbackItem[];
+  itemCount?: number;
+  resolvedCount?: number;
+};
+
+export type DraftReviewComment = {
+  id: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  comment: string;
+};

--- a/apps/web/src/hooks/use-agent-reviews.ts
+++ b/apps/web/src/hooks/use-agent-reviews.ts
@@ -1,0 +1,157 @@
+import { useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import type {
+  Review,
+  ReviewFeedbackItem,
+  ReviewThreadMessage,
+} from "@/components/app/types";
+
+/** A feedback item enriched with reviewer context, for inline annotations. */
+export type FeedbackItemAnnotation = Omit<ReviewFeedbackItem, "messages"> & {
+  reviewerType: "human" | "agent";
+  firstMessage: ReviewThreadMessage | null;
+};
+
+export function agentReviewsQueryKey(agentId: string): string[] {
+  return ["agent-reviews", agentId];
+}
+
+export function agentFeedbackItemsQueryKey(agentId: string): string[] {
+  return ["agent-reviews", agentId, "feedback"];
+}
+
+export function agentReviewDetailQueryKey(
+  agentId: string,
+  reviewId: string
+): string[] {
+  return ["agent-reviews", agentId, reviewId];
+}
+
+type ReviewListResponse = {
+  reviews: Review[];
+};
+
+type ReviewDetailResponse = {
+  review: Review;
+};
+
+type SubmitReviewInput = {
+  summary?: string;
+  items: {
+    filePath?: string;
+    startLine?: number;
+    endLine?: number;
+    comment: string;
+  }[];
+};
+
+export function useAgentReviews(
+  agentId: string | null,
+  enabled = true
+): {
+  data: Review[] | undefined;
+  isLoading: boolean;
+  refresh: () => void;
+} {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<Review[]>({
+    queryKey: agentReviewsQueryKey(agentId ?? ""),
+    queryFn: async () => {
+      const res = await api<ReviewListResponse>(
+        `/api/v1/agents/${agentId}/reviews`
+      );
+      return res.reviews;
+    },
+    enabled: enabled && !!agentId,
+    staleTime: 10_000,
+  });
+
+  const refresh = useCallback(() => {
+    if (agentId) {
+      void queryClient.invalidateQueries({
+        queryKey: agentReviewsQueryKey(agentId),
+      });
+    }
+  }, [agentId, queryClient]);
+
+  return { data: query.data, isLoading: query.isLoading, refresh };
+}
+
+export function useAgentReviewDetail(
+  agentId: string | null,
+  reviewId: string | null,
+  enabled = true
+): {
+  data: Review | undefined;
+  isLoading: boolean;
+} {
+  const query = useQuery<Review>({
+    queryKey: agentReviewDetailQueryKey(agentId ?? "", reviewId ?? ""),
+    queryFn: async () => {
+      const res = await api<ReviewDetailResponse>(
+        `/api/v1/agents/${agentId}/reviews/${reviewId}`
+      );
+      return res.review;
+    },
+    enabled: enabled && !!agentId && !!reviewId,
+    staleTime: 10_000,
+  });
+
+  return { data: query.data, isLoading: query.isLoading };
+}
+
+export function useSubmitReview(agentId: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: SubmitReviewInput) => {
+      if (!agentId) throw new Error("No agent selected");
+      const res = await api<ReviewDetailResponse>(
+        `/api/v1/agents/${agentId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify(input),
+        }
+      );
+      return res.review;
+    },
+    onSuccess: () => {
+      if (agentId) {
+        void queryClient.invalidateQueries({
+          queryKey: agentReviewsQueryKey(agentId),
+        });
+      }
+    },
+  });
+}
+
+/**
+ * Fetch all feedback items across all reviews for an agent.
+ * Used by the diff view to render inline annotations at file/line ranges.
+ */
+export function useAgentFeedbackItems(
+  agentId: string | null,
+  enabled = true
+): {
+  data: FeedbackItemAnnotation[] | undefined;
+  isLoading: boolean;
+} {
+  type FeedbackListResponse = { items: FeedbackItemAnnotation[] };
+
+  const query = useQuery<FeedbackItemAnnotation[]>({
+    queryKey: agentFeedbackItemsQueryKey(agentId ?? ""),
+    queryFn: async () => {
+      const res = await api<FeedbackListResponse>(
+        `/api/v1/agents/${agentId}/reviews/feedback`
+      );
+      return res.items;
+    },
+    enabled: enabled && !!agentId,
+    staleTime: 10_000,
+  });
+
+  return { data: query.data, isLoading: query.isLoading };
+}

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -37,6 +37,14 @@ type UiEvent =
   | { type: "stream.stopped"; agentId: string }
   | { type: "feedback.created"; agentId: string }
   | { type: "feedback.updated"; agentId: string }
+  | { type: "review.created"; agentId: string; reviewId: string }
+  | { type: "review.updated"; agentId: string; reviewId: string }
+  | {
+      type: "review_feedback.updated";
+      agentId: string;
+      reviewId: string;
+      itemId: string;
+    }
   | { type: "job.changed" }
   | { type: "template.changed" }
   | { type: "brain.changed"; repoRoot: string }
@@ -173,6 +181,17 @@ export function useSSE(authState: AuthState): void {
           payload.type === "feedback.updated"
         ) {
           void queryClient.invalidateQueries({ queryKey: ["feedback"] });
+          return;
+        }
+
+        if (
+          payload.type === "review.created" ||
+          payload.type === "review.updated" ||
+          payload.type === "review_feedback.updated"
+        ) {
+          void queryClient.invalidateQueries({
+            queryKey: ["agent-reviews", payload.agentId],
+          });
           return;
         }
 

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -137,7 +137,7 @@ export function reconcileAgentSidebarOrder(
   return nextOrder;
 }
 
-export type MediaSidebarTab = "pins" | "media" | "brain";
+export type MediaSidebarTab = "pins" | "media" | "brain" | "reviews";
 
 export type MediaSidebarState = {
   isOpen: boolean;


### PR DESCRIPTION
## Summary

- Adds structured review system for agent diffs (Phase 3a from the diff review design spec)
- Human reviewers can enter review mode in the Changes tab, accumulate draft comments anchored to code lines, and submit them as a batch review
- On submission: persisted to DB (3 new tables), tmux notification sent to agent, SSE event for live updates
- New "Reviews" tab in the right sidebar showing all reviews with expandable cards, status chips, and progress bars
- Inline annotations in the diff view show persisted feedback items at their line ranges as collapsible widgets

### New files
- `apps/server/src/db/migrations/0029_reviews.sql` -- 3 tables: reviews, review_feedback_items, review_thread_messages
- `apps/server/src/agents/reviews.ts` -- data layer (create, list, get review, list all feedback items)
- `apps/server/src/routes/agents/review-routes.ts` -- 4 API endpoints (POST/GET reviews, GET detail, GET feedback)
- `apps/web/src/components/app/reviews-tab-content.tsx` -- sidebar Reviews tab UI
- `apps/web/src/hooks/use-agent-reviews.ts` -- React Query hooks for reviews and feedback

### Modified files
- Route registration, SSE event types, frontend types, sidebar tab, diff viewer (review mode + annotations)

## Test plan
- [x] `pnpm run check` (TypeScript) passes
- [x] `pnpm run finalize:web` (production build) passes
- [x] `pnpm run test` (188 unit tests pass, including migration-repair test)
- [x] `pnpm run test:e2e` (172 E2E tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)