### PR TITLE
Fix review feedback MCP tools: SQL bug, ownership, naming, and list tool

### DIFF
--- a/apps/server/src/agents/reviews.ts
+++ b/apps/server/src/agents/reviews.ts
@@ -260,8 +260,16 @@ export async function resolveReviewFeedbackItem(
        SET status = 'resolved', resolution = $1, resolution_note = $2,
            resolved_by = $3, resolved_at = NOW(), updated_at = NOW()
        FROM reviews r
-       WHERE fi.id = $4 AND fi.review_id = r.id AND r.agent_id = $5
-       RETURNING ${FEEDBACK_ITEM_SELECT}, r.agent_id AS "agentId"`,
+       WHERE fi.id = $4 AND fi.review_id = r.id
+         AND (r.agent_id = $5 OR r.assigned_agent_id = $5)
+       RETURNING
+         fi.id, fi.review_id AS "reviewId", fi.file_path AS "filePath",
+         fi.line_start AS "lineStart", fi.line_end AS "lineEnd",
+         fi.diff_snapshot AS "diffSnapshot", fi.base_ref AS "baseRef",
+         fi.status, fi.resolution, fi.resolution_note AS "resolutionNote",
+         fi.resolved_by AS "resolvedBy", fi.resolved_at AS "resolvedAt",
+         fi.created_at AS "createdAt", fi.updated_at AS "updatedAt",
+         r.agent_id AS "agentId"`,
       [resolution, opts.note ?? null, opts.resolvedBy ?? null, itemId, agentId]
     );
     const item = itemResult.rows[0];
