### PR TITLE
Extract the agents-view dialog cluster into agents-view-dialogs.tsx

### DIFF
--- a/apps/web/src/components/app/agents-view-dialogs.tsx
+++ b/apps/web/src/components/app/agents-view-dialogs.tsx
@@ -1,0 +1,132 @@
+import { type ComponentProps } from "react";
+
+import { LaunchTemplateDialog } from "@/components/app/automations-launch-dialog";
+import {
+  CommandPalette,
+  type CommandAction,
+  type CommandGroup,
+} from "@/components/app/command-palette";
+import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
+import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
+import { MediaLightbox } from "@/components/app/media-lightbox";
+import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
+import { type Agent } from "@/components/app/types";
+import { type Template } from "@/hooks/use-templates";
+import { type AgentType, isCliAgentType } from "@/lib/agent-types";
+
+type AgentsViewDialogsProps = {
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+  paletteActions: CommandAction[];
+  paletteGroups: CommandGroup[];
+  launchTemplate: Template | null;
+  setLaunchTemplateId: (id: string | null) => void;
+  enabledAgentTypes: AgentType[];
+  createOpen: boolean;
+  initialAgentType: AgentType | null;
+  onCreateOpenChange: (open: boolean) => void;
+  resolveCreateDefaultCwd: () => string;
+  onAgentCreated: (agent: Agent, agentType: AgentType) => Promise<void>;
+  deleteConfirmOpen: boolean;
+  deleteTarget: Agent | null;
+  setDeleteConfirmOpen: (open: boolean) => void;
+  setDeleteTarget: (agent: Agent | null) => void;
+  onDelete: (agent: Agent, cleanupWorktree?: string) => Promise<void>;
+  stopConfirmOpen: boolean;
+  stopTarget: Agent | null;
+  setStopConfirmOpen: (open: boolean) => void;
+  setStopTarget: (agent: Agent | null) => void;
+  onStop: (agent: Agent) => Promise<void>;
+  lightboxItem: ComponentProps<typeof MediaLightbox>["item"];
+  lightboxIndex: number;
+  mediaFileCount: number;
+  setLightboxIndex: (nextIndex: number | null) => void;
+};
+
+/**
+ * The modal/overlay cluster rendered at the end of the agents view: command
+ * palette, template launch dialog, create/delete/stop agent dialogs, and the
+ * media lightbox. Purely presentational — all state lives in the parent.
+ */
+export function AgentsViewDialogs({
+  paletteOpen,
+  setPaletteOpen,
+  paletteActions,
+  paletteGroups,
+  launchTemplate,
+  setLaunchTemplateId,
+  enabledAgentTypes,
+  createOpen,
+  initialAgentType,
+  onCreateOpenChange,
+  resolveCreateDefaultCwd,
+  onAgentCreated,
+  deleteConfirmOpen,
+  deleteTarget,
+  setDeleteConfirmOpen,
+  setDeleteTarget,
+  onDelete,
+  stopConfirmOpen,
+  stopTarget,
+  setStopConfirmOpen,
+  setStopTarget,
+  onStop,
+  lightboxItem,
+  lightboxIndex,
+  mediaFileCount,
+  setLightboxIndex,
+}: AgentsViewDialogsProps): JSX.Element {
+  return (
+    <>
+      <CommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        actions={paletteActions}
+        groups={paletteGroups}
+      />
+
+      {launchTemplate ? (
+        <LaunchTemplateDialog
+          template={launchTemplate}
+          open={!!launchTemplate}
+          onOpenChange={(open) => {
+            if (!open) setLaunchTemplateId(null);
+          }}
+          agentTypes={enabledAgentTypes.filter(isCliAgentType)}
+        />
+      ) : null}
+
+      <CreateAgentDialog
+        open={createOpen}
+        enabledAgentTypes={enabledAgentTypes}
+        initialAgentType={initialAgentType}
+        setOpen={onCreateOpenChange}
+        resolveDefaultCwd={resolveCreateDefaultCwd}
+        onCreated={onAgentCreated}
+      />
+
+      <DeleteAgentDialog
+        open={deleteConfirmOpen}
+        deleteTarget={deleteTarget}
+        setOpen={setDeleteConfirmOpen}
+        setDeleteTarget={setDeleteTarget}
+        onDelete={onDelete}
+      />
+
+      <StopAgentDialog
+        open={stopConfirmOpen}
+        stopTarget={stopTarget}
+        setOpen={setStopConfirmOpen}
+        setStopTarget={setStopTarget}
+        onStop={onStop}
+      />
+
+      <MediaLightbox
+        item={lightboxItem}
+        currentIndex={lightboxIndex}
+        totalItems={mediaFileCount}
+        setLightboxIndex={setLightboxIndex}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/app/agents-view.tsx
+++ b/apps/web/src/components/app/agents-view.tsx
@@ -29,9 +29,7 @@ import {
   readExpandedAgentId,
   readLastUsedAgentType,
 } from "@/components/app/agents-view-utils";
-import { CreateAgentDialog } from "@/components/app/create-agent-dialog";
-import { DeleteAgentDialog } from "@/components/app/delete-agent-dialog";
-import { MediaLightbox } from "@/components/app/media-lightbox";
+import { AgentsViewDialogs } from "@/components/app/agents-view-dialogs";
 import {
   MediaSidebar,
   MediaSidebarContent,
@@ -39,7 +37,6 @@ import {
 import { TerminalCopyModeBannerLayer } from "@/components/app/terminal-copy-mode-banner";
 import { MobileTerminalToolbar } from "@/components/app/mobile-terminal-toolbar";
 import { SidebarShell, type NavSection } from "@/components/app/sidebar-shell";
-import { StopAgentDialog } from "@/components/app/stop-agent-dialog";
 import { QuickPhrasesButton } from "@/components/app/quick-phrases";
 import { TerminalPane } from "@/components/app/terminal-pane";
 import { AmbientTipBar } from "@/components/tips/ambient-tip-bar";
@@ -52,11 +49,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { GlassSidebar } from "@/components/ui/glass-sidebar";
 import { uploadAgentMedia } from "@/lib/media-upload";
-import {
-  type AgentType,
-  isCliAgentType,
-  isNestedReviewAgent,
-} from "@/lib/agent-types";
+import { type AgentType, isNestedReviewAgent } from "@/lib/agent-types";
 import { type IdeType } from "@/lib/ide-types";
 import { type CenterTab } from "@/lib/store";
 import { cn } from "@/lib/utils";
@@ -71,8 +64,6 @@ import { useMediaSidebarState } from "@/hooks/use-media-sidebar-state";
 import { useTerminal } from "@/hooks/use-terminal";
 import { useAgentFocus } from "@/hooks/use-agent-focus";
 import { useAgentsViewRouting } from "@/hooks/use-agents-view-routing";
-import { LaunchTemplateDialog } from "@/components/app/automations-launch-dialog";
-import { CommandPalette } from "@/components/app/command-palette";
 import { useAgentHotkeys } from "@/hooks/use-agent-hotkeys";
 
 type AgentsViewProps = {
@@ -875,53 +866,32 @@ export function AgentsView({
         </GlassSidebar>
       ) : null}
 
-      <CommandPalette
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-        actions={paletteActions}
-        groups={paletteGroups}
-      />
-
-      {launchTemplate ? (
-        <LaunchTemplateDialog
-          template={launchTemplate}
-          open={!!launchTemplate}
-          onOpenChange={(open) => {
-            if (!open) setLaunchTemplateId(null);
-          }}
-          agentTypes={enabledAgentTypes.filter(isCliAgentType)}
-        />
-      ) : null}
-
-      <CreateAgentDialog
-        open={createOpen}
+      <AgentsViewDialogs
+        paletteOpen={paletteOpen}
+        setPaletteOpen={setPaletteOpen}
+        paletteActions={paletteActions}
+        paletteGroups={paletteGroups}
+        launchTemplate={launchTemplate}
+        setLaunchTemplateId={setLaunchTemplateId}
         enabledAgentTypes={enabledAgentTypes}
+        createOpen={createOpen}
         initialAgentType={requestedCreateType ?? lastUsedAgentType}
-        setOpen={handleCreateOpenChange}
-        resolveDefaultCwd={resolveCreateDefaultCwd}
-        onCreated={handleAgentCreated}
-      />
-
-      <DeleteAgentDialog
-        open={deleteConfirmOpen}
+        onCreateOpenChange={handleCreateOpenChange}
+        resolveCreateDefaultCwd={resolveCreateDefaultCwd}
+        onAgentCreated={handleAgentCreated}
+        deleteConfirmOpen={deleteConfirmOpen}
         deleteTarget={deleteTarget}
-        setOpen={setDeleteConfirmOpen}
+        setDeleteConfirmOpen={setDeleteConfirmOpen}
         setDeleteTarget={setDeleteTarget}
         onDelete={deleteAgent}
-      />
-
-      <StopAgentDialog
-        open={stopConfirmOpen}
+        stopConfirmOpen={stopConfirmOpen}
         stopTarget={stopTarget}
-        setOpen={setStopConfirmOpen}
+        setStopConfirmOpen={setStopConfirmOpen}
         setStopTarget={setStopTarget}
         onStop={stopAgent}
-      />
-
-      <MediaLightbox
-        item={lightboxItem}
-        currentIndex={lightboxIndex}
-        totalItems={mediaFiles.length}
+        lightboxItem={lightboxItem}
+        lightboxIndex={lightboxIndex}
+        mediaFileCount={mediaFiles.length}
         setLightboxIndex={setLightboxIndex}
       />
 


### PR DESCRIPTION
## What

The trailing block of `apps/web/src/components/app/agents-view.tsx` rendered six unrelated overlays inline — `CommandPalette`, `LaunchTemplateDialog`, `CreateAgentDialog`, `DeleteAgentDialog`, `StopAgentDialog`, `MediaLightbox`. Moved that block into a new purely presentational `AgentsViewDialogs` component (`agents-view-dialogs.tsx`).

All state, handlers, and effects stay in the parent — the new component only receives props and renders the same JSX. Removed the six now-unused component imports and the `isCliAgentType` import from `agents-view.tsx`.

`agents-view.tsx`: 933 → 906 lines.

## Why it's tech debt

`agents-view.tsx` is one of the largest components in the web app and has been shrunk incrementally over several runs (#799, #800, #803). This block was self-contained prop-passing with no refs, effects, or terminal/WebSocket involvement — the lowest-risk remaining extraction. No behavior change.

## Validation

- `pnpm run check` ✅
- `pnpm run finalize:web` ✅
- `pnpm run test:e2e` ✅ (169 passed, 12 skipped)

## Next run

Queued: extract the center-pane header toolbar (the `h-14 grid-cols-[1fr_auto_1fr]` block: sidebar toggle, `QuickPhrasesButton`, `CenterPaneTabBar`, `ChangesSettingsPopover`, media button) into a `CenterPaneHeader` component — or, if `agents-view.tsx` is getting churny, a fresh dead-code/duplication scan.