### PR TITLE
Stop the E2E server restarting mid-run, and cover terminal uploads

### DIFF
--- a/apps/web/src/hooks/terminal-uploads.test.ts
+++ b/apps/web/src/hooks/terminal-uploads.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UploadedMedia } from "@/lib/media-upload";
+
+import { uploadTerminalFiles } from "./terminal-uploads";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/media-upload", () => ({
+  isAcceptedUploadFile: vi.fn(),
+  uploadAgentMedia: vi.fn(),
+}));
+
+const { toast } = await import("sonner");
+const { isAcceptedUploadFile, uploadAgentMedia } =
+  await import("@/lib/media-upload");
+
+const mockAccepted = vi.mocked(isAcceptedUploadFile);
+const mockUpload = vi.mocked(uploadAgentMedia);
+const mockError = vi.mocked(toast.error);
+const mockInfo = vi.mocked(toast.info);
+
+function file(name: string): File {
+  return new File(["x"], name);
+}
+
+/** Accept only names matching this suffix list; everything else is unsupported. */
+function acceptSuffixes(...suffixes: string[]) {
+  mockAccepted.mockImplementation((name: string) =>
+    suffixes.some((suffix) => name.endsWith(suffix))
+  );
+}
+
+const UPLOADED = {} as UploadedMedia;
+
+/**
+ * Wait for the fire-and-forget upload IIFE to finish. Clearing the uploading
+ * flag happens in its `finally`, so this is the signal that no further work is
+ * queued and the next test starts from a clean slate.
+ */
+function settle(setUploading: ReturnType<typeof vi.fn>) {
+  return vi.waitFor(() =>
+    expect(setUploading).toHaveBeenNthCalledWith(2, false)
+  );
+}
+
+describe("uploadTerminalFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpload.mockResolvedValue(UPLOADED);
+    // Default: everything is a supported type.
+    mockAccepted.mockReturnValue(true);
+  });
+
+  // uploadTerminalFiles kicks off a fire-and-forget async IIFE, and some tests
+  // assert only on its synchronous prelude. Restore mocks (notably the
+  // console.warn spy) so nothing leaks into the next test or file.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("guard clauses", () => {
+    it("is a no-op for an empty file list", () => {
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [], setUploading);
+
+      expect(setUploading).not.toHaveBeenCalled();
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockInfo).not.toHaveBeenCalled();
+    });
+
+    it("errors without uploading when no agent is connected", () => {
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles(null, [file("a.png")], setUploading);
+
+      expect(mockError).toHaveBeenCalledWith(
+        "Connect to an agent before uploading files."
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(setUploading).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unsupported file types", () => {
+    it("names the file when a single unsupported file is dropped", () => {
+      mockAccepted.mockReturnValue(false);
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [file("notes.xyz")], setUploading);
+
+      expect(mockError).toHaveBeenCalledWith(
+        "Unsupported file type: notes.xyz"
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(setUploading).not.toHaveBeenCalled();
+    });
+
+    it("uses the generic message when every file of several is unsupported", () => {
+      mockAccepted.mockReturnValue(false);
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles(
+        "agt_1",
+        [file("a.xyz"), file("b.xyz")],
+        setUploading
+      );
+
+      expect(mockError).toHaveBeenCalledWith(
+        "None of the dropped files are a supported type."
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("partial skips", () => {
+    it("uploads the accepted files and reports the skipped ones", async () => {
+      acceptSuffixes(".png");
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles(
+        "agt_1",
+        [file("keep.png"), file("skip.xyz")],
+        setUploading
+      );
+
+      expect(mockInfo).toHaveBeenCalledWith(
+        "Skipped 1 unsupported file: skip.xyz"
+      );
+      await vi.waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
+      expect(mockUpload).toHaveBeenCalledWith(
+        "agt_1",
+        expect.objectContaining({ name: "keep.png" }),
+        { inject: true }
+      );
+      await settle(setUploading);
+    });
+
+    it("pluralizes and lists every skipped file name", async () => {
+      acceptSuffixes(".png");
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles(
+        "agt_1",
+        [file("keep.png"), file("a.xyz"), file("b.xyz")],
+        setUploading
+      );
+
+      expect(mockInfo).toHaveBeenCalledWith(
+        "Skipped 2 unsupported files: a.xyz, b.xyz"
+      );
+      await settle(setUploading);
+    });
+
+    it("does not report skips when every file is supported", async () => {
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [file("a.png")], setUploading);
+
+      expect(mockInfo).not.toHaveBeenCalled();
+      await settle(setUploading);
+    });
+  });
+
+  describe("upload lifecycle", () => {
+    it("toggles the uploading flag on, then off once uploads settle", async () => {
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [file("a.png")], setUploading);
+
+      // Set synchronously so the UI reflects the upload immediately.
+      expect(setUploading).toHaveBeenNthCalledWith(1, true);
+
+      await vi.waitFor(() =>
+        expect(setUploading).toHaveBeenNthCalledWith(2, false)
+      );
+      expect(setUploading).toHaveBeenCalledTimes(2);
+    });
+
+    it("uploads every accepted file with the inject flag", async () => {
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles(
+        "agt_1",
+        [file("a.png"), file("b.png")],
+        setUploading
+      );
+
+      // Wait for the flag reset, not just the last upload call — that is the
+      // IIFE's final step, so the failure toast (if any) has already run.
+      await vi.waitFor(() =>
+        expect(setUploading).toHaveBeenNthCalledWith(2, false)
+      );
+
+      // Assert on file names: mapping the agent id would pass even if the same
+      // file were uploaded twice and the second one never sent.
+      expect(mockUpload.mock.calls.map((call) => call[1].name)).toEqual([
+        "a.png",
+        "b.png",
+      ]);
+      expect(mockUpload.mock.calls.every((call) => call[2]?.inject)).toBe(true);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("upload failures", () => {
+    it("names the file when a single upload fails", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockUpload.mockRejectedValue(new Error("boom"));
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [file("a.png")], setUploading);
+
+      await vi.waitFor(() =>
+        expect(mockError).toHaveBeenCalledWith("Failed to upload a.png.")
+      );
+      expect(setUploading).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it("counts the failures when several uploads fail", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockUpload.mockRejectedValue(new Error("boom"));
+
+      uploadTerminalFiles("agt_1", [file("a.png"), file("b.png")], vi.fn());
+
+      await vi.waitFor(() =>
+        expect(mockError).toHaveBeenCalledWith("Failed to upload 2 files.")
+      );
+    });
+
+    it("keeps uploading the remaining files after one fails", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockUpload
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValue(undefined as never);
+
+      uploadTerminalFiles("agt_1", [file("a.png"), file("b.png")], vi.fn());
+
+      await vi.waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() =>
+        expect(mockError).toHaveBeenCalledWith("Failed to upload a.png.")
+      );
+    });
+
+    it("still clears the uploading flag when uploads fail", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockUpload.mockRejectedValue(new Error("boom"));
+      const setUploading = vi.fn();
+
+      uploadTerminalFiles("agt_1", [file("a.png")], setUploading);
+
+      await vi.waitFor(() =>
+        expect(setUploading).toHaveBeenNthCalledWith(2, false)
+      );
+    });
+  });
+});

--- a/e2e/split-pane.spec.ts
+++ b/e2e/split-pane.spec.ts
@@ -73,9 +73,7 @@ test.describe("Split pane", () => {
     await expect(page.getByTestId("terminal-pane")).toBeVisible();
   });
 
-  // Disabled temporarily: under parallel suite load the app shell can fail to
-  // become visible, while this flow passes consistently in isolated runs.
-  test.skip("unsplit button exits split mode", async ({ page, request }) => {
+  test("unsplit button exits split mode", async ({ page, request }) => {
     const agent = await createAgentViaAPI(request, {
       name: `e2e-split-unsplit-${Date.now()}`,
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,9 +43,15 @@ export default defineConfig({
     extraHTTPHeaders: {},
   },
   webServer: {
+    // `start` runs the server without `bun --watch`. Watch mode is actively
+    // harmful here: `prepare:runtime-assets` (run by test/check/build/start)
+    // unconditionally rewrites apps/server/src/generated/runtime-assets.js,
+    // which is inside the watched tree. Any concurrent pnpm task therefore
+    // restarted the server mid-run and surfaced as `socket hang up` on
+    // whatever request was in flight. E2E never needs hot reload.
     command: process.env.E2E_SKIP_WEB_BUILD
-      ? "pnpm run dev"
-      : "pnpm run build:web && pnpm run dev",
+      ? "pnpm run start"
+      : "pnpm run build:web && pnpm run start",
     env: {
       DATABASE_URL: databaseUrl,
       DISPATCH_PORT: devPort,


### PR DESCRIPTION
## The failure

The local E2E suite failed on `worktree.spec.ts:310` with `apiRequestContext.post: socket hang up`, aborting the run (56 tests did not run).

`socket hang up` means the server dropped the connection, not that it timed out. The log confirms it: an ANSI clear-screen and a duplicate startup banner land at the exact failure timestamp — the server **restarted mid-request**.

## Why

The E2E `webServer` command was `pnpm run dev`, which is `bun --watch src/main.ts`.

`prepare:runtime-assets` runs at the start of the server's `test`, `check`, `build`, and `start` scripts, and unconditionally rewrites `apps/server/src/generated/runtime-assets.js` — a file *inside the watched tree*. So any concurrent pnpm task during an E2E run restarts the server and kills whatever request is in flight.

That makes the harness non-deterministic in a way that looks like random, load-correlated flakiness — which is exactly how it has been showing up.

## The fix

Use `pnpm run start`: the same boot path, minus the watcher. E2E never needs hot reload, and the asset write inside `start` completes before the server binds, so it cannot restart itself.

A/B on `e2e/worktree.spec.ts` under continuous concurrent asset regeneration:

| config | result |
| --- | --- |
| `pnpm run dev` (before) | **6 failed** / 18 passed (51.6s) |
| `pnpm run start` (after) | **24 passed** (10.3s) |

The full suite also passes under that same pressure (169 passed / 12 skipped). Side benefit: a genuine server crash mid-suite is no longer masked by a watch-triggered restart.

## Re-enabled a test this was blocking

This is a credible root cause for the recorded "app shell fails to become visible under parallel load" flake — a restart during a page reload stalls that one page while unrelated tests keep passing, which matches the recorded forensics (shell rendered in screenshots, neighbours passing in 1–2s).

`split-pane.spec.ts` had `test.skip("unsplit button exits split mode")` disabled solely for that flake. Re-enabled: 30/30 via `--repeat-each=5` under the same write pressure, plus two clean full-suite runs.

## Coverage: `uploadTerminalFiles`

Had no tests since it was extracted in #796. Adds 13 covering the guard clauses, supported/unsupported partitioning and message pluralization, the uploading-flag lifecycle, and per-file failure aggregation.

The function ends in a fire-and-forget `void (async () => …)`, so the tests await the flag reset in its `finally` rather than sleeping.

Verified non-vacuous by mutation testing — each of these fails at least one test: dropping the `finally` reset, breaking pluralization, flipping the `inject` flag, breaking out of the loop on first failure, uploading the first file twice, and emitting a spurious failure toast on success.

## Validation

`check` ✅ · server 2285 ✅ · web 245 (+13) ✅ · browser-extension 51 ✅ · `finalize:web` ✅ · E2E 169 passed / 12 skipped ✅

CI scan of the last 50 runs found no new flakes — all `CI` runs green; the only failures are the known Release-workflow infra issues on `main` from 2026-07-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)