### PR TITLE
Document worktree-creation failure UX in in-app docs

### DIFF
--- a/apps/web/src/components/app/docs-sections/worktrees.tsx
+++ b/apps/web/src/components/app/docs-sections/worktrees.tsx
@@ -26,6 +26,20 @@ export function WorktreesContent() {
       </Section>
 
       <Section>
+        <H3>When creation fails</H3>
+        <P>
+          Because you asked for an isolated worktree, Dispatch won't silently
+          fall back to running in the main checkout. If the worktree can't be
+          created — a name collision, a missing starting branch, or another git
+          error — the agent is marked <Code>stopped</Code> with the underlying
+          git error in its <strong>Last error</strong>, and its card shows an{" "}
+          <strong>Attention</strong> badge. Any partially-created worktree or
+          branch is cleaned up, so fixing the cause and relaunching starts from
+          a clean slate.
+        </P>
+      </Section>
+
+      <Section>
         <H3>Branch options</H3>
         <P>
           Pick a <strong>Starting branch</strong> from the dropdown — that's the


### PR DESCRIPTION
## What was audited

Docs-audit run scoped to `next_focus`: the in-app **Worktrees** docs section (`apps/web/src/components/app/docs-sections/worktrees.tsx`) against `apps/server/src/shared/git/worktree.ts`, following the concurrent-create `.git/config` lock fix in #794.

Verified every existing claim against source and found them all accurate:
- "Create managed git worktree" checkbox default-on (`createUseWorktree = useState(true)`), disabled + noted when not a git repo.
- `.env` copy + dependency install across `pnpm-lock.yaml` / `yarn.lock` / `package-lock.json` / `bun.lockb` (`workspace-prep.ts`, `setup-script.ts`).
- Branch options: "Starting branch" dropdown, "Create a new branch" checkbox default-on and remembered per working directory (`createNewBranchPrefAtom`, `atomWithLocalStorage` keyed by cwd), auto-generated name when blank.
- Worktree location (sibling default vs `.dispatch/worktrees/`), cleanup logic, and parallel-agent isolation (now reliably true post-#794).

## What changed

Added a **"When creation fails"** paragraph — the one genuine gap. This path is user-visible but was undocumented: because the user explicitly asked for an isolated worktree, Dispatch refuses to fall back to the main checkout. On failure the agent is marked `stopped` with the git error in `last_error` (surfaced as an **Attention** badge tooltip + **Last error** field on the card, per `manager.ts` and `agent-card.tsx`), and any partial worktree/branch is cleaned up so a relaunch starts clean. This resolves the long-standing backlog item from #409.

## Deferred to next run

- Next focus: audit docs-pane **Status Events** / **Notifications** sections against source.
- Backlog retains the callable-jobs palette UI regression and other pre-existing items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)