@@ -314,7 +322,7 @@ export async function addThreadMessage(
     `SELECT fi.review_id AS "reviewId"
      FROM review_feedback_items fi
      JOIN reviews r ON r.id = fi.review_id
-     WHERE fi.id = $1 AND r.agent_id = $2`,
+     WHERE fi.id = $1 AND (r.agent_id = $2 OR r.assigned_agent_id = $2)`,
     [itemId, agentId]
   );
   if (ownership.rows.length === 0) return null;
@@ -354,7 +362,7 @@ export async function listFeedbackItemsForAgent(
             fi.created_at AS "createdAt", fi.updated_at AS "updatedAt"
      FROM review_feedback_items fi
      JOIN reviews r ON r.id = fi.review_id
-     WHERE r.agent_id = $1
+     WHERE (r.agent_id = $1 OR r.assigned_agent_id = $1)
      ORDER BY fi.created_at ASC`,
     [agentId]
   );

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -57,6 +57,7 @@ type McpRouteDeps = {
   mcpResolveFeedback: unknown;
   mcpResolveReviewFeedback: unknown;
   mcpAddReviewThreadMessage: unknown;
+  mcpListReviewFeedback: unknown;
   mcpSubmitResolution: unknown;
   mcpCancelRecheck: unknown;
   mcpUpsertPin: unknown;
@@ -216,6 +217,7 @@ export async function registerMcpRoutes(
       resolveFeedback: deps.mcpResolveFeedback,
       resolveReviewFeedback: deps.mcpResolveReviewFeedback,
       addReviewThreadMessage: deps.mcpAddReviewThreadMessage,
+      listReviewFeedback: deps.mcpListReviewFeedback,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
       sendMessage: deps.mcpSendMessage,
@@ -301,6 +303,7 @@ export async function registerMcpRoutes(
       resolveFeedback: deps.mcpResolveFeedback,
       resolveReviewFeedback: deps.mcpResolveReviewFeedback,
       addReviewThreadMessage: deps.mcpAddReviewThreadMessage,
+      listReviewFeedback: deps.mcpListReviewFeedback,
       submitResolution: deps.mcpSubmitResolution,
       cancelRecheck: deps.mcpCancelRecheck,
       sendMessage: deps.mcpSendMessage,

--- a/apps/server/src/routes/reviews.ts
+++ b/apps/server/src/routes/reviews.ts
@@ -202,16 +202,19 @@ export async function registerReviewRoutes(
       notifLines.push("");
       notifLines.push("How to handle this review:");
       notifLines.push(
-        "1. Read each feedback item. For each one, decide whether to fix it, push back, or dismiss it."
+        "1. Call dispatch_review_list_feedback to see all feedback items and their IDs."
       );
       notifLines.push(
-        "2. If you have a question or want to explain your approach before acting, use dispatch_add_review_message to reply on that item's thread."
+        "2. Read each feedback item. For each one, decide whether to fix it, push back, or dismiss it."
       );
       notifLines.push(
-        "3. After addressing an item (or deciding not to), call dispatch_resolve_review_feedback to mark it as fixed, ignored, or wont_fix. Include a note when dismissing so the reviewer understands why."
+        "3. If you have a question or want to explain your approach before acting, use dispatch_review_add_message to reply on that item's thread."
       );
       notifLines.push(
-        "4. Work through all items — the review status updates automatically as you resolve each one."
+        "4. After addressing an item (or deciding not to), call dispatch_review_resolve to mark it as fixed, ignored, or wont_fix. Include a note when dismissing so the reviewer understands why."
+      );
+      notifLines.push(
+        "5. Work through all items — the review status updates automatically as you resolve each one."
       );
       notifLines.push("--- END ---");
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -484,6 +484,7 @@ async function registerRoutes() {
     mcpResolveFeedback: mcpHandlers.resolveFeedback,
     mcpResolveReviewFeedback: mcpHandlers.resolveReviewFeedback,
     mcpAddReviewThreadMessage: mcpHandlers.addReviewThreadMessage,
+    mcpListReviewFeedback: mcpHandlers.listReviewFeedback,
     mcpSubmitResolution: mcpHandlers.submitResolution,
     mcpCancelRecheck: mcpHandlers.cancelRecheck,
     mcpSendMessage: mcpHandlers.sendMessage,

--- a/apps/server/src/server/mcp-review-handlers.ts
+++ b/apps/server/src/server/mcp-review-handlers.ts
@@ -40,6 +40,7 @@ import { runCommand } from "../shared/lib/run-command.js";
 import {
   resolveReviewFeedbackItem,
   addThreadMessage,
+  listFeedbackItemsForAgent,
 } from "../agents/reviews.js";
 import type {
   ParentContextResult,
@@ -310,6 +311,10 @@ export function createReviewHandlers(deps: CreateReviewHandlersDeps) {
         submittedAt: resolution?.submittedAt ?? null,
         resolutions,
       };
+    },
+
+    async listReviewFeedback(agentId: string) {
+      return listFeedbackItemsForAgent(pool, agentId);
     },
 
     async resolveReviewFeedback(

--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -24,6 +24,7 @@ export type PersonaInteractionCallbacks = {
   resolveFeedback?: McpRequestContext["resolveFeedback"];
   resolveReviewFeedback?: McpRequestContext["resolveReviewFeedback"];
   addReviewThreadMessage?: McpRequestContext["addReviewThreadMessage"];
+  listReviewFeedback?: McpRequestContext["listReviewFeedback"];
   submitResolution?: McpRequestContext["submitResolution"];
 };
 
@@ -248,15 +249,47 @@ export function registerPersonaInteractionTools(
     );
   }
 
-  // ── dispatch_resolve_review_feedback ──────────────────────────────
+  // ── dispatch_review_list_feedback ────────────────────────────────
   if (
-    allowed.has("dispatch_resolve_review_feedback") &&
+    allowed.has("dispatch_review_list_feedback") &&
+    callbacks.listReviewFeedback
+  ) {
+    const listReviewFeedback = callbacks.listReviewFeedback;
+
+    server.registerTool(
+      "dispatch_review_list_feedback",
+      {
+        description:
+          "List human review feedback items for this agent. Returns all feedback items across all reviews, including their IDs, file paths, status, resolution, and thread messages. Use this to discover item IDs before calling dispatch_review_resolve or dispatch_review_add_message.",
+        inputSchema: {},
+      },
+      async () => {
+        try {
+          const items = await listReviewFeedback(agentId);
+          const summary =
+            items.length === 0
+              ? "No review feedback items found."
+              : `Found ${items.length} review feedback item(s).`;
+          return {
+            content: [{ type: "text", text: summary }],
+            structuredContent: { items },
+          };
+        } catch (error) {
+          return toToolError(error);
+        }
+      }
+    );
+  }
+
+  // ── dispatch_review_resolve ──────────────────────────────────────
+  if (
+    allowed.has("dispatch_review_resolve") &&
     callbacks.resolveReviewFeedback
   ) {
     const resolveReviewFeedback = callbacks.resolveReviewFeedback;
 
     server.registerTool(
-      "dispatch_resolve_review_feedback",
+      "dispatch_review_resolve",
       {
         description:
           "Resolve a human review feedback item. Marks the item as fixed, dismissed, or wont_fix. The parent review status is automatically recomputed (open → partially_resolved → resolved).",
@@ -303,15 +336,15 @@ export function registerPersonaInteractionTools(
     );
   }
 
-  // ── dispatch_add_review_message ─────────────────────────────────
+  // ── dispatch_review_add_message ──────────────────────────────────
   if (
-    allowed.has("dispatch_add_review_message") &&
+    allowed.has("dispatch_review_add_message") &&
     callbacks.addReviewThreadMessage
   ) {
     const addReviewThreadMessage = callbacks.addReviewThreadMessage;
 
     server.registerTool(
-      "dispatch_add_review_message",
+      "dispatch_review_add_message",
       {
         description:
           "Add a message to a review feedback item's thread. Use this to reply to a human review comment — for example, to ask a clarifying question or explain your approach before resolving.",

--- a/apps/server/src/shared/mcp/server.ts
+++ b/apps/server/src/shared/mcp/server.ts
@@ -93,8 +93,9 @@ const AGENT_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
-  "dispatch_resolve_review_feedback",
-  "dispatch_add_review_message",
+  "dispatch_review_list_feedback",
+  "dispatch_review_resolve",
+  "dispatch_review_add_message",
   "dispatch_submit_resolution",
   "dispatch_cancel_recheck",
   "list_agents",
@@ -139,8 +140,9 @@ const JOB_TOOLS = new Set([
   "dispatch_launch_persona",
   "dispatch_get_feedback",
   "dispatch_resolve_feedback",
-  "dispatch_resolve_review_feedback",
-  "dispatch_add_review_message",
+  "dispatch_review_list_feedback",
+  "dispatch_review_resolve",
+  "dispatch_review_add_message",
   "dispatch_submit_resolution",
   "dispatch_cancel_recheck",
   "job_complete",
@@ -360,6 +362,30 @@ export type McpRequestContext = {
     message: { id: number; feedbackItemId: number; content: { body: string } };
     reviewId: number;
   }>;
+  listReviewFeedback?: (agentId: string) => Promise<
+    Array<{
+      id: number;
+      reviewId: number;
+      filePath: string | null;
+      lineStart: number | null;
+      lineEnd: number | null;
+      diffSnapshot: string | null;
+      baseRef: string | null;
+      status: string;
+      resolution: string | null;
+      resolutionNote: string | null;
+      resolvedBy: string | null;
+      resolvedAt: string | null;
+      createdAt: string;
+      updatedAt: string;
+      messages: Array<{
+        id: number;
+        authorType: string;
+        content: { body: string };
+        createdAt: string;
+      }>;
+    }>
+  >;
   submitResolution?: (
     agentId: string,
     input: { personaAgentId: string; summary: string }
@@ -530,6 +556,7 @@ async function createDispatchMcpServer(
       resolveFeedback: context.resolveFeedback,
       resolveReviewFeedback: context.resolveReviewFeedback,
       addReviewThreadMessage: context.addReviewThreadMessage,
+      listReviewFeedback: context.listReviewFeedback,
       submitResolution: context.submitResolution,
     });
   }

--- a/apps/server/test/mcp-auth-integration.test.ts
+++ b/apps/server/test/mcp-auth-integration.test.ts
@@ -352,8 +352,9 @@ describe("MCP auth integration", () => {
     expect(response.body).toContain("dispatch_launch_persona");
     expect(response.body).toContain("dispatch_get_feedback");
     expect(response.body).toContain("dispatch_resolve_feedback");
-    expect(response.body).toContain("dispatch_resolve_review_feedback");
-    expect(response.body).toContain("dispatch_add_review_message");
+    expect(response.body).toContain("dispatch_review_list_feedback");
+    expect(response.body).toContain("dispatch_review_resolve");
+    expect(response.body).toContain("dispatch_review_add_message");
     expect(response.body).toContain("dispatch_submit_resolution");
     expect(response.body).toContain("dispatch_cancel_recheck");
     expect(response.body).toContain("job_complete");

--- a/apps/server/test/review-feedback.test.ts
+++ b/apps/server/test/review-feedback.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Integration tests for human review feedback operations:
+ * - Creating reviews with feedback items
+ * - Resolving feedback items (dispatch_review_resolve)
+ * - Adding thread messages (dispatch_review_add_message)
+ * - Listing feedback items (dispatch_review_list_feedback)
+ * - Ownership checks (agent_id and assigned_agent_id)
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useInjectApp } from "./helpers/inject-app.js";
+
+const ctx = useInjectApp();
+let sessionCookie: string;
+
+const AGENT_ID = "agt_reviewfb_01";
+const OTHER_AGENT_ID = "agt_reviewfb_02";
+
+beforeEach(async () => {
+  await ctx.pool.query("DELETE FROM review_thread_messages");
+  await ctx.pool.query("DELETE FROM review_feedback_items");
+  await ctx.pool.query("DELETE FROM reviews");
+  await ctx.pool.query("DELETE FROM agent_events");
+  await ctx.pool.query("DELETE FROM agents");
+  await ctx.pool.query("DELETE FROM sessions");
+  sessionCookie = await ctx.sessionCookie();
+
+  await ctx.pool.query(
+    `INSERT INTO agents (id, name, type, status, cwd, full_access)
+     VALUES ($1, 'review-agent', 'codex', 'running', '/tmp', false)`,
+    [AGENT_ID]
+  );
+  await ctx.pool.query(
+    `INSERT INTO agents (id, name, type, status, cwd, full_access)
+     VALUES ($1, 'other-agent', 'codex', 'running', '/tmp', false)`,
+    [OTHER_AGENT_ID]
+  );
+});
+
+async function createReview(
+  agentId: string,
+  items: Array<{ comment: string; filePath?: string; startLine?: number }>
+) {
+  const response = await ctx.app.inject({
+    method: "POST",
+    url: `/api/v1/agents/${agentId}/reviews`,
+    headers: { cookie: sessionCookie, "content-type": "application/json" },
+    payload: { items },
+  });
+  expect(response.statusCode).toBe(200);
+  return response.json().review;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/reviews — create review
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/reviews", () => {
+  it("creates a review with feedback items", async () => {
+    const review = await createReview(AGENT_ID, [
+      { comment: "Fix this bug", filePath: "src/foo.ts", startLine: 10 },
+      { comment: "General comment" },
+    ]);
+
+    expect(review.id).toBeTypeOf("number");
+    expect(review.agentId).toBe(AGENT_ID);
+    expect(review.reviewerType).toBe("human");
+    expect(review.status).toBe("open");
+    expect(review.items).toHaveLength(2);
+    expect(review.items[0].filePath).toBe("src/foo.ts");
+    expect(review.items[0].lineStart).toBe(10);
+    expect(review.items[0].messages).toHaveLength(1);
+    expect(review.items[0].messages[0].content.body).toBe("Fix this bug");
+    expect(review.items[1].filePath).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/agents/:id/reviews/items/:itemId — resolve feedback
+// ---------------------------------------------------------------------------
+describe("PATCH /api/v1/agents/:id/reviews/items/:itemId", () => {
+  it("resolves a feedback item as fixed", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${itemId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "fixed" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const result = response.json();
+    expect(result.item.id).toBe(itemId);
+    expect(result.item.status).toBe("resolved");
+    expect(result.item.resolution).toBe("fixed");
+  });
+
+  it("resolves a feedback item as ignored with a note", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Do this" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${itemId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "ignored", note: "Not applicable" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().item.resolution).toBe("ignored");
+    expect(response.json().item.resolutionNote).toBe("Not applicable");
+  });
+
+  it("resolves a feedback item as wont_fix", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Refactor" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${itemId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "wont_fix", note: "By design" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().item.resolution).toBe("wont_fix");
+  });
+
+  it("updates review status to resolved when all items are resolved", async () => {
+    const review = await createReview(AGENT_ID, [
+      { comment: "Bug 1" },
+      { comment: "Bug 2" },
+    ]);
+
+    for (const item of review.items) {
+      await ctx.app.inject({
+        method: "PATCH",
+        url: `/api/v1/agents/${AGENT_ID}/reviews/items/${item.id}`,
+        headers: { cookie: sessionCookie, "content-type": "application/json" },
+        payload: { resolution: "fixed" },
+      });
+    }
+
+    const reviewResponse = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/${review.id}`,
+      headers: { cookie: sessionCookie },
+    });
+    expect(reviewResponse.json().review.status).toBe("resolved");
+  });
+
+  it("sets review status to partially_resolved when some items are resolved", async () => {
+    const review = await createReview(AGENT_ID, [
+      { comment: "Bug 1" },
+      { comment: "Bug 2" },
+    ]);
+
+    await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${review.items[0].id}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "fixed" },
+    });
+
+    const reviewResponse = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/${review.id}`,
+      headers: { cookie: sessionCookie },
+    });
+    expect(reviewResponse.json().review.status).toBe("partially_resolved");
+  });
+
+  it("returns 404 for item belonging to different agent", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Private" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${OTHER_AGENT_ID}/reviews/items/${itemId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "fixed" },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("allows assigned_agent_id to resolve items", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    // Manually set assigned_agent_id to OTHER_AGENT_ID
+    await ctx.pool.query(
+      "UPDATE reviews SET assigned_agent_id = $1 WHERE id = $2",
+      [OTHER_AGENT_ID, review.id]
+    );
+
+    const response = await ctx.app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${OTHER_AGENT_ID}/reviews/items/${itemId}`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { resolution: "fixed" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().item.resolution).toBe("fixed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/reviews/items/:itemId/messages — add message
+// ---------------------------------------------------------------------------
+describe("POST /api/v1/agents/:id/reviews/items/:itemId/messages", () => {
+  it("adds a message to a feedback item thread", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${itemId}/messages`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { body: "Working on it now" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().message.content.body).toBe("Working on it now");
+  });
+
+  it("returns 404 for item belonging to different agent", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${OTHER_AGENT_ID}/reviews/items/${itemId}/messages`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { body: "Intruder" },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("allows assigned_agent_id to add messages", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    await ctx.pool.query(
+      "UPDATE reviews SET assigned_agent_id = $1 WHERE id = $2",
+      [OTHER_AGENT_ID, review.id]
+    );
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${OTHER_AGENT_ID}/reviews/items/${itemId}/messages`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { body: "I can help too" },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/reviews/feedback-items — list feedback
+// ---------------------------------------------------------------------------
+describe("GET /api/v1/agents/:id/reviews/feedback-items", () => {
+  it("lists all feedback items for an agent", async () => {
+    await createReview(AGENT_ID, [
+      { comment: "Bug 1", filePath: "a.ts", startLine: 5 },
+      { comment: "Bug 2" },
+    ]);
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/feedback-items`,
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const { items } = response.json();
+    expect(items).toHaveLength(2);
+    expect(items[0].filePath).toBe("a.ts");
+    expect(items[0].messages).toHaveLength(1);
+    expect(items[0].messages[0].content.body).toBe("Bug 1");
+  });
+
+  it("returns empty array for agent with no reviews", async () => {
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/feedback-items`,
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().items).toEqual([]);
+  });
+
+  it("includes thread messages from both humans and agents", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    await ctx.app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/items/${itemId}/messages`,
+      headers: { cookie: sessionCookie, "content-type": "application/json" },
+      payload: { body: "Reply from agent" },
+    });
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/feedback-items`,
+      headers: { cookie: sessionCookie },
+    });
+
+    const { items } = response.json();
+    expect(items[0].messages).toHaveLength(2);
+    expect(items[0].messages[0].content.body).toBe("Fix this");
+    expect(items[0].messages[1].content.body).toBe("Reply from agent");
+  });
+
+  it("does not return items from other agents", async () => {
+    await createReview(AGENT_ID, [{ comment: "Agent 1 review" }]);
+    await createReview(OTHER_AGENT_ID, [{ comment: "Agent 2 review" }]);
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${AGENT_ID}/reviews/feedback-items`,
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(response.json().items).toHaveLength(1);
+    expect(response.json().items[0].messages[0].content.body).toBe(
+      "Agent 1 review"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix ambiguous SQL column** in `resolveReviewFeedbackItem` — the `RETURNING` clause reused unqualified column names (`id`, `status`, etc.) that are present on both `review_feedback_items` and `reviews`, causing PostgreSQL to throw "column reference 'id' is ambiguous" on every call. Fixed by inlining `fi.`-qualified columns.
- **Broaden ownership checks** to accept `assigned_agent_id` in addition to `agent_id` across resolve, thread message, and list queries — so an agent assigned to handle a review can actually use the tools.
- **Rename tools** to `dispatch_review_*` prefix for consistency: `dispatch_resolve_review_feedback` → `dispatch_review_resolve`, `dispatch_add_review_message` → `dispatch_review_add_message`.
- **Add `dispatch_review_list_feedback` tool** so agents can discover review feedback item IDs instead of guessing (previously only exposed via REST, not MCP).
- **Add 15 integration tests** covering create, resolve (fixed/ignored/wont_fix), status progression, ownership enforcement, assigned_agent_id access, thread messages, and listing.
- **Fix incomplete context type** for `listReviewFeedback` — added missing fields (`diffSnapshot`, `baseRef`, `resolvedBy`, `resolvedAt`, `updatedAt`) to match the actual return type.

## Test plan

- [x] `pnpm run check` — types pass
- [x] `pnpm run test` — 2236 unit tests pass (125 files)
- [x] `pnpm run test:e2e` — 172 e2e tests pass
- [x] New test file `apps/server/test/review-feedback.test.ts` — 15 tests covering all review feedback operations
- [x] Backend security review persona approved (round 1 + round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)