### PR TITLE
fix: migrate pnpm build approvals for v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,6 @@
     "test:e2e": "bash scripts/e2e-isolated.sh",
     "prepare": "husky"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
-  },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx,json,css,md,yaml,yml}": [
       "prettier --write"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - "apps/*"
+
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary
- migrate removed `pnpm.onlyBuiltDependencies` configuration to workspace-level `allowBuilds`
- retain explicit build-script approvals for `esbuild` and `sharp`
- keep `pnpm-lock.yaml` unchanged

## Validation
- `CI=true corepack pnpm@11 install --frozen-lockfile` (pnpm 11.13.0; approved esbuild and sharp scripts ran)
- `pnpm run check`
- `pnpm run test:e2e`