### PR TITLE
Fix optional reply hint for inter-agent messages

### DIFF
--- a/apps/server/src/server/mcp-handlers.ts
+++ b/apps/server/src/server/mcp-handlers.ts
@@ -537,7 +537,7 @@ export function createMcpHandlers(deps: CreateMcpHandlersDeps) {
         message: input.message,
         replyTarget: agentId,
       });
-      const prompt = `--- DISPATCH MESSAGE ---\n${envelope}\n--- END MESSAGE ---\nReply with dispatch_send_message using the replyTarget above.`;
+      const prompt = `--- DISPATCH MESSAGE ---\n${envelope}\n--- END MESSAGE ---\nOptional reply channel: If a response is necessary, use dispatch_send_message with the replyTarget above. Do not acknowledge routine status updates or completion messages unless a reply is explicitly requested.`;
 
       // Deliver first: a persistence failure must never block delivery.
       let delivered = false;

--- a/apps/server/test/mcp-handlers.test.ts
+++ b/apps/server/test/mcp-handlers.test.ts
@@ -1454,7 +1454,19 @@ describe("createMcpHandlers", () => {
       expect(result.targetAgentId).toBe("agt_target1");
       expect(deps.sendAgentPrompt).toHaveBeenCalledWith(
         "agt_target1",
-        expect.stringContaining("DISPATCH MESSAGE"),
+        `--- DISPATCH MESSAGE ---\n${JSON.stringify({
+          from: "test-agent",
+          senderId: "agt_test1",
+          message: "hello",
+          replyTarget: "agt_test1",
+        })}\n--- END MESSAGE ---\nOptional reply channel: If a response is necessary, use dispatch_send_message with the replyTarget above. Do not acknowledge routine status updates or completion messages unless a reply is explicitly requested.`,
+        { swallowFailure: false }
+      );
+      expect(deps.sendAgentPrompt).not.toHaveBeenCalledWith(
+        "agt_target1",
+        expect.stringContaining(
+          "Reply with dispatch_send_message using the replyTarget above."
+        ),
         { swallowFailure: false }
       );
     });


### PR DESCRIPTION
## Summary
- present `replyTarget` as an optional response channel instead of a reply command
- discourage acknowledgements for routine status and completion messages
- preserve the existing JSON envelope and `replyTarget`
- add focused coverage for the exact wrapper and removal of the mandatory wording

## Checks
- `pnpm run check`
- `pnpm run test`
- `pnpm run test:e2e` (168 passed, 12 skipped)