### PR TITLE
Limit agent review replies to 600 characters

### DIFF
--- a/apps/server/src/agents/reviews.ts
+++ b/apps/server/src/agents/reviews.ts
@@ -1,5 +1,7 @@
 import type { Pool } from "pg";
 
+import { AGENT_REVIEW_REPLY_MAX_CHARS } from "../shared/review-limits.js";
+
 export type ReviewRecord = {
   id: number;
   agentId: string;
@@ -382,9 +384,9 @@ export async function addThreadMessage(
   body: string,
   authorAgentId?: string | null
 ): Promise<{ message: ReviewThreadMessageRecord; reviewId: number } | null> {
-  if (authorType === "agent" && body.length > 1_200) {
+  if (authorType === "agent" && body.length > AGENT_REVIEW_REPLY_MAX_CHARS) {
     throw new Error(
-      "Agent review thread replies must be 1,200 characters or fewer."
+      `Agent review thread replies must be ${AGENT_REVIEW_REPLY_MAX_CHARS} characters or fewer.`
     );
   }
   const ownership = await pool.query<{ reviewId: number }>(

--- a/apps/server/src/routes/reviews.ts
+++ b/apps/server/src/routes/reviews.ts
@@ -6,6 +6,7 @@ import type { UiEvent } from "../server/ui-events.js";
 import * as reviewQueries from "../agents/reviews.js";
 import { getAgentFileDiff } from "../shared/git/agent-diff.js";
 import { extractHunkAroundLines } from "../shared/lib/extract-hunk.js";
+import { AGENT_REVIEW_REPLY_GUIDANCE } from "../shared/review-limits.js";
 
 type ReviewRouteDeps = {
   pool: Pool;
@@ -209,7 +210,7 @@ export async function registerReviewRoutes(
         "2. Read each feedback item. For each one, decide whether to fix it, push back, or dismiss it."
       );
       notifLines.push(
-        "3. If you have a question or need to explain your approach, use dispatch_review_add_message to reply on that item's thread. Keep replies to 1–3 short sentences (max 1,200 characters)."
+        `3. If a reply is useful, use dispatch_review_add_message on that item's thread. ${AGENT_REVIEW_REPLY_GUIDANCE}`
       );
       notifLines.push(
         "4. After addressing an item (or deciding not to), call dispatch_review_resolve to mark it as fixed or dismissed. Include a brief note when dismissing so the reviewer understands why."
@@ -362,7 +363,7 @@ export async function registerReviewRoutes(
             [
               "--- DISPATCH: Review Thread Reply ---",
               `Feedback item #${itemId}: ${body.body.trim()}`,
-              "Reply only if useful. Keep any reply to 1–3 short sentences (max 1,200 characters).",
+              `Reply only if useful. ${AGENT_REVIEW_REPLY_GUIDANCE}`,
               "--- END ---",
             ].join("\n")
           );

--- a/apps/server/src/shared/mcp/persona-interaction-tools.ts
+++ b/apps/server/src/shared/mcp/persona-interaction-tools.ts
@@ -1,6 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 
+import {
+  AGENT_REVIEW_REPLY_GUIDANCE,
+  AGENT_REVIEW_REPLY_MAX_CHARS,
+} from "../review-limits.js";
+
 import { mergePersonasWithWorktreePrecedence } from "../../personas/loader.js";
 import type { McpRequestContext } from "./server.js";
 import { toToolError } from "./tool-error.js";
@@ -346,8 +351,7 @@ export function registerPersonaInteractionTools(
     server.registerTool(
       "dispatch_review_add_message",
       {
-        description:
-          "Add a concise message to a review feedback item's thread. Use this to ask a clarifying question or explain your approach before resolving. Keep it to 1–3 short sentences (maximum 1,200 characters).",
+        description: `Add a concise message to a review feedback item's thread. Use it only for a necessary clarifying question or essential explanation before resolving. ${AGENT_REVIEW_REPLY_GUIDANCE}`,
         inputSchema: {
           itemId: z
             .number()
@@ -359,9 +363,9 @@ export function registerPersonaInteractionTools(
           body: z
             .string()
             .min(1)
-            .max(1_200)
+            .max(AGENT_REVIEW_REPLY_MAX_CHARS)
             .describe(
-              "A brief plain-text or Markdown reply (1–3 short sentences)."
+              "A brief plain-text or Markdown reply (1–2 short sentences)."
             ),
         },
       },

--- a/apps/server/src/shared/review-limits.ts
+++ b/apps/server/src/shared/review-limits.ts
@@ -1,0 +1,5 @@
+export const AGENT_REVIEW_REPLY_MAX_CHARS = 600;
+
+export const AGENT_REVIEW_REPLY_GUIDANCE =
+  `Keep replies to 1–2 short sentences (max ${AGENT_REVIEW_REPLY_MAX_CHARS} characters). ` +
+  "State only the decision, result, or essential reason. Do not restate the feedback or narrate your work.";

--- a/apps/server/test/persona-interaction-tools.test.ts
+++ b/apps/server/test/persona-interaction-tools.test.ts
@@ -203,6 +203,30 @@ describe("registerPersonaInteractionTools", () => {
     expect(names).toContain("dispatch_submit_resolution");
   });
 
+  it("caps dispatch_review_add_message input at 600 characters", () => {
+    const callbacks: PersonaInteractionCallbacks = {
+      agentId,
+      addReviewThreadMessage: vi.fn(async () => ({
+        message: { id: 1 },
+        reviewId: 1,
+      })),
+    };
+    registerPersonaInteractionTools(
+      server as any,
+      new Set(["dispatch_review_add_message"]),
+      callbacks
+    );
+
+    const inputSchema = server.tools[0].config.inputSchema as {
+      body: {
+        safeParse: (value: string) => { success: boolean };
+      };
+    };
+    expect(inputSchema.body.safeParse("a".repeat(600)).success).toBe(true);
+    expect(inputSchema.body.safeParse("a".repeat(601)).success).toBe(false);
+    expect(server.tools[0].config.description).toContain("max 600 characters");
+  });
+
   describe("tool handlers", () => {
     it("list_personas calls resolvePersonaList with correct roots", async () => {
       const personas = [

--- a/apps/server/test/review-feedback.test.ts
+++ b/apps/server/test/review-feedback.test.ts
@@ -8,6 +8,8 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { addThreadMessage } from "../src/agents/reviews.js";
+import { AGENT_REVIEW_REPLY_MAX_CHARS } from "../src/shared/review-limits.js";
 import { useInjectApp } from "./helpers/inject-app.js";
 
 const ctx = useInjectApp();
@@ -282,6 +284,43 @@ describe("POST /api/v1/agents/:id/reviews/items/:itemId/messages", () => {
     });
 
     expect(response.statusCode).toBe(200);
+  });
+
+  it("limits new agent replies to 600 characters without limiting humans", async () => {
+    const review = await createReview(AGENT_ID, [{ comment: "Fix this" }]);
+    const itemId = review.items[0].id;
+
+    await expect(
+      addThreadMessage(
+        ctx.pool,
+        itemId,
+        AGENT_ID,
+        "agent",
+        "a".repeat(AGENT_REVIEW_REPLY_MAX_CHARS),
+        AGENT_ID
+      )
+    ).resolves.not.toBeNull();
+
+    await expect(
+      addThreadMessage(
+        ctx.pool,
+        itemId,
+        AGENT_ID,
+        "agent",
+        "a".repeat(AGENT_REVIEW_REPLY_MAX_CHARS + 1),
+        AGENT_ID
+      )
+    ).rejects.toThrow("600 characters or fewer");
+
+    await expect(
+      addThreadMessage(
+        ctx.pool,
+        itemId,
+        AGENT_ID,
+        "human",
+        "h".repeat(AGENT_REVIEW_REPLY_MAX_CHARS + 1)
+      )
+    ).resolves.not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- cap new agent-authored review thread replies at 600 characters in both the MCP schema and persistence service
- inject concise 1–2 sentence guidance that discourages restating feedback or narrating work
- preserve the existing 10,000-character human message limit and leave historical production rows untouched
- centralize the limit and guidance to keep enforcement and prompts aligned

No database migration or constraint is included because production already contains historical agent replies above the new application limit.

## Validation

- `pnpm run check`
- `pnpm run test` — server: 2,389 passed / 8 skipped; web: 196 passed
- targeted review-feedback and MCP tests — 40 passed
- Playwright parallel project — 122 passed; one unrelated split-pane timing timeout
- split-pane Playwright spec rerun in isolation — 6 passed
- Playwright serial project — 46 passed / 11 expected live-terminal skips
- author-requested `backend-security-review` persona — approved with no findings