### PR TITLE
Extract terminal file-upload logic into terminal-uploads.ts

### DIFF
--- a/apps/web/src/hooks/terminal-uploads.ts
+++ b/apps/web/src/hooks/terminal-uploads.ts
@@ -1,0 +1,63 @@
+import { toast } from "sonner";
+
+import { isAcceptedUploadFile, uploadAgentMedia } from "@/lib/media-upload";
+
+// Unified upload for both drag-and-drop and clipboard paste. The server
+// handles delivery (clipboard injection or typed path) via the `inject`
+// flag — the client just uploads and lets the server decide.
+//
+// Extracted from useTerminal so the hook body stays focused on the terminal
+// connection lifecycle. Takes the currently-connected agent id (or null) plus
+// a setter for the "uploading" UI flag, and orchestrates validation, upload,
+// and toast feedback.
+export function uploadTerminalFiles(
+  agentId: string | null,
+  files: File[],
+  setUploadingFiles: (uploading: boolean) => void
+): void {
+  if (files.length === 0) return;
+  if (!agentId) {
+    toast.error("Connect to an agent before uploading files.");
+    return;
+  }
+  const accepted = files.filter((file) => isAcceptedUploadFile(file.name));
+  const skipped = files.filter((file) => !isAcceptedUploadFile(file.name));
+  if (accepted.length === 0) {
+    toast.error(
+      files.length === 1
+        ? `Unsupported file type: ${files[0].name}`
+        : "None of the dropped files are a supported type."
+    );
+    return;
+  }
+  if (skipped.length > 0) {
+    toast.info(
+      `Skipped ${skipped.length} unsupported file${
+        skipped.length > 1 ? "s" : ""
+      }: ${skipped.map((file) => file.name).join(", ")}`
+    );
+  }
+  setUploadingFiles(true);
+  void (async () => {
+    const failures: string[] = [];
+    try {
+      for (const file of accepted) {
+        try {
+          await uploadAgentMedia(agentId, file, { inject: true });
+        } catch (err) {
+          console.warn(`Upload failed for ${file.name}:`, err);
+          failures.push(file.name);
+        }
+      }
+    } finally {
+      setUploadingFiles(false);
+    }
+    if (failures.length > 0) {
+      toast.error(
+        failures.length === 1
+          ? `Failed to upload ${failures[0]}.`
+          : `Failed to upload ${failures.length} files.`
+      );
+    }
+  })();
+}

--- a/apps/web/src/hooks/use-terminal.ts
+++ b/apps/web/src/hooks/use-terminal.ts
@@ -18,9 +18,7 @@ import {
   type TerminalUiState,
 } from "@/components/app/types";
 import { api } from "@/lib/api";
-import { toast } from "sonner";
 
-import { isAcceptedUploadFile, uploadAgentMedia } from "@/lib/media-upload";
 import { recordWSReconnect } from "@/lib/energy-metrics";
 import { type ThemeId, getTerminalPalette } from "@/hooks/use-theme";
 import {
@@ -36,6 +34,7 @@ import {
   probeTerminalSocket,
 } from "@/hooks/terminal-socket";
 import { createTerminalSurface } from "@/hooks/terminal-surface";
+import { uploadTerminalFiles } from "@/hooks/terminal-uploads";
 
 function focusTerminalSurface(term: XTerm | null): void {
   if (!term) return;
@@ -589,56 +588,8 @@ export function useTerminal(args: {
     terminalRef.current?.focus();
   }, []);
 
-  // Unified upload for both drag-and-drop and clipboard paste. The server
-  // handles delivery (clipboard injection or typed path) via the `inject`
-  // flag — the client just uploads and lets the server decide.
   const uploadFiles = useCallback((files: File[]) => {
-    if (files.length === 0) return;
-    const agentId = connectedAgentIdRef.current;
-    if (!agentId) {
-      toast.error("Connect to an agent before uploading files.");
-      return;
-    }
-    const accepted = files.filter((file) => isAcceptedUploadFile(file.name));
-    const skipped = files.filter((file) => !isAcceptedUploadFile(file.name));
-    if (accepted.length === 0) {
-      toast.error(
-        files.length === 1
-          ? `Unsupported file type: ${files[0].name}`
-          : "None of the dropped files are a supported type."
-      );
-      return;
-    }
-    if (skipped.length > 0) {
-      toast.info(
-        `Skipped ${skipped.length} unsupported file${
-          skipped.length > 1 ? "s" : ""
-        }: ${skipped.map((file) => file.name).join(", ")}`
-      );
-    }
-    setUploadingFiles(true);
-    void (async () => {
-      const failures: string[] = [];
-      try {
-        for (const file of accepted) {
-          try {
-            await uploadAgentMedia(agentId, file, { inject: true });
-          } catch (err) {
-            console.warn(`Upload failed for ${file.name}:`, err);
-            failures.push(file.name);
-          }
-        }
-      } finally {
-        setUploadingFiles(false);
-      }
-      if (failures.length > 0) {
-        toast.error(
-          failures.length === 1
-            ? `Failed to upload ${failures[0]}.`
-            : `Failed to upload ${failures.length} files.`
-        );
-      }
-    })();
+    uploadTerminalFiles(connectedAgentIdRef.current, files, setUploadingFiles);
   }, []);
   uploadFilesRef.current = uploadFiles;
 


### PR DESCRIPTION
## What

Moves the self-contained file-upload orchestration out of the 916-line `use-terminal.ts` hook into a new `apps/web/src/hooks/terminal-uploads.ts` module. The hook's `uploadFiles` callback now delegates to `uploadTerminalFiles(agentId, files, setUploadingFiles)`.

## Why it's tech debt

`use-terminal.ts` is a flagged complexity hotspot. The drag/drop + clipboard-paste upload logic (file-type validation, the upload loop, and toast feedback) had **no dependency on the terminal connection lifecycle** — it only needed the connected agent id and the "uploading" state setter. Pulling it into a module continues the established extraction pattern already applied to this file (`terminal-socket.ts` #659, `terminal-surface.ts` #664) and keeps the hook body focused on the WebSocket/connection lifecycle.

This is a **pure behavior-preserving code move** — the extracted function is byte-identical logic, and the hook sheds its `sonner` and `media-upload` imports. Hook shrinks 916 → 867 lines.

## Not in scope

The backlog item's original framing ("split `use-terminal.ts` into focused connection/resize/reconnect/focus hooks") was deliberately **not** attempted — that logic is tightly coupled through ~15 shared refs and the subtle WebSocket reconnect lifecycle, so a hook split would be high-risk churn with no behavior change. This PR takes the safe, incremental slice instead. Pre-existing issues in the file are untouched.

## Validation

- `pnpm run check` ✓
- `pnpm run finalize:web` ✓
- `pnpm run test:e2e` ✓ (168 passed, 13 `terminal-live` tests skipped as usual — they require a live tmux env)

## Queued for next run

Re-audit remaining complexity hotspots; `agents-view.tsx` (1006 lines) is on the backlog but is a hot, frequently-changed file — verify no in-flight work before touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)