### PR TITLE
Fix built-in tools list drift in docs-pane and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,51 +153,54 @@ Every agent launched by Dispatch gets access to MCP tools via an agent-scoped en
 
 ### Interactive agents
 
-| Tool                         | Description                                                                |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| `create_pr`                  | Create a GitHub pull request                                               |
-| `get_pr_status`              | Check PR CI status and reviews                                             |
-| `dispatch_event`             | Report agent status (`working`, `blocked`, `waiting_user`, `done`, `idle`) |
-| `dispatch_rename_session`    | Update the current session's display name                                  |
-| `dispatch_notify`            | Send a Slack notification from the agent                                   |
-| `dispatch_pin`               | Surface key info in the sidebar (URLs, ports, PRs, files)                  |
-| `dispatch_share`             | Upload screenshots and media to the agent's media pane                     |
-| `dispatch_list_media`        | List media files shared with or by this agent                              |
-| `dispatch_feedback`          | Submit structured review findings                                          |
-| `list_personas`              | List available persona reviewers for this project                          |
-| `dispatch_launch_persona`    | Launch a persona child agent for automated review                          |
-| `dispatch_get_feedback`      | Retrieve feedback submitted by child persona agents                        |
-| `dispatch_resolve_feedback`  | Mark a feedback item as fixed or ignored                                   |
-| `dispatch_submit_resolution` | Submit the parent agent's response package for a reviewer recheck          |
-| `dispatch_cancel_recheck`    | Cancel a pending reviewer recheck loop                                     |
-| `dispatch_launch_agent`      | Launch a new child agent to work on a subtask                              |
-| `list_agents`                | List other agents in the same repo with IDs, statuses, and activity        |
-| `dispatch_send_message`      | Send a message to another running agent by ID or name                      |
-| `get_activity_summary`       | Summarize agent activity over a time range                                 |
-| `get_agent_history`          | Get detailed agent session history                                         |
-| `get_feedback_summary`       | Aggregate persona review feedback for pattern detection                    |
-| `brain_get_object`           | Read a shared object from the repo-scoped Brain                            |
-| `brain_store_object`         | Create or update a shared Brain object (optimistic concurrency)            |
-| `brain_list_objects`         | List Brain objects, optionally filtered by collection or prefix            |
-| `brain_delete_object`        | Delete a shared Brain object                                               |
-| `brain_list_push`            | Append one or more items to a shared Brain list                            |
-| `brain_list_remove`          | Remove one item from a shared Brain list by index or field match           |
-| `brain_list_get`             | Read items from a shared Brain list with paging and ordering               |
-| `brain_list_set`             | Replace one item in a shared Brain list by index                           |
-| `brain_list_delete`          | Delete a shared Brain list and all of its items                            |
-| `brain_append_event`         | Append a structured event to the Brain's immutable event log               |
-| `brain_query_events`         | Query Brain events by collection, kind, subject, tags, and time range      |
-| `list_jobs`                  | List jobs scoped to a directory                                            |
-| `get_job`                    | Get a single job by ID or name                                             |
-| `create_job`                 | Create a new job                                                           |
-| `update_job`                 | Update an existing job's configuration                                     |
-| `delete_job`                 | Delete a job                                                               |
-| `run_job`                    | Trigger an immediate run of a job                                          |
-| `list_templates`             | List templates scoped to a directory                                       |
-| `get_template`               | Get a single template by ID or name                                        |
-| `create_template`            | Create a new reusable agent launch template                                |
-| `update_template`            | Update an existing template                                                |
-| `delete_template`            | Delete a template                                                          |
+| Tool                            | Description                                                                |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `create_pr`                     | Create a GitHub pull request                                               |
+| `get_pr_status`                 | Check PR CI status and reviews                                             |
+| `dispatch_event`                | Report agent status (`working`, `blocked`, `waiting_user`, `done`, `idle`) |
+| `dispatch_rename_session`       | Update the current session's display name                                  |
+| `dispatch_notify`               | Send a Slack notification from the agent                                   |
+| `dispatch_pin`                  | Surface key info in the sidebar (URLs, ports, PRs, files)                  |
+| `dispatch_share`                | Upload screenshots and media to the agent's media pane                     |
+| `dispatch_list_media`           | List media files shared with or by this agent                              |
+| `dispatch_feedback`             | Submit structured review findings                                          |
+| `list_personas`                 | List available persona reviewers for this project                          |
+| `dispatch_launch_persona`       | Launch a persona child agent for automated review                          |
+| `dispatch_get_feedback`         | Retrieve feedback submitted by child persona agents                        |
+| `dispatch_resolve_feedback`     | Mark a feedback item as fixed or ignored                                   |
+| `dispatch_submit_resolution`    | Submit the parent agent's response package for a reviewer recheck          |
+| `dispatch_review_list_feedback` | List human review feedback items with statuses and threads                 |
+| `dispatch_review_resolve`       | Resolve a review feedback item as fixed or dismissed                       |
+| `dispatch_review_add_message`   | Reply to a review feedback thread                                          |
+| `dispatch_cancel_recheck`       | Cancel a pending reviewer recheck loop                                     |
+| `dispatch_launch_agent`         | Launch a new child agent to work on a subtask                              |
+| `list_agents`                   | List other agents in the same repo with IDs, names, statuses, and activity |
+| `dispatch_send_message`         | Send a message to another running agent by ID or name                      |
+| `get_activity_summary`          | Summarize agent activity over a time range                                 |
+| `get_agent_history`             | Get detailed agent session history                                         |
+| `get_feedback_summary`          | Aggregate persona review feedback for pattern detection                    |
+| `brain_get_object`              | Read a shared object from the repo-scoped Brain                            |
+| `brain_store_object`            | Create or update a shared Brain object (optimistic concurrency)            |
+| `brain_list_objects`            | List Brain objects, optionally filtered by collection or prefix            |
+| `brain_delete_object`           | Delete a shared Brain object                                               |
+| `brain_list_push`               | Append one or more items to a shared Brain list                            |
+| `brain_list_remove`             | Remove one item from a shared Brain list by index or field match           |
+| `brain_list_get`                | Read items from a shared Brain list with paging and ordering               |
+| `brain_list_set`                | Replace one item in a shared Brain list by index                           |
+| `brain_list_delete`             | Delete a shared Brain list and all of its items                            |
+| `brain_append_event`            | Append a structured event to the Brain's immutable event log               |
+| `brain_query_events`            | Query Brain events by collection, kind, subject, tags, and time range      |
+| `list_jobs`                     | List jobs scoped to a directory                                            |
+| `get_job`                       | Get a single job by ID or name                                             |
+| `create_job`                    | Create a new job                                                           |
+| `update_job`                    | Update an existing job's configuration                                     |
+| `delete_job`                    | Delete a job                                                               |
+| `run_job`                       | Trigger an immediate run of a job                                          |
+| `list_templates`                | List templates scoped to a directory                                       |
+| `get_template`                  | Get a single template by ID or name                                        |
+| `create_template`               | Create a new reusable agent launch template                                |
+| `update_template`               | Update an existing template                                                |
+| `delete_template`               | Delete a template                                                          |
 
 ### Persona agents
 
