### PR TITLE
Add MCP tools for review feedback resolution

### DIFF
--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -55,6 +55,8 @@ type McpRouteDeps = {
   mcpLaunchAgent: unknown;
   mcpGetFeedback: unknown;
   mcpResolveFeedback: unknown;
+  mcpResolveReviewFeedback: unknown;
+  mcpAddReviewThreadMessage: unknown;
   mcpSubmitResolution: unknown;
   mcpCancelRecheck: unknown;
   mcpUpsertPin: unknown;
@@ -212,6 +214,8 @@ export async function registerMcpRoutes(
       launchAgent: deps.mcpLaunchAgent,
       getFeedback: deps.mcpGetFeedback,
       resolveFeedback: deps.mcpResolveFeedback,
+      resolveReviewFeedback: deps.mcpResolveReviewFeedback,
+      addReviewThreadMessage: deps.mcpAddReviewThreadMessage,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
       sendMessage: deps.mcpSendMessage,
@@ -295,6 +299,8 @@ export async function registerMcpRoutes(
       launchAgent: deps.mcpLaunchAgent,
       getFeedback: deps.mcpGetFeedback,
       resolveFeedback: deps.mcpResolveFeedback,
+      resolveReviewFeedback: deps.mcpResolveReviewFeedback,
+      addReviewThreadMessage: deps.mcpAddReviewThreadMessage,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
       sendMessage: deps.mcpSendMessage,

--- a/apps/server/src/routes/reviews.ts
+++ b/apps/server/src/routes/reviews.ts
@@ -200,8 +200,18 @@ export async function registerReviewRoutes(
         }
       }
       notifLines.push("");
+      notifLines.push("How to handle this review:");
       notifLines.push(
-        "Review each item above and address the feedback in your code."
+        "1. Read each feedback item. For each one, decide whether to fix it, push back, or dismiss it."
+      );
+      notifLines.push(
+        "2. If you have a question or want to explain your approach before acting, use dispatch_add_review_message to reply on that item's thread."
+      );
+      notifLines.push(
+        "3. After addressing an item (or deciding not to), call dispatch_resolve_review_feedback to mark it as fixed, ignored, or wont_fix. Include a note when dismissing so the reviewer understands why."
+      );
+      notifLines.push(
+        "4. Work through all items — the review status updates automatically as you resolve each one."
       );
       notifLines.push("--- END ---");
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -482,6 +482,8 @@ async function registerRoutes() {
     mcpLaunchAgent: mcpHandlers.launchAgent,
     mcpGetFeedback: mcpHandlers.getFeedback,
     mcpResolveFeedback: mcpHandlers.resolveFeedback,
+    mcpResolveReviewFeedback: mcpHandlers.resolveReviewFeedback,
+    mcpAddReviewThreadMessage: mcpHandlers.addReviewThreadMessage,
     mcpSubmitResolution: mcpHandlers.submitResolution,
     mcpCancelRecheck: mcpHandlers.cancelRecheck,
     mcpSendMessage: mcpHandlers.sendMessage,

--- a/apps/server/src/server/mcp-review-handlers.ts
+++ b/apps/server/src/server/mcp-review-handlers.ts
@@ -37,6 +37,10 @@ import {
 import { getPrStatus } from "../shared/github/pr.js";
 import { resolveHeadSha } from "../shared/git/worktree.js";
 import { runCommand } from "../shared/lib/run-command.js";
+import {
+  resolveReviewFeedbackItem,
+  addThreadMessage,
+} from "../agents/reviews.js";
 import type {
   ParentContextResult,
   RecheckContextResult,
@@ -305,6 +309,94 @@ export function createReviewHandlers(deps: CreateReviewHandlersDeps) {
         gitDiffCommand: compareRange ? `git diff ${compareRange}` : null,
         submittedAt: resolution?.submittedAt ?? null,
         resolutions,
+      };
+    },
+
+    async resolveReviewFeedback(
+      agentId: string,
+      itemId: number,
+      resolution: "fixed" | "ignored" | "wont_fix",
+      opts: { note?: string | null } = {}
+    ): Promise<{
+      item: {
+        id: number;
+        reviewId: number;
+        status: string;
+        resolution: string;
+      };
+      reviewStatus: string;
+    }> {
+      const result = await resolveReviewFeedbackItem(
+        pool,
+        itemId,
+        agentId,
+        resolution,
+        { note: opts.note ?? null, resolvedBy: agentId }
+      );
+      if (!result) {
+        throw new Error(
+          `Review feedback item #${itemId} not found or not owned by this agent.`
+        );
+      }
+      publishUiEvent({
+        type: "review_feedback.updated",
+        agentId,
+        feedbackItemId: itemId,
+      });
+      publishUiEvent({
+        type: "review.updated",
+        agentId,
+        reviewId: result.reviewId,
+        status: result.reviewStatus,
+      });
+      return {
+        item: {
+          id: result.item.id,
+          reviewId: result.reviewId,
+          status: result.item.status,
+          resolution: result.item.resolution!,
+        },
+        reviewStatus: result.reviewStatus,
+      };
+    },
+
+    async addReviewThreadMessage(
+      agentId: string,
+      itemId: number,
+      body: string
+    ): Promise<{
+      message: {
+        id: number;
+        feedbackItemId: number;
+        content: { body: string };
+      };
+      reviewId: number;
+    }> {
+      const result = await addThreadMessage(
+        pool,
+        itemId,
+        agentId,
+        "agent",
+        body,
+        agentId
+      );
+      if (!result) {
+        throw new Error(
+          `Review feedback item #${itemId} not found or not owned by this agent.`
+        );
+      }
+      publishUiEvent({
+        type: "review_feedback.updated",
+        agentId,
+        feedbackItemId: itemId,
+      });
+      return {
+        message: {
+          id: result.message.id,
+          feedbackItemId: result.message.feedbackItemId,
+          content: result.message.content,
+        },
+        reviewId: result.reviewId,
       };
     },
 

--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -22,6 +22,8 @@ export type PersonaInteractionCallbacks = {
   launchPersona?: McpRequestContext["launchPersona"];
   getFeedback?: McpRequestContext["getFeedback"];
   resolveFeedback?: McpRequestContext["resolveFeedback"];
+  resolveReviewFeedback?: McpRequestContext["resolveReviewFeedback"];
+  addReviewThreadMessage?: McpRequestContext["addReviewThreadMessage"];
   submitResolution?: McpRequestContext["submitResolution"];
 };
 
@@ -236,6 +238,110 @@ export function registerPersonaInteractionTools(
               {
                 type: "text",
                 text: `Feedback #${result.id} marked as ${result.status}.`,
+              },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_resolve_review_feedback ──────────────────────────────
+  if (
+    allowed.has("dispatch_resolve_review_feedback") &&
+    callbacks.resolveReviewFeedback
+  ) {
+    const resolveReviewFeedback = callbacks.resolveReviewFeedback;
+
+    server.registerTool(
+      "dispatch_resolve_review_feedback",
+      {
+        description:
+          "Resolve a human review feedback item. Marks the item as fixed, dismissed, or wont_fix. The parent review status is automatically recomputed (open → partially_resolved → resolved).",
+        inputSchema: {
+          itemId: z
+            .number()
+            .int()
+            .positive()
+            .describe("The ID of the review feedback item to resolve."),
+          resolution: z
+            .enum(["fixed", "ignored", "wont_fix"])
+            .describe(
+              "Resolution type: 'fixed' if addressed, 'ignored' if not applicable, 'wont_fix' if acknowledged but intentionally left."
+            ),
+          note: z
+            .string()
+            .max(10_000)
+            .optional()
+            .describe(
+              "Optional note explaining the resolution. Encouraged for 'dismissed' and 'wont_fix'."
+            ),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await resolveReviewFeedback(
+            agentId,
+            args.itemId,
+            args.resolution,
+            { note: args.note ?? null }
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Review feedback #${result.item.id} marked as ${args.resolution}. Review status: ${result.reviewStatus}.`,
+              },
+            ],
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_add_review_message ─────────────────────────────────
+  if (
+    allowed.has("dispatch_add_review_message") &&
+    callbacks.addReviewThreadMessage
+  ) {
+    const addReviewThreadMessage = callbacks.addReviewThreadMessage;
+
+    server.registerTool(
+      "dispatch_add_review_message",
+      {
+        description:
+          "Add a message to a review feedback item's thread. Use this to reply to a human review comment — for example, to ask a clarifying question or explain your approach before resolving.",
+        inputSchema: {
+          itemId: z
+            .number()
+            .int()
+            .positive()
+            .describe(
+              "The ID of the review feedback item to add a message to."
+            ),
+          body: z
+            .string()
+            .min(1)
+            .max(50_000)
+            .describe("The message body (plain text or markdown)."),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await addReviewThreadMessage(
+            agentId,
+            args.itemId,
+            args.body
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message added to review feedback #${args.itemId} (message #${result.message.id}).`,
               },
             ],
           };

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -139,6 +139,8 @@ const JOB_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
+  "dispatch_resolve_review_feedback",
+  "dispatch_add_review_message",
   "dispatch_submit_resolution",
   "dispatch_cancel_recheck",
   "job_complete",

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -93,6 +93,8 @@ const AGENT_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
+  "dispatch_resolve_review_feedback",
+  "dispatch_add_review_message",
   "dispatch_submit_resolution",
   "dispatch_cancel_recheck",
   "list_agents",
@@ -339,6 +341,23 @@ export type McpRequestContext = {
     status: "fixed" | "ignored",
     options?: { reason?: string | null }
   ) => Promise<FeedbackItem>;
+  resolveReviewFeedback?: (
+    agentId: string,
+    itemId: number,
+    resolution: "fixed" | "ignored" | "wont_fix",
+    opts?: { note?: string | null }
+  ) => Promise<{
+    item: { id: number; reviewId: number; status: string; resolution: string };
+    reviewStatus: string;
+  }>;
+  addReviewThreadMessage?: (
+    agentId: string,
+    itemId: number,
+    body: string
+  ) => Promise<{
+    message: { id: number; feedbackItemId: number; content: { body: string } };
+    reviewId: number;
+  }>;
   submitResolution?: (
     agentId: string,
     input: { personaAgentId: string; summary: string }
@@ -507,6 +526,8 @@ async function createDispatchMcpServer(
       launchPersona: context.launchPersona,
       getFeedback: context.getFeedback,
       resolveFeedback: context.resolveFeedback,
+      resolveReviewFeedback: context.resolveReviewFeedback,
+      addReviewThreadMessage: context.addReviewThreadMessage,
       submitResolution: context.submitResolution,
     });
   }

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -352,6 +352,8 @@ describe("MCP auth integration", () => {
     expect(response.body).toContain("dispatch_launch_persona");
     expect(response.body).toContain("dispatch_get_feedback");
     expect(response.body).toContain("dispatch_resolve_feedback");
+    expect(response.body).toContain("dispatch_resolve_review_feedback");
+    expect(response.body).toContain("dispatch_add_review_message");
     expect(response.body).toContain("dispatch_submit_resolution");
     expect(response.body).toContain("dispatch_cancel_recheck");
     expect(response.body).toContain("job_complete");

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -62,6 +62,32 @@ vi.mock("../src/shared/lib/run-command.js", () => ({
   runCommand: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
 }));
 
+vi.mock("../src/agents/reviews.js", () => ({
+  resolveReviewFeedbackItem: vi.fn(async () => ({
+    item: {
+      id: 10,
+      reviewId: 5,
+      status: "resolved",
+      resolution: "fixed",
+      resolutionNote: null,
+    },
+    reviewId: 5,
+    reviewStatus: "partially_resolved",
+  })),
+  addThreadMessage: vi.fn(async () => ({
+    message: {
+      id: 20,
+      feedbackItemId: 10,
+      authorType: "agent",
+      authorAgentId: "agt_test1",
+      type: "text",
+      content: { body: "I fixed this" },
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+    reviewId: 5,
+  })),
+}));
+
 vi.mock("../src/shared/media.js", () => ({
   isMediaFile: vi.fn(() => true),
   isTextFile: vi.fn(() => false),
@@ -99,6 +125,10 @@ import {
 } from "../src/personas/loader.js";
 import { getEnabledAgentTypes } from "../src/agent-type-settings.js";
 import { isMediaFile, isTextFile } from "../src/shared/media.js";
+import {
+  resolveReviewFeedbackItem,
+  addThreadMessage,
+} from "../src/agents/reviews.js";
 
 function createMockDeps() {
   return {
@@ -1962,6 +1992,89 @@ describe("createMcpHandlers", () => {
           update: "missing.png",
         })
       ).rejects.toThrow("No media file found");
+    });
+  });
+
+  describe("resolveReviewFeedback", () => {
+    it("resolves item and publishes both feedback and review events", async () => {
+      const result = await handlers.resolveReviewFeedback(
+        "agt_test1",
+        10,
+        "fixed",
+        { note: "addressed in latest commit" }
+      );
+      expect(result.item.id).toBe(10);
+      expect(result.reviewStatus).toBe("partially_resolved");
+      expect(resolveReviewFeedbackItem).toHaveBeenCalledWith(
+        deps.pool,
+        10,
+        "agt_test1",
+        "fixed",
+        { note: "addressed in latest commit", resolvedBy: "agt_test1" }
+      );
+      expect(deps.publishUiEvent).toHaveBeenCalledWith({
+        type: "review_feedback.updated",
+        agentId: "agt_test1",
+        feedbackItemId: 10,
+      });
+      expect(deps.publishUiEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "review.updated",
+          agentId: "agt_test1",
+          reviewId: 5,
+          status: "partially_resolved",
+        })
+      );
+    });
+
+    it("throws when item not found", async () => {
+      vi.mocked(resolveReviewFeedbackItem).mockResolvedValueOnce(null);
+      await expect(
+        handlers.resolveReviewFeedback("agt_test1", 99, "fixed")
+      ).rejects.toThrow("Review feedback item #99 not found");
+    });
+
+    it("defaults note to null when omitted", async () => {
+      await handlers.resolveReviewFeedback("agt_test1", 10, "ignored");
+      expect(resolveReviewFeedbackItem).toHaveBeenCalledWith(
+        deps.pool,
+        10,
+        "agt_test1",
+        "ignored",
+        { note: null, resolvedBy: "agt_test1" }
+      );
+    });
+  });
+
+  describe("addReviewThreadMessage", () => {
+    it("adds message and publishes feedback event", async () => {
+      const result = await handlers.addReviewThreadMessage(
+        "agt_test1",
+        10,
+        "I fixed this"
+      );
+      expect(result.message.id).toBe(20);
+      expect(result.reviewId).toBe(5);
+      expect(addThreadMessage).toHaveBeenCalledWith(
+        deps.pool,
+        10,
+        "agt_test1",
+        "agent",
+        "I fixed this",
+        "agt_test1"
+      );
+      expect(deps.publishUiEvent).toHaveBeenCalledWith({
+        type: "review_feedback.updated",
+        agentId: "agt_test1",
+        feedbackItemId: 10,
+      });
+    });
+
+    it("throws when item not found", async () => {
+      vi.mocked(addThreadMessage).mockResolvedValueOnce(null);
+      await expect(
+        handlers.addReviewThreadMessage("agt_test1", 99, "hello")
+      ).rejects.toThrow("Review feedback item #99 not found");
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `dispatch_resolve_review_feedback` MCP tool — agents can resolve human review feedback items as fixed, ignored, or wont_fix, with optional note. Parent review status auto-recomputes.
- Adds `dispatch_add_review_message` MCP tool — agents can reply to review feedback threads (e.g. ask clarifying questions before resolving).
- Full MCP plumbing: callback types on `McpRequestContext`, handler implementations in `mcp-review-handlers.ts`, zod-schema tool registrations in `persona-interaction-tools.ts`, wiring in `mcp.ts` and `server.ts`.

## Test plan
- [x] Server type check passes (`pnpm --filter @dispatch/server check`)
- [x] Full type check passes (`pnpm run check`)
- [x] Unit tests pass (`pnpm run test`)
- [ ] E2E tests (blocked by pre-existing `react-diff-view` install issue in worktrees — passes once `pnpm install` runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)