### PR TITLE
Document diff review mode, split pane, and new review MCP tools

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -186,9 +186,32 @@ export function AgentsContent() {
         </P>
         <P>
           Select one or more lines in a diff, then click the comment icon to
-          leave a note for the agent. The comment is injected into the agent's
-          terminal with the file path and line range so the agent can act on it
-          immediately.
+          leave feedback. The primary action is <strong>Start a review</strong>,
+          which enters review mode and saves the comment as a draft. Use the
+          dropdown to pick <strong>Chat</strong> instead — that sends the
+          comment directly to the agent's terminal as a one-off message (the
+          original behavior).
+        </P>
+        <P>
+          In review mode, a bar at the top shows your draft count and a{" "}
+          <strong>Submit review</strong> button. Keep adding draft comments
+          across different files, then submit them all at once with an optional
+          summary. Each comment becomes a feedback item the agent can see via
+          its <Code>dispatch_review_list_feedback</Code> tool. The agent can
+          reply to individual items, resolve them, or ask clarifying questions —
+          all visible in the <strong>Reviews</strong> tab of the media sidebar.
+        </P>
+      </Section>
+
+      <Section>
+        <H3>Split pane</H3>
+        <P>
+          Drag an inactive tab (<strong>Terminal</strong> or{" "}
+          <strong>Changes</strong>) onto the left or right drop zone to show
+          both side by side. A resize handle between the panes lets you adjust
+          the ratio. Click the <strong>unsplit</strong> button on the divider to
+          return to single-tab view. The split layout persists per agent. Split
+          pane is not available on mobile.
         </P>
       </Section>
 
@@ -283,15 +306,6 @@ export function AgentsContent() {
           Archiving a parent does not archive its launched children — they
           continue running on their own. This differs from persona reviewers,
           which are always archived alongside their parent.
-        </P>
-      </Section>
-
-      <Section>
-        <H3>Reordering agents</H3>
-        <P>
-          Drag and drop agent cards in the sidebar to reorder them. You can also
-          focus a card and press <Code>Alt+↑</Code> or <Code>Alt+↓</Code> to
-          move it. The custom order is saved per session.
         </P>
       </Section>
     </>

--- a/apps/web/src/components/app/docs-sections/media.tsx
+++ b/apps/web/src/components/app/docs-sections/media.tsx
@@ -97,9 +97,9 @@ export function MediaContent() {
         <H3>Media sidebar</H3>
         <P>
           Click any agent's media count badge (or press{" "}
-          <Code>Mod+Shift+&gt;</Code>) to open the sidebar. The sidebar has
-          three tabs: <strong>Pins</strong>, <strong>Media</strong>, and{" "}
-          <strong>Brain</strong>.
+          <Code>Mod+Shift+&gt;</Code>) to open the sidebar. The sidebar has four
+          tabs: <strong>Pins</strong>, <strong>Media</strong>,{" "}
+          <strong>Brain</strong>, and <strong>Reviews</strong>.
         </P>
         <P>
           The <strong>Pins</strong> tab shows values the agent has surfaced via{" "}
@@ -110,7 +110,12 @@ export function MediaContent() {
           with a badge. The <strong>Brain</strong> tab displays shared-memory
           objects, lists, and events the agent has written — useful for
           inspecting job state or inter-agent coordination without calling the
-          Brain tools yourself.
+          Brain tools yourself. The <strong>Reviews</strong> tab shows human
+          review feedback submitted from the Changes tab — each review has a
+          status badge (open, partially resolved, or resolved), and you can
+          expand it to see individual items, threaded messages, diff snapshots,
+          and resolutions. Click a file path to jump to that location in the
+          Changes tab.
         </P>
         <P>
           The sidebar opens in <strong>drawer</strong> mode by default —

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -171,8 +171,22 @@ export function ToolsContent() {
             the reviewer exits cleanly
           </li>
           <li>
-            <Code>dispatch_launch_agent</Code> — launch a new child agent to
-            work on a subtask (see the Agents section for details)
+            <Code>dispatch_review_list_feedback</Code> — list human review
+            feedback items for this agent, including file paths, statuses, and
+            thread messages
+          </li>
+          <li>
+            <Code>dispatch_review_resolve</Code> — resolve a review feedback
+            item as fixed, ignored, or wont_fix
+          </li>
+          <li>
+            <Code>dispatch_review_add_message</Code> — reply to a review
+            feedback thread (ask a clarifying question or explain an approach)
+          </li>
+          <li>
+            <Code>dispatch_launch_agent</Code> — launch a new agent as a child
+            of the current session with a name, prompt, and optional agent type,
+            worktree settings, full access mode, or template
           </li>
           <li>
             <Code>list_agents</Code> — list other agents in the same repo with
@@ -181,11 +195,6 @@ export function ToolsContent() {
           <li>
             <Code>dispatch_send_message</Code> — send a message to another
             running agent by ID or name; the target can reply the same way
-          </li>
-          <li>
-            <Code>dispatch_launch_agent</Code> — launch a new agent as a child
-            of the current session with a name, prompt, and optional agent type,
-            worktree settings, full access mode, or template
           </li>
           <li>
             <Code>get_activity_summary</Code>, <Code>get_agent_history</Code>,{" "}

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -154,6 +154,22 @@ export const tips: Tip[] = [
     since: "0.24.0",
     surfaces: ["ambient"],
   },
+  {
+    id: "diff-review",
+    title: "Diff Review",
+    body: "Select lines in the Changes tab and submit review comments. The agent can respond, resolve items, or ask questions in threaded conversations.",
+    docsSection: "agents",
+    since: "0.27.0",
+    surfaces: ["ambient"],
+  },
+  {
+    id: "split-pane",
+    title: "Split Pane",
+    body: "Drag the Terminal or Changes tab to the left or right drop zone to view them side by side. Click the split button on the divider to unsplit.",
+    docsSection: "agents",
+    since: "0.27.0",
+    surfaces: ["ambient"],
+  },
 ];
 
 export function getTipById(id: string): Tip | undefined {


### PR DESCRIPTION
## Summary

Diff-driven docs audit for changes since `0a4abfb6` (PRs #730, #741–#746). Updates in-app docs to cover:

- **Diff review mode** — Changes tab inline comment form now defaults to "Start a review" (batch draft comments, submit with summary). "Chat" remains in the dropdown. Review mode bar, submit dialog, and the new Reviews tab in the media sidebar are documented.
- **Split pane** — Terminal and Changes can now be shown side by side via drag-and-drop. New agents docs section.
- **New MCP tools** — `dispatch_review_list_feedback`, `dispatch_review_resolve`, `dispatch_review_add_message` added to built-in tools list.
- **Cleanup** — removed duplicate "Reordering agents" section and duplicate `dispatch_launch_agent` entry in tools list.
- **Tips** — added ambient tips for diff review and split pane (`since: 0.27.0`).

## Deferred to next run

- Updates section deep-dive (assisted-update flow, release checks, version display) — original `next_focus`, deferred because the diff was more urgent.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)