### PR TITLE
Fix Automations docs: webhook location, add dispatch_launch_agent

### DIFF
--- a/apps/web/src/components/app/docs-sections/automations.tsx
+++ b/apps/web/src/components/app/docs-sections/automations.tsx
@@ -201,12 +201,6 @@ export function AutomationsContent() {
             run can be active at a time. Turn off to allow overlapping runs of
             the same job.
           </li>
-          <li>
-            <strong>Webhook trigger</strong> — enable to generate a secret URL
-            that triggers a run via HTTP POST. The URL is shown after saving and
-            can be copied from the settings panel. No auth header is required —
-            the secret in the URL is the credential.
-          </li>
         </ul>
         <P>
           Open <strong>Advanced settings</strong> for the rest:
@@ -238,6 +232,12 @@ export function AutomationsContent() {
             this to leave the agent (and its worktree) around for inspection.
           </li>
         </ul>
+        <P>
+          After creating a job, open its <strong>Settings</strong> tab to
+          configure additional options like <strong>Webhook trigger</strong> —
+          enable it to generate a secret URL that fires a run via HTTP POST. No
+          auth header is needed; the secret in the URL is the credential.
+        </P>
       </Section>
 
       <Section>
@@ -315,10 +315,11 @@ export function AutomationsContent() {
           <li>
             <strong>Discovery &amp; messaging</strong> —{" "}
             <Code>list_agents</Code>, <Code>dispatch_send_message</Code>,{" "}
-            <Code>list_personas</Code>, <Code>list_recent_persona_reviews</Code>
-            , <Code>list_recent_feedback</Code>,{" "}
-            <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,
-            and <Code>get_feedback_summary</Code> let a job sweep over recent
+            <Code>dispatch_launch_agent</Code>, <Code>list_personas</Code>,{" "}
+            <Code>list_recent_persona_reviews</Code>,{" "}
+            <Code>list_recent_feedback</Code>, <Code>get_activity_summary</Code>
+            , <Code>get_agent_history</Code>, and{" "}
+            <Code>get_feedback_summary</Code> let a job sweep over recent
             activity, coordinate with other agents, or post a summary.
           </li>
           <li>


### PR DESCRIPTION
## Summary
- Moved **Webhook trigger** from the "Creating a job" basic fields list to a post-creation Settings tab note — the toggle only exists in `jobs-settings-tab.tsx`, not in `jobs-add-dialog.tsx`
- Added `dispatch_launch_agent` to the job tools "Discovery & messaging" list to match `JOB_TOOLS` in `server.ts`

## Audit scope
Deep-dive of the Automations section in `docs-pane.tsx` (`docs-sections/automations.tsx`):
- Verified all template form fields against `automations-form-fields.tsx` and `automations-create-dialog.tsx`
- Verified all job create fields against `jobs-add-dialog.tsx`
- Verified job settings fields against `jobs-settings-tab.tsx`
- Verified job tools list against `JOB_TOOLS` in `apps/server/src/shared/mcp/server.ts`
- Verified run statuses, trigger sources, history tab columns, and prompt preamble
- Verified template launch dialog, runtime arguments, and the Automations UI tabs

## Deferred
Next run will audit the Notifications section against `notification-settings.tsx` and the notification subsystem routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)