### PR TITLE
fix: replace console.log/warn with structured logger

### DIFF
--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -671,8 +671,9 @@ export async function registerReleaseRoutes(
         pendingMigrationManifests = evaluation.pending.map((m) => m.manifest);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.warn(
-          `[release/assisted/launch] migration evaluation failed for ${body.tag}, falling back to legacy metadata: ${message}`
+        request.log.warn(
+          { tag: body.tag, err: message },
+          "Migration evaluation failed, falling back to legacy metadata"
         );
       }
 

--- a/apps/server/src/routes/release.ts
+++ b/apps/server/src/routes/release.ts
@@ -670,9 +670,8 @@ export async function registerReleaseRoutes(
         }
         pendingMigrationManifests = evaluation.pending.map((m) => m.manifest);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
         request.log.warn(
-          { tag: body.tag, err: message },
+          { tag: body.tag, err },
           "Migration evaluation failed, falling back to legacy metadata"
         );
       }

--- a/apps/server/src/server/agent-lifecycle-runtime.ts
+++ b/apps/server/src/server/agent-lifecycle-runtime.ts
@@ -104,8 +104,9 @@ export function createAgentLifecycleRuntime(
             if (archivingAgentIds.has(agent.id)) {
               continue;
             }
-            console.log(
-              `[reconcile] Agent ${agent.id} (${agent.name}) resuming interrupted archive`
+            appLog.info(
+              { agentId: agent.id, agentName: agent.name },
+              "Resuming interrupted archive"
             );
             publishUiEvent({
               type: "agent.upsert",
@@ -136,8 +137,9 @@ export function createAgentLifecycleRuntime(
             });
             trackArchive(agent.id, archivePromise);
           } else {
-            console.log(
-              `[reconcile] Agent ${agent.id} (${agent.name}) status corrected to stopped`
+            appLog.info(
+              { agentId: agent.id, agentName: agent.name },
+              "Agent status corrected to stopped"
             );
             publishUiEvent({
               type: "agent.upsert",


### PR DESCRIPTION
## Summary

- Replaced 2× `console.log` in `agent-lifecycle-runtime.ts` (reconciliation messages) with `appLog.info` using structured metadata (`agentId`, `agentName`)
- Replaced 1× `console.warn` in `release.ts` (migration evaluation fallback) with `request.log.warn` using structured metadata (`tag`, `err`)
- Production server code should use the Pino-based structured logger for consistent, queryable output — `console.*` bypasses log levels, formatting, and transports

## What qualifies as tech debt

These were the last `console.log`/`console.warn` calls in request-handling server code. The remaining `console.*` calls in the codebase are in startup/config code and standalone migration scripts, which is appropriate since they run before the Fastify logger is initialized.

## Next run

Unsafe type cast in `apps/web/src/components/app/unified-diff-view.tsx:267` — `as unknown as MouseEvent` double-cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)