### PR TITLE
docs: update sidebar tabs for agent messages

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -295,7 +295,7 @@ export function AgentsContent() {
           worktree with unmerged commits or uncommitted changes, you'll be asked
           whether to keep or remove the worktree. Archived agents are preserved
           in the History section of the Activity page, where you can review
-          their events, media, pins, and feedback.
+          their events, media, pins, feedback, and messages.
         </P>
       </Section>
 
@@ -307,7 +307,9 @@ export function AgentsContent() {
           independently and appears as a top-level entry in the sidebar — it
           inherits the parent's working directory and full-access mode by
           default. Each child is told which agent launched it and can coordinate
-          back using <Code>dispatch_send_message</Code>.
+          back using <Code>dispatch_send_message</Code>. Messages are persisted
+          and visible in the <strong>Messages</strong> tab of the media sidebar,
+          grouped by conversation partner.
         </P>
         <P>
           Archiving a parent does not archive its launched children — they

--- a/apps/web/src/components/app/docs-sections/media.tsx
+++ b/apps/web/src/components/app/docs-sections/media.tsx
@@ -99,7 +99,7 @@ export function MediaContent() {
           Click any agent's media count badge (or press{" "}
           <Code>Mod+Shift+&gt;</Code>) to open the sidebar. The sidebar has four
           tabs: <strong>Pins</strong>, <strong>Media</strong>,{" "}
-          <strong>Brain</strong>, and <strong>Reviews</strong>.
+          <strong>Reviews</strong>, and <strong>Messages</strong>.
         </P>
         <P>
           The <strong>Pins</strong> tab shows values the agent has surfaced via{" "}
@@ -107,15 +107,15 @@ export function MediaContent() {
           other key info. The <strong>Media</strong> tab shows shared files in
           reverse chronological order (most recent 50); click an item to open
           the full-screen lightbox. New items since your last visit are marked
-          with a badge. The <strong>Brain</strong> tab displays shared-memory
-          objects, lists, and events the agent has written — useful for
-          inspecting job state or inter-agent coordination without calling the
-          Brain tools yourself. The <strong>Reviews</strong> tab shows human
-          review feedback submitted from the Changes tab — each review has a
-          status badge (open, partially resolved, or resolved), and you can
-          expand it to see individual items, threaded messages, diff snapshots,
-          and resolutions. Click a file path to jump to that location in the
-          Changes tab.
+          with a badge. The <strong>Reviews</strong> tab shows human review
+          feedback submitted from the Changes tab — each review has a status
+          badge (open, partially resolved, or resolved), and you can expand it
+          to see individual items, threaded messages, diff snapshots, and
+          resolutions. Click a file path to jump to that location in the Changes
+          tab. The <strong>Messages</strong> tab shows inter-agent messages
+          grouped by conversation partner — sent and received messages appear in
+          chat-style bubbles with timestamps and delivery status. Unread
+          messages show a badge count on the tab.
         </P>
         <P>
           The sidebar opens in <strong>drawer</strong> mode by default —

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -260,8 +260,8 @@ export function ToolsContent() {
           findings or assessments between recurring job runs, sharing
           configuration between agents working in the same repo, and recording
           structured observations that other agents can query. You can inspect
-          an agent's Brain activity in the <strong>Brain</strong> tab of the
-          sidebar.
+          Brain activity from the <strong>Brains</strong> tab on the Automations
+          page.
         </P>
       </Section>
 
@@ -275,9 +275,10 @@ export function ToolsContent() {
         </P>
         <P>
           Use <Code>list_agents</Code> to discover running agents and{" "}
-          <Code>dispatch_send_message</Code> to coordinate between them. The
-          launched agent receives the parent's ID in its startup context so it
-          can message back.
+          <Code>dispatch_send_message</Code> to coordinate between them.
+          Messages are persisted and visible in the <strong>Messages</strong>{" "}
+          tab of the media sidebar. The launched agent receives the parent's ID
+          in its startup context so it can message back.
         </P>
       </Section>
 

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -173,6 +173,14 @@ export const tips: Tip[] = [
     surfaces: ["ambient"],
   },
   {
+    id: "agent-messages",
+    title: "Agent Messages",
+    body: "Open the Messages tab in the media sidebar to see all inter-agent messages grouped by conversation partner, with delivery status and timestamps.",
+    docsSection: "media",
+    since: "0.28.0",
+    surfaces: ["ambient"],
+  },
+  {
     id: "split-pane",
     title: "Split Pane",
     body: "Drag the Terminal or Changes tab to the left or right drop zone to view them side by side. Click the split button on the divider to unsplit.",


### PR DESCRIPTION
## Summary

- Media sidebar replaced the Brain tab with a Messages tab (PR #736), but docs still referenced the old layout
- Updated media.tsx: tab listing from "Pins, Media, Brain, Reviews" → "Pins, Media, Reviews, Messages", replaced Brain tab description with Messages tab description
- Updated agents.tsx: added "messages" to archived agent history enumeration, added message persistence note to orchestration section
- Updated tools.tsx: Brain inspection now points to Automations page Brains tab instead of (removed) sidebar Brain tab, added message persistence note to orchestration section
- Added `agent-messages` ambient tip for sidebar Messages tab discovery

## What's deferred

- Updates section audit (next_focus for next run)
- Backlog items (48 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)