@@ -205,7 +208,7 @@ Persona agents get a narrower set focused on reviewing their parent's work: `rev
 
 ### Job agents
 
-Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `dispatch_launch_agent`, `list_agents`, `dispatch_send_message`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
+Job agents get lifecycle and reporting tools: `job_complete`, `job_failed`, `job_needs_input`, `job_log`, plus `create_pr`, `get_pr_status`, `dispatch_event`, `dispatch_rename_session`, `dispatch_notify`, `dispatch_pin`, `dispatch_share`, `dispatch_list_media`, `dispatch_launch_persona`, `dispatch_get_feedback`, `dispatch_resolve_feedback`, `dispatch_review_list_feedback`, `dispatch_review_resolve`, `dispatch_review_add_message`, `dispatch_submit_resolution`, `dispatch_cancel_recheck`, `dispatch_launch_agent`, `list_agents`, `dispatch_send_message`, `list_personas`, `list_recent_persona_reviews`, `list_recent_feedback`, `get_activity_summary`, `get_agent_history`, `get_feedback_summary`, `brain_get_object`, `brain_store_object`, `brain_list_objects`, `brain_delete_object`, `brain_list_push`, `brain_list_remove`, `brain_list_get`, `brain_list_set`, `brain_list_delete`, `brain_append_event`, `brain_query_events`, `list_jobs`, `get_job`, `create_job`, `update_job`, `delete_job`, `run_job`, `list_templates`, `get_template`, `create_template`, `update_template`, and `delete_template`.
 
 ### Repo-specific tools
 

--- a/apps/web/src/components/app/docs-sections/tools.tsx
+++ b/apps/web/src/components/app/docs-sections/tools.tsx
@@ -186,11 +186,11 @@ export function ToolsContent() {
           <li>
             <Code>dispatch_launch_agent</Code> — launch a new agent as a child
             of the current session with a name, prompt, and optional agent type,
-            worktree settings, full access mode, or template
+            working directory, worktree settings, full access mode, or template
           </li>
           <li>
             <Code>list_agents</Code> — list other agents in the same repo with
-            their IDs, statuses, and latest activity
+            their IDs, names, statuses, and latest activity
           </li>
           <li>
             <Code>dispatch_send_message</Code> — send a message to another


### PR DESCRIPTION
## Summary

Docs audit deep-dive of the Repo Tools built-in tools list in `tools.tsx`, verifying each tool's one-liner description against its actual MCP handler registration.

- **docs-pane `tools.tsx`**: Added missing `cwd` (working directory) parameter to `dispatch_launch_agent` description; added missing "names" to `list_agents` return description.
- **README interactive agents table**: Added `dispatch_review_list_feedback`, `dispatch_review_resolve`, and `dispatch_review_add_message` — these three tools were added to `AGENT_TOOLS` in PR #748 but weren't reflected in the README table.
- **README job agents list**: Added the same three `dispatch_review_*` tools to the inline job tools enumeration.

### Deferred to next run

Next focus: audit the `docs-pane` Automations section (automations.tsx) — verify the Jobs and Templates subsections against the current create/edit form fields, trigger types, and job run lifecycle. The job form gained advanced settings (callable/singleton) and the template form gained fields (description, allowMedia) that may not be fully documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)