### PR TITLE
docs: fix factual drift in Updates docs section

### DIFF
--- a/apps/web/src/components/app/docs-sections/updates.tsx
+++ b/apps/web/src/components/app/docs-sections/updates.tsx
@@ -16,9 +16,10 @@ export function UpdatesContent() {
         <H3>Current version</H3>
         <P>
           The top of the pane shows the deployed release tag and when it was
-          deployed, plus an expandable card with the package version, git SHA,
-          and release notes. If the release page is on GitHub, a link opens it
-          in a new tab.
+          deployed, with a detail card below showing the package version and git
+          SHA. Release notes are in a separate collapsible section — click the
+          header to expand. If the release is on GitHub, a link next to the
+          header opens it in a new tab.
         </P>
       </Section>
 
@@ -158,11 +159,11 @@ export function UpdatesContent() {
       <Section>
         <H3>Reload</H3>
         <P>
-          <strong>Reload</strong> picks up the latest web bundle by forcing the
-          service worker to take control on the next load. The dropdown offers{" "}
-          <strong>Clear cache &amp; reload</strong>, which unregisters all
-          service workers and clears the Cache Storage API entries first —
-          useful if the app feels stuck on a stale build.
+          <strong>Reload</strong> unregisters the service worker and reloads so
+          the next page load picks up the latest build directly. The dropdown
+          offers <strong>Clear cache &amp; reload</strong>, which also clears
+          all Cache Storage API entries before reloading — useful if the app
+          feels stuck on a stale build.
         </P>
       </Section>
     </>


### PR DESCRIPTION
## Summary

- Fixed "Current version" subsection: described version info card as "expandable" containing release notes, but the card is always visible and release notes are a separate collapsible section with a GitHub link on its header.
- Fixed "Reload" subsection: claimed it "forces the service worker to take control" but `reloadApp()` actually unregisters all service workers so the next load bypasses the precache entirely.

## Audit scope

Deep-dive of the Updates docs section (`docs-sections/updates.tsx`) against:
- `release-auto-check.ts` — auto-check interval, modes
- `release-checks.ts` — required check names and implementations
- `release-metadata.ts` — metadata schema, mode enum, appliesFrom
- `release-runtime.ts` — update phases, assisted phases
- `release-manager.tsx` — UI layout, split button behavior
- `release-update-actions.tsx` — button labels
- `release-available-toast.tsx` — toast copy
- `pwa-update.ts` — reload/clear cache behavior
- `release-notes/AUTHORING.md` — migration manifest schema

Everything else in the Updates section is accurate. Deferred to next run: nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)