### PR TITLE
docs: fix review resolution states, add human-side interactions

### DIFF
--- a/apps/web/src/components/app/docs-sections/agents.tsx
+++ b/apps/web/src/components/app/docs-sections/agents.tsx
@@ -205,9 +205,15 @@ export function AgentsContent() {
           <strong>Submit review</strong> button. Keep adding draft comments
           across different files, then submit them all at once with an optional
           summary. Each comment becomes a feedback item the agent can see via
-          its <Code>dispatch_review_list_feedback</Code> tool. The agent can
-          reply to individual items, resolve them, or ask clarifying questions —
-          all visible in the <strong>Reviews</strong> tab of the media sidebar.
+          its <Code>dispatch_review_list_feedback</Code> tool.
+        </P>
+        <P>
+          Feedback threads are interactive from both sides. The agent can reply,
+          resolve items as <strong>fixed</strong> or <strong>dismissed</strong>,
+          or ask clarifying questions via MCP tools. You can do the same from
+          the UI — reply to a thread, mark an item resolved, or reopen it —
+          either inline in the diff or from the <strong>Reviews</strong> tab of
+          the media sidebar.
         </P>
       </Section>
 

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -177,7 +177,7 @@ export function ToolsContent() {
           </li>
           <li>
             <Code>dispatch_review_resolve</Code> — resolve a review feedback
-            item as fixed, ignored, or wont_fix
+            item as fixed or dismissed
           </li>
           <li>
             <Code>dispatch_review_add_message</Code> — reply to a review

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -167,7 +167,7 @@ export const tips: Tip[] = [
   {
     id: "diff-review",
     title: "Diff Review",
-    body: "Select lines in the Changes tab and submit review comments. The agent can respond, resolve items, or ask questions in threaded conversations.",
+    body: "Select lines in the Changes tab and submit review comments. Both you and the agent can reply, resolve, or reopen items in threaded conversations.",
     docsSection: "agents",
     since: "0.27.0",
     surfaces: ["ambient"],


### PR DESCRIPTION
## Summary

- **tools.tsx**: `dispatch_review_resolve` resolution options updated from `fixed/ignored/wont_fix` to `fixed/dismissed` (matching PR #767's DB migration and MCP handler changes)
- **agents.tsx**: Documented that humans can now reply to threads, resolve items, and reopen feedback directly from the UI — both inline in the diff and from the Reviews sidebar tab
- **tips.ts**: Updated diff-review tip to reflect bidirectional interaction ("Both you and the agent can reply, resolve, or reopen items")

## Deferred to next run

- Full Repo Tools deep-dive (tool handler descriptions vs docs summaries) — the tool list itself is accurate; this run focused on the resolution state drift from the recent diff
- `dispatch_review_add_message` body max reduced from 50,000 to 1,200 chars — the docs description doesn't mention the limit, and the tool's own schema describes it to agents directly

## Test plan

- [x] `pnpm run format:write` — clean
- [x] `pnpm run check` — types pass
- No runtime behavior changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)