### PR TITLE
fix(web): remove unnecessary double type cast in unified-diff-view

### DIFF
--- a/apps/web/src/components/app/unified-diff-view.tsx
+++ b/apps/web/src/components/app/unified-diff-view.tsx
@@ -264,9 +264,7 @@ export const UnifiedDiffView = memo(function UnifiedDiffView({
         const ln = getNewLineNumber(change);
         if (ln === null) return;
 
-        const mouseEvent = e as unknown as MouseEvent;
-
-        if (mouseEvent.shiftKey && lineSelection) {
+        if (e.shiftKey && lineSelection) {
           const start = Math.min(lineSelection.anchorLine, ln);
           const end = Math.max(lineSelection.anchorLine, ln);
           onLineSelection({


### PR DESCRIPTION
## Summary

- Removed the `as unknown as MouseEvent` double-cast in `unified-diff-view.tsx` gutter click handler
- The `EventMap` type from `react-diff-view` already provides `React.MouseEvent<HTMLElement>` which includes `shiftKey` — the intermediate cast through `unknown` was unnecessary tech debt

## Why this qualifies as tech debt

Double-casting through `unknown` bypasses TypeScript's type safety, making it harder to catch real type errors if the upstream library changes its event types. Since the correct type is already available, the cast added noise with no benefit.

## Next up

The backlog is now empty — next run will re-audit for fresh issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)