### PR TITLE
Correct focus-suppression claims and document tips in Notifications docs

### DIFF
--- a/apps/web/src/components/app/docs-sections/notifications.tsx
+++ b/apps/web/src/components/app/docs-sections/notifications.tsx
@@ -34,11 +34,13 @@ export function NotificationsContent() {
         <H3>Browser notifications</H3>
         <P>
           Grant the browser permission, then toggle{" "}
-          <strong>Enable browser notifications</strong>. When the app is open in
-          at least one tab, matching events are delivered as native desktop or
-          mobile banners instead of Slack. If no tab is open to acknowledge the
-          notification within a few seconds, Dispatch falls back to Slack
-          automatically.
+          <strong>Enable browser notifications</strong> — the toggle stays
+          disabled until permission is granted. When the app is open in at least
+          one tab, matching events are delivered as native desktop or mobile
+          banners instead of Slack. If no tab acknowledges the notification
+          within about three seconds, Dispatch falls back to Slack
+          automatically. <strong>Send test</strong> fires a sample banner so you
+          can confirm the setup.
         </P>
         <P>
           On iOS and iPadOS, notifications only work after installing Dispatch
@@ -79,14 +81,28 @@ export function NotificationsContent() {
       </Section>
 
       <Section>
+        <H3>Tips &amp; guidance</H3>
+        <P>
+          The same settings pane hosts <strong>Tips &amp; Guidance</strong> —
+          short contextual hints that point out features and link into these
+          docs. They're per-device like sound cues. Untick{" "}
+          <strong>Show tips</strong> to turn them off, or use{" "}
+          <strong>Reset dismissed tips</strong> to bring back everything you've
+          already dismissed.
+        </P>
+      </Section>
+
+      <Section>
         <H3>Focus-aware suppression</H3>
         <P>
           Dispatch suppresses browser and Slack notifications for an agent
-          you're already looking at. Tabs that have an agent selected send
-          periodic focus heartbeats while the tab is visible and focused;
-          notifications for that agent are dropped until the heartbeat lapses (a
-          ~30 second TTL after you switch tabs, change agents, or blur the
-          window). Sound cues are not filtered by focus.
+          you're already looking at. Tabs that have an agent selected send a
+          focus heartbeat every 15 seconds while the tab is visible and focused,
+          and notifications for that agent are dropped while it's live. Blurring
+          the window, hiding the tab, or switching agents clears focus
+          immediately, so notifications resume right away; the heartbeat also
+          expires on its own after 30 seconds if a tab goes away without
+          reporting. Sound cues are not filtered by focus.
         </P>
       </Section>
 


### PR DESCRIPTION
Nightly docs audit — Notifications slice (`next_focus` from the previous run, which also lines up with the `notification-settings.tsx` split in #799).

## Audited
`apps/web/src/components/app/docs-sections/notifications.tsx` against `notification-settings.tsx` + its new section components, `notification-settings-constants.ts`, `sound-cues.ts`, `focus-tracker.ts`, `use-agent-focus.ts`, `server/notification-runtime.ts`, `notifications/slack.ts`, and `agent-lifecycle-tools.ts`.

## Changed
- **Focus-aware suppression** was wrong: it said notifications stay suppressed "until the heartbeat lapses (~30s after you switch tabs, change agents, or blur the window)". The client posts a null-focus signal on blur/hide/deselect and the server clears focus immediately, so notifications resume right away. The 30s TTL is only the safety net for a tab that disappears without reporting. Also named the real 15s heartbeat interval.
- **Browser notifications**: noted the enable toggle is disabled until permission is granted, made the Slack-fallback window concrete (~3s ack timeout), and mentioned the **Send test** button.
- **Tips & guidance**: new short section. The Tips & Guidance block (Show tips toggle + Reset dismissed tips) lives in Settings → Notifications and had no docs coverage anywhere.

## Verified accurate, no change
Configurable events (done / waiting_user / blocked), sound cue inventory (4 status cues + mobile tap), per-device sound behavior and no focus filtering, Slack test button label, Slack fallback conditions, and every `dispatch_notify` parameter, default, and limit (3000/150 chars, 5/min, `respectFocus` default false, persona agents excluded).

No new ambient tip — `notifications` already has one.

## Deferred
Backlog unchanged apart from this slice; next run points at the docs-pane Status Events section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)