### PR TITLE
Correct the Status Events docs and document automatic status correction

### DIFF
--- a/apps/web/src/components/app/docs-sections/events.tsx
+++ b/apps/web/src/components/app/docs-sections/events.tsx
@@ -6,7 +6,9 @@ export function EventsContent() {
       <P>
         Agents report their status throughout a task using the{" "}
         <Code>dispatch_event</Code> tool. These events drive the status
-        indicators in the sidebar and enable Slack notifications.
+        indicators in the sidebar, and <Code>done</Code>,{" "}
+        <Code>waiting_user</Code>, and <Code>blocked</Code> also trigger browser
+        and Slack notifications.
       </P>
 
       <Section>
@@ -17,8 +19,9 @@ export function EventsContent() {
             writing code, running tests)
           </li>
           <li>
-            <Code>blocked</Code> — hit an error or obstacle that needs
-            resolution
+            <Code>blocked</Code> — completely stuck with no further approach to
+            try (not for errors or test failures the agent plans to fix next —
+            those stay <Code>working</Code>)
           </li>
           <li>
             <Code>waiting_user</Code> — needs a decision or approval before
@@ -39,20 +42,38 @@ export function EventsContent() {
         <P>
           Each agent's card in the sidebar shows the latest event's status label
           (Working / Blocked / Waiting / Done / Idle, color-coded), a relative
-          timestamp (e.g. "just now", "5m ago"), and the message. Events are
-          also stored in the database for activity tracking — the Activity page
-          uses them to build heatmaps, working-time breakdowns, and daily status
-          charts.
+          timestamp (e.g. "just now", "5m ago"), and the repo name. Expanding
+          the card adds the event message below that line. Events are also
+          stored in the database for activity tracking — the Activity page uses
+          them to build the activity and active-hours heatmaps, working-time
+          stats, and the status breakdown chart.
+        </P>
+      </Section>
+
+      <Section>
+        <H3>Automatic status correction</H3>
+        <P>
+          Agents don't always report accurately, so Dispatch cross-checks each
+          running agent's status against its terminal activity. If the terminal
+          is producing output but the status isn't <Code>working</Code>, it's
+          corrected to <Code>working</Code> with the message "Activity
+          detected". If the status is <Code>working</Code> but the terminal has
+          been silent for three minutes, it's corrected to <Code>idle</Code>{" "}
+          with "No recent activity detected". A correction is skipped if the
+          agent reported a new event in the meantime, so a live agent always
+          wins over the check.
         </P>
       </Section>
 
       <Section>
         <H3>Configuring agent instructions</H3>
         <P>
-          To get agents to report events, add instructions to your repo's{" "}
-          <Code>CLAUDE.md</Code> (or equivalent config) telling the agent to
-          call <Code>dispatch_event</Code> at key checkpoints: start of turn,
-          phase transitions, errors, and before the final response.
+          Dispatch already injects startup rules at launch telling the agent
+          which event types to use and when to emit them, so reporting works
+          without any setup. To reinforce or customize the behavior, add
+          instructions to your repo's <Code>CLAUDE.md</Code> (or equivalent
+          config) covering the checkpoints that matter to you: start of turn,
+          phase transitions, and a terminal event before the final response.
         </P>
       </Section>
     </>


### PR DESCRIPTION
Nightly docs audit. This run's slice was the in-app **Status Events** section (`docs-sections/events.tsx`), carried over from the previous run's `next_focus`.

Verified against `agent-lifecycle-tools.ts` (tool registration), `agents/types.ts` (`AgentLatestEventType`), `tmux/command-builder.ts` (injected startup rules), `agents/activity-monitor.ts`, `agent-card-status.tsx` / `agent-event-utils.ts` (sidebar rendering), `notifications/slack.ts` + `web-notifications.ts`, and the Activity pane routes.

## What changed

- **`blocked` was described wrong.** The docs said "hit an error or obstacle that needs resolution." The guidance Dispatch actually injects at launch says the opposite: blocked means *completely stuck with no further approach to try*, explicitly **not** errors or test failures the agent plans to fix next. Rewrote to match.
- **Sidebar claim was inaccurate.** It listed label + timestamp + message for every card. Collapsed cards show label + timestamp + **repo name**; only expanded cards add the message.
- **Notification claim was imprecise.** Said "enable Slack notifications" generally — only `done`, `waiting_user`, and `blocked` trigger them, and they drive browser notifications too. Named the three.
- **New section: Automatic status correction.** The activity monitor was entirely undocumented despite being user-visible — it rewrites statuses and its messages ("Activity detected", "No recent activity detected") show up in the sidebar with no explanation anywhere. Documented both correction directions, the 3-minute stale window, and the conditional-write guard.
- **"Configuring agent instructions" overstated setup.** It implied you must add CLAUDE.md instructions to get events at all; Dispatch injects startup rules automatically. Reframed as reinforce/customize.
- **Activity page claims** matched to the real headings (activity + active-hours heatmaps, working-time stats, "Status breakdown" chart).

Event type list itself (5 types), labels, colors, and relative-time formats were all verified accurate and unchanged.

## Not changed

No new ambient tip. The auto-correction is explanatory rather than a discoverable feature with an action to take, so it didn't clear the bar in `tips.ts`.

## Deferred to next run

`next_focus` points at the docs-pane **Media & Sharing** section vs `media-sidebar.tsx` tabs and the `dispatch_share` handler. Backlog additions: `dispatch_event` `metadata` param is now worth documenting given the auto-correction section, and `docs/04-agent-lifecycle.md` has no activity-monitor coverage.

## Validation

`pnpm run format:write`, `pnpm run check` (server + web + extension + scripts) all clean; pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)