### PR TITLE
Fix Automations docs drift: job palette claim, run-time args, Configure tab, history card

### DIFF
--- a/apps/web/src/components/app/docs-sections/automations.tsx
+++ b/apps/web/src/components/app/docs-sections/automations.tsx
@@ -187,14 +187,18 @@ export function AutomationsContent() {
           </li>
           <li>
             <strong>Prompt</strong> — the instructions sent as the agent's first
-            message. Supports <Code>{"{{D:Arg Name}}"}</Code> placeholders just
-            like templates. Dispatch prepends a short preamble that names the
-            job, includes the run ID, and reminds the agent to drive the run to
-            a terminal state. Required before a run can start.
+            message. Dispatch prepends a short preamble that identifies the job
+            and run and reminds the agent to drive the run to a terminal state.
+            Required before a run can start. Unlike templates, jobs never
+            collect arguments at run time — <Code>{"{{D:Arg Name}}"}</Code>{" "}
+            placeholders are only substituted from default values saved via the
+            API.
           </li>
           <li>
-            <strong>Show in command palette</strong> — when on, the job appears
-            in the <Code>Mod+K</Code> palette for quick launch.
+            <strong>Show in command palette</strong> — marks the job as
+            callable, shown as a badge in the jobs list. Quick launch from the{" "}
+            <Code>Mod+K</Code> palette is currently only available for
+            templates.
           </li>
           <li>
             <strong>Single instance</strong> — when on (the default), only one
@@ -233,10 +237,11 @@ export function AutomationsContent() {
           </li>
         </ul>
         <P>
-          After creating a job, open its <strong>Settings</strong> tab to
-          configure additional options like <strong>Webhook trigger</strong> —
-          enable it to generate a secret URL that fires a run via HTTP POST. No
-          auth header is needed; the secret in the URL is the credential.
+          After creating a job, open its <strong>Configure</strong> tab to
+          adjust these settings and options like{" "}
+          <strong>Webhook trigger</strong> — enable it to generate a secret URL
+          that fires a run via HTTP POST. No auth header is needed; the secret
+          in the URL is the credential.
         </P>
       </Section>
 
@@ -391,10 +396,12 @@ export function AutomationsContent() {
       <Section>
         <H3>History and status</H3>
         <P>
-          Each job card shows the last run's status, when it finished, and the
-          next scheduled fire time. Open the <strong>History</strong> tab on a
-          job to browse past runs with their reports, durations, and trigger
-          source (Manual, Scheduled, or Webhook).
+          Each job in the sidebar list shows its last run's status alongside its
+          schedule and enabled state, and the Jobs overview (shown when no job
+          is selected) lists upcoming scheduled runs. Open the{" "}
+          <strong>History</strong> tab on a job to browse past runs with their
+          start time, duration, trigger source (Manual, Scheduled, or Webhook),
+          and expandable report.
         </P>
       </Section>
 

--- a/apps/web/src/lib/tips/tips.ts
+++ b/apps/web/src/lib/tips/tips.ts
@@ -196,6 +196,14 @@ export const tips: Tip[] = [
     since: "0.27.0",
     surfaces: ["ambient"],
   },
+  {
+    id: "job-webhook-trigger",
+    title: "Job Webhook Triggers",
+    body: "Fire a job from CI or any external system: enable Webhook trigger in the job's Configure tab to get a secret URL that starts a run on HTTP POST.",
+    docsSection: "automations",
+    since: "0.29.0",
+    surfaces: ["ambient"],
+  },
 ];
 
 export function getTipById(id: string): Tip | undefined {


### PR DESCRIPTION
Nightly docs audit — deep-dive on the in-app **Automations** docs section (Jobs + Templates) against the current forms, trigger types, and run lifecycle.

## Audited
- Template create fields (`automations-form-fields.tsx`) — all accurate, including terminal-type field skipping, allowMedia default, and launch flows.
- Job create dialog + Configure tab (`jobs-add-dialog.tsx`, `jobs-settings-tab.tsx`) — fields, defaults (30 min run timeout, 24 h wait-for-input), webhook trigger.
- Run lifecycle tools/statuses, trigger source labels (Manual/Scheduled/Webhook), job-agent tool lists (already refreshed by #782), state-across-runs, Automations UI tabs.

## Fixed
- **"Show in command palette" (jobs)** — docs claimed callable jobs appear in the ⌘K palette. That was removed in the #515 template split; callable jobs now only get a badge in the jobs list. Reworded to match actual behavior. *Note: the form toggle copy still says "Launch this job from the ⌘K palette" — this is a UI regression worth a product decision (restore palette entries or drop the toggle); flagged in the audit backlog.*
- **Job prompt arguments** — docs said placeholders work "just like templates". Jobs never collect args at run time; `{{D:...}}` is only substituted from API-saved `defaultArgs`. Also tightened the preamble claim (it includes job/run IDs, not the job name).
- **"Settings" tab** → the job detail tab is labeled **Configure**.
- **History and status** — job cards don't show finished time or next fire time; they show status + schedule + enabled state, with upcoming runs on the Jobs overview and per-run detail in History.

## Added
- Ambient tip `job-webhook-trigger` (since 0.29.0) — webhook triggers are buried in the job Configure tab and easy to miss.

## Deferred
- Browser feedback extension (#783) has no docs coverage — queued as next run's focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)