### PR TITLE
Refactor create-agent-dialog: extract hook and type select

### DIFF
--- a/apps/web/src/components/app/agent-type-select.tsx
+++ b/apps/web/src/components/app/agent-type-select.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { useClickOutside } from "@/hooks/use-click-outside";
+import {
+  AGENT_TYPE_LABELS,
+  type AgentType,
+  sortAgentTypes,
+} from "@/lib/agent-types";
+import { cn } from "@/lib/utils";
+
+type AgentTypeSelectProps = {
+  value: AgentType;
+  onChange: (type: AgentType) => void;
+  agentTypes: AgentType[];
+  onOpenChange?: (open: boolean) => void;
+};
+
+export function AgentTypeSelect({
+  value,
+  onChange,
+  agentTypes,
+  onOpenChange,
+}: AgentTypeSelectProps): JSX.Element {
+  const sortedTypes = useMemo(() => sortAgentTypes(agentTypes), [agentTypes]);
+  const [open, setOpen] = useState(false);
+  const cmdRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const updateOpen = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange]
+  );
+
+  const closeDropdown = useCallback(() => updateOpen(false), [updateOpen]);
+  useClickOutside(cmdRef, open, closeDropdown);
+
+  return (
+    <div className="relative space-y-1" ref={cmdRef}>
+      <label className="text-sm text-muted-foreground">Type</label>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => updateOpen(!open)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            if (!open) updateOpen(true);
+          }
+        }}
+        className={cn(
+          "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
+          "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
+        )}
+      >
+        {AGENT_TYPE_LABELS[value]}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
+          <Command
+            shouldFilter={false}
+            ref={(el) => {
+              if (el) requestAnimationFrame(() => el.focus());
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                updateOpen(false);
+                requestAnimationFrame(() => triggerRef.current?.focus());
+              }
+            }}
+          >
+            <CommandList>
+              <CommandGroup>
+                {sortedTypes.map((agentType) => (
+                  <CommandItem
+                    key={agentType}
+                    value={agentType}
+                    onSelect={() => {
+                      onChange(agentType);
+                      updateOpen(false);
+                      requestAnimationFrame(() => triggerRef.current?.focus());
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-3 w-3 shrink-0",
+                        agentType === value ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    {AGENT_TYPE_LABELS[agentType]}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/app/create-agent-dialog.tsx
+++ b/apps/web/src/components/app/create-agent-dialog.tsx
@@ -1,42 +1,15 @@
-import {
-  type ClipboardEvent,
-  type DragEvent,
-  type FormEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { Check, ChevronDown, ChevronLeft } from "lucide-react";
-import { toast } from "sonner";
+import { useState } from "react";
+import { ChevronLeft } from "lucide-react";
 
+import { AgentTypeSelect } from "@/components/app/agent-type-select";
 import { ContextPicker } from "@/components/app/context-picker";
-import {
-  createClipboardSuggestionFromText,
-  getClipboardFilesFromEvent,
-  startupFileKey,
-} from "@/components/app/create-agent-dialog-clipboard";
-import {
-  CONTEXT_PROMPT_ID,
-  LAST_USED_CWD_KEY,
-  LAST_USED_TYPE_KEY,
-  readLastUsedAgentType,
-  readLastUsedCwd,
-  useCwdHistory,
-  useCreateAgentPrefs,
-} from "@/components/app/create-agent-dialog-utils";
+import { CONTEXT_PROMPT_ID } from "@/components/app/create-agent-dialog-utils";
 import { WorktreeSection } from "@/components/app/create-agent-worktree-section";
 import { PathInput } from "@/components/app/path-input";
+import { useCreateAgentForm } from "@/components/app/use-create-agent-form";
 import { ActivityBars } from "@/components/ui/activity-bars";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -46,15 +19,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { type Agent } from "@/components/app/types";
-import { useClickOutside } from "@/hooks/use-click-outside";
 import { useRadixPopoverZFix } from "@/hooks/use-radix-popover-z-fix";
-import { useSystemDefaults } from "@/hooks/use-system-defaults";
-import {
-  AGENT_TYPE_LABELS,
-  type AgentType,
-  sortAgentTypes,
-} from "@/lib/agent-types";
-import { api } from "@/lib/api";
+import { type AgentType } from "@/lib/agent-types";
 import { swallowEscapeFromCombobox } from "@/lib/dialog-escape";
 import { cn } from "@/lib/utils";
 
@@ -97,312 +63,15 @@ function CreateAgentDialogContent({
   resolveDefaultCwd,
   onCreated,
 }: Omit<CreateAgentDialogProps, "open">): JSX.Element {
-  const [step, setStep] = useState<"config" | "context">("config");
-  const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
-  const [createName, setCreateName] = useState("");
-  const [createType, setCreateType] = useState<AgentType>(() => {
-    const preferred = initialAgentType ?? readLastUsedAgentType();
-    return preferred && enabledAgentTypes.includes(preferred)
-      ? preferred
-      : (enabledAgentTypes[0] ?? "codex");
-  });
-  const [createCwd, setCreateCwd] = useState(() => {
-    const resolved = resolveDefaultCwd().trim();
-    return resolved || readLastUsedCwd();
-  });
-  const [createCwdInitialized, setCreateCwdInitialized] = useState(
-    () => createCwd.trim().length > 0
-  );
-  const [createUseWorktree, setCreateUseWorktree] = useState(true);
-  const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
-  const [cwdIsGitRepo, setCwdIsGitRepo] = useState<boolean | null>(null);
-  const cwdPathInfoRef = useRef<{ isGitRepo: boolean } | null>(null);
-  const [initialPrompt, setInitialPrompt] = useState("");
-  const [startupFiles, setStartupFiles] = useState<File[]>([]);
-  const [startupLinks, setStartupLinks] = useState<string[]>([]);
-  const [draggingFiles, setDraggingFiles] = useState(false);
-  const [contextDraftInvalid, setContextDraftInvalid] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const {
-    history: cwdHistory,
-    removableHistory: removableCwdHistory,
-    historyMetadata: cwdHistoryMetadata,
-    add: addCwdHistory,
-    remove: removeCwdHistory,
-  } = useCwdHistory();
-  const {
-    fullAccess: createFullAccess,
-    setFullAccess: setCreateFullAccess,
-    autoReview: createAutoReview,
-    setAutoReview: setCreateAutoReview,
-    baseBranch: createBaseBranch,
-    setBaseBranch: setCreateBaseBranch,
-    createNewBranch,
-    setCreateNewBranch,
-  } = useCreateAgentPrefs(createCwd);
-
-  // The new-branch name is per-cwd in spirit (a branch named "repo-A-feature"
-  // doesn't make sense in repo B); clear it whenever cwd changes so a name
-  // typed for one repo doesn't leak into another.
-  useEffect(() => {
-    setCreateWorktreeBranch("");
-  }, [createCwd]);
-
-  const { data: systemDefaults, isError: systemDefaultsError } =
-    useSystemDefaults();
-  useEffect(() => {
-    if (createCwdInitialized) return;
-    if (systemDefaults) {
-      setCreateCwd(systemDefaults.homeDir);
-      setCreateCwdInitialized(true);
-    } else if (systemDefaultsError) {
-      // Seed nothing on failure, but unblock the dialog as before.
-      setCreateCwdInitialized(true);
-    }
-  }, [createCwdInitialized, systemDefaults, systemDefaultsError]);
-
-  useEffect(() => {
-    if (enabledAgentTypes.includes(createType)) return;
-    setCreateType(enabledAgentTypes[0] ?? "codex");
-  }, [createType, enabledAgentTypes]);
-
-  useEffect(() => {
-    if (step === "context") {
-      requestAnimationFrame(() => promptTextareaRef.current?.focus());
-    }
-  }, [step]);
-
-  useEffect(() => {
-    if (step !== "context") {
-      setDraggingFiles(false);
-    }
-  }, [step]);
-
-  const sortedAgentTypes = useMemo(
-    () => sortAgentTypes(enabledAgentTypes),
-    [enabledAgentTypes]
-  );
   const [typeDropdownOpen, setTypeDropdownOpen] = useState(false);
-  const typeCmdRef = useRef<HTMLDivElement>(null);
-  const typeTriggerRef = useRef<HTMLButtonElement>(null);
-  const closeTypeDropdown = useCallback(() => setTypeDropdownOpen(false), []);
-  useClickOutside(typeCmdRef, typeDropdownOpen, closeTypeDropdown);
-
-  const handlePathInfoChange = useCallback(
-    (info: { isGitRepo: boolean } | null) => {
-      cwdPathInfoRef.current = info;
-      setCwdIsGitRepo(info ? info.isGitRepo : null);
-    },
-    []
-  );
-
-  // Object URLs for image previews are tracked in a ref so they're created
-  // and revoked synchronously alongside the file list, not derived from an
-  // effect — that avoids both a one-frame paperclip→thumbnail flicker on add
-  // and unnecessary URL churn for unchanged chips on every mutation.
-  const startupFilePreviewsRef = useRef<Map<string, string>>(new Map());
-
-  const appendStartupFiles = useCallback((files: File[]) => {
-    if (files.length === 0) return;
-    setStartupFiles((current) => {
-      const next = [...current];
-      const seen = new Set(current.map(startupFileKey));
-      for (const file of files) {
-        const key = startupFileKey(file);
-        if (seen.has(key)) continue;
-        seen.add(key);
-        next.push(file);
-        if (
-          file.type.startsWith("image/") &&
-          !startupFilePreviewsRef.current.has(key)
-        ) {
-          startupFilePreviewsRef.current.set(key, URL.createObjectURL(file));
-        }
-      }
-      return next;
-    });
-  }, []);
-
-  const handleAddLink = useCallback((url: string) => {
-    setStartupLinks((current) =>
-      current.includes(url) ? current : [...current, url]
-    );
-  }, []);
-
-  const handleStartupPaste = useCallback(
-    (event: ClipboardEvent<HTMLElement>) => {
-      const target = event.target;
-      const targetIsPrompt =
-        target instanceof HTMLElement && target.id === CONTEXT_PROMPT_ID;
-      if (!targetIsPrompt) return;
-
-      const pastedFiles = getClipboardFilesFromEvent(event);
-      if (pastedFiles.length > 0) {
-        event.preventDefault();
-        appendStartupFiles(pastedFiles);
-        return;
-      }
-
-      const textSuggestion = createClipboardSuggestionFromText(
-        event.clipboardData.getData("text/plain")
-      );
-      if (textSuggestion?.kind === "url") {
-        event.preventDefault();
-        handleAddLink(textSuggestion.url);
-      }
-    },
-    [appendStartupFiles, handleAddLink]
-  );
-
-  const handleStartupDrop = useCallback(
-    (event: DragEvent<HTMLElement>) => {
-      const droppedFiles = Array.from(event.dataTransfer.files ?? []);
-      if (droppedFiles.length === 0) return;
-      event.preventDefault();
-      setDraggingFiles(false);
-      appendStartupFiles(droppedFiles);
-    },
-    [appendStartupFiles]
-  );
-
-  const handleRemoveStartupFile = useCallback((fileToRemove: File) => {
-    const key = startupFileKey(fileToRemove);
-    const url = startupFilePreviewsRef.current.get(key);
-    if (url) {
-      URL.revokeObjectURL(url);
-      startupFilePreviewsRef.current.delete(key);
-    }
-    setStartupFiles((current) =>
-      current.filter((file) => startupFileKey(file) !== key)
-    );
-  }, []);
-
-  useEffect(() => {
-    const previews = startupFilePreviewsRef.current;
-    return () => {
-      for (const url of previews.values()) {
-        URL.revokeObjectURL(url);
-      }
-      previews.clear();
-    };
-  }, []);
-
-  const handleRemoveStartupLink = useCallback((linkToRemove: string) => {
-    setStartupLinks((current) =>
-      current.filter((link) => link !== linkToRemove)
-    );
-  }, []);
-
-  const handleClipboardText = useCallback((text: string) => {
-    setInitialPrompt((current) =>
-      current.trim().length === 0 ? text : `${current.trimEnd()}\n\n${text}`
-    );
-    requestAnimationFrame(() => promptTextareaRef.current?.focus());
-  }, []);
-
-  const enterContextStep = useCallback(() => {
-    setStep("context");
-  }, []);
+  const form = useCreateAgentForm({
+    enabledAgentTypes,
+    initialAgentType,
+    resolveDefaultCwd,
+    onCreated,
+  });
 
   useRadixPopoverZFix();
-
-  const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      const cwd = createCwd.trim();
-      if (!cwd) return;
-
-      setCreating(true);
-      try {
-        // The managed-worktree section is hidden for non-git cwds; force the
-        // payload to skip worktree creation in that case so the server doesn't
-        // try to run git in a non-repo directory.
-        const latestPathInfo = cwdPathInfoRef.current;
-        const submitUseWorktree =
-          latestPathInfo?.isGitRepo === false ? false : createUseWorktree;
-        const contextInitialPrompt =
-          step === "context" ? initialPrompt.trim() || undefined : undefined;
-        const payloadBase = {
-          name: createName.trim(),
-          cwd,
-          type: createType,
-          fullAccess: createFullAccess,
-          autoReview: createAutoReview,
-          useWorktree: submitUseWorktree,
-          createNewBranch: submitUseWorktree ? createNewBranch : undefined,
-          worktreeBranch:
-            submitUseWorktree && createNewBranch
-              ? createWorktreeBranch.trim() || undefined
-              : undefined,
-          baseBranch:
-            submitUseWorktree && createBaseBranch !== "main"
-              ? createBaseBranch
-              : undefined,
-          initialPrompt: contextInitialPrompt,
-        };
-        const resolvedStartupLinks = startupLinks;
-        const useStartupContext =
-          step === "context" &&
-          (startupFiles.length > 0 || resolvedStartupLinks.length > 0);
-        const payload = useStartupContext
-          ? await (async () => {
-              const formData = new FormData();
-              for (const [key, value] of Object.entries(payloadBase)) {
-                if (value === undefined || value === "") continue;
-                formData.append(key, String(value));
-              }
-              formData.append(
-                "startupLinks",
-                JSON.stringify(resolvedStartupLinks)
-              );
-              for (const file of startupFiles) {
-                formData.append("startupFiles", file);
-              }
-              return api<{ agent: Agent }>("/api/v1/agents", {
-                method: "POST",
-                body: formData,
-              });
-            })()
-          : await api<{ agent: Agent }>("/api/v1/agents", {
-              method: "POST",
-              body: JSON.stringify(payloadBase),
-            });
-
-        if (typeof window !== "undefined") {
-          window.localStorage.setItem(LAST_USED_CWD_KEY, cwd);
-          window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
-        }
-        addCwdHistory(cwd);
-        await onCreated(payload.agent, createType);
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : "Failed to create agent.";
-        toast.error(message);
-      } finally {
-        setCreating(false);
-      }
-    },
-    [
-      createAutoReview,
-      createBaseBranch,
-      createCwd,
-      createFullAccess,
-      createName,
-      createNewBranch,
-      createType,
-      createUseWorktree,
-      createWorktreeBranch,
-      initialPrompt,
-      addCwdHistory,
-      onCreated,
-      startupFiles,
-      startupLinks,
-      step,
-    ]
-  );
-
-  const worktreeAvailable = cwdIsGitRepo === true;
-  const worktreeChecked = worktreeAvailable && createUseWorktree;
 
   return (
     <DialogContent
@@ -412,13 +81,13 @@ function CreateAgentDialogContent({
         if (typeDropdownOpen) {
           e.preventDefault();
         }
-        if (step === "context") {
+        if (form.step === "context") {
           e.preventDefault();
-          setStep("config");
+          form.setStep("config");
         }
       }}
     >
-      {step === "config" ? (
+      {form.step === "config" ? (
         <>
           <DialogHeader>
             <DialogTitle>Create Agent</DialogTitle>
@@ -430,97 +99,23 @@ function CreateAgentDialogContent({
           <form
             data-testid="create-agent-form"
             className="flex min-h-0 flex-col"
-            onSubmit={(event) => void handleSubmit(event)}
+            onSubmit={(event) => void form.handleSubmit(event)}
           >
             <div className="min-h-0 flex-1 overflow-y-auto px-1">
               <div className="space-y-3">
-                <div className="relative space-y-1" ref={typeCmdRef}>
-                  <label className="text-sm text-muted-foreground">Type</label>
-                  <button
-                    ref={typeTriggerRef}
-                    type="button"
-                    role="combobox"
-                    tabIndex={0}
-                    aria-expanded={typeDropdownOpen}
-                    onClick={() => setTypeDropdownOpen((prev) => !prev)}
-                    onKeyDown={(e) => {
-                      if (
-                        e.key === "ArrowDown" ||
-                        e.key === "Enter" ||
-                        e.key === " "
-                      ) {
-                        e.preventDefault();
-                        if (!typeDropdownOpen) setTypeDropdownOpen(true);
-                      }
-                    }}
-                    className={cn(
-                      "flex h-9 w-full items-center justify-between rounded-md border border-white/[0.12] bg-white/[0.04] px-3 py-2 text-sm shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] backdrop-blur-md",
-                      "ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
-                    )}
-                  >
-                    {AGENT_TYPE_LABELS[createType]}
-                    <ChevronDown
-                      className={cn(
-                        "h-4 w-4 text-muted-foreground transition-transform",
-                        typeDropdownOpen && "rotate-180"
-                      )}
-                    />
-                  </button>
-                  {typeDropdownOpen ? (
-                    <div className="absolute left-0 right-0 z-[80] mt-1 rounded-md border border-white/[0.2] bg-[hsl(var(--card))] shadow-[0_16px_64px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.15)] backdrop-blur-2xl">
-                      <Command
-                        shouldFilter={false}
-                        ref={(el) => {
-                          if (el) requestAnimationFrame(() => el.focus());
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === "Escape") {
-                            e.preventDefault();
-                            setTypeDropdownOpen(false);
-                            requestAnimationFrame(() =>
-                              typeTriggerRef.current?.focus()
-                            );
-                          }
-                        }}
-                      >
-                        <CommandList>
-                          <CommandGroup>
-                            {sortedAgentTypes.map((agentType) => (
-                              <CommandItem
-                                key={agentType}
-                                value={agentType}
-                                onSelect={() => {
-                                  setCreateType(agentType);
-                                  setTypeDropdownOpen(false);
-                                  requestAnimationFrame(() =>
-                                    typeTriggerRef.current?.focus()
-                                  );
-                                }}
-                              >
-                                <Check
-                                  className={cn(
-                                    "mr-2 h-3 w-3 shrink-0",
-                                    agentType === createType
-                                      ? "opacity-100"
-                                      : "opacity-0"
-                                  )}
-                                />
-                                {AGENT_TYPE_LABELS[agentType]}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </div>
-                  ) : null}
-                </div>
+                <AgentTypeSelect
+                  value={form.createType}
+                  onChange={form.setCreateType}
+                  agentTypes={enabledAgentTypes}
+                  onOpenChange={setTypeDropdownOpen}
+                />
 
                 <div className="space-y-1">
                   <label className="text-sm text-muted-foreground">Name</label>
                   <Input
                     autoFocus
-                    value={createName}
-                    onChange={(event) => setCreateName(event.target.value)}
+                    value={form.createName}
+                    onChange={(event) => form.setCreateName(event.target.value)}
                     placeholder="agent name"
                     data-testid="create-agent-name"
                   />
@@ -531,39 +126,39 @@ function CreateAgentDialogContent({
                 </div>
 
                 <PathInput
-                  value={createCwd}
-                  onChange={setCreateCwd}
+                  value={form.createCwd}
+                  onChange={form.setCreateCwd}
                   label="Working directory"
-                  history={cwdHistory}
-                  removableHistory={removableCwdHistory}
-                  historyMetadata={cwdHistoryMetadata}
-                  onRemoveHistory={removeCwdHistory}
-                  onPathInfoChange={handlePathInfoChange}
+                  history={form.cwdHistory}
+                  removableHistory={form.removableCwdHistory}
+                  historyMetadata={form.cwdHistoryMetadata}
+                  onRemoveHistory={form.removeCwdHistory}
+                  onPathInfoChange={form.handlePathInfoChange}
                   data-testid="create-agent-cwd"
                   historyItemTestId="create-agent-cwd-history-option"
                 />
 
                 <WorktreeSection
-                  cwd={createCwd}
-                  worktreeAvailable={worktreeAvailable}
-                  worktreeChecked={worktreeChecked}
-                  useWorktree={createUseWorktree}
-                  onUseWorktreeChange={setCreateUseWorktree}
-                  baseBranch={createBaseBranch}
-                  onBaseBranchChange={setCreateBaseBranch}
-                  worktreeBranch={createWorktreeBranch}
-                  onWorktreeBranchChange={setCreateWorktreeBranch}
-                  createNewBranch={createNewBranch}
-                  onCreateNewBranchChange={setCreateNewBranch}
+                  cwd={form.createCwd}
+                  worktreeAvailable={form.worktreeAvailable}
+                  worktreeChecked={form.worktreeChecked}
+                  useWorktree={form.createUseWorktree}
+                  onUseWorktreeChange={form.setCreateUseWorktree}
+                  baseBranch={form.createBaseBranch}
+                  onBaseBranchChange={form.setCreateBaseBranch}
+                  worktreeBranch={form.createWorktreeBranch}
+                  onWorktreeBranchChange={form.setCreateWorktreeBranch}
+                  createNewBranch={form.createNewBranch}
+                  onCreateNewBranchChange={form.setCreateNewBranch}
                 />
 
-                {createType !== "terminal" ? (
+                {form.createType !== "terminal" ? (
                   <>
                     <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
                       <Checkbox
-                        checked={createFullAccess}
+                        checked={form.createFullAccess}
                         onCheckedChange={() =>
-                          setCreateFullAccess((current) => !current)
+                          form.setCreateFullAccess((current) => !current)
                         }
                         className="mt-0.5"
                         title="Toggle full access"
@@ -581,9 +176,9 @@ function CreateAgentDialogContent({
 
                     <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3">
                       <Checkbox
-                        checked={createAutoReview}
+                        checked={form.createAutoReview}
                         onCheckedChange={() =>
-                          setCreateAutoReview((current) => !current)
+                          form.setCreateAutoReview((current) => !current)
                         }
                         className="mt-0.5"
                         title="Toggle autonomous review"
@@ -613,14 +208,14 @@ function CreateAgentDialogContent({
               >
                 Cancel
               </Button>
-              {createType !== "terminal" ? (
+              {form.createType !== "terminal" ? (
                 <Button
                   type="button"
                   variant="default"
                   tabIndex={0}
-                  disabled={creating || !createCwd.trim()}
+                  disabled={form.creating || !form.createCwd.trim()}
                   data-testid="create-agent-with-context"
-                  onClick={enterContextStep}
+                  onClick={form.enterContextStep}
                 >
                   Create with context
                 </Button>
@@ -629,10 +224,10 @@ function CreateAgentDialogContent({
                 type="submit"
                 variant="primary"
                 tabIndex={0}
-                disabled={creating}
+                disabled={form.creating}
                 data-testid="create-agent-submit"
               >
-                {creating ? (
+                {form.creating ? (
                   <ActivityBars size={16} className="mr-1.5" />
                 ) : null}
                 Create
@@ -653,11 +248,11 @@ function CreateAgentDialogContent({
           <form
             data-testid="create-agent-context-form"
             className="flex min-h-0 flex-1 flex-col"
-            onSubmit={(event) => void handleSubmit(event)}
+            onSubmit={(event) => void form.handleSubmit(event)}
             onDragOver={(event) => {
               if (event.dataTransfer.types.includes("Files")) {
                 event.preventDefault();
-                setDraggingFiles(true);
+                form.setDraggingFiles(true);
               }
             }}
             onDragLeave={(event) => {
@@ -666,9 +261,9 @@ function CreateAgentDialogContent({
               ) {
                 return;
               }
-              setDraggingFiles(false);
+              form.setDraggingFiles(false);
             }}
-            onDrop={handleStartupDrop}
+            onDrop={form.handleStartupDrop}
           >
             <div
               className={cn(
@@ -685,10 +280,12 @@ function CreateAgentDialogContent({
                   </label>
                   <textarea
                     id={CONTEXT_PROMPT_ID}
-                    ref={promptTextareaRef}
-                    value={initialPrompt}
-                    onChange={(event) => setInitialPrompt(event.target.value)}
-                    onPaste={handleStartupPaste}
+                    ref={form.promptTextareaRef}
+                    value={form.initialPrompt}
+                    onChange={(event) =>
+                      form.setInitialPrompt(event.target.value)
+                    }
+                    onPaste={form.handleStartupPaste}
                     placeholder="Enter instructions for the agent..."
                     data-testid="create-agent-initial-prompt"
                     className={cn(
@@ -700,16 +297,16 @@ function CreateAgentDialogContent({
                 </div>
 
                 <ContextPicker
-                  files={startupFiles}
-                  links={startupLinks}
-                  draggingFiles={draggingFiles}
-                  filePreviewsRef={startupFilePreviewsRef}
-                  onAppendFiles={appendStartupFiles}
-                  onRemoveFile={handleRemoveStartupFile}
-                  onAddLink={handleAddLink}
-                  onRemoveLink={handleRemoveStartupLink}
-                  onClipboardText={handleClipboardText}
-                  onDraftInvalid={setContextDraftInvalid}
+                  files={form.startupFiles}
+                  links={form.startupLinks}
+                  draggingFiles={form.draggingFiles}
+                  filePreviewsRef={form.startupFilePreviewsRef}
+                  onAppendFiles={form.appendStartupFiles}
+                  onRemoveFile={form.handleRemoveStartupFile}
+                  onAddLink={form.handleAddLink}
+                  onRemoveLink={form.handleRemoveStartupLink}
+                  onClipboardText={form.handleClipboardText}
+                  onDraftInvalid={form.setContextDraftInvalid}
                   testIdPrefix="create-agent-context"
                 />
               </div>
@@ -721,7 +318,7 @@ function CreateAgentDialogContent({
                 variant="ghost"
                 tabIndex={0}
                 className="min-h-11 px-3"
-                onClick={() => setStep("config")}
+                onClick={() => form.setStep("config")}
                 data-testid="create-agent-context-back"
               >
                 <ChevronLeft className="mr-1 h-4 w-4" />
@@ -742,10 +339,10 @@ function CreateAgentDialogContent({
                   variant="primary"
                   tabIndex={0}
                   className="min-h-11 px-3"
-                  disabled={creating || contextDraftInvalid}
+                  disabled={form.creating || form.contextDraftInvalid}
                   data-testid="create-agent-context-submit"
                 >
-                  {creating ? (
+                  {form.creating ? (
                     <ActivityBars size={16} className="mr-1.5" />
                   ) : null}
                   Create

--- a/apps/web/src/components/app/use-create-agent-form.ts
+++ b/apps/web/src/components/app/use-create-agent-form.ts
@@ -1,0 +1,377 @@
+import {
+  type ClipboardEvent,
+  type DragEvent,
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { toast } from "sonner";
+
+import {
+  createClipboardSuggestionFromText,
+  getClipboardFilesFromEvent,
+  startupFileKey,
+} from "@/components/app/create-agent-dialog-clipboard";
+import {
+  CONTEXT_PROMPT_ID,
+  LAST_USED_CWD_KEY,
+  LAST_USED_TYPE_KEY,
+  readLastUsedAgentType,
+  readLastUsedCwd,
+  useCwdHistory,
+  useCreateAgentPrefs,
+} from "@/components/app/create-agent-dialog-utils";
+import { type Agent } from "@/components/app/types";
+import { useSystemDefaults } from "@/hooks/use-system-defaults";
+import { type AgentType } from "@/lib/agent-types";
+import { api } from "@/lib/api";
+
+type UseCreateAgentFormOptions = {
+  enabledAgentTypes: AgentType[];
+  initialAgentType: AgentType | null;
+  resolveDefaultCwd: () => string;
+  onCreated: (agent: Agent, agentType: AgentType) => Promise<void>;
+};
+
+export function useCreateAgentForm({
+  enabledAgentTypes,
+  initialAgentType,
+  resolveDefaultCwd,
+  onCreated,
+}: UseCreateAgentFormOptions) {
+  const [step, setStep] = useState<"config" | "context">("config");
+  const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const [createName, setCreateName] = useState("");
+  const [createType, setCreateType] = useState<AgentType>(() => {
+    const preferred = initialAgentType ?? readLastUsedAgentType();
+    return preferred && enabledAgentTypes.includes(preferred)
+      ? preferred
+      : (enabledAgentTypes[0] ?? "codex");
+  });
+  const [createCwd, setCreateCwd] = useState(() => {
+    const resolved = resolveDefaultCwd().trim();
+    return resolved || readLastUsedCwd();
+  });
+  const [createCwdInitialized, setCreateCwdInitialized] = useState(
+    () => createCwd.trim().length > 0
+  );
+  const [createUseWorktree, setCreateUseWorktree] = useState(true);
+  const [createWorktreeBranch, setCreateWorktreeBranch] = useState("");
+  const [cwdIsGitRepo, setCwdIsGitRepo] = useState<boolean | null>(null);
+  const cwdPathInfoRef = useRef<{ isGitRepo: boolean } | null>(null);
+  const [initialPrompt, setInitialPrompt] = useState("");
+  const [startupFiles, setStartupFiles] = useState<File[]>([]);
+  const [startupLinks, setStartupLinks] = useState<string[]>([]);
+  const [draggingFiles, setDraggingFiles] = useState(false);
+  const [contextDraftInvalid, setContextDraftInvalid] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const {
+    history: cwdHistory,
+    removableHistory: removableCwdHistory,
+    historyMetadata: cwdHistoryMetadata,
+    add: addCwdHistory,
+    remove: removeCwdHistory,
+  } = useCwdHistory();
+  const {
+    fullAccess: createFullAccess,
+    setFullAccess: setCreateFullAccess,
+    autoReview: createAutoReview,
+    setAutoReview: setCreateAutoReview,
+    baseBranch: createBaseBranch,
+    setBaseBranch: setCreateBaseBranch,
+    createNewBranch,
+    setCreateNewBranch,
+  } = useCreateAgentPrefs(createCwd);
+
+  useEffect(() => {
+    setCreateWorktreeBranch("");
+  }, [createCwd]);
+
+  const { data: systemDefaults, isError: systemDefaultsError } =
+    useSystemDefaults();
+  useEffect(() => {
+    if (createCwdInitialized) return;
+    if (systemDefaults) {
+      setCreateCwd(systemDefaults.homeDir);
+      setCreateCwdInitialized(true);
+    } else if (systemDefaultsError) {
+      setCreateCwdInitialized(true);
+    }
+  }, [createCwdInitialized, systemDefaults, systemDefaultsError]);
+
+  useEffect(() => {
+    if (enabledAgentTypes.includes(createType)) return;
+    setCreateType(enabledAgentTypes[0] ?? "codex");
+  }, [createType, enabledAgentTypes]);
+
+  useEffect(() => {
+    if (step === "context") {
+      requestAnimationFrame(() => promptTextareaRef.current?.focus());
+    }
+  }, [step]);
+
+  useEffect(() => {
+    if (step !== "context") {
+      setDraggingFiles(false);
+    }
+  }, [step]);
+
+  const handlePathInfoChange = useCallback(
+    (info: { isGitRepo: boolean } | null) => {
+      cwdPathInfoRef.current = info;
+      setCwdIsGitRepo(info ? info.isGitRepo : null);
+    },
+    []
+  );
+
+  const startupFilePreviewsRef = useRef<Map<string, string>>(new Map());
+
+  const appendStartupFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+    setStartupFiles((current) => {
+      const next = [...current];
+      const seen = new Set(current.map(startupFileKey));
+      for (const file of files) {
+        const key = startupFileKey(file);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        next.push(file);
+        if (
+          file.type.startsWith("image/") &&
+          !startupFilePreviewsRef.current.has(key)
+        ) {
+          startupFilePreviewsRef.current.set(key, URL.createObjectURL(file));
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const handleAddLink = useCallback((url: string) => {
+    setStartupLinks((current) =>
+      current.includes(url) ? current : [...current, url]
+    );
+  }, []);
+
+  const handleStartupPaste = useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      const target = event.target;
+      const targetIsPrompt =
+        target instanceof HTMLElement && target.id === CONTEXT_PROMPT_ID;
+      if (!targetIsPrompt) return;
+
+      const pastedFiles = getClipboardFilesFromEvent(event);
+      if (pastedFiles.length > 0) {
+        event.preventDefault();
+        appendStartupFiles(pastedFiles);
+        return;
+      }
+
+      const textSuggestion = createClipboardSuggestionFromText(
+        event.clipboardData.getData("text/plain")
+      );
+      if (textSuggestion?.kind === "url") {
+        event.preventDefault();
+        handleAddLink(textSuggestion.url);
+      }
+    },
+    [appendStartupFiles, handleAddLink]
+  );
+
+  const handleStartupDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      const droppedFiles = Array.from(event.dataTransfer.files ?? []);
+      if (droppedFiles.length === 0) return;
+      event.preventDefault();
+      setDraggingFiles(false);
+      appendStartupFiles(droppedFiles);
+    },
+    [appendStartupFiles]
+  );
+
+  const handleRemoveStartupFile = useCallback((fileToRemove: File) => {
+    const key = startupFileKey(fileToRemove);
+    const url = startupFilePreviewsRef.current.get(key);
+    if (url) {
+      URL.revokeObjectURL(url);
+      startupFilePreviewsRef.current.delete(key);
+    }
+    setStartupFiles((current) =>
+      current.filter((file) => startupFileKey(file) !== key)
+    );
+  }, []);
+
+  useEffect(() => {
+    const previews = startupFilePreviewsRef.current;
+    return () => {
+      for (const url of previews.values()) {
+        URL.revokeObjectURL(url);
+      }
+      previews.clear();
+    };
+  }, []);
+
+  const handleRemoveStartupLink = useCallback((linkToRemove: string) => {
+    setStartupLinks((current) =>
+      current.filter((link) => link !== linkToRemove)
+    );
+  }, []);
+
+  const handleClipboardText = useCallback((text: string) => {
+    setInitialPrompt((current) =>
+      current.trim().length === 0 ? text : `${current.trimEnd()}\n\n${text}`
+    );
+    requestAnimationFrame(() => promptTextareaRef.current?.focus());
+  }, []);
+
+  const enterContextStep = useCallback(() => {
+    setStep("context");
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const cwd = createCwd.trim();
+      if (!cwd) return;
+
+      setCreating(true);
+      try {
+        const latestPathInfo = cwdPathInfoRef.current;
+        const submitUseWorktree =
+          latestPathInfo?.isGitRepo === false ? false : createUseWorktree;
+        const contextInitialPrompt =
+          step === "context" ? initialPrompt.trim() || undefined : undefined;
+        const payloadBase = {
+          name: createName.trim(),
+          cwd,
+          type: createType,
+          fullAccess: createFullAccess,
+          autoReview: createAutoReview,
+          useWorktree: submitUseWorktree,
+          createNewBranch: submitUseWorktree ? createNewBranch : undefined,
+          worktreeBranch:
+            submitUseWorktree && createNewBranch
+              ? createWorktreeBranch.trim() || undefined
+              : undefined,
+          baseBranch:
+            submitUseWorktree && createBaseBranch !== "main"
+              ? createBaseBranch
+              : undefined,
+          initialPrompt: contextInitialPrompt,
+        };
+        const resolvedStartupLinks = startupLinks;
+        const useStartupContext =
+          step === "context" &&
+          (startupFiles.length > 0 || resolvedStartupLinks.length > 0);
+        const payload = useStartupContext
+          ? await (async () => {
+              const formData = new FormData();
+              for (const [key, value] of Object.entries(payloadBase)) {
+                if (value === undefined || value === "") continue;
+                formData.append(key, String(value));
+              }
+              formData.append(
+                "startupLinks",
+                JSON.stringify(resolvedStartupLinks)
+              );
+              for (const file of startupFiles) {
+                formData.append("startupFiles", file);
+              }
+              return api<{ agent: Agent }>("/api/v1/agents", {
+                method: "POST",
+                body: formData,
+              });
+            })()
+          : await api<{ agent: Agent }>("/api/v1/agents", {
+              method: "POST",
+              body: JSON.stringify(payloadBase),
+            });
+
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(LAST_USED_CWD_KEY, cwd);
+          window.localStorage.setItem(LAST_USED_TYPE_KEY, createType);
+        }
+        addCwdHistory(cwd);
+        await onCreated(payload.agent, createType);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to create agent.";
+        toast.error(message);
+      } finally {
+        setCreating(false);
+      }
+    },
+    [
+      createAutoReview,
+      createBaseBranch,
+      createCwd,
+      createFullAccess,
+      createName,
+      createNewBranch,
+      createType,
+      createUseWorktree,
+      createWorktreeBranch,
+      initialPrompt,
+      addCwdHistory,
+      onCreated,
+      startupFiles,
+      startupLinks,
+      step,
+    ]
+  );
+
+  const worktreeAvailable = cwdIsGitRepo === true;
+  const worktreeChecked = worktreeAvailable && createUseWorktree;
+
+  return {
+    step,
+    setStep,
+    promptTextareaRef,
+    createName,
+    setCreateName,
+    createType,
+    setCreateType,
+    createCwd,
+    setCreateCwd,
+    createUseWorktree,
+    setCreateUseWorktree,
+    createWorktreeBranch,
+    setCreateWorktreeBranch,
+    initialPrompt,
+    setInitialPrompt,
+    startupFiles,
+    startupLinks,
+    draggingFiles,
+    setDraggingFiles,
+    contextDraftInvalid,
+    setContextDraftInvalid,
+    creating,
+    createFullAccess,
+    setCreateFullAccess,
+    createAutoReview,
+    setCreateAutoReview,
+    createBaseBranch,
+    setCreateBaseBranch,
+    createNewBranch,
+    setCreateNewBranch,
+    cwdHistory,
+    removableCwdHistory,
+    cwdHistoryMetadata,
+    removeCwdHistory,
+    worktreeAvailable,
+    worktreeChecked,
+    startupFilePreviewsRef,
+    handlePathInfoChange,
+    appendStartupFiles,
+    handleAddLink,
+    handleStartupPaste,
+    handleStartupDrop,
+    handleRemoveStartupFile,
+    handleRemoveStartupLink,
+    handleClipboardText,
+    enterContextStep,
+    handleSubmit,
+  };
+}


### PR DESCRIPTION
## Summary

- Extracted `use-create-agent-form.ts` (377 lines) — all form state, effects, callbacks, and the submit handler moved into a custom hook
- Extracted `agent-type-select.tsx` (119 lines) — self-contained agent type dropdown combobox with its own open/close state management
- `create-agent-dialog.tsx` reduced from 760 → 357 lines, now a thin render shell

## Why this was a candidate

The create-agent dialog had 760 lines with 15+ useState hooks, 6 useEffect hooks, 9 useCallback handlers, and a complex submit handler — all mixed with a two-step form JSX. The hook extraction separates logic from presentation; the type select extracts a self-contained UI widget.

## New file structure

```
create-agent-dialog.tsx          357 lines  (was 760) — render shell
use-create-agent-form.ts         377 lines  (new)     — form logic hook
agent-type-select.tsx            119 lines  (new)     — type dropdown
create-agent-dialog-utils.ts     (unchanged)          — prefs, cwd history
create-agent-dialog-clipboard.ts (unchanged)          — clipboard helpers
create-agent-worktree-section.tsx (unchanged)          — worktree UI
```

## Next run

The next componentizer run will tackle `feedback-panel.tsx` (660 lines).

## Test plan

- [x] `pnpm run finalize:web` — type check + production build pass
- [x] `pnpm run test:e2e` — all 172 tests pass (12 terminal-live skipped as expected)
- [x] Pre-commit hooks (prettier, eslint, tsc) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)