### PR TITLE
docs: fix "stop button" → "pause button" in Agents docs

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -121,9 +121,10 @@ export function AgentsContent() {
       <Section>
         <H3>Starting and stopping</H3>
         <P>
-          Press the play button to resume a stopped agent. Press the stop button
-          to terminate it. Click an agent card to attach your terminal to its
-          session, or click again to detach without stopping.
+          Press the play button to resume a stopped agent. Press the pause
+          button to stop it — a confirmation dialog appears first, and you can
+          resume the session later. Click an agent card to attach your terminal
+          to its session, or click again to detach without stopping.
         </P>
       </Section>
 


### PR DESCRIPTION
## Summary

- The in-app Agents docs "Starting and stopping" section said "Press the stop button to terminate it." The UI consistently uses **Pause** terminology — the button icon is Pause, the aria-label says "Pause", the confirmation dialog title says "Pause Agent", and the dialog body says "The session will be paused. Resume it later to continue where you left off."
- Updated the docs to say "Press the pause button to stop it — a confirmation dialog appears first, and you can resume the session later." Removed the misleading "terminate" wording.

## Audit scope

Deep-dive of the full **Agents** docs section (`docs-sections/agents.tsx`) against `agent-card.tsx`, `create-agent-dialog.tsx`, `create-agent-worktree-section.tsx`, `use-create-agent-form.ts`, `agent-sidebar.tsx`, `center-pane-tab-bar.tsx`, `stop-agent-dialog.tsx`, `diff-stat-badge.tsx`, and `agent-event-utils.ts`.

Verified accurate (no changes needed):
- Creating an agent: all 6 form fields, type list, "Create with context" flow
- Setup phases: all 4 phase labels match
- Status indicators: all 4 color mappings, collapsed vs expanded content
- Sidebar badges: Attention, Job, Update — all 3 match
- Reordering: drag-and-drop + Alt+↑/↓ keyboard shortcut
- Sessions are persistent: tmux claim
- Agent details: worktree vs non-worktree metadata, diff-stats badge, access mode badge, feedback panel, persona launcher, persona agent display
- Diff-stats badge: hidden when zero, flash on change, stale opacity, click-to-refresh, tooltip file count
- Changes tab, Split pane, Tmux scrollback, Quick Phrases, Renaming, Archiving, Orchestration — all verified

## Deferred to next run

Next focus: audit docs-pane Repo Tools section against `apps/server/src/shared/mcp/server.ts` AGENT_TOOLS/JOB_TOOLS/PERSONA_TOOLS sets, and verify each repo tool's description matches the actual tool handler behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)