### PR TITLE
Install dependencies before release preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- install the frozen pnpm dependency graph before preparing release versions
- ensure the browser extension `version` lifecycle can resolve TypeScript when it synchronizes the manifest
- fix the immediate `ERR_MODULE_NOT_FOUND` failure from release run 29548420807

## Validation

- `pnpm run check`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @dispatch/browser-extension sync:manifest-version`
- `pnpm run test:e2e` (unrelated parallel timeout flakes; all original failures passed on focused rerun)
- focused rerun of the remaining callable-jobs timeout passed with one worker