### PR TITLE
Fix duplicate sidebar reorder tip

### DIFF
--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -131,14 +131,6 @@ export const tips: Tip[] = [
     surfaces: ["ambient"],
   },
   {
-    id: "sidebar-reorder",
-    title: "Reorder Agents",
-    body: "Drag and drop agent cards in the sidebar to reorder them. You can also focus a card and press Alt+↑ or Alt+↓.",
-    docsSection: "agents",
-    since: "0.24.2",
-    surfaces: ["ambient"],
-  },
-  {
     id: "worktrees",
     title: "Worktrees",
     body: "Each agent gets its own git worktree by default — isolated branches, no conflicts. Run multiple agents in parallel on the same repo.",


### PR DESCRIPTION
## Summary
- Remove the older duplicate `sidebar-reorder` tip entry so tip IDs are unique
- Keep the newer sidebar reorder tip copy that mentions persistence

## Verification
- `pnpm vitest run apps/web/src/lib/tips/__tests__/tips.test.ts`
- `pnpm run check`
- `pnpm run finalize:web`
- `pnpm run test:e2e` (`172 passed`, `12 skipped`)